### PR TITLE
[automation] update elastic stack version for testing 8.2.0-a12f7069

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-190af159-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-a12f7069-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.2.0-190af159-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.2.0-a12f7069-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Fri, 4 Mar 2022 14:54:03 GMT, release_branch:master, prefix:, end_time:Fri, 4 Mar 2022 20:48:39 GMT, manifest_version:2.0.0, version:8.2.0-SNAPSHOT, branch:master, build_id:8.2.0-a12f7069, build_duration_seconds:21276]