### PR TITLE
Disable linter on merge/push on branches

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,10 +1,10 @@
 name: golangci-lint
 on:
-  push:
-    branches:
-      - main
-      - 8.*
-      - 7.17
+  #push:
+  #  branches:
+  #    - main
+  #    - 8.*
+  #    - 7.17
   pull_request:
 permissions:
   contents: read


### PR DESCRIPTION
This make the linter run on new code only in a pull-request and disable
the linter on the main branch until we have clean all the alert.