### PR TITLE
ci: run on MacOS12

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -277,7 +277,7 @@ def isCodeCoverageEnabled() {
 
 def withPackageEnv(platform, Closure body) {
   if (isUnix()) {
-    if (platform.contains('macosx')) {
+    if (isDarwin()) {
       withPackageDarwinEnv() {
         body()
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
         axes {
           axis {
             name 'PLATFORM'
-            values 'ubuntu-20.04 && immutable', 'aws && aarch64', 'windows-2016 && windows-immutable', 'windows-2022 && windows-immutable', 'darwin && orka && x86_64'
+            values 'ubuntu-20.04 && immutable', 'aws && aarch64', 'windows-2016 && windows-immutable', 'windows-2022 && windows-immutable', 'macos12 && x86_64'
           }
         }
         stages {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@test/isdarwin') _
+@Library('apm@current') _
 
 pipeline {
   agent { label 'ubuntu-20.04 && immutable' }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@current') _
+@Library('apm@test/isdarwin') _
 
 pipeline {
   agent { label 'ubuntu-20.04 && immutable' }


### PR DESCRIPTION
## What does this PR do?

- Update labels to run on MacOS12
- Use `isDarwin`

## Why is it important?

- Ensure labels are the ones with the OS version to be tested otherwise it's hard to know what's the OS version for Darwin

## Issue

Requires https://github.com/elastic/apm-pipeline-library/pull/1774