### PR TITLE
Add download progress reporter to HTTP downloader.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,7 +33,9 @@ linters:
     - goconst # finds repeated strings that could be replaced by a constant
     - dupl # tool for code clone detection
     - forbidigo # forbids identifiers	matched by reg exps
-    - gomoddirectives # manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
+    # 'replace' is used in go.mod for many dependencies that come from libbeat. We should work to remove those,
+    # so we can re-enable this linter.
+    # - gomoddirectives # manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
     - gosimple # linter for Go source code that specializes in simplifying a code
     - misspell # finds commonly misspelled English words in comments
     - nakedret # finds naked returns in functions greater than a specified function length

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -178,4 +178,4 @@
 - Add support for Cloudbeat. {pull}179[179]
 - Fix download verification in snapshot builds. {issue}252[252]
 - Add support for kubernetes cronjobs {pull}279[279]
-- Increase download artifact download to 10mins and add download statistics log messages. {pull}308[308]
+- Increase the download artifact timeout to 10mins and add log download statistics. {pull}308[308]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -178,3 +178,4 @@
 - Add support for Cloudbeat. {pull}179[179]
 - Fix download verification in snapshot builds. {issue}252[252]
 - Add support for kubernetes cronjobs {pull}279[279]
+- Increase download artifact download to 10mins and add download statistics log messages. {pull}308[308]

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -371,6 +371,207 @@ third-party archives.
 
 
 --------------------------------------------------------------------------------
+Dependency : github.com/docker/go-units
+Version: v0.4.0
+Licence type (autodetected): Apache-2.0
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/docker/go-units@v0.4.0/LICENSE:
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2015 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+--------------------------------------------------------------------------------
 Dependency : github.com/elastic/beats/v7
 Version: v7.0.0-alpha2.0.20220303073437-a28c413604b8
 Licence type (autodetected): Elastic
@@ -7394,207 +7595,6 @@ Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
 Contents of probable licence file $GOMODCACHE/github.com/docker/go-connections@v0.4.0/LICENSE:
-
-
-                                 Apache License
-                           Version 2.0, January 2004
-                        https://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   Copyright 2015 Docker, Inc.
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       https://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-
---------------------------------------------------------------------------------
-Dependency : github.com/docker/go-units
-Version: v0.4.0
-Licence type (autodetected): Apache-2.0
---------------------------------------------------------------------------------
-
-Contents of probable licence file $GOMODCACHE/github.com/docker/go-units@v0.4.0/LICENSE:
 
 
                                  Apache License

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2
 	github.com/cavaliercoder/go-rpm v0.0.0-20190131055624-7a9c54e3d83e
 	github.com/coreos/go-systemd/v22 v22.3.2
+	github.com/docker/go-units v0.4.0
 	github.com/elastic/e2e-testing v1.99.2-0.20220117192005-d3365c99b9c4
 	github.com/elastic/elastic-agent-client/v7 v7.0.0-20210727140539-f0905d9377f6
 	github.com/elastic/elastic-agent-libs v0.1.1
@@ -67,7 +68,6 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v20.10.7+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
-	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dop251/goja v0.0.0-20200831102558-9af81ddcf0e1 // indirect
 	github.com/dop251/goja_nodejs v0.0.0-20171011081505-adff31b136e6 // indirect
 	github.com/elastic/go-structform v0.0.9 // indirect

--- a/internal/pkg/agent/application/upgrade/step_download.go
+++ b/internal/pkg/agent/application/upgrade/step_download.go
@@ -68,12 +68,12 @@ func newDownloader(version string, log *logger.Logger, settings *artifact.Config
 	}
 
 	// try snapshot repo before official
-	snapDownloader, err := snapshot.NewDownloader(settings, version)
+	snapDownloader, err := snapshot.NewDownloader(log, settings, version)
 	if err != nil {
 		return nil, err
 	}
 
-	httpDownloader, err := http.NewDownloader(settings)
+	httpDownloader, err := http.NewDownloader(log, settings)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/artifact/config.go
+++ b/internal/pkg/artifact/config.go
@@ -13,6 +13,12 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 )
 
