### PR TITLE
action: validate changelog fragment

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
-    - name: check changelog
+    - name: check pr-has-fragment
       run: |
         GOBIN=$PWD/bin go install github.com/elastic/elastic-agent-changelog-tool@latest
         ./bin/elastic-agent-changelog-tool pr-has-fragment --repo ${{ github.event.repository.name }} ${{github.event.number}}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,17 @@
+name: Changelog
+on: [pull_request]
+
+jobs:
+  fragments:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Fetch Go version from .go-version
+      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
+    - uses: actions/setup-go@v3
+      with:
+        go-version: ${{ env.GO_VERSION }}
+    - name: check changelog
+      run: |
+        GOBIN=$PWD/bin go install github.com/elastic/elastic-agent-changelog-tool@latest
+        ./bin/elastic-agent-changelog-tool pr-has-fragment --repo ${{ github.event.repository.name }} ${{github.event.number}}


### PR DESCRIPTION
## What does this PR do?

Enable validation for PRs with the changelog fragment approach

## Why is it important?

Use GitHub actions for this set of actions so the main pipeline will work as usual.

Similarly done in https://github.com/elastic/elastic-agent-changelog-tool/blob/ddafc5a717d1a9c3ed2651020bddffbb810846a2/.github/workflows/pull-request.yaml#L94-L114