### PR TITLE
mergify: remove backport automation for non active branches

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -181,32 +181,6 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to 8.0 branch
-    conditions:
-      - merged
-      - label=backport-v8.0.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.0"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to 8.1 branch
-    conditions:
-      - merged
-      - label=backport-v8.1.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.1"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.2 branch
     conditions:
       - merged


### PR DESCRIPTION
## What does this PR do?

Support only active release branches.

## Why is it important?

Avoid backports to non-active releases

## Issue

Similar to https://github.com/elastic/beats/pull/32092