### PR TITLE
Avoid reporting `Unhealthy` on fleet connectivity issues

### DIFF
--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -297,7 +297,7 @@ func (f *fleetGateway) doExecute() (*fleetapi.CheckinResponse, error) {
 				// do not update status reporter with failure
 				// status reporter would report connection failure on first successfull connection, leading to
 				// stale result for certain period causing slight confusion.
-				f.log.Error(fmt.Sprintf("checking number %d failed: %s", f.checkinFailCounter, err.Error()))
+				f.log.Errorf("checking number %d failed: %s", f.checkinFailCounter, err.Error())
 			}
 			continue
 		}

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -291,15 +291,13 @@ func (f *fleetGateway) doExecute() (*fleetapi.CheckinResponse, error) {
 				)
 
 				f.log.Error(err)
-				f.statusReporter.Update(state.Failed, err.Error(), nil)
 				return nil, err
 			}
 			if f.checkinFailCounter > 1 {
-				// Update status reporter for gateway to degraded when there are two consecutive failures.
-				// Note that this may not propagate to fleet-server as the agent is having issues checking in.
-				// It may also (falsely) report a degraded session for 30s if it is eventually successful.
-				// However this component will allow the agent to report fleet gateway degredation locally.
-				f.statusReporter.Update(state.Degraded, fmt.Sprintf("checkin failed: %v", err), nil)
+				// do not update status reporter with failure
+				// status reporter would report connection failure on first successfull connection, leading to
+				// stale result for certain period causing slight confusion.
+				f.log.Error(fmt.Sprintf("checking number %d failed: %s", f.checkinFailCounter, err.Error()))
 			}
 			continue
 		}

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -295,7 +295,7 @@ func (f *fleetGateway) doExecute() (*fleetapi.CheckinResponse, error) {
 			}
 			if f.checkinFailCounter > 1 {
 				// do not update status reporter with failure
-				// status reporter would report connection failure on first successfull connection, leading to
+				// status reporter would report connection failure on first successful connection, leading to
 				// stale result for certain period causing slight confusion.
 				f.log.Errorf("checking number %d failed: %s", f.checkinFailCounter, err.Error())
 			}

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/storage"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/storage/store"
-	"github.com/elastic/elastic-agent/internal/pkg/core/state"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
 	noopacker "github.com/elastic/elastic-agent/internal/pkg/fleetapi/acker/noop"
 	"github.com/elastic/elastic-agent/internal/pkg/scheduler"
@@ -705,7 +704,6 @@ func TestRetriesOnFailures(t *testing.T) {
 		queue.On("Actions").Return([]fleetapi.Action{})
 
 		fleetReporter := &testutils.MockReporter{}
-		fleetReporter.On("Update", state.Degraded, mock.Anything, mock.Anything).Times(2)
 		fleetReporter.On("Update", mock.Anything, mock.Anything, mock.Anything).Maybe()
 		fleetReporter.On("Unregister").Maybe()
 


### PR DESCRIPTION
## What does this PR do?

As per discussion on #1148 
When agent experiences connectivity issues on checkin it saves `Unhealthy` state but it does not report it. 
Offline is computed on kibana/fleet side and it does not make sense for us to report offline as we don't have ability to send the result.

At the point when agent is successful with checkin, `Unhealthy` state for gateway is not up to date anymore as connectivity was just restored. Therefore we don't report `Unhealthy` on connectivity issues so we don;t end up reporting `Unhealthy` for healthy agent as `Unhealthy` is historic state. 

We still log it as error so we know something's wrong.
We still use Unhealthy for other issues with gateway as dispatching config.

## Why is it important?

Avoid confusion with reported states

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
