### PR TITLE
[automation] update elastic stack version for testing 8.4.3-0900b129

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.3-d0e42d08-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.3-0900b129-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.3-d0e42d08-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.3-0900b129-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Thu, 29 Sep 2022 00:19:36 GMT, release_branch:8.4, prefix:, end_time:Thu, 29 Sep 2022 06:25:42 GMT, manifest_version:2.1.0, version:8.4.3-SNAPSHOT, branch:8.4, build_id:8.4.3-0900b129, build_duration_seconds:21966]