### PR TITLE
Fix Elastic Agent non-fleet broken upgrade between 8.3.x releases

### DIFF
--- a/internal/pkg/agent/application/paths/paths_linux.go
+++ b/internal/pkg/agent/application/paths/paths_linux.go
@@ -14,5 +14,5 @@ const defaultAgentVaultPath = "vault"
 
 // AgentVaultPath is the directory that contains all the files for the value
 func AgentVaultPath() string {
-	return filepath.Join(Home(), defaultAgentVaultPath)
+	return filepath.Join(Top(), defaultAgentVaultPath)
 }

--- a/internal/pkg/agent/application/paths/paths_windows.go
+++ b/internal/pkg/agent/application/paths/paths_windows.go
@@ -42,5 +42,5 @@ func ArePathsEqual(expected, actual string) bool {
 
 // AgentVaultPath is the directory that contains all the files for the value
 func AgentVaultPath() string {
-	return filepath.Join(Home(), defaultAgentVaultPath)
+	return filepath.Join(Top(), defaultAgentVaultPath)
 }

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -37,6 +37,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/control/server"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/migration"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/storage"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
@@ -119,6 +120,21 @@ func run(override cfgOverrider) error {
 	createAgentID := true
 	if cfg.Fleet != nil && cfg.Fleet.Server != nil && cfg.Fleet.Server.Bootstrap {
 		createAgentID = false
+	}
+
+	// This is specific for the agent upgrade from 8.3.0 - 8.3.2 to 8.x and above on Linux and Windows platforms.
+	// Addresses the issue: https://github.com/elastic/elastic-agent/issues/682
+	// The vault directory was located in the hash versioned "Home" directory of the agent.
+	// This moves the vault directory two levels up into  the "Config" directory next to fleet.enc file
+	// in order to be able to "upgrade" the agent from deb/rpm that is not invoking the upgrade handle and
+	// doesn't perform the migration of the state or vault.
+	// If the agent secret doesn't exist, then search for the newest agent secret in the agent data directories
+	// and migrate it into the new vault location.
+	err = migration.MigrateAgentSecret(logger)
+	logger.Debug("migration of agent secret completed, err: %v", err)
+	if err != nil {
+		logger.Error(err)
+		return err
 	}
 
 	// Ensure we have the agent secret created.

--- a/internal/pkg/agent/migration/migrate_secret.go
+++ b/internal/pkg/agent/migration/migrate_secret.go
@@ -1,0 +1,136 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package migration
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/secret"
+)
+
+const (
+	darwin = "darwin"
+)
+
+// MigrateAgentSecret migrates agent secret if the secret doesn't exists agent upgrade from 8.3.0 - 8.3.2 to 8.x and above on Linux and Windows platforms.
+func MigrateAgentSecret(log *logp.Logger) error {
+	// Nothing to migrate for darwin
+	if runtime.GOOS == darwin {
+		return nil
+	}
+
+	// Check if the secret already exists
+	log.Debug("migrate agent secret, check if secret already exists")
+	_, err := secret.GetAgentSecret()
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// The secret doesn't exists, perform migration below
+			log.Debug("agent secret doesn't exists, perform migration")
+		} else {
+			log.Errorf("failed read the agent secret: %v", err)
+			return err
+		}
+	} else {
+		// The secret already exists, nothing to migrate
+		log.Debug("secret already exists nothing to migrate")
+		return nil
+	}
+
+	// Check if the secret was copied by the fleet upgrade handler to the legacy location
+	log.Debug("check if secret was copied over by 8.3.0-8.3.2 version of the agent")
+	sec, err := getAgentSecretFromHomePath(paths.Home())
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// The secret is not found in this instance of the vault, continue with migration
+			log.Debug("agent secret copied from 8.3.0-.8.3.2 doesn't exists, continue with migration")
+		} else {
+			log.Errorf("failed agent 8.3.0-8.3.2 secret check: %v", err)
+			return err
+		}
+	} else {
+		// The secret is found, save in the new agent vault
+		log.Debug("agent secret from 8.3.0-.8.3.2 is found, migrate to the new vault")
+		return secret.SetAgentSecret(sec)
+	}
+
+	// Scan other agent data directories, find the latest agent secret
+	log.Debug("search for possible latest agent 8.3.0-.8.3.2 secret")
+	dataDir := paths.Data()
+
+	sec, err = findPreviousAgentSecret(dataDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// The secret is not found
+			log.Debug("no previous agent 8.3.0-.8.3.2 secrets found, nothing to migrate")
+			return nil
+		}
+		log.Errorf("search for possible latest agent 8.3.0-.8.3.2 secret failed: %v", err)
+		return err
+	}
+	log.Debug("found previous agent 8.3.0-.8.3.2 secret, migrate to the new vault")
+	return secret.SetAgentSecret(sec)
+}
+
+func findPreviousAgentSecret(dataDir string) (sec secret.Secret, err error) {
+	found := false
+	fileSystem := os.DirFS(dataDir)
+	err = fs.WalkDir(fileSystem, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if strings.HasPrefix(d.Name(), "elastic-agent-") {
+				vaultPath := getLegacyVaultPathFromPath(filepath.Join(dataDir, path))
+				s, err := secret.GetAgentSecret(secret.WithVaultPath(vaultPath))
+				// Ignore if error, keep scanning
+				if err != nil {
+					if errors.Is(err, fs.ErrNotExist) {
+						return nil
+					}
+					return err
+				}
+				if s.CreatedOn.After(sec.CreatedOn) {
+					sec = s
+					found = true
+				}
+			} else if d.Name() != "." {
+				return fs.SkipDir
+			}
+		}
+		return nil
+	})
+	if !found {
+		return sec, fs.ErrNotExist
+	}
+	return sec, err
+}
+
+func getAgentSecretFromHomePath(homePath string) (sec secret.Secret, err error) {
+	vaultPath := getLegacyVaultPathFromPath(homePath)
+	fi, err := os.Stat(vaultPath)
+	if err != nil {
+		return
+	}
+
+	if !fi.IsDir() {
+		return sec, fs.ErrNotExist
+	}
+	return secret.GetAgentSecret(secret.WithVaultPath(vaultPath))
+}
+
+func getLegacyVaultPath() string {
+	return getLegacyVaultPathFromPath(paths.Home())
+}
+
+func getLegacyVaultPathFromPath(homePath string) string {
+	return filepath.Join(homePath, "vault")
+}

