### PR TITLE
[automation] update elastic stack version for testing 8.5.0-d04a8a8e

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.0-fcf3d4c2-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.0-d04a8a8e-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.5.0-fcf3d4c2-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.5.0-d04a8a8e-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Sun, 25 Sep 2022 00:18:09 GMT, release_branch:8.5, prefix:, end_time:Sun, 25 Sep 2022 05:49:46 GMT, manifest_version:2.1.0, version:8.5.0-SNAPSHOT, branch:8.5, build_id:8.5.0-d04a8a8e, build_duration_seconds:19897]