### PR TITLE
[automation] update elastic stack version for testing 8.2.0-9bac538c

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-fee3b8d2-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-9bac538c-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.2.0-fee3b8d2-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.2.0-9bac538c-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Tue, 15 Mar 2022 12:16:35 GMT, release_branch:master, prefix:, end_time:Tue, 15 Mar 2022 16:54:57 GMT, manifest_version:2.0.0, version:8.2.0-SNAPSHOT, branch:master, build_id:8.2.0-9bac538c, build_duration_seconds:16702]