### PR TITLE
Create the archive path if it doesn't already exist

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -894,8 +894,13 @@ func movePackagesToArchive(dropPath string, requiredPackages []string) string {
 				continue
 			}
 
-			targetPath := filepath.Join(archivePath, rp)
-			if err := os.Rename(f, filepath.Join(targetPath, filepath.Base(f))); err != nil {
+			targetDir := filepath.Join(archivePath, rp, filepath.Base(f))
+			targetPath := filepath.Join(targetDir, filepath.Base(f))
+			if err := os.MkdirAll(targetDir, 0750); err != nil {
+				fmt.Printf("warning: failed to create directory %s: %s", targetDir, err)
+			}
+
+			if err := os.Rename(f, targetPath); err != nil {
 				panic(errors.Wrap(err, "failed renaming file"))
 			}
 		}


### PR DESCRIPTION
While experimenting with the V2 branch I noticed when using AGENT_DROP_PATH that the `os.Rename` call in this diff would fail on my M1 Mac if the target directory for the renamed file didn't exist. This fixes that build error.

The `os.Rename` documentation says "OS-specific restrictions may apply when oldpath and newpath are in different directories" without specifying what they are.