### PR TITLE
Fix RPM/DEB clean install

### DIFF
--- a/dev-tools/packaging/templates/linux/postinstall.sh.tmpl
+++ b/dev-tools/packaging/templates/linux/postinstall.sh.tmpl
@@ -1,25 +1,26 @@
 #!/usr/bin/env bash
 
+set -e
+
 symlink="/usr/share/elastic-agent/bin/elastic-agent"
 old_agent_dir=""
 
 # check if $symlink exists for the previous install
-if test -f "$symlink"; then
-    resolved_symlink="$(readlink -f -e -- "$symlink")"
+# and derive the old agent directory
+if test -L "$symlink"; then
+    resolved_symlink="$(readlink -f -- "$symlink")"
     # check if it is resolved to non empty string
     if ! [ -z "$resolved_symlink" ]; then
         old_agent_dir="$( dirname "$resolved_symlink" )"
     fi
 fi
 
-set -e
-
 commit_hash="{{ commit_short }}"
 
 new_agent_dir="/var/lib/elastic-agent/data/elastic-agent-$commit_hash"
 
 # copy the state files if there was a previous agent install
-if ! [ -z "$old_agent_dir" ]; then
+if ! [ -z "$old_agent_dir" ] && ! [ "$old_agent_dir" -ef "$new_agent_dir" ]; then
     yml_path="$old_agent_dir/state.yml"
     enc_path="$old_agent_dir/state.enc"
     echo "migrate state from $old_agent_dir to $new_agent_dir"

--- a/dev-tools/packaging/templates/linux/postinstall.sh.tmpl
+++ b/dev-tools/packaging/templates/linux/postinstall.sh.tmpl
@@ -1,18 +1,27 @@
 #!/usr/bin/env bash
 
-set -e
-
 symlink="/usr/share/elastic-agent/bin/elastic-agent"
-old_agent_dir="$( dirname "$(readlink -f -- "$symlink")" )"
+old_agent_dir=""
+
+# check if $symlink exists for the previous install
+if test -f "$symlink"; then
+    resolved_symlink="$(readlink -f -e -- "$symlink")"
+    # check if it is resolved to non empty string
+    if ! [ -z "$resolved_symlink" ]; then
+        old_agent_dir="$( dirname "$resolved_symlink" )"
+    fi
+fi
+
+set -e
 
 commit_hash="{{ commit_short }}"
 
-yml_path="$old_agent_dir/state.yml"
-enc_path="$old_agent_dir/state.enc"
+new_agent_dir="/var/lib/elastic-agent/data/elastic-agent-$commit_hash"
 
-new_agent_dir="$( dirname "$old_agent_dir")/elastic-agent-$commit_hash"
-
-if ! [[ "$old_agent_dir" -ef "$new_agent_dir" ]]; then
+# copy the state files if there was a previous agent install
+if ! [ -z "$old_agent_dir" ]; then
+    yml_path="$old_agent_dir/state.yml"
+    enc_path="$old_agent_dir/state.enc"
     echo "migrate state from $old_agent_dir to $new_agent_dir"
 
     if test -f "$yml_path"; then
@@ -24,15 +33,17 @@ if ! [[ "$old_agent_dir" -ef "$new_agent_dir" ]]; then
         echo "found "$enc_path", copy to "$new_agent_dir"."
         cp "$enc_path" "$new_agent_dir"
     fi
-
-    if test -f "$symlink"; then
-        echo "found symlink $symlink, unlink"
-        unlink "$symlink"
-    fi
-
-    echo "create symlink "$symlink" to "$new_agent_dir/elastic-agent""
-    ln -s "$new_agent_dir/elastic-agent" "$symlink"
 fi
+
+# delete symlink if exists
+if test -f "$symlink"; then
+    echo "found symlink $symlink, unlink"
+    unlink "$symlink"
+fi
+
+# create symlink to the new agent
+echo "create symlink "$symlink" to "$new_agent_dir/elastic-agent""
+ln -s "$new_agent_dir/elastic-agent" "$symlink"
 
 systemctl daemon-reload 2> /dev/null
 exit 0

--- a/dev-tools/packaging/templates/linux/postinstall.sh.tmpl
+++ b/dev-tools/packaging/templates/linux/postinstall.sh.tmpl
@@ -37,7 +37,7 @@ if ! [ -z "$old_agent_dir" ] && ! [ "$old_agent_dir" -ef "$new_agent_dir" ]; the
 fi
 
 # delete symlink if exists
-if test -f "$symlink"; then
+if test -L "$symlink"; then
     echo "found symlink $symlink, unlink"
     unlink "$symlink"
 fi


### PR DESCRIPTION
## What does this PR do?

Updates post-install script to handle the clean RPM/DEB install correctly if there were no previous agent installs were on the system.

## Why is it important?

Fixes the https://github.com/elastic/elastic-agent/issues/803 for 8.4.0 and latest 8.3.4 builds.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas


## How to test this PR locally

* Clean Install
1. Install 8.4.0 from RPM with not previous installs or previous agent data on the system.

* Upgrade Install
1. Install 8.3.1 from RPM, enroll and make sure it runs correctly
2. Stop the agent service.
3. Install 8.4.0 from RPM, start the service, make sure it runs correctly


## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/803

