### PR TITLE
[automation] update elastic stack version for testing 8.2.3-4b95b897

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.1-f86dca4c-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.3-4b95b897-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.2.1-f86dca4c-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.2.3-4b95b897-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Sun, 12 Jun 2022 17:15:28 GMT, release_branch:8.2, prefix:, end_time:Sun, 12 Jun 2022 21:10:17 GMT, manifest_version:2.1.0, version:8.2.3-SNAPSHOT, branch:8.2, build_id:8.2.3-4b95b897, build_duration_seconds:14089]