### PR TITLE
Force golangci-lint to run on every supported Os

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Echo details
         env:
-          - GOOS: ${{ matrix.GOOS }}
+           GOOS: ${{ matrix.GOOS }}
         run: echo Go GOOS=$GOOS
 
       - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
 
       - name: golangci-lint
         env:
-          - GOOS: ${{ matrix.GOOS }}
+          GOOS: ${{ matrix.GOOS }}
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Echo details
+        env:
+          - GOOS: ${{ matrix.GOOS }}
         run: echo Go GOOS=$GOOS
 
       - uses: actions/checkout@v2
@@ -36,6 +38,8 @@ jobs:
           go-version: "${{ steps.goversion.outputs.version }}"
 
       - name: golangci-lint
+        env:
+          - GOOS: ${{ matrix.GOOS }}
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,9 +12,18 @@ permissions:
   pull-requests: read
 jobs:
   golangci:
+    strategy:
+      matrix:
+        include:
+          - GOOS: windows
+          - GOOS: linux
+          - GOOS: darwin
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - name: Echo details
+        run: echo Go GOOS=$GOOS
+
       - uses: actions/checkout@v2
 
       # Uses Go version from the repository.


### PR DESCRIPTION
By default `golangci-lint` will run the linters for the current running
platform and will only include the files for this platform. Using the `GOOS`
environment variable and a matrix defined in the github action we force
the linter to try all the supported operating system.