### PR TITLE
snapshot/downloader: fix fetching snapshot URI

### DIFF
--- a/internal/pkg/agent/application/upgrade/artifact/download/snapshot/downloader.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/snapshot/downloader.go
@@ -131,11 +131,9 @@ func snapshotURI(versionOverride string, config *artifact.Config) (string, error
 		}
 
 		index := strings.Index(uri, "/beats/elastic-agent/")
-		if index == -1 {
-			return "", fmt.Errorf("not an agent uri: '%s'", uri)
+		if index != -1 {
+			return uri[:index], nil
 		}
-
-		return uri[:index], nil
 	}
 
 	return "", fmt.Errorf("uri not detected")

--- a/internal/pkg/agent/application/upgrade/artifact/download/snapshot/downloader.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/snapshot/downloader.go
@@ -130,6 +130,14 @@ func snapshotURI(versionOverride string, config *artifact.Config) (string, error
 			return "", fmt.Errorf("uri is not a string")
 		}
 
+		// Because we're iterating over a map from the API response,
+		// the order is random and some elements there do not contain the
+		// `/beats/elastic-agent/` substring, so we need to go through the
+		// whole map before returning an error.
+		//
+		// One of the elements that might be there and do not contain this
+		// substring is the `elastic-agent-shipper`, whose URL is something like:
+		// https://snapshots.elastic.co/8.7.0-d050210c/downloads/elastic-agent-shipper/elastic-agent-shipper-8.7.0-SNAPSHOT-linux-x86_64.tar.gz
 		index := strings.Index(uri, "/beats/elastic-agent/")
 		if index != -1 {
 			return uri[:index], nil


### PR DESCRIPTION
## What does this PR do?

When parsing the response from the artifacts-api to get the latest snapshot (https://artifacts-api.elastic.co/v1/search/%s-SNAPSHOT/elastic-agent) it could happen that an entry that is not from the Elastic-Agent (like the Elastic-Agent-Shipper) would be evaluated and it would cause the `snapshotURI` function return an error.

This PR fixes it by iterating the whole map before returning an error.

## Why is it important?

It fixes a bug

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~
## How to test this PR locally

### Manual testing
1. Build the `8.6` branch (it will build the version `8.6.0`)
2. Build the `main` branch with `SNAPSHOT=true` (it will build the version `8.7.0-SNAPSHOT`)
3. Get a Elastic-Stack up and running with Fleet server
4. Install the Elastic-Agent `v8.6.0`
5. Ensure it is healthy
6. Stop the Elastic-Agent
7. Edit it's `elastic-agent.yml` and add the `dropPath` settings:
    ```yaml
    agent.download:
      dropPath: /home/vagrant/dropPath
    ````
8. Copy the built artefacts to the drop path
8. Restart the Elastic-Agent
9. Run the upgrade command as root (just to be on the safe side, also export the dropPath env var):
    ```
    AGENT_DROP_PATH=/home/vagrant/dropPath/ ./elastic-agent upgrade 8.7.0-SNAPSHOT -v -e -d "*"
    ```

The caveat here is that because the bug depends on the order the API response is iterated on, sometimes it just works.

### Automated version
1. Grab my unittest file: https://github.com/belimawr/elastic-agent/blob/4e7a3b7ee3a011e4f8ac43c66984bc789448c251/internal/pkg/agent/application/upgrade/upgrade_integration_test.go
2. Run it.

The same problem as testing manually, it depends on the order of iteration on the map, so it was an intermittent bug.

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~

