### PR TITLE
github actions: enable for branches

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,10 +1,13 @@
 name: macos
 
 on:
+  push:
+    branches:
+      - main
+      - 8.*
   pull_request:
     branches:
       - main
-      - 7.1*
       - 8.*
 
 jobs:


### PR DESCRIPTION
## What does this PR do?

Enable GitHub actions on MacOS for merge commits for the main and release branches.

## Why is it important?

Ensure the CI validates merges on branches.