### PR TITLE
ci: use a new CI controller

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -4,7 +4,7 @@
 ##### GLOBAL METADATA
 
 - meta:
-    cluster: internal-ci
+    cluster: beats-ci
 
 ##### JOB DEFAULTS
 


### PR DESCRIPTION
### What

Point to the new CI controller


### IMPORTANT

We could potentially wait for `fleets-ci` and then move this project there. What do you think?