### PR TITLE
Fix upgrade under V2

### DIFF
--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -255,7 +255,7 @@ func (c *Coordinator) ReExec(callback reexec.ShutdownCallbackFn, argOverrides ..
 // Upgrade runs the upgrade process.
 func (c *Coordinator) Upgrade(ctx context.Context, version string, sourceURI string, action *fleetapi.ActionUpgrade) error {
 	// early check outside of upgrader before overridding the state
-	if c.upgradeMgr.Upgradeable() {
+	if !c.upgradeMgr.Upgradeable() {
 		return ErrNotUpgradable
 	}
 


### PR DESCRIPTION
## What does this PR do?

Fix a typo that was preventing upgrades under V2.

## Why is it important?

It fixes the upgrade process for versions >= 8.6.0

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~
## How to test this PR locally
1. Build the `8.6` branch (it will build the version `8.6.0`)
2. Build the `main` branch (it will build the version `8.7.0`)
3. Get a Elastic-Stack up and running with Fleet server
4. Install the Elastic-Agent `v8.6.0`
5. Ensure it is healthy
6. Stop the Elastic-Agent
7. Edit it's `elastic-agent.yml` and add the `dropPath` settings:
    ```yaml
    agent.download:
      dropPath: /home/vagrant/dropPath
    ````
8. Restart the Elastic-Agent
9. Run the upgrade command as root (just to be on the safe side, also export the dropPath env var):
    ```
    AGENT_DROP_PATH=/home/vagrant/dropPath/ ./elastic-agent upgrade  8.7.0  -v -e -d "*"
    ```
10. Ensure the new version (`v8.7.0`) is installed by running `elastic-agent status`

### Caveats
- On my tests after the upgrade the Elastic-Agent was unhealthy, that's probably due to the older Elastic-Stack.
- I'm currently working on unittests for the Elastic-Agent upgrade (https://github.com/elastic/elastic-agent/issues/1359, [WIP test](https://github.com/belimawr/elastic-agent/blob/4e7a3b7ee3a011e4f8ac43c66984bc789448c251/internal/pkg/agent/application/upgrade/upgrade_integration_test.go#L148-L166), it's not ready to be merged yet, but it shows that my fix works)


~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
