### PR TITLE
Inject input.policy.revision without overwriting.

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -327,9 +327,13 @@ func (r *RuntimeSpecs) PolicyToComponents(policy map[string]interface{}) ([]Comp
 
 // Injects or creates a policy.revision sub-object in the input map.
 func injectInputPolicyID(fleetPolicy map[string]interface{}, input map[string]interface{}) {
+	if input == nil {
+		return
+	}
+
 	// If there is no top level fleet policy revision, there's nothing to inject.
 	revision, exists := fleetPolicy["revision"]
-	if !exists || input == nil {
+	if !exists {
 		return
 	}
 

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -1518,6 +1518,68 @@ func TestToComponents(t *testing.T) {
 	}
 }
 
+func TestInjectingInputPolicyID(t *testing.T) {
+	const testRevision = 10
+	fleetPolicy := map[string]interface{}{
+		"revision": testRevision,
+	}
+
+	tests := []struct {
+		name   string
+		policy map[string]interface{}
+		in     map[string]interface{}
+		out    map[string]interface{}
+	}{
+		{"NilEverything", nil, nil, nil},
+		{"NilInput", fleetPolicy, nil, nil},
+		{"NilPolicy", nil,
+			map[string]interface{}{},
+			map[string]interface{}{},
+		},
+		{"EmptyPolicy", map[string]interface{}{},
+			map[string]interface{}{},
+			map[string]interface{}{},
+		},
+		{"CreatePolicyRevision", fleetPolicy,
+			map[string]interface{}{},
+			map[string]interface{}{
+				"policy": map[string]interface{}{"revision": testRevision},
+			},
+		},
+		{"NilPolicyObjectType", fleetPolicy,
+			map[string]interface{}{
+				"policy": nil,
+			},
+			map[string]interface{}{
+				"policy": map[string]interface{}{"revision": testRevision},
+			},
+		},
+		{"InjectPolicyRevision", fleetPolicy,
+			map[string]interface{}{
+				"policy": map[string]interface{}{"key": "value"},
+			},
+			map[string]interface{}{
+				"policy": map[string]interface{}{"key": "value", "revision": testRevision},
+			},
+		},
+		{"UnknownPolicyObjectType", fleetPolicy,
+			map[string]interface{}{
+				"policy": map[string]int{"key": 10},
+			},
+			map[string]interface{}{
+				"policy": map[string]int{"key": 10},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			injectInputPolicyID(tc.policy, tc.in)
+			assert.Equal(t, tc.out, tc.in)
+		})
+	}
+}
+
 func assertEqualUnitExpectedConfigs(t *testing.T, expected *Unit, actual *Unit) {
 	t.Helper()
 	assert.Equal(t, expected.ID, actual.ID)


### PR DESCRIPTION
Ensure each input configuration gets a policy.revision key that contains the revision number of the Fleet policy, but correctly handle the case where a policy object already exists.

The policy.revision key was added as a requirement to support endpoint security, and is probably generally useful for detecting when the overall agent policy has changed.

Output from `elastic-agent inspect components --show-config` with this change showing the policy.revision field is correctly injected into the existing endpoint policy object:

<img width="502" alt="Screen Shot 2022-11-21 at 8 50 51 PM" src="https://user-images.githubusercontent.com/3466215/203197691-e4ed9130-0f34-4603-8125-af0cfa6579d7.png">


- Closes https://github.com/elastic/elastic-agent/issues/1757