### PR TITLE
Pre-create `state/` directory inside Docker image to allow writes to named volumes

### DIFF
--- a/changelog/fragments/1675352435-Pre-create-state-directory-inside-Docker-image-to-allow-writes-to-named-volumes.yaml
+++ b/changelog/fragments/1675352435-Pre-create-state-directory-inside-Docker-image-to-allow-writes-to-named-volumes.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Allows the state directory to be mounted from a named volume inside the container image.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 1727
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue:

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -8,7 +8,7 @@ FROM {{ .buildFrom }} AS home
 
 COPY beat {{ $beatHome }}
 
-RUN mkdir -p {{ $beatHome }}/data {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/logs && \
+RUN mkdir -p {{ $beatHome }}/data {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/logs {{ $beatHome }}/state && \
     chown -R root:root {{ $beatHome }} && \
     find {{ $beatHome }} -type d -exec chmod 0755 {} \; && \
     find {{ $beatHome }} -type f -exec chmod 0644 {} \; && \


### PR DESCRIPTION
Type of change: Enhancement

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Allows the state directory to be [mounted from a named volume](https://github.com/deviantony/docker-elk/blob/1943f25282082c561072a4705d450b9cfe246a40/extensions/fleet/fleet-compose.yml#L9-L10).

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without this change, Docker creates the directory with owner `root:root` (✅) and permissions `0640` (group read-only ❌) while mounting the volume, which prevents the default [`elastic-agent:root`](https://github.com/elastic/elastic-agent/blob/v8.6.1/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl#L143-L145) user/group from writing inside of it.

This approach is also used in the [container image for Elasticsearch](https://github.com/elastic/elasticsearch/blob/4c15cd8a6af2572e69cee48ab6021e31864197b4/distribution/docker/src/docker/Dockerfile#L106) to permit writes to the the `data/` directory.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Create a named volume:

    ```console
    $ docker volume create fleet-state
    fleet-state
    ```

1. Run the elastic-agent image and mount the volume at the location of the `state` directory. Observe that it fails because the `elastic-agent` user doesn't have permissions to write in this directory:

    ```console
    $ docker container run --rm -v fleet-state:/usr/share/elastic-agent/state docker.elastic.co/beats/elastic-agent:8.5.0
    Error: preparing STATE_PATH(/usr/share/elastic-agent/state) failed: mkdir /usr/share/elastic-agent/state/data: permission denied
    ```

1. Build the image with the change from this PR, then run the agent like above, this time with the new image. Observe that the agent starts and populates the `state` directory:

    ```console
    $ docker container run --rm -v fleet-state:/usr/share/elastic-agent/state newimage:latest
    (it works)
    ```

<details><summary>:page_facing_up: Rest of the requested PR information</summary>

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] (not applicable) I have commented my code, particularly in hard-to-understand areas
- [x] (not applicable) I have made corresponding changes to the documentation
- [x] (not applicable) I have made corresponding change to the default configuration files
- [x] (not applicable) I have added tests that prove my fix is effective or that my feature works
- [x] (not applicable) I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
  
</details>