### PR TITLE
Generate checksum file for components

### DIFF
--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -761,7 +761,7 @@ func CreateSHA512File(file string) error {
 	out := fmt.Sprintf("%v  %v", computedHash, filepath.Base(file))
 
 	//nolint:gosec // permissions are correct
-	return ioutil.WriteFile(file+".sha512", []byte(out), 0644)
+	return os.WriteFile(file+".sha512", []byte(out), 0644)
 }
 func GetSHA512Hash(file string) (string, error) {
 	f, err := os.Open(file)

--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -754,22 +754,29 @@ func VerifySHA256(file string, hash string) error {
 // CreateSHA512File computes the sha512 sum of the specified file the writes
 // a sidecar file containing the hash and filename.
 func CreateSHA512File(file string) error {
+	computedHash, err := GetSHA512Hash(file)
+	if err != nil {
+		return err
+	}
+	out := fmt.Sprintf("%v  %v", computedHash, filepath.Base(file))
+
+	//nolint:gosec // permissions are correct
+	return ioutil.WriteFile(file+".sha512", []byte(out), 0644)
+}
+func GetSHA512Hash(file string) (string, error) {
 	f, err := os.Open(file)
 	if err != nil {
-		return errors.Wrap(err, "failed to open file for sha512 summing")
+		return "", errors.Wrap(err, "failed to open file for sha512 summing")
 	}
 	defer f.Close()
 
 	sum := sha512.New()
 	if _, err := io.Copy(sum, f); err != nil {
-		return errors.Wrap(err, "failed reading from input file")
+		return "", errors.Wrap(err, "failed reading from input file")
 	}
 
 	computedHash := hex.EncodeToString(sum.Sum(nil))
-	out := fmt.Sprintf("%v  %v", computedHash, filepath.Base(file))
-
-	//nolint:gosec // permissions are correct
-	return ioutil.WriteFile(file+".sha512", []byte(out), 0644)
+	return computedHash, nil
 }
 
 // Mage executes mage targets in the specified directory.

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -906,10 +906,6 @@ func addFileToTar(ar *tar.Writer, baseDir string, pkgFile PackageFile) error {
 			header.Mode = int64(0755)
 		}
 
-		if strings.Contains(info.Name(), "disabled") {
-			log.Println(">>>>>", info.Name(), pkgFile.ConfigMode, "matches", configFilePattern.MatchString(info.Name()), "or", componentConfigFilePattern.MatchString(info.Name()))
-		}
-
 		if filepath.IsAbs(pkgFile.Target) {
 			baseDir = ""
 		}

--- a/magefile.go
+++ b/magefile.go
@@ -840,9 +840,10 @@ func packageAgent(requiredPackages []string, packagingFn func()) {
 }
 func copyComponentSpecs(componentName, versionedDropPath string) (string, error) {
 	sourceSpecFile := filepath.Join("specs", componentName+specSuffix)
-	err := devtools.Copy(sourceSpecFile, filepath.Join(versionedDropPath, componentName+specSuffix))
+	targetPath := filepath.Join(versionedDropPath, componentName+specSuffix)
+	err := devtools.Copy(sourceSpecFile, targetPath)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed copying spec file %q to %q")
+		return "", errors.Wrapf(err, "failed copying spec file %q to %q", sourceSpecFile, targetPath)
 	}
 
 	// compute checksum

--- a/magefile.go
+++ b/magefile.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -377,7 +376,7 @@ func AssembleDarwinUniversal() error {
 	cmd := "lipo"
 
 	if _, err := exec.LookPath(cmd); err != nil {
-		return fmt.Errorf("'%s' is required to assemble the universal binary: %w",
+		return fmt.Errorf("%q is required to assemble the universal binary: %w",
 			cmd, err)
 	}
 
@@ -441,7 +440,7 @@ func requiredPackagesPresent(basePath, beat, version string, requiredPackages []
 		path := filepath.Join(basePath, "build", "distributions", packageName)
 
 		if _, err := os.Stat(path); err != nil {
-			fmt.Printf("Package '%s' does not exist on path: %s\n", packageName, path)
+			fmt.Printf("Package %q does not exist on path: %s\n", packageName, path)
 			return false
 		}
 	}
@@ -843,7 +842,7 @@ func copyComponentSpecs(componentName, versionedDropPath string) (string, error)
 	sourceSpecFile := filepath.Join("specs", componentName+specSuffix)
 	err := devtools.Copy(sourceSpecFile, filepath.Join(versionedDropPath, componentName+specSuffix))
 	if err != nil {
-		return "", errors.Wrapf(err, "failed copying spec file '%s' to '%s'")
+		return "", errors.Wrapf(err, "failed copying spec file %q to %q")
 	}
 
 	// compute checksum
@@ -860,7 +859,7 @@ func appendComponentChecksums(versionedDropPath string, checksums map[string]str
 		componentFile := strings.TrimSuffix(file, specSuffix)
 		hash, err := devtools.GetSHA512Hash(filepath.Join(versionedDropPath, componentFile))
 		if errors.Is(err, os.ErrNotExist) {
-			fmt.Printf(">>> Computing hash for '%s' failed: file not present\n", componentFile)
+			fmt.Printf(">>> Computing hash for %q failed: file not present\n", componentFile)
 			continue
 		} else if err != nil {
 			return err
@@ -874,7 +873,7 @@ func appendComponentChecksums(versionedDropPath string, checksums map[string]str
 		return err
 	}
 
-	return ioutil.WriteFile(filepath.Join(versionedDropPath, checksumFilename), content, 0644)
+	return os.WriteFile(filepath.Join(versionedDropPath, checksumFilename), content, 0644)
 }
 
 func movePackagesToArchive(dropPath string, requiredPackages []string) string {


### PR DESCRIPTION
## What does this PR do?

During packaging for each spec file we compute sha512 hash as well as for its binary counterpart
Result:

![image](https://user-images.githubusercontent.com/1522652/175323874-ef93c06c-1bac-4195-a104-37975ee117d4.png)

## Why is it important?

Future trust/verification of integrity

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
