### PR TITLE
Re-implement processes route to restore compatibility with the current cloud health checks

### DIFF
--- a/changelog/fragments/1669159455-reimplement-processes-route.yaml
+++ b/changelog/fragments/1669159455-reimplement-processes-route.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: reimplement processes route
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: Re-implement processes route to restore compatibility with the current cloud health checks
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 1773
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 1731

--- a/internal/pkg/agent/application/monitoring/error.go
+++ b/internal/pkg/agent/application/monitoring/error.go
@@ -1,0 +1,33 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package monitoring
+
+import "fmt"
+
+func errorWithStatus(status int, err error) *statusError {
+	return &statusError{
+		err:    err,
+		status: status,
+	}
+}
+
+func errorfWithStatus(status int, msg string, args ...string) *statusError {
+	err := fmt.Errorf(msg, args)
+	return errorWithStatus(status, err)
+}
+
+// StatusError holds correlation between error and a status
+type statusError struct {
+	err    error
+	status int
+}
+
+func (s *statusError) Status() int {
+	return s.status
+}
+
+func (s *statusError) Error() string {
+	return s.err.Error()
+}

--- a/internal/pkg/agent/application/monitoring/process.go
+++ b/internal/pkg/agent/application/monitoring/process.go
@@ -9,9 +9,10 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/gorilla/mux"
+
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
-	"github.com/gorilla/mux"
 )
 
 const processIDKey = "processID"

--- a/internal/pkg/agent/application/monitoring/process.go
+++ b/internal/pkg/agent/application/monitoring/process.go
@@ -1,0 +1,62 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package monitoring
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/gorilla/mux"
+)
+
+const processIDKey = "processID"
+
+func processHandler(coord *coordinator.Coordinator, statsHandler func(http.ResponseWriter, *http.Request) error) func(http.ResponseWriter, *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+		vars := mux.Vars(r)
+		id, found := vars[processIDKey]
+
+		if !found {
+			return errorfWithStatus(http.StatusNotFound, "productID not found")
+		}
+
+		if id == "" || id == paths.BinaryName {
+			// proxy stats for elastic agent process
+			return statsHandler(w, r)
+		}
+
+		state := coord.State(false)
+
+		for _, c := range state.Components {
+			if c.Component.ID == id {
+				data := struct {
+					State   string `json:"state"`
+					Message string `json:"message"`
+				}{
+					State:   c.State.State.String(),
+					Message: c.State.Message,
+				}
+
+				bytes, err := json.Marshal(data)
+				var content string
+				if err != nil {
+					content = fmt.Sprintf("Not valid json: %v", err)
+				} else {
+					content = string(bytes)
+				}
+				fmt.Fprint(w, content)
+
+				return nil
+			}
+		}
+
+		return errorWithStatus(http.StatusNotFound, fmt.Errorf("matching component %v not found", id))
+	}
+}

--- a/internal/pkg/agent/application/monitoring/processes.go
+++ b/internal/pkg/agent/application/monitoring/processes.go
@@ -49,9 +49,11 @@ func processesHandler(coord *coordinator.Coordinator) func(http.ResponseWriter, 
 		state := coord.State(false)
 
 		for _, c := range state.Components {
-			procs = append(procs, process{c.Component.ID, c.Component.InputSpec.BinaryName,
-				c.LegacyPID,
-				sourceFromComponentID(c.Component.ID)})
+			if c.Component.InputSpec != nil {
+				procs = append(procs, process{c.Component.ID, c.Component.InputSpec.BinaryName,
+					c.LegacyPID,
+					sourceFromComponentID(c.Component.ID)})
+			}
 		}
 		data := struct {
 			Processes []process `json:"processes"`

--- a/internal/pkg/agent/application/monitoring/processes.go
+++ b/internal/pkg/agent/application/monitoring/processes.go
@@ -1,0 +1,73 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package monitoring
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
+)
+
+type source struct {
+	Kind    string   `json:"kind"`
+	Outputs []string `json:"outputs"`
+}
+
+type process struct {
+	ID     string `json:"id"`
+	PID    string `json:"pid,omitempty"`
+	Binary string `json:"binary"`
+	Source source `json:"source"`
+}
+
+func sourceFromComponentID(procID string) source {
+	var s source
+	var out string
+	if pos := strings.LastIndex(procID, "-"); pos != -1 {
+		out = procID[pos+1:]
+	}
+	if strings.HasSuffix(out, "monitoring") {
+		s.Kind = "internal"
+	} else {
+		s.Kind = "configured"
+	}
+	s.Outputs = []string{out}
+	return s
+}
+
+func processesHandler(coord *coordinator.Coordinator) func(http.ResponseWriter, *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+		procs := make([]process, 0)
+
+		state := coord.State(false)
+
+		for _, c := range state.Components {
+			procs = append(procs, process{c.Component.ID, c.Component.InputSpec.BinaryName,
+				c.LegacyPID,
+				sourceFromComponentID(c.Component.ID)})
+		}
+		data := struct {
+			Processes []process `json:"processes"`
+		}{
+			Processes: procs,
+		}
+
+		bytes, err := json.Marshal(data)
+		var content string
+		if err != nil {
+			content = fmt.Sprintf("Not valid json: %v", err)
+		} else {
+			content = string(bytes)
+		}
+		fmt.Fprint(w, content)
+
+		return nil
+	}
+}

