### PR TITLE
monitoring: fix JSON logs parsing for Beats

### DIFF
--- a/changelog/fragments/1668591286-fix-beats-logs.yaml
+++ b/changelog/fragments/1668591286-fix-beats-logs.yaml
@@ -16,8 +16,8 @@ summary: "monitoring: fix JSON logs parsing for Beats"
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
 description: >-
-  This commit fixes the JSON parsing from Beats logs. The configuration sent to
-  Filebeat did not contain the input type, hence a log input  instead of a
+  Fixes the JSON parsing from Beats logs. The configuration sent to
+  Filebeat did not contain the input type, hence a log input instead of a
   filestream one was being started.
 
   This commit also improves the configuraiton of the ndjson parser.

--- a/changelog/fragments/1668591286-fix-beats-logs.yaml
+++ b/changelog/fragments/1668591286-fix-beats-logs.yaml
@@ -1,0 +1,36 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: "monitoring: fix JSON logs parsing for Beats"
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: >-
+  This commit fixes the JSON parsing from Beats logs. The configuration sent to
+  Filebeat did not contain the input type, hence a log input  instead of a
+  filestream one was being started.
+
+  This commit also improves the configuraiton of the ndjson parser.
+
+# Affected component; a word indicating the component this changeset affects.
+component: monitoring
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 1735
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: 1234

--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -296,12 +296,14 @@ func (b *BeatsMonitor) injectLogsInput(cfg map[string]interface{}, componentIDTo
 
 	streams := []interface{}{
 		map[string]interface{}{
-			idKey: "logs-monitoring-agent",
+			idKey: "filestream-monitoring-agent",
+			// "data_stream" is not used when creating an Input on Filebeat
 			"data_stream": map[string]interface{}{
-				"type":      "logs",
+				"type":      "filestream",
 				"dataset":   "elastic_agent",
 				"namespace": monitoringNamespace,
 			},
+			"type": "filestream",
 			"paths": []interface{}{
 				filepath.Join(logsDrop, agentName+"-*.ndjson"),
 				filepath.Join(logsDrop, agentName+"-watcher-*.ndjson"),
@@ -315,8 +317,10 @@ func (b *BeatsMonitor) injectLogsInput(cfg map[string]interface{}, componentIDTo
 			"parsers": []interface{}{
 				map[string]interface{}{
 					"ndjson": map[string]interface{}{
-						"overwrite_keys": true,
 						"message_key":    "message",
+						"overwrite_keys": true,
+						"add_error_key":  true,
+						"target":         "",
 					},
 				},
 			},
@@ -376,12 +380,14 @@ func (b *BeatsMonitor) injectLogsInput(cfg map[string]interface{}, componentIDTo
 		name := strings.ReplaceAll(unit, "-", "_") // conform with index naming policy
 		logFile := loggingPath(unit, b.operatingSystem)
 		streams = append(streams, map[string]interface{}{
-			idKey: "logs-monitoring-" + name,
+			idKey: "filestream-monitoring-" + name,
 			"data_stream": map[string]interface{}{
-				"type":      "logs",
+				// "data_stream" is not used when creating an Input on Filebeat
+				"type":      "filestream",
 				"dataset":   fmt.Sprintf("elastic_agent.%s", fixedBinaryName),
 				"namespace": monitoringNamespace,
 			},
+			"type":  "filestream",
 			"index": fmt.Sprintf("logs-elastic_agent.%s-%s", fixedBinaryName, monitoringNamespace),
 			"paths": []interface{}{logFile, logFile + "*"},
 			"close": map[string]interface{}{
@@ -392,8 +398,10 @@ func (b *BeatsMonitor) injectLogsInput(cfg map[string]interface{}, componentIDTo
 			"parsers": []interface{}{
 				map[string]interface{}{
 					"ndjson": map[string]interface{}{
-						"overwrite_keys": true,
 						"message_key":    "message",
+						"overwrite_keys": true,
+						"add_error_key":  true,
+						"target":         "",
 					},
 				},
 			},
@@ -448,8 +456,8 @@ func (b *BeatsMonitor) injectLogsInput(cfg map[string]interface{}, componentIDTo
 
 	inputs := []interface{}{
 		map[string]interface{}{
-			idKey:        "logs-monitoring-agent",
-			"name":       "logs-monitoring-agent",
+			idKey:        "filestream-monitoring-agent",
+			"name":       "filestream-monitoring-agent",
 			"type":       "filestream",
 			useOutputKey: monitoringOutput,
 			"data_stream": map[string]interface{}{


### PR DESCRIPTION
## What does this PR do?
This commit fixes the JSON parsing from Beats logs. The configuration
sent to Filebeat did not contain the input type, hence a log input
instead of a filestream one was being started.

This commit also improves the configuraiton of the ndjson parser.

## Why is it important?
It fixes a bug.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ] Are the changes on IDs I made correct?

## How to test this PR locally
1. Build and run the Elastic-Agent
2. Go to Kibana and assert the logs from Beats and Elastic-Agent are being correctly parsed

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
