### PR TITLE
Expand status reporter/controller interfaces to allow local reporters

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -117,6 +117,7 @@
 - Fix a panic caused by a race condition when installing the Elastic Agent. {issues}806[806]
 - Use at least warning level for all status logs {pull}1218[1218]
 - Remove fleet event reporter and events from checkin body. {issue}993[993]
+- Create separate status reporter for local only events so that degraded fleet-checkins no longer affect health on successful fleet-checkins. {issue}1157[1157] {pull}1285[1285]
 
 ==== New features
 

--- a/internal/pkg/agent/application/gateway/fleet/noop_status_controller_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/noop_status_controller_test.go
@@ -13,13 +13,17 @@ import (
 
 type noopController struct{}
 
-func (*noopController) SetAgentID(_ string)                        {}
-func (*noopController) RegisterComponent(_ string) status.Reporter { return &noopReporter{} }
+func (*noopController) SetAgentID(_ string)                             {}
+func (*noopController) RegisterComponent(_ string) status.Reporter      { return &noopReporter{} }
+func (*noopController) RegisterLocalComponent(_ string) status.Reporter { return &noopReporter{} }
 func (*noopController) RegisterComponentWithPersistance(_ string, _ bool) status.Reporter {
 	return &noopReporter{}
 }
-func (*noopController) RegisterApp(_ string, _ string) status.Reporter   { return &noopReporter{} }
-func (*noopController) Status() status.AgentStatus                       { return status.AgentStatus{Status: status.Healthy} }
+func (*noopController) RegisterApp(_ string, _ string) status.Reporter { return &noopReporter{} }
+func (*noopController) Status() status.AgentStatus                     { return status.AgentStatus{Status: status.Healthy} }
+func (*noopController) LocalStatus() status.AgentStatus {
+	return status.AgentStatus{Status: status.Healthy}
+}
 func (*noopController) StatusCode() status.AgentStatusCode               { return status.Healthy }
 func (*noopController) UpdateStateID(_ string)                           {}
 func (*noopController) StatusString() string                             { return "online" }

--- a/internal/pkg/core/status/handler.go
+++ b/internal/pkg/core/status/handler.go
@@ -19,10 +19,11 @@ type LivenessResponse struct {
 }
 
 // ServeHTTP is an HTTP Handler for the status controller.
+// It uses the local agent status so it is able to report a degraded state if the fleet-server checkin has issues.
 // Respose code is 200 for a healthy agent, and 503 otherwise.
 // Response body is a JSON object that contains the agent ID, status, message, and the last status update time.
 func (r *controller) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
-	s := r.Status()
+	s := r.LocalStatus()
 	lr := LivenessResponse{
 		ID:         r.agentID,
 		Status:     s.Status.String(),

--- a/internal/pkg/core/status/reporter.go
+++ b/internal/pkg/core/status/reporter.go
@@ -227,7 +227,7 @@ func (r *controller) Status() AgentStatus {
 	}
 }
 
-// LocalStatus returns the status from the local registed components if they are different from the agent status.
+// LocalStatus returns the status from the local registered components if they are different from the agent status.
 // If the agent status is more severe then the local status (failed vs degraded for example) agent status is used.
 // If they are equal (healthy and healthy) agent status is used.
 func (r *controller) LocalStatus() AgentStatus {

--- a/internal/pkg/core/status/reporter.go
+++ b/internal/pkg/core/status/reporter.go
@@ -58,9 +58,11 @@ type AgentStatus struct {
 type Controller interface {
 	SetAgentID(string)
 	RegisterComponent(string) Reporter
+	RegisterLocalComponent(string) Reporter
 	RegisterComponentWithPersistance(string, bool) Reporter
 	RegisterApp(id string, name string) Reporter
 	Status() AgentStatus
+	LocalStatus() AgentStatus
 	StatusCode() AgentStatusCode
 	StatusString() string
 	UpdateStateID(string)
@@ -68,15 +70,19 @@ type Controller interface {
 }
 
 type controller struct {
-	updateTime   time.Time
-	log          *logger.Logger
-	reporters    map[string]*reporter
-	appReporters map[string]*reporter
-	stateID      string
-	message      string
-	agentID      string
-	status       AgentStatusCode
-	mx           sync.Mutex
+	updateTime     time.Time
+	log            *logger.Logger
+	reporters      map[string]*reporter
+	localReporters map[string]*reporter
+	appReporters   map[string]*reporter
+	stateID        string
+	message        string
+	agentID        string
+	status         AgentStatusCode
+	localStatus    AgentStatusCode
+	localMessage   string
+	localTime      time.Time
+	mx             sync.Mutex
 }
 
 // NewController creates a new reporter.
@@ -124,6 +130,28 @@ func (r *controller) UpdateStateID(stateID string) {
 	r.mx.Unlock()
 
 	r.updateStatus()
+}
+
+// RegisterLocalComponent registers new component for local-only status updates.
+func (r *controller) RegisterLocalComponent(componentIdentifier string) Reporter {
+	id := componentIdentifier + "-" + uuid.New().String()[:8]
+	rep := &reporter{
+		name:         componentIdentifier,
+		isRegistered: true,
+		unregisterFunc: func() {
+			r.mx.Lock()
+			delete(r.localReporters, id)
+			r.mx.Unlock()
+		},
+		notifyChangeFunc: r.updateStatus,
+		isPersistent:     false,
+	}
+
+	r.mx.Lock()
+	r.localReporters[id] = rep
+	r.mx.Unlock()
+
+	return rep
 }
 
 // Register registers new component for status updates.
@@ -199,6 +227,25 @@ func (r *controller) Status() AgentStatus {
 	}
 }
 
+// LocalStatus returns the status from the local registed components if they are different from the agent status.
+// If the agent status is more severe then the local status (failed vs degraded for example) agent status is used.
+// If they are equal (healthy and healthy) agent status is used.
+func (r *controller) LocalStatus() AgentStatus {
+	status := r.Status()
+	r.mx.Lock()
+	defer r.mx.Unlock()
+
+	if r.localStatus > status.Status {
+		return AgentStatus{
+			Status:     r.localStatus,
+			Message:    r.localMessage,
+			UpdateTime: r.localTime,
+		}
+	}
+	return status
+
+}
+
 // StatusCode retrieves current agent status code.
 func (r *controller) StatusCode() AgentStatusCode {
 	r.mx.Lock()
@@ -208,9 +255,23 @@ func (r *controller) StatusCode() AgentStatusCode {
 
 func (r *controller) updateStatus() {
 	status := Healthy
+	lStatus := Healthy
 	message := ""
+	lMessage := ""
 
 	r.mx.Lock()
+	for id, rep := range r.localReporters {
+		s := statusToAgentStatus(rep.status)
+		if s > lStatus {
+			lStatus = s
+			lMessage = fmt.Sprintf("component %s: %s", id, rep.message)
+		}
+		r.log.Debugf("local component '%s' has status '%s'", id, s)
+		if status == Failed {
+			break
+		}
+	}
+
 	for id, rep := range r.reporters {
 		s := statusToAgentStatus(rep.status)
 		if s > status {
@@ -243,6 +304,11 @@ func (r *controller) updateStatus() {
 		r.status = status
 		r.message = message
 		r.updateTime = time.Now().UTC()
+	}
+	if r.localStatus != lStatus {
+		r.localStatus = lStatus
+		r.localMessage = lMessage
+		r.localTime = time.Now().UTC()
 	}
 
 	r.mx.Unlock()

--- a/internal/pkg/testutils/status_reporter.go
+++ b/internal/pkg/testutils/status_reporter.go
@@ -25,6 +25,11 @@ func (m *MockController) RegisterComponent(id string) status.Reporter {
 	return args.Get(0).(status.Reporter)
 }
 
+func (m *MockController) RegisterLocalComponent(id string) status.Reporter {
+	args := m.Called(id)
+	return args.Get(0).(status.Reporter)
+}
+
 func (m *MockController) RegisterComponentWithPersistance(id string, b bool) status.Reporter {
 	args := m.Called(id, b)
 	return args.Get(0).(status.Reporter)
@@ -36,6 +41,11 @@ func (m *MockController) RegisterApp(id, name string) status.Reporter {
 }
 
 func (m *MockController) Status() status.AgentStatus {
+	args := m.Called()
+	return args.Get(0).(status.AgentStatus)
+}
+
+func (m *MockController) LocalStatus() status.AgentStatus {
 	args := m.Called()
 	return args.Get(0).(status.AgentStatus)
 }


### PR DESCRIPTION
## What does this PR do?

Add a local reporter map to the status controller. These reporters are not used when updating status with fleet-server, they are only used to gather local state information - specifically if the agent is degraded because checkin with fleet-server has failed. Local reporters are used to generate a separate status. This status is used in the liveness endpoint.

## Why is it important?

This bypasses the bug (#1148) that was introduced with the liveness endpoint (#569) where the agent could checkin (to fleet-server) with a degraded status because a previous checkin failed, causing the agent to appear as unhealthy in the fleet-server when it checked in successfully. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #1157 