### PR TITLE
[automation] update elastic stack version for testing 8.7.0-11ac5926

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.7.0-c5c709bf-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.7.0-11ac5926-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.7.0-c5c709bf-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.7.0-11ac5926-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Wed, 23 Nov 2022 12:14:56 GMT, release_branch:master, prefix:, end_time:Wed, 23 Nov 2022 16:05:51 GMT, manifest_version:2.1.0, version:8.7.0-SNAPSHOT, branch:master, build_id:8.7.0-11ac5926, build_duration_seconds:13855]