### PR TITLE
Add filemod times to contents of diagnostics collect command

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -102,6 +102,7 @@
 - Update API calls that the agent makes to Kibana when running the container command. {pull}253[253]
 - diagnostics collect log names are fixed on Windows machines, command will ignore failures. AgentID is included in diagnostics(and diagnostics collect) output. {issue}81[81] {issue}92[92] {issue}190[190] {pull}262[262]
 - Collects stdout and stderr of applications run as a process and logs them. {issue}[88]
+- diagnostics collect file mod times are set. {pull}570[570]
 
 ==== New features
 

--- a/internal/pkg/agent/cmd/diagnostics.go
+++ b/internal/pkg/agent/cmd/diagnostics.go
@@ -454,6 +454,7 @@ func gatherConfig() (AgentConfig, error) {
 // The passed DiagnosticsInfo and AgentConfig data is written in the specified output format.
 // Any local log files are collected and copied into the archive.
 func createZip(fileName, outputFormat string, diag DiagnosticsInfo, cfg AgentConfig, pprof map[string][]client.ProcPProf, metrics *proto.ProcMetricsResponse, errs []error) error {
+	ts := time.Now().UTC()
 	f, err := os.Create(fileName)
 	if err != nil {
 		return err
@@ -461,7 +462,11 @@ func createZip(fileName, outputFormat string, diag DiagnosticsInfo, cfg AgentCon
 	zw := zip.NewWriter(f)
 
 	if len(errs) > 0 {
-		zf, err := zw.Create("errors.txt")
+		zf, err := zw.CreateHeader(&zip.FileHeader{
+			Name:     "errors.txt",
+			Method:   zip.Deflate,
+			Modified: ts,
+		})
 		if err != nil {
 			return closeHandlers(err, zw, f)
 		}
@@ -470,12 +475,20 @@ func createZip(fileName, outputFormat string, diag DiagnosticsInfo, cfg AgentCon
 		}
 	}
 
-	_, err = zw.Create("meta/")
+	_, err = zw.CreateHeader(&zip.FileHeader{
+		Name:     "meta/",
+		Method:   zip.Deflate,
+		Modified: ts,
+	})
 	if err != nil {
 		return closeHandlers(err, zw, f)
 	}
 
-	zf, err := zw.Create("meta/elastic-agent-version." + outputFormat)
+	zf, err := zw.CreateHeader(&zip.FileHeader{
+		Name:     "meta/elastic-agent-version" + outputFormat,
+		Method:   zip.Deflate,
+		Modified: ts,
+	})
 	if err != nil {
 		return closeHandlers(err, zw, f)
 	}
@@ -485,7 +498,11 @@ func createZip(fileName, outputFormat string, diag DiagnosticsInfo, cfg AgentCon
 	}
 
 	for _, m := range diag.ProcMeta {
-		zf, err = zw.Create("meta/" + m.Name + "-" + m.RouteKey + "." + outputFormat)
+		zf, err := zw.CreateHeader(&zip.FileHeader{
+			Name:     "meta/" + m.Name + "-" + m.RouteKey + "." + outputFormat,
+			Method:   zip.Deflate,
+			Modified: ts,
+		})
 		if err != nil {
 			return closeHandlers(err, zw, f)
 		}
@@ -495,12 +512,20 @@ func createZip(fileName, outputFormat string, diag DiagnosticsInfo, cfg AgentCon
 		}
 	}
 
-	_, err = zw.Create("config/")
+	_, err = zw.CreateHeader(&zip.FileHeader{
+		Name:     "config/",
+		Method:   zip.Deflate,
+		Modified: ts,
+	})
 	if err != nil {
 		return closeHandlers(err, zw, f)
 	}
 
-	zf, err = zw.Create("config/elastic-agent-local." + outputFormat)
+	zf, err = zw.CreateHeader(&zip.FileHeader{
+		Name:     "config/elastic-agent-local." + outputFormat,
+		Method:   zip.Deflate,
+		Modified: ts,
+	})
 	if err != nil {
 		return closeHandlers(err, zw, f)
 	}
@@ -508,7 +533,11 @@ func createZip(fileName, outputFormat string, diag DiagnosticsInfo, cfg AgentCon
 		return closeHandlers(err, zw, f)
 	}
 
-	zf, err = zw.Create("config/elastic-agent-policy." + outputFormat)
+	zf, err = zw.CreateHeader(&zip.FileHeader{
+		Name:     "config/elastic-agent-policy." + outputFormat,
+		Method:   zip.Deflate,
+		Modified: ts,
+	})
 	if err != nil {
 		return closeHandlers(err, zw, f)
 	}
@@ -516,7 +545,11 @@ func createZip(fileName, outputFormat string, diag DiagnosticsInfo, cfg AgentCon
 		return closeHandlers(err, zw, f)
 	}
 	for name, appCfg := range cfg.AppConfig {
-		zf, err := zw.Create("config/" + name + "." + outputFormat)
+		zf, err := zw.CreateHeader(&zip.FileHeader{
+			Name:     "config/" + name + "." + outputFormat,
+			Method:   zip.Deflate,
+			Modified: ts,
+		})
 		if err != nil {
 			return closeHandlers(err, zw, f)
 		}
@@ -525,19 +558,19 @@ func createZip(fileName, outputFormat string, diag DiagnosticsInfo, cfg AgentCon
 		}
 	}
 
-	if err := zipLogs(zw); err != nil {
+	if err := zipLogs(zw, ts); err != nil {
 		return closeHandlers(err, zw, f)
 	}
 
 	if pprof != nil {
-		err := zipProfs(zw, pprof)
+		err := zipProfs(zw, pprof, ts)
 		if err != nil {
 			return closeHandlers(err, zw, f)
 		}
 	}
 
 	if metrics != nil && len(metrics.Result) > 0 {
-		err := zipMetrics(zw, metrics)
+		err := zipMetrics(zw, metrics, ts)
 		if err != nil {
 			return closeHandlers(err, zw, f)
 		}
@@ -547,8 +580,12 @@ func createZip(fileName, outputFormat string, diag DiagnosticsInfo, cfg AgentCon
 }
 
 // zipLogs walks paths.Logs() and copies the file structure into zw in "logs/"
-func zipLogs(zw *zip.Writer) error {
-	_, err := zw.Create("logs/")
+func zipLogs(zw *zip.Writer, ts time.Time) error {
+	_, err := zw.CreateHeader(&zip.FileHeader{
+		Name:     "logs/",
+		Method:   zip.Deflate,
+		Modified: ts,
+	})
 	if err != nil {
 		return err
 	}
@@ -575,7 +612,16 @@ func zipLogs(zw *zip.Writer) error {
 		}
 
 		if d.IsDir() {
-			_, err := zw.Create("logs/" + name + "/")
+			dirTS := ts
+			di, err := d.Info()
+			if err == nil {
+				dirTS = di.ModTime()
+			}
+			_, err = zw.CreateHeader(&zip.FileHeader{
+				Name:     "logs/" + name + "/",
+				Method:   zip.Deflate,
+				Modified: dirTS,
+			})
 			if err != nil {
 				return fmt.Errorf("unable to create log directory in archive: %w", err)
 			}
@@ -625,7 +671,15 @@ func saveLogs(name string, logPath string, zw *zip.Writer) error {
 	if err != nil {
 		return fmt.Errorf("unable to open log file: %w", err)
 	}
-	zf, err := zw.Create("logs/" + name)
+	lfs, err := lf.Stat()
+	if err != nil {
+		return closeHandlers(fmt.Errorf("unable to stat log file: %w", err), lf)
+	}
+	zf, err := zw.CreateHeader(&zip.FileHeader{
+		Name:     "logs/" + name,
+		Method:   zip.Deflate,
+		Modified: lfs.ModTime(),
+	})
 	if err != nil {
 		return closeHandlers(fmt.Errorf("unable to create log file in archive: %w", err), lf)
 	}
@@ -681,20 +735,32 @@ func getAllPprof(ctx context.Context, d time.Duration) (map[string][]client.Proc
 	return daemon.Pprof(ctx, d, pprofTypes, "", "")
 }
 
-func zipProfs(zw *zip.Writer, pprof map[string][]client.ProcPProf) error {
-	_, err := zw.Create("pprof/")
+func zipProfs(zw *zip.Writer, pprof map[string][]client.ProcPProf, ts time.Time) error {
+	_, err := zw.CreateHeader(&zip.FileHeader{
+		Name:     "pprof/",
+		Method:   zip.Deflate,
+		Modified: ts,
+	})
 	if err != nil {
 		return err
 	}
 
 	for pType, profs := range pprof {
-		_, err := zw.Create("pprof/" + pType + "/")
+		_, err = zw.CreateHeader(&zip.FileHeader{
+			Name:     "pprof/" + pType + "/",
+			Method:   zip.Deflate,
+			Modified: ts,
+		})
 		if err != nil {
 			return err
 		}
 		for _, p := range profs {
 			if p.Error != "" {
-				zf, err := zw.Create("pprof/" + pType + "/" + p.Name + "_" + p.RouteKey + "_error.txt")
+				zf, err := zw.CreateHeader(&zip.FileHeader{
+					Name:     "pprof/" + pType + "/" + p.Name + "_" + p.RouteKey + "_error.txt",
+					Method:   zip.Deflate,
+					Modified: ts,
+				})
 				if err != nil {
 					return err
 				}
@@ -704,7 +770,11 @@ func zipProfs(zw *zip.Writer, pprof map[string][]client.ProcPProf) error {
 				}
 				continue
 			}
-			zf, err := zw.Create("pprof/" + pType + "/" + p.Name + "_" + p.RouteKey + ".pprof")
+			zf, err := zw.CreateHeader(&zip.FileHeader{
+				Name:     "pprof/" + pType + "/" + p.Name + "_" + p.RouteKey + ".pprof",
+				Method:   zip.Deflate,
+				Modified: ts,
+			})
 			if err != nil {
 				return err
 			}
@@ -717,16 +787,24 @@ func zipProfs(zw *zip.Writer, pprof map[string][]client.ProcPProf) error {
 	return nil
 }
 
-func zipMetrics(zw *zip.Writer, metrics *proto.ProcMetricsResponse) error {
+func zipMetrics(zw *zip.Writer, metrics *proto.ProcMetricsResponse, ts time.Time) error {
 	//nolint:staticcheck,wastedassign // false positive
-	zf, err := zw.Create("metrics/")
+	_, err := zw.CreateHeader(&zip.FileHeader{
+		Name:     "metrics/",
+		Method:   zip.Deflate,
+		Modified: ts,
+	})
 	if err != nil {
 		return err
 	}
 
 	for _, m := range metrics.Result {
 		if m.Error != "" {
-			zf, err = zw.Create("metrics/" + m.AppName + "_" + m.RouteKey + "_error.txt")
+			zf, err := zw.CreateHeader(&zip.FileHeader{
+				Name:     "metrics/" + m.AppName + "_" + m.RouteKey + "_error.txt",
+				Method:   zip.Deflate,
+				Modified: ts,
+			})
 			if err != nil {
 				return err
 			}
@@ -736,7 +814,11 @@ func zipMetrics(zw *zip.Writer, metrics *proto.ProcMetricsResponse) error {
 			}
 			continue
 		}
-		zf, err = zw.Create("metrics/" + m.AppName + "_" + m.RouteKey + ".json")
+		zf, err := zw.CreateHeader(&zip.FileHeader{
+			Name:     "metrics/" + m.AppName + "_" + m.RouteKey + ".json",
+			Method:   zip.Deflate,
+			Modified: ts,
+		})
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/agent/cmd/diagnostics.go
+++ b/internal/pkg/agent/cmd/diagnostics.go
@@ -97,10 +97,7 @@ func newDiagnosticsCollectCommandWithArgs(_ []string, streams *cli.IOStreams) *c
 			}
 
 			output, _ := c.Flags().GetString("output")
-			switch output {
-			case "yaml":
-			case "json":
-			default:
+			if _, ok := diagOutputs[output]; !ok {
 				return fmt.Errorf("unsupported output: %s", output)
 			}
 
@@ -788,7 +785,6 @@ func zipProfs(zw *zip.Writer, pprof map[string][]client.ProcPProf, ts time.Time)
 }
 
 func zipMetrics(zw *zip.Writer, metrics *proto.ProcMetricsResponse, ts time.Time) error {
-	//nolint:staticcheck,wastedassign // false positive
 	_, err := zw.CreateHeader(&zip.FileHeader{
 		Name:     "metrics/",
 		Method:   zip.Deflate,


### PR DESCRIPTION
## What does this PR do?

Add filemod times to the files and directories in the zip archive.
Log files (and sub dirs) will use the modtime returned by the fileinfo
for the source. Others will use the timestamp from when the zip is
created.

## Why is it important?

Makes it easier to review diagnostics bundle content.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Run `elastic-agent diagnostics collect`
- Unzip diagnostics bundle
- modtimes for directories and files will reflect reality