### PR TITLE
ci: refactor the meta k8s stage

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -193,14 +193,9 @@ pipeline {
     stage('Full K8s') {
       when {
         // Always when running builds on branches/tags
-        // On a PR basis, skip if changes are only related to docs.
         // Enable if k8s related changes.
         anyOf {
           not { changeRequest() }                           // If no PR
-          allOf {                                           // If PR and no docs changes
-            expression { return env.ONLY_DOCS == "false" }
-            changeRequest()
-          }
           expression { return env.K8S_CHANGES == "true" }   // If k8s changes
         }
       }


### PR DESCRIPTION
### What

- Use the declarative syntax rather than the parallel scripted approach
- Run full k8s tests if no PRs or k8s changes.