### PR TITLE
Update will cleanup unneeded artifacts.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -110,6 +110,7 @@
 - Allow ':' characters in dynamic variables {issue}624[624] {pull}680[680]
 - Allow the - char to appear as part of variable names in eql expressions. {issue}709[709] {pull}710[710]
 - Allow the / char in variable names in eql and transpiler. {issue}715[715] {pull}718[718]
+- Agent updates will clean up unneeded artifacts. {issue}693[693] {issue}694[694] {pull}752[752]
 
 ==== New features
 

--- a/internal/pkg/agent/application/upgrade/cleanup.go
+++ b/internal/pkg/agent/application/upgrade/cleanup.go
@@ -5,6 +5,7 @@
 package upgrade
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,34 +17,35 @@ import (
 func preUpgradeCleanup(version string) error {
 	files, err := os.ReadDir(paths.Downloads())
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to read directory %q: %w", paths.Downloads(), err)
 	}
+	var rErr error
 	for _, file := range files {
 		if file.IsDir() {
 			continue
 		}
 		if !strings.Contains(file.Name(), version) {
 			if err := os.Remove(filepath.Join(paths.Downloads(), file.Name())); err != nil {
-				return err
+				rErr = muliterror.Append(rErr, fmt.Errorf("unable to remove file %q: %w", filepath.Joing(paths.Downloads(), file.Name()), err))
 			}
 		}
 	}
-	return nil
+	return rErr
 }
 
 // cleanAllDownloads will remove all files from the downloads directory
 func cleanAllDownloads() error {
 	files, err := os.ReadDir(paths.Downloads())
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to read directory %q: %w", paths.Downloads(), err)
 	}
 	for _, file := range files {
 		if file.IsDir() {
 			continue
 		}
 		if err := os.Remove(filepath.Join(paths.Downloads(), file.Name())); err != nil {
-			return err
+			rErr = muliterror.Append(rErr, fmt.Errorf("unable to remove file %q: %w", filepath.Joing(paths.Downloads(), file.Name()), err))
 		}
 	}
-	return nil
+	return rErr
 }

