### PR TITLE
ci: force GO_VERSION

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -61,6 +61,8 @@ pipeline {
           setEnvVar('K8S_CHANGES', isGitRegionMatch(patterns: [ '(^deploy/kubernetes/.*|^version/docs/version.asciidoc|.ci/Jenkinsfile)' ], shouldMatchAll: false).toString())
           setEnvVar('EXT_WINDOWS_CHANGES', isGitRegionMatch(patterns: [ '.ci/Jenkinsfile' ], shouldMatchAll: false).toString())
           setEnvVar('EXT_M1_CHANGES', isGitRegionMatch(patterns: [ '.ci/Jenkinsfile' ], shouldMatchAll: false).toString())
+          // set the GO_VERSION env variable with the go version to be used in withMageEnv
+          setEnvVar('GO_VERSION', readFile(file: '.go-version')?.trim())
         }
       }
     }


### PR DESCRIPTION
## What does this PR do?

Set the environment variable earlier

## Why

`withMageEnv` calls `withGoEnv` and it does use [goDefaultVersion](https://github.com/elastic/apm-pipeline-library/blob/main/vars/goDefaultVersion.groovy) but for some reason it does not use the `.go-version` file but the default hardcoded version in https://github.com/elastic/apm-pipeline-library/blob/54b4c9b43747d5a0c58bb8605f9f0c0d2d6510d5/vars/goDefaultVersion.groovy#L41



