### PR TITLE
no e2e if only docs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -236,6 +236,7 @@ pipeline {
         beforeAgent true
         anyOf {
           not { changeRequest() }
+          // package artefacts are not generated if ONLY_DOCS, therefore e2e should not run if ONLY_DOCS
           expression { return isE2eEnabled() && env.ONLY_DOCS == "false"}
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -236,7 +236,7 @@ pipeline {
         beforeAgent true
         anyOf {
           not { changeRequest() }
-          expression { return isE2eEnabled() }
+          expression { return isE2eEnabled() && env.ONLY_DOCS == "false"}
         }
       }
       steps {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -236,7 +236,7 @@ pipeline {
         beforeAgent true
         anyOf {
           not { changeRequest() }
-          // package artefacts are not generated if ONLY_DOCS, therefore e2e should not run if ONLY_DOCS
+          // package artifacts are not generated if ONLY_DOCS, therefore e2e should not run if ONLY_DOCS
           expression { return isE2eEnabled() && env.ONLY_DOCS == "false"}
         }
       }


### PR DESCRIPTION
Adding condition for e2e tests to not run if there are only doc changes

## Why is it important?

e2e tests have failed after PR merge because of missing artifacts for docs only, the changes in Jenkins checks if files modified are limited to docs and does not run the tests.

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


