### PR TITLE
Fix docker provider add_fields processors

### DIFF
--- a/changelog/fragments/1664989867-fix-docker-provider-processors.yaml
+++ b/changelog/fragments/1664989867-fix-docker-provider-processors.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix docker provider add_fields processors
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: providers
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: 1234
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: 1234

--- a/internal/pkg/composable/providers/docker/docker.go
+++ b/internal/pkg/composable/providers/docker/docker.go
@@ -149,7 +149,7 @@ func generateData(event bus.Event) (*dockerContainerData, error) {
 						"image":  container.Image,
 						"labels": processorLabelMap,
 					},
-					"to": "container",
+					"target": "container",
 				},
 			},
 		},

--- a/internal/pkg/composable/providers/docker/docker_test.go
+++ b/internal/pkg/composable/providers/docker/docker_test.go
@@ -53,7 +53,7 @@ func TestGenerateData(t *testing.T) {
 						"co_elastic_logs/disable": "true",
 					},
 				},
-				"to": "container",
+				"target": "container",
 			},
 		},
 	}


### PR DESCRIPTION
## What does this PR do?
The Docker provider was using a wrong key when defining the `add_fields` processor, this causes Filebeat not to start the input and stay on a unhealthy state. This processor seems to be defined every time a variable like `${docker}` is used on a input configuration.

This commit fixes it.

## Why is it important?
It fixes a bug on Docker auto discovery provider

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist
 - [x] Decide about backports (7.17?)
 - [x] Backport to 7.17.x (PR on Beats repo)

## How to test this PR locally
1. Make sure you have Docker installed and running
1. Deploy Elastic Stack
1. Start a container that will generate logs (e.g: `docker run --rm --name flog -d mingrammer/flog /bin/flog -s1 -d1 -l -f rfc3164`).
2. Create a standalone Elastic-Agent policy [using Kibana as suggested in the documentation](https://www.elastic.co/guide/en/fleet/current/create-standalone-agent-policy.html#create-standalone-agent-policy).
3. On this policy add the "Custom Logs Integration" configuring the path as `/var/lib/docker/containers/${docker.container.id}/*-json.log`.
4. Download the policy (e.g: `/tmp/elastic-agent.yml`), adjust the Elasticsearch credentials as needed.
5. Start the Elastic-Agent with log debug (running as root is usually required to read `/var/lib/docker/*)`:
   ```
   sudo elastic-agent  -e -d "*"
   ```
6. You should see logs on Kibana

## Related issues
- Fixes https://github.com/elastic/beats/issues/29030
- Backport for 7.17.x: https://github.com/elastic/beats/pull/33269

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
