### PR TITLE
Move `platformcheck` and `common/proc` from libbeat

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2913,6 +2913,76 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 --------------------------------------------------------------------------------
+Dependency : github.com/shirou/gopsutil/v3
+Version: v3.21.12
+Licence type (autodetected): BSD-3-Clause
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/shirou/gopsutil/v3@v3.21.12/LICENSE:
+
+gopsutil is distributed under BSD license reproduced below.
+
+Copyright (c) 2014, WAKAYAMA Shirou
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the gopsutil authors nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+-------
+internal/common/binary.go in the gopsutil is copied and modifid from golang/encoding/binary.go.
+
+
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
 Dependency : github.com/spf13/cobra
 Version: v1.3.0
 Licence type (autodetected): Apache-2.0
@@ -13264,76 +13334,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
-
---------------------------------------------------------------------------------
-Dependency : github.com/shirou/gopsutil/v3
-Version: v3.21.12
-Licence type (autodetected): BSD-3-Clause
---------------------------------------------------------------------------------
-
-Contents of probable licence file $GOMODCACHE/github.com/shirou/gopsutil/v3@v3.21.12/LICENSE:
-
-gopsutil is distributed under BSD license reproduced below.
-
-Copyright (c) 2014, WAKAYAMA Shirou
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
- * Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
- * Neither the name of the gopsutil authors nor the names of its contributors
-   may be used to endorse or promote products derived from this software without
-   specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
--------
-internal/common/binary.go in the gopsutil is copied and modifid from golang/encoding/binary.go.
-
-
-
-Copyright (c) 2009 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/sirupsen/logrus

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/otiai10/copy v1.2.0
 	github.com/pierrre/gotestcover v0.0.0-20160517101806-924dca7d15f0
 	github.com/pkg/errors v0.9.1
+	github.com/shirou/gopsutil/v3 v3.21.12
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
 	github.com/tsg/go-daemon v0.0.0-20200207173439-e704b93fd89b
@@ -106,7 +107,6 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/santhosh-tekuri/jsonschema v1.2.4 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
-	github.com/shirou/gopsutil/v3 v3.21.12 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tklauser/go-sysconf v0.3.9 // indirect

--- a/internal/pkg/agent/cmd/platformcheck.go
+++ b/internal/pkg/agent/cmd/platformcheck.go
@@ -1,0 +1,36 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build linux || windows
+// +build linux windows
+
+package cmd
+
+import (
+	"fmt"
+	"math/bits"
+	"strings"
+
+	"github.com/shirou/gopsutil/v3/host"
+)
+
+func CheckNativePlatformCompat() error {
+	const compiledArchBits = bits.UintSize // 32 if the binary was compiled for 32 bit architecture.
+
+	if compiledArchBits > 32 {
+		// We assume that 64bit binaries can only be run on 64bit systems
+		return nil
+	}
+
+	arch, err := host.KernelArch()
+	if err != nil {
+		return err
+	}
+
+	if strings.Contains(arch, "64") {
+		return fmt.Errorf("trying to run %vBit binary on 64Bit system", compiledArchBits)
+	}
+
+	return nil
+}

--- a/internal/pkg/agent/cmd/platformcheck.go
+++ b/internal/pkg/agent/cmd/platformcheck.go
@@ -15,6 +15,9 @@ import (
 	"github.com/shirou/gopsutil/v3/host"
 )
 
+// CheckNativePlatformCompat checks if the binary is running
+// on an appropriate system. 32-bit binaries can only run on
+// 32-bit systems and 64-bit binaries only run on 64-bit systems.
 func CheckNativePlatformCompat() error {
 	const compiledArchBits = bits.UintSize // 32 if the binary was compiled for 32 bit architecture.
 

--- a/internal/pkg/agent/cmd/platformcheck_other.go
+++ b/internal/pkg/agent/cmd/platformcheck_other.go
@@ -1,0 +1,12 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !linux && !windows
+// +build !linux,!windows
+
+package cmd
+
+func CheckNativePlatformCompat() error {
+	return nil
+}

--- a/internal/pkg/agent/cmd/platformcheck_test.go
+++ b/internal/pkg/agent/cmd/platformcheck_test.go
@@ -1,0 +1,52 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckPlatformCompat(t *testing.T) {
+	if !(runtime.GOARCH == "amd64" && (runtime.GOOS == "linux" ||
+		runtime.GOOS == "windows")) {
+		t.Skip("Test not support on current platform")
+	}
+
+	// compile test helper
+	tmp := t.TempDir()
+	helper := filepath.Join(tmp, "helper")
+
+	cmd := exec.Command("go", "test", "-c", "-o", helper)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(), "GOARCH=386")
+	require.NoError(t, cmd.Run(), "failed to compile test helper")
+
+	// run test helper
+	cmd = exec.Command(helper, "-test.v", "-test.run", "TestHelper")
+	cmd.Env = []string{"GO_USE_HELPER=1"}
+	output, err := cmd.Output()
+	if err != nil {
+		t.Logf("32bit binary tester failed.\n Output: %s", output)
+	}
+}
+
+func TestHelper(t *testing.T) {
+	if os.Getenv("GO_USE_HELPER") != "1" {
+		t.Log("ignore helper")
+		return
+	}
+
+	err := CheckNativePlatformCompat()
+	if err.Error() != "trying to run 32Bit binary on 64Bit system" {
+		t.Error("expected the native platform check to fail")
+	}
+}

