### PR TITLE
remove `-d` flag ad it only gets the package, does not install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ export MAGE_IMPORT_PATH
 mage:
 ifndef MAGE_PRESENT
 	@echo Installing mage $(MAGE_VERSION).
-	@go get -d -ldflags="-X $(MAGE_IMPORT_PATH)/mage.gitTag=$(MAGE_VERSION)" ${MAGE_IMPORT_PATH}@$(MAGE_VERSION)
+	@go get -ldflags="-X $(MAGE_IMPORT_PATH)/mage.gitTag=$(MAGE_VERSION)" ${MAGE_IMPORT_PATH}@$(MAGE_VERSION)
 	@-mage -clean
 endif
 	@true

--- a/magefile.go
+++ b/magefile.go
@@ -175,7 +175,7 @@ func (Dev) Build() {
 	mg.Deps(Build.All)
 }
 
-// Package packages the agent binary with DEV flag set.
+// Package bundles the agent binary with DEV flag set.
 func (Dev) Package() {
 	dev := os.Getenv(devEnv)
 	defer os.Setenv(devEnv, dev)


### PR DESCRIPTION
## What does this PR do?

removes `-d` flag as it only gets the package, does not install

## Why is it important?

remove `-d` flag as it only gets the package, does not install

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

related to issue https://github.com/elastic/elastic-agent/issues/264 and wrongly added in https://github.com/elastic/elastic-agent/pull/265 to remove the deprecation message