### PR TITLE
Set explicit ExitTimeOut for MacOS agent launchd plist

### DIFF
--- a/internal/pkg/agent/install/svc.go
+++ b/internal/pkg/agent/install/svc.go
@@ -85,9 +85,9 @@ var darwinLaunchdConfig = `<?xml version='1.0' encoding='UTF-8'?>
     <string>{{html .UserName}}</string>{{end}}
     {{if .ChRoot}}<key>RootDirectory</key>
     <string>{{html .ChRoot}}</string>{{end}}
-	{{if .Config.Option.ExitTimeOut}}<key>ExitTimeOut</key>
+    {{if .Config.Option.ExitTimeOut}}<key>ExitTimeOut</key>
     <integer>{{html .Config.Option.ExitTimeOut}}</integer>{{end}}
-	{{if .WorkingDirectory}}<key>WorkingDirectory</key>
+    {{if .WorkingDirectory}}<key>WorkingDirectory</key>
     <string>{{html .WorkingDirectory}}</string>{{end}}
     <key>SessionCreate</key>
     <{{bool .SessionCreate}}/>

--- a/internal/pkg/agent/install/svc.go
+++ b/internal/pkg/agent/install/svc.go
@@ -6,6 +6,7 @@ package install
 
 import (
 	"path/filepath"
+	"runtime"
 
 	"github.com/kardianos/service"
 
@@ -18,6 +19,12 @@ const (
 
 	// ServiceDescription is the description for the service.
 	ServiceDescription = "Elastic Agent is a unified agent to observe, monitor and protect your system."
+
+	// Set the launch daemon ExitTimeOut to 60 seconds in order to allow the agent to shutdown gracefully
+	// At the moment the version 8.3 & 8.4 of the agent are taking about 11 secs to shutdown
+	// and the launchd sends SIGKILL after 5 secs which causes the beats processes to be left running orphant
+	// depending on the shutdown timing.
+	darwinServiceExitTimeout = 60
 )
 
 // ExecutablePath returns the path for the installed Agents executable.
@@ -30,7 +37,7 @@ func ExecutablePath() string {
 }
 
 func newService() (service.Service, error) {
-	return service.New(nil, &service.Config{
+	cfg := &service.Config{
 		Name:             paths.ServiceName,
 		DisplayName:      ServiceDisplayName,
 		Description:      ServiceDescription,
@@ -45,5 +52,57 @@ func newService() (service.Service, error) {
 			"OnFailureDelayDuration": "1s",
 			"OnFailureResetPeriod":   10,
 		},
-	})
+	}
+
+	if runtime.GOOS == "darwin" {
+		// The github.com/kardianos/service library doesn't support ExitTimeOut in their prebuilt template.
+		// This option allows to pass our own template for the launch daemon plist, which is a copy
+		// of the prebuilt template with added ExitTimeOut option
+		cfg.Option["LaunchdConfig"] = darwinLaunchdConfig
+		cfg.Option["ExitTimeOut"] = darwinServiceExitTimeout
+	}
+
+	return service.New(nil, cfg)
 }
+
+// A copy of the launchd plist template from github.com/kardianos/service
+// with added .Config.Option.ExitTimeOut option
+var darwinLaunchdConfig = `<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
+"http://www.apple.com/DTDs/PropertyList-1.0.dtd" >
+<plist version='1.0'>
+  <dict>
+    <key>Label</key>
+    <string>{{html .Name}}</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>{{html .Path}}</string>
+    {{range .Config.Arguments}}
+      <string>{{html .}}</string>
+    {{end}}
+    </array>
+    {{if .UserName}}<key>UserName</key>
+    <string>{{html .UserName}}</string>{{end}}
+    {{if .ChRoot}}<key>RootDirectory</key>
+    <string>{{html .ChRoot}}</string>{{end}}
+	{{if .Config.Option.ExitTimeOut}}<key>ExitTimeOut</key>
+    <integer>{{html .Config.Option.ExitTimeOut}}</integer>{{end}}
+	{{if .WorkingDirectory}}<key>WorkingDirectory</key>
+    <string>{{html .WorkingDirectory}}</string>{{end}}
+    <key>SessionCreate</key>
+    <{{bool .SessionCreate}}/>
+    <key>KeepAlive</key>
+    <{{bool .KeepAlive}}/>
+    <key>RunAtLoad</key>
+    <{{bool .RunAtLoad}}/>
+    <key>Disabled</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/usr/local/var/log/{{html .Name}}.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/usr/local/var/log/{{html .Name}}.err.log</string>
+
+  </dict>
+</plist>
+`

--- a/internal/pkg/agent/install/svc.go
+++ b/internal/pkg/agent/install/svc.go
@@ -22,7 +22,7 @@ const (
 
 	// Set the launch daemon ExitTimeOut to 60 seconds in order to allow the agent to shutdown gracefully
 	// At the moment the version 8.3 & 8.4 of the agent are taking about 11 secs to shutdown
-	// and the launchd sends SIGKILL after 5 secs which causes the beats processes to be left running orphant
+	// and the launchd sends SIGKILL after 5 secs which causes the beats processes to be left running orphaned
 	// depending on the shutdown timing.
 	darwinServiceExitTimeout = 60
 )
@@ -67,7 +67,7 @@ func newService() (service.Service, error) {
 
 // A copy of the launchd plist template from github.com/kardianos/service
 // with added .Config.Option.ExitTimeOut option
-var darwinLaunchdConfig = `<?xml version='1.0' encoding='UTF-8'?>
+const darwinLaunchdConfig = `<?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
 "http://www.apple.com/DTDs/PropertyList-1.0.dtd" >
 <plist version='1.0'>


### PR DESCRIPTION
## What does this PR do?

Set explicit ExitTimeOut for MacOS agent launchd plist to 60 secs.
Addresses the issue https://github.com/elastic/elastic-agent/issues/593 where the agent is killed prematurely by launchd without having a chance to shut down gracefully.
See the issue https://github.com/elastic/elastic-agent/issues/593 for more details.

## Why is it important?

Addresses the issue https://github.com/elastic/elastic-agent/issues/593

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## How to test this PR locally

The agent should be able to stop without leaving any child processes running. The agent should not receive SIGKILL from launchd. Refer to the issue for details https://github.com/elastic/elastic-agent/issues/593

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/593

## Screenshots
The updated agent ```/Library/LaunchDaemons/co.elastic.elastic-agent.plist``` installed with ```ExitTimeOut```
<img width="697" alt="Screen Shot 2022-06-22 at 12 03 11 PM" src="https://user-images.githubusercontent.com/872351/175081354-905ac59b-b430-40fb-b4e1-f64f65131d0f.png">

## Logs
Launchd log after the change:
<img width="1551" alt="Screen Shot 2022-06-22 at 12 06 08 PM" src="https://user-images.githubusercontent.com/872351/175081285-d078af16-37fd-467d-9db2-2be85a9a8a4a.png">

