### PR TITLE
Alter github action to run on different OSs

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,18 +14,10 @@ jobs:
   golangci:
     strategy:
       matrix:
-        include:
-          - GOOS: windows
-          - GOOS: linux
-          - GOOS: darwin
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ${{  matrix.os }}
     steps:
-      - name: Echo details
-        env:
-           GOOS: ${{ matrix.GOOS }}
-        run: echo Go GOOS=$GOOS
-
       - uses: actions/checkout@v2
 
       # Uses Go version from the repository.
@@ -38,8 +30,6 @@ jobs:
           go-version: "${{ steps.goversion.outputs.version }}"
 
       - name: golangci-lint
-        env:
-          GOOS: ${{ matrix.GOOS }}
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version

--- a/internal/pkg/agent/application/secret/secret.go
+++ b/internal/pkg/agent/application/secret/secret.go
@@ -2,6 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+// Package secret manages application secrets.
 package secret
 
 import (


### PR DESCRIPTION
## What does this PR do?

Alter the linter action to run on different OSs instead of on linux with
the $GOOS env var.

## Why is it important?

We have issues in other PRs where the linter actions create a lot of false positives.

## Related issues

- Closes #486 