### PR TITLE
Fix action dispatching that was using ActionType instead of InputType as before

### DIFF
--- a/internal/pkg/agent/application/actions/handlers/handler_action_application.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_application.go
@@ -78,7 +78,7 @@ func (h *AppAction) Handle(ctx context.Context, a fleetapi.Action, acker acker.A
 		h.log.Debugf("handlerAppAction: action '%v' started with timeout: %v", action.ActionType, timeout)
 		ctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
-		res, err = h.coord.PerformAction(ctx, unit, action.ActionType, params)
+		res, err = h.coord.PerformAction(ctx, unit, action.InputType, params)
 	}
 	end := time.Now().UTC()
 
@@ -111,11 +111,12 @@ var (
 )
 
 // appendActionResponse appends the action response property with all the action response values excluding the ones specified in excludeActionResponseFields
-// "action_response": {
-// 	   "endpoint": {
-// 		   "acked": true
-// 	   }
-//  }
+//
+//	"action_response": {
+//		   "endpoint": {
+//			   "acked": true
+//		   }
+//	 }
 func appendActionResponse(action *fleetapi.ActionApp, inputType string, res map[string]interface{}) {
 	if len(res) == 0 {
 		return


### PR DESCRIPTION
## What does this PR do?

Fixes action dispatching that was using ActionType instead of InputType as before

## Why is it important?

Without this fix the osquerybeat action fails with "action undefined" error, because the unit actions were using input type as the key for the lookup.

It's one line change, and there was a comment that got auto-formatted on save. Think it's convenient to have it fixed. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Screenshots
<img width="1294" alt="Screen Shot 2022-08-22 at 5 37 02 PM" src="https://user-images.githubusercontent.com/872351/186023316-eb2c9a58-7a9f-4038-9394-e7632d99830b.png">

