### PR TITLE
update ironbank image product name

### DIFF
--- a/dev-tools/packaging/templates/ironbank/hardening_manifest.yaml.tmpl
+++ b/dev-tools/packaging/templates/ironbank/hardening_manifest.yaml.tmpl
@@ -35,7 +35,7 @@ labels:
   ## This value can be "opensource" or "commercial"
   mil.dso.ironbank.image.type: "commercial"
   ## Product the image belongs to for grouping multiple images
-  mil.dso.ironbank.product.name: "beats"
+  mil.dso.ironbank.product.name: "elastic-agent"
 
 # List of resources to make available to the offline build context
 resources:


### PR DESCRIPTION
## What does this PR do?

This PR updates the image product name in the ironbank labels.

## Why is it important?

This is required to automate the creation of the ironbank merge requests as the ubireleaser is using this field to compute the elastic-agent artifact url. 

For example it is now trying to retrieve https://artifacts.elastic.co/downloads/beats/elastic-agent-8.4.0-linux-x86_64.tar.gz instead of https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-8.4.0-linux-x86_64.tar.gz

Relates to https://github.com/elastic/apm-server/pull/8959