### PR TITLE
V2: Provide fleet configuration to APM server

### DIFF
--- a/changelog/fragments/1668645651-apm-fleet-config.yaml
+++ b/changelog/fragments/1668645651-apm-fleet-config.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: V2 Provide fleet configuration to APM server
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: 1234
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 1737

--- a/internal/pkg/agent/application/application.go
+++ b/internal/pkg/agent/application/application.go
@@ -105,7 +105,7 @@ func New(
 
 			composableManaged = true
 			compModifiers = append(compModifiers, FleetServerComponentModifier(cfg.Fleet.Server),
-				EndpointComponentModifier(cfg.Fleet))
+				InjectFleetConfigComponentModifier(cfg.Fleet))
 
 			managed, err = newManagedConfigManager(log, agentInfo, cfg, store, runtime)
 			if err != nil {

--- a/internal/pkg/agent/application/fleet_server_bootstrap.go
+++ b/internal/pkg/agent/application/fleet_server_bootstrap.go
@@ -22,6 +22,7 @@ const (
 	elasticsearch = "elasticsearch"
 	fleetServer   = "fleet-server"
 	endpoint      = "endpoint"
+	apmServer     = "apm"
 )
 
 // injectFleetServerInput is the base configuration that is used plus the FleetServerComponentModifier that adjusts
@@ -83,15 +84,14 @@ func FleetServerComponentModifier(serverCfg *configuration.FleetServerConfig) co
 	}
 }
 
-// EndpointComponentModifier the modifier for the Endpoint configuration.
-// The Endpoint expects the fleet configuration passed to it by the Agent
-// because it needs to be able to connect to the fleet server directly.
-func EndpointComponentModifier(fleetCfg *configuration.FleetAgentConfig) coordinator.ComponentsModifier {
+// InjectFleetConfigComponentModifier The modifier that injects the fleet configuration for the components
+// that need to be able to connect to fleet server.
+func InjectFleetConfigComponentModifier(fleetCfg *configuration.FleetAgentConfig) coordinator.ComponentsModifier {
 	return func(comps []component.Component, cfg map[string]interface{}) ([]component.Component, error) {
 		for i, comp := range comps {
-			if comp.InputSpec != nil && comp.InputSpec.InputType == endpoint {
+			if comp.InputSpec != nil && (comp.InputSpec.InputType == endpoint || comp.InputSpec.InputType == apmServer) {
 				for j, unit := range comp.Units {
-					if unit.Type == client.UnitTypeInput && unit.Config.Type == endpoint {
+					if unit.Type == client.UnitTypeInput && (unit.Config.Type == endpoint || unit.Config.Type == apmServer) {
 						unitCfgMap, err := toMapStr(unit.Config.Source.AsMap(), map[string]interface{}{"fleet": fleetCfg})
 						if err != nil {
 							return nil, err


### PR DESCRIPTION
## What does this PR do?

Injects the fleet configuration for APM the same way it was done for Endpoint.
Tested against APM PR for V2 https://github.com/elastic/apm-server/pull/9544

## Why is it important?

Fixes Agent with APM for V2.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/1737

## Logs

The following is the APM input configuration captured in apm-server built off of the PR https://github.com/elastic/apm-server/pull/9544

```
{
    "apm-server": {
        "agent_config": [],
        "aggregation": {
            "service": {
                "enabled": false
            }
        },
        "auth": {
            "anonymous": {
                "allow_agent": [
                    "rum-js",
                    "js-base",
                    "iOS/swift"
                ],
                "allow_service": null,
                "enabled": true,
                "rate_limit": {
                    "event_limit": 300,
                    "ip_limit": 1000
                }
            },
            "api_key": {
                "enabled": false,
                "limit": 100
            },
            "secret_token": null
        },
        "capture_personal_data": true,
        "default_service_environment": null,
        "expvar": {
            "enabled": false
        },
        "host": "localhost:8255",
        "idle_timeout": "45s",
        "java_attacher": {
            "discovery-rules": null,
            "download-agent-version": null,
            "enabled": false
        },
        "max_connections": 0,
        "max_event_size": 307200,
        "max_header_size": 1048576,
        "pprof": {
            "enabled": false
        },
        "read_timeout": "3600s",
        "response_headers": null,
        "rum": {
            "allow_headers": null,
            "allow_origins": [
                "*"
            ],
            "enabled": true,
            "exclude_from_grouping": "^/webpack",
            "library_pattern": "node_modules|bower_components|~",
            "response_headers": null,
            "source_mapping": {
                "metadata": []
            }
        },
        "sampling": {
            "tail": {
                "enabled": false,
                "interval": "1m",
                "policies": [
                    {
                        "sample_rate": 0.1
                    }
                ],
                "storage_limit": "3GB"
            }
        },
        "shutdown_timeout": "30s",
        "ssl": {
            "certificate": null,
            "cipher_suites": null,
            "curve_types": null,
            "enabled": false,
            "key": null,
            "key_passphrase": null,
            "supported_protocols": [
                "TLSv1.1",
                "TLSv1.2",
                "TLSv1.3"
            ]
        },
        "write_timeout": "30s"
    },
    "data_stream": {
        "namespace": "default"
    },
    "fleet": {
        "access_api_key": "xxxxxxdvUUJITm80OFQyb1YwOU86clBNalZ2ZjNUM0M5a0U2SEgzc2N4Zw==",
        "agent": {
            "id": "ea466602-1c24-4704-8054-28fbacbf3e96"
        },
        "enabled": true,
        "host": {
            "id": "2628AB39-F770-5FC3-B7F1-8CC95E506B0D"
        },
        "hosts": [
            "https://ffffe9b5f47d409099163e5e8e5e4f4e.fleet.us-west2.gcp.elastic-cloud.com:443"
        ],
        "protocol": "http",
        "ssl": {
            "renegotiation": "never",
            "verification_mode": "full"
        },
        "timeout": "10m0s"
    },
    "id": "a055c8da-5886-4989-b969-8b6674666711",
    "meta": {
        "package": {
            "name": "apm",
            "version": "8.6.0"
        }
    },
    "name": "apm-1",
    "package_policy_id": "a055c8da-5886-4989-b969-8b6674666711",
    "policy": {
        "revision": 3
    },
    "revision": 2,
    "type": "apm"
}
```
