### PR TITLE
crossbuild: add fix to set ulimit for debian images

### DIFF
--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -281,6 +281,15 @@ func (b GolangCrossBuilder) Build() error {
 		verbose = "true"
 	}
 	var args []string
+	// There's a bug on certain debian versions:
+	// https://discuss.linuxcontainers.org/t/debian-jessie-containers-have-extremely-low-performance/1272
+	// basically, apt-get has a bug where will try to iterate through every possible FD as set by the NOFILE ulimit.
+	// On certain docker installs, docker will set the ulimit to a value > 10^9, which means apt-get will take >1 hour.
+	// This runs across all possible debian platforms, since there's no real harm in it.
+	if strings.Contains(image, "debian") {
+		args = append(args, "--ulimit", "nofile=262144:262144")
+	}
+
 	if runtime.GOOS != "windows" {
 		args = append(args,
 			"--env", "EXEC_UID="+strconv.Itoa(os.Getuid()),


### PR DESCRIPTION
Signed-off-by: Florian Lehner <florian.lehner@elastic.co>

## What does this PR do?

This PR ports over the fix that got into `elastic/beats` with https://github.com/elastic/beats/commit/d938679b499465690fae4a5a9b86ca8d8ff61df5 and https://github.com/elastic/beats/commit/ee6f4708451824bd8b8ee767e10e4f7f9a583ee7 as `elastic/elastic-agent` faces the very same issue.

## Why is it important?

For details about this bug please checkout https://github.com/elastic/beats/pull/32580.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
   No impacting changes for end users. So no update to the documentation.
- [ ] ~~I have made corresponding change to the default configuration files~~
  No changes to the configuration files are required.
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
-  [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
  This is a fix impacting developers and not end user facing. So I did not add an entry.
