### PR TITLE
Mount /etc directory in Kubernetes DaemonSet manifests.

### DIFF
--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -83,20 +83,11 @@ spec:
             - name: varlog
               mountPath: /var/log
               readOnly: true
-            - name: etc-kubernetes
-              mountPath: /hostfs/etc/kubernetes
+            - name: etc-full
+              mountPath: /hostfs/etc
               readOnly: true
             - name: var-lib
               mountPath: /hostfs/var/lib
-              readOnly: true
-            - name: passwd
-              mountPath: /hostfs/etc/passwd
-              readOnly: true
-            - name: group
-              mountPath: /hostfs/etc/group
-              readOnly: true
-            - name: etcsysmd
-              mountPath: /hostfs/etc/systemd
               readOnly: true
             - name: etc-mid
               mountPath: /etc/machine-id
@@ -114,26 +105,15 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
-        # Needed for cloudbeat
-        - name: etc-kubernetes
+        # The following volumes are needed for Cloud Security Posture integration (cloudbeat)
+        # If you are not using this integration, then these volumes and the corresponding
+        # mounts can be removed.
+        - name: etc-full
           hostPath:
-            path: /etc/kubernetes
-        # Needed for cloudbeat
+            path: /etc
         - name: var-lib
           hostPath:
             path: /var/lib
-        # Needed for cloudbeat
-        - name: passwd
-          hostPath:
-            path: /etc/passwd
-        # Needed for cloudbeat
-        - name: group
-          hostPath:
-            path: /etc/group
-        # Needed for cloudbeat
-        - name: etcsysmd
-          hostPath:
-            path: /etc/systemd
         # Mount /etc/machine-id from the host to determine host ID
         # Needed for Elastic Security integration
         - name: etc-mid

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -83,20 +83,11 @@ spec:
             - name: varlog
               mountPath: /var/log
               readOnly: true
-            - name: etc-kubernetes
-              mountPath: /hostfs/etc/kubernetes
+            - name: etc-full
+              mountPath: /hostfs/etc
               readOnly: true
             - name: var-lib
               mountPath: /hostfs/var/lib
-              readOnly: true
-            - name: passwd
-              mountPath: /hostfs/etc/passwd
-              readOnly: true
-            - name: group
-              mountPath: /hostfs/etc/group
-              readOnly: true
-            - name: etcsysmd
-              mountPath: /hostfs/etc/systemd
               readOnly: true
             - name: etc-mid
               mountPath: /etc/machine-id
@@ -114,26 +105,15 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
-        # Needed for cloudbeat
-        - name: etc-kubernetes
+        # The following volumes are needed for Cloud Security Posture integration (cloudbeat)
+        # If you are not using this integration, then these volumes and the corresponding
+        # mounts can be removed.
+        - name: etc-full
           hostPath:
-            path: /etc/kubernetes
-        # Needed for cloudbeat
+            path: /etc
         - name: var-lib
           hostPath:
             path: /var/lib
-        # Needed for cloudbeat
-        - name: passwd
-          hostPath:
-            path: /etc/passwd
-        # Needed for cloudbeat
-        - name: group
-          hostPath:
-            path: /etc/group
-        # Needed for cloudbeat
-        - name: etcsysmd
-          hostPath:
-            path: /etc/systemd
         # Mount /etc/machine-id from the host to determine host ID
         # Needed for Elastic Security integration
         - name: etc-mid

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -722,20 +722,11 @@ spec:
             - name: varlog
               mountPath: /var/log
               readOnly: true
-            - name: etc-kubernetes
-              mountPath: /hostfs/etc/kubernetes
+            - name: etc-full
+              mountPath: /hostfs/etc
               readOnly: true
             - name: var-lib
               mountPath: /hostfs/var/lib
-              readOnly: true
-            - name: passwd
-              mountPath: /hostfs/etc/passwd
-              readOnly: true
-            - name: group
-              mountPath: /hostfs/etc/group
-              readOnly: true
-            - name: etcsysmd
-              mountPath: /hostfs/etc/systemd
               readOnly: true
       volumes:
         - name: datastreams
@@ -757,26 +748,15 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
-        # Needed for cloudbeat
-        - name: etc-kubernetes
+        # The following volumes are needed for Cloud Security Posture integration (cloudbeat)
+        # If you are not using this integration, then these volumes and the corresponding
+        # mounts can be removed.
+        - name: etc-full
           hostPath:
-            path: /etc/kubernetes
-        # Needed for cloudbeat
+            path: /etc
         - name: var-lib
           hostPath:
             path: /var/lib
-        # Needed for cloudbeat
-        - name: passwd
-          hostPath:
-            path: /etc/passwd
-        # Needed for cloudbeat
-        - name: group
-          hostPath:
-            path: /etc/group
-        # Needed for cloudbeat
-        - name: etcsysmd
-          hostPath:
-            path: /etc/systemd
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
@@ -94,20 +94,11 @@ spec:
             - name: varlog
               mountPath: /var/log
               readOnly: true
-            - name: etc-kubernetes
-              mountPath: /hostfs/etc/kubernetes
+            - name: etc-full
+              mountPath: /hostfs/etc
               readOnly: true
             - name: var-lib
               mountPath: /hostfs/var/lib
-              readOnly: true
-            - name: passwd
-              mountPath: /hostfs/etc/passwd
-              readOnly: true
-            - name: group
-              mountPath: /hostfs/etc/group
-              readOnly: true
-            - name: etcsysmd
-              mountPath: /hostfs/etc/systemd
               readOnly: true
       volumes:
         - name: datastreams
@@ -129,23 +120,12 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
-        # Needed for cloudbeat
-        - name: etc-kubernetes
+        # The following volumes are needed for Cloud Security Posture integration (cloudbeat)
+        # If you are not using this integration, then these volumes and the corresponding
+        # mounts can be removed.
+        - name: etc-full
           hostPath:
-            path: /etc/kubernetes
-        # Needed for cloudbeat
+            path: /etc
         - name: var-lib
           hostPath:
             path: /var/lib
-        # Needed for cloudbeat
-        - name: passwd
-          hostPath:
-            path: /etc/passwd
-        # Needed for cloudbeat
-        - name: group
-          hostPath:
-            path: /etc/group
-        # Needed for cloudbeat
-        - name: etcsysmd
-          hostPath:
-            path: /etc/systemd


### PR DESCRIPTION
## What does this PR do?

Changes made on a Kubernetes node to files like `/etc/passwd` using Linux tools like `useradd` are not reflected in the mounted file on the Agent, because the tool replaces the file instead of changing it in-place.

Mounting the parent directory solves this problem.

## Why is it important?

Without this change, in some scenarios it is possible for users of the Cloud Security Posture integration on Kibana to be shown outdated/incorrect information.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Verify that no existing mount in the Agent DaemonSet is removed by this change.

## How to test this PR locally

Use the new manifest to install and run an Agent, and ensure that it has access to the node's `/etc` directory via the mount at `/hostfs/etc`.

## Related issues

Closes https://github.com/elastic/cloudbeat/issues/235