### PR TITLE
Add a base set of issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,21 @@
+---
+name: Bug
+about: "Report confirmed bugs. For unconfirmed bugs please visit https://discuss.elastic.co/c/beats"
+labels: ["bug"]
+
+---
+
+Please post all questions and issues concerning the Elastic Agent on https://discuss.elastic.co/c/beats
+before opening a Github Issue. Your questions will reach a wider audience there,
+and if we confirm that there is a bug, then you can open a new issue.
+
+For security vulnerabilities please only send reports to security@elastic.co.
+See https://www.elastic.co/community/security for more information.
+
+Please include configurations and logs if available.
+
+For confirmed bugs, please report:
+- Version:
+- Operating System:
+- Discuss Forum URL:
+- Steps to Reproduce:

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,10 @@
+---
+name: Enhancement request
+about: Elastic Agent can't do all the things, but maybe it can do your things.
+
+---
+
+**Describe the enhancement:**
+
+**Describe a specific use case for the enhancement or feature:**
+

--- a/.github/ISSUE_TEMPLATE/flaky-test.md
+++ b/.github/ISSUE_TEMPLATE/flaky-test.md
@@ -1,0 +1,19 @@
+---
+name: Flaky Test
+about: Report a flaky test (one that doesn't pass consistently)
+
+---
+
+## Flaky Test
+
+* **Test Name:** Name of the failing test.
+* **Link:** Link to file/line number in github.
+* **Branch:** Git branch the test was seen in. If a PR, the branch the PR was based off.
+* **Artifact Link:** If available, attach the generated zip artifact associated with the stack trace for this failure.
+* **Notes:** Additional details about the test. e.g. theory as to failure cause
+
+### Stack Trace
+
+```
+paste stack trace here
+```

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,18 @@
+---
+name: Question
+about: Who, what, when, where, and how?
+
+---
+
+Hey, stop right there!
+
+We use GitHub to track feature requests and bug reports. Please do not submit issues for questions about how to use features of Elastic Agent, how to set Elastic Agent up, best practices, or development related help.
+
+However, we do want to help! Head on over to our official Beats forums and ask
+your questions there. In additional to awesome, knowledgeable community
+contributors, core Elastic Agent developers are on the forums every single day to help
+you out.
+
+The forums are here: https://discuss.elastic.co/c/beats
+
+We can't stop you from opening an issue here, but it will likely linger without a response for days or weeks before it is closed and we ask you to join us on the forums instead. Save yourself the time, and ask on the forums today.


### PR DESCRIPTION
This uses the same template from the beats repository and adjusts the
wording for the Elastic Agent.