### PR TITLE
Fix [V2]: Elastic Agent Install is broken.

### DIFF
--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -19,8 +19,8 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/transpiler"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/vars"
 	"github.com/elastic/elastic-agent/internal/pkg/capabilities"
-	"github.com/elastic/elastic-agent/internal/pkg/composable"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/config/operations"
 	"github.com/elastic/elastic-agent/pkg/component"
@@ -195,13 +195,10 @@ func applyDynamics(ctx context.Context, log *logger.Logger, cfg *config.Config) 
 	// apply dynamic inputs
 	inputs, ok := transpiler.Lookup(ast, "inputs")
 	if ok {
-		varsArray := make([]*transpiler.Vars, 0)
-
-		ctrl, err := composable.New(log, cfg)
+		varsArray, err := vars.WaitForVariables(ctx, log, cfg, 0)
 		if err != nil {
 			return nil, err
 		}
-		_ = ctrl.Run(ctx)
 
 		renderedInputs, err := transpiler.RenderInputs(inputs, varsArray)
 		if err != nil {

--- a/internal/pkg/agent/vars/vars.go
+++ b/internal/pkg/agent/vars/vars.go
@@ -1,0 +1,78 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package vars
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/transpiler"
+	"github.com/elastic/elastic-agent/internal/pkg/composable"
+	"github.com/elastic/elastic-agent/internal/pkg/config"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+	"golang.org/x/sync/errgroup"
+)
+
+func WaitForVariables(ctx context.Context, l *logger.Logger, cfg *config.Config, wait time.Duration) ([]*transpiler.Vars, error) {
+	var cancel context.CancelFunc
+	var vars []*transpiler.Vars
+
+	composable, err := composable.New(l, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create composable controller: %w", err)
+	}
+
+	hasTimeout := false
+	if wait > time.Duration(0) {
+		hasTimeout = true
+		ctx, cancel = context.WithTimeout(ctx, wait)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
+	defer cancel()
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		var err error
+		for {
+			select {
+			case <-ctx.Done():
+				if err == nil {
+					err = ctx.Err()
+				}
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					err = nil
+				}
+				return err
+			case cErr := <-composable.Errors():
+				err = cErr
+				if err != nil {
+					cancel()
+				}
+			case cVars := <-composable.Watch():
+				vars = cVars
+				if !hasTimeout {
+					cancel()
+				}
+			}
+		}
+	})
+
+	g.Go(func() error {
+		err := composable.Run(ctx)
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			err = nil
+		}
+		return err
+	})
+
+	err = g.Wait()
+	if err != nil {
+		return nil, err
+	}
+	return vars, nil
+}


### PR DESCRIPTION
## What does this PR do?

Fixes Elastic Agent install, to be precise the uninstall.
The uninstall was blocking at running composable controller @ 
https://github.com/elastic/elastic-agent/blob/feature-arch-v2/internal/pkg/agent/install/uninstall.go#L204
due to the V2 controller change to the watch channel instead of callbacks and in this particular place nothing was listening to these channels.

```
goroutine 1 [select]:
github.com/elastic/elastic-agent/internal/pkg/composable.(*controller).Run(0xc00089a810, {0x562b52028480, 0xc0000540c0})
	/home/amaus/elastic/elastic-agent/internal/pkg/composable/controller.go:156 +0xa94
github.com/elastic/elastic-agent/internal/pkg/agent/install.applyDynamics({0x562b52028480, 0xc0000540c0}, 0xc00069f910, 0xc000834d50)
	/home/amaus/elastic/elastic-agent/internal/pkg/agent/install/uninstall.go:217 +0x462
github.com/elastic/elastic-agent/internal/pkg/agent/install.uninstallComponents({0x562b52028480, 0xc0000540c0}, {0xc00005a280, 0x4c})
	/home/amaus/elastic/elastic-agent/internal/pkg/agent/install/uninstall.go:135 +0x610
github.com/elastic/elastic-agent/internal/pkg/agent/install.Uninstall({0xc00005a280, 0x4c})
	/home/amaus/elastic/elastic-agent/internal/pkg/agent/install/uninstall.go:49 +0x40a
github.com/elastic/elastic-agent/internal/pkg/agent/install.Install({0xc00005a280, 0x4c})
	/home/amaus/elastic/elastic-agent/internal/pkg/agent/install/install.go:28 +0x285
github.com/elastic/elastic-agent/internal/pkg/agent/cmd.installCmd(0xc00070c090, 0xc000641900)
	/home/amaus/elastic/elastic-agent/internal/pkg/agent/cmd/install.go:172 +0x11ea
github.com/elastic/elastic-agent/internal/pkg/agent/cmd.newInstallCommandWithArgs.func1(0xc000641900, {0xc0005ceba0, 0x0, 0x2})
	/home/amaus/elastic/elastic-agent/internal/pkg/agent/cmd/install.go:36 +0x45
github.com/spf13/cobra.(*Command).execute(0xc000641900, {0xc0005ceb80, 0x2, 0x2})
	/home/amaus/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:860 +0xb67
github.com/spf13/cobra.(*Command).ExecuteC(0xc000640f00)
	/home/amaus/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:974 +0x8b3
github.com/spf13/cobra.(*Command).Execute(0xc000640f00)
	/home/amaus/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:902 +0x2f
main.main()
	/home/amaus/elastic/elastic-agent/main.go:33 +0x345
```

I refactored/extracted the code that was used already for "inspect" for waiting for variables and reused it for uninstall.


## Why is it important?

Fixes V2 install and uninstall.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas


## How to test this PR locally

Make sure the agent can be installed and uninstalled. Before this change the install was blocking forever.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/1125

