### PR TITLE
Adding support for v1.25.0 k8s

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -224,7 +224,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_VERSION'
-            values "v1.25.0-beta.0","v1.24.3", "v1.23.6", "v1.22.9"
+            values "v1.25.0","v1.24.3", "v1.23.6", "v1.22.9"
           }
         }
         stages {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -152,7 +152,7 @@ pipeline {
               }
             }
             steps {
-              runK8s(k8sVersion: 'v1.23.0', kindVersion: 'v0.11.1', context: "K8s-${PLATFORM}")
+              runK8s(k8sVersion: 'v1.25.0-beta.0', kindVersion: 'v0.14.0', context: "K8s-${PLATFORM}")
             }
           }
           stage('Package') {
@@ -224,7 +224,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_VERSION'
-            values "v1.25.0","v1.24.3", "v1.23.9", "v1.22.12"
+            values "v1.25.0-beta.0","v1.24.3", "v1.23.6", "v1.22.9"
           }
         }
         stages {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -224,7 +224,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_VERSION'
-            values "v1.24.0", "v1.23.6", "v1.22.9", "v1.21.12"
+            values "v1.25.0","v1.24.3", "v1.23.9", "v1.22.12"
           }
         }
         stages {


### PR DESCRIPTION
## What does this PR do?

Adds the new version of v1.25.0 in the list of the supported/tested versions.

Part of https://github.com/elastic/observability-dev/issues/2195