### PR TITLE
[automation] update elastic stack version for testing 8.5.0-7783a03c

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.0-feb644de-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.0-7783a03c-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.5.0-feb644de-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.5.0-7783a03c-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Wed, 24 Aug 2022 12:16:09 GMT, release_branch:master, prefix:, end_time:Wed, 24 Aug 2022 17:36:28 GMT, manifest_version:2.1.0, version:8.5.0-SNAPSHOT, branch:master, build_id:8.5.0-7783a03c, build_duration_seconds:19219]