### PR TITLE
make policy change handler try all fleet hosts before failing

### DIFF
--- a/changelog/fragments/1666281194-Fix-how-multiple-Fleet-Server-hosts-are-handled.yaml
+++ b/changelog/fragments/1666281194-Fix-how-multiple-Fleet-Server-hosts-are-handled.yaml
@@ -1,0 +1,35 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix how multiple Fleet Server hosts are handled
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: It fixes the bug when the Elastic Agent would be enrolled using
+  a valid Fleet Server URL, but the policy would contain more than one, being
+  the first URL unreachable. In that case the Elastic Agent would enroll with
+  Fleet Server, but become unhealthy as it'd get stuck trying only the first,
+  unreachable Fleet Server host.
+
+# Affected component; a word indicating the component this changeset affects.
+#component:
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 1329
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: 1234

--- a/internal/pkg/agent/application/pipeline/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/pipeline/actions/handlers/handler_action_policy_change.go
@@ -147,25 +147,10 @@ func (h *PolicyChange) handleFleetServerHosts(ctx context.Context, c *config.Con
 	ctx, cancel := context.WithTimeout(ctx, apiStatusTimeout)
 	defer cancel()
 
-	// The new client might have several fleet hosts, we need to try all of them before failing.
-	// As it's a new client, just trying
-	hostsCount := len(h.config.Fleet.Client.Hosts)
-	var resp *http.Response
-	for i := 0; i < hostsCount; i++ {
-		resp, err = client.Send(ctx, http.MethodGet, "/api/status", nil, nil, nil)
-		if err == nil {
-			break // at least one fleet host is reachable, that is enough.
-		}
-
-		h.log.Warnf(
-			"fail to communicate with new Fleet Server API client host %d of %d host. Will try next one",
-			i, hostsCount)
-	}
+	resp, err := client.Send(ctx, http.MethodGet, "/api/status", nil, nil, nil)
 	if err != nil {
 		return errors.New(
-			err,
-			fmt.Sprintf("fail to communicate with all %d new Fleet Server API client hosts",
-				hostsCount),
+			err, "fail to communicate with Fleet Server API client hosts",
 			errors.TypeNetwork, errors.M("hosts", h.config.Fleet.Client.Hosts))
 	}
 

--- a/internal/pkg/fleetapi/client/client.go
+++ b/internal/pkg/fleetapi/client/client.go
@@ -87,7 +87,7 @@ func NewWithConfig(log *logger.Logger, cfg remote.Config) (*remote.Client, error
 
 // ExtractError extracts error from a fleet-server response
 func ExtractError(resp io.Reader) error {
-	// Lets try to extract a high level fleet-server error.
+	// Let's try to extract a high level fleet-server error.
 	e := &struct {
 		StatusCode int    `json:"statusCode"`
 		Error      string `json:"error"`

--- a/internal/pkg/remote/client.go
+++ b/internal/pkg/remote/client.go
@@ -43,7 +43,7 @@ type requestClient struct {
 // Client wraps a http.Client and takes care of making the raw calls, the client should
 // stay simple and specifics should be implemented in external action instead of adding new methods
 // to the client. For authenticated calls or sending fields on every request, create a custom RoundTripper
-// implementation that will take care of the boiler plate.
+// implementation that will take care of the boilerplate.
 type Client struct {
 	log      *logger.Logger
 	clientMu sync.Mutex

--- a/internal/pkg/remote/client.go
+++ b/internal/pkg/remote/client.go
@@ -16,10 +16,10 @@ import (
 	"sync"
 	"time"
 
-	urlutil "github.com/elastic/elastic-agent-libs/kibana"
-	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 	"github.com/hashicorp/go-multierror"
 
+	urlutil "github.com/elastic/elastic-agent-libs/kibana"
+	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/id"
 	"github.com/elastic/elastic-agent/pkg/core/logger"

--- a/internal/pkg/remote/client.go
+++ b/internal/pkg/remote/client.go
@@ -6,6 +6,7 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -15,8 +16,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/pkg/errors"
 
 	urlutil "github.com/elastic/elastic-agent-libs/kibana"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
@@ -204,7 +203,7 @@ func (c *Client) Send(
 
 			msg := fmt.Sprintf("requester %d/%d to host %s errored",
 				i, len(c.clients), requester.host)
-			multiErr = fmt.Errorf("%s: %s: %s", msg, err, multiErr)
+			multiErr = fmt.Errorf("%s: %s: %w", msg, err, multiErr)
 
 			// Using debug level as the error is only relevant if all clients fail.
 			c.log.With("error", err).Debugf(msg)

--- a/internal/pkg/remote/client.go
+++ b/internal/pkg/remote/client.go
@@ -6,7 +6,6 @@ package remote
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -29,8 +28,6 @@ import (
 const (
 	retryOnBadConnTimeout = 5 * time.Minute
 )
-
-var errRequestFailed = errors.New("request failed")
 
 type wrapperFunc func(rt http.RoundTripper) (http.RoundTripper, error)
 

--- a/internal/pkg/remote/client.go
+++ b/internal/pkg/remote/client.go
@@ -204,10 +204,9 @@ func (c *Client) Send(
 			requester.lastErr = err
 			requester.lastErrOcc = time.Now().UTC()
 
-			multiErr = multierror.Append(multiErr, err)
 			msg := fmt.Sprintf("requester %d/%d to host %s errored",
 				i, len(c.clients), requester.host)
-			multiErr = fmt.Errorf("%s: %s: %w", msg, err, multiErr)
+			multiErr = multierror.Append(multiErr, fmt.Errorf("%s: %w", msg, err))
 
 			// Using debug level as the error is only relevant if all clients fail.
 			c.log.With("error", err).Debugf(msg)

--- a/internal/pkg/remote/client_test.go
+++ b/internal/pkg/remote/client_test.go
@@ -78,13 +78,13 @@ func TestHTTPClient(t *testing.T) {
 	l, err := logger.New("", false)
 	require.NoError(t, err)
 
+	const successResp = `{"message":"hello"}`
 	t.Run("Guard against double slashes on path", withServer(
 		func(t *testing.T) *http.ServeMux {
-			msg := `{ message: "hello" }`
 			mux := http.NewServeMux()
 			mux.HandleFunc("/nested/echo-hello", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprint(w, msg)
+				fmt.Fprint(w, successResp)
 			})
 			return addCatchAll(mux, t)
 		}, func(t *testing.T, host string) {
@@ -104,17 +104,16 @@ func TestHTTPClient(t *testing.T) {
 			body, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)
 			defer resp.Body.Close()
-			assert.Equal(t, `{ message: "hello" }`, string(body))
+			assert.Equal(t, successResp, string(body))
 		},
 	))
 
 	t.Run("Simple call", withServer(
 		func(t *testing.T) *http.ServeMux {
-			msg := `{ message: "hello" }`
 			mux := http.NewServeMux()
 			mux.HandleFunc("/echo-hello", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprint(w, msg)
+				fmt.Fprint(w, successResp)
 			})
 			return mux
 		}, func(t *testing.T, host string) {
@@ -130,17 +129,16 @@ func TestHTTPClient(t *testing.T) {
 			body, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)
 			defer resp.Body.Close()
-			assert.Equal(t, `{ message: "hello" }`, string(body))
+			assert.Equal(t, successResp, string(body))
 		},
 	))
 
 	t.Run("Simple call with a prefix path", withServer(
 		func(t *testing.T) *http.ServeMux {
-			msg := `{ message: "hello" }`
 			mux := http.NewServeMux()
 			mux.HandleFunc("/mycustompath/echo-hello", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprint(w, msg)
+				fmt.Fprint(w, successResp)
 			})
 			return mux
 		}, func(t *testing.T, host string) {
@@ -157,17 +155,16 @@ func TestHTTPClient(t *testing.T) {
 			body, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)
 			defer resp.Body.Close()
-			assert.Equal(t, `{ message: "hello" }`, string(body))
+			assert.Equal(t, successResp, string(body))
 		},
 	))
 
 	t.Run("Tries all the hosts", withServer(
 		func(t *testing.T) *http.ServeMux {
-			msg := `{ message: "hello" }`
 			mux := http.NewServeMux()
 			mux.HandleFunc("/echo-hello", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprint(w, msg)
+				fmt.Fprint(w, successResp)
 			})
 			return mux
 		}, func(t *testing.T, host string) {
@@ -184,7 +181,7 @@ func TestHTTPClient(t *testing.T) {
 			body, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)
 			defer resp.Body.Close()
-			assert.Equal(t, `{ message: "hello" }`, string(body))
+			assert.Equal(t, successResp, string(body))
 		},
 	))
 
@@ -204,11 +201,10 @@ func TestHTTPClient(t *testing.T) {
 
 	t.Run("Custom user agent", withServer(
 		func(t *testing.T) *http.ServeMux {
-			msg := `{ message: "hello" }`
 			mux := http.NewServeMux()
 			mux.HandleFunc("/echo-hello", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprint(w, msg)
+				fmt.Fprint(w, successResp)
 				require.Equal(t, r.Header.Get("User-Agent"), "custom-agent")
 			})
 			return mux
@@ -228,17 +224,16 @@ func TestHTTPClient(t *testing.T) {
 			body, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)
 			defer resp.Body.Close()
-			assert.Equal(t, `{ message: "hello" }`, string(body))
+			assert.Equal(t, successResp, string(body))
 		},
 	))
 
 	t.Run("Allows to debug HTTP request between a client and a server", withServer(
 		func(t *testing.T) *http.ServeMux {
-			msg := `{ "message": "hello" }`
 			mux := http.NewServeMux()
 			mux.HandleFunc("/echo-hello", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprint(w, msg)
+				fmt.Fprint(w, successResp)
 			})
 			return mux
 		}, func(t *testing.T, host string) {
@@ -260,7 +255,7 @@ func TestHTTPClient(t *testing.T) {
 			body, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)
 			defer resp.Body.Close()
-			assert.Equal(t, `{ "message": "hello" }`, string(body))
+			assert.Equal(t, successResp, string(body))
 
 			for _, m := range debugger.messages {
 				fmt.Println(m)
@@ -272,11 +267,10 @@ func TestHTTPClient(t *testing.T) {
 
 	t.Run("RequestId", withServer(
 		func(t *testing.T) *http.ServeMux {
-			msg := `{ message: "hello" }`
 			mux := http.NewServeMux()
 			mux.HandleFunc("/echo-hello", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprint(w, msg)
+				fmt.Fprint(w, successResp)
 				require.NotEmpty(t, r.Header.Get("X-Request-ID"))
 			})
 			return mux
@@ -293,7 +287,7 @@ func TestHTTPClient(t *testing.T) {
 			body, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)
 			defer resp.Body.Close()
-			assert.Equal(t, `{ message: "hello" }`, string(body))
+			assert.Equal(t, successResp, string(body))
 		},
 	))
 }
@@ -302,7 +296,7 @@ func TestSortClients(t *testing.T) {
 	t.Run("Picks first requester on initial call", func(t *testing.T) {
 		one := &requestClient{}
 		two := &requestClient{}
-		client, err := new(nil, Config{}, one, two)
+		client, err := newClient(nil, Config{}, one, two)
 		require.NoError(t, err)
 
 		client.sortClients()
@@ -312,11 +306,12 @@ func TestSortClients(t *testing.T) {
 
 	t.Run("Picks second requester when first has error", func(t *testing.T) {
 		one := &requestClient{
+			lastUsed:   time.Now().UTC(),
 			lastErr:    fmt.Errorf("fake error"),
 			lastErrOcc: time.Now().UTC(),
 		}
 		two := &requestClient{}
-		client, err := new(nil, Config{}, one, two)
+		client, err := newClient(nil, Config{}, one, two)
 		require.NoError(t, err)
 
 		client.sortClients()
@@ -329,7 +324,7 @@ func TestSortClients(t *testing.T) {
 			lastUsed: time.Now().UTC(),
 		}
 		two := &requestClient{}
-		client, err := new(nil, Config{}, one, two)
+		client, err := newClient(nil, Config{}, one, two)
 		require.NoError(t, err)
 
 		client.sortClients()
@@ -347,7 +342,7 @@ func TestSortClients(t *testing.T) {
 		three := &requestClient{
 			lastUsed: time.Now().UTC().Add(-2 * time.Minute),
 		}
-		client, err := new(nil, Config{}, one, two, three)
+		client, err := newClient(nil, Config{}, one, two, three)
 		require.NoError(t, err)
 
 		client.sortClients()
@@ -390,7 +385,7 @@ func TestSortClients(t *testing.T) {
 			lastErr:    fmt.Errorf("fake error"),
 			lastErrOcc: time.Now().Add(-2 * time.Minute),
 		}
-		client, err := new(nil, Config{}, one, two, three)
+		client, err := newClient(nil, Config{}, one, two, three)
 		require.NoError(t, err)
 
 		client.sortClients()

--- a/internal/pkg/remote/client_test.go
+++ b/internal/pkg/remote/client_test.go
@@ -258,7 +258,7 @@ func TestHTTPClient(t *testing.T) {
 			assert.Equal(t, successResp, string(body))
 
 			for _, m := range debugger.messages {
-				fmt.Println(m)
+				fmt.Println(m) //nolint:forbidigo // printing debug messages on a test.
 			}
 
 			assert.Equal(t, 1, len(debugger.messages))

--- a/internal/pkg/remote/client_test.go
+++ b/internal/pkg/remote/client_test.go
@@ -171,13 +171,13 @@ func TestHTTPClient(t *testing.T) {
 			})
 			return mux
 		}, func(t *testing.T, host string) {
-			cfg := config.MustNewConfigFrom(map[string]interface{}{
-				"hosts": []string{"http://must.fail", "http://must.fail", host},
-			})
+			one := &requestClient{host: "http://must.fail-1.co/"}
+			two := &requestClient{host: "http://must.fail-2.co/"}
+			three := &requestClient{host: fmt.Sprintf("http://%s/", host)}
 
-			client, err := NewWithRawConfig(nil, cfg, nil)
+			c := &Client{clients: []*requestClient{one, two, three}, log: l}
 			require.NoError(t, err)
-			resp, err := client.Send(ctx, http.MethodGet, "/echo-hello", nil, nil, nil)
+			resp, err := c.Send(ctx, http.MethodGet, "/echo-hello", nil, nil, nil)
 			require.NoError(t, err)
 
 			assert.Equal(t, http.StatusOK, resp.StatusCode)


### PR DESCRIPTION
## What does this PR do?

Fix how the agent handles fleet-server hosts.

**It changes the fleet-server client to:**
 - when creating a new client:
   - succeed if at least one host is health
   - shuffle the hosts, avoiding all the agents reacing to the same fleet-server on the first request
 - makes `(remote.*Client).Send` try all the hosts before failing, returning the last error if all hosts fail
   - if debug logs are enabled, `Send` will log each error as with debug level
 - modifies `remopte.requestClient`:
   - now `requestClient` holds its host
   - remove `requestFunc`
   - `(remopte.requestClient).newRequest uses the new `host` property to build the final URL for the request

## Why is it important?

Right now, when creating a new fleet API client it only verifies if one new host is reachable, therefore if the first isn't reachable, it ignore the others.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Check https://github.com/elastic/elastic-agent/issues/1328 to see how to reproduce the issue.

## Related issues

- Fixes #1328
