### PR TITLE
Add input name alias for cloudbeat integrations

### DIFF
--- a/specs/cloudbeat.spec.yml
+++ b/specs/cloudbeat.spec.yml
@@ -25,3 +25,9 @@ inputs:
         - "setup.template.enabled=false"
         - "-E"
         - "gc_percent=${CLOUDBEAT_GOGC:100}"
+  - name: cloudbeat/cis_k8s
+    description: "CIS Kubernetes monitoring"
+    platforms: *platforms
+    outputs: *outputs
+    command:
+      args: *args

--- a/specs/cloudbeat.spec.yml
+++ b/specs/cloudbeat.spec.yml
@@ -2,7 +2,7 @@ version: 2
 inputs:
   - name: cloudbeat
     description: "Cloudbeat"
-    platforms:
+    platforms: &platforms
       - linux/amd64
       - linux/arm64
       - darwin/amd64
@@ -10,13 +10,13 @@ inputs:
       - windows/amd64
       - container/amd64
       - container/arm64
-    outputs:
+    outputs: &outputs
       - elasticsearch
       - kafka
       - logstash
       - redis
     command:
-      args:
+      args: &args
         - "-E"
         - "management.enabled=true"
         - "-E"

--- a/specs/cloudbeat.spec.yml
+++ b/specs/cloudbeat.spec.yml
@@ -31,3 +31,9 @@ inputs:
     outputs: *outputs
     command:
       args: *args
+  - name: cloudbeat/cis_eks
+    description: "CIS elastic Kubernetes monitoring"
+    platforms: *platforms
+    outputs: *outputs
+    command:
+      args: *args


### PR DESCRIPTION
## What does this PR do?
This is part of https://github.com/elastic/cloudbeat/pull/458

The cloudbeat folks are running into an issue where they're getting a `input not supported` error when installing an integration, and I assume the issue is because the name used in the integration (`- input: cloudbeat/cis_k8s`) doesn't appear in the specfile. 

I did a quick grep through the integrations, and it appears that `cloudbeat/cis_k8s` is the only cloudbeat input type, so I think this is all we'll need to add?

## Why is it important?

We need cloudbeat to work under V2.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
