### PR TITLE
[automation] update elastic stack version for testing 8.3.0-bf0ad929

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.3.0-3a5a0cd2-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.3.0-bf0ad929-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.3.0-3a5a0cd2-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.3.0-bf0ad929-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Mon, 23 May 2022 21:11:48 GMT, release_branch:master, prefix:, end_time:Tue, 24 May 2022 01:53:25 GMT, manifest_version:2.1.0, version:8.3.0-SNAPSHOT, branch:master, build_id:8.3.0-bf0ad929, build_duration_seconds:16897]