### PR TITLE
Fix/panic with composable renderer

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -112,7 +112,7 @@
 - Allow the / char in variable names in eql and transpiler. {issue}715[715] {pull}718[718]
 - Fix data duplication for standalone agent on Kubernetes using the default manifest {issue-beats}31512[31512] {pull}742[742]
 - Agent updates will clean up unneeded artifacts. {issue}693[693] {issue}694[694] {pull}752[752]
-- Fix a panic cause by a race condition when installing the Elastic Agent. {issues}806[806]
+- Fix a panic caused by a race condition when installing the Elastic Agent. {issues}806[806]
 
 ==== New features
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -112,6 +112,7 @@
 - Allow the / char in variable names in eql and transpiler. {issue}715[715] {pull}718[718]
 - Fix data duplication for standalone agent on Kubernetes using the default manifest {issue-beats}31512[31512] {pull}742[742]
 - Agent updates will clean up unneeded artifacts. {issue}693[693] {issue}694[694] {pull}752[752]
+- Fix a panic cause by a race condition when installing the Elastic Agent. {issues}806[806]
 
 ==== New features
 

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -235,10 +235,11 @@ func applyDynamics(ctx context.Context, log *logger.Logger, cfg *config.Config) 
 	if ok {
 		varsArray := make([]*transpiler.Vars, 0)
 
-		// Gie some time for the providers to replaces the variables
+		// Give some time for the providers to replace the variables
 		const timeout = 15 * time.Second
 		var doOnce sync.Once
 		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
 
 		// The composable system will continuously run, we are only interested in the first run on of the
 		// renderer to collect the variables we should stop the execution.

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -235,9 +235,15 @@ func applyDynamics(ctx context.Context, log *logger.Logger, cfg *config.Config) 
 		varsArray := make([]*transpiler.Vars, 0)
 		var wg sync.WaitGroup
 		wg.Add(1)
+
+		ctx, cancel := context.WithCancel(ctx)
+
+		// The composable system will continuously run, we are only interested in the first run on of the
+		// renderer to collect the variables we should stop the execution.
 		varsCallback := func(vv []*transpiler.Vars) {
 			varsArray = vv
 			wg.Done()
+			cancel()
 		}
 
 		ctrl, err := composable.New(log, cfg)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

In the code to retrieve the variables from the configuration files we
need to pass a execution callback, this callback will be called in a
goroutine. This callback can be executed multiple time until the
composable renderer is stopped. There were a problem in the code that
made the callback called multiple time and it made the waitgroup
internal counter to do to a negative values.

This commit change the behavior, it start the composable renderer give
it a callback when the callback receives the variables it will stop the
composable's Run method using the context.

This ensure that the callback will be called a single time and that the
variables are correctly retrieved.

Fixes: https://github.com/elastic/elastic-agent/issues/806

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

This is hard race bug to reproduce, it was found using automation tools to deploy elastic agent on multiple machine.
Just enrolling the Agent could trigger this issue. Try to enroll gent on slower machines, its pretty hard to reproduce it, I was able to reproduce it on a Linux VM but in a loop.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
-->
- Closes #806


## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
