### PR TITLE
Add install path prefix option on agent install

### DIFF
--- a/internal/pkg/agent/application/info/state.go
+++ b/internal/pkg/agent/application/info/state.go
@@ -24,7 +24,7 @@ const (
 // This verifies the running executable path based on hard-coded paths
 // for each platform type.
 func RunningInstalled() bool {
-	expectedPaths := []string{filepath.Join(paths.InstallPath, paths.BinaryName)}
+	expectedPaths := []string{filepath.Join(paths.InstallDirectoryPath(), paths.BinaryName)}
 	if runtime.GOOS == darwin {
 		// For the symlink on darwin the execPath is /usr/local/bin/elastic-agent
 		expectedPaths = append(expectedPaths, paths.ShellWrapperPath)

--- a/internal/pkg/agent/application/paths/common.go
+++ b/internal/pkg/agent/application/paths/common.go
@@ -27,14 +27,15 @@ const (
 )
 
 var (
-	topPath         string
-	configPath      string
-	configFilePath  string
-	logsPath        string
-	downloadsPath   string
-	installPath     string
-	unversionedHome bool
-	tmpCreator      sync.Once
+	topPath              string
+	configPath           string
+	configFilePath       string
+	logsPath             string
+	downloadsPath        string
+	installPath          string
+	unversionedHome      bool
+	tmpCreator           sync.Once
+	installDirectoryPath string
 )
 
 func init() {
@@ -51,6 +52,7 @@ func init() {
 	fs.StringVar(&logsPath, "path.logs", logsPath, "Logs path contains Agent log output")
 	fs.StringVar(&downloadsPath, "path.downloads", downloadsPath, "Downloads path contains binaries Agent downloads")
 	fs.StringVar(&installPath, "path.install", installPath, "Install path contains binaries Agent extracts")
+	fs.StringVar(&installDirectoryPath, "path.prefix.install", installDirectoryPath, "Install elastic agent directory path")
 }
 
 // Top returns the top directory for Elastic Agent, all the versioned
@@ -159,6 +161,14 @@ func Downloads() string {
 // SetDownloads updates the path for the downloads.
 func SetDownloads(path string) {
 	downloadsPath = path
+}
+
+// InstallDirectoryPath installs elastic agent.
+func InstallDirectoryPath() string {
+	if installDirectoryPath == "" {
+		installDirectoryPath = DefaultInstallPrefixPath
+	}
+	return filepath.Join(installDirectoryPath, InstallSubPath)
 }
 
 // Install returns the install directory for Agent

--- a/internal/pkg/agent/application/paths/paths.go
+++ b/internal/pkg/agent/application/paths/paths.go
@@ -11,8 +11,11 @@ const (
 	// BinaryName is the name of the installed binary.
 	BinaryName = "elastic-agent"
 
-	// InstallPath is the installation path using for install command.
-	InstallPath = "/opt/Elastic/Agent"
+	// DefaultInstallPrefixPath is the installation path using for install command.
+	DefaultInstallPrefixPath = `/opt`
+
+	// InstallSubPath is the installation path using for install command.
+	InstallSubPath = `Elastic/Agent`
 
 	// SocketPath is the socket path used when installed.
 	SocketPath = "unix:///run/elastic-agent.sock"

--- a/internal/pkg/agent/application/paths/paths_darwin.go
+++ b/internal/pkg/agent/application/paths/paths_darwin.go
@@ -11,8 +11,11 @@ const (
 	// BinaryName is the name of the installed binary.
 	BinaryName = "elastic-agent"
 
-	// InstallPath is the installation path using for install command.
-	InstallPath = "/Library/Elastic/Agent"
+	// DefaultInstallPrefixPath is the installation path using for install command.
+	DefaultInstallPrefixPath = `/Library`
+
+	// InstallSubPath is the installation path using for install command.
+	InstallSubPath = `Elastic/Agent`
 
 	// SocketPath is the socket path used when installed.
 	SocketPath = "unix:///var/run/elastic-agent.sock"

--- a/internal/pkg/agent/application/paths/paths_windows.go
+++ b/internal/pkg/agent/application/paths/paths_windows.go
@@ -16,8 +16,11 @@ const (
 	// BinaryName is the name of the installed binary.
 	BinaryName = "elastic-agent.exe"
 
-	// InstallPath is the installation path using for install command.
-	InstallPath = `C:\Program Files\Elastic\Agent`
+	// DefaultInstallPrefixPath is the installation path using for install command.
+	DefaultInstallPrefixPath = `C:\Program Files`
+
+	// InstallSubPath is the installation path using for install command.
+	InstallSubPath = `Elastic\Agent`
 
 	// SocketPath is the socket path used when installed.
 	SocketPath = `\\.\pipe\elastic-agent-system`

--- a/internal/pkg/agent/application/upgrade/service.go
+++ b/internal/pkg/agent/application/upgrade/service.go
@@ -134,7 +134,7 @@ func (p *sysvPidProvider) PID(ctx context.Context) (int, error) {
 		return 0, errors.New(fmt.Sprintf("'%v' is not running", paths.ServiceName))
 	}
 
-	pidofLine, err := exec.Command("pidof", filepath.Join(paths.InstallPath, paths.BinaryName)).Output()
+	pidofLine, err := exec.Command("pidof", filepath.Join(paths.InstallDirectoryPath(), paths.BinaryName)).Output()
 	if err != nil {
 		return 0, errors.New(fmt.Sprintf("PID not found for'%v': %v", paths.ServiceName, err))
 	}

--- a/internal/pkg/agent/cmd/common.go
+++ b/internal/pkg/agent/cmd/common.go
@@ -47,7 +47,7 @@ func NewCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Command {
 	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.logs"))
 	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.downloads"))
 	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.install"))
-
+	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.prefix.install"))
 	// logging flags
 	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("v"))
 	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("e"))

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -393,6 +393,9 @@ func buildEnrollArgs(cfg setupConfig, token string, policyID string) ([]string, 
 	if paths.Install() != "" {
 		args = append(args, "--path.install", paths.Install())
 	}
+	if paths.InstallDirectoryPath() != "" {
+		args = append(args, "--path.prefix.install", paths.InstallDirectoryPath())
+	}
 	if !paths.IsVersionHome() {
 		args = append(args, "--path.home.unversioned")
 	}

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -596,6 +596,9 @@ func (c *enrollCmd) startAgent(ctx context.Context) (<-chan *os.ProcessState, er
 	if paths.Install() != "" {
 		args = append(args, "--path.install", paths.Install())
 	}
+	if paths.InstallDirectoryPath() != "" {
+		args = append(args, "--path.prefix.install", paths.InstallDirectoryPath())
+	}
 	if !paths.IsVersionHome() {
 		args = append(args, "--path.home.unversioned")
 	}

--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -58,7 +58,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 	status, reason := install.Status()
 	force, _ := cmd.Flags().GetBool("force")
 	if status == install.Installed && !force {
-		return fmt.Errorf("already installed at: %s", paths.InstallPath)
+		return fmt.Errorf("already installed at: %s", paths.InstallDirectoryPath())
 	}
 
 	nonInteractive, _ := cmd.Flags().GetBool("non-interactive")
@@ -83,7 +83,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 	if status == install.Broken {
 		if !force && !nonInteractive {
 			fmt.Fprintf(streams.Out, "Elastic Agent is installed but currently broken: %s\n", reason)
-			confirm, err := cli.Confirm(fmt.Sprintf("Continuing will re-install Elastic Agent over the current installation at %s. Do you want to continue?", paths.InstallPath), true)
+			confirm, err := cli.Confirm(fmt.Sprintf("Continuing will re-install Elastic Agent over the current installation at %s. Do you want to continue?", paths.InstallDirectoryPath()), true)
 			if err != nil {
 				return fmt.Errorf("problem reading prompt response")
 			}
@@ -93,7 +93,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		}
 	} else if status != install.PackageInstall {
 		if !force && !nonInteractive {
-			confirm, err := cli.Confirm(fmt.Sprintf("Elastic Agent will be installed at %s and will run as a service. Do you want to continue?", paths.InstallPath), true)
+			confirm, err := cli.Confirm(fmt.Sprintf("Elastic Agent will be installed at %s and will run as a service. Do you want to continue?", paths.InstallDirectoryPath()), true)
 			if err != nil {
 				return fmt.Errorf("problem reading prompt response")
 			}

--- a/internal/pkg/agent/cmd/uninstall.go
+++ b/internal/pkg/agent/cmd/uninstall.go
@@ -57,7 +57,7 @@ func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 	if status == install.Broken {
 		if !force {
 			fmt.Fprintf(streams.Out, "Elastic Agent is installed but currently broken: %s\n", reason)
-			confirm, err := cli.Confirm(fmt.Sprintf("Continuing will uninstall the broken Elastic Agent at %s. Do you want to continue?", paths.InstallPath), true)
+			confirm, err := cli.Confirm(fmt.Sprintf("Continuing will uninstall the broken Elastic Agent at %s. Do you want to continue?", paths.InstallDirectoryPath()), true)
 			if err != nil {
 				return fmt.Errorf("problem reading prompt response")
 			}
@@ -67,7 +67,7 @@ func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		}
 	} else {
 		if !force {
-			confirm, err := cli.Confirm(fmt.Sprintf("Elastic Agent will be uninstalled from your system at %s. Do you want to continue?", paths.InstallPath), true)
+			confirm, err := cli.Confirm(fmt.Sprintf("Elastic Agent will be uninstalled from your system at %s. Do you want to continue?", paths.InstallDirectoryPath()), true)
 			if err != nil {
 				return fmt.Errorf("problem reading prompt response")
 			}
@@ -83,6 +83,6 @@ func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 	}
 	fmt.Fprintf(streams.Out, "Elastic Agent has been uninstalled.\n")
 
-	_ = install.RemovePath(paths.InstallPath)
+	_ = install.RemovePath(paths.InstallDirectoryPath())
 	return nil
 }

--- a/internal/pkg/agent/install/install.go
+++ b/internal/pkg/agent/install/install.go
@@ -36,14 +36,14 @@ func Install(cfgFile string) error {
 	}
 
 	// ensure parent directory exists, copy source into install path
-	err = os.MkdirAll(filepath.Dir(paths.InstallPath), 0755)
+	err = os.MkdirAll(filepath.Dir(paths.InstallDirectoryPath()), 0755)
 	if err != nil {
 		return errors.New(
 			err,
-			fmt.Sprintf("failed to create installation parent directory (%s)", filepath.Dir(paths.InstallPath)),
-			errors.M("directory", filepath.Dir(paths.InstallPath)))
+			fmt.Sprintf("failed to create installation parent directory (%s)", filepath.Dir(paths.InstallDirectoryPath())),
+			errors.M("directory", filepath.Dir(paths.InstallDirectoryPath())))
 	}
-	err = copy.Copy(dir, paths.InstallPath, copy.Options{
+	err = copy.Copy(dir, paths.InstallDirectoryPath(), copy.Options{
 		OnSymlink: func(_ string) copy.SymlinkAction {
 			return copy.Shallow
 		},
@@ -52,8 +52,8 @@ func Install(cfgFile string) error {
 	if err != nil {
 		return errors.New(
 			err,
-			fmt.Sprintf("failed to copy source directory (%s) to destination (%s)", dir, paths.InstallPath),
-			errors.M("source", dir), errors.M("destination", paths.InstallPath))
+			fmt.Sprintf("failed to copy source directory (%s) to destination (%s)", dir, paths.InstallDirectoryPath()),
+			errors.M("source", dir), errors.M("destination", paths.InstallDirectoryPath()))
 	}
 
 	// place shell wrapper, if present on platform
@@ -103,7 +103,7 @@ func Install(cfgFile string) error {
 		return errors.New(
 			err,
 			"failed to perform permission changes",
-			errors.M("destination", paths.InstallPath))
+			errors.M("destination", paths.InstallDirectoryPath()))
 	}
 
 	// install service

--- a/internal/pkg/agent/install/install_windows.go
+++ b/internal/pkg/agent/install/install_windows.go
@@ -19,7 +19,7 @@ import (
 // postInstall performs post installation for Windows systems.
 func postInstall() error {
 	// delete the top-level elastic-agent.exe
-	binary := filepath.Join(paths.InstallPath, paths.BinaryName)
+	binary := filepath.Join(paths.InstallDirectoryPath(), paths.BinaryName)
 	err := os.Remove(binary)
 	if err != nil {
 		// do not handle does not exist, it should have existed
@@ -27,7 +27,7 @@ func postInstall() error {
 	}
 
 	// create top-level symlink to nested binary
-	realBinary := filepath.Join(paths.InstallPath, "data", fmt.Sprintf("elastic-agent-%s", release.ShortCommit()), paths.BinaryName)
+	realBinary := filepath.Join(paths.InstallDirectoryPath(), "data", fmt.Sprintf("elastic-agent-%s", release.ShortCommit()), paths.BinaryName)
 	err = os.Symlink(realBinary, binary)
 	if err != nil {
 		return err

--- a/internal/pkg/agent/install/perms_unix.go
+++ b/internal/pkg/agent/install/perms_unix.go
@@ -18,7 +18,7 @@ import (
 
 // fixPermissions fixes the permissions so only root:root is the owner and no world read-able permissions
 func fixPermissions() error {
-	return recursiveRootPermissions(paths.InstallPath)
+	return recursiveRootPermissions(paths.InstallDirectoryPath())
 }
 
 func recursiveRootPermissions(path string) error {

--- a/internal/pkg/agent/install/perms_windows.go
+++ b/internal/pkg/agent/install/perms_windows.go
@@ -20,7 +20,7 @@ import (
 
 // fixPermissions fixes the permissions so only SYSTEM and Administrators have access to the files in the install path
 func fixPermissions() error {
-	return recursiveSystemAdminPermissions(paths.InstallPath)
+	return recursiveSystemAdminPermissions(paths.InstallDirectoryPath())
 }
 
 func recursiveSystemAdminPermissions(path string) error {

--- a/internal/pkg/agent/install/svc.go
+++ b/internal/pkg/agent/install/svc.go
@@ -29,7 +29,7 @@ const (
 
 // ExecutablePath returns the path for the installed Agents executable.
 func ExecutablePath() string {
-	exec := filepath.Join(paths.InstallPath, paths.BinaryName)
+	exec := filepath.Join(paths.InstallDirectoryPath(), paths.BinaryName)
 	if paths.ShellWrapperPath != "" {
 		exec = paths.ShellWrapperPath
 	}
@@ -42,7 +42,7 @@ func newService() (service.Service, error) {
 		DisplayName:      ServiceDisplayName,
 		Description:      ServiceDescription,
 		Executable:       ExecutablePath(),
-		WorkingDirectory: paths.InstallPath,
+		WorkingDirectory: paths.InstallDirectoryPath(),
 		Option: map[string]interface{}{
 			// Linux (systemd) always restart on failure
 			"Restart": "always",

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -75,7 +75,7 @@ func Uninstall(cfgFile string) error {
 	}
 
 	// remove existing directory
-	err = os.RemoveAll(paths.InstallPath)
+	err = os.RemoveAll(paths.InstallDirectoryPath())
 	if err != nil {
 		if runtime.GOOS == "windows" { //nolint:goconst // it is more readable this way
 			// possible to fail on Windows, because elastic-agent.exe is running from
@@ -84,8 +84,8 @@ func Uninstall(cfgFile string) error {
 		}
 		return errors.New(
 			err,
-			fmt.Sprintf("failed to remove installation directory (%s)", paths.InstallPath),
-			errors.M("directory", paths.InstallPath))
+			fmt.Sprintf("failed to remove installation directory (%s)", paths.InstallDirectoryPath()),
+			errors.M("directory", paths.InstallDirectoryPath()))
 	}
 
 	return nil


### PR DESCRIPTION
[Description coming soon]
## What does this PR do?

Add install path prefix option on agent install

## Why is it important?

Add install path prefix option on agent install

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes [#141](https://github.com/elastic/elastic-agent/issues/141)

- 
