### PR TITLE
[automation] update elastic stack version for testing 8.5.0-7e528e3e

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.0-792499b4-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.0-7e528e3e-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.5.0-792499b4-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.5.0-7e528e3e-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Wed, 19 Oct 2022 00:16:15 GMT, release_branch:8.5, prefix:, end_time:Wed, 19 Oct 2022 06:05:43 GMT, manifest_version:2.1.0, version:8.5.0-SNAPSHOT, branch:8.5, build_id:8.5.0-7e528e3e, build_duration_seconds:20968]