### PR TITLE
[Heartbeat] Unpack beats at build time on docker

### DIFF
--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -482,6 +482,7 @@ shared:
       user: '{{ .BeatName }}'
       linux_capabilities: ''
       image_name: ''
+      beats_install_path: "install"
     files:
       'elastic-agent.yml':
         source: 'elastic-agent.docker.yml'

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -182,6 +182,7 @@ RUN chown {{ .user }} /app
 {{- end }}
 {{- end }}
 
+# Unpack beats to default install directory
 RUN mkdir -p {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/{{ .beats_install_path }} && \
     for beatPath in {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/downloads/*.tar.gz; do \
     tar xf $beatPath -C {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/{{ .beats_install_path }}; \
@@ -189,6 +190,7 @@ RUN mkdir -p {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/{{ .beats_ins
     chown -R {{ .user }}:{{ .user }} {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/{{ .beats_install_path }} && \
     chown -R root:root {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/{{ .beats_install_path }}/*/*.yml && \
     chmod 0644 {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/{{ .beats_install_path }}/*/*.yml && \
+    # heartbeat requires cap_net_raw,cap_setuid to run ICMP checks and change npm user
     setcap cap_net_raw,cap_setuid+p {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/{{ .beats_install_path }}/heartbeat-*/heartbeat
 
 USER {{ .user }}

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -32,7 +32,7 @@ FROM {{ .from }}
 ENV BEAT_SETUID_AS={{ .user }}
 
 {{- if contains .from "ubi-minimal" }}
-RUN for iter in {1..10}; do microdnf update -y && microdnf install -y findutils shadow-utils && microdnf clean all && exit_code=0 && break || exit_code=$? && echo "microdnf error: retry $iter in 10s" && sleep 10; done; (exit $exit_code)
+RUN for iter in {1..10}; do microdnf update -y && microdnf install -y tar gzip findutils shadow-utils && microdnf clean all && exit_code=0 && break || exit_code=$? && echo "microdnf error: retry $iter in 10s" && sleep 10; done; (exit $exit_code)
 {{- else }}
 
 RUN for iter in {1..10}; do \
@@ -181,6 +181,16 @@ RUN mkdir /app
 RUN chown {{ .user }} /app
 {{- end }}
 {{- end }}
+
+RUN mkdir -p {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/{{ .beats_install_path }} && \
+    for beatPath in {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/downloads/*.tar.gz; do \
+    tar xf $beatPath -C {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/{{ .beats_install_path }}; \
+    done && \
+    chown -R {{ .user }}:{{ .user }} {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/{{ .beats_install_path }} && \
+    chown -R root:root {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/{{ .beats_install_path }}/*/*.yml && \
+    chmod 0644 {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/{{ .beats_install_path }}/*/*.yml && \
+    setcap cap_net_raw,cap_setuid+p {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/{{ .beats_install_path }}/heartbeat-*/heartbeat
+
 USER {{ .user }}
 
 {{- if (and (contains .image_name "-complete") (not (contains .from "ubi-minimal")))  }}


### PR DESCRIPTION
## What does this PR do?

This PR enables unpacking of beats inside the container at build time, so that required `cap_net_raw, cap_setuid` capabilities can be assigned to the binary.

## Why is it important?

Without the required capabilities, heartbeat cannot execute ICMP pings or setuid calls. As it is now, agent is unpacking beats at runtime, most likely with a user that doesn't have permission to assign capabilities.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files

## Author's Checklist

- [ ]

## How to test this PR locally

- Build elastic-agent containers, run:
`DEV=true SNAPSHOT=true PLATFORMS=linux/amd64 TYPES=docker mage package`
- Run one of the built containers and provide some heartbeat configuration:
```
docker run --name agent -it -u root --env FLEET_ENROLL=1 --env \
FLEET_URL=<url> --env \ 
FLEET_ENROLLMENT_TOKEN=<token> \ 
docker.elastic.co/beats/elastic-agent:8.2.0-SNAPSHOT
```

## Related issues
- Relates elastic/beats#27651

## Screenshots
![image](https://user-images.githubusercontent.com/95703246/158195787-9742edb7-5c6d-417f-ad3d-9fea644976e8.png)


## Logs
````bash
15:38:37.323
elastic_agent.heartbeat
[elastic_agent.heartbeat][info] heartbeat start running.
15:38:37.323
elastic_agent.heartbeat
[elastic_agent.heartbeat][warn] BETA: Fleet management is enabled
15:38:37.323
elastic_agent.heartbeat
[elastic_agent.heartbeat][info] Starting fleet management service
15:38:37.323
elastic_agent.heartbeat
[elastic_agent.heartbeat][info] heartbeat is running! Hit CTRL-C to stop it.
15:38:37.323
elastic_agent.heartbeat
[elastic_agent.heartbeat][info] Effective user/group ids: 1000/1000, with groups: [0]
````