### PR TITLE
Add not dedoted k8s pod labels in autodiscover provider to be used for templating, exactly like annotations

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -120,6 +120,7 @@
 - Fix unintended reset of source URI when downloading components {pull}1252[1252]
 - Create separate status reporter for local only events so that degraded fleet-checkins no longer affect health on successful fleet-checkins. {issue}1157[1157] {pull}1285[1285]
 - Add success log message after previous checkin failures {pull}1327[1327]
+- Fix inconsistency between kubernetes pod annotations and labels in autodiscovery templates {pull}1327[1327]
 
 ==== New features
 

--- a/internal/pkg/composable/providers/kubernetes/pod.go
+++ b/internal/pkg/composable/providers/kubernetes/pod.go
@@ -267,6 +267,12 @@ func generatePodData(
 		_ = safemapstr.Put(annotations, k, v)
 	}
 	k8sMapping["annotations"] = annotations
+	// Pass labels(not dedoted) to all events so that they can be used in templating.
+	labels := mapstr.M{}
+	for k, v := range pod.GetObjectMeta().GetLabels() {
+		_ = safemapstr.Put(labels, k, v)
+	}
+	k8sMapping["labels"] = labels
 
 	processors := []map[string]interface{}{}
 	// meta map includes metadata that go under kubernetes.*
@@ -305,6 +311,12 @@ func generateContainerData(
 		_ = safemapstr.Put(annotations, k, v)
 	}
 
+	// Pass labels to all events so that it can be used in templating.
+	labels := mapstr.M{}
+	for k, v := range pod.GetObjectMeta().GetLabels() {
+		_ = safemapstr.Put(labels, k, v)
+	}
+
 	for _, c := range containers {
 		// If it doesn't have an ID, container doesn't exist in
 		// the runtime, emit only an event if we are stopping, so
@@ -329,8 +341,9 @@ func generateContainerData(
 		if len(namespaceAnnotations) != 0 {
 			k8sMapping["namespace_annotations"] = namespaceAnnotations
 		}
-		// add annotations to be discoverable by templates
+		// add annotations and labels to be discoverable by templates
 		k8sMapping["annotations"] = annotations
+		k8sMapping["labels"] = labels
 
 		//container ECS fields
 		cmeta := mapstr.M{


### PR DESCRIPTION
## What does this PR do?

After discussions in https://github.com/elastic/elastic-agent/issues/1284 there is an inconsistency when it comes to how kubernetes pod labels and annotations are handled in template based autodiscovery.

As stated in https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-autodiscover.html annotations can be used for condition matching in templates exactly as set inside the pod.

metricbeat example (same is for elastic-agent)
```
providers:
    - type: kubernetes
      include_annotations: ["prometheus.io.scrape"]
      templates:
        - condition:
            contains:
              kubernetes.annotations.prometheus.io/scrape: "true"
          config:
            - module: prometheus
              metricsets: ["collector"]
              hosts: "${data.host}:${data.port}"
```

For labels the situation is different. Labels are getting devoted first (when needed) and then user has to use the denoted version in condition matching like:
```
- name: redis
        type: redis/metrics
        use_output: default
        meta:
          package:
            name: redis
            version: 0.3.6
        data_stream:
          namespace: default
        streams:
          - data_stream:
              dataset: redis.info
              type: metrics
            metricsets:
              - info
            hosts:
              - '${kubernetes.pod.ip}:6379'
            idle_timeout: 20s
            maxconn: 10
            network: tcp
            period: 10s
            condition: ${kubernetes.labels.redis_scraped} == "true"
```
when the user has set the label `redis.scraped=true` in the Redis pod.

## Why is it important?

This inconsistency is pointless, misleading and not documented.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Start a redis pod with `redis.scraped=true` label.
2. Start standalone agent with the following input:
```
inputs:
      - name: redis
        type: redis/metrics
        use_output: default
        meta:
          package:
            name: redis
            version: 0.3.6
        data_stream:
          namespace: default
        streams:
          - data_stream:
              dataset: redis.info
              type: metrics
            metricsets:
              - info
            hosts:
              - '${kubernetes.pod.ip}:6379'
            idle_timeout: 20s
            maxconn: 10
            network: tcp
            period: 10s
            condition: ${kubernetes.annotations.redis.scraped} == "true"
```
3. The Redis info metricset should start collecting Redis info metrics.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->




