### PR TITLE
Improve logging for agent upgrades.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -204,3 +204,4 @@
 - Fix incorrectly creating a filebeat redis input when a policy contains a packetbeat redis input. {issue}[427] {pull}[700]
 - Add `lumberjack` input type to the Filebeat spec. {pull}[959]
 - Add support for hints' based autodiscovery in kubernetes provider. {pull}[698]
+- Improve logging during upgrades. {pull}[1287]

--- a/internal/pkg/agent/application/pipeline/actions/handlers/handler_action_upgrade.go
+++ b/internal/pkg/agent/application/pipeline/actions/handlers/handler_action_upgrade.go
@@ -39,6 +39,14 @@ func (h *Upgrade) Handle(ctx context.Context, a fleetapi.Action, acker store.Fle
 	}
 
 	_, err := h.upgrader.Upgrade(ctx, &upgradeAction{action}, true)
+	if err != nil {
+		// Always log upgrade failures at the error level. Action errors are logged at debug level
+		// by default higher up the stack in ActionDispatcher.Dispatch()
+		h.log.Errorw("Upgrade action failed", "error.message", err,
+			"action.version", action.Version, "action.source_uri", action.SourceURI, "action.id", action.ActionID,
+			"action.start_time", action.StartTime, "action.expiration", action.ActionExpiration)
+	}
+
 	return err
 }
 

