### PR TITLE
ci: propagate e2e-testing errors

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -256,7 +256,9 @@ pipeline {
                elasticAgentVersion: "${env.BEAT_VERSION}-SNAPSHOT",
                gitHubCheckName: "e2e-tests",
                gitHubCheckRepo: env.REPO,
-               gitHubCheckSha1: env.GIT_BASE_COMMIT)
+               gitHubCheckSha1: env.GIT_BASE_COMMIT,
+               propagate: true,
+               wait: true)
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Propagate the `e2e-testing` result within the main pipeline

## Why is it important?

GitHub checks are the ones reporting those errors in the Git commit history https://github.com/elastic/elastic-agent/commits/main

But the build failure reporting, https://github.com/elastic/elastic-agent/pull/595, does not report any e2e-testing errors as they are async-mode running.

This will help to surface any errors with the e2e-testing to the consumers much faster by tracking those failures as GitHub issues

## Important

- If the `e2e-testing` are failing constantly, there will be a GitHub issue per build failure.

