### PR TITLE
Fixing makefile check

### DIFF
--- a/deploy/kubernetes/Makefile
+++ b/deploy/kubernetes/Makefile
@@ -52,7 +52,6 @@ ci-clone-kibana-repository:
 $(eval HASDIFF =$(shell sh -c "git status | grep $(FILE_REPO) | wc -l"))
 .PHONY: ci-create-kubernetes-templates-pull-request
 ci-create-kubernetes-templates-pull-request:
-	echo $(HASDIFF)
 ifeq ($(HASDIFF),1)
 	echo "INFO: Create branch to update k8s templates"
 	git config user.name obscloudnativemonitoring

--- a/deploy/kubernetes/Makefile
+++ b/deploy/kubernetes/Makefile
@@ -49,11 +49,11 @@ ci-clone-kibana-repository:
 	cp $(FILE_REPO)  $(ELASTIC_AGENT_REPO)/$(ELASTIC_AGENT_REPO_PATH)
 	
 ## ci-create-kubernetes-templates-pull-request : Create the pull request for the kubernetes templates
+$(eval HASDIFF =$(shell sh -c "git status | grep $(FILE_REPO) | wc -l"))
 .PHONY: ci-create-kubernetes-templates-pull-request
 ci-create-kubernetes-templates-pull-request:
-	HASDIFF=`git status | grep $(FILE_REPO) | wc -l`; \
-	echo $${HASDIFF}
-ifeq ($${HASDIFF},1)
+	echo $(HASDIFF)
+ifeq ($(HASDIFF),1)
 	echo "INFO: Create branch to update k8s templates"
 	git config user.name obscloudnativemonitoring
 	git config user.email obs-cloudnative-monitoring@elastic.co
@@ -79,8 +79,7 @@ else
 		--base main \
 		--head $(ELASTIC_AGENT_BRANCH) \
 		--reviewer elastic/obs-cloudnative-monitoring
-endif 
-
+endif
 else
 	echo "No differences found with kibana git repository"
 endif


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
Fixing error in makefile step `Sync k8` of job: https://fleet-ci.elastic.co/blue/organizations/jenkins/elastic-agent%2Felastic-agent-mbp/detail/main/497/pipeline/1935

In more details tab: `make ci-clone-kibana-repository cp Makefile ./kibana cd kibana make ci-create-kubernetes-templates-pull-request`

Fails with no diffs found



<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## How to test this PR locally

Locally by running:

Step 1:
```bash
cd deploy/kubernetes
```

Step2: Make a change in one of manifests

Step3:
```bash
WITHOUTCONFIG=true make generate-k8s
./creator_k8s_manifest.sh .
make ci-clone-kibana-repository
cp elastic_agent_manifest.ts  kibana/x-pack/plugins/fleet/server/services/
cp Makefile ./kibana
cd kibana
DRY_RUN=TRUE make ci-create-kubernetes-templates-pull-request
```

Outcome:
```bash
DRY_RUN=TRUE make ci-create-kubernetes-templates-pull-request
echo 1
1
echo "INFO: Create branch to update k8s templates"
INFO: Create branch to update k8s templates
git config user.name obscloudnativemonitoring
git config user.email obs-cloudnative-monitoring@elastic.co
git checkout -b update-k8s-templates-20221012182048
Switched to a new branch 'update-k8s-templates-20221012182048'
echo "INFO: add files if any"
INFO: add files if any
git add x-pack/plugins/fleet/server/services/elastic_agent_manifest.ts
echo "INFO: commit changes if any"
INFO: commit changes if any
git diff --staged --quiet || git commit -m "[Automated PR] Publish kubernetes templates for elastic-agent"
[update-k8s-templates-20221012182048 8e978e98e54] [Automated PR] Publish kubernetes templates for elastic-agent
 1 file changed, 51 insertions(+), 62 deletions(-)
echo "INFO: show remote details"
INFO: show remote details
git remote -v
origin  git@github.com:elastic/kibana.git (fetch)
origin  git@github.com:elastic/kibana.git (push)
echo "INFO: skip pushing branch"
INFO: skip pushing branch
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
