### PR TITLE
Fix components permissions on build

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -19,7 +19,10 @@ RUN mkdir -p {{ $beatHome }}/data {{ $beatHome }}/data/elastic-agent-{{ commit_s
     chmod 0755 {{ $beatHome }}/data/elastic-agent-*/elastic-agent && \
     chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/*beat && \
     (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/apm-server || true) && \
-    (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/elastic-endpoint || true) && \
+    (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/endpoint-security || true) && \
+    (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/fleet-server || true) && \
+    (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/elastic-agent-shipper || true) && \
+    (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/prodfiler || true) && \
     find {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/components -name "*.yml*" -type f -exec chown root:root {} \; && \
     find {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/components -name "*.yml*" -type f -exec chmod 0644 {} \; && \
 {{- range $i, $modulesd := .ModulesDirs }}

--- a/magefile.go
+++ b/magefile.go
@@ -142,6 +142,11 @@ func (Dev) Package() {
 	defer os.Setenv(devEnv, dev)
 
 	os.Setenv(devEnv, "true")
+
+	if _, hasExternal := os.LookupEnv(externalArtifacts); !hasExternal {
+		devtools.ExternalBuild = true
+	}
+
 	devtools.DevBuild = true
 	Package()
 }

--- a/magefile.go
+++ b/magefile.go
@@ -644,10 +644,18 @@ func packageAgent(requiredPackages []string, packagingFn func()) {
 		// cleanup after build
 		defer os.Unsetenv(agentDropPath)
 
-		packedBeats := []string{"filebeat", "heartbeat", "metricbeat", "osquerybeat"}
 		if devtools.ExternalBuild == true {
+			// for external go for all dependencies
+			dependencies := []string{
+				"auditbeat", "filebeat", "heartbeat", "metricbeat", "osquerybeat", "packetbeat", // beat dependencies
+				"apm-server",
+				// "cloudbeat", // TODO: add once working
+				"elastic-agent-shipper",
+				"endpoint-security",
+				"fleet-server",
+			}
 			ctx := context.Background()
-			for _, beat := range packedBeats {
+			for _, beat := range dependencies {
 				for _, reqPackage := range requiredPackages {
 					targetPath := filepath.Join(archivePath, reqPackage)
 					os.MkdirAll(targetPath, 0755)
@@ -659,6 +667,7 @@ func packageAgent(requiredPackages []string, packagingFn func()) {
 				}
 			}
 		} else {
+			packedBeats := []string{"filebeat", "heartbeat", "metricbeat", "osquerybeat"}
 			// build from local repo, will assume beats repo is located on the same root level
 			for _, b := range packedBeats {
 				pwd, err := filepath.Abs(filepath.Join("../beats/x-pack", b))


### PR DESCRIPTION
## What does this PR do?

Endpoint and fleet server permissions were incorrectly set.
This PR fixes that to be 755 instead of 660

This PR also makes EXTERNAL true by default so each dependency is fetched on build for packaging when using `mage dev:package` 
EXTERNAL is not set when EXTERNAL was already provided or DROP PATH is used.

When using EXTERNAL all dependencies (incl fleet-server, apm, endpoint) are fetched compared to the list of beats from beats repo when used without this flag.  This is to be as close to CI package as possible.

## Why is it important?

Fixes: #1712 

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
