### PR TITLE
ci: cache stages

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -86,12 +86,14 @@ pipeline {
         stages {
           stage('build'){
             steps {
-              withGithubNotify(context: "Build-${PLATFORM}") {
-                deleteDir()
-                unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
-                withMageEnv(){
-                  dir("${BASE_DIR}"){
-                    cmd(label: 'Go build', script: 'mage build')
+              stageStatusCache(id: "Build-${PLATFORM}") {
+                withGithubNotify(context: "Build-${PLATFORM}") {
+                  deleteDir()
+                  unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
+                  withMageEnv(){
+                    dir("${BASE_DIR}"){
+                      cmd(label: 'Go build', script: 'mage build')
+                    }
                   }
                 }
               }
@@ -99,10 +101,12 @@ pipeline {
           }
           stage('Test') {
             steps {
-              withGithubNotify(context: "Test-${PLATFORM}") {
-                withMageEnv(){
-                  dir("${BASE_DIR}"){
-                    cmd(label: 'Go unitTest', script: 'mage unitTest')
+              stageStatusCache(id: "Test-${PLATFORM}") {
+                withGithubNotify(context: "Test-${PLATFORM}") {
+                  withMageEnv(){
+                    dir("${BASE_DIR}"){
+                      cmd(label: 'Go unitTest', script: 'mage unitTest')
+                    }
                   }
                 }
               }
@@ -143,7 +147,9 @@ pipeline {
               }
             }
             steps {
-              runK8s(k8sVersion: 'v1.23.0', kindVersion: 'v0.11.1', context: "K8s-${PLATFORM}")
+              stageStatusCache(id: "K8s-${PLATFORM}") {
+                runK8s(k8sVersion: 'v1.23.0', kindVersion: 'v0.11.1', context: "K8s-${PLATFORM}")
+              }
             }
           }
           stage('Package') {
@@ -165,31 +171,33 @@ pipeline {
               EXTERNAL = true
             }
             steps {
-              withGithubNotify(context: "Package ${PLATFORM}") {
-                deleteDir()
-                unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
-                withMageEnv(){
-                  dir("${BASE_DIR}"){
-                    withPackageEnv("${PLATFORM}") {
-                      cmd(label: 'Go package', script: 'mage package')
-                      uploadPackagesToGoogleBucket(
-                        credentialsId: env.JOB_GCS_EXT_CREDENTIALS,
-                        repo: env.REPO,
-                        bucket: env.JOB_GCS_EXT_BUCKET,
-                        pattern: "build/distributions/**/*")
-                      pushDockerImages(
-                        registry: env.DOCKER_REGISTRY,
-                        secret: env.DOCKER_ELASTIC_SECRET,
-                        snapshot: env.SNAPSHOT,
-                        version: env.BEAT_VERSION,
-                        images: [
-                          [ source: "beats/elastic-agent", arch: env.ARCH, target: "observability-ci/elastic-agent"],
-                          [ source: "beats/elastic-agent-oss", arch: env.ARCH, target: "observability-ci/elastic-agent-oss"],
-                          [ source: "beats/elastic-agent-ubi8", arch: env.ARCH, target: "observability-ci/elastic-agent-ubi8"],
-                          [ source: "beats/elastic-agent-complete", arch: env.ARCH, target: "observability-ci/elastic-agent-complete"],
-                          [ source: "beats-ci/elastic-agent-cloud", arch: env.ARCH, target: "observability-ci/elastic-agent-cloud"]
-                        ]
-                      )
+              stageStatusCache(id: "Package-${PLATFORM}") {
+                withGithubNotify(context: "Package ${PLATFORM}") {
+                  deleteDir()
+                  unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
+                  withMageEnv(){
+                    dir("${BASE_DIR}"){
+                      withPackageEnv("${PLATFORM}") {
+                        cmd(label: 'Go package', script: 'mage package')
+                        uploadPackagesToGoogleBucket(
+                          credentialsId: env.JOB_GCS_EXT_CREDENTIALS,
+                          repo: env.REPO,
+                          bucket: env.JOB_GCS_EXT_BUCKET,
+                          pattern: "build/distributions/**/*")
+                        pushDockerImages(
+                          registry: env.DOCKER_REGISTRY,
+                          secret: env.DOCKER_ELASTIC_SECRET,
+                          snapshot: env.SNAPSHOT,
+                          version: env.BEAT_VERSION,
+                          images: [
+                            [ source: "beats/elastic-agent", arch: env.ARCH, target: "observability-ci/elastic-agent"],
+                            [ source: "beats/elastic-agent-oss", arch: env.ARCH, target: "observability-ci/elastic-agent-oss"],
+                            [ source: "beats/elastic-agent-ubi8", arch: env.ARCH, target: "observability-ci/elastic-agent-ubi8"],
+                            [ source: "beats/elastic-agent-complete", arch: env.ARCH, target: "observability-ci/elastic-agent-complete"],
+                            [ source: "beats-ci/elastic-agent-cloud", arch: env.ARCH, target: "observability-ci/elastic-agent-cloud"]
+                          ]
+                        )
+                      }
                     }
                   }
                 }
@@ -221,9 +229,11 @@ pipeline {
         stages {
           stage('K8s') {
             steps {
-              deleteDir()
-              unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
-              runK8s(k8sVersion: K8S_VERSION, kindVersion: 'v0.11.1', context: "K8s-${K8S_VERSION}")
+              stageStatusCache(id: "K8s-${K8S_VERSION}") {
+                deleteDir()
+                unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
+                runK8s(k8sVersion: K8S_VERSION, kindVersion: 'v0.11.1', context: "K8s-${K8S_VERSION}")
+              }
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -55,12 +55,14 @@ pipeline {
     }
     stage('Check'){
       steps {
-        withGithubNotify(context: "Check") {
-          withMageEnv(){
-           dir("${BASE_DIR}"){
-              setEnvVar('BEAT_VERSION', sh(label: 'Get beat version', script: 'make get-version', returnStdout: true)?.trim())
-              log(level: 'INFO', text: "env.BEAT_VERSION=${env.BEAT_VERSION}")
-              cmd(label: 'check', script: 'make check-ci')
+        stageStatusCache(id: "Check", bucket: env.JOB_GCS_BUCKET, credentialsId: env.JOB_GCS_EXT_CREDENTIALS) {
+          withGithubNotify(context: "Check") {
+            withMageEnv(){
+             dir("${BASE_DIR}"){
+                setEnvVar('BEAT_VERSION', sh(label: 'Get beat version', script: 'make get-version', returnStdout: true)?.trim())
+                log(level: 'INFO', text: "env.BEAT_VERSION=${env.BEAT_VERSION}")
+                cmd(label: 'check', script: 'make check-ci')
+              }
             }
           }
         }
@@ -86,7 +88,7 @@ pipeline {
         stages {
           stage('build'){
             steps {
-              stageStatusCache(id: "Build-${PLATFORM}") {
+              stageStatusCache(id: "Build-${PLATFORM}", bucket: env.JOB_GCS_BUCKET, credentialsId: env.JOB_GCS_EXT_CREDENTIALS) {
                 withGithubNotify(context: "Build-${PLATFORM}") {
                   deleteDir()
                   unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
@@ -101,7 +103,7 @@ pipeline {
           }
           stage('Test') {
             steps {
-              stageStatusCache(id: "Test-${PLATFORM}") {
+              stageStatusCache(id: "Test-${PLATFORM}", bucket: env.JOB_GCS_BUCKET, credentialsId: env.JOB_GCS_EXT_CREDENTIALS) {
                 withGithubNotify(context: "Test-${PLATFORM}") {
                   withMageEnv(){
                     dir("${BASE_DIR}"){
@@ -147,7 +149,7 @@ pipeline {
               }
             }
             steps {
-              stageStatusCache(id: "K8s-${PLATFORM}") {
+              stageStatusCache(id: "K8s-${PLATFORM}", bucket: env.JOB_GCS_BUCKET, credentialsId: env.JOB_GCS_EXT_CREDENTIALS) {
                 runK8s(k8sVersion: 'v1.23.0', kindVersion: 'v0.11.1', context: "K8s-${PLATFORM}")
               }
             }
@@ -171,7 +173,7 @@ pipeline {
               EXTERNAL = true
             }
             steps {
-              stageStatusCache(id: "Package-${PLATFORM}") {
+              stageStatusCache(id: "Package-${PLATFORM}", bucket: env.JOB_GCS_BUCKET, credentialsId: env.JOB_GCS_EXT_CREDENTIALS) {
                 withGithubNotify(context: "Package ${PLATFORM}") {
                   deleteDir()
                   unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
@@ -229,7 +231,7 @@ pipeline {
         stages {
           stage('K8s') {
             steps {
-              stageStatusCache(id: "K8s-${K8S_VERSION}") {
+              stageStatusCache(id: "K8s-${K8S_VERSION}", bucket: env.JOB_GCS_BUCKET, credentialsId: env.JOB_GCS_EXT_CREDENTIALS) {
                 deleteDir()
                 unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
                 runK8s(k8sVersion: K8S_VERSION, kindVersion: 'v0.11.1', context: "K8s-${K8S_VERSION}")


### PR DESCRIPTION
### What

Enable `stageStatusCache` to cache the stages in case there is any kind of flakiness those stages that passed won't be retried again.

Thus, it will speed up the build when using `github commands` for the e2e-testing for instance.

### Test

Without caching this PR took 30 minutes (packaging does not normally happen on a PR basis unless changes are related to the packaging, including the `.ci/Jenkinsfile`)

<img width="2004" alt="image" src="https://user-images.githubusercontent.com/2871786/156746152-c04945de-b43c-4b95-b309-53eb0c1f8057.png">

With caching -> https://github.com/elastic/elastic-agent/pull/67#issuecomment-1059033005 triggered a build (for the same commit) then build should only enable those stages that did fail in a previous build for the same commit, in this case none.


With caching this PR took 11 minutes (the matrix requires to provision workers, and it adds some slowness in the caching)
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/2871786/157000479-ce0e8f57-b1d4-4efd-b3c7-989701f0c1d3.png">
