### PR TITLE
Fix APM server not being available in cloud.

### DIFF
--- a/internal/pkg/agent/application/monitoring/processes.go
+++ b/internal/pkg/agent/application/monitoring/processes.go
@@ -50,7 +50,15 @@ func processesHandler(coord *coordinator.Coordinator) func(http.ResponseWriter, 
 
 		for _, c := range state.Components {
 			if c.Component.InputSpec != nil {
-				procs = append(procs, process{c.Component.ID, c.Component.InputSpec.BinaryName,
+				displayID := c.Component.ID
+				if strings.Contains(displayID, "apm") {
+					// Cloud explicitly looks for an ID of "apm-server" to determine if APM is in managed mode.
+					// Ensure that this is the ID we use, at the time of writing it is "apm-default".
+					// Otherwise apm-server won't be routable/accessible in cloud.
+					// https://github.com/elastic/elastic-agent/issues/1731#issuecomment-1325862913
+					displayID = "apm-server"
+				}
+				procs = append(procs, process{displayID, c.Component.InputSpec.BinaryName,
 					c.LegacyPID,
 					sourceFromComponentID(c.Component.ID)})
 			}

--- a/internal/pkg/agent/application/monitoring/processes.go
+++ b/internal/pkg/agent/application/monitoring/processes.go
@@ -51,16 +51,19 @@ func processesHandler(coord *coordinator.Coordinator) func(http.ResponseWriter, 
 		for _, c := range state.Components {
 			if c.Component.InputSpec != nil {
 				displayID := c.Component.ID
-				if strings.Contains(displayID, "apm") {
+				if strings.Contains(c.Component.InputSpec.BinaryName, "apm-server") {
 					// Cloud explicitly looks for an ID of "apm-server" to determine if APM is in managed mode.
 					// Ensure that this is the ID we use, at the time of writing it is "apm-default".
 					// Otherwise apm-server won't be routable/accessible in cloud.
 					// https://github.com/elastic/elastic-agent/issues/1731#issuecomment-1325862913
 					displayID = "apm-server"
 				}
-				procs = append(procs, process{displayID, c.Component.InputSpec.BinaryName,
-					c.LegacyPID,
-					sourceFromComponentID(c.Component.ID)})
+				procs = append(procs, process{
+					ID:     displayID,
+					PID:    c.LegacyPID,
+					Binary: c.Component.InputSpec.BinaryName,
+					Source: sourceFromComponentID(c.Component.ID),
+				})
 			}
 		}
 		data := struct {


### PR DESCRIPTION
Cloud monitoring is hard coded to look for /processes/apm-server using the processes API. Force us to always use that name for reporting when APM server is running.

This is can certainly be considered a hack, but it's simple and it should work.

- Relates #1780
