### PR TITLE
Query just related files on build

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -776,7 +776,7 @@ func packageAgent(requiredPackages []string, packagingFn func()) {
 			}
 		}
 
-		files, err := filepath.Glob(filepath.Join(versionedFlatPath, "*"))
+		files, err := filepath.Glob(filepath.Join(versionedFlatPath, fmt.Sprintf("*%s*", version)))
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
## What does this PR do?

Changes glob patter used during build to ignore all files in the drop path which don't include version number in the name

## Why is it important?

Proper build
without this all files are considered which creates a version conflics