+const (
+	osDarwin  = "darwin"
+	osLinux   = "linux"
+	osWindows = "windows"
+)
+
 // Config is a configuration used for verifier and downloader
 type Config struct {
 	// OperatingSystem: operating system [linux, windows, darwin]
@@ -64,12 +70,12 @@ func (c *Config) OS() string {
 	}
 
 	switch runtime.GOOS {
-	case "windows":
-		c.OperatingSystem = "windows"
-	case "darwin":
-		c.OperatingSystem = "darwin"
+	case osWindows:
+		c.OperatingSystem = osWindows
+	case osDarwin:
+		c.OperatingSystem = osDarwin
 	default:
-		c.OperatingSystem = "linux"
+		c.OperatingSystem = osLinux
 	}
 
 	return c.OperatingSystem

--- a/internal/pkg/artifact/config.go
+++ b/internal/pkg/artifact/config.go
@@ -44,8 +44,10 @@ type Config struct {
 func DefaultConfig() *Config {
 	transport := httpcommon.DefaultHTTPTransportSettings()
 
-	// binaries are a getting bit larger it might take >30s to download them
-	transport.Timeout = 120 * time.Second
+	// Elastic Agent binary is rather large and based on the network bandwidth it could take some time
+	// to download the full file. 10 minutes is a very large value, but we really want it to finish.
+	// The HTTP download will log progress in the case that it is taking a while to download.
+	transport.Timeout = 10 * time.Minute
 
 	return &Config{
 		SourceURI:             "https://artifacts.elastic.co/downloads/",

--- a/internal/pkg/artifact/config.go
+++ b/internal/pkg/artifact/config.go
@@ -14,9 +14,9 @@ import (
 )
 
 const (
-	osDarwin  = "darwin"
-	osLinux   = "linux"
-	osWindows = "windows"
+	darwin  = "darwin"
+	linux   = "linux"
+	windows = "windows"
 )
 
 // Config is a configuration used for verifier and downloader
@@ -70,12 +70,12 @@ func (c *Config) OS() string {
 	}
 
 	switch runtime.GOOS {
-	case osWindows:
-		c.OperatingSystem = osWindows
-	case osDarwin:
-		c.OperatingSystem = osDarwin
+	case windows:
+		c.OperatingSystem = windows
+	case darwin:
+		c.OperatingSystem = darwin
 	default:
-		c.OperatingSystem = osLinux
+		c.OperatingSystem = linux
 	}
 
 	return c.OperatingSystem

--- a/internal/pkg/artifact/download/http/downloader.go
+++ b/internal/pkg/artifact/download/http/downloader.go
@@ -12,18 +12,33 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strconv"
 	"strings"
+	"time"
+
+	"github.com/docker/go-units"
 
 	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
-	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
+	"github.com/elastic/elastic-agent-libs/atomic"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/release"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
 const (
 	packagePermissions = 0660
+
+	// Reports the current download progress when percentage of time has passed in the overall interval for the
+	// complete download to complete. 5% is a good default, as the default timeout is 10 minutes and this will have it
+	// log every 30 seconds.
+	downloadProgressIntervalPercentage = 0.05
+
+	// Reports the log messages as a warning once the amount of time passed is this percentage or more of the total
+	// allotted time to download.
+	warningProgressIntervalPercentage = 0.75
 )
 
 var headers = map[string]string{
@@ -32,12 +47,13 @@ var headers = map[string]string{
 
 // Downloader is a downloader able to fetch artifacts from elastic.co web page.
 type Downloader struct {
+	log    *logger.Logger
 	config *artifact.Config
 	client http.Client
 }
 
 // NewDownloader creates and configures Elastic Downloader
-func NewDownloader(config *artifact.Config) (*Downloader, error) {
+func NewDownloader(log *logger.Logger, config *artifact.Config) (*Downloader, error) {
 	client, err := config.HTTPTransportSettings.Client(
 		httpcommon.WithAPMHTTPInstrumentation(),
 	)
@@ -46,12 +62,13 @@ func NewDownloader(config *artifact.Config) (*Downloader, error) {
 	}
 
 	client.Transport = withHeaders(client.Transport, headers)
-	return NewDownloaderWithClient(config, *client), nil
+	return NewDownloaderWithClient(log, config, *client), nil
 }
 
 // NewDownloaderWithClient creates Elastic Downloader with specific client used
-func NewDownloaderWithClient(config *artifact.Config, client http.Client) *Downloader {
+func NewDownloaderWithClient(log *logger.Logger, config *artifact.Config, client http.Client) *Downloader {
 	return &Downloader{
+		log:    log,
 		config: config,
 		client: client,
 	}
@@ -156,10 +173,147 @@ func (e *Downloader) downloadFile(ctx context.Context, artifactName, filename, f
 		return "", errors.New(fmt.Sprintf("call to '%s' returned unsuccessful status code: %d", sourceURI, resp.StatusCode), errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
 	}
 
-	_, err = io.Copy(destinationFile, resp.Body)
-	if err != nil {
-		return "", errors.New(err, "fetching package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
+	fileSize := -1
+	if contentLength := resp.Header.Get("Content-Length"); contentLength != "" {
+		if length, err := strconv.Atoi(contentLength); err != nil {
+			fileSize = length
+		}
 	}
 
+	reportCtx, reportCancel := context.WithCancel(ctx)
+	dp := newDownloadProgressReporter(e.log, sourceURI, e.config.HTTPTransportSettings.Timeout, fileSize)
+	dp.Report(reportCtx)
+	_, err = io.Copy(destinationFile, io.TeeReader(resp.Body, dp))
+	if err != nil {
+		reportCancel()
+		dp.ReportFailed(err)
+		return "", errors.New(err, "fetching package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
+	}
+	reportCancel()
+	dp.ReportComplete()
+
 	return fullPath, nil
+}
+
+type downloadProgressReporter struct {
+	log         *logger.Logger
+	sourceURI   string
+	timeout     time.Duration
+	interval    time.Duration
+	warnTimeout time.Duration
+	length      float64
+
+	downloaded atomic.Int
+	started    time.Time
+}
+
+func newDownloadProgressReporter(log *logger.Logger, sourceURI string, timeout time.Duration, length int) *downloadProgressReporter {
+	return &downloadProgressReporter{
+		log:         log,
+		sourceURI:   sourceURI,
+		timeout:     timeout,
+		interval:    time.Duration(float64(timeout) * downloadProgressIntervalPercentage),
+		warnTimeout: time.Duration(float64(timeout) * warningProgressIntervalPercentage),
+		length:      float64(length),
+	}
+}
+
+func (dp *downloadProgressReporter) Write(b []byte) (int, error) {
+	n := len(b)
+	dp.downloaded.Add(n)
+	return n, nil
+}
+
+func (dp *downloadProgressReporter) Report(ctx context.Context) {
+	started := time.Now()
+	dp.started = started
+	sourceURI := dp.sourceURI
+	log := dp.log
+	length := dp.length
+	warnTimeout := dp.warnTimeout
+
+	go func() {
+		t := time.NewTimer(dp.interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				now := time.Now()
+				timePast := now.Sub(started)
+				downloaded := float64(dp.downloaded.Load())
+				bytesPerSecond := downloaded / float64(timePast/time.Second)
+
+				msg := ""
+				var args []interface{}
+				if length > 0 {
+					// length of the download is known, so more detail can be provided
+					percentComplete := downloaded / length * 100.0
+					msg = "download progress from %s is %s/%s (%.2f%% complete) @ %sps"
+					args = []interface{}{
+						sourceURI, units.HumanSize(downloaded), units.HumanSize(length), percentComplete, units.HumanSize(bytesPerSecond),
+					}
+				} else {
+					// length unknown so provide the amount downloaded and the speed
+					msg = "download progress from %s has fetched %s @ %sps"
+					args = []interface{}{
+						sourceURI, units.HumanSize(downloaded), units.HumanSize(bytesPerSecond),
+					}
+				}
+
+				log.Infof(msg, args...)
+				if timePast >= warnTimeout {
+					// duplicate to warn when over the warnTimeout; this still has it logging to info that way if
+					// they are filtering the logs to info they still see the messages when over the warnTimeout, but
+					// when filtering only by warn they see these messages only
+					log.Warnf(msg, args...)
+				}
+			}
+		}
+	}()
+}
+
+func (dp *downloadProgressReporter) ReportComplete() {
+	now := time.Now()
+	timePast := now.Sub(dp.started)
+	downloaded := float64(dp.downloaded.Load())
+	bytesPerSecond := downloaded / float64(timePast/time.Second)
+	msg := "download from %s completed in %s @ %sps"
+	args := []interface{}{
+		dp.sourceURI, units.HumanDuration(timePast), units.HumanSize(bytesPerSecond),
+	}
+	dp.log.Infof(msg, args...)
+	if timePast >= dp.warnTimeout {
+		// see reason in `Report`
+		dp.log.Warnf(msg, args...)
+	}
+}
+
+func (dp *downloadProgressReporter) ReportFailed(err error) {
+	now := time.Now()
+	timePast := now.Sub(dp.started)
+	downloaded := float64(dp.downloaded.Load())
+	bytesPerSecond := downloaded / float64(timePast/time.Second)
+	msg := ""
+	var args []interface{}
+	if dp.length > 0 {
+		// length of the download is known, so more detail can be provided
+		percentComplete := downloaded / dp.length * 100.0
+		msg = "download from %s failed at %s/%s (%.2f%% complete) @ %sps - %s"
+		args = []interface{}{
+			dp.sourceURI, units.HumanSize(downloaded), units.HumanSize(dp.length), percentComplete, units.HumanSize(bytesPerSecond), err,
+		}
+	} else {
+		// length unknown so provide the amount downloaded and the speed
+		msg = "download from %s failed at %s @ %sps - %s"
+		args = []interface{}{
+			dp.sourceURI, units.HumanSize(downloaded), units.HumanSize(bytesPerSecond), err,
+		}
+	}
+	dp.log.Infof(msg, args...)
+	if timePast >= dp.warnTimeout {
+		// see reason in `Report`
+		dp.log.Warnf(msg, args...)
+	}
 }

--- a/internal/pkg/artifact/download/http/downloader.go
+++ b/internal/pkg/artifact/download/http/downloader.go
@@ -245,7 +245,7 @@ func (dp *downloadProgressReporter) Report(ctx context.Context) {
 				downloaded := float64(dp.downloaded.Load())
 				bytesPerSecond := downloaded / float64(timePast/time.Second)
 
-				msg := ""
+				var msg string
 				var args []interface{}
 				if length > 0 {
 					// length of the download is known, so more detail can be provided
@@ -295,7 +295,7 @@ func (dp *downloadProgressReporter) ReportFailed(err error) {
 	timePast := now.Sub(dp.started)
 	downloaded := float64(dp.downloaded.Load())
 	bytesPerSecond := downloaded / float64(timePast/time.Second)
-	msg := ""
+	var msg string
 	var args []interface{}
 	if dp.length > 0 {
 		// length of the download is known, so more detail can be provided

--- a/internal/pkg/artifact/download/http/downloader.go
+++ b/internal/pkg/artifact/download/http/downloader.go
@@ -30,13 +30,13 @@ import (
 const (
 	packagePermissions = 0660
 
-	// Reports the current download progress when percentage of time has passed in the overall interval for the
-	// complete download to complete. 5% is a good default, as the default timeout is 10 minutes and this will have it
-	// log every 30 seconds.
+	// downloadProgressIntervalPercentage defines how often to report the current download progress when percentage
+	// of time has passed in the overall interval for the complete download to complete. 5% is a good default, as
+	// the default timeout is 10 minutes and this will have it log every 30 seconds.
 	downloadProgressIntervalPercentage = 0.05
 
-	// Reports the log messages as a warning once the amount of time passed is this percentage or more of the total
-	// allotted time to download.
+	// warningProgressIntervalPercentage defines how often to log messages as a warning once the amount of time
+	// passed is this percentage or more of the total allotted time to download.
 	warningProgressIntervalPercentage = 0.75
 )
 
@@ -300,13 +300,13 @@ func (dp *downloadProgressReporter) ReportFailed(err error) {
 	if dp.length > 0 {
 		// length of the download is known, so more detail can be provided
 		percentComplete := downloaded / dp.length * 100.0
-		msg = "download from %s failed at %s/%s (%.2f%% complete) @ %sps - %s"
+		msg = "download from %s failed at %s/%s (%.2f%% complete) @ %sps: %s"
 		args = []interface{}{
 			dp.sourceURI, units.HumanSize(downloaded), units.HumanSize(dp.length), percentComplete, units.HumanSize(bytesPerSecond), err,
 		}
 	} else {
 		// length unknown so provide the amount downloaded and the speed
-		msg = "download from %s failed at %s @ %sps - %s"
+		msg = "download from %s failed at %s @ %sps: %s"
 		args = []interface{}{
 			dp.sourceURI, units.HumanSize(downloaded), units.HumanSize(bytesPerSecond), err,
 		}

--- a/internal/pkg/artifact/download/http/downloader_test.go
+++ b/internal/pkg/artifact/download/http/downloader_test.go
@@ -11,9 +11,16 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
+	"sync"
 	"testing"
+	"time"
 
-	"github.com/elastic/elastic-agent/pkg/core/logger"
+	"github.com/docker/go-units"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
 
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
 )
@@ -47,11 +54,149 @@ func TestDownloadBodyError(t *testing.T) {
 		Architecture:    "64",
 	}
 
-	log, _ := logger.New("", false)
+	log := newRecordLogger()
 	testClient := NewDownloaderWithClient(log, config, *client)
 	artifactPath, err := testClient.Download(context.Background(), beatSpec, version)
+	os.Remove(artifactPath)
 	if err == nil {
-		os.Remove(artifactPath)
 		t.Fatal("expected Download to return an error")
 	}
+
+	require.Len(t, log.info, 1, "download error not logged at info level")
+	assert.Equal(t, log.info[0].record, "download from %s failed at %s @ %sps - %s")
+	require.Len(t, log.warn, 1, "download error not logged at warn level")
+	assert.Equal(t, log.warn[0].record, "download from %s failed at %s @ %sps - %s")
+}
+
+func TestDownloadLogProgressWithLength(t *testing.T) {
+	fileSize := 100 * units.MiB
+	chunks := 100
+	chunk := make([]byte, fileSize/chunks)
+	delayBetweenChunks := 10 * time.Millisecond
+	totalTime := time.Duration(chunks) * (delayBetweenChunks + 1*time.Millisecond)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(fileSize))
+		w.WriteHeader(http.StatusOK)
+		for i := 0; i < chunks; i++ {
+			w.Write(chunk)
+			w.(http.Flusher).Flush()
+			<-time.After(delayBetweenChunks)
+		}
+	}))
+	defer srv.Close()
+	client := srv.Client()
+
+	targetDir, err := ioutil.TempDir(os.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := &artifact.Config{
+		SourceURI:       srv.URL,
+		TargetDirectory: targetDir,
+		OperatingSystem: "linux",
+		Architecture:    "64",
+		HTTPTransportSettings: httpcommon.HTTPTransportSettings{
+			Timeout: totalTime,
+		},
+	}
+
+	log := newRecordLogger()
+	testClient := NewDownloaderWithClient(log, config, *client)
+	artifactPath, err := testClient.Download(context.Background(), beatSpec, version)
+	os.Remove(artifactPath)
+	require.NoError(t, err, "Download should not have errored")
+
+	// 2 files are downloaded so 4 log messages are expected in the info level and only the complete is over the warn
+	// window as 2 log messages for warn.
+	require.Len(t, log.info, 4)
+	assert.Equal(t, log.info[0].record, "download progress from %s is %s/%s (%.2f%% complete) @ %sps")
+	assert.Equal(t, log.info[1].record, "download from %s completed in %s @ %sps")
+	assert.Equal(t, log.info[2].record, "download progress from %s is %s/%s (%.2f%% complete) @ %sps")
+	assert.Equal(t, log.info[3].record, "download from %s completed in %s @ %sps")
+	require.Len(t, log.warn, 2)
+	assert.Equal(t, log.warn[0].record, "download from %s completed in %s @ %sps")
+	assert.Equal(t, log.warn[1].record, "download from %s completed in %s @ %sps")
+}
+
+func TestDownloadLogProgressWithoutLength(t *testing.T) {
+	fileSize := 100 * units.MiB
+	chunks := 100
+	chunk := make([]byte, fileSize/chunks)
+	delayBetweenChunks := 10 * time.Millisecond
+	totalTime := time.Duration(chunks) * (delayBetweenChunks + 1*time.Millisecond)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		for i := 0; i < chunks; i++ {
+			w.Write(chunk)
+			w.(http.Flusher).Flush()
+			<-time.After(delayBetweenChunks)
+		}
+	}))
+	defer srv.Close()
+	client := srv.Client()
+
+	targetDir, err := ioutil.TempDir(os.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := &artifact.Config{
+		SourceURI:       srv.URL,
+		TargetDirectory: targetDir,
+		OperatingSystem: "linux",
+		Architecture:    "64",
+		HTTPTransportSettings: httpcommon.HTTPTransportSettings{
+			Timeout: totalTime,
+		},
+	}
+
+	log := newRecordLogger()
+	testClient := NewDownloaderWithClient(log, config, *client)
+	artifactPath, err := testClient.Download(context.Background(), beatSpec, version)
+	os.Remove(artifactPath)
+	require.NoError(t, err, "Download should not have errored")
+
+	// 2 files are downloaded so 4 log messages are expected in the info level and only the complete is over the warn
+	// window as 2 log messages for warn.
+	require.Len(t, log.info, 4)
+	assert.Equal(t, log.info[0].record, "download progress from %s has fetched %s @ %sps")
+	assert.Equal(t, log.info[1].record, "download from %s completed in %s @ %sps")
+	assert.Equal(t, log.info[2].record, "download progress from %s has fetched %s @ %sps")
+	assert.Equal(t, log.info[3].record, "download from %s completed in %s @ %sps")
+	require.Len(t, log.warn, 2)
+	assert.Equal(t, log.warn[0].record, "download from %s completed in %s @ %sps")
+	assert.Equal(t, log.warn[1].record, "download from %s completed in %s @ %sps")
+}
+
+type logMessage struct {
+	record string
+	args   []interface{}
+}
+
+type recordLogger struct {
+	lock sync.RWMutex
+	info []logMessage
+	warn []logMessage
+}
+
+func newRecordLogger() *recordLogger {
+	return &recordLogger{
+		info: make([]logMessage, 0, 10),
+		warn: make([]logMessage, 0, 10),
+	}
+}
+
+func (f *recordLogger) Infof(record string, args ...interface{}) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.info = append(f.info, logMessage{record, args})
+}
+
+func (f *recordLogger) Warnf(record string, args ...interface{}) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.warn = append(f.warn, logMessage{record, args})
 }

--- a/internal/pkg/artifact/download/http/downloader_test.go
+++ b/internal/pkg/artifact/download/http/downloader_test.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
 )
 
@@ -45,7 +47,8 @@ func TestDownloadBodyError(t *testing.T) {
 		Architecture:    "64",
 	}
 
-	testClient := NewDownloaderWithClient(config, *client)
+	log, _ := logger.New("", false)
+	testClient := NewDownloaderWithClient(log, config, *client)
 	artifactPath, err := testClient.Download(context.Background(), beatSpec, version)
 	if err == nil {
 		os.Remove(artifactPath)

--- a/internal/pkg/artifact/download/http/downloader_test.go
+++ b/internal/pkg/artifact/download/http/downloader_test.go
@@ -33,8 +33,10 @@ func TestDownloadBodyError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.(http.Flusher).Flush()
-		conn := r.Context().Value(connKey{}).(net.Conn)
-		conn.Close()
+		conn, ok := r.Context().Value(connKey{}).(net.Conn)
+		if ok {
+			conn.Close()
+		}
 	}))
 	defer srv.Close()
 	client := srv.Client()
@@ -79,7 +81,10 @@ func TestDownloadLogProgressWithLength(t *testing.T) {
 		w.Header().Set("Content-Length", strconv.Itoa(fileSize))
 		w.WriteHeader(http.StatusOK)
 		for i := 0; i < chunks; i++ {
-			w.Write(chunk)
+			_, err := w.Write(chunk)
+			if err != nil {
+				panic(err)
+			}
 			w.(http.Flusher).Flush()
 			<-time.After(delayBetweenChunks)
 		}
@@ -130,7 +135,10 @@ func TestDownloadLogProgressWithoutLength(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		for i := 0; i < chunks; i++ {
-			w.Write(chunk)
+			_, err := w.Write(chunk)
+			if err != nil {
+				panic(err)
+			}
 			w.(http.Flusher).Flush()
 			<-time.After(delayBetweenChunks)
 		}

--- a/internal/pkg/artifact/download/http/downloader_test.go
+++ b/internal/pkg/artifact/download/http/downloader_test.go
@@ -65,9 +65,9 @@ func TestDownloadBodyError(t *testing.T) {
 	}
 
 	require.Len(t, log.info, 1, "download error not logged at info level")
-	assert.Equal(t, log.info[0].record, "download from %s failed at %s @ %sps - %s")
+	assert.Equal(t, log.info[0].record, "download from %s failed at %s @ %sps: %s")
 	require.Len(t, log.warn, 1, "download error not logged at warn level")
-	assert.Equal(t, log.warn[0].record, "download from %s failed at %s @ %sps - %s")
+	assert.Equal(t, log.warn[0].record, "download from %s failed at %s @ %sps: %s")
 }
 
 func TestDownloadLogProgressWithLength(t *testing.T) {

--- a/internal/pkg/artifact/download/http/elastic_test.go
+++ b/internal/pkg/artifact/download/http/elastic_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
@@ -50,6 +52,7 @@ func TestDownload(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	log, _ := logger.New("", false)
 	timeout := 30 * time.Second
 	testCases := getTestCases()
 	elasticClient := getElasticCoClient()
@@ -68,7 +71,7 @@ func TestDownload(t *testing.T) {
 			config.OperatingSystem = testCase.system
 			config.Architecture = testCase.arch
 
-			testClient := NewDownloaderWithClient(config, elasticClient)
+			testClient := NewDownloaderWithClient(log, config, elasticClient)
 			artifactPath, err := testClient.Download(context.Background(), beatSpec, version)
 			if err != nil {
 				t.Fatal(err)
@@ -90,6 +93,7 @@ func TestVerify(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	log, _ := logger.New("", false)
 	timeout := 30 * time.Second
 	testCases := getRandomTestCases()
 	elasticClient := getElasticCoClient()
@@ -108,7 +112,7 @@ func TestVerify(t *testing.T) {
 			config.OperatingSystem = testCase.system
 			config.Architecture = testCase.arch
 
-			testClient := NewDownloaderWithClient(config, elasticClient)
+			testClient := NewDownloaderWithClient(log, config, elasticClient)
 			artifact, err := testClient.Download(context.Background(), beatSpec, version)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/pkg/artifact/download/http/elastic_test.go
+++ b/internal/pkg/artifact/download/http/elastic_test.go
@@ -150,7 +150,7 @@ func getTestCases() []testCase {
 	}
 }
 
-//nolint:gosec,G404
+//nolint:gosec,G404 // this is just for unit tests secure random number is not needed
 func getRandomTestCases() []testCase {
 	tt := getTestCases()
 

--- a/internal/pkg/artifact/download/http/elastic_test.go
+++ b/internal/pkg/artifact/download/http/elastic_test.go
@@ -150,6 +150,7 @@ func getTestCases() []testCase {
 	}
 }
 
+//nolint:gosec,G404
 func getRandomTestCases() []testCase {
 	tt := getTestCases()
 
@@ -189,9 +190,15 @@ func getElasticCoClient() http.Client {
 		content := []byte(packageName)
 		if isShaReq {
 			hash := sha512.Sum512(content)
-			w.Write([]byte(fmt.Sprintf("%x %s", hash, packageName)))
+			_, err := w.Write([]byte(fmt.Sprintf("%x %s", hash, packageName)))
+			if err != nil {
+				panic(err)
+			}
 		} else {
-			w.Write(content)
+			_, err := w.Write(content)
+			if err != nil {
+				panic(err)
+			}
 		}
 	})
 	server := httptest.NewServer(handler)

--- a/internal/pkg/artifact/download/localremote/downloader.go
+++ b/internal/pkg/artifact/download/localremote/downloader.go
@@ -23,7 +23,7 @@ func NewDownloader(log *logger.Logger, config *artifact.Config) (download.Downlo
 
 	// try snapshot repo before official
 	if release.Snapshot() {
-		snapDownloader, err := snapshot.NewDownloader(config, "")
+		snapDownloader, err := snapshot.NewDownloader(log, config, "")
 		if err != nil {
 			log.Error(err)
 		} else {
@@ -31,7 +31,7 @@ func NewDownloader(log *logger.Logger, config *artifact.Config) (download.Downlo
 		}
 	}
 
-	httpDownloader, err := http.NewDownloader(config)
+	httpDownloader, err := http.NewDownloader(log, config)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/artifact/download/snapshot/downloader.go
+++ b/internal/pkg/artifact/download/snapshot/downloader.go
@@ -30,7 +30,7 @@ func NewDownloader(log *logger.Logger, config *artifact.Config, versionOverride 
 func snapshotConfig(config *artifact.Config, versionOverride string) (*artifact.Config, error) {
 	snapshotURI, err := snapshotURI(versionOverride, config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to detect remote snapshot repo, proceeding with configured: %v", err)
+		return nil, fmt.Errorf("failed to detect remote snapshot repo, proceeding with configured: %w", err)
 	}
 
 	return &artifact.Config{
@@ -47,9 +47,7 @@ func snapshotConfig(config *artifact.Config, versionOverride string) (*artifact.
 func snapshotURI(versionOverride string, config *artifact.Config) (string, error) {
 	version := release.Version()
 	if versionOverride != "" {
-		if strings.HasSuffix(versionOverride, "-SNAPSHOT") {
-			versionOverride = strings.TrimSuffix(versionOverride, "-SNAPSHOT")
-		}
+		versionOverride = strings.TrimSuffix(versionOverride, "-SNAPSHOT")
 		version = versionOverride
 	}
 

--- a/internal/pkg/artifact/download/snapshot/downloader.go
+++ b/internal/pkg/artifact/download/snapshot/downloader.go
@@ -14,16 +14,17 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download/http"
 	"github.com/elastic/elastic-agent/internal/pkg/release"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
 // NewDownloader creates a downloader which first checks local directory
 // and then fallbacks to remote if configured.
-func NewDownloader(config *artifact.Config, versionOverride string) (download.Downloader, error) {
+func NewDownloader(log *logger.Logger, config *artifact.Config, versionOverride string) (download.Downloader, error) {
 	cfg, err := snapshotConfig(config, versionOverride)
 	if err != nil {
 		return nil, err
 	}
-	return http.NewDownloader(cfg)
+	return http.NewDownloader(log, cfg)
 }
 
 func snapshotConfig(config *artifact.Config, versionOverride string) (*artifact.Config, error) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds reporting of download progress every 5% interval of the total timeout for an artifact download over HTTP. Sets default timeout of downloading artifacts to 10 minutes.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

There is no observability on the speed/time for downloading of artifacts, mainly an upgrade version for the Elastic Agent. In many cases on a slow network the download can timeout, with no information on why. This PR increases this timeout and provides downloading statistics so its clear how fast it is downloading and how long it is taking.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Provides download speed
- [x] Provides completed amount
- [x] Provides percentage complete
- [x] Increases timeout of download

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Easiest way to test is to compile the package with `SNAPSHOT="true" mage dev:package` then extract the *.tar.gz or *.zip depending on the system your on. Then remove the downloads directory contents, before starting the elastic-agent with a simple `./elastic-agent run`. It will proceed to download the file removed from the downloads directory and it will log the download statistics.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #104 

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

```
{"log.level":"info","@timestamp":"2022-04-13T13:06:09.313-0400","log.origin":{"file.name":"http/downloader.go","file.line":286},"message":"download from https://snapshots.elastic.co/8.3.0-2c8f9574/downloads/beats/metricbeat/metricbeat-8.3.0-SNAPSHOT-darwin-x86_64.tar.gz completed in 6 seconds @ 10.9MBps","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-04-13T13:06:09.523-0400","log.origin":{"file.name":"http/downloader.go","file.line":286},"message":"download from https://snapshots.elastic.co/8.3.0-2c8f9574/downloads/beats/metricbeat/metricbeat-8.3.0-SNAPSHOT-darwin-x86_64.tar.gz.sha512 completed in Less than a second @ +InfYBps","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-04-13T13:06:09.524-0400","log.origin":{"file.name":"operation/operation_fetch.go","file.line":75},"message":"downloaded binary 'metricbeat.8.3.0-SNAPSHOT' into '/Users/blake/Code/elastic/beats/src/github.com/elastic/elastic-agent/build/distributions/elastic-agent-8.3.0-SNAPSHOT-darwin-x86_64/data/elastic-agent-e9557f/downloads/metricbeat-8.3.0-SNAPSHOT-darwin-x86_64.tar.gz' as part of operation 'operation-fetch'","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-04-13T13:06:31.836-0400","log.origin":{"file.name":"log/reporter.go","file.line":40},"message":"2022-04-13T13:06:31-04:00 - message: Application: metricbeat--8.3.0-SNAPSHOT[aa44369b-08c5-4743-8d78-cdea6e224816]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-04-13T13:06:34.570-0400","log.origin":{"file.name":"http/downloader.go","file.line":286},"message":"download from https://snapshots.elastic.co/8.3.0-2c8f9574/downloads/beats/filebeat/filebeat-8.3.0-SNAPSHOT-darwin-x86_64.tar.gz completed in 2 seconds @ 26.99MBps","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-04-13T13:06:34.785-0400","log.origin":{"file.name":"http/downloader.go","file.line":286},"message":"download from https://snapshots.elastic.co/8.3.0-2c8f9574/downloads/beats/filebeat/filebeat-8.3.0-SNAPSHOT-darwin-x86_64.tar.gz.sha512 completed in Less than a second @ +InfYBps","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-04-13T13:06:34.785-0400","log.origin":{"file.name":"operation/operation_fetch.go","file.line":75},"message":"downloaded binary 'filebeat.8.3.0-SNAPSHOT' into '/Users/blake/Code/elastic/beats/src/github.com/elastic/elastic-agent/build/distributions/elastic-agent-8.3.0-SNAPSHOT-darwin-x86_64/data/elastic-agent-e9557f/downloads/filebeat-8.3.0-SNAPSHOT-darwin-x86_64.tar.gz' as part of operation 'operation-fetch'","ecs.version":"1.6.0"}
```
