### PR TITLE
[test] orka versus github actions

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -89,7 +89,8 @@ pipeline {
         axes {
           axis {
             name 'PLATFORM'
-            values 'ubuntu-20.04 && immutable', 'aws && aarch64', 'windows-2016 && windows-immutable', 'windows-2022 && windows-immutable', 'macos12 && x86_64'
+            // Orka workers are not healthy (memory and connectivity issues)
+            values 'ubuntu-20.04 && immutable', 'aws && aarch64', 'windows-2016 && windows-immutable', 'windows-2022 && windows-immutable' //, 'macos12 && x86_64'
           }
         }
         stages {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -89,8 +89,7 @@ pipeline {
         axes {
           axis {
             name 'PLATFORM'
-            // Orka workers are not healthy (memory and connectivity issues)
-            values 'ubuntu-20.04 && immutable', 'aws && aarch64', 'windows-2016 && windows-immutable', 'windows-2022 && windows-immutable' //, 'macos12 && x86_64'
+            values 'macos11 && x86_64', 'macos12 && x86_64'
           }
         }
         stages {

--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -1,4 +1,4 @@
-name: macos-12
+name: macos-11
 
 on:
   pull_request:
@@ -8,8 +8,8 @@ on:
       - 8.*
 
 jobs:
-  macos:
-    runs-on: macos-12
+  macos-11:
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v3
     - name: Fetch Go version from .go-version

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,25 @@
+name: macos
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 8.*
+
+jobs:
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Fetch Go version from .go-version
+      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
+    - uses: actions/setup-go@v3
+      with:
+        go-version: ${{ env.GO_VERSION }}
+    - name: Install dependencies
+      run:  go install github.com/magefile/mage
+    - name: Run build
+      run: mage build
+    - name: Run test
+      run: mage unitTest


### PR DESCRIPTION
### What

Enable MacOS12 and MacOS11 for CI Jenkins and GitHub actions

### Why

For testing purposes whether macos12 and macos11 workers for Orka and GitHub actions produce the same outcome.


### Specs

I already configured the `Orka` workers with 16 Gb ram and 4 CPUs
while `GitHub` runners for MacOS uses:

> Hardware specification for macOS virtual machines:
3-core CPU (x86_64)
14 GB of RAM

see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources