### PR TITLE
Fix: Endpoint collision between monitoring and regular beats

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -112,6 +112,7 @@
 - Allow the / char in variable names in eql and transpiler. {issue}715[715] {pull}718[718]
 - Fix data duplication for standalone agent on Kubernetes using the default manifest {issue-beats}31512[31512] {pull}742[742]
 - Agent updates will clean up unneeded artifacts. {issue}693[693] {issue}694[694] {pull}752[752]
+- Fix a panic caused by a race condition when installing the Elastic Agent. {issues}806[806]
 
 ==== New features
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ export MAGE_IMPORT_PATH
 mage:
 ifndef MAGE_PRESENT
 	@echo Installing mage $(MAGE_VERSION).
-	@go get -ldflags="-X $(MAGE_IMPORT_PATH)/mage.gitTag=$(MAGE_VERSION)" ${MAGE_IMPORT_PATH}@$(MAGE_VERSION)
+	@go install ${MAGE_IMPORT_PATH}@$(MAGE_VERSION)
 	@-mage -clean
 endif
 	@true

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ in the [observability-docs](https://github.com/elastic/observability-docs) repo.
 Prerequisites:
 - installed [mage](https://github.com/magefile/mage)
 - [Docker](https://docs.docker.com/get-docker/)
-- [X-pack](https://github.com/elastic/beats/tree/main/x-pack) to pre-exist in the parent folder of the local Git repository checkout
+- [X-pack](https://github.com/elastic/beats/tree/8.4/x-pack) to pre-exist in the parent folder of the local Git repository checkout
 
 If you are on a Mac with M1 chip, don't forget to export some docker variable to be able to build for AMD
 ```
@@ -40,10 +40,10 @@ for the standard variant.
 ### Testing Elastic Agent on Kubernetes
 
 #### Prerequisites
-- create kubernetes cluster using kind, check [here](https://github.com/elastic/beats/blob/main/metricbeat/module/kubernetes/_meta/test/docs/README.md) for details
-- deploy kube-state-metrics, check [here](https://github.com/elastic/beats/blob/main/metricbeat/module/kubernetes/_meta/test/docs/README.md) for details
+- create kubernetes cluster using kind, check [here](https://github.com/elastic/beats/blob/8.4/metricbeat/module/kubernetes/_meta/test/docs/README.md) for details
+- deploy kube-state-metrics, check [here](https://github.com/elastic/beats/blob/8.4/metricbeat/module/kubernetes/_meta/test/docs/README.md) for details
 - deploy required infrastructure:
-    - for elastic agent in standalone mode: EK stack or use [elastic cloud](https://cloud.elastic.co), check [here](https://github.com/elastic/beats/blob/main/metricbeat/module/kubernetes/_meta/test/docs/README.md) for details
+    - for elastic agent in standalone mode: EK stack or use [elastic cloud](https://cloud.elastic.co), check [here](https://github.com/elastic/beats/blob/8.4/metricbeat/module/kubernetes/_meta/test/docs/README.md) for details
     - for managed mode: use [elastic cloud](https://cloud.elastic.co) or bring up the stack on docker and then connect docker network with kubernetes kind nodes:
   ```
   elastic-package stack up -d -v

--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -15,9 +15,11 @@ spec:
       labels:
         app: elastic-agent
     spec:
-      # Tolerations are needed to run Elastic Agent on Kubernetes master nodes.
-      # Agents running on master nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
+      # Tolerations are needed to run Elastic Agent on Kubernetes control-plane nodes.
+      # Agents running on control-plane nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
       tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
       serviceAccountName: elastic-agent

--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -28,7 +28,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: elastic-agent
-          image: docker.elastic.co/beats/elastic-agent:8.3.0
+          image: docker.elastic.co/beats/elastic-agent:8.4.0
           env:
             # Set to 1 for enrollment into Fleet server. If not set, Elastic Agent is run in standalone mode
             - name: FLEET_ENROLL

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -15,9 +15,11 @@ spec:
       labels:
         app: elastic-agent
     spec:
-      # Tolerations are needed to run Elastic Agent on Kubernetes master nodes.
-      # Agents running on master nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
+      # Tolerations are needed to run Elastic Agent on Kubernetes control-plane nodes.
+      # Agents running on control-plane nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
       tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
       serviceAccountName: elastic-agent

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -640,9 +640,11 @@ spec:
       labels:
         app: elastic-agent-standalone
     spec:
-      # Tolerations are needed to run Elastic Agent on Kubernetes master nodes.
-      # Agents running on master nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
+      # Tolerations are needed to run Elastic Agent on Kubernetes control-plane nodes.
+      # Agents running on control-plane nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
       tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
       serviceAccountName: elastic-agent-standalone

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -650,7 +650,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: elastic-agent-standalone
-          image: docker.elastic.co/beats/elastic-agent:8.3.0
+          image: docker.elastic.co/beats/elastic-agent:8.4.0
           args: [
             "-c", "/etc/agent.yml",
             "-e",

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
@@ -14,9 +14,11 @@ spec:
       labels:
         app: elastic-agent-standalone
     spec:
-      # Tolerations are needed to run Elastic Agent on Kubernetes master nodes.
-      # Agents running on master nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
+      # Tolerations are needed to run Elastic Agent on Kubernetes control-plane nodes.
+      # Agents running on control-plane nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
       tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
       serviceAccountName: elastic-agent-standalone

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -281,6 +281,15 @@ func (b GolangCrossBuilder) Build() error {
 		verbose = "true"
 	}
 	var args []string
+	// There's a bug on certain debian versions:
+	// https://discuss.linuxcontainers.org/t/debian-jessie-containers-have-extremely-low-performance/1272
+	// basically, apt-get has a bug where will try to iterate through every possible FD as set by the NOFILE ulimit.
+	// On certain docker installs, docker will set the ulimit to a value > 10^9, which means apt-get will take >1 hour.
+	// This runs across all possible debian platforms, since there's no real harm in it.
+	if strings.Contains(image, "debian") {
+		args = append(args, "--ulimit", "nofile=262144:262144")
+	}
+
 	if runtime.GOOS != "windows" {
 		args = append(args,
 			"--env", "EXEC_UID="+strconv.Itoa(os.Getuid()),

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -44,48 +44,6 @@ RUN for iter in {1..10}; do \
     (exit $exit_code)
 {{- end }}
 
-{{- if (and (contains .image_name "-complete") (not (contains .from "ubi-minimal"))) }}
-RUN apt-get update -y && \
-    for iter in {1..10}; do \
-        DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
-        libglib2.0-0\
-        libnss3\
-        libnspr4\
-        libatk1.0-0\
-        libatk-bridge2.0-0\
-        libcups2\
-        libdrm2\
-        libdbus-1-3\
-        libxcb1\
-        libxkbcommon0\
-        libx11-6\
-        libxcomposite1\
-        libxdamage1\
-        libxext6\
-        libxfixes3\
-        libxrandr2\
-        libgbm1\
-        libpango-1.0-0\
-        libcairo2\
-        libasound2\
-        libatspi2.0-0\
-        libxshmfence1 \
-        fonts-noto-core\
-        fonts-noto-cjk &&\
-        apt-get clean all && \
-        exit_code=0 && break || exit_code=$? && echo "apt-get error: retry $iter in 10s" && sleep 10; \
-    done; \
-    (exit $exit_code)
-ENV NODE_PATH={{ $beatHome }}/.node
-RUN echo \
-    $NODE_PATH \
-    {{ $beatHome }}/.config \
-    {{ $beatHome }}/.synthetics \
-    {{ $beatHome }}/.npm \
-    {{ $beatHome }}/.cache \
-    | xargs -IDIR sh -c 'mkdir -p DIR && chmod 0770 DIR'
-{{- end }}
-
 LABEL \
   org.label-schema.build-date="{{ date }}" \
   org.label-schema.schema-version="1.0" \
@@ -172,9 +130,7 @@ RUN mkdir /app
 {{- else }}
 RUN groupadd --gid 1000 {{ .BeatName }}
 RUN useradd -M --uid 1000 --gid 1000 --groups 0 --home {{ $beatHome }} {{ .user }}
-{{- if (and (contains .image_name "-complete") (not (contains .from "ubi-minimal")))  }}
-RUN chown {{ .user }} $NODE_PATH
-{{- end }}
+
 {{- if contains .image_name "-cloud" }}
 # Generate folder for a stub command that will be overwritten at runtime
 RUN mkdir /app
@@ -193,12 +149,19 @@ RUN mkdir -p {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/{{ .beats_ins
     # heartbeat requires cap_net_raw,cap_setuid to run ICMP checks and change npm user
     setcap cap_net_raw,cap_setuid+p {{ $beatHome }}/data/{{.BeatName}}-{{ commit_short }}/{{ .beats_install_path }}/heartbeat-*/heartbeat
 
-USER {{ .user }}
-
 {{- if (and (contains .image_name "-complete") (not (contains .from "ubi-minimal")))  }}
+USER root
+ENV NODE_PATH={{ $beatHome }}/.node
+RUN echo \
+    $NODE_PATH \
+    {{ $beatHome }}/.config \
+    {{ $beatHome }}/.synthetics \
+    {{ $beatHome }}/.npm \
+    {{ $beatHome }}/.cache \
+    | xargs -IDIR sh -c 'mkdir -p DIR && chmod 0770 DIR'
+
 # Setup synthetics env vars
 ENV ELASTIC_SYNTHETICS_CAPABLE=true
-ENV SUITES_DIR={{ $beatHome }}/suites
 ENV NODE_VERSION=16.15.0
 ENV PATH="$NODE_PATH/node/bin:$PATH"
 # Install the latest version of @elastic/synthetics forcefully ignoring the previously
@@ -207,6 +170,9 @@ ENV PATH="$NODE_PATH/node/bin:$PATH"
 RUN cd {{$beatHome}}/.node \
   && NODE_DOWNLOAD_URL="" \
   && case "$(arch)" in \
+        arm64) \
+           NODE_DOWNLOAD_URL=https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz \
+           ;; \
        x86_64) \
            NODE_DOWNLOAD_URL=https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz \
            ;; \
@@ -219,9 +185,31 @@ RUN cd {{$beatHome}}/.node \
      esac \
   && mkdir -p node \
   && curl ${NODE_DOWNLOAD_URL} | tar -xJ --strip 1 -C node \
-  && chmod ug+rwX -R $NODE_PATH \
-  && npm i -g -f @elastic/synthetics && chmod ug+rwX -R $NODE_PATH
+  && chmod ug+rwX -R $NODE_PATH
+
+# Install synthetics as a regular user, installing npm deps as root odesn't work
+RUN chown -R {{ .user }} $NODE_PATH
+USER {{ .user }}
+# If this fails dump the NPM logs
+RUN npm i -g --loglevel verbose -f @elastic/synthetics || sh -c 'tail -n +1 /root/.npm/_logs/* && exit 1'
+RUN chmod ug+rwX -R $NODE_PATH 
+USER root
+
+# Install the deps as needed by the exact version of playwright elastic synthetics uses
+# We don't use npx playwright install-deps because that could pull a newer version
+# Install additional fonts as well
+RUN for iter in {1..10}; do \
+    apt-get update -y && \
+    $NODE_PATH/node/lib/node_modules/@elastic/synthetics/node_modules/.bin/playwright install-deps chromium && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
+    fonts-noto \
+    fonts-noto-cjk && \
+    exit_code=0 && break || exit_code=$? && echo "apt-get error: retry $iter in 10s" && sleep 10; \
+    done; \
+    (exit $exit_code)
+
 {{- end }}
+USER {{ .user }} 
 
 
 {{- range $i, $port := .ExposePorts }}

--- a/dev-tools/packaging/templates/linux/postinstall.sh.tmpl
+++ b/dev-tools/packaging/templates/linux/postinstall.sh.tmpl
@@ -3,16 +3,26 @@
 set -e
 
 symlink="/usr/share/elastic-agent/bin/elastic-agent"
-old_agent_dir="$( dirname "$(readlink -f -- "$symlink")" )"
+old_agent_dir=""
+
+# check if $symlink exists for the previous install
+# and derive the old agent directory
+if test -L "$symlink"; then
+    resolved_symlink="$(readlink -f -- "$symlink")"
+    # check if it is resolved to non empty string
+    if ! [ -z "$resolved_symlink" ]; then
+        old_agent_dir="$( dirname "$resolved_symlink" )"
+    fi
+fi
 
 commit_hash="{{ commit_short }}"
 
-yml_path="$old_agent_dir/state.yml"
-enc_path="$old_agent_dir/state.enc"
+new_agent_dir="/var/lib/elastic-agent/data/elastic-agent-$commit_hash"
 
-new_agent_dir="$( dirname "$old_agent_dir")/elastic-agent-$commit_hash"
-
-if ! [[ "$old_agent_dir" -ef "$new_agent_dir" ]]; then
+# copy the state files if there was a previous agent install
+if ! [ -z "$old_agent_dir" ] && ! [ "$old_agent_dir" -ef "$new_agent_dir" ]; then
+    yml_path="$old_agent_dir/state.yml"
+    enc_path="$old_agent_dir/state.enc"
     echo "migrate state from $old_agent_dir to $new_agent_dir"
 
     if test -f "$yml_path"; then
@@ -24,15 +34,17 @@ if ! [[ "$old_agent_dir" -ef "$new_agent_dir" ]]; then
         echo "found "$enc_path", copy to "$new_agent_dir"."
         cp "$enc_path" "$new_agent_dir"
     fi
-
-    if test -f "$symlink"; then
-        echo "found symlink $symlink, unlink"
-        unlink "$symlink"
-    fi
-
-    echo "create symlink "$symlink" to "$new_agent_dir/elastic-agent""
-    ln -s "$new_agent_dir/elastic-agent" "$symlink"
 fi
+
+# delete symlink if exists
+if test -L "$symlink"; then
+    echo "found symlink $symlink, unlink"
+    unlink "$symlink"
+fi
+
+# create symlink to the new agent
+echo "create symlink "$symlink" to "$new_agent_dir/elastic-agent""
+ln -s "$new_agent_dir/elastic-agent" "$symlink"
 
 systemctl daemon-reload 2> /dev/null
 exit 0

--- a/internal/pkg/agent/application/managed_mode.go
+++ b/internal/pkg/agent/application/managed_mode.go
@@ -146,6 +146,11 @@ func newManaged(
 		return nil, errors.New(err, "failed to initialize composable controller")
 	}
 
+	routerArtifactReloader, ok := router.(emitter.Reloader)
+	if !ok {
+		return nil, errors.New("router not capable of artifact reload") // Needed for client reloading
+	}
+
 	emit, err := emitter.New(
 		managedApplication.bgContext,
 		log,
@@ -159,6 +164,7 @@ func newManaged(
 		caps,
 		monitor,
 		artifact.NewReloader(cfg.Settings.DownloadConfig, log),
+		routerArtifactReloader,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/agent/application/pipeline/emitter/controller.go
+++ b/internal/pkg/agent/application/pipeline/emitter/controller.go
@@ -21,7 +21,7 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
-type reloadable interface {
+type Reloader interface {
 	Reload(cfg *config.Config) error
 }
 
@@ -32,7 +32,7 @@ type Controller struct {
 	controller  composable.Controller
 	router      pipeline.Router
 	modifiers   *pipeline.ConfigModifiers
-	reloadables []reloadable
+	reloadables []Reloader
 	caps        capabilities.Capability
 
 	// state
@@ -51,7 +51,7 @@ func NewController(
 	router pipeline.Router,
 	modifiers *pipeline.ConfigModifiers,
 	caps capabilities.Capability,
-	reloadables ...reloadable,
+	reloadables ...Reloader,
 ) *Controller {
 	init, _ := transpiler.NewVars(map[string]interface{}{}, nil)
 

--- a/internal/pkg/agent/application/pipeline/emitter/emitter.go
+++ b/internal/pkg/agent/application/pipeline/emitter/emitter.go
@@ -22,7 +22,7 @@ import (
 )
 
 // New creates a new emitter function.
-func New(ctx context.Context, log *logger.Logger, agentInfo *info.AgentInfo, controller composable.Controller, router pipeline.Router, modifiers *pipeline.ConfigModifiers, caps capabilities.Capability, reloadables ...reloadable) (pipeline.EmitterFunc, error) {
+func New(ctx context.Context, log *logger.Logger, agentInfo *info.AgentInfo, controller composable.Controller, router pipeline.Router, modifiers *pipeline.ConfigModifiers, caps capabilities.Capability, reloadables ...Reloader) (pipeline.EmitterFunc, error) {
 	log.Debugf("Supported programs: %s", strings.Join(program.KnownProgramNames(), ", "))
 
 	ctrl := NewController(log, agentInfo, controller, router, modifiers, caps, reloadables...)

--- a/internal/pkg/agent/application/pipeline/router/router.go
+++ b/internal/pkg/agent/application/pipeline/router/router.go
@@ -11,8 +11,10 @@ import (
 	"time"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/pipeline"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/pipeline/emitter"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configrequest"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
+	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/sorted"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
@@ -33,6 +35,27 @@ func New(log *logger.Logger, factory pipeline.StreamFunc) (pipeline.Router, erro
 		}
 	}
 	return &router{log: log, streamFactory: factory, routes: sorted.NewSet()}, nil
+}
+
+func (r *router) Reload(c *config.Config) error {
+	keys := r.routes.Keys()
+	for _, key := range keys {
+		route, found := r.routes.Get(key)
+		if !found {
+			continue
+		}
+
+		routeReloader, ok := route.(emitter.Reloader)
+		if !ok {
+			continue
+		}
+
+		if err := routeReloader.Reload(c); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (r *router) Routes() *sorted.Set {

--- a/internal/pkg/agent/application/pipeline/stream/operator_stream.go
+++ b/internal/pkg/agent/application/pipeline/stream/operator_stream.go
@@ -10,8 +10,10 @@ import (
 	"go.elastic.co/apm"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/pipeline"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/pipeline/emitter"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configrequest"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
+	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/core/state"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
@@ -27,6 +29,15 @@ type stater interface {
 
 type specer interface {
 	Specs() map[string]program.Spec
+}
+
+func (b *operatorStream) Reload(c *config.Config) error {
+	r, ok := b.configHandler.(emitter.Reloader)
+	if !ok {
+		return nil
+	}
+
+	return r.Reload(c)
 }
 
 func (b *operatorStream) Close() error {

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/kardianos/service"
 
@@ -233,11 +234,20 @@ func applyDynamics(ctx context.Context, log *logger.Logger, cfg *config.Config) 
 	inputs, ok := transpiler.Lookup(ast, "inputs")
 	if ok {
 		varsArray := make([]*transpiler.Vars, 0)
-		var wg sync.WaitGroup
-		wg.Add(1)
+
+		// Give some time for the providers to replace the variables
+		const timeout = 15 * time.Second
+		var doOnce sync.Once
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		// The composable system will continuously run, we are only interested in the first run on of the
+		// renderer to collect the variables we should stop the execution.
 		varsCallback := func(vv []*transpiler.Vars) {
-			varsArray = vv
-			wg.Done()
+			doOnce.Do(func() {
+				varsArray = vv
+				cancel()
+			})
 		}
 
 		ctrl, err := composable.New(log, cfg)
@@ -245,7 +255,14 @@ func applyDynamics(ctx context.Context, log *logger.Logger, cfg *config.Config) 
 			return nil, err
 		}
 		_ = ctrl.Run(ctx, varsCallback)
-		wg.Wait()
+
+		// Wait for the first callback to retrieve the variables from the providers.
+		<-ctx.Done()
+
+		// Bail out if callback was not executed in time.
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, errors.New("failed to get transpiler vars", err)
+		}
 
 		renderedInputs, err := transpiler.RenderInputs(inputs, varsArray)
 		if err != nil {

--- a/internal/pkg/artifact/config.go
+++ b/internal/pkg/artifact/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	c "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
@@ -23,6 +24,10 @@ const (
 
 	defaultSourceURI = "https://artifacts.elastic.co/downloads/"
 )
+
+type ConfigReloader interface {
+	Reload(*Config) error
+}
 
 // Config is a configuration used for verifier and downloader
 type Config struct {
@@ -52,18 +57,62 @@ type Config struct {
 }
 
 type Reloader struct {
-	log *logger.Logger
-	cfg *Config
+	log       *logger.Logger
+	cfg       *Config
+	reloaders []ConfigReloader
 }
 
-func NewReloader(cfg *Config, log *logger.Logger) *Reloader {
+func NewReloader(cfg *Config, log *logger.Logger, rr ...ConfigReloader) *Reloader {
 	return &Reloader{
-		cfg: cfg,
-		log: log,
+		cfg:       cfg,
+		log:       log,
+		reloaders: rr,
 	}
 }
 
 func (r *Reloader) Reload(rawConfig *config.Config) error {
+	if err := r.reloadConfig(rawConfig); err != nil {
+		return errors.New(err, "failed to reload config")
+	}
+
+	if err := r.reloadSourceURI(rawConfig); err != nil {
+		return errors.New(err, "failed to reload source URI")
+	}
+
+	for _, reloader := range r.reloaders {
+		if err := reloader.Reload(r.cfg); err != nil {
+			return errors.New(err, "failed reloading config")
+		}
+	}
+
+	return nil
+}
+
+func (r *Reloader) reloadConfig(rawConfig *config.Config) error {
+	type reloadConfig struct {
+		C *Config `json:"agent.download" config:"agent.download"`
+	}
+	tmp := &reloadConfig{
+		C: DefaultConfig(),
+	}
+	if err := rawConfig.Unpack(&tmp); err != nil {
+		return err
+	}
+
+	*(r.cfg) = Config{
+		OperatingSystem:       tmp.C.OperatingSystem,
+		Architecture:          tmp.C.Architecture,
+		SourceURI:             tmp.C.SourceURI,
+		TargetDirectory:       tmp.C.TargetDirectory,
+		InstallPath:           tmp.C.InstallPath,
+		DropPath:              tmp.C.DropPath,
+		HTTPTransportSettings: tmp.C.HTTPTransportSettings,
+	}
+
+	return nil
+}
+
+func (r *Reloader) reloadSourceURI(rawConfig *config.Config) error {
 	type reloadConfig struct {
 		// SourceURI: source of the artifacts, e.g https://artifacts.elastic.co/downloads/
 		SourceURI string `json:"agent.download.sourceURI" config:"agent.download.sourceURI"`
@@ -78,11 +127,11 @@ func (r *Reloader) Reload(rawConfig *config.Config) error {
 	}
 
 	var newSourceURI string
-	if cfg.FleetSourceURI != "" {
+	if fleetURI := strings.TrimSpace(cfg.FleetSourceURI); fleetURI != "" {
 		// fleet configuration takes precedence
-		newSourceURI = cfg.FleetSourceURI
-	} else if cfg.SourceURI != "" {
-		newSourceURI = cfg.SourceURI
+		newSourceURI = fleetURI
+	} else if sourceURI := strings.TrimSpace(cfg.SourceURI); sourceURI != "" {
+		newSourceURI = sourceURI
 	}
 
 	if newSourceURI != "" {
@@ -147,4 +196,43 @@ func (c *Config) Arch() string {
 
 	c.Architecture = arch
 	return c.Architecture
+}
+
+// Unpack reads a config object into the settings.
+func (c *Config) Unpack(cfg *c.C) error {
+	tmp := struct {
+		OperatingSystem string `json:"-" config:",ignore"`
+		Architecture    string `json:"-" config:",ignore"`
+		SourceURI       string `json:"sourceURI" config:"sourceURI"`
+		TargetDirectory string `json:"targetDirectory" config:"target_directory"`
+		InstallPath     string `yaml:"installPath" config:"install_path"`
+		DropPath        string `yaml:"dropPath" config:"drop_path"`
+	}{
+		OperatingSystem: c.OperatingSystem,
+		Architecture:    c.Architecture,
+		SourceURI:       c.SourceURI,
+		TargetDirectory: c.TargetDirectory,
+		InstallPath:     c.InstallPath,
+		DropPath:        c.DropPath,
+	}
+
+	if err := cfg.Unpack(&tmp); err != nil {
+		return err
+	}
+
+	transport := DefaultConfig().HTTPTransportSettings
+	if err := cfg.Unpack(&transport); err != nil {
+		return err
+	}
+
+	*c = Config{
+		OperatingSystem:       tmp.OperatingSystem,
+		Architecture:          tmp.Architecture,
+		SourceURI:             tmp.SourceURI,
+		TargetDirectory:       tmp.TargetDirectory,
+		InstallPath:           tmp.InstallPath,
+		DropPath:              tmp.DropPath,
+		HTTPTransportSettings: transport,
+	}
+	return nil
 }

--- a/internal/pkg/artifact/config_test.go
+++ b/internal/pkg/artifact/config_test.go
@@ -1,0 +1,247 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package artifact
+
+import (
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent/internal/pkg/config"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReload(t *testing.T) {
+	type testCase struct {
+		input                    string
+		initialConfig            *Config
+		expectedSourceURI        string
+		expectedTargetDirectory  string
+		expectedInstallDirectory string
+		expectedDropDirectory    string
+		expectedFingerprint      string
+		expectedTLS              bool
+		expectedTLSEnabled       bool
+		expectedDisableProxy     bool
+		expectedTimeout          time.Duration
+	}
+	defaultValues := DefaultConfig()
+	testCases := []testCase{
+		{
+			input: `agent.download:
+  sourceURI: "testing.uri"
+  target_directory: "a/b/c"
+  install_path: "i/p"
+  drop_path: "d/p"
+  proxy_disable: true
+  timeout: 33s
+  ssl.enabled: true
+  ssl.ca_trusted_fingerprint: "my_finger_print"
+`,
+			initialConfig:            DefaultConfig(),
+			expectedSourceURI:        "testing.uri",
+			expectedTargetDirectory:  "a/b/c",
+			expectedInstallDirectory: "i/p",
+			expectedDropDirectory:    "d/p",
+			expectedFingerprint:      "my_finger_print",
+			expectedTLS:              true,
+			expectedTLSEnabled:       true,
+			expectedDisableProxy:     true,
+			expectedTimeout:          33 * time.Second,
+		},
+		{
+			input: `agent.download:
+  sourceURI: "testing.uri"
+`,
+			initialConfig:            DefaultConfig(),
+			expectedSourceURI:        "testing.uri",
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: `agent.download:
+  sourceURI: ""
+`,
+			initialConfig: &Config{
+				SourceURI:             "testing.uri",
+				HTTPTransportSettings: defaultValues.HTTPTransportSettings,
+			},
+			expectedSourceURI:        defaultValues.SourceURI, // fallback to default when set to empty
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: ``,
+			initialConfig: &Config{
+				SourceURI:             "testing.uri",
+				HTTPTransportSettings: defaultValues.HTTPTransportSettings,
+			},
+			expectedSourceURI:        defaultValues.SourceURI, // fallback to default when not set
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: `agent.download:
+  sourceURI: " "
+`,
+			initialConfig: &Config{
+				SourceURI:             "testing.uri",
+				HTTPTransportSettings: defaultValues.HTTPTransportSettings,
+			},
+			expectedSourceURI:        defaultValues.SourceURI, // fallback to default when set to whitespace
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: `agent.download:
+  source_uri: " "
+`,
+			initialConfig: &Config{
+				SourceURI:             "testing.uri",
+				HTTPTransportSettings: defaultValues.HTTPTransportSettings,
+			},
+			expectedSourceURI:        defaultValues.SourceURI, // fallback to default when set to whitespace
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: `agent.download:
+  source_uri: " "
+  sourceURI: " "
+`,
+			initialConfig:            DefaultConfig(),
+			expectedSourceURI:        defaultValues.SourceURI, // fallback to default when set to whitespace
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: ``,
+			initialConfig: &Config{
+				SourceURI:             "testing.uri",
+				HTTPTransportSettings: defaultValues.HTTPTransportSettings,
+			},
+			expectedSourceURI:        defaultValues.SourceURI,
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: `agent.download:
+  source_uri: " "
+  sourceURI: "testing.uri"
+`,
+			initialConfig:            DefaultConfig(),
+			expectedSourceURI:        "testing.uri",
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: `agent.download:
+  source_uri: "testing.uri"
+  sourceURI: " "
+`,
+			initialConfig:            DefaultConfig(),
+			expectedSourceURI:        "testing.uri",
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+		{
+			input: `agent.download:
+  source_uri: "testing.uri"
+  sourceURI: "another.uri"
+`,
+			initialConfig:            DefaultConfig(),
+			expectedSourceURI:        "testing.uri",
+			expectedTargetDirectory:  defaultValues.TargetDirectory,
+			expectedInstallDirectory: defaultValues.InstallPath,
+			expectedDropDirectory:    defaultValues.DropPath,
+			expectedFingerprint:      "",
+			expectedTLS:              defaultValues.TLS != nil,
+			expectedTLSEnabled:       false,
+			expectedDisableProxy:     defaultValues.Proxy.Disable,
+			expectedTimeout:          defaultValues.Timeout,
+		},
+	}
+
+	l, _ := logger.NewTesting("t")
+	for _, tc := range testCases {
+		cfg := tc.initialConfig
+		reloader := NewReloader(cfg, l)
+
+		c, err := config.NewConfigFrom(tc.input)
+		require.NoError(t, err)
+
+		require.NoError(t, reloader.Reload(c))
+
+		require.Equal(t, tc.expectedSourceURI, cfg.SourceURI)
+		require.Equal(t, tc.expectedTargetDirectory, cfg.TargetDirectory)
+		require.Equal(t, tc.expectedInstallDirectory, cfg.InstallPath)
+		require.Equal(t, tc.expectedDropDirectory, cfg.DropPath)
+		require.Equal(t, tc.expectedTimeout, cfg.Timeout)
+
+		require.Equal(t, tc.expectedDisableProxy, cfg.Proxy.Disable)
+
+		if tc.expectedTLS {
+			require.NotNil(t, cfg.TLS)
+			require.Equal(t, tc.expectedTLSEnabled, *cfg.TLS.Enabled)
+			require.Equal(t, tc.expectedFingerprint, cfg.TLS.CATrustedFingerprint)
+		} else {
+			require.Nil(t, cfg.TLS)
+		}
+	}
+}

--- a/internal/pkg/artifact/download/composed/verifier.go
+++ b/internal/pkg/artifact/download/composed/verifier.go
@@ -5,11 +5,11 @@
 package composed
 
 import (
-	"errors"
-
 	"github.com/hashicorp/go-multierror"
 
+	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
+	"github.com/elastic/elastic-agent/internal/pkg/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download"
 )
 
@@ -53,4 +53,18 @@ func (e *Verifier) Verify(spec program.Spec, version string) error {
 	}
 
 	return err
+}
+
+func (e *Verifier) Reload(c *artifact.Config) error {
+	for _, v := range e.vv {
+		reloadable, ok := v.(download.Reloader)
+		if !ok {
+			continue
+		}
+
+		if err := reloadable.Reload(c); err != nil {
+			return errors.New(err, "failed reloading artifact config for composed verifier")
+		}
+	}
+	return nil
 }

--- a/internal/pkg/artifact/download/http/downloader.go
+++ b/internal/pkg/artifact/download/http/downloader.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/atomic"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
-
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
@@ -73,6 +72,23 @@ func NewDownloaderWithClient(log progressLogger, config *artifact.Config, client
 	}
 }
 
+func (e *Downloader) Reload(c *artifact.Config) error {
+	// reload client
+	client, err := c.HTTPTransportSettings.Client(
+		httpcommon.WithAPMHTTPInstrumentation(),
+	)
+	if err != nil {
+		return errors.New(err, "http.downloader: failed to generate client out of config")
+	}
+
+	client.Transport = withHeaders(client.Transport, headers)
+
+	e.client = *client
+	e.config = c
+
+	return nil
+}
+
 // Download fetches the package from configured source.
 // Returns absolute path to downloaded package and an error.
 func (e *Downloader) Download(ctx context.Context, spec program.Spec, version string) (_ string, err error) {
@@ -80,7 +96,9 @@ func (e *Downloader) Download(ctx context.Context, spec program.Spec, version st
 	defer func() {
 		if err != nil {
 			for _, path := range downloadedFiles {
-				os.Remove(path)
+				if err := os.Remove(path); err != nil {
+					e.log.Warnf("failed to cleanup %s: %v", path, err)
+				}
 			}
 		}
 	}()
@@ -164,12 +182,14 @@ func (e *Downloader) downloadFile(ctx context.Context, artifactName, filename, f
 
 	resp, err := e.client.Do(req.WithContext(ctx))
 	if err != nil {
-		return "", errors.New(err, "fetching package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
+		// return path, file already exists and needs to be cleaned up
+		return fullPath, errors.New(err, "fetching package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return "", errors.New(fmt.Sprintf("call to '%s' returned unsuccessful status code: %d", sourceURI, resp.StatusCode), errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
+		// return path, file already exists and needs to be cleaned up
+		return fullPath, errors.New(fmt.Sprintf("call to '%s' returned unsuccessful status code: %d", sourceURI, resp.StatusCode), errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
 	}
 
 	fileSize := -1
@@ -186,7 +206,8 @@ func (e *Downloader) downloadFile(ctx context.Context, artifactName, filename, f
 	if err != nil {
 		reportCancel()
 		dp.ReportFailed(err)
-		return "", errors.New(err, "fetching package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
+		// return path, file already exists and needs to be cleaned up
+		return fullPath, errors.New(err, "copying fetched package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
 	}
 	reportCancel()
 	dp.ReportComplete()

--- a/internal/pkg/artifact/download/http/verifier.go
+++ b/internal/pkg/artifact/download/http/verifier.go
@@ -60,6 +60,24 @@ func NewVerifier(config *artifact.Config, allowEmptyPgp bool, pgp []byte) (*Veri
 	return v, nil
 }
 
+func (v *Verifier) Reload(c *artifact.Config) error {
+	// reload client
+	client, err := c.HTTPTransportSettings.Client(
+		httpcommon.WithAPMHTTPInstrumentation(),
+		httpcommon.WithModRoundtripper(func(rt http.RoundTripper) http.RoundTripper {
+			return withHeaders(rt, headers)
+		}),
+	)
+	if err != nil {
+		return errors.New(err, "http.verifier: failed to generate client out of config")
+	}
+
+	v.client = *client
+	v.config = c
+
+	return nil
+}
+
 // Verify checks downloaded package on preconfigured
 // location against a key stored on elastic.co website.
 func (v *Verifier) Verify(spec program.Spec, version string) error {

--- a/internal/pkg/artifact/download/reloadable.go
+++ b/internal/pkg/artifact/download/reloadable.go
@@ -1,0 +1,14 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package download
+
+import (
+	"github.com/elastic/elastic-agent/internal/pkg/artifact"
+)
+
+// Reloader is an interface allowing to reload artifact config
+type Reloader interface {
+	Reload(*artifact.Config) error
+}

--- a/internal/pkg/artifact/download/snapshot/downloader.go
+++ b/internal/pkg/artifact/download/snapshot/downloader.go
@@ -5,17 +5,25 @@
 package snapshot
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download/http"
 	"github.com/elastic/elastic-agent/internal/pkg/release"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
+
+type Downloader struct {
+	downloader      download.Downloader
+	versionOverride string
+}
 
 // NewDownloader creates a downloader which first checks local directory
 // and then fallbacks to remote if configured.
@@ -24,7 +32,36 @@ func NewDownloader(log *logger.Logger, config *artifact.Config, versionOverride 
 	if err != nil {
 		return nil, err
 	}
-	return http.NewDownloader(log, cfg)
+
+	httpDownloader, err := http.NewDownloader(log, cfg)
+	if err != nil {
+		return nil, errors.New(err, "failed to create snapshot downloader")
+	}
+
+	return &Downloader{
+		downloader:      httpDownloader,
+		versionOverride: versionOverride,
+	}, nil
+}
+
+func (e *Downloader) Reload(c *artifact.Config) error {
+	reloader, ok := e.downloader.(artifact.ConfigReloader)
+	if !ok {
+		return nil
+	}
+
+	cfg, err := snapshotConfig(c, e.versionOverride)
+	if err != nil {
+		return errors.New(err, "snapshot.downloader: failed to generate snapshot config")
+	}
+
+	return reloader.Reload(cfg)
+}
+
+// Download fetches the package from configured source.
+// Returns absolute path to downloaded package and an error.
+func (e *Downloader) Download(ctx context.Context, spec program.Spec, version string) (string, error) {
+	return e.downloader.Download(ctx, spec, version)
 }
 
 func snapshotConfig(config *artifact.Config, versionOverride string) (*artifact.Config, error) {
@@ -34,12 +71,13 @@ func snapshotConfig(config *artifact.Config, versionOverride string) (*artifact.
 	}
 
 	return &artifact.Config{
-		OperatingSystem:       config.OperatingSystem,
-		Architecture:          config.Architecture,
-		SourceURI:             snapshotURI,
-		TargetDirectory:       config.TargetDirectory,
-		InstallPath:           config.InstallPath,
-		DropPath:              config.DropPath,
+		OperatingSystem: config.OperatingSystem,
+		Architecture:    config.Architecture,
+		SourceURI:       snapshotURI,
+		TargetDirectory: config.TargetDirectory,
+		InstallPath:     config.InstallPath,
+		DropPath:        config.DropPath,
+
 		HTTPTransportSettings: config.HTTPTransportSettings,
 	}, nil
 }

--- a/internal/pkg/artifact/download/snapshot/verifier.go
+++ b/internal/pkg/artifact/download/snapshot/verifier.go
@@ -5,10 +5,17 @@
 package snapshot
 
 import (
+	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download"
 	"github.com/elastic/elastic-agent/internal/pkg/artifact/download/http"
 )
+
+type Verifier struct {
+	verifier        download.Verifier
+	versionOverride string
+}
 
 // NewVerifier creates a downloader which first checks local directory
 // and then fallbacks to remote if configured.
@@ -17,5 +24,33 @@ func NewVerifier(config *artifact.Config, allowEmptyPgp bool, pgp []byte, versio
 	if err != nil {
 		return nil, err
 	}
-	return http.NewVerifier(cfg, allowEmptyPgp, pgp)
+	v, err := http.NewVerifier(cfg, allowEmptyPgp, pgp)
+	if err != nil {
+		return nil, errors.New(err, "failed to create snapshot verifier")
+	}
+
+	return &Verifier{
+		verifier:        v,
+		versionOverride: versionOverride,
+	}, nil
+}
+
+// Verify checks the package from configured source.
+func (e *Verifier) Verify(spec program.Spec, version string) error {
+	return e.verifier.Verify(spec, version)
+}
+
+func (e *Verifier) Reload(c *artifact.Config) error {
+	reloader, ok := e.verifier.(artifact.ConfigReloader)
+	if !ok {
+		return nil
+	}
+
+	cfg, err := snapshotConfig(c, e.versionOverride)
+	if err != nil {
+		return errors.New(err, "snapshot.downloader: failed to generate snapshot config")
+	}
+
+	return reloader.Reload(cfg)
+
 }

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.3.2
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -20,7 +20,7 @@ services:
       - "script.context.template.cache_max_size=2000"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:8.0.0
+    image: docker.elastic.co/logstash/logstash:8.3.2
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 300
@@ -30,7 +30,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.0.0
+    image: docker.elastic.co/kibana/kibana:8.3.2
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5601"]
       retries: 300

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.3.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -20,7 +20,7 @@ services:
       - "script.context.template.cache_max_size=2000"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:8.3.2
+    image: docker.elastic.co/logstash/logstash:8.4.0
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 300
@@ -30,7 +30,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.3.2
+    image: docker.elastic.co/kibana/kibana:8.4.0
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5601"]
       retries: 300

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-910fe5e1-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-7f4eb04b-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-910fe5e1-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-7f4eb04b-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-fea9abbe-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-9bd354a1-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-fea9abbe-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-9bd354a1-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-b95305c2-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-910fe5e1-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-b95305c2-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-910fe5e1-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-9bd354a1-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-aff0df12-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-9bd354a1-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-aff0df12-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-d88c8a44-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-5954f776-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-d88c8a44-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-5954f776-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-4b3e8f6e-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-96568c7b-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-4b3e8f6e-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-96568c7b-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-7f4eb04b-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-fa661330-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-7f4eb04b-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-fa661330-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-c17572db-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-fea9abbe-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-c17572db-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-fea9abbe-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-9adc8090-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-c17572db-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-9adc8090-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-c17572db-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-5954f776-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-b5074ef3-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-5954f776-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-b5074ef3-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-b5074ef3-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-43c061d1-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-b5074ef3-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-43c061d1-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-d058e92f-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-d88c8a44-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-d058e92f-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-d88c8a44-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-fa661330-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.1-74c5d538-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-fa661330-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.1-74c5d538-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-aff0df12-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-b95305c2-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-aff0df12-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-b95305c2-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-43c061d1-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-4b3e8f6e-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-43c061d1-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-4b3e8f6e-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-96568c7b-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-9adc8090-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-96568c7b-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-9adc8090-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/version/docs/version.asciidoc
+++ b/version/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 8.3.0
+:stack-version: 8.4.0
 :doc-branch: main
 :go-version: 1.17.10
 :release-state: unreleased

--- a/version/version.go
+++ b/version/version.go
@@ -4,4 +4,4 @@
 
 package version
 
-const defaultBeatVersion = "8.4.0"
+const defaultBeatVersion = "8.4.1"


### PR DESCRIPTION
## What does this PR do?

This PRs adds a separate sidecar monitor which is used for sidecars only.
Atm noop monitor was used which was ok up until we introduced diagnostics command.
Diagnostics queries stats from all processes using monitoring endpoint which is expose by processes.
This was broken because of two things
- diagnostics queried endpoint of regular beat instead of monitoring beat
- monitoring beat does not export monitoring endpoint.

So we sometimes saw `error: Get "http://unix/": dial unix /Library/Elastic/Agent/data/tmp/default/filebeat/filebeat.sock: connect: no such file or directory` in diagnostics output.
(diagnostics was hitting `filebeat.sock` regular filebeat was off because no applicable config for it was retrieved and monitoring filebeat was running while not exposing any metrics)

Went with separate monitor instead of more complicated check if caller is a sidecar or not for readability. 

## Why is it important?

Fixes: https://github.com/elastic/elastic-agent/issues/1022

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
