### PR TITLE
[automation] update elastic stack version for testing 8.2.0-000e1c18

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-a7e9513d-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-000e1c18-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.2.0-a7e9513d-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.2.0-000e1c18-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Wed, 20 Apr 2022 12:14:52 GMT, release_branch:8.2, prefix:, end_time:Wed, 20 Apr 2022 17:25:38 GMT, manifest_version:2.0.0, version:8.2.0-SNAPSHOT, branch:8.2, build_id:8.2.0-000e1c18, build_duration_seconds:18646]