### PR TITLE
Elastic agent counterpart of https://github.com/elastic/beats/pull/33362

### DIFF
--- a/changelog/fragments/1665784342-use-stack-version-npm-synthetics.yaml
+++ b/changelog/fragments/1665784342-use-stack-version-npm-synthetics.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: use-stack-version-npm-synthetics
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: Always npm i the stack_release version of @elastic/synthetics
+
+# Affected component; a word indicating the component this changeset affects.
+component: synthetics-integration
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 1528
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: 1234

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -191,7 +191,7 @@ RUN cd {{$beatHome}}/.node \
 RUN chown -R {{ .user }} $NODE_PATH
 USER {{ .user }}
 # If this fails dump the NPM logs
-RUN npm i -g --loglevel verbose -f @elastic/synthetics || sh -c 'tail -n +1 /root/.npm/_logs/* && exit 1'
+RUN npm i -g --loglevel verbose -f @elastic/synthetics@stack_release || sh -c 'tail -n +1 /root/.npm/_logs/* && exit 1'
 RUN chmod ug+rwX -R $NODE_PATH 
 USER root
 

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -181,7 +181,7 @@ RUN cd /usr/share/heartbeat/.node \
   && mkdir -p node \
   && curl ${NODE_DOWNLOAD_URL} | tar -xJ --strip 1 -C node \
   && chmod ug+rwX -R $NODE_PATH \
-  && npm i -g -f @elastic/synthetics && chmod ug+rwX -R $NODE_PATH
+  && npm i -g -f @elastic/synthetics@stack_release && chmod ug+rwX -R $NODE_PATH
 {{- end }}
 
 {{- range $i, $port := .ExposePorts }}


### PR DESCRIPTION
Always use the `stack_release` label for `npm i`

No changelog necessary since there are no user-visible changes

This lets us ensure we've carefully reviewed and labeled the version of the `@elastic/synthetics` NPM library that's bundled in docker images

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
