### PR TITLE
Initialize logger directory to allow group access

### DIFF
--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -806,6 +806,13 @@ func setPaths(statePath, configPath, logsPath string, writePaths bool) error {
 			return fmt.Errorf("preparing LOGS_PATH(%s) failed: %w", logsPath, err)
 		}
 	}
+
+	// ensure that the internal logger directory exists
+	loggerPath := filepath.Join(paths.Home(), logger.DefaultLogDirectory)
+	if err := os.MkdirAll(loggerPath, 0755); err != nil {
+		return fmt.Errorf("preparing internal log path(%s) failed: %w", loggerPath, err)
+	}
+
 	// persist the paths so other commands in the container will use the correct paths
 	if writePaths {
 		if err := writeContainerPaths(originalTop, statePath, configPath, logsPath); err != nil {

--- a/pkg/core/logger/logger.go
+++ b/pkg/core/logger/logger.go
@@ -29,6 +29,9 @@ const iso8601Format = "2006-01-02T15:04:05.000Z0700"
 // DefaultLogLevel used in agent and its processes.
 const DefaultLogLevel = logp.InfoLevel
 
+// DefaultLogDirectory used in agent and its processes.
+const DefaultLogDirectory = "logs"
+
 // Logger alias ecslog.Logger with Logger.
 type Logger = logp.Logger
 
@@ -114,7 +117,7 @@ func makeInternalFileOutput(cfg *Config) (zapcore.Core, error) {
 	// defaultCfg is used to set the defaults for the file rotation of the internal logging
 	// these settings cannot be changed by a user configuration
 	defaultCfg := logp.DefaultConfig(logp.DefaultEnvironment)
-	filename := filepath.Join(paths.Home(), "logs", cfg.Beat)
+	filename := filepath.Join(paths.Home(), DefaultLogDirectory, cfg.Beat)
 
 	rotator, err := file.NewFileRotator(filename,
 		file.MaxSizeBytes(defaultCfg.Files.MaxSize),


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Additional changes required to close [https://github.com/elastic/beats/issues/30171](https://github.com/elastic/beats/pull/30869).

When started inside the container, elastic-agent will initialize the shared logs directory at `state/data/logs` with the [default directory mask](https://github.com/elastic/elastic-agent-libs/blob/cb28916182b8128fa73088caa965f77ced3f163b/file/rotator.go#L370). Since HB is running `setuid()`, it needs group access to be able to create log files inside `state/data/logs/default`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- Build beats and elastic-agent locally:
````
x-pack/elastic-agent $  env PLATFORMS="+all linux/amd64" mage dev:package
...
````

- Run the container locally as `root`:
```bash
docker run -u root --rm --name agent --env FLEET_ENROLL=1 --env FLEET_URL=<fleet url> --env FLEET_ENROLLMENT_TOKEN=<token> -it docker.elastic.co/beats/elastic-agent:8.3.0
````

- Attach to the container separately and verify that required directories have group write permissions:
````bash
root@b7a36bca24c8:/usr/share/elastic-agent# ls -al state/data/
...
drwxr-x--- 3 root root  4096 May 16 19:21 logs
````

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates to elastic/beats#30171

