### PR TITLE
fix: github comment

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger("(${obltGitHubComments()}|^run ((integration|end-to-end) tests|package)")
+    issueCommentTrigger("(${obltGitHubComments()}|^run (integration|end-to-end) tests|/package)")
   }
   parameters {
     // disabled by default, but required for merge, there are two GH checks:


### PR DESCRIPTION
Fixes the github command regex:

```
events","type":"User","site_admin":false}}, origin=140.82.115.95 ⇒ https://fleet-ci.elastic.co:8080/github-webhook/} hook, skipping...
java.util.regex.PatternSyntaxException: Unclosed group near index 125
((?i)(^(?:jenkins\W+)?run\W+(?:the\W+)?tests(?:\W+please)?.*|^/test(?:\W+.*)?$)|^run ((integration|end-to-end) tests|package)
```


In addition it uses `/package` as that's the existing command in Beats