### PR TITLE
ci: enable runE2E

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -141,10 +141,9 @@ pipeline {
               beforeAgent true
               allOf {
                 anyOf {
-                  expression { return env.GITHUB_COMMENT?.contains('package') }
-                  expression { matchesPrLabel(label: 'ci:package') }
+                  expression { return isE2eEnabled() }
+                  expression { return isPackageEnabled() }
                   not { changeRequest() }
-                  expression { return env.PACKAGING_CHANGES == "true" }
                 }
                 // Run packaging only for the linux specific arch
                 expression { return (PLATFORM.contains('ubuntu') || PLATFORM.contains('aarch64')) }
@@ -211,11 +210,7 @@ pipeline {
     stage('e2e tests') {
       when {
         beforeAgent true
-        anyOf {
-          expression { return params.end_to_end_tests_ci }
-          expression { return env.GITHUB_COMMENT?.contains('e2e tests') }
-          expression { matchesPrLabel(label: 'ci:end-to-end') }
-        }
+        expression { return isE2eEnabled() }
       }
       steps {
         // TODO: what's the testMatrixFile to be used if any
@@ -341,4 +336,18 @@ def runK8s(Map args=[:]) {
       }
     }
   }
+}
+
+/**
+* Wrapper to know if the build should enalbe the e2e stage
+*/
+def isE2eEnabled() {
+  return params.end_to_end_tests_ci || env.GITHUB_COMMENT?.contains('e2e tests') || matchesPrLabel(label: 'ci:end-to-end')
+}
+
+/**
+* Wrapper to know if the build should enalbe the package stage
+*/
+def isPackageEnabled() {
+  return env.PACKAGING_CHANGES == "true" || env.GITHUB_COMMENT?.contains('package') || matchesPrLabel(label: 'ci:package')
 }


### PR DESCRIPTION
### What

Enable the `rune2e` stage to trigger the jobs in https://fleet-ci.elastic.co/job/e2e-tests/job/e2e-testing-mbp/

This new stage gets trigger if `package` or `end2end` events are enabled

### Important

- `testMatrixFile` might need to be changed from default to the specific file in https://github.com/elastic/e2e-testing/tree/main/.ci
- e2e-testing are not available by default! Use labels, GitHub comments or the UI to trigger the build 

### Issues

Requires https://github.com/elastic/apm-pipeline-library/pull/1568