### PR TITLE
fix typo on package command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In Linux operating systems that you can not run docker as a root user you need t
 Running Elastic Agent in a docker container is a common use case. To build the Elastic Agent and create a docker image run the following command:
 
 ```
-DEV=true SNAPSHOT=true PLATFORMS=linux/amd64 TYPES=docker mage package
+DEV=true SNAPSHOT=true PLATFORMS=linux/amd64 PACKAGES=docker mage package
 ```
 
 If you are in the 7.13 branch, this will create the `docker.elastic.co/beats/elastic-agent:7.13.0-SNAPSHOT` image in your local environment. Now you can use this to for example test this container with the stack in elastic-package:
@@ -45,7 +45,7 @@ for the standard variant.
 
 1. Build elastic-agent:
 ```bash
-DEV=true PLATFORMS=linux/amd64 TYPES=docker mage package
+DEV=true PLATFORMS=linux/amd64 PACKAGES=docker mage package
 ```
 
 Use environmental variables `GOHOSTOS` and `GOHOSTARCH` to specify PLATFORMS variable accordingly. eg.


### PR DESCRIPTION
## What does this PR do?

This commit fixes the typo in the package command on the README.md.

## Why is it important?

It fixes a typo in the package command examples that can lead to very long build/waiting times.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areasv
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~
## How to test this PR locally
1. Copy/paste/execute the package commands from the README.md
2. Assert it only built the docker package

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
