### PR TITLE
Fix: Endpoint collision between monitoring and regular beats 

### DIFF
--- a/internal/pkg/agent/control/server/server.go
+++ b/internal/pkg/agent/control/server/server.go
@@ -225,7 +225,8 @@ func (s *Server) ProcMeta(ctx context.Context, _ *proto.Empty) (*proto.ProcMetaR
 	// gather spec data for all rk/apps running
 	specs := s.getSpecInfo("", "")
 	for _, si := range specs {
-		endpoint := monitoring.MonitoringEndpoint(si.spec, runtime.GOOS, si.rk)
+		isSidecar := strings.HasSuffix(si.app, "_monitoring")
+		endpoint := monitoring.MonitoringEndpoint(si.spec, runtime.GOOS, si.rk, isSidecar)
 		client := newSocketRequester(si.app, si.rk, endpoint)
 
 		procMeta := client.procMeta(ctx)
@@ -277,7 +278,7 @@ func (s *Server) Pprof(ctx context.Context, req *proto.PprofRequest) (*proto.Ppr
 		specs = s.getSpecInfo(req.RouteKey, req.AppName)
 	}
 	for _, si := range specs {
-		endpoint := monitoring.MonitoringEndpoint(si.spec, runtime.GOOS, si.rk)
+		endpoint := monitoring.MonitoringEndpoint(si.spec, runtime.GOOS, si.rk, false)
 		c := newSocketRequester(si.app, si.rk, endpoint)
 		// Launch a concurrent goroutine to gather all pprof endpoints from a socket.
 		for _, opt := range req.PprofType {
@@ -326,7 +327,8 @@ func (s *Server) ProcMetrics(ctx context.Context, _ *proto.Empty) (*proto.ProcMe
 	// gather metrics buffer data from all other processes
 	specs := s.getSpecInfo("", "")
 	for _, si := range specs {
-		endpoint := monitoring.MonitoringEndpoint(si.spec, runtime.GOOS, si.rk)
+		isSidecar := strings.HasSuffix(si.app, "_monitoring")
+		endpoint := monitoring.MonitoringEndpoint(si.spec, runtime.GOOS, si.rk, isSidecar)
 		client := newSocketRequester(si.app, si.rk, endpoint)
 
 		s.logger.Infof("gather metrics from %s", endpoint)

--- a/internal/pkg/agent/operation/operator.go
+++ b/internal/pkg/agent/operation/operator.go
@@ -27,7 +27,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/core/app"
 	"github.com/elastic/elastic-agent/internal/pkg/core/monitoring"
-	"github.com/elastic/elastic-agent/internal/pkg/core/monitoring/noop"
+	"github.com/elastic/elastic-agent/internal/pkg/core/monitoring/beats"
 	"github.com/elastic/elastic-agent/internal/pkg/core/plugin/process"
 	"github.com/elastic/elastic-agent/internal/pkg/core/plugin/service"
 	"github.com/elastic/elastic-agent/internal/pkg/core/state"
@@ -387,7 +387,7 @@ func (o *Operator) getApp(p Descriptor) (Application, error) {
 	appName := p.BinaryName()
 	if app.IsSidecar(p) {
 		// make watchers unmonitorable
-		monitor = noop.NewMonitor()
+		monitor = beats.NewSidecarMonitor(o.config.DownloadConfig, o.config.MonitoringConfig)
 		appName += "_monitoring"
 	}
 

--- a/internal/pkg/core/monitoring/beats/sidecar_monitor.go
+++ b/internal/pkg/core/monitoring/beats/sidecar_monitor.go
@@ -1,0 +1,149 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package beats
+
+import (
+	"os"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/program"
+	"github.com/elastic/elastic-agent/internal/pkg/artifact"
+	"github.com/elastic/elastic-agent/internal/pkg/config"
+	monitoringConfig "github.com/elastic/elastic-agent/internal/pkg/core/monitoring/config"
+)
+
+// Monitor is a monitoring interface providing information about the way
+// how beat is monitored
+type SidecarMonitor struct {
+	operatingSystem string
+	config          *monitoringConfig.MonitoringConfig
+}
+
+// NewSidecarMonitor creates a beats sidecar monitor, functionality is restricted purely on exposing
+// http endpoint for diagnostics.
+func NewSidecarMonitor(downloadConfig *artifact.Config, monitoringCfg *monitoringConfig.MonitoringConfig) *SidecarMonitor {
+	if monitoringCfg == nil {
+		monitoringCfg = monitoringConfig.DefaultConfig()
+		monitoringCfg.Pprof = &monitoringConfig.PprofConfig{Enabled: false}
+		monitoringCfg.HTTP.Buffer = &monitoringConfig.BufferConfig{Enabled: false}
+	}
+
+	return &SidecarMonitor{
+		operatingSystem: downloadConfig.OS(),
+		config:          monitoringCfg,
+	}
+}
+
+// Reload reloads state of the monitoring based on config.
+func (b *SidecarMonitor) Reload(rawConfig *config.Config) error {
+	cfg := configuration.DefaultConfiguration()
+	if err := rawConfig.Unpack(&cfg); err != nil {
+		return err
+	}
+
+	if cfg == nil || cfg.Settings == nil || cfg.Settings.MonitoringConfig == nil {
+		b.config = monitoringConfig.DefaultConfig()
+	} else {
+		if cfg.Settings.MonitoringConfig.Pprof == nil {
+			cfg.Settings.MonitoringConfig.Pprof = b.config.Pprof
+		}
+		if cfg.Settings.MonitoringConfig.HTTP.Buffer == nil {
+			cfg.Settings.MonitoringConfig.HTTP.Buffer = b.config.HTTP.Buffer
+		}
+		b.config = cfg.Settings.MonitoringConfig
+		logMetrics := true
+		if cfg.Settings.LoggingConfig != nil {
+			logMetrics = cfg.Settings.LoggingConfig.Metrics.Enabled
+		}
+		b.config.LogMetrics = logMetrics
+	}
+
+	return nil
+}
+
+// EnrichArgs enriches arguments provided to application, in order to enable
+// monitoring
+func (b *SidecarMonitor) EnrichArgs(spec program.Spec, pipelineID string, args []string) []string {
+	appendix := make([]string, 0, 7)
+
+	if endpoint := MonitoringEndpoint(spec, b.operatingSystem, pipelineID, true); endpoint != "" {
+		appendix = append(appendix,
+			"-E", "http.enabled=true",
+			"-E", "http.host="+endpoint,
+		)
+		if b.config.Pprof != nil && b.config.Pprof.Enabled {
+			appendix = append(appendix,
+				"-E", "http.pprof.enabled=true",
+			)
+		}
+		if b.config.HTTP.Buffer != nil && b.config.HTTP.Buffer.Enabled {
+			appendix = append(appendix,
+				"-E", "http.buffer.enabled=true",
+			)
+		}
+	}
+
+	return append(args, appendix...)
+}
+
+// Cleanup cleans up all drops.
+func (b *SidecarMonitor) Cleanup(spec program.Spec, pipelineID string) error {
+	endpoint := MonitoringEndpoint(spec, b.operatingSystem, pipelineID, true)
+	drop := monitoringDrop(endpoint)
+
+	return os.RemoveAll(drop)
+}
+
+// Close disables monitoring
+func (b *SidecarMonitor) Close() {
+	b.config.Enabled = false
+	b.config.MonitorMetrics = false
+	b.config.MonitorLogs = false
+}
+
+// Prepare executes steps in order for monitoring to work correctly
+func (b *SidecarMonitor) Prepare(spec program.Spec, pipelineID string, uid, gid int) error {
+	endpoint := MonitoringEndpoint(spec, b.operatingSystem, pipelineID, true)
+	drop := monitoringDrop(endpoint)
+
+	if err := os.MkdirAll(drop, 0775); err != nil {
+		return err
+	}
+
+	if err := changeOwner(drop, uid, gid); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LogPath describes a path where application stores logs. Empty if
+// application is not monitorable
+func (b *SidecarMonitor) LogPath(program.Spec, string) string {
+	return ""
+}
+
+// MetricsPath describes a location where application exposes metrics
+// collectable by metricbeat.
+func (b *SidecarMonitor) MetricsPath(program.Spec, string) string {
+	return ""
+}
+
+// MetricsPathPrefixed return metrics path prefixed with http+ prefix.
+func (b *SidecarMonitor) MetricsPathPrefixed(program.Spec, string) string {
+	return ""
+}
+
+// IsMonitoringEnabled returns true if monitoring is configured.
+func (b *SidecarMonitor) IsMonitoringEnabled() bool { return false }
+
+// WatchLogs return true if monitoring is configured and monitoring logs is enabled.
+func (b *SidecarMonitor) WatchLogs() bool { return false }
+
+// WatchMetrics return true if monitoring is configured and monitoring metrics is enabled.
+func (b *SidecarMonitor) WatchMetrics() bool { return false }
+
+// MonitoringNamespace returns monitoring namespace configured.
+func (b *SidecarMonitor) MonitoringNamespace() string { return "default" }

--- a/internal/pkg/core/monitoring/monitor.go
+++ b/internal/pkg/core/monitoring/monitor.go
@@ -19,7 +19,7 @@ type Monitor interface {
 	MetricsPathPrefixed(spec program.Spec, pipelineID string) string
 
 	Prepare(spec program.Spec, pipelineID string, uid, gid int) error
-	EnrichArgs(spec program.Spec, pipelineID string, args []string, isSidecar bool) []string
+	EnrichArgs(spec program.Spec, pipelineID string, args []string) []string
 	Cleanup(spec program.Spec, pipelineID string) error
 	Reload(cfg *config.Config) error
 	IsMonitoringEnabled() bool

--- a/internal/pkg/core/monitoring/noop/noop_monitor.go
+++ b/internal/pkg/core/monitoring/noop/noop_monitor.go
@@ -11,8 +11,7 @@ import (
 
 // Monitor is a monitoring interface providing information about the way
 // how beat is monitored
-type Monitor struct {
-}
+type Monitor struct{}
 
 // NewMonitor creates a beats monitor.
 func NewMonitor() *Monitor {
@@ -21,7 +20,7 @@ func NewMonitor() *Monitor {
 
 // EnrichArgs enriches arguments provided to application, in order to enable
 // monitoring
-func (b *Monitor) EnrichArgs(_ program.Spec, _ string, args []string, _ bool) []string {
+func (b *Monitor) EnrichArgs(_ program.Spec, _ string, args []string) []string {
 	return args
 }
 

--- a/internal/pkg/core/monitoring/server/process.go
+++ b/internal/pkg/core/monitoring/server/process.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	processIDKey      = "processID"
-	monitoringSuffix  = "-monitoring"
+	monitoringSuffix  = "_monitoring"
 	separator         = "-"
 	timeout           = 10 * time.Second
 	errTypeUnexpected = "UNEXPECTED"
@@ -150,15 +150,12 @@ func generateEndpoint(id string) (string, error) {
 		return "", err
 	}
 
-	endpoint := beats.MonitoringEndpoint(detail.spec, artifact.DefaultConfig().OS(), detail.output)
+	endpoint := beats.MonitoringEndpoint(detail.spec, artifact.DefaultConfig().OS(), detail.output, detail.isMonitoring)
 	if !strings.HasPrefix(endpoint, httpPlusPrefix) && !strings.HasPrefix(endpoint, "http") {
 		// add prefix for npipe and unix
 		endpoint = httpPlusPrefix + endpoint
 	}
 
-	if detail.isMonitoring {
-		endpoint += "_monitor"
-	}
 	return endpoint, nil
 }
 

--- a/internal/pkg/core/plugin/process/start.go
+++ b/internal/pkg/core/plugin/process/start.go
@@ -119,8 +119,7 @@ func (a *Application) start(ctx context.Context, t app.Taggable, cfg map[string]
 	spec.Args = injectLogLevel(a.logLevel, spec.Args)
 
 	// use separate file
-	isSidecar := app.IsSidecar(t)
-	spec.Args = a.monitor.EnrichArgs(a.desc.Spec(), a.pipelineID, spec.Args, isSidecar)
+	spec.Args = a.monitor.EnrichArgs(a.desc.Spec(), a.pipelineID, spec.Args)
 
 	// specify beat name to avoid data lock conflicts
 	// as for https://github.com/elastic/beats/v7/pull/14030 more than one instance


### PR DESCRIPTION
## What does this PR do?

This PRs adds a separate sidecar monitor which is used for sidecars only.
Atm noop monitor was used which was ok up until we introduced diagnostics command.
Diagnostics queries stats from all processes using monitoring endpoint which is expose by processes.
This was broken because of two things
- diagnostics queried endpoint of regular beat instead of monitoring beat
- monitoring beat does not export monitoring endpoint.

So we sometimes saw `error: Get "http://unix/": dial unix /Library/Elastic/Agent/data/tmp/default/filebeat/filebeat.sock: connect: no such file or directory` in diagnostics output.
(diagnostics was hitting `filebeat.sock` regular filebeat was off because no applicable config for it was retrieved and monitoring filebeat was running while not exposing any metrics)

Went with separate monitor instead of more complicated check if caller is a sidecar or not for readability. 

## Why is it important?

Fixes: https://github.com/elastic/elastic-agent/issues/1022

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
