### PR TITLE
Move mage targets to libraries so the shipper can use them

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,16 @@ issues:
 output:
   sort-results: true
 
+# Let the mage files run printf. As far as I can tell, most of our magefiles use Printf as opposed to starting up a logger, as the logger is a tad heavy and can bring in needless dependencies for a magefile.
+issues:
+  exclude-rules:
+    - path: dev-tools/mage
+      linters:
+        - forbidigo
+    - path: magefile.go
+      linters:
+        - forbidigo
+
 # Uncomment and add a path if needed to exclude
 # skip-dirs:
 #   - some/path

--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -309,6 +309,27 @@ func Extract(sourceFile, destinationDir string) error {
 	}
 }
 
+// Mkdir returns a function that create a directory.
+func Mkdir(dir string) func() error {
+	return func() error {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return fmt.Errorf("failed to create directory: %v, error: %+v", dir, err)
+		}
+		return nil
+	}
+}
+
+// RunGo runs go command and output the feedback to the stdout and the stderr.
+func RunGo(args ...string) error {
+	return sh.RunV(mg.GoCmd(), args...)
+}
+
+// GoGet fetch a remote dependencies.
+func GoGet(link string) error {
+	_, err := sh.Exec(map[string]string{"GO111MODULE": "off"}, os.Stdout, os.Stderr, "go", "get", link)
+	return err
+}
+
 func unzip(sourceFile, destinationDir string) error {
 	r, err := zip.OpenReader(sourceFile)
 	if err != nil {

--- a/dev-tools/mage/target/common/check.go
+++ b/dev-tools/mage/target/common/check.go
@@ -5,7 +5,10 @@
 package common
 
 import (
+	"fmt"
+
 	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
 
 	devtools "github.com/elastic/elastic-agent/dev-tools/mage"
 )
@@ -30,4 +33,29 @@ func Check() {
 // CheckLicenseHeaders checks license headers
 func CheckLicenseHeaders() {
 	mg.Deps(devtools.CheckLicenseHeaders)
+}
+
+// CheckNoChanges runs the linters and checks for changes in git
+func CheckNoChanges() error {
+	fmt.Println(">> fmt - go run")
+	err := sh.RunV("go", "mod", "tidy", "-v")
+	if err != nil {
+		return fmt.Errorf("failed running go mod tidy, please fix the issues reported: %w", err)
+	}
+	fmt.Println(">> fmt - git diff")
+	err = sh.RunV("git", "diff")
+	if err != nil {
+		return fmt.Errorf("failed running git diff, please fix the issues reported: %w", err)
+	}
+	fmt.Println(">> fmt - git update-index")
+	err = sh.RunV("git", "update-index", "--refresh")
+	if err != nil {
+		return fmt.Errorf("failed running git update-index --refresh, please fix the issues reported: %w", err)
+	}
+	fmt.Println(">> fmt - git diff-index")
+	err = sh.RunV("git", "diff-index", "--exit-code", "HEAD", " --")
+	if err != nil {
+		return fmt.Errorf("failed running go mod tidy, please fix the issues reported: %w", err)
+	}
+	return nil
 }

--- a/dev-tools/mage/target/notice/notice.go
+++ b/dev-tools/mage/target/notice/notice.go
@@ -1,0 +1,58 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package notice
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+
+	"github.com/magefile/mage/sh"
+)
+
+// Notice regenerates the NOTICE.txt file.
+func Notice() error {
+	fmt.Println(">> Generating NOTICE")
+	fmt.Println(">> fmt - go mod tidy")
+	err := sh.RunV("go", "mod", "tidy", "-v")
+	if err != nil {
+		return fmt.Errorf("failed running go mod tidy, please fix the issues reported: %w", err)
+	}
+	fmt.Println(">> fmt - go mod download")
+	err = sh.RunV("go", "mod", "download")
+	if err != nil {
+		return fmt.Errorf("failed running go mod download, please fix the issues reported: %w", err)
+	}
+	fmt.Println(">> fmt - go list")
+	str, err := sh.Output("go", "list", "-m", "-json", "all")
+	if err != nil {
+		return fmt.Errorf("failed running go list, please fix the issues reported: %w", err)
+	}
+	fmt.Println(">> fmt - go run")
+	cmd := exec.Command("go", "run", "go.elastic.co/go-licence-detector", "-includeIndirect", "-rules", "dev-tools/notice/rules.json", "-overrides", "dev-tools/notice/overrides.json", "-noticeTemplate", "dev-tools/notice/NOTICE.txt.tmpl",
+		"-noticeOut", "NOTICE.txt")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("failed running go run, please fix the issues reported: %w", err)
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer stdin.Close()
+		defer wg.Done()
+		if _, err := io.WriteString(stdin, str); err != nil {
+			fmt.Println(err)
+		}
+	}()
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed combined output, please fix the issues reported: %w - %s", err, out)
+	}
+	wg.Wait()
+
+	return nil
+}

