### PR TITLE
Fix failures when using npipe monitoring endpoints

### DIFF
--- a/internal/pkg/core/monitoring/beats/sidecar_monitor.go
+++ b/internal/pkg/core/monitoring/beats/sidecar_monitor.go
@@ -88,6 +88,10 @@ func (b *SidecarMonitor) EnrichArgs(spec program.Spec, pipelineID string, args [
 func (b *SidecarMonitor) Cleanup(spec program.Spec, pipelineID string) error {
 	endpoint := MonitoringEndpoint(spec, b.operatingSystem, pipelineID, true)
 	drop := monitoringDrop(endpoint)
+	if drop == "" {
+		// not exposed using sockets
+		return nil
+	}
 
 	return os.RemoveAll(drop)
 }
@@ -103,6 +107,11 @@ func (b *SidecarMonitor) Close() {
 func (b *SidecarMonitor) Prepare(spec program.Spec, pipelineID string, uid, gid int) error {
 	endpoint := MonitoringEndpoint(spec, b.operatingSystem, pipelineID, true)
 	drop := monitoringDrop(endpoint)
+
+	if drop == "" {
+		// not exposed using sockets
+		return nil
+	}
 
 	if err := os.MkdirAll(drop, 0775); err != nil {
 		return errors.New(err, fmt.Sprintf("failed to create a directory %q", drop))


### PR DESCRIPTION
When enpoint is published over a network or npipe `monitorDrop` returns `""` 
In this valid scenario agent fails and reports unhealthy when it tries to create directory at this invalid path.

Fixes: #1361 

## What does this PR do?

Fix just guards agains empty values and if drop is empty it does not proceed with a setup

## Why is it important?

Monitoring on Windows

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
