### PR TITLE
Set hostPID=true for managed agent in k8s

### DIFF
--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -19,6 +19,7 @@ spec:
           effect: NoSchedule
       serviceAccountName: elastic-agent
       hostNetwork: true
+      hostPID: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: elastic-agent

--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -19,6 +19,8 @@ spec:
           effect: NoSchedule
       serviceAccountName: elastic-agent
       hostNetwork: true
+      # Sharing the host process ID namespace gives visibility of all processes running on the same host.
+      # This enables the Elastic Security integration to observe all process exec events on the host.
       hostPID: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -19,6 +19,7 @@ spec:
           effect: NoSchedule
       serviceAccountName: elastic-agent
       hostNetwork: true
+      hostPID: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: elastic-agent

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -19,6 +19,8 @@ spec:
           effect: NoSchedule
       serviceAccountName: elastic-agent
       hostNetwork: true
+      # Sharing the host process ID namespace gives visibility of all processes running on the same host.
+      # This enables the Elastic Security integration to observe all process exec events on the host.
       hostPID: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:


### PR DESCRIPTION
## What does this PR do?

Set hostPID to true in the yaml for managed Agent in kubernetes. hostPID is a pod-wide policy that makes it so all containers in that pod share the host PID namespace.

## Why is it important?

This change enables containers in an elastic-agent pod to have visibility of other processes in the node where that pod is running, enabling integrations with capabilities that involve observing and/or affecting other processes (e.g., killing a process running).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #459 .