### PR TITLE
Add fleet-server to elastic-agent inspect output

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -98,6 +98,7 @@
 - Reduce Elastic Agent shut down time by stopping processes concurrently {pull}29650[29650]
 - Move `context cancelled` error from fleet gateway into debug level. {pull}187[187]
 - Update library containerd to 1.5.10. {pull}186[186]
+- Add fleet-server to output of elastic-agent inspect output command (and diagnostic bundle). {pull}243[243]
 
 ==== New features
 

--- a/internal/pkg/agent/cmd/inspect.go
+++ b/internal/pkg/agent/cmd/inspect.go
@@ -324,9 +324,15 @@ func getProgramsFromConfig(log *logger.Logger, agentInfo *info.AgentInfo, cfg *c
 }
 
 func getFleetInput(o map[string]interface{}) map[string]interface{} {
-	arr := o["inputs"].([]interface{})
+	arr, ok := o["inputs"].([]interface{})
+	if !ok {
+		return nil
+	}
 	for _, iface := range arr {
-		input := iface.(map[string]interface{})
+		input, ok := iface.(map[string]interface{})
+		if !ok {
+			continue
+		}
 		t, ok := input["type"]
 		if !ok {
 			continue

--- a/internal/pkg/agent/cmd/inspect_test.go
+++ b/internal/pkg/agent/cmd/inspect_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestgetFleetInput(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string]interface{}
+		expect map[string]interface{}
+	}{{
+		name: "fleet-server input found",
+		input: map[string]interface{}{
+			"inputs": []map[string]interface{}{
+				map[string]interface{}{
+					"type": "fleet-server",
+				}},
+		},
+		expect: map[string]interface{}{
+			"type": "fleet-server",
+		},
+	}, {
+		name: "no fleet-server input",
+		input: map[string]interface{}{
+			"inputs": []map[string]interface{}{
+				map[string]interface{}{
+					"type": "test-server",
+				}},
+		},
+		expect: nil,
+	}, {
+		name: "wrong input formant",
+		input: map[string]interface{}{
+			"inputs": "example",
+		},
+		expect: nil,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := getFleetInput(tt.input)
+			if tt.expect == nil && r != nil {
+				t.Error("expected nil")
+			}
+		})
+	}
+}

--- a/internal/pkg/agent/cmd/inspect_test.go
+++ b/internal/pkg/agent/cmd/inspect_test.go
@@ -1,10 +1,14 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package cmd
 
 import (
 	"testing"
 )
 
-func TestgetFleetInput(t *testing.T) {
+func TestGetFleetInput(t *testing.T) {
 	tests := []struct {
 		name   string
 		input  map[string]interface{}


### PR DESCRIPTION
Add the fleet-server input from the full filled config that is parsed
for programs in elastic-agent inspect output. This will show the policy
for fleet-server instead of the contents of fleet.yml

- Closes #103 

### Testing

1. Create a policy that includes the fleet integration.
2. Enroll an agent using a the policy, and fleet flags.
3. Once the agent is healthy, run `elastic-agent inspect output -o default`
4. `fleet-server` should appear as a program in the output, i.e.:
```
[default] fleet-server:
data_stream:
  namespace: default
id: fleet-server-fleet_server-da3b4b9e-24d1-47fc-9779-b0bc89ed113c
meta:
  package:
    name: fleet_server
    version: 1.1.1
name: fleet_server-1
revision: 1
server:
  host: 0.0.0.0
  port: 8220
type: fleet-server
use_output: default
```