### PR TITLE
Sync components with state during container start

### DIFF
--- a/internal/pkg/agent/application/paths/common.go
+++ b/internal/pkg/agent/application/paths/common.go
@@ -35,6 +35,7 @@ var (
 	configFilePath  string
 	logsPath        string
 	downloadsPath   string
+	componentsPath  string
 	installPath     string
 	unversionedHome bool
 	tmpCreator      sync.Once
@@ -46,14 +47,21 @@ func init() {
 	logsPath = topPath
 	unversionedHome = false // only versioned by container subcommand
 
+	// these should never change
+	versionedHome := VersionedHome(topPath)
+	downloadsPath = filepath.Join(versionedHome, "downloads")
+	componentsPath = filepath.Join(versionedHome, "components")
+
 	fs := flag.CommandLine
 	fs.StringVar(&topPath, "path.home", topPath, "Agent root path")
 	fs.BoolVar(&unversionedHome, "path.home.unversioned", unversionedHome, "Agent root path is not versioned based on build")
 	fs.StringVar(&configPath, "path.config", configPath, "Config path is the directory Agent looks for its config file")
 	fs.StringVar(&configFilePath, "c", DefaultConfigName, "Configuration file, relative to path.config")
 	fs.StringVar(&logsPath, "path.logs", logsPath, "Logs path contains Agent log output")
-	fs.StringVar(&downloadsPath, "path.downloads", downloadsPath, "Downloads path contains binaries Agent downloads")
 	fs.StringVar(&installPath, "path.install", installPath, "Install path contains binaries Agent extracts")
+
+	// enable user to download update artifacts to alternative place
+	fs.StringVar(&downloadsPath, "path.downloads", downloadsPath, "Downloads path contains binaries Agent downloads")
 }
 
 // Top returns the top directory for Elastic Agent, all the versioned
@@ -146,7 +154,7 @@ func Run() string {
 
 // Components returns the component directory for Agent
 func Components() string {
-	return filepath.Join(Home(), "components")
+	return componentsPath
 }
 
 // Logs returns the log directory for Agent
@@ -166,9 +174,6 @@ func VersionedHome(base string) string {
 
 // Downloads returns the downloads directory for Agent
 func Downloads() string {
-	if downloadsPath == "" {
-		return filepath.Join(Home(), "downloads")
-	}
 	return downloadsPath
 }
 

--- a/internal/pkg/agent/application/paths/common.go
+++ b/internal/pkg/agent/application/paths/common.go
@@ -61,6 +61,8 @@ func init() {
 	fs.StringVar(&installPath, "path.install", installPath, "Install path contains binaries Agent extracts")
 
 	// enable user to download update artifacts to alternative place
+	// TODO: remove path.downloads support on next major (this can be configured using `agent.download.targetDirectory`)
+	// `path.download` serves just as init value for `agent.download.targetDirectory`
 	fs.StringVar(&downloadsPath, "path.downloads", downloadsPath, "Downloads path contains binaries Agent downloads")
 }
 

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -787,6 +787,13 @@ func setPaths(statePath, configPath, logsPath string, writePaths bool) error {
 	if err := syncDir(paths.Downloads(), destDownloads); err != nil {
 		return fmt.Errorf("syncing download directory to STATE_PATH(%s) failed: %w", statePath, err)
 	}
+
+	// sync components to data directory
+	destComponents := filepath.Join(statePath, "data", "components")
+	if err := syncDir(paths.Components(), destComponents); err != nil {
+		return fmt.Errorf("syncing components directory to STATE_PATH(%s) failed: %w", statePath, err)
+	}
+
 	originalInstall := paths.Install()
 	originalTop := paths.Top()
 	paths.SetTop(topPath)
@@ -867,6 +874,10 @@ func tryContainerLoadPaths() error {
 }
 
 func syncDir(src string, dest string) error {
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return fmt.Errorf("creating directory %q failed with error: %w", dest, err)
+	}
+
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			if os.IsNotExist(err) {


### PR DESCRIPTION
## What does this PR do?

Syncs components in a containers so they are available at the runtime

## Why is it important?

Container agent won't run components without this. It will run into input not supported

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

cc @cmacknz
