### PR TITLE
Use local `github.com/elastic/elastic-agent/internal/pkg/agent/cmd/proc` package instead of the one from libbeat

### DIFF
--- a/internal/pkg/core/process/process.go
+++ b/internal/pkg/core/process/process.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/elastic/beats/v7/x-pack/libbeat/common/proc"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/cmd/proc"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )

--- a/internal/pkg/core/process/process.go
+++ b/internal/pkg/core/process/process.go
@@ -37,7 +37,7 @@ type Option func(c *exec.Cmd)
 // - process id
 // - error
 func Start(logger *logger.Logger, path string, config *Config, uid, gid int, args []string, opts ...Option) (proc *Info, err error) {
-	return StartContext(nil, logger, path, config, uid, gid, args, opts...)
+	return StartContext(nil, logger, path, config, uid, gid, args, opts...) //nolint:staticcheck // calls a different function if no ctx
 }
 
 // StartContext starts a new process with context.


### PR DESCRIPTION
## What does this PR do?

The package `github.com/elastic/elastic-agent/internal/pkg/agent/cmd/proc` was moved to the Agent repo in https://github.com/elastic/elastic-agent/pull/258. In this PR I switch to the new local package, instead of using the one in libbeat.

## Why is it important?

One more step away from libbeat.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
