### PR TITLE
Add mount of /etc/machine-id for managed Agent in k8s

### DIFF
--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -85,6 +85,9 @@ spec:
             - name: etcsysmd
               mountPath: /hostfs/etc/systemd
               readOnly: true
+            - name: etc-mid
+              mountPath: /etc/machine-id
+              readOnly: true
       volumes:
         - name: proc
           hostPath:
@@ -113,6 +116,10 @@ spec:
         - name: etcsysmd
           hostPath:
             path: /etc/systemd
+        - name: etc-mid
+          hostPath:
+            path: /etc/machine-id
+            type: File
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -85,6 +85,9 @@ spec:
             - name: etcsysmd
               mountPath: /hostfs/etc/systemd
               readOnly: true
+            - name: etc-mid
+              mountPath: /etc/machine-id
+              readOnly: true
       volumes:
         - name: proc
           hostPath:
@@ -113,3 +116,7 @@ spec:
         - name: etcsysmd
           hostPath:
             path: /etc/systemd
+        - name: etc-mid
+          hostPath:
+            path: /etc/machine-id
+            type: File


### PR DESCRIPTION
## What does this PR do?

Mount the host's /etc/machine-id into the Elastic Agent container.

## Why is it important?

To determine host ID, Agent needs the content of /etc/machine-id (see https://github.com/elastic/go-sysinfo/blob/main/providers/linux/machineid.go#L32).

Currently, the file is present in the container, but empty, which results in Agent using the value "" when determining the host ID, and sending an empty host ID to endpoint. That makes the policy status unhealthy because Endpoint requires a valid host ID.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #512 .
