### PR TITLE
Enable integration only when datastreams are not defined

### DIFF
--- a/internal/pkg/composable/providers/kubernetes/hints.go
+++ b/internal/pkg/composable/providers/kubernetes/hints.go
@@ -193,7 +193,7 @@ func GenerateHintsMapping(hints mapstr.M, kubeMeta mapstr.M, logger *logp.Logger
 
 	dataStreams := builder.getDataStreams(hints)
 	if len(dataStreams) == 0 {
-		integrationHints.Put("enabled", true)
+		_, _ = integrationHints.Put("enabled", true)
 	}
 	for _, dataStream := range dataStreams {
 		streamHints := mapstr.M{

--- a/internal/pkg/composable/providers/kubernetes/hints.go
+++ b/internal/pkg/composable/providers/kubernetes/hints.go
@@ -144,9 +144,7 @@ func GenerateHintsMapping(hints mapstr.M, kubeMeta mapstr.M, logger *logp.Logger
 	if integration == "" {
 		return hintsMapping
 	}
-	integrationHints := mapstr.M{
-		"enabled": true,
-	}
+	integrationHints := mapstr.M{}
 
 	if containerID != "" {
 		_, _ = hintsMapping.Put("container_id", containerID)
@@ -194,6 +192,9 @@ func GenerateHintsMapping(hints mapstr.M, kubeMeta mapstr.M, logger *logp.Logger
 	}
 
 	dataStreams := builder.getDataStreams(hints)
+	if len(dataStreams) == 0 {
+		integrationHints.Put("enabled", true)
+	}
 	for _, dataStream := range dataStreams {
 		streamHints := mapstr.M{
 			"enabled": true,


### PR DESCRIPTION
## What does this PR do?
This PR improves the way that hints mappings are emitted:
1. If no data_streams are specified enable the integration level so as the defaults to be enabled.
2. If data_streams are specified only those will be enabled.

Related to https://github.com/elastic/package-storage-infra/pull/264

## How to test this localy

With the given configuration:
```yml
providers:
  kubernetes:
    kube_config: /home/chrismark/.kube/config
    node: "kind-control-plane"
    hints.enabled: true
    #include_annotations: ["foo"]

inputs:
  - name: redis/metrics-redis
    type: redis/metrics
    use_output: default
    streams:
      - condition: ${kubernetes.hints.redis.info.enabled} == true or ${kubernetes.hints.redis.enabled} == true
        data_stream:
          dataset: redis.info
          type: metrics
        hosts:
          - ${kubernetes.hints.redis.info.host|kubernetes.hints.redis.host|'127.0.0.1:6379'}
        idle_timeout: 20s
        maxconn: 10
        metricsets:
          - info
        network: tcp
        password: ${kubernetes.hints.redis.info.password|kubernetes.hints.redis.password|''}
        period: ${kubernetes.hints.redis.info.period|kubernetes.hints.redis.period|'10s'}
      - condition: ${kubernetes.hints.redis.key.enabled} == true or ${kubernetes.hints.redis.enabled} == true
        data_stream:
          dataset: redis.key
          type: metrics
        hosts:
          - ${kubernetes.hints.redis.key.host|kubernetes.hints.redis.host|'127.0.0.1:6379'}
        idle_timeout: 20s
        key.patterns:
          - limit: 20
            pattern: '*'
        maxconn: 10
        metricsets:
          - key
        network: tcp
        password: ${kubernetes.hints.redis.key.password|kubernetes.hints.redis.password|''}
        period: ${kubernetes.hints.redis.key.period|kubernetes.hints.redis.period|'10s'}
      - condition: ${kubernetes.hints.redis.keyspace.enabled} == true or ${kubernetes.hints.redis.enabled} == true
        data_stream:
          dataset: redis.keyspace
          type: metrics
        hosts:
          - ${kubernetes.hints.redis.keyspace.host|kubernetes.hints.redis.host|'127.0.0.1:6379'}
        idle_timeout: 20s
        maxconn: 10
        metricsets:
          - keyspace
        network: tcp
        password: ${kubernetes.hints.redis.keyspace.password|kubernetes.hints.redis.password|''}
        period: ${kubernetes.hints.redis.keyspace.period|kubernetes.hints.redis.period|'10s'}
    data_stream.namespace: default
```

And a Pod annotated with:
```yml
  annotations:
    co.elastic.hints/package: redis
    co.elastic.hints/data_streams: info, key
    co.elastic.hints/host: '${kubernetes.pod.ip}:6379'
    co.elastic.hints/info.period: 5s
```

Run `./elastic-agent inspect output -o default -c elastic-agent.yml -e` 

And verify that only `info, key` inputs are enabled.

Then remove the `co.elastic.hints/data_streams: info, key` run inspect again and verify that the defaults are enabled.