### PR TITLE
[8.4](backport #848) Reload downloader client on config change

### DIFF
--- a/internal/pkg/agent/application/local_mode.go
+++ b/internal/pkg/agent/application/local_mode.go
@@ -119,6 +119,11 @@ func newLocal(
 		return nil, errors.New(err, "failed to initialize composable controller")
 	}
 
+	routerArtifactReloader, ok := router.(emitter.Reloader)
+	if !ok {
+		return nil, errors.New("router not capable of artifact reload") // Needed for client reloading
+	}
+
 	discover := discoverer(pathConfigFile, cfg.Settings.Path, externalConfigsGlob())
 	emit, err := emitter.New(
 		localApplication.bgContext,
@@ -133,6 +138,7 @@ func newLocal(
 		caps,
 		monitor,
 		artifact.NewReloader(cfg.Settings.DownloadConfig, log),
+		routerArtifactReloader,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/agent/application/local_mode.go
+++ b/internal/pkg/agent/application/local_mode.go
@@ -22,6 +22,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/operation"
+	"github.com/elastic/elastic-agent/internal/pkg/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/capabilities"
 	"github.com/elastic/elastic-agent/internal/pkg/composable"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
@@ -131,6 +132,7 @@ func newLocal(
 		},
 		caps,
 		monitor,
+		artifact.NewReloader(cfg.Settings.DownloadConfig, log),
 	)
 	if err != nil {
 		return nil, err
@@ -203,7 +205,7 @@ func (l *Local) AgentInfo() *info.AgentInfo {
 }
 
 func discoverer(patterns ...string) discoverFunc {
-	var p []string
+	p := make([]string, 0, len(patterns))
 	for _, newP := range patterns {
 		if len(newP) == 0 {
 			continue

--- a/internal/pkg/agent/application/managed_mode.go
+++ b/internal/pkg/agent/application/managed_mode.go
@@ -146,6 +146,11 @@ func newManaged(
 		return nil, errors.New(err, "failed to initialize composable controller")
 	}
 
+	routerArtifactReloader, ok := router.(emitter.Reloader)
+	if !ok {
+		return nil, errors.New("router not capable of artifact reload") // Needed for client reloading
+	}
+
 	emit, err := emitter.New(
 		managedApplication.bgContext,
 		log,
@@ -159,6 +164,7 @@ func newManaged(
 		caps,
 		monitor,
 		artifact.NewReloader(cfg.Settings.DownloadConfig, log),
+		routerArtifactReloader,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/agent/application/pipeline/emitter/controller.go
+++ b/internal/pkg/agent/application/pipeline/emitter/controller.go
@@ -21,7 +21,7 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
-type reloadable interface {
+type Reloader interface {
 	Reload(cfg *config.Config) error
 }
 
@@ -32,7 +32,7 @@ type Controller struct {
 	controller  composable.Controller
 	router      pipeline.Router
 	modifiers   *pipeline.ConfigModifiers
-	reloadables []reloadable
+	reloadables []Reloader
 	caps        capabilities.Capability
 
 	// state
@@ -51,7 +51,7 @@ func NewController(
 	router pipeline.Router,
 	modifiers *pipeline.ConfigModifiers,
 	caps capabilities.Capability,
-	reloadables ...reloadable,
+	reloadables ...Reloader,
 ) *Controller {
 	init, _ := transpiler.NewVars(map[string]interface{}{}, nil)
 

--- a/internal/pkg/agent/application/pipeline/emitter/emitter.go
+++ b/internal/pkg/agent/application/pipeline/emitter/emitter.go
@@ -22,7 +22,7 @@ import (
 )
 
 // New creates a new emitter function.
-func New(ctx context.Context, log *logger.Logger, agentInfo *info.AgentInfo, controller composable.Controller, router pipeline.Router, modifiers *pipeline.ConfigModifiers, caps capabilities.Capability, reloadables ...reloadable) (pipeline.EmitterFunc, error) {
+func New(ctx context.Context, log *logger.Logger, agentInfo *info.AgentInfo, controller composable.Controller, router pipeline.Router, modifiers *pipeline.ConfigModifiers, caps capabilities.Capability, reloadables ...Reloader) (pipeline.EmitterFunc, error) {
 	log.Debugf("Supported programs: %s", strings.Join(program.KnownProgramNames(), ", "))
 
 	ctrl := NewController(log, agentInfo, controller, router, modifiers, caps, reloadables...)

--- a/internal/pkg/agent/application/pipeline/router/router.go
+++ b/internal/pkg/agent/application/pipeline/router/router.go
@@ -11,8 +11,10 @@ import (
 	"time"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/pipeline"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/pipeline/emitter"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configrequest"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
+	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/sorted"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
@@ -33,6 +35,27 @@ func New(log *logger.Logger, factory pipeline.StreamFunc) (pipeline.Router, erro
 		}
 	}
 	return &router{log: log, streamFactory: factory, routes: sorted.NewSet()}, nil
+}
+
+func (r *router) Reload(c *config.Config) error {
+	keys := r.routes.Keys()
+	for _, key := range keys {
+		route, found := r.routes.Get(key)
+		if !found {
+			continue
+		}
+
+		routeReloader, ok := route.(emitter.Reloader)
+		if !ok {
+			continue
+		}
+
+		if err := routeReloader.Reload(c); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (r *router) Routes() *sorted.Set {

--- a/internal/pkg/agent/application/pipeline/stream/operator_stream.go
+++ b/internal/pkg/agent/application/pipeline/stream/operator_stream.go
@@ -10,8 +10,10 @@ import (
 	"go.elastic.co/apm"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/pipeline"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/pipeline/emitter"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configrequest"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
+	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/core/state"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
@@ -27,6 +29,15 @@ type stater interface {
 
 type specer interface {
 	Specs() map[string]program.Spec
+}
+
+func (b *operatorStream) Reload(c *config.Config) error {
+	r, ok := b.configHandler.(emitter.Reloader)
+	if !ok {
+		return nil
+	}
+
+	return r.Reload(c)
 }
 
 func (b *operatorStream) Close() error {

--- a/internal/pkg/artifact/config.go
+++ b/internal/pkg/artifact/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	c "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
@@ -64,6 +65,42 @@ func NewReloader(cfg *Config, log *logger.Logger) *Reloader {
 }
 
 func (r *Reloader) Reload(rawConfig *config.Config) error {
+	if err := r.reloadConfig(rawConfig); err != nil {
+		return errors.New(err, "failed to reload config")
+	}
+
+	if err := r.reloadSourceURI(rawConfig); err != nil {
+		return errors.New(err, "failed to reload source URI")
+	}
+
+	return nil
+}
+
+func (r *Reloader) reloadConfig(rawConfig *config.Config) error {
+	type reloadConfig struct {
+		C *Config `json:"agent.download" config:"agent.download"`
+	}
+	tmp := &reloadConfig{
+		C: DefaultConfig(),
+	}
+	if err := rawConfig.Unpack(&tmp); err != nil {
+		return err
+	}
+
+	*(r.cfg) = Config{
+		OperatingSystem:       tmp.C.OperatingSystem,
+		Architecture:          tmp.C.Architecture,
+		SourceURI:             tmp.C.SourceURI,
+		TargetDirectory:       tmp.C.TargetDirectory,
+		InstallPath:           tmp.C.InstallPath,
+		DropPath:              tmp.C.DropPath,
+		HTTPTransportSettings: tmp.C.HTTPTransportSettings,
+	}
+
+	return nil
+}
+
+func (r *Reloader) reloadSourceURI(rawConfig *config.Config) error {
 	type reloadConfig struct {
 		// SourceURI: source of the artifacts, e.g https://artifacts.elastic.co/downloads/
 		SourceURI string `json:"agent.download.sourceURI" config:"agent.download.sourceURI"`
@@ -78,11 +115,11 @@ func (r *Reloader) Reload(rawConfig *config.Config) error {
 	}
 
 	var newSourceURI string
-	if cfg.FleetSourceURI != "" {
+	if fleetURI := strings.TrimSpace(cfg.FleetSourceURI); fleetURI != "" {
 		// fleet configuration takes precedence
-		newSourceURI = cfg.FleetSourceURI
-	} else if cfg.SourceURI != "" {
-		newSourceURI = cfg.SourceURI
+		newSourceURI = fleetURI
+	} else if sourceURI := strings.TrimSpace(cfg.SourceURI); sourceURI != "" {
+		newSourceURI = sourceURI
 	}
 
 	if newSourceURI != "" {
@@ -147,4 +184,43 @@ func (c *Config) Arch() string {
 
 	c.Architecture = arch
 	return c.Architecture
+}
+
+// Unpack reads a config object into the settings.
+func (c *Config) Unpack(cfg *c.C) error {
+	tmp := struct {
+		OperatingSystem string `json:"-" config:",ignore"`
+		Architecture    string `json:"-" config:",ignore"`
+		SourceURI       string `json:"sourceURI" config:"sourceURI"`
+		TargetDirectory string `json:"targetDirectory" config:"target_directory"`
+		InstallPath     string `yaml:"installPath" config:"install_path"`
+		DropPath        string `yaml:"dropPath" config:"drop_path"`
+	}{
+		OperatingSystem: c.OperatingSystem,
+		Architecture:    c.Architecture,
+		SourceURI:       c.SourceURI,
+		TargetDirectory: c.TargetDirectory,
+		InstallPath:     c.InstallPath,
+		DropPath:        c.DropPath,
+	}
+
+	if err := cfg.Unpack(&tmp); err != nil {
+		return err
+	}
+
+	transport := DefaultConfig().HTTPTransportSettings
+	if err := cfg.Unpack(&transport); err != nil {
+		return err
+	}
+
+	*c = Config{
+		OperatingSystem:       tmp.OperatingSystem,
+		Architecture:          tmp.Architecture,
+		SourceURI:             tmp.SourceURI,
+		TargetDirectory:       tmp.TargetDirectory,
+		InstallPath:           tmp.InstallPath,
+		DropPath:              tmp.DropPath,
+		HTTPTransportSettings: transport,
+	}
+	return nil
 }

--- a/internal/pkg/artifact/config_test.go
+++ b/internal/pkg/artifact/config_test.go
@@ -1,0 +1,247 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package artifact
+
+import (
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent/internal/pkg/config"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReload(t *testing.T) {
+	type testCase struct {
+		input                    string
+		initialConfig            *Config
+		expectedSourceURI        string
+		expectedTargetDirectory  string
+		expectedInstallDirectory string
+		expectedDropDirectory    string
+		expectedFingerprint      string
+		expectedTLS              bool
+		expectedTLSEnabled       bool
+		expectedDisableProxy     bool
+		expectedTimeout          time.Duration
+	}
+	defaultValues := DefaultConfig()
+	testCases := []testCase{
+		{
+			input: `agent.download:
+  sourceURI: "testing.uri"
+  target_directory: "a/b/c"
+  install_path: "i/p"
+  drop_path: "d/p"
+  proxy_disable: true
+  timeout: 33s
+  ssl.enabled: true
+  ssl.ca_trusted_fingerprint: "my_finger_print"
+`,
+			initialConfig:            DefaultConfig(),
+			expectedSourceURI:        "testing.uri",
+			expectedTargetDirectory:  "a/b/c",
+			expectedInstallDirectory: "i/p",
+			expectedDropDirectory:    "d/p",
+			expectedFingerprint:      "my_finger_print",
+			expectedTLS:              true,
+			expectedTLSEnabled:       true,
+			expectedDisableProxy:     true,
+			expectedTimeout:          33 * time.Second,
+		},
+		{
+			input: `agent.download:
+  sourceURI: "testing.uri"
+`,
+			initialConfig:            DefaultConfig(),
+			expectedSourceURI:        "testing.uri",
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: `agent.download:
+  sourceURI: ""
+`,
+			initialConfig: &Config{
+				SourceURI:             "testing.uri",
+				HTTPTransportSettings: defaultValues.HTTPTransportSettings,
+			},
+			expectedSourceURI:        defaultValues.SourceURI, // fallback to default when set to empty
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: ``,
+			initialConfig: &Config{
+				SourceURI:             "testing.uri",
+				HTTPTransportSettings: defaultValues.HTTPTransportSettings,
+			},
+			expectedSourceURI:        defaultValues.SourceURI, // fallback to default when not set
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: `agent.download:
+  sourceURI: " "
+`,
+			initialConfig: &Config{
+				SourceURI:             "testing.uri",
+				HTTPTransportSettings: defaultValues.HTTPTransportSettings,
+			},
+			expectedSourceURI:        defaultValues.SourceURI, // fallback to default when set to whitespace
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: `agent.download:
+  source_uri: " "
+`,
+			initialConfig: &Config{
+				SourceURI:             "testing.uri",
+				HTTPTransportSettings: defaultValues.HTTPTransportSettings,
+			},
+			expectedSourceURI:        defaultValues.SourceURI, // fallback to default when set to whitespace
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: `agent.download:
+  source_uri: " "
+  sourceURI: " "
+`,
+			initialConfig:            DefaultConfig(),
+			expectedSourceURI:        defaultValues.SourceURI, // fallback to default when set to whitespace
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: ``,
+			initialConfig: &Config{
+				SourceURI:             "testing.uri",
+				HTTPTransportSettings: defaultValues.HTTPTransportSettings,
+			},
+			expectedSourceURI:        defaultValues.SourceURI,
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: `agent.download:
+  source_uri: " "
+  sourceURI: "testing.uri"
+`,
+			initialConfig:            DefaultConfig(),
+			expectedSourceURI:        "testing.uri",
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: `agent.download:
+  source_uri: "testing.uri"
+  sourceURI: " "
+`,
+			initialConfig:            DefaultConfig(),
+			expectedSourceURI:        "testing.uri",
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: `agent.download:
+  source_uri: "testing.uri"
+  sourceURI: "another.uri"
+`,
+			initialConfig:            DefaultConfig(),
+			expectedSourceURI:        "testing.uri",
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+	}
+
+	l, _ := logger.NewTesting("t")
+	for _, tc := range testCases {
+		cfg := tc.initialConfig
+		reloader := NewReloader(cfg, l)
+
+		c, err := config.NewConfigFrom(tc.input)
+		require.NoError(t, err)
+
+		require.NoError(t, reloader.Reload(c))
+
+		require.Equal(t, tc.expectedSourceURI, cfg.SourceURI)
+		require.Equal(t, tc.expectedTargetDirectory, cfg.TargetDirectory)
+		require.Equal(t, tc.expectedInstallDirectory, cfg.InstallPath)
+		require.Equal(t, tc.expectedDropDirectory, cfg.DropPath)
+		require.Equal(t, tc.expectedTimeout, cfg.Timeout)
+
+		require.Equal(t, tc.expectedDisableProxy, cfg.Proxy.Disable)
+
+		if tc.expectedTLS {
+			require.NotNil(t, cfg.TLS)
+			require.Equal(t, tc.expectedTLSEnabled, *cfg.TLS.Enabled)
+			require.Equal(t, tc.expectedFingerprint, cfg.TLS.CATrustedFingerprint)
+		} else {
+			require.Nil(t, cfg.TLS)
+		}
+	}
+}

--- a/internal/pkg/artifact/download/composed/verifier.go
+++ b/internal/pkg/artifact/download/composed/verifier.go
@@ -5,11 +5,11 @@
 package composed
 
 import (
-	"errors"
-
 	"github.com/hashicorp/go-multierror"
 
+	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
+	"github.com/elastic/elastic-agent/internal/pkg/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download"
 )
 
@@ -53,4 +53,18 @@ func (e *Verifier) Verify(spec program.Spec, version string) error {
 	}
 
 	return err
+}
+
+func (e *Verifier) Reload(c *artifact.Config) error {
+	for _, v := range e.vv {
+		reloadable, ok := v.(download.Reloader)
+		if !ok {
+			continue
+		}
+
+		if err := reloadable.Reload(c); err != nil {
+			return errors.New(err, "failed reloading artifact config for composed verifier")
+		}
+	}
+	return nil
 }

--- a/internal/pkg/artifact/download/http/downloader.go
+++ b/internal/pkg/artifact/download/http/downloader.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/atomic"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
-
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
@@ -73,6 +72,23 @@ func NewDownloaderWithClient(log progressLogger, config *artifact.Config, client
 	}
 }
 
+func (e *Downloader) Reload(c *artifact.Config) error {
+	// reload client
+	client, err := c.HTTPTransportSettings.Client(
+		httpcommon.WithAPMHTTPInstrumentation(),
+	)
+	if err != nil {
+		return errors.New(err, "http.downloader: failed to generate client out of config")
+	}
+
+	client.Transport = withHeaders(client.Transport, headers)
+
+	e.client = *client
+	e.config = c
+
+	return nil
+}
+
 // Download fetches the package from configured source.
 // Returns absolute path to downloaded package and an error.
 func (e *Downloader) Download(ctx context.Context, spec program.Spec, version string) (_ string, err error) {
@@ -80,7 +96,9 @@ func (e *Downloader) Download(ctx context.Context, spec program.Spec, version st
 	defer func() {
 		if err != nil {
 			for _, path := range downloadedFiles {
-				os.Remove(path)
+				if err := os.Remove(path); err != nil {
+					e.log.Warnf("failed to cleanup %s: %v", path, err)
+				}
 			}
 		}
 	}()
@@ -164,12 +182,14 @@ func (e *Downloader) downloadFile(ctx context.Context, artifactName, filename, f
 
 	resp, err := e.client.Do(req.WithContext(ctx))
 	if err != nil {
-		return "", errors.New(err, "fetching package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
+		// return path, file already exists and needs to be cleaned up
+		return fullPath, errors.New(err, "fetching package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return "", errors.New(fmt.Sprintf("call to '%s' returned unsuccessful status code: %d", sourceURI, resp.StatusCode), errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
+		// return path, file already exists and needs to be cleaned up
+		return fullPath, errors.New(fmt.Sprintf("call to '%s' returned unsuccessful status code: %d", sourceURI, resp.StatusCode), errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
 	}
 
 	fileSize := -1
@@ -186,7 +206,8 @@ func (e *Downloader) downloadFile(ctx context.Context, artifactName, filename, f
 	if err != nil {
 		reportCancel()
 		dp.ReportFailed(err)
-		return "", errors.New(err, "fetching package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
+		// return path, file already exists and needs to be cleaned up
+		return fullPath, errors.New(err, "copying fetched package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
 	}
 	reportCancel()
 	dp.ReportComplete()

--- a/internal/pkg/artifact/download/http/verifier.go
+++ b/internal/pkg/artifact/download/http/verifier.go
@@ -60,6 +60,24 @@ func NewVerifier(config *artifact.Config, allowEmptyPgp bool, pgp []byte) (*Veri
 	return v, nil
 }
 
+func (v *Verifier) Reload(c *artifact.Config) error {
+	// reload client
+	client, err := c.HTTPTransportSettings.Client(
+		httpcommon.WithAPMHTTPInstrumentation(),
+		httpcommon.WithModRoundtripper(func(rt http.RoundTripper) http.RoundTripper {
+			return withHeaders(rt, headers)
+		}),
+	)
+	if err != nil {
+		return errors.New(err, "http.verifier: failed to generate client out of config")
+	}
+
+	v.client = *client
+	v.config = c
+
+	return nil
+}
+
 // Verify checks downloaded package on preconfigured
 // location against a key stored on elastic.co website.
 func (v *Verifier) Verify(spec program.Spec, version string) error {

--- a/internal/pkg/artifact/download/reloadable.go
+++ b/internal/pkg/artifact/download/reloadable.go
@@ -1,0 +1,14 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package download
+
+import (
+	"github.com/elastic/elastic-agent/internal/pkg/artifact"
+)
+
+// Reloader is an interface allowing to reload artifact config
+type Reloader interface {
+	Reload(*artifact.Config) error
+}

--- a/internal/pkg/artifact/download/snapshot/downloader.go
+++ b/internal/pkg/artifact/download/snapshot/downloader.go
@@ -34,12 +34,13 @@ func snapshotConfig(config *artifact.Config, versionOverride string) (*artifact.
 	}
 
 	return &artifact.Config{
-		OperatingSystem:       config.OperatingSystem,
-		Architecture:          config.Architecture,
-		SourceURI:             snapshotURI,
-		TargetDirectory:       config.TargetDirectory,
-		InstallPath:           config.InstallPath,
-		DropPath:              config.DropPath,
+		OperatingSystem: config.OperatingSystem,
+		Architecture:    config.Architecture,
+		SourceURI:       snapshotURI,
+		TargetDirectory: config.TargetDirectory,
+		InstallPath:     config.InstallPath,
+		DropPath:        config.DropPath,
+
 		HTTPTransportSettings: config.HTTPTransportSettings,
 	}, nil
 }

--- a/internal/pkg/artifact/download/snapshot/downloader.go
+++ b/internal/pkg/artifact/download/snapshot/downloader.go
@@ -5,17 +5,25 @@
 package snapshot
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download/http"
 	"github.com/elastic/elastic-agent/internal/pkg/release"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
+
+type Downloader struct {
+	downloader      download.Downloader
+	versionOverride string
+}
 
 // NewDownloader creates a downloader which first checks local directory
 // and then fallbacks to remote if configured.
@@ -24,7 +32,36 @@ func NewDownloader(log *logger.Logger, config *artifact.Config, versionOverride 
 	if err != nil {
 		return nil, err
 	}
-	return http.NewDownloader(log, cfg)
+
+	httpDownloader, err := http.NewDownloader(log, cfg)
+	if err != nil {
+		return nil, errors.New(err, "failed to create snapshot downloader")
+	}
+
+	return &Downloader{
+		downloader:      httpDownloader,
+		versionOverride: versionOverride,
+	}, nil
+}
+
+func (e *Downloader) Reload(c *artifact.Config) error {
+	reloader, ok := e.downloader.(artifact.ConfigReloader)
+	if !ok {
+		return nil
+	}
+
+	cfg, err := snapshotConfig(c, e.versionOverride)
+	if err != nil {
+		return errors.New(err, "snapshot.downloader: failed to generate snapshot config")
+	}
+
+	return reloader.Reload(cfg)
+}
+
+// Download fetches the package from configured source.
+// Returns absolute path to downloaded package and an error.
+func (e *Downloader) Download(ctx context.Context, spec program.Spec, version string) (string, error) {
+	return e.downloader.Download(ctx, spec, version)
 }
 
 func snapshotConfig(config *artifact.Config, versionOverride string) (*artifact.Config, error) {

--- a/internal/pkg/artifact/download/snapshot/verifier.go
+++ b/internal/pkg/artifact/download/snapshot/verifier.go
@@ -5,10 +5,17 @@
 package snapshot
 
 import (
+	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download/http"
 )
+
+type Verifier struct {
+	verifier        download.Verifier
+	versionOverride string
+}
 
 // NewVerifier creates a downloader which first checks local directory
 // and then fallbacks to remote if configured.
@@ -17,5 +24,33 @@ func NewVerifier(config *artifact.Config, allowEmptyPgp bool, pgp []byte, versio
 	if err != nil {
 		return nil, err
 	}
-	return http.NewVerifier(cfg, allowEmptyPgp, pgp)
+	v, err := http.NewVerifier(cfg, allowEmptyPgp, pgp)
+	if err != nil {
+		return nil, errors.New(err, "failed to create snapshot verifier")
+	}
+
+	return &Verifier{
+		verifier:        v,
+		versionOverride: versionOverride,
+	}, nil
+}
+
+// Verify checks the package from configured source.
+func (e *Verifier) Verify(spec program.Spec, version string) error {
+	return e.verifier.Verify(spec, version)
+}
+
+func (e *Verifier) Reload(c *artifact.Config) error {
+	reloader, ok := e.verifier.(artifact.ConfigReloader)
+	if !ok {
+		return nil
+	}
+
+	cfg, err := snapshotConfig(c, e.versionOverride)
+	if err != nil {
+		return errors.New(err, "snapshot.downloader: failed to generate snapshot config")
+	}
+
+	return reloader.Reload(cfg)
+
 }


### PR DESCRIPTION
Backport of #848 and #776 as prerequisite 

## What does this PR do?

Downloaders have own instance of client which is used to download artifacts.
This client is created when constructing a downloader instance and exists for the time being. 
When configuration changes for `artifacts.download` client should be recreated to reflect new proxy/TLS/timeout settings.

On top of that this also fixes an issue when agent after failed download does not remove corrupted files which leads to retry of verification loop which fails on `asc and sha512` not found errors making downloads and upgrades unusable in a future.
This is source of many SDHs which requires manual intervention and cleaning up download directory by user. 

## Why is it important?

- reflecting changes in a client 
- reducing incident count for failed upgrades
- required to properly respond to proxy changes