### PR TITLE
ci: support dynamic stages (docs only, packaging, k8s)

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -124,10 +124,15 @@ pipeline {
           }
           stage('K8s') {
             when {
-              // TODO: Run only if changes in
-              //  - "^deploy/kubernetes/.*"
-              //  - "^version/docs/version.asciidoc"
-              expression { return env.PLATFORM == 'ubuntu-20.04 && immutable' }
+              // Always when running builds on branches/tags
+              // Enable if k8s related changes.
+              allOf {
+                expression { return env.PLATFORM == 'ubuntu-20.04 && immutable' }
+                anyOf {
+                  not { changeRequest() }                           // If no PR
+                  expression { return env.K8S_CHANGES == "true" }
+                }
+              }
             }
             steps {
               runK8s(k8sVersion: 'v1.23.0', kindVersion: 'v0.11.1', context: "K8s-${PLATFORM}")


### PR DESCRIPTION
### What

Enable/disable stages on a PR basis if:
- only docs
- k8s changes
- packaging changes.

The k8s and packaging will always run for branches/tags

### Why

Run what's needed based on the changeset, this will speed up PRs by testing what's needed, and therefore reduce the feedback loop.

### Implementation details

- `ONLY_DOCS` is the one tha detect if PRs are only changes related. See https://github.com/elastic/beats/blob/1499d30edf2d015d54922a85c5bd7d68889d843c/Jenkinsfile#L67
- `PACKAGING_CHANGES` is the one that detects if PRs contain changes in the packaging. See https://github.com/elastic/beats/blob/1499d30edf2d015d54922a85c5bd7d68889d843c/Jenkinsfile#L69
- `K8S_CHANGES` is the one that detects if PRs contain changes in the k8s specific implementations. See https://github.com/elastic/beats/blob/1499d30edf2d015d54922a85c5bd7d68889d843c/deploy/kubernetes/Jenkinsfile.yml#L3-L5