### PR TITLE
[Release] Update version to 8.6.1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -4,4 +4,4 @@
 
 package version
 
-const defaultBeatVersion = "8.6.0"
+const defaultBeatVersion = "8.6.1"


### PR DESCRIPTION
Updates references to the new release 8.6.1.

Merge after the release 8.6.0.