### PR TITLE
Fix k8s template link versioning

### DIFF
--- a/deploy/kubernetes/Makefile
+++ b/deploy/kubernetes/Makefile
@@ -1,5 +1,6 @@
 ALL=elastic-agent-standalone elastic-agent-managed
 BEAT_VERSION=$(shell head -n 1 ../../version/docs/version.asciidoc | cut -c 17- )
+BRANCH_VERSION=$(shell sed -n '2p' ../../version/docs/version.asciidoc | cut -c 14- )
 
 #variables needed for ci-create-kubernetes-templates-pull-request
 ELASTIC_AGENT_REPO=kibana
@@ -9,7 +10,7 @@ ELASTIC_AGENT_BRANCH=update-k8s-templates-$(shell date "+%Y%m%d%H%M%S")
 
 .PHONY: generate-k8s $(ALL)
 generate-k8s: $(ALL)
-	
+
 test: generate-k8s
 	for FILE in $(shell ls *-kubernetes.yaml); do \
 		BEAT=$$(echo $$FILE | cut -d \- -f 1); \
@@ -19,21 +20,21 @@ test: generate-k8s
 clean:
 	@for f in $(ALL); do rm -f "$$f-kubernetes.yaml"; done
 
-$(ALL): 
+$(ALL):
 ifdef WITHOUTCONFIG
 	@echo "Generating $@-kubernetes-without-configmap.yaml"
 	@rm -f $@-kubernetes-without-configmap.yaml
 	@for f in $(shell ls $@/*.yaml | grep -v daemonset-configmap); do \
-		sed "s/%VERSION%/VERSION/g" $$f >> $@-kubernetes-without-configmap.yaml; \
+		sed -e "s/%VERSION%/VERSION/g" -e "s/%BRANCH%/${BRANCH_VERSION}/g" $$f >> $@-kubernetes-without-configmap.yaml; \
 		echo --- >> $@-kubernetes-without-configmap.yaml; \
 	done
 else
-	@echo "Generating $@-kubernetes.yaml" 
-	@rm -f $@-kubernetes.yaml 
+	@echo "Generating $@-kubernetes.yaml"
+	@rm -f $@-kubernetes.yaml
 	@for f in $(shell ls $@/*.yaml); do \
-		sed "s/%VERSION%/${BEAT_VERSION}/g" $$f >> $@-kubernetes.yaml; \
+		sed -e "s/%VERSION%/${BEAT_VERSION}/g" -e "s/%BRANCH%/${BRANCH_VERSION}/g" $$f >> $@-kubernetes.yaml; \
 		echo --- >> $@-kubernetes.yaml; \
-	done 
+	done
 endif
 
 CHDIR_SHELL := $(SHELL)
@@ -47,7 +48,7 @@ endef
 ci-clone-kibana-repository:
 	git clone git@github.com:elastic/kibana.git
 	cp $(FILE_REPO)  $(ELASTIC_AGENT_REPO)/$(ELASTIC_AGENT_REPO_PATH)
-	
+
 ## ci-create-kubernetes-templates-pull-request : Create the pull request for the kubernetes templates
 $(eval HASDIFF =$(shell sh -c "git status | grep $(FILE_REPO) | wc -l"))
 .PHONY: ci-create-kubernetes-templates-pull-request
@@ -79,6 +80,7 @@ else
 		--head $(ELASTIC_AGENT_BRANCH) \
 		--reviewer elastic/obs-cloudnative-monitoring
 endif
+
 else
 	echo "No differences found with kibana git repository"
 endif

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -662,7 +662,7 @@ spec:
       #      - -c
       #      - >-
       #        mkdir -p /etc/elastic-agent/inputs.d &&
-      #        wget -O - https://github.com/elastic/elastic-agent/archive/8.3.0.tar.gz | tar xz -C /etc/elastic-agent/inputs.d --strip=5 "elastic-agent-main/deploy/kubernetes/elastic-agent-standalone/templates.d"
+      #        wget -O - https://github.com/elastic/elastic-agent/archive/main.tar.gz | tar xz -C /etc/elastic-agent/inputs.d --strip=5 "elastic-agent-main/deploy/kubernetes/elastic-agent-standalone/templates.d"
       #    volumeMounts:
       #      - name: external-inputs
       #        mountPath: /etc/elastic-agent/inputs.d

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
@@ -34,7 +34,7 @@ spec:
       #      - -c
       #      - >-
       #        mkdir -p /etc/elastic-agent/inputs.d &&
-      #        wget -O - https://github.com/elastic/elastic-agent/archive/%VERSION%.tar.gz | tar xz -C /etc/elastic-agent/inputs.d --strip=5 "elastic-agent-main/deploy/kubernetes/elastic-agent-standalone/templates.d"
+      #        wget -O - https://github.com/elastic/elastic-agent/archive/%BRANCH%.tar.gz | tar xz -C /etc/elastic-agent/inputs.d --strip=5 "elastic-agent-main/deploy/kubernetes/elastic-agent-standalone/templates.d"
       #    volumeMounts:
       #      - name: external-inputs
       #        mountPath: /etc/elastic-agent/inputs.d


### PR DESCRIPTION
## What does this PR do?
We need to use branch version and release version in the archive link we use to download the k8s templates. 

Correct: `wget -O - https://github.com/elastic/elastic-agent/archive/8.5.tar.gz`
Wrong: `wget -O - https://github.com/elastic/elastic-agent/archive/8.5.0.tar.gz`