### PR TITLE
Simple fixes for the diagnostics command

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -100,6 +100,7 @@
 - Update library containerd to 1.5.10. {pull}186[186]
 - Add fleet-server to output of elastic-agent inspect output command (and diagnostic bundle). {pull}243[243]
 - Update API calls that the agent makes to Kibana when running the container command. {pull}253[253]
+- diagnostics collect log names are fixed on Windows machines, command will ignore failures. AgentID is included in diagnostics(and diagnostics collect) output. {issue}81[81] {issue}92[92] {issue}190[190] {pull}262[262]
 
 ==== New features
 

--- a/internal/pkg/agent/cmd/diagnostics.go
+++ b/internal/pkg/agent/cmd/diagnostics.go
@@ -535,7 +535,9 @@ func zipLogs(zw *zip.Writer) error {
 			return fmt.Errorf("unable to walk log dir: %w", fErr)
 		}
 
-		name := strings.TrimPrefix(path, logPath)
+		// name is the relative dir/file name replacing any filepath seperators with /
+		// this will clean log names on windows machines and will nop on *nix
+		name := filepath.ToSlash(strings.TrimPrefix(path, logPath))
 		if name == "" {
 			return nil
 		}

--- a/internal/pkg/agent/cmd/diagnostics_test.go
+++ b/internal/pkg/agent/cmd/diagnostics_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 var testDiagnostics = DiagnosticsInfo{
-	AgentVersion: client.Version{
+	AgentInfo: AgentInfo{
+		ID:        "test-id",
 		Version:   "test-version",
 		Commit:    "test-commit",
 		BuildTime: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -58,7 +59,7 @@ var testDiagnostics = DiagnosticsInfo{
 func Example_humanDiagnosticsOutput() {
 	humanDiagnosticsOutput(os.Stdout, testDiagnostics)
 	// Output:
-	// elastic-agent  version: test-version
+	// elastic-agent  id: test-id                version: test-version
 	//                build_commit: test-commit  build_time: 2021-01-01 00:00:00 +0000 UTC  snapshot_build: false
 	// Applications:
 	//   *  name: filebeat                        route_key: test


### PR DESCRIPTION
## What does this PR do?

Three separate small fixes for the `elastic-agent diagnostic` command (including `collect`):

1. `diagnostics collect` will ignore failures where possible and log to stderr and to an `errors.txt` file in the archive.
2. Fixed log names when `diagnostics collect` is ran on a Windows machine
3. Add the elastic-agent ID to the output of `elastic-agent diagnostics` and into the archive in the `meta/elastic-agent.yaml` and `config/elastic-agent-local.yaml` files

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [] ~~I have made corresponding changes to the documentation~~
- [] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

### Testing log name fix

Run the agent on a Windows machine and run `elastic-agent diagnostics collect`.
Extract the archive (on a *nix machine) and ensure that the logs are named correctly, i.e.:
```
$ unzip elastic-agent-diagnostics-2022-03-28T20-26-59Z-00.zip
Archive:  elastic-agent-diagnostics-2022-03-28T20-26-59Z-00.zip
   creating: meta/
  inflating: meta/elastic-agent-version.yaml
  inflating: meta/filebeat-default.yaml
  inflating: meta/metricbeat-default.yaml
  inflating: meta/filebeat_monitoring-default.yaml
  inflating: meta/metricbeat_monitoring-default.yaml
   creating: config/
  inflating: config/elastic-agent-local.yaml
  inflating: config/elastic-agent-policy.yaml
  inflating: config/filebeat_default.yaml
  inflating: config/metricbeat_default.yaml
  inflating: config/fleet_monitoring_default.yaml
   creating: logs/
   creating: logs/default/
  inflating: logs/default/filebeat-20220328-1.ndjson
  inflating: logs/default/filebeat-20220328.ndjson
  inflating: logs/default/metricbeat-20220328-1.ndjson
  inflating: logs/default/metricbeat-20220328.ndjson
  inflating: logs/elastic-agent-20220328-1.ndjson
  inflating: logs/elastic-agent-20220328.ndjson
```

### Agent ID

Run `elastic-agent diagnostics` and ensure `id` is part of the agent description:
```
vagrant@ubuntu-focal:~$ sudo /opt/Elastic/Agent/elastic-agent diagnostics
elastic-agent  id: 814a02ee-0a26-45dd-bf96-e7005260a3d5                version: 8.2.0
               build_commit: cafa251125139303a7795977455a13d97d99095e  build_time: 2022-03-28 23:41:57 +0000 UTC  snapshot_build: true
```

`elastic-agent diagnostics collect` should include this id as part of `meta/elastic-agent-version.yaml` and `config/leastic-agent-local.yaml`.

## Related issues

- Closes #190 
- Closes #81 
- Closes #92 