### PR TITLE
Config encryption: Fix the vault possible race conditions, harden the code for concurrent access

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -5236,6 +5236,43 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 --------------------------------------------------------------------------------
+Dependency : golang.org/x/sync
+Version: v0.0.0-20210220032951-036812b2e83c
+Licence type (autodetected): BSD-3-Clause
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/LICENSE:
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+--------------------------------------------------------------------------------
 Dependency : golang.org/x/sys
 Version: v0.0.0-20220405052023-b1e9470b6e64
 Licence type (autodetected): BSD-3-Clause
@@ -15222,43 +15259,6 @@ Licence type (autodetected): BSD-3-Clause
 --------------------------------------------------------------------------------
 
 Contents of probable licence file $GOMODCACHE/golang.org/x/oauth2@v0.0.0-20211104180415-d3ed0bb246c8/LICENSE:
-
-Copyright (c) 2009 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
---------------------------------------------------------------------------------
-Dependency : golang.org/x/sync
-Version: v0.0.0-20210220032951-036812b2e83c
-Licence type (autodetected): BSD-3-Clause
---------------------------------------------------------------------------------
-
-Contents of probable licence file $GOMODCACHE/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/LICENSE:
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	go.uber.org/zap v1.21.0
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220405052023-b1e9470b6e64
 	golang.org/x/tools v0.1.9
 	google.golang.org/grpc v1.42.0
