### PR TITLE
Add control-plane toleration to Agent K8S manifests.

### DIFF
--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -15,8 +15,8 @@ spec:
       labels:
         app: elastic-agent
     spec:
-      # Tolerations are needed to run Elastic Agent on Kubernetes master nodes.
-      # Agents running on master nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
+      # Tolerations are needed to run Elastic Agent on Kubernetes control-plane nodes.
+      # Agents running on control-plane nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule

--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -18,6 +18,8 @@ spec:
       # Tolerations are needed to run Elastic Agent on Kubernetes master nodes.
       # Agents running on master nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
       tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
       serviceAccountName: elastic-agent

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -15,8 +15,8 @@ spec:
       labels:
         app: elastic-agent
     spec:
-      # Tolerations are needed to run Elastic Agent on Kubernetes master nodes.
-      # Agents running on master nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
+      # Tolerations are needed to run Elastic Agent on Kubernetes control-plane nodes.
+      # Agents running on control-plane nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       # Tolerations are needed to run Elastic Agent on Kubernetes master nodes.
       # Agents running on master nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
       tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
       serviceAccountName: elastic-agent

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -643,6 +643,8 @@ spec:
       # Tolerations are needed to run Elastic Agent on Kubernetes master nodes.
       # Agents running on master nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
       tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
       serviceAccountName: elastic-agent-standalone

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -640,8 +640,8 @@ spec:
       labels:
         app: elastic-agent-standalone
     spec:
-      # Tolerations are needed to run Elastic Agent on Kubernetes master nodes.
-      # Agents running on master nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
+      # Tolerations are needed to run Elastic Agent on Kubernetes control-plane nodes.
+      # Agents running on control-plane nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
@@ -14,8 +14,8 @@ spec:
       labels:
         app: elastic-agent-standalone
     spec:
-      # Tolerations are needed to run Elastic Agent on Kubernetes master nodes.
-      # Agents running on master nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
+      # Tolerations are needed to run Elastic Agent on Kubernetes control-plane nodes.
+      # Agents running on control-plane nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
@@ -17,6 +17,8 @@ spec:
       # Tolerations are needed to run Elastic Agent on Kubernetes master nodes.
       # Agents running on master nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
       tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
       serviceAccountName: elastic-agent-standalone


### PR DESCRIPTION
## What does this PR do?

The K8S taint with key `node-role.kubernetes.io/control-plane` is set to replace the deprecated taint with key `node-role.kubernetes.io/master` which will be removed by Kubernetes v1.25, as described [here](https://kubernetes.io/docs/reference/labels-annotations-taints/#node-role-kubernetes-io-master).

Newly provisioned K8S clusters will have either both taints on the control-plane (previously known as master) node, or only the one with the new key. Example on a multi-node K8S v1.24 cluster provisioned with `kind`:

![Screenshot 2022-08-05 at 11 32 55 AM](https://user-images.githubusercontent.com/9020112/183011857-483422b0-b6dd-4f0b-87dc-6539fda4a267.png)

The effect in either case is that with our existing manifests, an Elastic Agent pod won't be scheduled on the control-plane node. Adding a toleration to these manifests that matches the new taint key fixes this problem.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ It's a minor configuration change.
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] The change shouldn't affect behavior of applying our manifests to existing K8S clusters with only the old taint. I have verified this on such a cluster.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Using `kind` with the following `config.yml`:
```
# two node (1 control plane 1 worker) cluster config  
kind: Cluster  
apiVersion: kind.x-k8s.io/v1alpha4  
nodes:  
- role: control-plane  
- role: worker
```
Create the cluster:
```
kind create cluster --name taint-test --config config.yml --image=kindest/node:v1.24.2
```
Verify that the node has the new taint with key `node-role.kubernetes.io/control-plane`:
```
kubectl describe node taint-test-control-plane | grep -i taints -A 5
```

Applying our K8S manifests from before this change will schedule pods for only the worker node. After this change, the manifest ensures that pods will be scheduled for all nodes.

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
Prevents problems for users deploying Elastic Agent on K8S clusters.
