### PR TITLE
automation: enable bump elasticstack snapshots automation

### DIFF
--- a/.ci/bump-stack-version.sh
+++ b/.ci/bump-stack-version.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Given the stack version this script will bump the version.
+#
+# This script is executed by the automation we are putting in place
+# and it requires the git add/commit commands.
+#
+# Parameters:
+#	$1 -> the version to be bumped. Mandatory.
+#	$2 -> whether to create a branch where to commit the changes to.
+#		  this is required when reusing an existing Pull Request.
+#		  Optional. Default true.
+#
+set -euo pipefail
+MSG="parameter missing."
+VERSION=${1:?$MSG}
+CREATE_BRANCH=${2:-true}
+
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+
+if [ "${OS}" == "darwin" ] ; then
+	SED="sed -i .bck"
+else
+	SED="sed -i"
+fi
+
+echo "Update stack with version ${VERSION}"
+${SED} -E -e "s#(image: docker\.elastic\.co/.*):[0-9]+\.[0-9]+\.[0-9]+(-[a-f0-9]{8})?#\1:${VERSION}#g" testing/environments/snapshot.yml
+
+echo "Commit changes"
+if [ "$CREATE_BRANCH" = "true" ]; then
+	base=$(git rev-parse --abbrev-ref HEAD | sed 's#/#-#g')
+	git checkout -b "update-stack-version-$(date "+%Y%m%d%H%M%S")-${base}"
+else
+	echo "Branch creation disabled."
+fi
+
+git add testing/environments/snapshot.yml
+git diff --staged --quiet || git commit -m "[Automation] Update elastic stack version to ${VERSION} for testing"
+git --no-pager log -1
+
+echo "You can now push and create a Pull Request"


### PR DESCRIPTION
### IMPORTANT

The upstream dependencies with Filebeat/Metricbeat and so on are not pinned, so the team should decide when to address this to be able to consume stable artifacts rather than the later one from the `artifact-api` itself

### What

Enable the bump automation for the ElasticStack snapshots.

### Test

`.ci/bump-stack-version.sh 8.2.0-aaaaaaaa`

produced:

```diff
 git --no-pager diff                     
diff --git a/testing/environments/snapshot.yml b/testing/environments/snapshot.yml
index 873d80ca6..184727b93 100644
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-ff5ac1e4-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-aaaaaaaa-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.2.0-ff5ac1e4-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.2.0-aaaaaaaa-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"
```


### Issue

Notifies https://github.com/elastic/apm-pipeline-library/pull/1563