### PR TITLE
Fix whitespaces in vault_darwin.c

### DIFF
--- a/internal/pkg/agent/vault/vault_darwin.c
+++ b/internal/pkg/agent/vault/vault_darwin.c
@@ -209,10 +209,10 @@ OSStatus RemoveKeychainItem(SecKeychainRef keychain, const char *name, const cha
 char* GetOSStatusMessage(OSStatus status) {
     CFStringRef s = SecCopyErrorMessageString(status, NULL);
     char *p;
-	int n;
-	n = CFStringGetLength(s)*8;	
-	p = malloc(n);
-	CFStringGetCString(s, p, n, kCFStringEncodingUTF8);
+    int n;
+    n = CFStringGetLength(s)*8;
+    p = malloc(n);
+    CFStringGetCString(s, p, n, kCFStringEncodingUTF8);
     CFRelease(s);
-	return p;
+    return p;
 }


### PR DESCRIPTION
## What does this PR do?

Cleans up tabs to whitespaces indentation in darwin_vault.c

## Why is it important?

Just stumbled upon this while browsing some of my old code. Consistent indentation is importante.

## Checklist

- [x] My code follows the style guidelines of this project
