### PR TITLE
ci: enable windows-2022 support

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -87,11 +87,18 @@ pipeline {
             name 'PLATFORM'
             // TODO: 'macosx && x86_64' to be added once macosx is available in fleet-ci
             //       for the time being we use macos
-            values 'ubuntu-20.04 && immutable', 'aarch64', 'windows-2019 && windows-immutable'
+            values 'ubuntu-20.04 && immutable', 'aarch64', 'windows-2019 && windows-immutable', 'windows-2022 && windows-immutable'
           }
         }
         stages {
           stage('build'){
+            when {
+              beforeAgent true
+              allOf {
+                expression { return env.PLATFORM == 'windows-2022 && windows-immutable' }
+                not { changeRequest() }
+              }
+            }
             steps {
               withGithubNotify(context: "Build-${PLATFORM}") {
                 deleteDir()
@@ -105,6 +112,13 @@ pipeline {
             }
           }
           stage('Test') {
+            when {
+              beforeAgent true
+              allOf {
+                expression { return env.PLATFORM == 'windows-2022 && windows-immutable' }
+                not { changeRequest() }
+              }
+            }
             steps {
               withGithubNotify(context: "Test-${PLATFORM}") {
                 withMageEnv(){
@@ -122,6 +136,7 @@ pipeline {
           }
           stage('K8s') {
             when {
+              beforeAgent true
               // Always when running builds on branches/tags
               // Enable if k8s related changes.
               allOf {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -81,6 +81,16 @@ pipeline {
       failFast false
       matrix {
         agent {label "${PLATFORM}"}
+        when {
+          beforeAgent true
+          anyOf {
+            allOf {
+              expression { return env.PLATFORM == 'windows-2022 && windows-immutable' }
+              not { changeRequest() }
+            }
+            expression { return env.PLATFORM != 'windows-2022 && windows-immutable' }
+          }
+        }
         options { skipDefaultCheckout() }
         axes {
           axis {
@@ -92,13 +102,6 @@ pipeline {
         }
         stages {
           stage('build'){
-            when {
-              beforeAgent true
-              allOf {
-                expression { return env.PLATFORM != 'windows-2022 && windows-immutable' }
-                not { changeRequest() }
-              }
-            }
             steps {
               withGithubNotify(context: "Build-${PLATFORM}") {
                 deleteDir()
@@ -112,13 +115,6 @@ pipeline {
             }
           }
           stage('Test') {
-            when {
-              beforeAgent true
-              allOf {
-                expression { return env.PLATFORM != 'windows-2022 && windows-immutable' }
-                not { changeRequest() }
-              }
-            }
             steps {
               withGithubNotify(context: "Test-${PLATFORM}") {
                 withMageEnv(){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -95,7 +95,7 @@ pipeline {
             when {
               beforeAgent true
               allOf {
-                expression { return env.PLATFORM == 'windows-2022 && windows-immutable' }
+                expression { return env.PLATFORM != 'windows-2022 && windows-immutable' }
                 not { changeRequest() }
               }
             }
@@ -115,7 +115,7 @@ pipeline {
             when {
               beforeAgent true
               allOf {
-                expression { return env.PLATFORM == 'windows-2022 && windows-immutable' }
+                expression { return env.PLATFORM != 'windows-2022 && windows-immutable' }
                 not { changeRequest() }
               }
             }


### PR DESCRIPTION
### What

Run build/test stages on Windows-2022 __ONLY__ for branches/tags, therefore, it won't run on a PR basis


### Question

- Do we want this kind of implementation? Or it does not require this kind of validation in the CI but using the e2e-testing instead (see https://github.com/elastic/e2e-testing/pull/2023) ?


### Issue

Waiting for the support for windows-2022 in `fleet-ci`, infra is on it.