--- a/internal/pkg/agent/migration/migrate_secret_test.go
+++ b/internal/pkg/agent/migration/migrate_secret_test.go
@@ -1,0 +1,320 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build linux || windows
+// +build linux windows
+
+package migration
+
+import (
+	"errors"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/secret"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/vault"
+	"github.com/gofrs/uuid"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFindAgentSecretFromHomePath(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		setupFn func(homePath string) error
+		wantErr error
+	}{
+		{
+			name:    "no data dir",
+			wantErr: fs.ErrNotExist,
+		},
+		{
+			name: "no vault dir",
+			setupFn: func(homePath string) error {
+				return os.MkdirAll(homePath, 0750)
+			},
+			wantErr: fs.ErrNotExist,
+		},
+		{
+			name: "vault file instead of directory",
+			setupFn: func(homePath string) error {
+				err := os.MkdirAll(homePath, 0750)
+				if err != nil {
+					return err
+				}
+				return ioutil.WriteFile(getLegacyVaultPathFromPath(homePath), []byte{}, 0600)
+			},
+			wantErr: fs.ErrNotExist,
+		},
+		{
+			name: "empty vault directory",
+			setupFn: func(homePath string) error {
+				return os.MkdirAll(getLegacyVaultPathFromPath(homePath), 0750)
+			},
+			wantErr: fs.ErrNotExist,
+		},
+		{
+			name: "empty vault",
+			setupFn: func(homePath string) error {
+				v, err := vault.New(getLegacyVaultPathFromPath(homePath))
+				if err != nil {
+					return err
+				}
+				defer v.Close()
+				return nil
+			},
+			wantErr: fs.ErrNotExist,
+		},
+		{
+			name: "vault dir with no seed",
+			setupFn: func(homePath string) error {
+				vaultPath := getLegacyVaultPathFromPath(homePath)
+				v, err := vault.New(vaultPath)
+				if err != nil {
+					return err
+				}
+				defer v.Close()
+				return os.Remove(filepath.Join(vaultPath, ".seed"))
+			},
+			wantErr: fs.ErrNotExist,
+		},
+		{
+			name: "vault with secret and misplaced seed vault",
+			setupFn: func(homePath string) error {
+				vaultPath := getLegacyVaultPathFromPath(homePath)
+				err := secret.CreateAgentSecret(secret.WithVaultPath(vaultPath))
+				if err != nil {
+					return err
+				}
+				return os.Remove(filepath.Join(vaultPath, ".seed"))
+			},
+			wantErr: fs.ErrNotExist,
+		},
+		{
+			name: "vault with valid secret",
+			setupFn: func(homePath string) error {
+				vaultPath := getLegacyVaultPathFromPath(homePath)
+				return secret.CreateAgentSecret(secret.WithVaultPath(vaultPath))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			top := t.TempDir()
+			paths.SetTop(top)
+			homePath := paths.Home()
+
+			if tc.setupFn != nil {
+				if err := tc.setupFn(homePath); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			sec, err := getAgentSecretFromHomePath(homePath)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("want err: %v, got err: %v", tc.wantErr, err)
+			}
+
+			foundSec, err := findPreviousAgentSecret(filepath.Dir(homePath))
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("want err: %v, got err: %v", tc.wantErr, err)
+			}
+			diff := cmp.Diff(sec, foundSec)
+			if diff != "" {
+				t.Fatal(diff)
+			}
+
+		})
+	}
+}
+
+func TestFindNewestAgentSecret(t *testing.T) {
+	top := t.TempDir()
+	paths.SetTop(top)
+	dataDir := paths.Data()
+
+	wantSecret, err := generateTestSecrets(dataDir, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sec, err := findPreviousAgentSecret(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diff := cmp.Diff(sec, wantSecret)
+	if diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestMigrateAgentSecret(t *testing.T) {
+	top := t.TempDir()
+	paths.SetTop(top)
+	dataDir := paths.Data()
+
+	// No vault home path
+	homePath := generateTestHomePath(dataDir)
+	if err := os.MkdirAll(homePath, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty vault home path
+	homePath = generateTestHomePath(dataDir)
+	vaultPath := getLegacyVaultPathFromPath(homePath)
+	if err := os.MkdirAll(vaultPath, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Vault with missing seed
+	homePath = generateTestHomePath(dataDir)
+	vaultPath = getLegacyVaultPathFromPath(homePath)
+	v, err := vault.New(vaultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer v.Close()
+
+	if err = os.Remove(filepath.Join(vaultPath, ".seed")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate few valid secrets to scan for
+	wantSecret, err := generateTestSecrets(dataDir, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expect no agent secret found
+	_, err = secret.GetAgentSecret(secret.WithVaultPath(paths.AgentVaultPath()))
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("expected err: %v", fs.ErrNotExist)
+	}
+
+	// Perform migration
+	log := logp.NewLogger("test_agent_secret")
+	err = MigrateAgentSecret(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expect the agent secret is migrated now
+	sec, err := secret.GetAgentSecret(secret.WithVaultPath(paths.AgentVaultPath()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compare the migrated secret with the expected newest one
+	diff := cmp.Diff(sec, wantSecret)
+	if diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestMigrateAgentSecretAlreadyExists(t *testing.T) {
+	top := t.TempDir()
+	paths.SetTop(top)
+	err := secret.CreateAgentSecret(secret.WithVaultPath(paths.AgentVaultPath()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expect agent secret created
+	wantSecret, err := secret.GetAgentSecret(secret.WithVaultPath(paths.AgentVaultPath()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Perform migration
+	log := logp.NewLogger("test_agent_secret")
+	err = MigrateAgentSecret(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sec, err := secret.GetAgentSecret(secret.WithVaultPath(paths.AgentVaultPath()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compare, should be the same secret
+	diff := cmp.Diff(sec, wantSecret)
+	if diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestMigrateAgentSecretFromLegacyLocation(t *testing.T) {
+	top := t.TempDir()
+	paths.SetTop(top)
+	vaultPath := getLegacyVaultPath()
+	err := secret.CreateAgentSecret(secret.WithVaultPath(vaultPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expect agent secret created
+	wantSecret, err := secret.GetAgentSecret(secret.WithVaultPath(vaultPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Perform migration
+	log := logp.NewLogger("test_agent_secret")
+	err = MigrateAgentSecret(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sec, err := secret.GetAgentSecret(secret.WithVaultPath(paths.AgentVaultPath()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compare, should be the same secret
+	diff := cmp.Diff(sec, wantSecret)
+	if diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func generateTestHomePath(dataDir string) string {
+	suffix := uuid.Must(uuid.NewV4()).String()[:6]
+	return filepath.Join(dataDir, "elastic-agent-"+suffix)
+}
+
+func generateTestSecrets(dataDir string, count int) (newestSecret secret.Secret, err error) {
+	now := time.Now()
+
+	// Generate multiple home paths
+	//homePaths := make([]string, count)
+	for i := 0; i < count; i++ {
+		homePath := generateTestHomePath(dataDir)
+		k, err := vault.NewKey(vault.AES256)
+		if err != nil {
+			return newestSecret, err
+		}
+
+		sec := secret.Secret{
+			Value:     k,
+			CreatedOn: now.Add(-time.Duration(i+1) * time.Minute),
+		}
+		if i == 0 {
+			newestSecret = sec
+		}
+
+		err = secret.SetAgentSecret(sec, secret.WithVaultPath(getLegacyVaultPathFromPath(homePath)))
+		if err != nil {
+			return newestSecret, err
+		}
+	}
+	return newestSecret, nil
+}

--- a/internal/pkg/agent/vault/seed.go
+++ b/internal/pkg/agent/vault/seed.go
@@ -9,6 +9,7 @@ package vault
 
 import (
 	"errors"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -24,6 +25,24 @@ var (
 )
 
 func getSeed(path string) ([]byte, error) {
+	fp := filepath.Join(path, seedFile)
+
+	mxSeed.Lock()
+	defer mxSeed.Unlock()
+
+	b, err := ioutil.ReadFile(fp)
+	if err != nil {
+		return nil, err
+	}
+
+	// return fs.ErrNotExists if invalid length of bytes returned
+	if len(b) != int(AES256) {
+		return nil, fs.ErrNotExist
+	}
+	return b, nil
+}
+
+func createSeedIfNotExists(path string) ([]byte, error) {
 	fp := filepath.Join(path, seedFile)
 
 	mxSeed.Lock()

--- a/internal/pkg/agent/vault/vault_darwin.go
+++ b/internal/pkg/agent/vault/vault_darwin.go
@@ -38,7 +38,7 @@ type Vault struct {
 
 // New initializes the vault store
 // Call Close when done to release the resouces
-func New(name string) (*Vault, error) {
+func New(name string, opts ...OptionFunc) (*Vault, error) {
 	var keychain C.SecKeychainRef
 	err := statusToError(C.OpenKeychain(keychain))
 	if err != nil {

--- a/internal/pkg/agent/vault/vault_linux.go
+++ b/internal/pkg/agent/vault/vault_linux.go
@@ -29,8 +29,9 @@ type Vault struct {
 	mx   sync.Mutex
 }
 
-// Open initializes the vault store
-func New(path string) (*Vault, error) {
+// New creates the vault store
+func New(path string, opts ...OptionFunc) (v *Vault, err error) {
+	options := applyOptions(opts...)
 	dir := filepath.Dir(path)
 
 	// If there is no specific path then get the executable directory
@@ -43,12 +44,29 @@ func New(path string) (*Vault, error) {
 		path = filepath.Join(dir, path)
 	}
 
-	err := os.MkdirAll(path, 0750)
-	if err != nil {
-		return nil, err
+	if options.readonly {
+		fi, err := os.Stat(path)
+		if err != nil {
+			return nil, err
+		}
+		if !fi.IsDir() {
+			return nil, fs.ErrNotExist
+		}
+	} else {
+		err := os.MkdirAll(path, 0750)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	key, err := getSeed(path)
+	var key []byte
+
+	if options.readonly {
+		key, err = getSeed(path)
+	} else {
+		key, err = createSeedIfNotExists(path)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/agent/vault/vault_options.go
+++ b/internal/pkg/agent/vault/vault_options.go
@@ -1,0 +1,27 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package vault
+
+type Options struct {
+	readonly bool
+}
+
+type OptionFunc func(o *Options)
+
+func WithReadonly(readonly bool) OptionFunc {
+	return func(o *Options) {
+		o.readonly = readonly
+	}
+}
+
+func applyOptions(opts ...OptionFunc) Options {
+	var options Options
+
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	return options
+}

--- a/internal/pkg/agent/vault/vault_windows.go
+++ b/internal/pkg/agent/vault/vault_windows.go
@@ -27,7 +27,8 @@ type Vault struct {
 }
 
 // Open initializes the vault store
-func New(path string) (*Vault, error) {
+func New(path string, opts ...OptionFunc) (v *Vault, err error) {
+	options := applyOptions(opts...)
 	dir := filepath.Dir(path)
 
 	// If there is no specific path then get the executable directory
@@ -40,16 +41,33 @@ func New(path string) (*Vault, error) {
 		path = filepath.Join(dir, path)
 	}
 
-	err := os.MkdirAll(path, 0750)
-	if err != nil {
-		return nil, err
-	}
-	err = systemAdministratorsOnly(path, false)
-	if err != nil {
-		return nil, err
+	if options.readonly {
+		fi, err := os.Stat(path)
+		if err != nil {
+			return nil, err
+		}
+		if !fi.IsDir() {
+			return nil, fs.ErrNotExist
+		}
+	} else {
+		err := os.MkdirAll(path, 0750)
+		if err != nil {
+			return nil, err
+		}
+		err = systemAdministratorsOnly(path, false)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	entropy, err := getSeed(path)
+	var entropy []byte
+
+	if options.readonly {
+		entropy, err = getSeed(path)
+	} else {
+		entropy, err = createSeedIfNotExists(path)
+	}
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What does this PR do?

* Migrates vault directory on linux and windows to the top directory of the
  agent, so it can be shared without needing the upgrade handler call,
  like for example with side-by-side install/upgrade from .rpm/.deb
* Extends vault to allow read-only open, useful when the vault at particular location needs to be only read not created.
* Full unit test coverage for all kinds of agent migration scenarios

Regression tested upgrades with fleet:
1. 8.2.4 ->8.4.0 (8.3.3)
2. 8.3.1 ->8.4.0 (8.3.3)
Tested install of the agent on top of existing install, replacing the symlink to the newly installed agent.


## Why is it important?

Addresses the issue https://github.com/elastic/elastic-agent/issues/682 where agent install/upgrade side-by-side (without upgrade handler invocation doesn't properly migrate the agent secret)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/682

## Screenshots

<img width="1250" alt="Screen Shot 2022-07-10 at 11 26 03 AM" src="https://user-images.githubusercontent.com/872351/178155470-f70680c2-dce3-4e8d-9534-54c3e2e27ef8.png">
 