### PR TITLE
Fix disable optimizations and inlining for debug

### DIFF
--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -53,7 +53,7 @@ func DefaultBuildArgs() BuildArgs {
 
 	if DevBuild {
 		// Disable optimizations (-N) and inlining (-l) for debugging.
-		args.ExtraFlags = append(args.ExtraFlags, `-gcflags`, `"all=-N -l"`)
+		args.ExtraFlags = append(args.ExtraFlags, `-gcflags=all=-N -l`)
 	} else {
 		// Strip all debug symbols from binary (does not affect Go stack traces).
 		args.LDFlags = append(args.LDFlags, "-s")


### PR DESCRIPTION
## What does this PR do?

Fix hot the `gcflags` to disable inlining and optimizations are passed to mage.sh and after the go tool chain.

## Why is it important?

Currently even compiling in dev mode (`DEV=true`) inlining and optimizations are enabled, therefore adding breakpoints when debugging ins't possible in several places where it should.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

 - compile with `DEV=true`
    - `DEV=true SNAPSHOT=true EXTERNAL=true PLATFORMS="linux/amd64" PACKAGES="tar.gz" mage -v build`
 - check the `objdump --dwarf build/elastic-agent | grep -A 7 'DW_TAG_compile_unit' | grep 'DW_AT_name\|DW_AT_producer' | grep -C 2 'github.com/elastic/elastic-agent/internal/pkg/'`

if the no inlining, no optimization was applied, you should see entries like:
```text
    <69178e>   DW_AT_name        : github.com/elastic/elastic-agent/internal/pkg/agent/storage
    <6917dd>   DW_AT_producer    : Go cmd/compile go1.18.1; -N -l -shared regabi
```

if they weren't applied, they'll look like
```text
    <6602a7>   DW_AT_name        : github.com/elastic/elastic-agent/internal/pkg/agent/storage
    <6602f6>   DW_AT_producer    : Go cmd/compile go1.18.1; -shared regabi
```

## Use cases

This is required to be able to add breakpoints when debugging in parts of the code that would be optimized or inlined by the compiler. 

