### PR TITLE
Change kibana api paths used in container command

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -99,6 +99,7 @@
 - Move `context cancelled` error from fleet gateway into debug level. {pull}187[187]
 - Update library containerd to 1.5.10. {pull}186[186]
 - Add fleet-server to output of elastic-agent inspect output command (and diagnostic bundle). {pull}243[243]
+- Update API calls that the agent makes to Kibana when running the container command. {pull}253[253]
 
 ==== New features
 

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -360,7 +360,7 @@ func ensureServiceToken(streams *cli.IOStreams, cfg *setupConfig) error {
 	if err != nil {
 		return err
 	}
-	code, r, err := client.Connection.Request("POST", "/api/fleet/service-tokens", nil, nil, nil)
+	code, r, err := client.Connection.Request("POST", "/api/fleet/service_tokens", nil, nil, nil)
 	if err != nil {
 		return fmt.Errorf("request to get security token from Kibana failed: %w", err)
 	}
@@ -503,7 +503,7 @@ func kibanaFetchPolicy(cfg setupConfig, client *kibana.Client, streams *cli.IOSt
 
 func kibanaFetchToken(cfg setupConfig, client *kibana.Client, policy *kibanaPolicy, streams *cli.IOStreams, tokenName string) (string, error) {
 	var keys kibanaAPIKeys
-	err := performGET(cfg, client, "/api/fleet/enrollment-api-keys", &keys, streams.Err, "Kibana fetch token")
+	err := performGET(cfg, client, "/api/fleet/enrollment_api_keys", &keys, streams.Err, "Kibana fetch token")
 	if err != nil {
 		return "", err
 	}
@@ -512,7 +512,7 @@ func kibanaFetchToken(cfg setupConfig, client *kibana.Client, policy *kibanaPoli
 		return "", err
 	}
 	var keyDetail kibanaAPIKeyDetail
-	err = performGET(cfg, client, fmt.Sprintf("/api/fleet/enrollment-api-keys/%s", key.ID), &keyDetail, streams.Err, "Kibana fetch token detail")
+	err = performGET(cfg, client, fmt.Sprintf("/api/fleet/enrollment_api_keys/%s", key.ID), &keyDetail, streams.Err, "Kibana fetch token detail")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## What does this PR do?

Change the API paths used by the container command to reflect the updated paths.

## Why is it important?

Old paths are deprecated.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [] ~~I have made corresponding changes to the documentation~~
- [] ~~I have made corresponding change to the default configuration files~~
- [] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #111 