### PR TITLE
Add success log message after previous checkin failures

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -119,6 +119,7 @@
 - Remove fleet event reporter and events from checkin body. {issue}993[993]
 - Fix unintended reset of source URI when downloading components {pull}1252[1252]
 - Create separate status reporter for local only events so that degraded fleet-checkins no longer affect health on successful fleet-checkins. {issue}1157[1157] {pull}1285[1285]
+- Add success log message after previous checkin failures {pull}1327[1327]
 
 ==== New features
 


### PR DESCRIPTION
## What does this PR do?

Adds an additional log message when a checkin with Fleet Server succeeds after previous failed attempts.

## Why is it important?

Helps users understand when the system recovered after failures

## Checklist

- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Related to https://github.com/elastic/elastic-agent/pull/1218