### PR TITLE
ci: move macos to github actions

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -89,7 +89,8 @@ pipeline {
         axes {
           axis {
             name 'PLATFORM'
-            values 'ubuntu-20.04 && immutable', 'aws && aarch64', 'windows-2016 && windows-immutable', 'windows-2022 && windows-immutable', 'macos12 && x86_64'
+            // Orka workers are not healthy (memory and connectivity issues)
+            values 'ubuntu-20.04 && immutable', 'aws && aarch64', 'windows-2016 && windows-immutable', 'windows-2022 && windows-immutable' //, 'macos12 && x86_64'
           }
         }
         stages {

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,25 @@
+name: macos
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 8.*
+
+jobs:
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Fetch Go version from .go-version
+      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
+    - uses: actions/setup-go@v3
+      with:
+        go-version: ${{ env.GO_VERSION }}
+    - name: Install dependencies
+      run:  go install github.com/magefile/mage
+    - name: Run build
+      run: mage build
+    - name: Run test
+      run: mage unitTest


### PR DESCRIPTION


## What does this PR do?

Use GitHub actions for the MacOS specific build/testing

## Why is it important?

Orka workers are causing some troubles in the last few days, already reported to the System owners, meanwhile let's avoid CI disruptions by using the SaaS provided by GitHub actions