@@ -122,7 +123,6 @@ require (
 	golang.org/x/mod v0.5.1 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect

--- a/internal/pkg/agent/application/secret/secret.go
+++ b/internal/pkg/agent/application/secret/secret.go
@@ -7,6 +7,7 @@ package secret
 import (
 	"encoding/json"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
@@ -14,6 +15,9 @@ import (
 )
 
 const agentSecretKey = "secret"
+
+// mutex for secret create calls
+var mxCreate sync.Mutex
 
 // Secret is the structure that is JSON serialized and stored
 type Secret struct {
@@ -51,6 +55,10 @@ func Create(key string, opts ...OptionFunc) error {
 		return err
 	}
 	defer v.Close()
+
+	// Thread-safe key creation
+	mxCreate.Lock()
+	defer mxCreate.Unlock()
 
 	// Check if the key exists
 	exists, err := v.Exists(key)

--- a/internal/pkg/agent/storage/encrypted_disk_storage_windows_linux_test.go
+++ b/internal/pkg/agent/storage/encrypted_disk_storage_windows_linux_test.go
@@ -16,8 +16,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/secret"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/secret"
 )
 
 const (

--- a/internal/pkg/agent/vault/seed.go
+++ b/internal/pkg/agent/vault/seed.go
@@ -12,12 +12,22 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sync"
 )
 
-const seedFile = ".seed"
+const (
+	seedFile = ".seed"
+)
+
+var (
+	mxSeed sync.Mutex
+)
 
 func getSeed(path string) ([]byte, error) {
 	fp := filepath.Join(path, seedFile)
+
+	mxSeed.Lock()
+	defer mxSeed.Unlock()
 
 	b, err := ioutil.ReadFile(fp)
 	if err != nil {

--- a/internal/pkg/agent/vault/seed_test.go
+++ b/internal/pkg/agent/vault/seed_test.go
@@ -8,15 +8,18 @@
 package vault
 
 import (
+	"context"
+	"encoding/hex"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/errgroup"
 )
 
 func TestGetSeed(t *testing.T) {
-
 	dir := t.TempDir()
 
 	fp := filepath.Join(dir, seedFile)
@@ -32,4 +35,42 @@ func TestGetSeed(t *testing.T) {
 	if diff != "" {
 		t.Error(diff)
 	}
+}
+
+func TestGetSeedRace(t *testing.T) {
+	var err error
+
+	dir := t.TempDir()
+
+	g, _ := errgroup.WithContext(context.Background())
+
+	const count = 10
+	res := make([][]byte, count)
+	var mx sync.Mutex
+
+	for i := 0; i < count; i++ {
+		g.Go(func(idx int) func() error {
+			return func() error {
+				seed, err := getSeed(dir)
+				mx.Lock()
+				res[idx] = seed
+				mx.Unlock()
+				return err
+			}
+		}(i))
+	}
+
+	err = g.Wait()
+	assert.NoError(t, err)
+
+	set := make(map[string]struct{})
+
+	for _, item := range res {
+		set[hex.EncodeToString(item)] = struct{}{}
+	}
+
+	if len(set) > 1 {
+		t.Fatalf("more than one seeds were created: %#v\n", set)
+	}
+
 }

--- a/internal/pkg/agent/vault/vault_darwin.go
+++ b/internal/pkg/agent/vault/vault_darwin.go
@@ -25,6 +25,7 @@ extern char* GetOSStatusMessage(OSStatus status);
 import "C"
 import (
 	"fmt"
+	"sync"
 	"unsafe"
 )
 
@@ -32,6 +33,7 @@ import (
 type Vault struct {
 	name     string
 	keychain C.SecKeychainRef
+	mx       sync.Mutex
 }
 
 // New initializes the vault store
@@ -50,6 +52,9 @@ func New(name string) (*Vault, error) {
 
 // Close closes the vault store
 func (v *Vault) Close() error {
+	v.mx.Lock()
+	defer v.mx.Unlock()
+
 	if v.keychain != 0 {
 		C.CFRelease(C.CFTypeRef(v.keychain))
 		v.keychain = 0
@@ -59,6 +64,9 @@ func (v *Vault) Close() error {
 
 // Set sets the key in the vault store
 func (v *Vault) Set(key string, data []byte) error {
+	v.mx.Lock()
+	defer v.mx.Unlock()
+
 	cname := C.CString(v.name)
 	defer C.free(unsafe.Pointer(cname))
 
@@ -78,6 +86,9 @@ func (v *Vault) Get(key string) ([]byte, error) {
 		len  C.size_t
 	)
 
+	v.mx.Lock()
+	defer v.mx.Unlock()
+
 	cname := C.CString(v.name)
 	defer C.free(unsafe.Pointer(cname))
 
@@ -95,6 +106,8 @@ func (v *Vault) Get(key string) ([]byte, error) {
 
 // Exists checks if the key exists
 func (v *Vault) Exists(key string) (bool, error) {
+	v.mx.Lock()
+	defer v.mx.Unlock()
 
 	cname := C.CString(v.name)
 	defer C.free(unsafe.Pointer(cname))
@@ -115,6 +128,9 @@ func (v *Vault) Exists(key string) (bool, error) {
 
 // Remove will remove a key from the keychain.
 func (v *Vault) Remove(key string) error {
+	v.mx.Lock()
+	defer v.mx.Unlock()
+
 	cname := C.CString(v.name)
 	defer C.free(unsafe.Pointer(cname))
 

--- a/internal/pkg/agent/vault/vault_key.go
+++ b/internal/pkg/agent/vault/vault_key.go
@@ -1,0 +1,21 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build linux || windows
+// +build linux windows
+
+package vault
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// fileNameFromKey returns the filename as a hash of the vault seed combined with the key
+// this ties the key with the vault seed eliminating the change of attempting
+// to decrypt the key for the wrong vault seed value.
+func fileNameFromKey(seed []byte, key string) string {
+	hash := sha256.Sum256(append(seed, []byte(key)...))
+	return hex.EncodeToString(hash[:])
+}

--- a/internal/pkg/agent/vault/vault_linux.go
+++ b/internal/pkg/agent/vault/vault_linux.go
@@ -10,7 +10,6 @@ package vault
 import (
 	"crypto/rand"
 	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"io/fs"
 	"io/ioutil"
@@ -134,10 +133,5 @@ func deriveKey(pw []byte, salt []byte) ([]byte, []byte, error) {
 }
 
 func (v *Vault) filepathFromKey(key string) string {
-	return filepath.Join(v.path, fileNameFromKey(key))
-}
-
-func fileNameFromKey(key string) string {
-	hash := sha256.Sum256([]byte(key))
-	return hex.EncodeToString(hash[:])
+	return filepath.Join(v.path, fileNameFromKey(v.key, key))
 }

--- a/internal/pkg/agent/vault/vault_test.go
+++ b/internal/pkg/agent/vault/vault_test.go
@@ -8,6 +8,9 @@
 package vault
 
 import (
+	"errors"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"testing"
@@ -20,8 +23,55 @@ func getTestVaultPath(t *testing.T) string {
 	return filepath.Join(dir, "vault")
 }
 
-func TestVault(t *testing.T) {
+func TestVaultRekey(t *testing.T) {
+	const key = "foo"
 
+	vaultPath := getTestVaultPath(t)
+	v, err := New(vaultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer v.Close()
+
+	err = v.Set(key, []byte("bar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read seed file value
+	seedPath := filepath.Join(vaultPath, ".seed")
+	seedBytes, err := ioutil.ReadFile(seedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diff := cmp.Diff(int(AES256), len(seedBytes))
+	if diff != "" {
+		t.Fatal(diff)
+	}
+
+	// Remove the .seed file.
+	// This will cause the vault seed to be reinitialized for the new vault instance
+	err = os.Remove(seedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The vault with the new seed
+	v2, err := New(vaultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer v2.Close()
+
+	// The key should be not found
+	_, err = v2.Get(key)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatal(err)
+	}
+}
+
+func TestVault(t *testing.T) {
 	vaultPath := getTestVaultPath(t)
 
 	v, err := New(vaultPath)

--- a/internal/pkg/agent/vault/vault_windows.go
+++ b/internal/pkg/agent/vault/vault_windows.go
@@ -8,8 +8,6 @@
 package vault
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"io/fs"
 	"io/ioutil"
@@ -102,12 +100,7 @@ func (v *Vault) Remove(key string) error {
 }
 
 func (v *Vault) filepathFromKey(key string) string {
-	return filepath.Join(v.path, fileNameFromKey(key))
-}
-
-func fileNameFromKey(key string) string {
-	hash := sha256.Sum256([]byte(key))
-	return hex.EncodeToString(hash[:])
+	return filepath.Join(v.path, fileNameFromKey(v.entropy, key))
 }
 
 func systemAdministratorsOnly(path string, inherit bool) error {

--- a/internal/pkg/core/plugin/process/stdlogger.go
+++ b/internal/pkg/core/plugin/process/stdlogger.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package process
 
 import (

--- a/internal/pkg/core/plugin/process/stdlogger_test.go
+++ b/internal/pkg/core/plugin/process/stdlogger_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package process
 
 import (

--- a/pkg/core/logger/testing.go
+++ b/pkg/core/logger/testing.go
@@ -1,10 +1,15 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package logger
 
 import (
-	"github.com/elastic/elastic-agent-libs/logp"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 // NewTesting creates a testing logger that buffers the logs in memory and


### PR DESCRIPTION
## What does this PR do?

* Made the vault seed creation thread-safe
* Made the agent secret creation thread-safe
* Updated the calculation for the key file name, before it was hash(key), now it's a hash(seed+key).

## Why is it important?

Improves the implementation of the vault and the agent secret.
Should address the intermittent issue that popped up during E2E tests. 
https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/e2e-tests/pipelines/e2e-testing-mbp/pipelines/PR-2621/runs/1/nodes/701/steps/5681/log/?start=0

I could not reproduce the issue, but the looking at the implementation found couple of places where race condition was possible.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

