### PR TITLE
Increase upgrade download timeout to 2 hours

### DIFF
--- a/internal/pkg/artifact/config.go
+++ b/internal/pkg/artifact/config.go
@@ -151,9 +151,9 @@ func DefaultConfig() *Config {
 	transport := httpcommon.DefaultHTTPTransportSettings()
 
 	// Elastic Agent binary is rather large and based on the network bandwidth it could take some time
-	// to download the full file. 10 minutes is a very large value, but we really want it to finish.
+	// to download the full file. 120 minutes is a very large value, but we really want it to finish.
 	// The HTTP download will log progress in the case that it is taking a while to download.
-	transport.Timeout = 10 * time.Minute
+	transport.Timeout = 120 * time.Minute
 
 	return &Config{
 		SourceURI:             DefaultSourceURI,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Blocked by:
- [ ] https://github.com/elastic/elastic-agent/issues/1706

Increases the client-side timeout on downloading the agent upgrade binary to 120m. I've observed some machines on slow connections downloading as slow as 50Kb/s. Our largest artifact size is on linux, clocking in at around 370MB. My rough math shows that an agent downloading at this speed would take about 110 minutes to complete, so I chose 120 minutes as a new default value.

## Why is it important?

We want to improve the reliability of upgrades. Agents will soon retry their own upgrades start in 8.6 if they fail, but for agents on slow connections, they may never successfully complete with a 10 minute timeout. I can't think of a reason we need to have such a short timeout.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]