### PR TITLE
[v2] Add component spec command to validate component specifications

### DIFF
--- a/internal/pkg/agent/cmd/common.go
+++ b/internal/pkg/agent/cmd/common.go
@@ -67,6 +67,7 @@ func NewCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Command {
 	cmd.AddCommand(newContainerCommand(args, streams))
 	cmd.AddCommand(newStatusCommand(args, streams))
 	cmd.AddCommand(newDiagnosticsCommand(args, streams))
+	cmd.AddCommand(newComponentCommandWithArgs(args, streams))
 
 	// windows special hidden sub-command (only added on windows)
 	reexec := newReExecWindowsCommand(args, streams)

--- a/internal/pkg/agent/cmd/component.go
+++ b/internal/pkg/agent/cmd/component.go
@@ -1,0 +1,23 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/elastic-agent/internal/pkg/cli"
+)
+
+func newComponentCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "component <subcommand>",
+		Short: "Tools to work on components",
+		Long:  "Tools for viewing current component information and developing new components for Elastic Agent",
+	}
+
+	cmd.AddCommand(newComponentSpecCommandWithArgs(args, streams))
+
+	return cmd
+}

--- a/internal/pkg/agent/cmd/component_spec.go
+++ b/internal/pkg/agent/cmd/component_spec.go
@@ -1,0 +1,39 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/elastic-agent/pkg/component"
+
+	"github.com/elastic/elastic-agent/internal/pkg/cli"
+)
+
+func newComponentSpecCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "spec [file]",
+		Short: "Validates a component specification",
+		Long:  "Validates a component specification that instructs the Elastic Agent how it should be ran.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			data, err := ioutil.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			_, err = component.LoadSpec(data)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(streams.Out, "Component specification is valid")
+			return nil
+		},
+	}
+
+	return cmd
+}


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds `elastic-agent component spec <file>` command that validates the provided file is a validate v2 component specification file. 

Idea here is that other commands for components can be placed under `component`. I am thinking that `view` can be added that prints all the components for the current Elastic Agent and each of their inputs that it can run. A `trust` command that can generate the trust unsigned.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Allows component developers to easily validate that their written component specification is valid.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
