### PR TITLE
ci: run k8s validation for different versions

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -98,15 +98,7 @@ pipeline {
               expression { return env.PLATFORM == 'ubuntu-20.04 && immutable' }
             }
             steps {
-              withGithubNotify(context: "K8s-${PLATFORM}") {
-                withMageEnv(){
-                  withKindEnv(k8sVersion: 'v1.23.0', kindVersion: 'v0.11.1') {
-                    dir("${BASE_DIR}"){
-                      sh(label: "Deploy to kubernetes",script: "make -C deploy/kubernetes test")
-                    }
-                  }
-                }
-              }
+              runK8s(k8sVersion: 'v1.23.0', kindVersion: 'v0.11.1', context: "K8s-${PLATFORM}")
             }
           }
         }
@@ -141,6 +133,17 @@ pipeline {
             }
           }
         }
+      }
+    }
+    stage('K8s') {
+      when {
+        // TODO: Run only if changes in
+        //  - "^deploy/kubernetes/.*"
+        //  - "^version/docs/version.asciidoc"
+        not { changeRequest() }
+      }
+      steps {
+        runAllK8s(["v1.23.0", "v1.22.0", "v1.21.1", "v1.20.7", "v1.19.11", "v1.18.19"])
       }
     }
   }
@@ -219,5 +222,29 @@ def withPackageDarwinEnv(Closure body) {
     "PLATFORMS=${PLATFORMS}"
   ]) {
     body()
+  }
+}
+
+def runAllK8s(versions) {
+  def parallelTasks = [:]
+  versions.each { version ->
+    node('ubuntu-20.04 && immutable') {
+      deleteDir()
+      unstash 'source'
+      runK8s(k8sVersion: version, kindVersion: 'v0.11.1', context: "K8s-${version}")
+    }
+  }
+  parallel(parallelTasks)
+}
+
+def runK8s(Map args=[:]) {
+  withGithubNotify(context: args.context) {
+    withMageEnv(){
+      withKindEnv(args) {
+        dir("${BASE_DIR}"){
+          sh(label: "Deploy to kubernetes",script: "make -C deploy/kubernetes test")
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
### What

Include support for the list of versions defined in https://github.com/elastic/beats/blob/main/deploy/kubernetes/Jenkinsfile.yml#L21

Only run when merge-to-main