### PR TITLE
Fix packaging setup in .CI for the e2e testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,10 @@ snapshot:
 .PHONY: release
 release:
 	@mage dumpVariables
-	@$($(MAKE) -C $(BEATS) release || exit 1;)
-	@$(test -d $(BEATS)/build/distributions && test -n "$$(ls $(BEATS)/build/distributions)" || exit 0; \
-      mkdir -p build/distributions/$(subst '', '',$(BEATS)) && mv -f $(BEATS)/build/distributions/* build/distributions/$(subst '','',$(BEATS))/ || exit 1;)
+	@$(foreach var,$(BEATS) ,$(MAKE) -C $(var) release || exit 1;)
+	@$(foreach var,$(BEATS), \
+      test -d $(var)/build/distributions && test -n "$$(ls $(var)/build/distributions)" || exit 0; \
+      mkdir -p build/distributions/$(subst $(XPACK_SUFFIX),'',$(var)) && mv -f $(var)/build/distributions/* build/distributions/$(subst $(XPACK_SUFFIX),'',$(var))/ || exit 1;)
 
 ## release-manager-snapshot : Builds a snapshot release. The Go version defined in .go-version will be installed and used for the build.
 .PHONY: release-manager-snapshot


### PR DESCRIPTION
missing `DEV` flag in the package setup to bypass verification.
Flag is also set in the beats packaging .ci setup https://github.com/elastic/beats/blob/main/.ci/packaging.groovy#L382