### PR TITLE
Check and create downloads dir before using

### DIFF
--- a/internal/pkg/agent/application/upgrade/artifact/download/fs/downloader.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/fs/downloader.go
@@ -102,6 +102,12 @@ func (e *Downloader) downloadFile(filename, fullPath string) (string, error) {
 	}
 	defer sourceFile.Close()
 
+	if destinationDir := filepath.Dir(fullPath); destinationDir != "" && destinationDir != "." {
+		if err := os.MkdirAll(destinationDir, 0755); err != nil {
+			return "", err
+		}
+	}
+
 	destinationFile, err := os.OpenFile(fullPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, packagePermissions)
 	if err != nil {
 		return "", errors.New(err, "creating package file failed", errors.TypeFilesystem, errors.M(errors.MetaKeyPath, fullPath))

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/downloader.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/downloader.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -154,6 +155,12 @@ func (e *Downloader) downloadFile(ctx context.Context, artifactName, filename, f
 	req, err := http.NewRequest("GET", sourceURI, nil)
 	if err != nil {
 		return "", errors.New(err, "fetching package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
+	}
+
+	if destinationDir := filepath.Dir(fullPath); destinationDir != "" && destinationDir != "." {
+		if err := os.MkdirAll(destinationDir, 0755); err != nil {
+			return "", err
+		}
 	}
 
 	destinationFile, err := os.OpenFile(fullPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, packagePermissions)

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -860,6 +860,10 @@ func tryContainerLoadPaths() error {
 func syncDir(src string, dest string) error {
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			if os.IsNotExist(err) {
+				// source dir exists only if there's agent artifact
+				return nil
+			}
 			return err
 		}
 		relativePath := strings.TrimPrefix(path, src)


### PR DESCRIPTION
## What does this PR do?

2 things happening in this PR

syncDir fixed to be capable of ignoring missing downloads directory as this directory can but does not need to be present. It is present only in case agent has some artifacts related to agent upgrade there

update downloader to create download directory before using it in case it's missing.

## Why is it important?

Fixes file not found on container start preventing it to work correctly

Issue: https://github.com/elastic/elastic-agent/issues/1159

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
