### PR TITLE
ci: increase timeout and remove macos packaging 

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -101,7 +101,8 @@ pipeline {
         axes {
           axis {
             name 'PLATFORM'
-            values 'macosx && x86_64', 'ubuntu-20.04 && immutable', 'aarch64'
+            // TODO: 'macosx && x86_64' doesn't work since docker is not available in the internal-ci macosx workers
+            values 'ubuntu-20.04 && immutable', 'aarch64'
           }
         }
         stages {


### PR DESCRIPTION
### What

Increase the timeout since it takes a bit longer in the internal-ci
Remove macos packaging since docker is not available in the workers for macos

### Why

Keep the ci builds stable


Superseedes https://github.com/elastic/elastic-agent-poc/pull/13

