### PR TITLE
Disable creating GH issues for build failures.

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -425,7 +425,7 @@ pipeline {
     cleanup {
       notifyBuildResult(prComment: true,
                         analyzeFlakey: !isTag(), jobName: getFlakyJobName(withBranch: (isPR() ? env.CHANGE_TARGET : env.BRANCH_NAME)),
-                        githubIssue: isBranch() && currentBuild.currentResult != "SUCCESS",
+                        githubIssue: false, // Disable creating gh issues for build failures while the E2E tests are stabilized.
                         githubLabels: 'Team:Elastic-Agent-Control-Plane')
     }
   }


### PR DESCRIPTION
The E2E tests are still unstable and the issues reported for those failures is creating a lot of noise in the issue tracker.

Example: https://github.com/elastic/elastic-agent/issues