### PR TITLE
Add a Vagrant box for development

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -129,4 +129,43 @@ Vagrant.configure("2") do |config|
     end
   end
 
+    config.vm.define "dev" do |nodeconfig|
+      nodeconfig.vm.box = "ubuntu/impish64"
+
+      nodeconfig.vm.hostname = "elastic-agent-dev"
+
+      nodeconfig.vm.network "private_network",
+        hostname: true,
+        ip: "192.168.56.42" # only 192.168.56.0/21 range allowed: https://www.virtualbox.org/manual/ch06.html#network_hostonly
+      nodeconfig.vm.network "forwarded_port",
+        guest: 4242,
+        host: 4242,
+        id: "delve"
+
+      nodeconfig.vm.provider "virtualbox" do |vb|
+        # Display the VirtualBox GUI when booting the machine
+        vb.gui = false
+        vb.customize ["modifyvm", :id, "--vram", "128"]
+        # Customize the amount of memory on the VM:
+        vb.memory = "2048"
+      end
+
+      nodeconfig.vm.provision "shell", inline: <<-SHELL
+         apt-get update
+         apt-get install -y \
+          build-essential \
+          curl \
+          delve \
+          make \
+          unzip
+          vim \
+          wget
+         curl -sL -o /tmp/go#{GO_VERSION}.linux-amd64.tar.gz https://go.dev/dl/go#{GO_VERSION}.linux-amd64.tar.gz
+         tar -C /usr/local -xzf /tmp/go#{GO_VERSION}.linux-amd64.tar.gz
+         echo "alias ll='ls -la'" > /etc/profile.d/ll.sh
+         echo 'export PATH=$PATH:/usr/local/go/bin' > /etc/profile.d/go.sh
+         echo 'export PATH=$PATH:$(go env GOPATH)/bin' >> /etc/profile.d/go.sh
+      SHELL
+    end
+
 end


### PR DESCRIPTION
## What does this PR do?

Add a Vagrant box for development

## Why is it important?

The Vagrant file does not define a box intended for development, and having such box is quite useful.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally
If you have Vagrant and VirtualBox, run: 
```sh
vagrant up dev
vagrant ssh dev
```
You should be on a ssh session inside the Vagrant box with:
 - Go in the same version as the Agent is using
 - delve installed
 - host port `4242` forwarded to the `4242` port on the Vagrant box
 - a `ll` shell alias

## Related issues

N/A

## Use cases

Developing, testing and debugging the Elastic Agent on a Vagrant box