--- a/internal/pkg/agent/application/upgrade/cleanup.go
+++ b/internal/pkg/agent/application/upgrade/cleanup.go
@@ -1,0 +1,49 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+)
+
+// preUpgradeCleanup will remove files that do not have the passed version number from the downloads directory.
+func preUpgradeCleanup(version string) error {
+	files, err := os.ReadDir(paths.Downloads())
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		if !strings.Contains(file.Name(), version) {
+			if err := os.Remove(filepath.Join(paths.Downloads(), file.Name())); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// cleanAllDownloads will remove all files from the downloads directory
+func cleanAllDownloads() error {
+	files, err := os.ReadDir(paths.Downloads())
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		if err := os.Remove(filepath.Join(paths.Downloads(), file.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/pkg/agent/application/upgrade/cleanup.go
+++ b/internal/pkg/agent/application/upgrade/cleanup.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
+
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 )
 
@@ -26,7 +28,7 @@ func preUpgradeCleanup(version string) error {
 		}
 		if !strings.Contains(file.Name(), version) {
 			if err := os.Remove(filepath.Join(paths.Downloads(), file.Name())); err != nil {
-				rErr = muliterror.Append(rErr, fmt.Errorf("unable to remove file %q: %w", filepath.Joing(paths.Downloads(), file.Name()), err))
+				rErr = multierror.Append(rErr, fmt.Errorf("unable to remove file %q: %w", filepath.Join(paths.Downloads(), file.Name()), err))
 			}
 		}
 	}
@@ -39,12 +41,13 @@ func cleanAllDownloads() error {
 	if err != nil {
 		return fmt.Errorf("unable to read directory %q: %w", paths.Downloads(), err)
 	}
+	var rErr error
 	for _, file := range files {
 		if file.IsDir() {
 			continue
 		}
 		if err := os.Remove(filepath.Join(paths.Downloads(), file.Name())); err != nil {
-			rErr = muliterror.Append(rErr, fmt.Errorf("unable to remove file %q: %w", filepath.Joing(paths.Downloads(), file.Name()), err))
+			rErr = multierror.Append(rErr, fmt.Errorf("unable to remove file %q: %w", filepath.Join(paths.Downloads(), file.Name()), err))
 		}
 	}
 	return rErr

--- a/internal/pkg/agent/application/upgrade/cleanup.go
+++ b/internal/pkg/agent/application/upgrade/cleanup.go
@@ -34,21 +34,3 @@ func preUpgradeCleanup(version string) error {
 	}
 	return rErr
 }
-
-// cleanAllDownloads will remove all files from the downloads directory
-func cleanAllDownloads() error {
-	files, err := os.ReadDir(paths.Downloads())
-	if err != nil {
-		return fmt.Errorf("unable to read directory %q: %w", paths.Downloads(), err)
-	}
-	var rErr error
-	for _, file := range files {
-		if file.IsDir() {
-			continue
-		}
-		if err := os.Remove(filepath.Join(paths.Downloads(), file.Name())); err != nil {
-			rErr = multierror.Append(rErr, fmt.Errorf("unable to remove file %q: %w", filepath.Join(paths.Downloads(), file.Name()), err))
-		}
-	}
-	return rErr
-}

--- a/internal/pkg/agent/application/upgrade/cleanup_test.go
+++ b/internal/pkg/agent/application/upgrade/cleanup_test.go
@@ -19,19 +19,19 @@ func setupDir(t *testing.T) {
 	dir := t.TempDir()
 	paths.SetDownloads(dir)
 
-	err := os.WriteFile(filepath.Join(dir, "test-8.3.0-file"), []byte("hello, world!"), 0640)
+	err := os.WriteFile(filepath.Join(dir, "test-8.3.0-file"), []byte("hello, world!"), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = os.WriteFile(filepath.Join(dir, "test-8.4.0-file"), []byte("hello, world!"), 0640)
+	err = os.WriteFile(filepath.Join(dir, "test-8.4.0-file"), []byte("hello, world!"), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = os.WriteFile(filepath.Join(dir, "test-8.5.0-file"), []byte("hello, world!"), 0640)
+	err = os.WriteFile(filepath.Join(dir, "test-8.5.0-file"), []byte("hello, world!"), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = os.WriteFile(filepath.Join(dir, "test-hash-file"), []byte("hello, world!"), 0640)
+	err = os.WriteFile(filepath.Join(dir, "test-hash-file"), []byte("hello, world!"), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pkg/agent/application/upgrade/cleanup_test.go
+++ b/internal/pkg/agent/application/upgrade/cleanup_test.go
@@ -1,0 +1,61 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+
+	"github.com/stretchr/testify/require"
+)
+
+func setupDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	paths.SetDownloads(dir)
+
+	err := os.WriteFile(filepath.Join(dir, "test-8.3.0-file"), []byte("hello, world!"), 0640)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(filepath.Join(dir, "test-8.4.0-file"), []byte("hello, world!"), 0640)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(filepath.Join(dir, "test-8.5.0-file"), []byte("hello, world!"), 0640)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(filepath.Join(dir, "test-hash-file"), []byte("hello, world!"), 0640)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPreUpgradeCleanup(t *testing.T) {
+	setupDir(t)
+	err := preUpgradeCleanup("8.4.0")
+	require.NoError(t, err)
+
+	files, err := os.ReadDir(paths.Downloads())
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, "test-8.4.0-file", files[0].Name())
+	fi, err := files[0].Info()
+	require.NoError(t, err)
+	require.Greater(t, fi.Size(), int64(0))
+}
+
+func TestCleanAllDownloads(t *testing.T) {
+	setupDir(t)
+	err := cleanAllDownloads()
+	require.NoError(t, err)
+	files, err := os.ReadDir(paths.Downloads())
+	require.NoError(t, err)
+	require.Len(t, files, 0)
+}

--- a/internal/pkg/agent/application/upgrade/cleanup_test.go
+++ b/internal/pkg/agent/application/upgrade/cleanup_test.go
@@ -42,12 +42,3 @@ func TestPreUpgradeCleanup(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte("hello, world!"), p)
 }
-
-func TestCleanAllDownloads(t *testing.T) {
-	setupDir(t)
-	err := cleanAllDownloads()
-	require.NoError(t, err)
-	files, err := os.ReadDir(paths.Downloads())
-	require.NoError(t, err)
-	require.Len(t, files, 0)
-}

--- a/internal/pkg/agent/application/upgrade/cleanup_test.go
+++ b/internal/pkg/agent/application/upgrade/cleanup_test.go
@@ -20,21 +20,13 @@ func setupDir(t *testing.T) {
 	paths.SetDownloads(dir)
 
 	err := os.WriteFile(filepath.Join(dir, "test-8.3.0-file"), []byte("hello, world!"), 0600)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = os.WriteFile(filepath.Join(dir, "test-8.4.0-file"), []byte("hello, world!"), 0600)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = os.WriteFile(filepath.Join(dir, "test-8.5.0-file"), []byte("hello, world!"), 0600)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = os.WriteFile(filepath.Join(dir, "test-hash-file"), []byte("hello, world!"), 0600)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestPreUpgradeCleanup(t *testing.T) {
@@ -46,9 +38,9 @@ func TestPreUpgradeCleanup(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, files, 1)
 	require.Equal(t, "test-8.4.0-file", files[0].Name())
-	fi, err := files[0].Info()
+	p, err := os.ReadFile(filepath.Join(paths.Downloads(), files[0].Name()))
 	require.NoError(t, err)
-	require.Greater(t, fi.Size(), int64(0))
+	require.Equal(t, []byte("hello, world!"), p)
 }
 
 func TestCleanAllDownloads(t *testing.T) {

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -190,13 +190,16 @@ func (u *Upgrader) Upgrade(ctx context.Context, a Action, reexecNow bool) (_ ree
 
 	cb := shutdownCallback(u.log, paths.Home(), release.Version(), a.Version(), release.TrimCommit(newHash))
 	if reexecNow {
+		err = os.RemoveAll(paths.Downloads())
+		if err != nil {
+			u.log.Errorf("Unable to clean downloads dir %q after update: %v", paths.Downloads(), err)
+		}
 		u.reexec.ReExec(cb)
 		return nil, nil
 	}
 
 	// Clean everything from the downloads dir
-	// If we wanted to be a bit simpler we could call os.RemoveAll to remove the dir + children
-	err = cleanAllDownloads()
+	err = os.RemoveAll(paths.Downloads())
 	if err != nil {
 		u.log.Errorf("Unable to clean downloads dir %q after update: %v", paths.Downloads(), err)
 	}

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -126,7 +126,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, a Action, reexecNow bool) (_ ree
 				"running under control of the systems supervisor")
 	}
 
-	err = preUpgradeCleanup(a.Version())
+	err = preUpgradeCleanup(u.agentInfo.Version())
 	if err != nil {
 		u.log.Errorf("Unable to clean downloads dir %q before update: %v", paths.Downloads(), err)
 	}
@@ -144,7 +144,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, a Action, reexecNow bool) (_ ree
 	if err != nil {
 		// Run the same preUpgradeCleanup task to get rid of any newly downloaded files
 		// This may have an issue if users are upgrading to the same version number.
-		if dErr := preUpgradeCleanup(a.Version()); dErr != nil {
+		if dErr := preUpgradeCleanup(u.agentInfo.Version()); dErr != nil {
 			u.log.Errorf("Unable to remove file after verification failure: %v", dErr)
 		}
 		return nil, err


### PR DESCRIPTION
## What does this PR do?

The update process will cleanup unneeded artifacts. When an update
starts all artifacts that do not have the current version number in it's
name will be removed. If artifact retrieval fails, downloaded artifacts
are removed. On a successful upgrade, all contents of the downloads dir
will be removed.

## Why is it important?

If verification fails because of an issue with the download, the agent will not be able to upgrade future attempts.
If the agent goes through a lot of upgrades it will use a lot of storage for binaries that are not used.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. cherry-pick to `8.3`
2. Install agent running 8.4.0-SNAPSHOT
3. Upgrade agent through UI
4. After upgrade is successful, there is no `downloads` dir in old agent dir

## Related issues

- Closes #693 
- Closes #694 