--- a/internal/pkg/agent/cmd/proc/job_unix.go
+++ b/internal/pkg/agent/cmd/proc/job_unix.go
@@ -1,0 +1,39 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !windows
+// +build !windows
+
+package proc
+
+import (
+	"os"
+)
+
+// Job is noop on unix
+type Job int
+
+var (
+	// Public global JobObject, 0 value on linux
+	JobObject Job
+)
+
+func CreateJobObject() (pj Job, err error) {
+	return
+}
+
+// NewJob is noop on unix
+func NewJob() (Job, error) {
+	return 0, nil
+}
+
+// Close is noop on unix
+func (job Job) Close() error {
+	return nil
+}
+
+// Assign is noop on unix
+func (job Job) Assign(p *os.Process) error {
+	return nil
+}

--- a/internal/pkg/agent/cmd/proc/job_unix.go
+++ b/internal/pkg/agent/cmd/proc/job_unix.go
@@ -21,7 +21,7 @@ var (
 
 // CreateJobObject returns a job object.
 func CreateJobObject() (pj Job, err error) {
-	return
+	return pj, err
 }
 
 // NewJob is noop on unix

--- a/internal/pkg/agent/cmd/proc/job_unix.go
+++ b/internal/pkg/agent/cmd/proc/job_unix.go
@@ -15,10 +15,11 @@ import (
 type Job int
 
 var (
-	// Public global JobObject, 0 value on linux
+	// JobObject is public global JobObject, 0 value on linux
 	JobObject Job
 )
 
+// CreateJobObject returns a job object.
 func CreateJobObject() (pj Job, err error) {
 	return
 }

--- a/internal/pkg/agent/cmd/proc/job_windows.go
+++ b/internal/pkg/agent/cmd/proc/job_windows.go
@@ -1,0 +1,88 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build windows
+// +build windows
+
+package proc
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// Job is wrapper for windows JobObject
+// https://docs.microsoft.com/en-us/windows/win32/procthread/job-objects
+// This helper guarantees a clean process tree kill on job handler close
+type Job windows.Handle
+
+var (
+	// Public global JobObject should be initialized once in main
+	JobObject Job
+)
+
+// CreateJobObject creates JobObject on Windows, global per process
+// Should only be initialized once in main function
+func CreateJobObject() (pj Job, err error) {
+	if pj, err = NewJob(); err != nil {
+		return pj, err
+	}
+	JobObject = pj
+	return pj, nil
+}
+
+// NewJob creates a instance of the JobObject
+func NewJob() (Job, error) {
+	h, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	// From https://docs.microsoft.com/en-us/windows/win32/procthread/job-objects
+	// ... if the job has the JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE flag specified,
+	// closing the last job object handle terminates all associated processes
+	// and then destroys the job object itself.
+	// If a nested job has the JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE flag specified,
+	// closing the last job object handle terminates all processes associated
+	// with the job and its child jobs in the hierarchy.
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	if _, err := windows.SetInformationJobObject(
+		h,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info))); err != nil {
+		return 0, err
+	}
+
+	return Job(h), nil
+}
+
+// Close closes job handler
+func (job Job) Close() error {
+	if job == 0 {
+		return nil
+	}
+	return windows.CloseHandle(windows.Handle(job))
+}
+
+// Assign assigns the process to the JobObject
+func (job Job) Assign(p *os.Process) error {
+	if job == 0 || p == nil {
+		return nil
+	}
+	return windows.AssignProcessToJobObject(
+		windows.Handle(job),
+		windows.Handle((*process)(unsafe.Pointer(p)).Handle))
+}
+
+type process struct {
+	Pid    int
+	Handle uintptr
+}

--- a/main.go
+++ b/main.go
@@ -10,14 +10,13 @@ import (
 	"os"
 	"time"
 
-	"github.com/elastic/beats/v7/libbeat/cmd/platformcheck"
-	"github.com/elastic/beats/v7/x-pack/libbeat/common/proc"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/cmd"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/cmd/proc"
 )
 
 // Setups and Runs agent.
 func main() {
-	if err := platformcheck.CheckNativePlatformCompat(); err != nil {
+	if err := cmd.CheckNativePlatformCompat(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to initialize: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
## What does this PR do?

This PR copies two small packages from libbeat. I did not extract these because they are very small. As the Golang proverb says "a little copying is better than a little dependency".

Packages: 
* `github.com/elastic/beats/v7/libbeat/cmd/platformcheck`
* `github.com/elastic/beats/v7/x-pack/libbeat/common/proc`

## Why is it important?

This PR decreases the dependency on the beats repository.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
