### PR TITLE
[Heartbeat] Fix umask on docker entrypoint

### DIFF
--- a/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Update umask to retain group write permissions on runtime directories: $root/tmp/default, $root/logs/default and $root/run/default
+umask 0007
+
 set -eo pipefail
 
 # For information on the possible environment variables that can be passed into the container. Run the following


### PR DESCRIPTION
## What does this PR do?

These are `elastic-agent`  changes related to elastic/beats#30869.

We need to change the default `umask 022` to `007` in order to retain group write permissions when `setuid` is executed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Refer to elastic/beats#30869 instructions on how to test locally.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates to elastic/beats#30171.

