### PR TITLE
install mage with go install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ export MAGE_IMPORT_PATH
 mage:
 ifndef MAGE_PRESENT
 	@echo Installing mage $(MAGE_VERSION).
-	@go get -ldflags="-X $(MAGE_IMPORT_PATH)/mage.gitTag=$(MAGE_VERSION)" ${MAGE_IMPORT_PATH}@$(MAGE_VERSION)
+	@go install ${MAGE_IMPORT_PATH}@$(MAGE_VERSION)
 	@-mage -clean
 endif
 	@true


### PR DESCRIPTION
## What does this PR do?

Use [`go install`](https://pkg.go.dev/cmd/go#hdr-Compile_and_install_packages_and_dependencies). `go get` changes the  `go.mod` so it's not the preferred approach

## Why is it important?

After upgrading golang version `1.17.12` to `1.18.5` the `make mage` goal failed hence the Unified Release process cannot generate snapshots from `main`.

## Issues

Something similar was done when 1.16 was available, see https://github.com/elastic/apm-pipeline-library/pull/1300

## Test

```bash
VERBOSE=true ./dev-tools/run_with_go_ver make mage
VERBOSE=true ./dev-tools/run_with_go_ver mage build
VERBOSE=true ./dev-tools/run_with_go_ver mage package
```

<details><summary>Expand to view</summary>
<p>

```
 VERBOSE=true ./dev-tools/run_with_go_ver mage package                     
+ MSG='environment variable missing'
+ GO_VERSION=1.18.5
+ PROPERTIES_FILE=go_env.properties
+ HOME=/Users/user
++ uname -s
++ tr '[:upper:]' '[:lower:]'
+ OS=darwin
++ uname -m
++ tr '[:upper:]' '[:lower:]'
+ ARCH=x86_64
+ GVM_CMD=/Users/user/bin/gvm
+ command -v go
/usr/local/bin/go
+ set +e
+ echo 'Found Go. Checking version..'
Found Go. Checking version..
++ go version
++ awk '{print $3}'
++ sed s/go//
+ FOUND_GO_VERSION=1.16.3
+ '[' 1.16.3 == 1.18.5 ']'
+ set -e
+ '[' x86_64 == aarch64 ']'
+ '[' x86_64 == x86_64 ']'
+ GVM_ARCH_SUFFIX=amd64
+ echo 'UNMET DEP: Installing Go'
UNMET DEP: Installing Go
+ mkdir -p /Users/user/bin
+ curl -sSLo /Users/user/bin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.3.0/gvm-darwin-amd64
+ chmod +x /Users/user/bin/gvm
+ /Users/user/bin/gvm 1.18.5
+ cut -d ' ' -f 2
+ tr -d '\"'
++ /Users/user/bin/gvm 1.18.5
+ eval 'export GOROOT="/Users/user/.gvm/versions/go1.18.5.darwin.amd64"
export PATH="/Users/user/.gvm/versions/go1.18.5.darwin.amd64/bin:$PATH"'
++ export GOROOT=/Users/user/.gvm/versions/go1.18.5.darwin.amd64
++ GOROOT=/Users/user/.gvm/versions/go1.18.5.darwin.amd64
++ export PATH=/Users/user/.gvm/versions/go1.18.5.darwin.amd64/bin:/Users/user/bin:/usr/local/bin:/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin:/Users/user/bin:/Users/user/.sdkman/candidates/java/current/bin:/Users/user/.nvm/versions/node/v14.17.5/bin:/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin:/Users/user/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
++ PATH=/Users/user/.gvm/versions/go1.18.5.darwin.amd64/bin:/Users/user/bin:/usr/local/bin:/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin:/Users/user/bin:/Users/user/.sdkman/candidates/java/current/bin:/Users/user/.nvm/versions/node/v14.17.5/bin:/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin:/Users/user/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
DEBUG: GOPATH=/Users/user
DEBUG: go version go1.18.5 darwin/amd64
go version go1.18.5 darwin/amd64
...
Package 'filebeat-8.5.0-darwin-x86_64.tar.gz' does not exist on path: /Users/user/work/src/github.com/elastic/beats/x-pack/filebeat/build/distributions/filebeat-8.5.0-darwin-x86_64.tar.gz
No fields files for module azureeventhub
No fields files for module cloudfoundry
No fields files for module cometd
No fields files for module default-inputs
No fields files for module gcppubsub
No fields files for module http_endpoint
No fields files for module httpjson
No fields files for module o365audit
No fields files for module add_nomad_metadata
Generated fields.yml for filebeat to /Users/user/work/src/github.com/elastic/beats/x-pack/filebeat/fields.yml
>> Building filebeat.yml for linux/amd64
>> Building filebeat.reference.yml for linux/amd64
>> Building filebeat.docker.yml for linux/amd64
```