### PR TITLE
Update k8s testing versions to latest ones

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -219,7 +219,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_VERSION'
-            values "v1.23.0", "v1.22.0", "v1.21.1", "v1.20.7", "v1.19.11", "v1.18.19"
+            values "v1.24.0, v1.23.6, v1.22.9, v1.21.12"
           }
         }
         stages {
@@ -227,7 +227,7 @@ pipeline {
             steps {
               deleteDir()
               unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
-              runK8s(k8sVersion: K8S_VERSION, kindVersion: 'v0.11.1', context: "K8s-${K8S_VERSION}")
+              runK8s(k8sVersion: K8S_VERSION, kindVersion: 'v0.14.0', context: "K8s-${K8S_VERSION}")
             }
             post {
               always {


### PR DESCRIPTION
## What does this PR do?

Adds the new version of `v1.24.0` in the list of the supported/tested versions.

Part of https://github.com/elastic/observability-dev/issues/2178.