### PR TITLE
Stop unconditionally injecting a policy key.

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -132,7 +132,6 @@ func (r *RuntimeSpecs) ToComponents(policy map[string]interface{}, monitoringInj
 // PolicyToComponents takes the policy and generated a component model along with providing a mapping between component
 // and the running binary.
 func (r *RuntimeSpecs) PolicyToComponents(policy map[string]interface{}) ([]Component, map[string]string, error) {
-	const revision = "revision"
 	outputsMap, err := toIntermediate(policy)
 	if err != nil {
 		return nil, nil, err
@@ -221,11 +220,6 @@ func (r *RuntimeSpecs) PolicyToComponents(policy map[string]interface{}) ([]Comp
 				if !input.enabled {
 					// skip; not enabled
 					continue
-				}
-				if v, ok := policy[revision]; ok {
-					input.input["policy"] = map[string]interface{}{
-						revision: v,
-					}
 				}
 				cfg, cfgErr := ExpectedConfig(input.input)
 				if cfg != nil {


### PR DESCRIPTION
This collides with the existing endpoint security policy key, overwriting it.

If we need to keep this, we should do it with a reserved policy section or keyword we know does not collide. For now it seems unimportant and nobody depends on it, so I'm removing it.

Screenshots of the relevant parts of `elastic-agent inspect components --show-config`:

Before:
<img width="858" alt="Screen Shot 2022-11-21 at 3 37 36 PM" src="https://user-images.githubusercontent.com/3466215/203157240-b7899860-bc68-4c5f-b662-4c2b64363a7a.png">

After:
<img width="858" alt="Screen Shot 2022-11-21 at 3 43 41 PM" src="https://user-images.githubusercontent.com/3466215/203157248-fdc02f94-5088-4718-9eed-724ccf06c539.png">


- Closes https://github.com/elastic/elastic-agent/issues/1757
