### PR TITLE
[automation] update elastic stack version for testing 8.2.0-190af159

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-fdde08ec-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-190af159-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.2.0-fdde08ec-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.2.0-190af159-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Thu, 3 Mar 2022 00:17:14 GMT, release_branch:master, prefix:, end_time:Thu, 3 Mar 2022 05:11:32 GMT, manifest_version:2.0.0, version:8.2.0-SNAPSHOT, branch:master, build_id:8.2.0-190af159, build_duration_seconds:17658]