### PR TITLE
Expand check-in payload for V2

### DIFF
--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	eaclient "github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/dispatcher"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/gateway"
@@ -21,6 +22,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/acker"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
 	"github.com/elastic/elastic-agent/internal/pkg/scheduler"
+	"github.com/elastic/elastic-agent/pkg/component/runtime"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
@@ -298,6 +300,73 @@ func (f *fleetGateway) doExecute(ctx context.Context, bo backoff.Backoff) (*flee
 	return nil, ctx.Err()
 }
 
+func (f *fleetGateway) convertToCheckinComponents(components []runtime.ComponentComponentState) []fleetapi.CheckinComponent {
+	if components == nil {
+		return nil
+	}
+	stateString := func(s eaclient.UnitState) string {
+		switch s {
+		case eaclient.UnitStateStarting:
+			return "starting"
+		case eaclient.UnitStateConfiguring:
+			return "configuring"
+		case eaclient.UnitStateHealthy:
+			return "healthy"
+		case eaclient.UnitStateDegraded:
+			return "degraded"
+		case eaclient.UnitStateFailed:
+			return "failed"
+		case eaclient.UnitStateStopping:
+			return "stopping"
+		case eaclient.UnitStateStopped:
+			return "stopped"
+		}
+		return ""
+	}
+
+	unitTypeString := func(t eaclient.UnitType) string {
+		switch t {
+		case eaclient.UnitTypeInput:
+			return "input"
+		case eaclient.UnitTypeOutput:
+			return "output"
+		}
+		return ""
+	}
+
+	checkinComponents := make([]fleetapi.CheckinComponent, 0, len(components))
+
+	for _, item := range components {
+		component := item.Component
+		state := item.State
+
+		checkinComponent := fleetapi.CheckinComponent{
+			ID:      component.ID,
+			Type:    component.Spec.InputType,
+			Status:  stateString(state.State),
+			Message: state.Message,
+		}
+
+		if state.Units != nil {
+			units := make([]fleetapi.CheckinUnit, 0, len(state.Units))
+
+			for unitKey, unitState := range state.Units {
+				units = append(units, fleetapi.CheckinUnit{
+					ID:      unitKey.UnitID,
+					Type:    unitTypeString(unitKey.UnitType),
+					Status:  stateString(unitState.State),
+					Message: unitState.Message,
+					Payload: unitState.Payload,
+				})
+			}
+			checkinComponent.Units = units
+		}
+		checkinComponents = append(checkinComponents, checkinComponent)
+	}
+
+	return checkinComponents
+}
+
 func (f *fleetGateway) execute(ctx context.Context) (*fleetapi.CheckinResponse, error) {
 	ecsMeta, err := info.Metadata()
 	if err != nil {
@@ -313,12 +382,17 @@ func (f *fleetGateway) execute(ctx context.Context) (*fleetapi.CheckinResponse, 
 	// get current state
 	state := f.stateFetcher.State()
 
+	// convert components into checkin components structure
+	components := f.convertToCheckinComponents(state.Components)
+
 	// checkin
 	cmd := fleetapi.NewCheckinCmd(f.agentInfo, f.client)
 	req := &fleetapi.CheckinRequest{
-		AckToken: ackToken,
-		Metadata: ecsMeta,
-		Status:   agentStateToString(state.State),
+		AckToken:   ackToken,
+		Metadata:   ecsMeta,
+		Status:     agentStateToString(state.State),
+		Message:    state.Message,
+		Components: components,
 	}
 
 	resp, err := cmd.Execute(ctx, req)

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -29,6 +29,9 @@ import (
 // Max number of times an invalid API Key is checked
 const maxUnauthCounter int = 6
 
+// Const for decraded state or linter complains
+const degraded = "degraded"
+
 // Default Configuration for the Fleet Gateway.
 var defaultGatewaySettings = &fleetGatewaySettings{
 	Duration: 1 * time.Second,        // time between successful calls
@@ -313,7 +316,7 @@ func (f *fleetGateway) convertToCheckinComponents(components []runtime.Component
 		case eaclient.UnitStateHealthy:
 			return "healthy"
 		case eaclient.UnitStateDegraded:
-			return "degraded"
+			return degraded
 		case eaclient.UnitStateFailed:
 			return "failed"
 		case eaclient.UnitStateStopping:
@@ -446,5 +449,5 @@ func agentStateToString(state agentclient.State) string {
 	case agentclient.Failed:
 		return "error"
 	}
-	return "degraded"
+	return degraded
 }

--- a/internal/pkg/fleetapi/checkin_cmd.go
+++ b/internal/pkg/fleetapi/checkin_cmd.go
@@ -20,12 +20,30 @@ import (
 
 const checkingPath = "/api/fleet/agents/%s/checkin"
 
+type CheckinUnit struct {
+	ID      string                 `json:"id"`
+	Type    string                 `json:"type"`
+	Status  string                 `json:"status"`
+	Message string                 `json:"message"`
+	Payload map[string]interface{} `json:"payload,omitempty"`
+}
+
+type CheckinComponent struct {
+	ID      string        `json:"id"`
+	Type    string        `json:"type"`
+	Status  string        `json:"status"`
+	Message string        `json:"message"`
+	Units   []CheckinUnit `json:"units,omitempty"`
+}
+
 // CheckinRequest consists of multiple events reported to fleet ui.
 type CheckinRequest struct {
-	Status   string              `json:"status"`
-	AckToken string              `json:"ack_token,omitempty"`
-	Events   []SerializableEvent `json:"events"`
-	Metadata *info.ECSMeta       `json:"local_metadata,omitempty"`
+	Status     string              `json:"status"`
+	AckToken   string              `json:"ack_token,omitempty"`
+	Events     []SerializableEvent `json:"events"`
+	Metadata   *info.ECSMeta       `json:"local_metadata,omitempty"`
+	Message    string              `json:"message"`    // V2 Agent message
+	Components []CheckinComponent  `json:"components"` // V2 Agent components
 }
 
 // SerializableEvent is a representation of the event to be send to the Fleet Server API via the checkin


### PR DESCRIPTION
## What does this PR do?

Expands the checkin payload with the new V2 payload.

@blakerouse I noticed that you added the Stringer API to the status/state constants in the latest elastic-agent-client but it was not picked up on this branch yet. When I tried to update I saw code breakage in other places. So leaving it for now. Can remove stringers later as needed.
I left some questions in the doc https://docs.google.com/document/d/1I0PeZKIkUTaWiY2F_Dum_gSi0cpbblcftl-tz81iYak/edit, seems like few things are missing in the code to match the doc format.

Will update fleet-server next.

## Why is it important?

Better, more granular agent status information.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/100

## Example of checkin payload as tested

```
{
    "status": "online",
    "events": null,
    "local_metadata": {
        "elastic": {
            "agent": {
                "id": "f13f6476-2739-4be9-a615-9d492e6558d0",
                "version": "8.4.0",
                "snapshot": true,
                "build.original": "8.4.0-SNAPSHOT (build: 2cc23382db4c89e605faf057b651a11cfe567638 at 2022-08-12 18:54:56 +0000 UTC)",
                "upgradeable": true,
                "log_level": "info"
            }
        },
        "host": {
            "architecture": "x86_64",
            "hostname": "mars2020",
            "name": "mars2020",
            "id": "2628AB39-F770-5FC3-B7F1-8CC95E506B0D",
            "ip": [
                "127.0.0.1/8",
                "::1/128",
                "fe80::1/64",
                "fe80::aede:48ff:fe00:1122/64",
                "fe80::10c9:d85d:3022:447d/64",
                "10.0.0.18/24",
                "fe80::64b9:afff:fed0:eb77/64",
                "fe80::64b9:afff:fed0:eb77/64",
                "fe80::94c0:5e15:cad:5482/64",
                "fe80::ea11:53f7:9933:39cc/64",
                "fe80::ce81:b1c:bd2c:69e/64"
            ],
            "mac": [
                "ac:de:48:00:11:22",
                "a6:83:e7:76:80:31",
                "a4:83:e7:76:80:31",
                "66:b9:af:d0:eb:77",
                "66:b9:af:d0:eb:77",
                "82:52:53:a8:c0:05",
                "82:52:53:a8:c0:01",
                "82:52:53:a8:c0:00",
                "82:52:53:a8:c0:04",
                "82:52:53:a8:c0:01"
            ]
        },
        "os": {
            "family": "darwin",
            "kernel": "21.6.0",
            "platform": "darwin",
            "version": "12.5",
            "name": "macOS",
            "full": "macOS(12.5)"
        }
    },
    "message": "Running",
    "components": [
        {
            "id": "winlog-default",
            "type": "winlog",
            "status": "starting",
            "message": "Starting: spawned pid '41297'",
            "units": [
                {
                    "id": "winlog-default-winlog-system-066f58e7-8cb9-4ff1-9324-26361cc929d0",
                    "type": "input",
                    "status": "starting",
                    "message": "Starting: spawned pid '41297'"
                },
                {
                    "id": "winlog-default",
                    "type": "output",
                    "status": "starting",
                    "message": "Starting: spawned pid '41297'"
                }
            ]
        },
        {
            "id": "system/metrics-default",
            "type": "system/metrics",
            "status": "starting",
            "message": "Starting: spawned pid '41298'",
            "units": [
                {
                    "id": "system/metrics-default",
                    "type": "output",
                    "status": "starting",
                    "message": "Starting: spawned pid '41298'"
                },
                {
                    "id": "system/metrics-default-system/metrics-system-066f58e7-8cb9-4ff1-9324-26361cc929d0",
                    "type": "input",
                    "status": "starting",
                    "message": "Starting: spawned pid '41298'"
                }
            ]
        },
        {
            "id": "log-default",
            "type": "log",
            "status": "starting",
            "message": "Starting: spawned pid '41296'",
            "units": [
                {
                    "id": "log-default-logfile-system-066f58e7-8cb9-4ff1-9324-26361cc929d0",
                    "type": "input",
                    "status": "starting",
                    "message": "Starting: spawned pid '41296'"
                },
                {
                    "id": "log-default",
                    "type": "output",
                    "status": "starting",
                    "message": "Starting: spawned pid '41296'"
                }
            ]
        }
    ]
}
```