--- a/magefile.go
+++ b/magefile.go
@@ -97,12 +97,12 @@ func (Prepare) Env() {
 	mg.Deps(devtools.Mkdir("build"), Build.GenerateConfig)
 	err := devtools.RunGo("version")
 	if err != nil {
-		fmt.Printf("Error fetching version: %s\n", err) //nolint:forbidigo // we may not want to import the logging libraries here
+		fmt.Printf("Error fetching version: %s\n", err)
 		return
 	}
 	err = devtools.RunGo("env")
 	if err != nil {
-		fmt.Printf("Error fetching env: %s\n", err) //nolint:forbidigo // we may not want to import the logging libraries here
+		fmt.Printf("Error fetching env: %s\n", err)
 		return
 	}
 }
@@ -335,7 +335,7 @@ func AssembleDarwinUniversal() error { //nolint:deadcode // used by mage
 // Use VERSION_QUALIFIER to control the version qualifier.
 func Package() {
 	start := time.Now()
-	defer func() { fmt.Println("package ran for", time.Since(start)) }() //nolint:forbidigo // I don't think we want to import the logger here
+	defer func() { fmt.Println("package ran for", time.Since(start)) }()
 
 	platformPackages := []struct {
 		platform string
@@ -373,7 +373,7 @@ func requiredPackagesPresent(basePath, beat, version string, requiredPackages []
 		path := filepath.Join(basePath, "build", "distributions", packageName)
 
 		if _, err := os.Stat(path); err != nil {
-			fmt.Printf("Package '%s' does not exist on path: %s\n", packageName, path) //nolint:forbidigo // I don't think we want to import the logger here
+			fmt.Printf("Package '%s' does not exist on path: %s\n", packageName, path)
 			return false
 		}
 	}
@@ -417,7 +417,7 @@ func BuildSpec() error {
 	in := filepath.Join("internal", "spec", "*.yml")
 	out := filepath.Join("internal", "pkg", "agent", "program", "supported.go")
 
-	fmt.Printf(">> Buildspec from %s to %s\n", in, out) //nolint:forbidigo // I don't think we want to import the logger here
+	fmt.Printf(">> Buildspec from %s to %s\n", in, out)
 	return devtools.RunGo("run", goF, "--in", in, "--out", out)
 }
 
@@ -427,7 +427,7 @@ func BuildPGP() error {
 	in := "GPG-KEY-elasticsearch"
 	out := filepath.Join("internal", "pkg", "release", "pgp.go")
 
-	fmt.Printf(">> BuildPGP from %s to %s\n", in, out) //nolint:forbidigo // I don't think we want to import the logger here
+	fmt.Printf(">> BuildPGP from %s to %s\n", in, out)
 	return devtools.RunGo("run", goF, "--in", in, "--out", out)
 }
 
@@ -474,7 +474,7 @@ func BuildFleetCfg() error {
 	in := filepath.Join("_meta", "elastic-agent.fleet.yml")
 	out := filepath.Join("internal", "pkg", "agent", "application", "configuration_embed.go")
 
-	fmt.Printf(">> BuildFleetCfg %s to %s\n", in, out) //nolint:forbidigo // I don't think we want to import the logger here
+	fmt.Printf(">> BuildFleetCfg %s to %s\n", in, out)
 	return devtools.RunGo("run", goF, "--in", in, "--out", out)
 }
 
@@ -524,7 +524,7 @@ func runAgent(env map[string]string) error {
 
 		// build docker image
 		if err := dockerBuild(tag); err != nil {
-			fmt.Println(">> Building docker images again (after 10 seconds)") //nolint:forbidigo // I don't think we want to import the logger here
+			fmt.Println(">> Building docker images again (after 10 seconds)")
 			// This sleep is to avoid hitting the docker build issues when resources are not available.
 			time.Sleep(10 * time.Millisecond)
 			if err := dockerBuild(tag); err != nil {
@@ -659,7 +659,7 @@ func fetchBinaryFromArtifactsAPI(ctx context.Context, packageName, artifact, ver
 		false,
 		downloadPath,
 		true)
-	fmt.Println("downloaded binaries on location:", location) //nolint:forbidigo //no logger here
+	fmt.Println("downloaded binaries on location:", location)
 
 	return err
 }


### PR DESCRIPTION
## What does this PR do?

This moves a handful of functions and mage targets in the main `magefile.go` to helper libs in `dev-tools` so we can import them into the shipper.

This also fixes the `notice` target, which literally refused to run locally for me.

## Why is it important?

We need some of these targets in the shipper. 

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

