### PR TITLE
ci: fix labels that clashes with the Orka workers

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
         axes {
           axis {
             name 'PLATFORM'
-            values 'ubuntu-20.04 && immutable', 'aarch64', 'windows-2016 && windows-immutable', 'windows-2022 && windows-immutable', 'darwin && orka && x86_64'
+            values 'ubuntu-20.04 && immutable', 'aws && aarch64', 'windows-2016 && windows-immutable', 'windows-2022 && windows-immutable', 'darwin && orka && x86_64'
           }
         }
         stages {
@@ -164,7 +164,7 @@ pipeline {
               }
             }
             environment {
-              ARCH = "${PLATFORM.equals('aarch64') ? 'arm64' : 'amd64'}"
+              ARCH = "${PLATFORM.contains('aarch64') ? 'arm64' : 'amd64'}"
               DEV = true
               EXTERNAL = true
             }


### PR DESCRIPTION
Otherwise the `orka` workers will be provisioned since they have the same label