### PR TITLE
Reload downloader client on config change

### DIFF
--- a/internal/pkg/agent/application/local_mode.go
+++ b/internal/pkg/agent/application/local_mode.go
@@ -119,6 +119,11 @@ func newLocal(
 		return nil, errors.New(err, "failed to initialize composable controller")
 	}
 
+	routerArtifactReloader, ok := router.(emitter.Reloader)
+	if !ok {
+		return nil, errors.New("router not capable of artifact reload") // Needed for client reloading
+	}
+
 	discover := discoverer(pathConfigFile, cfg.Settings.Path, externalConfigsGlob())
 	emit, err := emitter.New(
 		localApplication.bgContext,
@@ -133,6 +138,7 @@ func newLocal(
 		caps,
 		monitor,
 		artifact.NewReloader(cfg.Settings.DownloadConfig, log),
+		routerArtifactReloader,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/agent/application/managed_mode.go
+++ b/internal/pkg/agent/application/managed_mode.go
@@ -146,6 +146,11 @@ func newManaged(
 		return nil, errors.New(err, "failed to initialize composable controller")
 	}
 
+	routerArtifactReloader, ok := router.(emitter.Reloader)
+	if !ok {
+		return nil, errors.New("router not capable of artifact reload") // Needed for client reloading
+	}
+
 	emit, err := emitter.New(
 		managedApplication.bgContext,
 		log,
@@ -159,6 +164,7 @@ func newManaged(
 		caps,
 		monitor,
 		artifact.NewReloader(cfg.Settings.DownloadConfig, log),
+		routerArtifactReloader,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/agent/application/pipeline/emitter/controller.go
+++ b/internal/pkg/agent/application/pipeline/emitter/controller.go
@@ -21,7 +21,7 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
-type reloadable interface {
+type Reloader interface {
 	Reload(cfg *config.Config) error
 }
 
@@ -32,7 +32,7 @@ type Controller struct {
 	controller  composable.Controller
 	router      pipeline.Router
 	modifiers   *pipeline.ConfigModifiers
-	reloadables []reloadable
+	reloadables []Reloader
 	caps        capabilities.Capability
 
 	// state
@@ -51,7 +51,7 @@ func NewController(
 	router pipeline.Router,
 	modifiers *pipeline.ConfigModifiers,
 	caps capabilities.Capability,
-	reloadables ...reloadable,
+	reloadables ...Reloader,
 ) *Controller {
 	init, _ := transpiler.NewVars(map[string]interface{}{}, nil)
 

--- a/internal/pkg/agent/application/pipeline/emitter/emitter.go
+++ b/internal/pkg/agent/application/pipeline/emitter/emitter.go
@@ -22,7 +22,7 @@ import (
 )
 
 // New creates a new emitter function.
-func New(ctx context.Context, log *logger.Logger, agentInfo *info.AgentInfo, controller composable.Controller, router pipeline.Router, modifiers *pipeline.ConfigModifiers, caps capabilities.Capability, reloadables ...reloadable) (pipeline.EmitterFunc, error) {
+func New(ctx context.Context, log *logger.Logger, agentInfo *info.AgentInfo, controller composable.Controller, router pipeline.Router, modifiers *pipeline.ConfigModifiers, caps capabilities.Capability, reloadables ...Reloader) (pipeline.EmitterFunc, error) {
 	log.Debugf("Supported programs: %s", strings.Join(program.KnownProgramNames(), ", "))
 
 	ctrl := NewController(log, agentInfo, controller, router, modifiers, caps, reloadables...)

--- a/internal/pkg/agent/application/pipeline/router/router.go
+++ b/internal/pkg/agent/application/pipeline/router/router.go
@@ -11,8 +11,10 @@ import (
 	"time"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/pipeline"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/pipeline/emitter"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configrequest"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
+	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/sorted"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
@@ -33,6 +35,27 @@ func New(log *logger.Logger, factory pipeline.StreamFunc) (pipeline.Router, erro
 		}
 	}
 	return &router{log: log, streamFactory: factory, routes: sorted.NewSet()}, nil
+}
+
+func (r *router) Reload(c *config.Config) error {
+	keys := r.routes.Keys()
+	for _, key := range keys {
+		route, found := r.routes.Get(key)
+		if !found {
+			continue
+		}
+
+		routeReloader, ok := route.(emitter.Reloader)
+		if !ok {
+			continue
+		}
+
+		if err := routeReloader.Reload(c); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (r *router) Routes() *sorted.Set {

--- a/internal/pkg/agent/application/pipeline/stream/operator_stream.go
+++ b/internal/pkg/agent/application/pipeline/stream/operator_stream.go
@@ -10,8 +10,10 @@ import (
 	"go.elastic.co/apm"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/pipeline"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/pipeline/emitter"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configrequest"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
+	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/core/state"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
@@ -27,6 +29,15 @@ type stater interface {
 
 type specer interface {
 	Specs() map[string]program.Spec
+}
+
+func (b *operatorStream) Reload(c *config.Config) error {
+	r, ok := b.configHandler.(emitter.Reloader)
+	if !ok {
+		return nil
+	}
+
+	return r.Reload(c)
 }
 
 func (b *operatorStream) Close() error {

--- a/internal/pkg/agent/operation/operator.go
+++ b/internal/pkg/agent/operation/operator.go
@@ -117,8 +117,8 @@ func NewOperator(
 
 	operator.initHandlerMap()
 
-	os.MkdirAll(config.DownloadConfig.TargetDirectory, 0755)
-	os.MkdirAll(config.DownloadConfig.InstallPath, 0755)
+	_ = os.MkdirAll(config.DownloadConfig.TargetDirectory, 0755)
+	_ = os.MkdirAll(config.DownloadConfig.InstallPath, 0755)
 
 	return operator, nil
 }
@@ -273,12 +273,12 @@ func (o *Operator) Shutdown() {
 			a.Shutdown()
 			wg.Done()
 			o.logger.Debugf("took %s to shutdown %s",
-				time.Now().Sub(started), a.Name())
+				time.Since(started), a.Name())
 		}(a)
 	}
 	wg.Wait()
 	o.logger.Debugf("took %s to shutdown %d apps",
-		time.Now().Sub(started), len(o.apps))
+		time.Since(started), len(o.apps))
 }
 
 // Start starts a new process based on a configuration

--- a/internal/pkg/artifact/config.go
+++ b/internal/pkg/artifact/config.go
@@ -80,7 +80,9 @@ func (r *Reloader) Reload(rawConfig *config.Config) error {
 	}
 
 	for _, reloader := range r.reloaders {
-		reloader.Reload(r.cfg)
+		if err := reloader.Reload(r.cfg); err != nil {
+			return errors.New(err, "failed reloading config")
+		}
 	}
 
 	return nil

--- a/internal/pkg/artifact/config.go
+++ b/internal/pkg/artifact/config.go
@@ -25,6 +25,10 @@ const (
 	defaultSourceURI = "https://artifacts.elastic.co/downloads/"
 )
 
+type ConfigReloader interface {
+	Reload(*Config) error
+}
+
 // Config is a configuration used for verifier and downloader
 type Config struct {
 	// OperatingSystem: operating system [linux, windows, darwin]
@@ -53,14 +57,16 @@ type Config struct {
 }
 
 type Reloader struct {
-	log *logger.Logger
-	cfg *Config
+	log       *logger.Logger
+	cfg       *Config
+	reloaders []ConfigReloader
 }
 
-func NewReloader(cfg *Config, log *logger.Logger) *Reloader {
+func NewReloader(cfg *Config, log *logger.Logger, rr ...ConfigReloader) *Reloader {
 	return &Reloader{
-		cfg: cfg,
-		log: log,
+		cfg:       cfg,
+		log:       log,
+		reloaders: rr,
 	}
 }
 
@@ -71,6 +77,10 @@ func (r *Reloader) Reload(rawConfig *config.Config) error {
 
 	if err := r.reloadSourceURI(rawConfig); err != nil {
 		return errors.New(err, "failed to reload source URI")
+	}
+
+	for _, reloader := range r.reloaders {
+		reloader.Reload(r.cfg)
 	}
 
 	return nil

--- a/internal/pkg/artifact/download/composed/downloader.go
+++ b/internal/pkg/artifact/download/composed/downloader.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"go.elastic.co/apm"
 
+	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download"
@@ -59,7 +60,9 @@ func (e *Downloader) Reload(c *artifact.Config) error {
 			continue
 		}
 
-		reloadable.Reload(c)
+		if err := reloadable.Reload(c); err != nil {
+			return errors.New(err, "failed reloading artifact config")
+		}
 	}
 	return nil
 }

--- a/internal/pkg/artifact/download/composed/downloader.go
+++ b/internal/pkg/artifact/download/composed/downloader.go
@@ -61,7 +61,7 @@ func (e *Downloader) Reload(c *artifact.Config) error {
 		}
 
 		if err := reloadable.Reload(c); err != nil {
-			return errors.New(err, "failed reloading artifact config")
+			return errors.New(err, "failed reloading artifact config for composed downloader")
 		}
 	}
 	return nil

--- a/internal/pkg/artifact/download/composed/downloader.go
+++ b/internal/pkg/artifact/download/composed/downloader.go
@@ -11,6 +11,7 @@ import (
 	"go.elastic.co/apm"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
+	"github.com/elastic/elastic-agent/internal/pkg/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download"
 )
 
@@ -49,4 +50,16 @@ func (e *Downloader) Download(ctx context.Context, spec program.Spec, version st
 	}
 
 	return "", err
+}
+
+func (e *Downloader) Reload(c *artifact.Config) error {
+	for _, d := range e.dd {
+		reloadable, ok := d.(download.Reloader)
+		if !ok {
+			continue
+		}
+
+		reloadable.Reload(c)
+	}
+	return nil
 }

--- a/internal/pkg/artifact/download/composed/verifier.go
+++ b/internal/pkg/artifact/download/composed/verifier.go
@@ -5,10 +5,9 @@
 package composed
 
 import (
-	"errors"
-
 	"github.com/hashicorp/go-multierror"
 
+	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download"
@@ -63,7 +62,9 @@ func (e *Verifier) Reload(c *artifact.Config) error {
 			continue
 		}
 
-		reloadable.Reload(c)
+		if err := reloadable.Reload(c); err != nil {
+			return errors.New(err, "failed reloading artifact config")
+		}
 	}
 	return nil
 }

--- a/internal/pkg/artifact/download/composed/verifier.go
+++ b/internal/pkg/artifact/download/composed/verifier.go
@@ -63,7 +63,7 @@ func (e *Verifier) Reload(c *artifact.Config) error {
 		}
 
 		if err := reloadable.Reload(c); err != nil {
-			return errors.New(err, "failed reloading artifact config")
+			return errors.New(err, "failed reloading artifact config for composed verifier")
 		}
 	}
 	return nil

--- a/internal/pkg/artifact/download/composed/verifier.go
+++ b/internal/pkg/artifact/download/composed/verifier.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
+	"github.com/elastic/elastic-agent/internal/pkg/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download"
 )
 
@@ -53,4 +54,16 @@ func (e *Verifier) Verify(spec program.Spec, version string) error {
 	}
 
 	return err
+}
+
+func (e *Verifier) Reload(c *artifact.Config) error {
+	for _, v := range e.vv {
+		reloadable, ok := v.(download.Reloader)
+		if !ok {
+			continue
+		}
+
+		reloadable.Reload(c)
+	}
+	return nil
 }

--- a/internal/pkg/artifact/download/http/downloader.go
+++ b/internal/pkg/artifact/download/http/downloader.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/atomic"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
-
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"

--- a/internal/pkg/artifact/download/http/downloader.go
+++ b/internal/pkg/artifact/download/http/downloader.go
@@ -73,6 +73,23 @@ func NewDownloaderWithClient(log progressLogger, config *artifact.Config, client
 	}
 }
 
+func (e *Downloader) Reload(c *artifact.Config) error {
+	// reload client
+	client, err := c.HTTPTransportSettings.Client(
+		httpcommon.WithAPMHTTPInstrumentation(),
+	)
+	if err != nil {
+		return errors.New(err, "failed to generate client out of config")
+	}
+
+	client.Transport = withHeaders(client.Transport, headers)
+
+	e.client = *client
+	e.config = c
+
+	return nil
+}
+
 // Download fetches the package from configured source.
 // Returns absolute path to downloaded package and an error.
 func (e *Downloader) Download(ctx context.Context, spec program.Spec, version string) (_ string, err error) {
@@ -80,7 +97,7 @@ func (e *Downloader) Download(ctx context.Context, spec program.Spec, version st
 	defer func() {
 		if err != nil {
 			for _, path := range downloadedFiles {
-				os.Remove(path)
+				_ = os.Remove(path)
 			}
 		}
 	}()
@@ -164,12 +181,14 @@ func (e *Downloader) downloadFile(ctx context.Context, artifactName, filename, f
 
 	resp, err := e.client.Do(req.WithContext(ctx))
 	if err != nil {
-		return "", errors.New(err, "fetching package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
+		// return path, file already exists and needs to be cleaned up
+		return fullPath, errors.New(err, "fetching package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return "", errors.New(fmt.Sprintf("call to '%s' returned unsuccessful status code: %d", sourceURI, resp.StatusCode), errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
+		// return path, file already exists and needs to be cleaned up
+		return fullPath, errors.New(fmt.Sprintf("call to '%s' returned unsuccessful status code: %d", sourceURI, resp.StatusCode), errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
 	}
 
 	fileSize := -1
@@ -186,7 +205,8 @@ func (e *Downloader) downloadFile(ctx context.Context, artifactName, filename, f
 	if err != nil {
 		reportCancel()
 		dp.ReportFailed(err)
-		return "", errors.New(err, "fetching package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
+		// return path, file already exists and needs to be cleaned up
+		return fullPath, errors.New(err, "copying fetched package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
 	}
 	reportCancel()
 	dp.ReportComplete()

--- a/internal/pkg/artifact/download/http/downloader.go
+++ b/internal/pkg/artifact/download/http/downloader.go
@@ -78,7 +78,7 @@ func (e *Downloader) Reload(c *artifact.Config) error {
 		httpcommon.WithAPMHTTPInstrumentation(),
 	)
 	if err != nil {
-		return errors.New(err, "failed to generate client out of config")
+		return errors.New(err, "http.downloader: failed to generate client out of config")
 	}
 
 	client.Transport = withHeaders(client.Transport, headers)
@@ -96,7 +96,9 @@ func (e *Downloader) Download(ctx context.Context, spec program.Spec, version st
 	defer func() {
 		if err != nil {
 			for _, path := range downloadedFiles {
-				_ = os.Remove(path)
+				if err := os.Remove(path); err != nil {
+					e.log.Warnf("failed to cleanup %s: %v", path, err)
+				}
 			}
 		}
 	}()

--- a/internal/pkg/artifact/download/http/verifier.go
+++ b/internal/pkg/artifact/download/http/verifier.go
@@ -60,6 +60,24 @@ func NewVerifier(config *artifact.Config, allowEmptyPgp bool, pgp []byte) (*Veri
 	return v, nil
 }
 
+func (v *Verifier) Reload(c *artifact.Config) error {
+	// reload client
+	client, err := c.HTTPTransportSettings.Client(
+		httpcommon.WithAPMHTTPInstrumentation(),
+		httpcommon.WithModRoundtripper(func(rt http.RoundTripper) http.RoundTripper {
+			return withHeaders(rt, headers)
+		}),
+	)
+	if err != nil {
+		return errors.New(err, "failed to generate client out of config")
+	}
+
+	v.client = *client
+	v.config = c
+
+	return nil
+}
+
 // Verify checks downloaded package on preconfigured
 // location against a key stored on elastic.co website.
 func (v *Verifier) Verify(spec program.Spec, version string) error {

--- a/internal/pkg/artifact/download/http/verifier.go
+++ b/internal/pkg/artifact/download/http/verifier.go
@@ -69,7 +69,7 @@ func (v *Verifier) Reload(c *artifact.Config) error {
 		}),
 	)
 	if err != nil {
-		return errors.New(err, "failed to generate client out of config")
+		return errors.New(err, "http.verifier: failed to generate client out of config")
 	}
 
 	v.client = *client

--- a/internal/pkg/artifact/download/reloadable.go
+++ b/internal/pkg/artifact/download/reloadable.go
@@ -1,0 +1,14 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package download
+
+import (
+	"github.com/elastic/elastic-agent/internal/pkg/artifact"
+)
+
+// Reloader is an interface allowing to reload artifact config
+type Reloader interface {
+	Reload(*artifact.Config) error
+}

--- a/internal/pkg/artifact/download/snapshot/downloader.go
+++ b/internal/pkg/artifact/download/snapshot/downloader.go
@@ -5,17 +5,25 @@
 package snapshot
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download/http"
 	"github.com/elastic/elastic-agent/internal/pkg/release"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
+
+type Downloader struct {
+	downloader      download.Downloader
+	versionOverride string
+}
 
 // NewDownloader creates a downloader which first checks local directory
 // and then fallbacks to remote if configured.
@@ -24,7 +32,36 @@ func NewDownloader(log *logger.Logger, config *artifact.Config, versionOverride 
 	if err != nil {
 		return nil, err
 	}
-	return http.NewDownloader(log, cfg)
+
+	httpDownloader, err := http.NewDownloader(log, cfg)
+	if err != nil {
+		return nil, errors.New(err, "failed to create downloader")
+	}
+
+	return &Downloader{
+		downloader:      httpDownloader,
+		versionOverride: versionOverride,
+	}, nil
+}
+
+func (e *Downloader) Reload(c *artifact.Config) error {
+	reloader, ok := e.downloader.(artifact.ConfigReloader)
+	if !ok {
+		return nil
+	}
+
+	cfg, err := snapshotConfig(c, e.versionOverride)
+	if err != nil {
+		return err
+	}
+
+	return reloader.Reload(cfg)
+}
+
+// Download fetches the package from configured source.
+// Returns absolute path to downloaded package and an error.
+func (e *Downloader) Download(ctx context.Context, spec program.Spec, version string) (string, error) {
+	return e.downloader.Download(ctx, spec, version)
 }
 
 func snapshotConfig(config *artifact.Config, versionOverride string) (*artifact.Config, error) {

--- a/internal/pkg/artifact/download/snapshot/downloader.go
+++ b/internal/pkg/artifact/download/snapshot/downloader.go
@@ -35,7 +35,7 @@ func NewDownloader(log *logger.Logger, config *artifact.Config, versionOverride 
 
 	httpDownloader, err := http.NewDownloader(log, cfg)
 	if err != nil {
-		return nil, errors.New(err, "failed to create downloader")
+		return nil, errors.New(err, "failed to create snapshot downloader")
 	}
 
 	return &Downloader{
@@ -52,7 +52,7 @@ func (e *Downloader) Reload(c *artifact.Config) error {
 
 	cfg, err := snapshotConfig(c, e.versionOverride)
 	if err != nil {
-		return err
+		return errors.New(err, "snapshot.downloader: failed to generate snapshot config")
 	}
 
 	return reloader.Reload(cfg)

--- a/internal/pkg/artifact/download/snapshot/verifier.go
+++ b/internal/pkg/artifact/download/snapshot/verifier.go
@@ -5,10 +5,17 @@
 package snapshot
 
 import (
+	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download/http"
 )
+
+type Verifier struct {
+	verifier        download.Verifier
+	versionOverride string
+}
 
 // NewVerifier creates a downloader which first checks local directory
 // and then fallbacks to remote if configured.
@@ -17,5 +24,33 @@ func NewVerifier(config *artifact.Config, allowEmptyPgp bool, pgp []byte, versio
 	if err != nil {
 		return nil, err
 	}
-	return http.NewVerifier(cfg, allowEmptyPgp, pgp)
+	v, err := http.NewVerifier(cfg, allowEmptyPgp, pgp)
+	if err != nil {
+		return nil, errors.New(err, "failed to create verifier")
+	}
+
+	return &Verifier{
+		verifier:        v,
+		versionOverride: versionOverride,
+	}, nil
+}
+
+// Verify checks the package from configured source.
+func (e *Verifier) Verify(spec program.Spec, version string) error {
+	return e.verifier.Verify(spec, version)
+}
+
+func (e *Verifier) Reload(c *artifact.Config) error {
+	reloader, ok := e.verifier.(artifact.ConfigReloader)
+	if !ok {
+		return nil
+	}
+
+	cfg, err := snapshotConfig(c, e.versionOverride)
+	if err != nil {
+		return err
+	}
+
+	return reloader.Reload(cfg)
+
 }

--- a/internal/pkg/artifact/download/snapshot/verifier.go
+++ b/internal/pkg/artifact/download/snapshot/verifier.go
@@ -26,7 +26,7 @@ func NewVerifier(config *artifact.Config, allowEmptyPgp bool, pgp []byte, versio
 	}
 	v, err := http.NewVerifier(cfg, allowEmptyPgp, pgp)
 	if err != nil {
-		return nil, errors.New(err, "failed to create verifier")
+		return nil, errors.New(err, "failed to create snapshot verifier")
 	}
 
 	return &Verifier{
@@ -48,7 +48,7 @@ func (e *Verifier) Reload(c *artifact.Config) error {
 
 	cfg, err := snapshotConfig(c, e.versionOverride)
 	if err != nil {
-		return err
+		return errors.New(err, "snapshot.downloader: failed to generate snapshot config")
 	}
 
 	return reloader.Reload(cfg)


### PR DESCRIPTION
## What does this PR do?

Downloaders have own instance of client which is used to download artifacts.
This client is created when constructing a downloader instance and exists for the time being. 
When configuration changes for `artifacts.download` client should be recreated to reflect new proxy/TLS/timeout settings.

On top of that this also fixes an issue when agent after failed download does not remove corrupted files which leads to retry of verification loop which fails on `asc and sha512` not found errors making downloads and upgrades unusable in a future.
This is source of many SDHs which requires manual intervention and cleaning up download directory by user. 

## Why is it important?

- reflecting changes in a client 
- reducing incident count for failed upgrades
- required to properly respond to proxy changes

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test
- build agent
- cleanup download before running
- set `agent.download.timeout` to `1s`
- run fleet or standalone
- see failures
- set timeout to `120s`
- should become healthy

@ph considering pushing this for 8.4 as a bug fix