--- a/internal/pkg/agent/application/monitoring/server.go
+++ b/internal/pkg/agent/application/monitoring/server.go
@@ -63,7 +63,6 @@ func exposeMetricsEndpoint(
 		r.Handle("/processes", createHandler(processesHandler(coord)))
 		r.Handle("/processes/{processID}", createHandler(processHandler(coord, statsHandler)))
 		r.Handle("/processes/{processID}/", createHandler(processHandler(coord, statsHandler)))
-		r.Handle("/processes/{processID}/{beatsPath}", createHandler(processHandler(coord, statsHandler)))
 	}
 
 	mux := http.NewServeMux()

--- a/internal/pkg/agent/application/monitoring/server.go
+++ b/internal/pkg/agent/application/monitoring/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/api"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/monitoring"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
@@ -27,6 +28,8 @@ func NewServer(
 	endpointConfig api.Config,
 	ns func(string) *monitoring.Namespace,
 	tracer *apm.Tracer,
+	coord *coordinator.Coordinator,
+	enableProcessStats bool,
 ) (*api.Server, error) {
 	if err := createAgentMonitoringDrop(endpointConfig.Host); err != nil {
 		// log but ignore
@@ -38,7 +41,7 @@ func NewServer(
 		return nil, err
 	}
 
-	return exposeMetricsEndpoint(log, cfg, ns, tracer)
+	return exposeMetricsEndpoint(log, cfg, ns, tracer, coord, enableProcessStats)
 }
 
 func exposeMetricsEndpoint(
@@ -46,6 +49,8 @@ func exposeMetricsEndpoint(
 	config *config.C,
 	ns func(string) *monitoring.Namespace,
 	tracer *apm.Tracer,
+	coord *coordinator.Coordinator,
+	enableProcessStats bool,
 ) (*api.Server, error) {
 	r := mux.NewRouter()
 	if tracer != nil {
@@ -53,6 +58,13 @@ func exposeMetricsEndpoint(
 	}
 	statsHandler := statsHandler(ns("stats"))
 	r.Handle("/stats", createHandler(statsHandler))
+
+	if enableProcessStats {
+		r.Handle("/processes", createHandler(processesHandler(coord)))
+		r.Handle("/processes/{processID}", createHandler(processHandler(coord, statsHandler)))
+		r.Handle("/processes/{processID}/", createHandler(processHandler(coord, statsHandler)))
+		r.Handle("/processes/{processID}/{beatsPath}", createHandler(processHandler(coord, statsHandler)))
+	}
 
 	mux := http.NewServeMux()
 	mux.Handle("/", r)

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -25,6 +25,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/service"
 	"github.com/elastic/elastic-agent-system-metrics/report"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/filelock"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/monitoring"
@@ -170,7 +171,7 @@ func run(override cfgOverrider, modifiers ...component.PlatformModifier) error {
 		return err
 	}
 
-	serverStopFn, err := setupMetrics(logger, cfg.Settings.DownloadConfig.OS(), cfg.Settings.MonitoringConfig, tracer)
+	serverStopFn, err := setupMetrics(logger, cfg.Settings.DownloadConfig.OS(), cfg.Settings.MonitoringConfig, tracer, coord)
 	if err != nil {
 		return err
 	}
@@ -452,6 +453,7 @@ func setupMetrics(
 	operatingSystem string,
 	cfg *monitoringCfg.MonitoringConfig,
 	tracer *apm.Tracer,
+	coord *coordinator.Coordinator,
 ) (func() error, error) {
 	if err := report.SetupMetrics(logger, agentName, version.GetDefaultVersion()); err != nil {
 		return nil, err
@@ -463,7 +465,7 @@ func setupMetrics(
 		Host:    monitoring.AgentMonitoringEndpoint(operatingSystem, cfg),
 	}
 
-	s, err := monitoring.NewServer(logger, endpointConfig, monitoringLib.GetNamespace, tracer)
+	s, err := monitoring.NewServer(logger, endpointConfig, monitoringLib.GetNamespace, tracer, coord, isProcessStatsEnabled(cfg))
 	if err != nil {
 		return nil, errors.New(err, "could not start the HTTP server for the API")
 	}
@@ -471,4 +473,8 @@ func setupMetrics(
 
 	// return server stopper
 	return s.Stop, nil
+}
+
+func isProcessStatsEnabled(cfg *monitoringCfg.MonitoringConfig) bool {
+	return cfg != nil && cfg.HTTP.Enabled
 }

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -396,7 +396,7 @@ func initTracer(agentName, version string, mcfg *monitoringCfg.MonitoringConfig)
 
 	cfg := mcfg.APM
 
-	// nolint:godox // the TODO is intentional
+	//nolint:godox // the TODO is intentional
 	// TODO(stn): Ideally, we'd use apmtransport.NewHTTPTransportOptions()
 	// but it doesn't exist today. Update this code once we have something
 	// available via the APM Go agent.


### PR DESCRIPTION
## What does this PR do?

Reimplemented the ```/processes``` routes as minimum sufficient health check for the cloud.

Addresses "V2: 8.6.0-SNAPSHOT not starting in ESS"
https://github.com/elastic/elastic-agent/issues/1731

This doesn't reimplement the full `/stats` collection functionality for example, because there is a new V2 way to check the health and stats that is decoupled from internal child processes handling implementation.
This change is added just to fix the cloud deployments health breakage short term. In the long term cloud would need to be updated for V2, @blakerouse can provide more details.

We had a brief conversation today about this today and reimplementing ```processes``` route fully would take longer, breaks V2 model and might not be necessary. It would be nice if @simitt or @gcpagano could validate the assumptions that this API implementation is sufficient, based on the sample request/response examples below.

Unfortunately I have not had a chance to test this with the actual cloud deployment yet (yet to figure how to) and will be out till the next week. @cmacknz, @blakerouse if I don't get it tested later tonight, could you please take care of this part?

## Why is it important?

Fixed the broken "V2: 8.6.0-SNAPSHOT not starting in ESS"

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/1731

## Examples of requests/responses with the `/processes` route

```
➜  curl -v 127.0.0.1:6791/processes
{"processes":[{"id":"beat/metrics-monitoring","pid":"metricbeat","binary":"80401","source":{"kind":"internal","outputs":["monitoring"]}},{"id":"http/metrics-monitoring","pid":"metricbeat","binary":"80402","source":{"kind":"internal","outputs":["monitoring"]}},{"id":"system/metrics-default","pid":"metricbeat","binary":"80395","source":{"kind":"configured","outputs":["default"]}},{"id":"osquery-default","pid":"osquerybeat","binary":"80396","source":{"kind":"configured","outputs":["default"]}},{"id":"log-default","pid":"filebeat","binary":"80397","source":{"kind":"configured","outputs":["default"]}},{"id":"winlog-default","pid":"filebeat","binary":"80399","source":{"kind":"configured","outputs":["default"]}},{"id":"filestream-monitoring","pid":"filebeat","binary":"80400","source":{"kind":"internal","outputs":["monitoring"]}}]}%

➜  curl -v 127.0.0.1:6791/processes/osquery-default
{"state":"healthy","message":"Healthy: communicating with pid '80396'"}%

➜  curl -v 127.0.0.1:6791/processes/foobar-something
* Connected to 127.0.0.1 (127.0.0.1) port 6791 (#0)
> GET /processes/foobar-something HTTP/1.1

< HTTP/1.1 404 Not Found
< Content-Type: application/json; charset=utf-8
< Date: Tue, 22 Nov 2022 21:39:00 GMT
< Content-Length: 78
<
{"type":"UNEXPECTED","reason":"matching component foobar-something not found"}
```
