### PR TITLE
automation: enable bump go automation

### DIFF
--- a/.ci/bump-go-release-version.sh
+++ b/.ci/bump-go-release-version.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Given the Golang release version this script will bump the version.
+#
+# This script is executed by the automation we are putting in place
+# and it requires the git add/commit commands.
+#
+# Parameters:
+#	$1 -> the Golang release version to be bumped. Mandatory.
+#
+set -euo pipefail
+MSG="parameter missing."
+GO_RELEASE_VERSION=${1:?$MSG}
+
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+
+if [ "${OS}" == "darwin" ] ; then
+	SED="sed -i .bck"
+else
+	SED="sed -i"
+fi
+
+echo "Update go version ${GO_RELEASE_VERSION}"
+echo "${GO_RELEASE_VERSION}" > .go-version
+git add .go-version
+
+find . -maxdepth 3 -name Dockerfile -print0 |
+    while IFS= read -r -d '' line; do
+        ${SED} -E -e "s#(FROM golang):[0-9]+\.[0-9]+\.[0-9]+#\1:${GO_RELEASE_VERSION}#g" "$line"
+        ${SED} -E -e "s#(ARG GO_VERSION)=[0-9]+\.[0-9]+\.[0-9]+#\1=${GO_RELEASE_VERSION}#g" "$line"
+        git add "${line}"
+    done
+
+${SED} -E -e "s#(:go-version:) [0-9]+\.[0-9]+\.[0-9]+#\1 ${GO_RELEASE_VERSION}#g" version/docs/version.asciidoc
+git add version/docs/version.asciidoc
+
+git diff --staged --quiet || git commit -m "[Automation] Update go release version to ${GO_RELEASE_VERSION}"
+git --no-pager log -1
+
+echo "You can now push and create a Pull Request"


### PR DESCRIPTION
### What

Enable the bump automation for the Golang.

### Test

`.ci/bump-go-release-version.sh 1.17.7`

```diff
git --no-pager diff
diff --git a/.go-version b/.go-version
index 622f042fd..3661bc037 100644
--- a/.go-version
+++ b/.go-version
@@ -1 +1 @@
-1.17.6
+1.17.7
diff --git a/Dockerfile b/Dockerfile
index 2e9b59912..a80af0cb1 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.17.6
+ARG GO_VERSION=1.17.7
 FROM circleci/golang:${GO_VERSION}
 
 
diff --git a/version/docs/version.asciidoc b/version/docs/version.asciidoc
index a09f29c66..e4b2bdaa8 100644
--- a/version/docs/version.asciidoc
+++ b/version/docs/version.asciidoc
@@ -1,6 +1,6 @@
 :stack-version: 8.0.0
 :doc-branch: master
-:go-version: 1.17.5
+:go-version: 1.17.7
 :release-state: unreleased
 :python: 3.7
 :docker: 1.12
```

### Issue

Notifies https://github.com/elastic/apm-pipeline-library/pull/1563