### PR TITLE
Use error.TypeLocal to report local issue for liveness endpoint

### DIFF
--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -118,6 +118,7 @@ type ComponentsModifier func(comps []component.Component) ([]component.Component
 // State provides the current state of the coordinator along with all the current states of components and units.
 type State struct {
 	State      agentclient.State
+	Local      string // local only error message
 	Message    string
 	Components []runtime.ComponentComponentState
 }
@@ -190,6 +191,10 @@ func (c *Coordinator) State() (s State) {
 			s.State = agentclient.Failed
 			s.Message = c.runtimeMgrErr.Error()
 		} else if c.configMgrErr != nil {
+			if errors.IsType(c.configMgrError, errors.TypeLocal) {
+				s.Local = c.configMgrErr.Error()
+				return s
+			}
 			s.State = agentclient.Failed
 			s.Message = c.configMgrErr.Error()
 		} else if c.varsMgrErr != nil {

--- a/internal/pkg/agent/application/coordinator/handler.go
+++ b/internal/pkg/agent/application/coordinator/handler.go
@@ -33,6 +33,10 @@ func (c *Coordinator) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 		// TODO(blakerouse): Coordinator should be changed to store the last timestamp that the state has changed.
 		UpdateTime: time.Now().UTC(),
 	}
+	// If there is a local error on an otherwise healthy agent set state to degraded.
+	if s.Local != "" && s.State != client.Healthy {
+		s.State = client.Degraded
+	}
 	status := http.StatusOK
 	if s.State != client.Healthy {
 		status = http.StatusServiceUnavailable

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -207,6 +207,7 @@ func (f *fleetGateway) doExecute(ctx context.Context, bo backoff.Backoff) (*flee
 				f.errCh <- err
 				return nil, err
 			}
+			f.errCh <- errors.New(err, errors.TypeLocal)
 			continue
 		}
 		// Request was successful, return the collected actions.

--- a/internal/pkg/agent/errors/error.go
+++ b/internal/pkg/agent/errors/error.go
@@ -13,6 +13,15 @@ import (
 	"github.com/pkg/errors"
 )
 
+// IsType returns if the passed error has the specified error type
+func IsType(err error, t ErrorType) bool {
+	var e Error
+	if goerrors.As(err, &e) && e.Type() == t {
+		return true
+	}
+	return false
+}
+
 // As is just a helper so user dont have to use multiple imports for errors.
 func As(err error, target interface{}) bool {
 	return goerrors.As(err, target)

--- a/internal/pkg/agent/errors/error_test.go
+++ b/internal/pkg/agent/errors/error_test.go
@@ -200,3 +200,29 @@ func TestMetaCallDoesNotModifyCollection(t *testing.T) {
 		t.Fatalf("err4.meta modified by calling Meta(): %v", resultingErr.meta)
 	}
 }
+
+func TestIsType(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		expect bool
+	}{{
+		name:   "error has type",
+		err:    New("an error", TypeLocal),
+		expect: true,
+	}, {
+		name:   "error does not have type",
+		err:    New("an error"),
+		expect: false,
+	}, {
+		name:   "error does not have Error interface",
+		err:    fmt.Errorf("an error"),
+		expect: false,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ok := IsType(tt.err, TypeLocal)
+			assert.Equal(t, tt.expect, ok)
+		})
+	}
+}

--- a/internal/pkg/agent/errors/types.go
+++ b/internal/pkg/agent/errors/types.go
@@ -24,6 +24,8 @@ const (
 	TypeFilesystem
 	// TypeSecurity represents set of errors related to security, encryption, etc.
 	TypeSecurity
+	// TypeLocal represents set of errors that are used only for local reporting and should not be sent to fleet-server
+	TypeLocal
 )
 
 const (
@@ -46,4 +48,5 @@ var readableTypes = map[ErrorType]string{
 	TypeNetwork:          "NETWORK",
 	TypeFilesystem:       "FILESYSTEM",
 	TypeSecurity:         "SECURITY",
+	TypeLocal:            "LOCAL",
 }


### PR DESCRIPTION
Add a new ErrorType TypeLocal that can be used to speicify if an error should effect the state that it reported to fleet-server or if it just appears under local checks. The current use of this type is to allow a checkin failure to degraded the state for the liveness endpoint so that liveness will return a 503 if there is an error, but a subsequent successful checkin will not report a degraded/failed state.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates #1157 