### PR TITLE
[automation] update elastic stack version for testing 8.4.2-4457f478

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.2-fda47f6e-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.2-4457f478-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.2-fda47f6e-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.2-4457f478-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Wed, 14 Sep 2022 00:16:00 GMT, release_branch:8.4, prefix:, end_time:Wed, 14 Sep 2022 04:59:09 GMT, manifest_version:2.1.0, version:8.4.2-SNAPSHOT, branch:8.4, build_id:8.4.2-4457f478, build_duration_seconds:16989]