--- a/internal/pkg/agent/application/upgrade/cleanup.go
+++ b/internal/pkg/agent/application/upgrade/cleanup.go
@@ -13,11 +13,15 @@ import (
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
-// preUpgradeCleanup will remove files that do not have the passed version number from the downloads directory.
-func preUpgradeCleanup(version string) error {
-	files, err := os.ReadDir(paths.Downloads())
+// cleanNonMatchingVersionsFromDownloads will remove files that do not have the passed version number from the downloads directory.
+func cleanNonMatchingVersionsFromDownloads(log *logger.Logger, version string) error {
+	downloadsPath := paths.Downloads()
+	log.Infow("Cleaning up non-matching downloaded versions", "version", version, "downloads.path", downloadsPath)
+
+	files, err := os.ReadDir(downloadsPath)
 	if err != nil {
 		return fmt.Errorf("unable to read directory %q: %w", paths.Downloads(), err)
 	}

--- a/internal/pkg/agent/application/upgrade/cleanup.go
+++ b/internal/pkg/agent/application/upgrade/cleanup.go
@@ -19,7 +19,7 @@ import (
 // cleanNonMatchingVersionsFromDownloads will remove files that do not have the passed version number from the downloads directory.
 func cleanNonMatchingVersionsFromDownloads(log *logger.Logger, version string) error {
 	downloadsPath := paths.Downloads()
-	log.Infow("Cleaning up non-matching downloaded versions", "version", version, "downloads.path", downloadsPath)
+	log.Debugw("Cleaning up non-matching downloaded versions", "version", version, "downloads.path", downloadsPath)
 
 	files, err := os.ReadDir(downloadsPath)
 	if err != nil {

--- a/internal/pkg/agent/application/upgrade/cleanup_test.go
+++ b/internal/pkg/agent/application/upgrade/cleanup_test.go
@@ -9,7 +9,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
 
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +33,8 @@ func setupDir(t *testing.T) {
 
 func TestPreUpgradeCleanup(t *testing.T) {
 	setupDir(t)
-	err := preUpgradeCleanup("8.4.0")
+	log := newErrorLogger(t)
+	err := cleanNonMatchingVersionsFromDownloads(log, "8.4.0")
 	require.NoError(t, err)
 
 	files, err := os.ReadDir(paths.Downloads())
@@ -41,4 +44,15 @@ func TestPreUpgradeCleanup(t *testing.T) {
 	p, err := os.ReadFile(filepath.Join(paths.Downloads(), files[0].Name()))
 	require.NoError(t, err)
 	require.Equal(t, []byte("hello, world!"), p)
+}
+
+func newErrorLogger(t *testing.T) *logger.Logger {
+	t.Helper()
+
+	loggerCfg := logger.DefaultLoggingConfig()
+	loggerCfg.Level = logp.ErrorLevel
+
+	log, err := logger.NewFromConfig("", loggerCfg, false)
+	require.NoError(t, err)
+	return log
 }

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -54,7 +54,7 @@ func Rollback(ctx context.Context, log *logger.Logger, prevHash string, currentH
 
 // Cleanup removes all artifacts and files related to a specified version.
 func Cleanup(log *logger.Logger, currentHash string, removeMarker bool) error {
-	log.Infow("Cleaning up upgrade", "hash", currentHash, "remove_marker", removeMarker)
+	log.Debugw("Cleaning up upgrade", "hash", currentHash, "remove_marker", removeMarker)
 	<-time.After(afterRestartDelay)
 
 	// remove upgrade marker

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -31,14 +31,14 @@ const (
 )
 
 // Rollback rollbacks to previous version which was functioning before upgrade.
-func Rollback(ctx context.Context, prevHash, currentHash string) error {
+func Rollback(ctx context.Context, log *logger.Logger, prevHash string, currentHash string) error {
 	// change symlink
-	if err := ChangeSymlink(ctx, prevHash); err != nil {
+	if err := ChangeSymlink(ctx, log, prevHash); err != nil {
 		return err
 	}
 
 	// revert active commit
-	if err := UpdateActiveCommit(prevHash); err != nil {
+	if err := UpdateActiveCommit(log, prevHash); err != nil {
 		return err
 	}
 
@@ -113,6 +113,7 @@ func InvokeWatcher(log *logger.Logger) error {
 		}
 	}()
 
+	log.Debugw("Starting upgrade watcher", "path", cmd.Path, "args", cmd.Args, "env", cmd.Env, "dir", cmd.Dir)
 	return cmd.Start()
 }
 

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -77,7 +77,7 @@ func Cleanup(log *logger.Logger, currentHash string, removeMarker bool) error {
 
 	// remove symlink to avoid upgrade failures, ignore error
 	prevSymlink := prevSymlinkPath()
-	log.Infow("Removing previous symlink path", "file.path", prevSymlinkPath())
+	log.Debugw("Removing previous symlink path", "file.path", prevSymlinkPath())
 	_ = os.Remove(prevSymlink)
 
 	dirPrefix := fmt.Sprintf("%s-", agentName)

--- a/internal/pkg/agent/application/upgrade/step_download.go
+++ b/internal/pkg/agent/application/upgrade/step_download.go
@@ -40,7 +40,7 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 		}
 	}
 
-	u.log.Infow("Downloading upgrade artifact", "version", version,
+	u.log.Debugw("Downloading upgrade artifact", "version", version,
 		"source_uri", settings.SourceURI, "drop_path", settings.DropPath,
 		"target_path", settings.TargetDirectory, "install_path", settings.InstallPath)
 

--- a/internal/pkg/agent/application/upgrade/step_download.go
+++ b/internal/pkg/agent/application/upgrade/step_download.go
@@ -40,6 +40,10 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 		}
 	}
 
+	u.log.Infow("Downloading upgrade artifact", "version", version,
+		"source_uri", settings.SourceURI, "drop_path", settings.DropPath,
+		"target_path", settings.TargetDirectory, "install_path", settings.InstallPath)
+
 	verifier, err := newVerifier(version, u.log, &settings)
 	if err != nil {
 		return "", errors.New(err, "initiating verifier")

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -17,6 +17,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/internal/pkg/release"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
 const markerFilename = ".update-marker"
@@ -91,7 +92,7 @@ func newMarkerSerializer(m *UpdateMarker) *updateMarkerSerializer {
 }
 
 // markUpgrade marks update happened so we can handle grace period
-func (u *Upgrader) markUpgrade(_ context.Context, hash string, action Action) error {
+func (u *Upgrader) markUpgrade(_ context.Context, log *logger.Logger, hash string, action Action) error {
 	prevVersion := release.Version()
 	prevHash := release.Commit()
 	if len(prevHash) > hashLen {
@@ -112,11 +113,12 @@ func (u *Upgrader) markUpgrade(_ context.Context, hash string, action Action) er
 	}
 
 	markerPath := markerFilePath()
+	log.Infow("Writing upgrade marker file", "file.path", markerPath, "hash", marker.Hash, "prev_hash", prevHash)
 	if err := ioutil.WriteFile(markerPath, markerBytes, 0600); err != nil {
 		return errors.New(err, errors.TypeFilesystem, "failed to create update marker file", errors.M(errors.MetaKeyPath, markerPath))
 	}
 
-	if err := UpdateActiveCommit(hash); err != nil {
+	if err := UpdateActiveCommit(log, hash); err != nil {
 		return err
 	}
 
@@ -124,8 +126,9 @@ func (u *Upgrader) markUpgrade(_ context.Context, hash string, action Action) er
 }
 
 // UpdateActiveCommit updates active.commit file to point to active version.
-func UpdateActiveCommit(hash string) error {
+func UpdateActiveCommit(log *logger.Logger, hash string) error {
 	activeCommitPath := filepath.Join(paths.Top(), agentCommitFile)
+	log.Infow("Updating active commit", "file.path", activeCommitPath, "hash", hash)
 	if err := ioutil.WriteFile(activeCommitPath, []byte(hash), 0600); err != nil {
 		return errors.New(err, errors.TypeFilesystem, "failed to update active commit", errors.M(errors.MetaKeyPath, activeCommitPath))
 	}

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -139,7 +139,7 @@ func UpdateActiveCommit(log *logger.Logger, hash string) error {
 // CleanMarker removes a marker from disk.
 func CleanMarker(log *logger.Logger) error {
 	markerFile := markerFilePath()
-	log.Infow("Removing marker file", "file.path", markerFile)
+	log.Debugw("Removing marker file", "file.path", markerFile)
 	if err := os.Remove(markerFile); !os.IsNotExist(err) {
 		return err
 	}

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -137,8 +137,9 @@ func UpdateActiveCommit(log *logger.Logger, hash string) error {
 }
 
 // CleanMarker removes a marker from disk.
-func CleanMarker() error {
+func CleanMarker(log *logger.Logger) error {
 	markerFile := markerFilePath()
+	log.Infow("Removing marker file", "file.path", markerFile)
 	if err := os.Remove(markerFile); !os.IsNotExist(err) {
 		return err
 	}

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -14,10 +14,11 @@ import (
 	"github.com/elastic/elastic-agent-libs/file"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
 // ChangeSymlink updates symlink paths to match current version.
-func ChangeSymlink(ctx context.Context, targetHash string) error {
+func ChangeSymlink(ctx context.Context, log *logger.Logger, targetHash string) error {
 	// create symlink to elastic-agent-{hash}
 	hashedDir := fmt.Sprintf("%s-%s", agentName, targetHash)
 
@@ -31,6 +32,7 @@ func ChangeSymlink(ctx context.Context, targetHash string) error {
 	}
 
 	prevNewPath := prevSymlinkPath()
+	log.Infow("Changing symlink", "symlink_path", symlinkPath, "new_path", newPath, "prev_path", prevNewPath)
 
 	// remove symlink to avoid upgrade failures
 	if err := os.Remove(prevNewPath); !os.IsNotExist(err) {

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
 // unpack unpacks archive correctly, skips root (symlink, config...) unpacks data/*
@@ -30,18 +31,21 @@ func (u *Upgrader) unpack(ctx context.Context, version, archivePath string) (str
 	var hash string
 	var err error
 	if runtime.GOOS == "windows" {
-		hash, err = unzip(version, archivePath)
+		hash, err = unzip(u.log, version, archivePath)
 	} else {
-		hash, err = untar(version, archivePath)
+		hash, err = untar(u.log, version, archivePath)
 	}
+
 	if err != nil {
+		u.log.Infow("Failed to unpack upgrade artifact", "error.message", err, "version", version, "file.path", archivePath, "hash", hash)
 		return "", err
 	}
 
+	u.log.Infow("Unpacked upgrade artifact", "version", version, "file.path", archivePath, "hash", hash)
 	return hash, nil
 }
 
-func unzip(version, archivePath string) (string, error) {
+func unzip(log *logger.Logger, version string, archivePath string) (string, error) {
 	var hash, rootDir string
 	r, err := zip.OpenReader(archivePath)
 	if err != nil {
@@ -82,8 +86,10 @@ func unzip(version, archivePath string) (string, error) {
 		path := filepath.Join(paths.Data(), strings.TrimPrefix(fileName, "data/"))
 
 		if f.FileInfo().IsDir() {
+			log.Debugw("Unpacking directory", "archive", "zip", "file.path", path)
 			os.MkdirAll(path, f.Mode())
 		} else {
+			log.Debugw("Unpacking file", "archive", "zip", "file.path", path)
 			os.MkdirAll(filepath.Dir(path), f.Mode())
 			f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
 			if err != nil {
@@ -119,7 +125,7 @@ func unzip(version, archivePath string) (string, error) {
 	return hash, nil
 }
 
-func untar(version, archivePath string) (string, error) {
+func untar(log *logger.Logger, version string, archivePath string) (string, error) {
 	r, err := os.Open(archivePath)
 	if err != nil {
 		return "", errors.New(fmt.Sprintf("artifact for 'elastic-agent' version '%s' could not be found at '%s'", version, archivePath), errors.TypeFilesystem, errors.M(errors.MetaKeyPath, archivePath))
@@ -183,6 +189,7 @@ func untar(version, archivePath string) (string, error) {
 		mode := fi.Mode()
 		switch {
 		case mode.IsRegular():
+			log.Debugw("Unpacking file", "archive", "tar", "file.path", abs)
 			// just to be sure, it should already be created by Dir type
 			if err := os.MkdirAll(filepath.Dir(abs), 0755); err != nil {
 				return "", errors.New(err, "TarInstaller: creating directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
@@ -201,6 +208,7 @@ func untar(version, archivePath string) (string, error) {
 				return "", fmt.Errorf("TarInstaller: error writing to %s: %w", abs, err)
 			}
 		case mode.IsDir():
+			log.Debugw("Unpacking directory", "archive", "tar", "file.path", abs)
 			if err := os.MkdirAll(abs, 0755); err != nil {
 				return "", errors.New(err, "TarInstaller: creating directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
 			}

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -37,7 +37,7 @@ func (u *Upgrader) unpack(ctx context.Context, version, archivePath string) (str
 	}
 
 	if err != nil {
-		u.log.Infow("Failed to unpack upgrade artifact", "error.message", err, "version", version, "file.path", archivePath, "hash", hash)
+		u.log.Errorw("Failed to unpack upgrade artifact", "error.message", err, "version", version, "file.path", archivePath, "hash", hash)
 		return "", err
 	}
 

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -301,7 +301,7 @@ func copyActionStore(log *logger.Logger, newHash string) error {
 	// copies legacy action_store.yml, state.yml and state.enc encrypted file if exists
 	storePaths := []string{paths.AgentActionStoreFile(), paths.AgentStateStoreYmlFile(), paths.AgentStateStoreFile()}
 	newHome := filepath.Join(filepath.Dir(paths.Home()), fmt.Sprintf("%s-%s", agentName, newHash))
-	log.Infow("Copying action store", "new_home_path", newHome)
+	log.Debugw("Copying action store", "new_home_path", newHome)
 
 	for _, currentActionStorePath := range storePaths {
 		newActionStorePath := filepath.Join(newHome, filepath.Base(currentActionStorePath))

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -195,7 +195,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, a Action, reexecNow bool) (_ ree
 	trimmedNewHash := release.TrimCommit(newHash)
 	cb := shutdownCallback(u.log, paths.Home(), release.Version(), a.Version(), trimmedNewHash)
 	if reexecNow {
-		u.log.Infow("Removing downloads directory", "file.path", paths.Downloads(), "rexec", reexecNow)
+		u.log.Debugw("Removing downloads directory", "file.path", paths.Downloads(), "rexec", reexecNow)
 		err = os.RemoveAll(paths.Downloads())
 		if err != nil {
 			u.log.Errorw("Unable to clean downloads after update", "error.message", err, "downloads.path", paths.Downloads())
@@ -207,7 +207,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, a Action, reexecNow bool) (_ ree
 	}
 
 	// Clean everything from the downloads dir
-	u.log.Infow("Removing downloads directory", "file.path", paths.Downloads(), "rexec", reexecNow)
+	u.log.Debugw("Removing downloads directory", "file.path", paths.Downloads(), "rexec", reexecNow)
 	err = os.RemoveAll(paths.Downloads())
 	if err != nil {
 		u.log.Errorw("Unable to clean downloads after update", "error.message", err, "file.path", paths.Downloads())

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -108,6 +108,7 @@ func (u *Upgrader) Upgradeable() bool {
 // Upgrade upgrades running agent, function returns shutdown callback if some needs to be executed for cases when
 // reexec is called by caller.
 func (u *Upgrader) Upgrade(ctx context.Context, a Action, reexecNow bool) (_ reexec.ShutdownCallbackFn, err error) {
+	u.log.Infow("Upgrading agent", "version", a.Version(), "source_uri", a.SourceURI())
 	span, ctx := apm.StartSpan(ctx, "upgrade", "app.internal")
 	defer span.End()
 	// report failed
@@ -126,9 +127,9 @@ func (u *Upgrader) Upgrade(ctx context.Context, a Action, reexecNow bool) (_ ree
 				"running under control of the systems supervisor")
 	}
 
-	err = preUpgradeCleanup(u.agentInfo.Version())
+	err = cleanNonMatchingVersionsFromDownloads(u.log, u.agentInfo.Version())
 	if err != nil {
-		u.log.Errorf("Unable to clean downloads dir %q before update: %v", paths.Downloads(), err)
+		u.log.Errorw("Unable to clean downloads before update", "error.message", err, "downloads.path", paths.Downloads())
 	}
 
 	if u.caps != nil {
@@ -142,10 +143,10 @@ func (u *Upgrader) Upgrade(ctx context.Context, a Action, reexecNow bool) (_ ree
 	sourceURI := u.sourceURI(a.SourceURI())
 	archivePath, err := u.downloadArtifact(ctx, a.Version(), sourceURI)
 	if err != nil {
-		// Run the same preUpgradeCleanup task to get rid of any newly downloaded files
+		// Run the same pre-upgrade cleanup task to get rid of any newly downloaded files
 		// This may have an issue if users are upgrading to the same version number.
-		if dErr := preUpgradeCleanup(u.agentInfo.Version()); dErr != nil {
-			u.log.Errorf("Unable to remove file after verification failure: %v", dErr)
+		if dErr := cleanNonMatchingVersionsFromDownloads(u.log, u.agentInfo.Version()); dErr != nil {
+			u.log.Errorw("Unable to remove file after verification failure", "error.message", dErr)
 		}
 		return nil, err
 	}
@@ -169,39 +170,47 @@ func (u *Upgrader) Upgrade(ctx context.Context, a Action, reexecNow bool) (_ ree
 		return nil, nil
 	}
 
-	if err := copyActionStore(newHash); err != nil {
+	if err := copyActionStore(u.log, newHash); err != nil {
 		return nil, errors.New(err, "failed to copy action store")
 	}
 
-	if err := ChangeSymlink(ctx, newHash); err != nil {
-		rollbackInstall(ctx, newHash)
+	if err := ChangeSymlink(ctx, u.log, newHash); err != nil {
+		u.log.Errorw("Rolling back: changing symlink failed", "error.message", err)
+		rollbackInstall(ctx, u.log, newHash)
 		return nil, err
 	}
 
-	if err := u.markUpgrade(ctx, newHash, a); err != nil {
-		rollbackInstall(ctx, newHash)
+	if err := u.markUpgrade(ctx, u.log, newHash, a); err != nil {
+		u.log.Errorw("Rolling back: marking upgrade failed", "error.message", err)
+		rollbackInstall(ctx, u.log, newHash)
 		return nil, err
 	}
 
 	if err := InvokeWatcher(u.log); err != nil {
-		rollbackInstall(ctx, newHash)
+		u.log.Errorw("Rolling back: starting watcher failed", "error.message", err)
+		rollbackInstall(ctx, u.log, newHash)
 		return nil, errors.New("failed to invoke rollback watcher", err)
 	}
 
-	cb := shutdownCallback(u.log, paths.Home(), release.Version(), a.Version(), release.TrimCommit(newHash))
+	trimmedNewHash := release.TrimCommit(newHash)
+	cb := shutdownCallback(u.log, paths.Home(), release.Version(), a.Version(), trimmedNewHash)
 	if reexecNow {
+		u.log.Infow("Removing downloads directory", "file.path", paths.Downloads(), "rexec", reexecNow)
 		err = os.RemoveAll(paths.Downloads())
 		if err != nil {
-			u.log.Errorf("Unable to clean downloads dir %q after update: %v", paths.Downloads(), err)
+			u.log.Errorw("Unable to clean downloads after update", "error.message", err, "downloads.path", paths.Downloads())
 		}
+		u.log.Infow("Restarting after upgrade", "new_version", release.Version(), "prev_version", a.Version(),
+			"hash", trimmedNewHash, "home", paths.Home())
 		u.reexec.ReExec(cb)
 		return nil, nil
 	}
 
 	// Clean everything from the downloads dir
+	u.log.Infow("Removing downloads directory", "file.path", paths.Downloads(), "rexec", reexecNow)
 	err = os.RemoveAll(paths.Downloads())
 	if err != nil {
-		u.log.Errorf("Unable to clean downloads dir %q after update: %v", paths.Downloads(), err)
+		u.log.Errorw("Unable to clean downloads after update", "error.message", err, "file.path", paths.Downloads())
 	}
 
 	return cb, nil
@@ -283,19 +292,20 @@ func (u *Upgrader) reportUpdating(version string) {
 	)
 }
 
-func rollbackInstall(ctx context.Context, hash string) {
+func rollbackInstall(ctx context.Context, log *logger.Logger, hash string) {
 	os.RemoveAll(filepath.Join(paths.Data(), fmt.Sprintf("%s-%s", agentName, hash)))
-	_ = ChangeSymlink(ctx, release.ShortCommit())
+	_ = ChangeSymlink(ctx, log, release.ShortCommit())
 }
 
-func copyActionStore(newHash string) error {
+func copyActionStore(log *logger.Logger, newHash string) error {
 	// copies legacy action_store.yml, state.yml and state.enc encrypted file if exists
 	storePaths := []string{paths.AgentActionStoreFile(), paths.AgentStateStoreYmlFile(), paths.AgentStateStoreFile()}
+	newHome := filepath.Join(filepath.Dir(paths.Home()), fmt.Sprintf("%s-%s", agentName, newHash))
+	log.Infow("Copying action store", "new_home_path", newHome)
 
 	for _, currentActionStorePath := range storePaths {
-		newHome := filepath.Join(filepath.Dir(paths.Home()), fmt.Sprintf("%s-%s", agentName, newHash))
 		newActionStorePath := filepath.Join(newHome, filepath.Base(currentActionStorePath))
-
+		log.Debugw("Copying action store path", "from", currentActionStorePath, "to", newActionStorePath)
 		currentActionStore, err := ioutil.ReadFile(currentActionStorePath)
 		if os.IsNotExist(err) {
 			// nothing to copy

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -89,7 +89,7 @@ func watchCmd(log *logp.Logger) error {
 		// if we're not within grace and marker is still there it might mean
 		// that cleanup was not performed ok, cleanup everything except current version
 		// hash is the same as hash of agent which initiated watcher.
-		if err := upgrade.Cleanup(release.ShortCommit(), true); err != nil {
+		if err := upgrade.Cleanup(log, release.ShortCommit(), true); err != nil {
 			log.Error("rollback failed", err)
 		}
 		// exit nicely
@@ -98,7 +98,7 @@ func watchCmd(log *logp.Logger) error {
 
 	ctx := context.Background()
 	if err := watch(ctx, tilGrace, log); err != nil {
-		log.Debug("Error detected proceeding to rollback: %v", err)
+		log.Error("Error detected proceeding to rollback: %v", err)
 		err = upgrade.Rollback(ctx, log, marker.PrevHash, marker.Hash)
 		if err != nil {
 			log.Error("rollback failed", err)
@@ -110,7 +110,7 @@ func watchCmd(log *logp.Logger) error {
 	// in windows it might leave self untouched, this will get cleaned up
 	// later at the start, because for windows we leave marker untouched.
 	removeMarker := !isWindows()
-	err = upgrade.Cleanup(marker.Hash, removeMarker)
+	err = upgrade.Cleanup(log, marker.Hash, removeMarker)
 	if err != nil {
 		log.Error("rollback failed", err)
 	}

--- a/internal/pkg/agent/control/server/server.go
+++ b/internal/pkg/agent/control/server/server.go
@@ -181,6 +181,7 @@ func (s *Server) Upgrade(ctx context.Context, request *proto.UpgradeRequest) (*p
 	}
 	cb, err := u.Upgrade(ctx, &upgradeRequest{request}, false)
 	if err != nil {
+		s.logger.Errorw("Upgrade failed", "error.message", err, "version", request.Version, "source_uri", request.SourceURI)
 		return &proto.UpgradeResponse{
 			Status: proto.ActionStatus_FAILURE,
 			Error:  err.Error(),
@@ -190,6 +191,7 @@ func (s *Server) Upgrade(ctx context.Context, request *proto.UpgradeRequest) (*p
 	// this ensures that the upgrade response over GRPC is returned
 	go func() {
 		<-time.After(time.Second)
+		s.logger.Info("Restarting after upgrade", "version", request.Version)
 		s.rex.ReExec(cb)
 	}()
 	return &proto.UpgradeResponse{


### PR DESCRIPTION
Improve our logging around agent upgrades, following the suggestions from https://github.com/elastic/elastic-agent/issues/1253.

The biggest issue I noticed was that we log action failures at the debug label by default, which includes the upgrade action. Upgrade action failures are infrequent and important enough that I switched to always logging them at error level. I think this will solve most of the problems, but I also followed through and added some additional logging in interesting places.

- Closes https://github.com/elastic/elastic-agent/issues/1253

Sample logs from a standalone upgrade, which always fails attempting to execute the upgrade watcher for reasons that aren't clear to me yet: `"fork/exec elastic-agent-8.5.0-SNAPSHOT-darwin-aarch64/data/elastic-agent-82ad1e/elastic-agent: no such file or directory"`

```json
{"log.level":"info","@timestamp":"2022-09-25T14:09:59.286-0400","log.origin":{"file.name":"upgrade/cleanup.go","file.line":22},"message":"Cleaning up non-matching downloaded versions","version":"8.6.0","downloads.path":"/Users/cmackenzie/Downloads/elastic-agent-8.5.0-SNAPSHOT-darwin-aarch64/data/elastic-agent-82ad1e/downloads","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-09-25T14:09:59.323-0400","log.origin":{"file.name":"log/reporter.go","file.line":40},"message":"2022-09-25T14:09:59-04:00 - message: Application: [7a5f506a-2836-40f4-91eb-70c20bb755b4]: State changed to UPDATING: Update to version '8.4.2' started - type: 'STATE' - sub_type: 'UPDATING'","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-09-25T14:09:59.323-0400","log.origin":{"file.name":"upgrade/step_download.go","file.line":43},"message":"Downloading upgrade artifact","version":"8.4.2","source_uri":"https://artifacts.elastic.co/downloads/","drop_path":"","target_path":"/Users/cmackenzie/Downloads/elastic-agent-8.5.0-SNAPSHOT-darwin-aarch64/data/elastic-agent-82ad1e/downloads","install_path":"/Users/cmackenzie/Downloads/elastic-agent-8.5.0-SNAPSHOT-darwin-aarch64/data/elastic-agent-82ad1e/install","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-09-25T14:10:18.636-0400","log.origin":{"file.name":"http/downloader.go","file.line":307},"message":"download from https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-8.4.2-darwin-aarch64.tar.gz completed in 18 seconds @ 14.53MBps","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-09-25T14:10:18.645-0400","log.origin":{"file.name":"http/downloader.go","file.line":307},"message":"download from https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-8.4.2-darwin-aarch64.tar.gz.sha512 completed in Less than a second @ +InfYBps","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-09-25T14:10:22.803-0400","log.origin":{"file.name":"upgrade/step_unpack.go","file.line":39},"message":"Unpacked upgrade artifact","version":"8.4.2","file.path":"/Users/cmackenzie/Downloads/elastic-agent-8.5.0-SNAPSHOT-darwin-aarch64/data/elastic-agent-82ad1e/downloads/elastic-agent-8.4.2-darwin-aarch64.tar.gz","hash":"d3eb3e","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-09-25T14:10:22.803-0400","log.origin":{"file.name":"upgrade/upgrade.go","file.line":303},"message":"Copying action store","new_home_path":"/Users/cmackenzie/Downloads/elastic-agent-8.5.0-SNAPSHOT-darwin-aarch64/data/elastic-agent-d3eb3e","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-09-25T14:10:22.803-0400","log.origin":{"file.name":"upgrade/step_relink.go","file.line":35},"message":"Changing symlink","symlink_path":"/Users/cmackenzie/Downloads/elastic-agent-8.5.0-SNAPSHOT-darwin-aarch64/elastic-agent","new_path":"/Users/cmackenzie/Downloads/elastic-agent-8.5.0-SNAPSHOT-darwin-aarch64/data/elastic-agent-d3eb3e/elastic-agent","prev_path":"/Users/cmackenzie/Downloads/elastic-agent-8.5.0-SNAPSHOT-darwin-aarch64/elastic-agent.prev","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-09-25T14:10:22.825-0400","log.origin":{"file.name":"upgrade/step_mark.go","file.line":116},"message":"Writing upgrade marker file","file.path":"/Users/cmackenzie/Downloads/elastic-agent-8.5.0-SNAPSHOT-darwin-aarch64/data/.update-marker","hash":"d3eb3e","prev_hash":"82ad1e","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-09-25T14:10:22.825-0400","log.origin":{"file.name":"upgrade/step_mark.go","file.line":131},"message":"Updating active commit","file.path":"/Users/cmackenzie/Downloads/elastic-agent-8.5.0-SNAPSHOT-darwin-aarch64/.elastic-agent.active.commit","hash":"d3eb3e","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2022-09-25T14:10:22.827-0400","log.origin":{"file.name":"upgrade/upgrade.go","file.line":189},"message":"Rolling back: starting watcher failed","error":{"message":"fork/exec /Users/cmackenzie/Downloads/elastic-agent-8.5.0-SNAPSHOT-darwin-aarch64/data/elastic-agent-82ad1e/elastic-agent: no such file or directory"},"ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-09-25T14:10:22.832-0400","log.origin":{"file.name":"upgrade/step_relink.go","file.line":35},"message":"Changing symlink","symlink_path":"/Users/cmackenzie/Downloads/elastic-agent-8.5.0-SNAPSHOT-darwin-aarch64/elastic-agent","new_path":"/Users/cmackenzie/Downloads/elastic-agent-8.5.0-SNAPSHOT-darwin-aarch64/data/elastic-agent-82ad1e/elastic-agent","prev_path":"/Users/cmackenzie/Downloads/elastic-agent-8.5.0-SNAPSHOT-darwin-aarch64/elastic-agent.prev","ecs.version":"1.6.0"}
```