### PR TITLE
Fix elastic-agent cloud image run issues

### DIFF
--- a/changelog/fragments/1666988983-cloud-build-paths.yaml
+++ b/changelog/fragments/1666988983-cloud-build-paths.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: fix runtime path setup when run in container mode
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: cmd/container.go
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 1630
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: 1234

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -791,8 +791,7 @@ func setPaths(statePath, configPath, logsPath string, writePaths bool) error {
 	originalTop := paths.Top()
 	paths.SetTop(statePath) // change this?
 	paths.SetConfig(configPath)
-	// when custom top path is provided the home directory is not versioned
-	//paths.SetVersionHome(false)
+
 	// install path stays on container default mount (otherwise a bind mounted directory could have noexec set)
 	paths.SetInstall(originalInstall)
 	// set LOGS_PATH is given

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -40,9 +40,9 @@ import (
 const (
 	requestRetrySleepEnv     = "KIBANA_REQUEST_RETRY_SLEEP"
 	maxRequestRetriesEnv     = "KIBANA_REQUEST_RETRY_COUNT"
-	defaultRequestRetrySleep = "1s"                             // sleep 1 sec between retries for HTTP requests
-	defaultMaxRequestRetries = "30"                             // maximum number of retries for HTTP requests
-	defaultStateDirectory    = "/usr/share/elastic-agent/state" // directory that will hold the state data
+	defaultRequestRetrySleep = "1s"                       // sleep 1 sec between retries for HTTP requests
+	defaultMaxRequestRetries = "30"                       // maximum number of retries for HTTP requests
+	defaultStateDirectory    = "/usr/share/elastic-agent" // directory that will hold the state data
 )
 
 var (
@@ -789,10 +789,10 @@ func setPaths(statePath, configPath, logsPath string, writePaths bool) error {
 	}
 	originalInstall := paths.Install()
 	originalTop := paths.Top()
-	paths.SetTop(topPath)
+	paths.SetTop(statePath) // change this?
 	paths.SetConfig(configPath)
 	// when custom top path is provided the home directory is not versioned
-	paths.SetVersionHome(false)
+	//paths.SetVersionHome(false)
 	// install path stays on container default mount (otherwise a bind mounted directory could have noexec set)
 	paths.SetInstall(originalInstall)
 	// set LOGS_PATH is given

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -766,13 +766,12 @@ func setPaths(statePath, configPath, logsPath string, writePaths bool) error {
 	if statePath == "" {
 		statePath = defaultStateDirectory
 	}
-	topPath := filepath.Join(statePath, "data")
 	configPath = envWithDefault(configPath, "CONFIG_PATH")
 	if configPath == "" {
 		configPath = statePath
 	}
 	// ensure that the directory and sub-directory data exists
-	if err := os.MkdirAll(topPath, 0755); err != nil {
+	if err := os.MkdirAll(statePath, 0755); err != nil {
 		return fmt.Errorf("preparing STATE_PATH(%s) failed: %w", statePath, err)
 	}
 	// ensure that the elastic-agent.yml exists in the state directory or if given in the config directory
@@ -789,7 +788,7 @@ func setPaths(statePath, configPath, logsPath string, writePaths bool) error {
 	}
 	originalInstall := paths.Install()
 	originalTop := paths.Top()
-	paths.SetTop(statePath) // change this?
+	paths.SetTop(statePath)
 	paths.SetConfig(configPath)
 
 	// install path stays on container default mount (otherwise a bind mounted directory could have noexec set)


### PR DESCRIPTION
## What does this PR do?

We're seeing issues with various docker builds of elastic-agent failing with an `"input not supported"` error. It appears that when elastic-agent starts up in container mode, it'll set the paths incorrectly under V2, so we aren't reading the specfiles from the component directory. 

This makes a few changes to the container setup to get the paths working under the "flat" V2 structure. I'm not 100% sure what else is happening under "container mode" so I want someone with a little more experience here to make sure I'm not breaking anything. I tested this natively and inside a container, and it seems to work.

In the future, we might want to modify the specfile `load.go` so we return an specific error if we can't find any specfiles

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
