### PR TITLE
Fix download verification in snapshot builds

### DIFF
--- a/internal/pkg/agent/application/upgrade/step_download.go
+++ b/internal/pkg/agent/application/upgrade/step_download.go
@@ -55,12 +55,8 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 		return "", errors.New(err, "failed upgrade of agent binary")
 	}
 
-	matches, err := verifier.Verify(agentSpec, version, true)
-	if err != nil {
+	if err := verifier.Verify(agentSpec, version); err != nil {
 		return "", errors.New(err, "failed verification of agent binary")
-	}
-	if !matches {
-		return "", errors.New("failed verification of agent binary, hash does not match", errors.TypeSecurity)
 	}
 
 	return path, nil

--- a/internal/pkg/agent/operation/common_test.go
+++ b/internal/pkg/agent/operation/common_test.go
@@ -150,8 +150,8 @@ var _ download.Downloader = &DummyDownloader{}
 
 type DummyVerifier struct{}
 
-func (*DummyVerifier) Verify(_ program.Spec, _ string, _ bool) (bool, error) {
-	return true, nil
+func (*DummyVerifier) Verify(_ program.Spec, _ string) error {
+	return nil
 }
 
 var _ download.Verifier = &DummyVerifier{}

--- a/internal/pkg/agent/operation/operation_verify.go
+++ b/internal/pkg/agent/operation/operation_verify.go
@@ -66,16 +66,9 @@ func (o *operationVerify) Run(_ context.Context, application Application) (err e
 		}
 	}()
 
-	isVerified, err := o.verifier.Verify(o.program.Spec(), o.program.Version(), true)
-	if err != nil {
+	if err := o.verifier.Verify(o.program.Spec(), o.program.Version()); err != nil {
 		return errors.New(err,
 			fmt.Sprintf("operation '%s' failed to verify %s.%s", o.Name(), o.program.BinaryName(), o.program.Version()),
-			errors.TypeSecurity)
-	}
-
-	if !isVerified {
-		return errors.New(err,
-			fmt.Sprintf("operation '%s' marked '%s.%s' corrupted", o.Name(), o.program.BinaryName(), o.program.Version()),
 			errors.TypeSecurity)
 	}
 

--- a/internal/pkg/artifact/download/composed/verifier.go
+++ b/internal/pkg/artifact/download/composed/verifier.go
@@ -5,6 +5,8 @@
 package composed
 
 import (
+	"errors"
+
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
@@ -30,17 +32,25 @@ func NewVerifier(verifiers ...download.Verifier) *Verifier {
 }
 
 // Verify checks the package from configured source.
-func (e *Verifier) Verify(spec program.Spec, version string, removeOnFailure bool) (bool, error) {
+func (e *Verifier) Verify(spec program.Spec, version string) error {
 	var err error
+	var checksumMismatchErr *download.ChecksumMismatchError
+	var invalidSignatureErr *download.InvalidSignatureError
 
 	for _, v := range e.vv {
-		b, e := v.Verify(spec, version, removeOnFailure)
+		e := v.Verify(spec, version)
 		if e == nil {
-			return b, nil
+			// Success
+			return nil
 		}
 
 		err = multierror.Append(err, e)
+
+		if errors.As(e, &checksumMismatchErr) || errors.As(err, &invalidSignatureErr) {
+			// Stop verification chain on checksum/signature errors.
+			break
+		}
 	}
 
-	return false, err
+	return err
 }

--- a/internal/pkg/artifact/download/composed/verifier_test.go
+++ b/internal/pkg/artifact/download/composed/verifier_test.go
@@ -18,9 +18,9 @@ type ErrorVerifier struct {
 	called bool
 }
 
-func (d *ErrorVerifier) Verify(spec program.Spec, version string, removeOnFailure bool) (bool, error) {
+func (d *ErrorVerifier) Verify(spec program.Spec, version string) error {
 	d.called = true
-	return false, errors.New("failing")
+	return errors.New("failing")
 }
 
 func (d *ErrorVerifier) Called() bool { return d.called }
@@ -29,21 +29,20 @@ type FailVerifier struct {
 	called bool
 }
 
-func (d *FailVerifier) Verify(spec program.Spec, version string, removeOnFailure bool) (bool, error) {
+func (d *FailVerifier) Verify(spec program.Spec, version string) error {
 	d.called = true
-	return false, nil
+	return &download.InvalidSignatureError{}
 }
 
 func (d *FailVerifier) Called() bool { return d.called }
 
 type SuccVerifier struct {
-	called          bool
-	removeOnFailure bool
+	called bool
 }
 
-func (d *SuccVerifier) Verify(spec program.Spec, version string, removeOnFailure bool) (bool, error) {
+func (d *SuccVerifier) Verify(spec program.Spec, version string) error {
 	d.called = true
-	return true, nil
+	return nil
 }
 
 func (d *SuccVerifier) Called() bool { return d.called }
@@ -75,9 +74,9 @@ func TestVerifier(t *testing.T) {
 
 	for _, tc := range testCases {
 		d := NewVerifier(tc.verifiers[0], tc.verifiers[1], tc.verifiers[2])
-		r, _ := d.Verify(program.Spec{Name: "a", Cmd: "a", Artifact: "a/a"}, "b", true)
+		err := d.Verify(program.Spec{Name: "a", Cmd: "a", Artifact: "a/a"}, "b")
 
-		assert.Equal(t, tc.expectedResult, r)
+		assert.Equal(t, tc.expectedResult, err == nil)
 
 		assert.True(t, tc.checkFunc(tc.verifiers))
 	}

--- a/internal/pkg/artifact/download/fs/verifier.go
+++ b/internal/pkg/artifact/download/fs/verifier.go
@@ -5,39 +5,32 @@
 package fs
 
 import (
-	"bufio"
-	"bytes"
-	"crypto/sha512"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
-
-	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
-
-	"golang.org/x/crypto/openpgp"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
+	"github.com/elastic/elastic-agent/internal/pkg/artifact/download"
 )
 
 const (
-	ascSuffix    = ".asc"
-	sha512Length = 128
+	ascSuffix = ".asc"
 )
 
-// Verifier verifies a downloaded package by comparing with public ASC
-// file from elastic.co website.
+// Verifier verifies an artifact's GPG signature as read from the filesystem.
+// The signature is validated against Elastic's public GPG key that is
+// embedded into Elastic Agent.
 type Verifier struct {
 	config        *artifact.Config
 	pgpBytes      []byte
 	allowEmptyPgp bool
 }
 
-// NewVerifier create a verifier checking downloaded package on preconfigured
-// location agains a key stored on elastic.co website.
+// NewVerifier creates a verifier checking downloaded package on preconfigured
+// location against a key stored on elastic.co website.
 func NewVerifier(config *artifact.Config, allowEmptyPgp bool, pgp []byte) (*Verifier, error) {
 	if len(pgp) == 0 && !allowEmptyPgp {
 		return nil, errors.New("expecting PGP but retrieved none", errors.TypeSecurity)
@@ -53,106 +46,50 @@ func NewVerifier(config *artifact.Config, allowEmptyPgp bool, pgp []byte) (*Veri
 }
 
 // Verify checks downloaded package on preconfigured
-// location agains a key stored on elastic.co website.
-func (v *Verifier) Verify(spec program.Spec, version string, removeOnFailure bool) (isMatch bool, err error) {
+// location against a key stored on elastic.co website.
+func (v *Verifier) Verify(spec program.Spec, version string) error {
 	filename, err := artifact.GetArtifactName(spec, version, v.config.OS(), v.config.Arch())
 	if err != nil {
-		return false, errors.New(err, "retrieving package name")
+		return errors.New(err, "retrieving package name")
 	}
 
 	fullPath := filepath.Join(v.config.TargetDirectory, filename)
-	defer func() {
-		if removeOnFailure && (!isMatch || err != nil) {
-			// remove bits so they can be redownloaded
+
+	if err = download.VerifySHA512Hash(fullPath); err != nil {
+		var checksumMismatchErr *download.ChecksumMismatchError
+		if errors.As(err, &checksumMismatchErr) {
 			os.Remove(fullPath)
 			os.Remove(fullPath + ".sha512")
+		}
+		return err
+	}
+
+	if err = v.verifyAsc(fullPath); err != nil {
+		var invalidSignatureErr *download.InvalidSignatureError
+		if errors.As(err, &invalidSignatureErr) {
 			os.Remove(fullPath + ".asc")
 		}
-	}()
-
-	if isMatch, err := v.verifyHash(filename, fullPath); !isMatch || err != nil {
-		return isMatch, err
+		return err
 	}
 
-	return v.verifyAsc(filename, fullPath)
+	return nil
 }
 
-func (v *Verifier) verifyHash(filename, fullPath string) (bool, error) {
-	hashFilePath := fullPath + ".sha512"
-	hashFileHandler, err := os.Open(hashFilePath)
-	if err != nil {
-		return false, err
-	}
-	defer hashFileHandler.Close()
-
-	// get hash
-	// content of a file is in following format
-	// hash  filename
-	var expectedHash string
-	scanner := bufio.NewScanner(hashFileHandler)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if !strings.HasSuffix(line, filename) {
-			continue
-		}
-
-		if len(line) > sha512Length {
-			expectedHash = strings.TrimSpace(line[:sha512Length])
-		}
-	}
-
-	if expectedHash == "" {
-		return false, fmt.Errorf("hash for '%s' not found in '%s'", filename, hashFilePath)
-	}
-
-	// compute file hash
-	fileReader, err := os.OpenFile(fullPath, os.O_RDONLY, 0666)
-	if err != nil {
-		return false, errors.New(err, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, fullPath))
-	}
-	defer fileReader.Close()
-
-	hash := sha512.New()
-	if _, err := io.Copy(hash, fileReader); err != nil {
-		return false, err
-	}
-	computedHash := fmt.Sprintf("%x", hash.Sum(nil))
-
-	return expectedHash == computedHash, nil
-}
-
-func (v *Verifier) verifyAsc(filename, fullPath string) (bool, error) {
+func (v *Verifier) verifyAsc(fullPath string) error {
 	if len(v.pgpBytes) == 0 {
 		// no pgp available skip verification process
-		return true, nil
+		return nil
 	}
 
 	ascBytes, err := v.getPublicAsc(fullPath)
 	if err != nil && v.allowEmptyPgp {
 		// asc not available but we allow empty for dev use-case
-		return true, nil
+		return nil
 	} else if err != nil {
-		return false, err
+		return err
 	}
 
-	pubkeyReader := bytes.NewReader(v.pgpBytes)
-	ascReader := bytes.NewReader(ascBytes)
-	fileReader, err := os.OpenFile(fullPath, os.O_RDONLY, 0666)
-	if err != nil {
-		return false, errors.New(err, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, fullPath))
-	}
-	defer fileReader.Close()
-
-	keyring, err := openpgp.ReadArmoredKeyRing(pubkeyReader)
-	if err != nil {
-		return false, errors.New(err, "read armored key ring", errors.TypeSecurity)
-	}
-	_, err = openpgp.CheckArmoredDetachedSignature(keyring, fileReader, ascReader)
-	if err != nil {
-		return false, errors.New(err, "check detached signature", errors.TypeSecurity)
-	}
-
-	return true, nil
+	return download.VerifyGPGSignature(fullPath, ascBytes, v.pgpBytes)
 }
 
 func (v *Verifier) getPublicAsc(fullPath string) ([]byte, error) {

--- a/internal/pkg/artifact/download/fs/verifier_test.go
+++ b/internal/pkg/artifact/download/fs/verifier_test.go
@@ -15,10 +15,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
+	"github.com/elastic/elastic-agent/internal/pkg/artifact/download"
+	"github.com/elastic/elastic-agent/internal/pkg/release"
 )
 
 const (
@@ -65,9 +68,9 @@ func TestFetchVerify(t *testing.T) {
 	// first download verify should fail:
 	// download skipped, as invalid package is prepared upfront
 	// verify fails and cleans download
-	matches, err := verifier.Verify(s, version, true)
-	assert.NoError(t, err)
-	assert.Equal(t, false, matches)
+	err = verifier.Verify(s, version)
+	var checksumErr *download.ChecksumMismatchError
+	assert.ErrorAs(t, err, &checksumErr)
 
 	_, err = os.Stat(targetFilePath)
 	assert.True(t, os.IsNotExist(err))
@@ -88,9 +91,50 @@ func TestFetchVerify(t *testing.T) {
 	_, err = os.Stat(hashTargetFilePath)
 	assert.NoError(t, err)
 
-	matches, err = verifier.Verify(s, version, true)
+	err = verifier.Verify(s, version)
 	assert.NoError(t, err)
-	assert.Equal(t, true, matches)
+
+	// Enable GPG signature validation.
+	verifier.allowEmptyPgp = false
+
+	// Bad GPG public key.
+	{
+		verifier.pgpBytes = []byte("garbage")
+
+		// Don't delete anything.
+		assertFileExists(t, targetFilePath)
+		assertFileExists(t, targetFilePath+".sha512")
+	}
+
+	// Setup proper GPG public key.
+	_, verifier.pgpBytes = release.PGP()
+
+	// Missing .asc file.
+	{
+		err = verifier.Verify(s, version)
+		require.Error(t, err)
+
+		// Don't delete these files when GPG validation failure.
+		assertFileExists(t, targetFilePath)
+		assertFileExists(t, targetFilePath+".sha512")
+	}
+
+	// Invalid signature.
+	{
+		err = ioutil.WriteFile(targetFilePath+".asc", []byte("bad sig"), 0o600)
+		require.NoError(t, err)
+
+		err = verifier.Verify(s, version)
+		var invalidSigErr *download.InvalidSignatureError
+		assert.ErrorAs(t, err, &invalidSigErr)
+
+		// Don't delete these files when GPG validation failure.
+		assertFileExists(t, targetFilePath)
+		assertFileExists(t, targetFilePath+".sha512")
+
+		// Bad .asc file should be removed.
+		assertFileNotExists(t, targetFilePath+".asc")
+	}
 }
 
 func prepareFetchVerifyTests(dropPath, targetDir, targetFilePath, hashTargetFilePath string) error {
@@ -164,14 +208,8 @@ func TestVerify(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	isOk, err := testVerifier.Verify(beatSpec, version, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !isOk {
-		t.Fatal("verify failed")
-	}
+	err = testVerifier.Verify(beatSpec, version)
+	require.NoError(t, err)
 
 	os.Remove(artifact)
 	os.Remove(artifact + ".sha512")
@@ -197,4 +235,16 @@ func prepareTestCase(beatSpec program.Spec, version string, cfg *artifact.Config
 	}
 
 	return ioutil.WriteFile(filepath.Join(cfg.DropPath, filename+".sha512"), []byte(hashContent), 0644)
+}
+
+func assertFileExists(t testing.TB, path string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	assert.NoError(t, err, "file %s does not exist", path)
+}
+
+func assertFileNotExists(t testing.TB, path string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/internal/pkg/artifact/download/http/elastic_test.go
+++ b/internal/pkg/artifact/download/http/elastic_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
@@ -122,14 +124,8 @@ func TestVerify(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			isOk, err := testVerifier.Verify(beatSpec, version, false)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if !isOk {
-				t.Fatal("verify failed")
-			}
+			err = testVerifier.Verify(beatSpec, version)
+			require.NoError(t, err)
 
 			os.Remove(artifact)
 			os.Remove(artifact + ".sha512")

--- a/internal/pkg/artifact/download/http/verifier.go
+++ b/internal/pkg/artifact/download/http/verifier.go
@@ -5,11 +5,7 @@
 package http
 
 import (
-	"bufio"
-	"bytes"
-	"crypto/sha512"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -17,18 +13,15 @@ import (
 	"path"
 	"strings"
 
-	"golang.org/x/crypto/openpgp"
-
 	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
+	"github.com/elastic/elastic-agent/internal/pkg/artifact/download"
 )
 
 const (
-	publicKeyURI = "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
-	ascSuffix    = ".asc"
-	sha512Length = 128
+	ascSuffix = ".asc"
 )
 
 // Verifier verifies a downloaded package by comparing with public ASC
@@ -68,127 +61,63 @@ func NewVerifier(config *artifact.Config, allowEmptyPgp bool, pgp []byte) (*Veri
 }
 
 // Verify checks downloaded package on preconfigured
-// location agains a key stored on elastic.co website.
-func (v *Verifier) Verify(spec program.Spec, version string, removeOnFailure bool) (isMatch bool, err error) {
-	filename, err := artifact.GetArtifactName(spec, version, v.config.OS(), v.config.Arch())
-	if err != nil {
-		return false, errors.New(err, "retrieving package name")
-	}
-
+// location against a key stored on elastic.co website.
+func (v *Verifier) Verify(spec program.Spec, version string) error {
 	fullPath, err := artifact.GetArtifactPath(spec, version, v.config.OS(), v.config.Arch(), v.config.TargetDirectory)
 	if err != nil {
-		return false, errors.New(err, "retrieving package path")
+		return errors.New(err, "retrieving package path")
 	}
 
-	defer func() {
-		if removeOnFailure && (!isMatch || err != nil) {
-			// remove bits so they can be redownloaded
+	if err = download.VerifySHA512Hash(fullPath); err != nil {
+		var checksumMismatchErr *download.ChecksumMismatchError
+		if errors.As(err, &checksumMismatchErr) {
 			os.Remove(fullPath)
 			os.Remove(fullPath + ".sha512")
+		}
+		return err
+	}
+
+	if err = v.verifyAsc(spec, version); err != nil {
+		var invalidSignatureErr *download.InvalidSignatureError
+		if errors.As(err, &invalidSignatureErr) {
 			os.Remove(fullPath + ".asc")
 		}
-	}()
-
-	if isMatch, err := v.verifyHash(filename, fullPath); !isMatch || err != nil {
-		return isMatch, err
+		return err
 	}
 
-	return v.verifyAsc(spec, version)
+	return nil
 }
 
-func (v *Verifier) verifyHash(filename, fullPath string) (bool, error) {
-	hashFilePath := fullPath + ".sha512"
-	hashFileHandler, err := os.Open(hashFilePath)
-	if err != nil {
-		return false, err
-	}
-	defer hashFileHandler.Close()
-
-	// get hash
-	// content of a file is in following format
-	// hash  filename
-	var expectedHash string
-	scanner := bufio.NewScanner(hashFileHandler)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if !strings.HasSuffix(line, filename) {
-			continue
-		}
-
-		if len(line) > sha512Length {
-			expectedHash = strings.TrimSpace(line[:sha512Length])
-		}
-	}
-
-	if expectedHash == "" {
-		return false, fmt.Errorf("hash for '%s' not found", filename)
-	}
-
-	// compute file hash
-	fileReader, err := os.OpenFile(fullPath, os.O_RDONLY, 0666)
-	if err != nil {
-		return false, errors.New(err, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, fullPath))
-	}
-	defer fileReader.Close()
-
-	// compute file hash
-	hash := sha512.New()
-	if _, err := io.Copy(hash, fileReader); err != nil {
-		return false, err
-	}
-	computedHash := fmt.Sprintf("%x", hash.Sum(nil))
-
-	return expectedHash == computedHash, nil
-}
-
-func (v *Verifier) verifyAsc(spec program.Spec, version string) (bool, error) {
+func (v *Verifier) verifyAsc(spec program.Spec, version string) error {
 	if len(v.pgpBytes) == 0 {
 		// no pgp available skip verification process
-		return true, nil
+		return nil
 	}
 
 	filename, err := artifact.GetArtifactName(spec, version, v.config.OS(), v.config.Arch())
 	if err != nil {
-		return false, errors.New(err, "retrieving package name")
+		return errors.New(err, "retrieving package name")
 	}
 
 	fullPath, err := artifact.GetArtifactPath(spec, version, v.config.OS(), v.config.Arch(), v.config.TargetDirectory)
 	if err != nil {
-		return false, errors.New(err, "retrieving package path")
+		return errors.New(err, "retrieving package path")
 	}
 
 	ascURI, err := v.composeURI(filename, spec.Artifact)
 	if err != nil {
-		return false, errors.New(err, "composing URI for fetching asc file", errors.TypeNetwork)
+		return errors.New(err, "composing URI for fetching asc file", errors.TypeNetwork)
 	}
 
 	ascBytes, err := v.getPublicAsc(ascURI)
 	if err != nil && v.allowEmptyPgp {
 		// asc not available but we allow empty for dev use-case
-		return true, nil
+		return nil
 	} else if err != nil {
-		return false, errors.New(err, fmt.Sprintf("fetching asc file from %s", ascURI), errors.TypeNetwork, errors.M(errors.MetaKeyURI, ascURI))
+		return errors.New(err, fmt.Sprintf("fetching asc file from %s", ascURI), errors.TypeNetwork, errors.M(errors.MetaKeyURI, ascURI))
 	}
 
-	pubkeyReader := bytes.NewReader(v.pgpBytes)
-	ascReader := bytes.NewReader(ascBytes)
-	fileReader, err := os.OpenFile(fullPath, os.O_RDONLY, 0666)
-	if err != nil {
-		return false, errors.New(err, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, fullPath))
-	}
-	defer fileReader.Close()
-
-	keyring, err := openpgp.ReadArmoredKeyRing(pubkeyReader)
-	if err != nil {
-		return false, errors.New(err, "read armored key ring", errors.TypeSecurity)
-	}
-	_, err = openpgp.CheckArmoredDetachedSignature(keyring, fileReader, ascReader)
-	if err != nil {
-		return false, errors.New(err, "check detached signature", errors.TypeSecurity)
-	}
-
-	return true, nil
-
+	return download.VerifyGPGSignature(fullPath, ascBytes, v.pgpBytes)
 }
 
 func (v *Verifier) composeURI(filename, artifactName string) (string, error) {

--- a/internal/pkg/artifact/download/verifier.go
+++ b/internal/pkg/artifact/download/verifier.go
@@ -21,6 +21,8 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 )
 
+// ChecksumMismatchError indicates the expected checksum for a file does not
+// match the computed checksum.
 type ChecksumMismatchError struct {
 	Expected string
 	Computed string
@@ -31,6 +33,7 @@ func (e *ChecksumMismatchError) Error() string {
 	return "checksum mismatch for " + e.File + ": expected " + e.Expected + ", computed " + e.Computed
 }
 
+// InvalidSignatureError indicates the file's GPG signature is invalid.
 type InvalidSignatureError struct {
 	File string
 	Err  error
@@ -40,12 +43,17 @@ func (e *InvalidSignatureError) Error() string {
 	return "invalid signature for " + e.File + ": " + e.Err.Error()
 }
 
+// Unwrap returns the cause.
 func (e *InvalidSignatureError) Unwrap() error { return e.Err }
 
 // Verifier is an interface verifying the SHA512 checksum and GPG signature and
 // of a downloaded artifact.
 type Verifier interface {
 	// Verify should verify the artifact and return an error if any checks fail.
+	// If the checksum does no match Verify returns a
+	// *download.ChecksumMismatchError. And if the GPG signature is invalid then
+	// Verify returns a *download.InvalidSignatureError. Use errors.As() to
+	// check error types.
 	Verify(spec program.Spec, version string) error
 }
 
@@ -85,7 +93,8 @@ func VerifySHA512Hash(filename string) error {
 
 // readChecksumFile reads the checksum of the file named in filename from
 // checksumFile. checksumFile is expected to contain the output from the
-// shasum family of tools (e.g. sha512sum).
+// shasum family of tools (e.g. sha512sum). If the checksum does not match then
+// a *download.ChecksumMismatchError is returned.
 func readChecksumFile(checksumFile, filename string) (string, error) {
 	f, err := os.Open(checksumFile)
 	if err != nil {
@@ -123,6 +132,10 @@ func readChecksumFile(checksumFile, filename string) (string, error) {
 	return checksum, nil
 }
 
+// VerifyGPGSignature verifies the GPG signature of a file. It accepts the path
+// to the file to verify, the ASCII armored signature, and the public key to
+// check against. If there is a problem with the signature then a
+// *download.InvalidSignatureError is returned.
 func VerifyGPGSignature(file string, asciiArmorSignature, publicKey []byte) error {
 	keyring, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(publicKey))
 	if err != nil {

--- a/internal/pkg/artifact/download/verifier.go
+++ b/internal/pkg/artifact/download/verifier.go
@@ -4,9 +4,141 @@
 
 package download
 
-import "github.com/elastic/elastic-agent/internal/pkg/agent/program"
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 
-// Verifier is an interface verifying GPG key of a downloaded artifact
+	"golang.org/x/crypto/openpgp"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
+)
+
+type ChecksumMismatchError struct {
+	Expected string
+	Computed string
+	File     string
+}
+
+func (e *ChecksumMismatchError) Error() string {
+	return "checksum mismatch for " + e.File + ": expected " + e.Expected + ", computed " + e.Computed
+}
+
+type InvalidSignatureError struct {
+	File string
+	Err  error
+}
+
+func (e *InvalidSignatureError) Error() string {
+	return "invalid signature for " + e.File + ": " + e.Err.Error()
+}
+
+func (e *InvalidSignatureError) Unwrap() error { return e.Err }
+
+// Verifier is an interface verifying the SHA512 checksum and GPG signature and
+// of a downloaded artifact.
 type Verifier interface {
-	Verify(spec program.Spec, version string, removeOnFailure bool) (bool, error)
+	// Verify should verify the artifact and return an error if any checks fail.
+	Verify(spec program.Spec, version string) error
+}
+
+// VerifySHA512Hash checks that a sidecar file containing a sha512 checksum
+// exists and that the checksum in the sidecar file matches the checksum of
+// the file. It returns an error if validation fails.
+func VerifySHA512Hash(filename string) error {
+	// Read expected checksum.
+	expectedHash, err := readChecksumFile(filename+".sha512", filepath.Base(filename))
+	if err != nil {
+		return err
+	}
+
+	// Compute sha512 checksum.
+	f, err := os.Open(filename)
+	if err != nil {
+		return errors.New(err, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, filename))
+	}
+	defer f.Close()
+
+	hash := sha512.New()
+	if _, err := io.Copy(hash, f); err != nil {
+		return err
+	}
+	computedHash := hex.EncodeToString(hash.Sum(nil))
+
+	if computedHash != expectedHash {
+		return &ChecksumMismatchError{
+			Expected: expectedHash,
+			Computed: computedHash,
+			File:     filename,
+		}
+	}
+
+	return nil
+}
+
+// readChecksumFile reads the checksum of the file named in filename from
+// checksumFile. checksumFile is expected to contain the output from the
+// shasum family of tools (e.g. sha512sum).
+func readChecksumFile(checksumFile, filename string) (string, error) {
+	f, err := os.Open(checksumFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to open checksum file %q: %w", checksumFile, err)
+	}
+	defer f.Close()
+
+	// The format is a checksum, a space, a character indicating input mode ('*'
+	// for binary, ' ' for text or where binary is insignificant), and name for
+	// each FILE. See man sha512sum.
+	//
+	// {hash} SPACE (ASTERISK|SPACE) [{directory} SLASH] {filename}
+	var checksum string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		parts := strings.Fields(scanner.Text())
+		if len(parts) != 2 {
+			// Ignore malformed.
+			continue
+		}
+
+		lineFilename := strings.TrimLeft(parts[1], "*")
+		if lineFilename != filename {
+			// Continue looking for a match.
+			continue
+		}
+
+		checksum = parts[0]
+	}
+
+	if len(checksum) == 0 {
+		return "", fmt.Errorf("checksum for %q was not found in %q", filename, checksumFile)
+	}
+
+	return checksum, nil
+}
+
+func VerifyGPGSignature(file string, asciiArmorSignature, publicKey []byte) error {
+	keyring, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(publicKey))
+	if err != nil {
+		return errors.New(err, "read armored key ring", errors.TypeSecurity)
+	}
+
+	f, err := os.Open(file)
+	if err != nil {
+		return errors.New(err, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, file))
+	}
+	defer f.Close()
+
+	_, err = openpgp.CheckArmoredDetachedSignature(keyring, f, bytes.NewReader(asciiArmorSignature))
+	if err != nil {
+		return &InvalidSignatureError{File: file, Err: err}
+	}
+
+	return nil
 }

--- a/internal/pkg/artifact/download/verifier.go
+++ b/internal/pkg/artifact/download/verifier.go
@@ -15,7 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"golang.org/x/crypto/openpgp"
+	"golang.org/x/crypto/openpgp" //nolint:staticcheck // crypto/openpgp is only receiving security updates.
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"


### PR DESCRIPTION
## What does this PR do?

Modify verifier to only delete the binary and .sha512 files when there is a
checksum mismatch. And only delete the .asc file when the signature does not
validate.

Fixes https://github.com/elastic/elastic-agent/issues/252

## Why is it important?

Downloaded artifacts fail signature validation in SNAPSHOT builds. You cannot test Packetbeat or Auditbeat with 8.2.0-SNAPSHOT builds.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Fixes https://github.com/elastic/elastic-agent/issues/252
