### PR TITLE
ci: increase timeout

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
     DEVELOPER_MODE=true
   }
   options {
-    timeout(time: 2, unit: 'HOURS')
+    timeout(time: 3, unit: 'HOURS')
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')


### PR DESCRIPTION
### What

Increase the timeout to up to 3 hours.

### Why

`e2e-testing` stage happens at the end (https://github.com/elastic/elastic-agent/pull/1169), it used to fail earlier so the timeout in the CI didn't happen until now.

Since there are more stages regarding [windows-ext ](https://github.com/elastic/elastic-agent/pull/683) and [m1 support](https://github.com/elastic/elastic-agent/pull/1123), the CI pipeline can take a bit longer for merge-commits.
