### PR TITLE
Remove experimental warning log in upgrade command

### DIFF
--- a/internal/pkg/agent/cmd/upgrade.go
+++ b/internal/pkg/agent/cmd/upgrade.go
@@ -36,8 +36,6 @@ func newUpgradeCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Comman
 }
 
 func upgradeCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error {
-	fmt.Fprintln(streams.Out, "The upgrade process of Elastic Agent is currently EXPERIMENTAL and should not be used in production")
-
 	version := args[0]
 	sourceURI, _ := cmd.Flags().GetString("source-uri")
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Remove experimental warning log in upgrade command: `The upgrade process of Elastic Agent is currently EXPERIMENTAL and should not be used in production`

## Why is it important?

We GA'd this feature in 8.3.0 but didn't remove the log warning and it's confusing users.
