### PR TITLE
[automation] update elastic stack version for testing 8.5.0-37418cf3

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.0-589a4a10-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.0-37418cf3-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.5.0-589a4a10-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.5.0-37418cf3-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Mon, 12 Sep 2022 00:15:39 GMT, release_branch:master, prefix:, end_time:Mon, 12 Sep 2022 13:52:02 GMT, manifest_version:2.1.0, version:8.5.0-SNAPSHOT, branch:master, build_id:8.5.0-37418cf3, build_duration_seconds:48983]