### PR TITLE
update dependency elastic/go-structform from v0.0.9 to v0.0.10

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -8227,11 +8227,11 @@ Contents of probable licence file $GOMODCACHE/github.com/docker/go-connections@v
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/go-structform
-Version: v0.0.9
+Version: v0.0.10
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/go-structform@v0.0.9/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/go-structform@v0.0.10/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v20.10.12+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
-	github.com/elastic/go-structform v0.0.9 // indirect
+	github.com/elastic/go-structform v0.0.10 // indirect
 	github.com/elastic/go-windows v1.0.1 // indirect
 	github.com/elastic/gosigar v0.14.2 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,9 @@ github.com/elastic/go-elasticsearch/v8 v8.0.0-20210317102009-a9d74cec0186/go.mod
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=
 github.com/elastic/go-licenser v0.4.0 h1:jLq6A5SilDS/Iz1ABRkO6BHy91B9jBora8FwGRsDqUI=
 github.com/elastic/go-licenser v0.4.0/go.mod h1:V56wHMpmdURfibNBggaSBfqgPxyT1Tldns1i87iTEvU=
-github.com/elastic/go-structform v0.0.9 h1:HpcS7xljL4kSyUfDJ8cXTJC6rU5ChL1wYb6cx3HLD+o=
 github.com/elastic/go-structform v0.0.9/go.mod h1:CZWf9aIRYY5SuKSmOhtXScE5uQiLZNqAFnwKR4OrIM4=
+github.com/elastic/go-structform v0.0.10 h1:oy08o/Ih2hHTkNcRY/1HhaYvIp5z6t8si8gnCJPDo1w=
+github.com/elastic/go-structform v0.0.10/go.mod h1:CZWf9aIRYY5SuKSmOhtXScE5uQiLZNqAFnwKR4OrIM4=
 github.com/elastic/go-sysinfo v1.1.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=
 github.com/elastic/go-sysinfo v1.7.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=


### PR DESCRIPTION
Signed-off-by: Florian Lehner <florian.lehner@elastic.co>


## What does this PR do?

Update the dependency `elastic/go-structform` from `v0.0.9` to `v0.0.10`.


## Why is it important?

The dependency `elastic/go-structform`  [v0.0.10](https://github.com/elastic/go-structform/commit/54c82b302f9adce354ec9b51abe9cef3bd4245ca) includes changes to reduce the memory footprint and so does have an positive effect also on `elastic/elastic-agent`.

## Checklist


- [ ] ~~My code follows the style guidelines of this project~~
PR does not introduce code changes.
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
PR does not introduce code changes.
- [ ] ~~I have made corresponding changes to the documentation~~
PR does not introduce code changes.
- [ ] ~~I have made corresponding change to the default configuration files~~
No configuration changes with this PR.
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
PR does not introduce code changes.
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
PR does not introduce code changes.