### PR TITLE
Handle requests for /processes/apm-server.

### DIFF
--- a/internal/pkg/agent/application/monitoring/process.go
+++ b/internal/pkg/agent/application/monitoring/process.go
@@ -36,7 +36,7 @@ func processHandler(coord *coordinator.Coordinator, statsHandler func(http.Respo
 		state := coord.State(false)
 
 		for _, c := range state.Components {
-			if c.Component.ID == id {
+			if matchesCloudProcessID(&c.Component, id) {
 				data := struct {
 					State   string `json:"state"`
 					Message string `json:"message"`

--- a/internal/pkg/agent/application/monitoring/processes.go
+++ b/internal/pkg/agent/application/monitoring/processes.go
@@ -50,16 +50,8 @@ func processesHandler(coord *coordinator.Coordinator) func(http.ResponseWriter, 
 
 		for _, c := range state.Components {
 			if c.Component.InputSpec != nil {
-				displayID := c.Component.ID
-				if strings.Contains(c.Component.InputSpec.BinaryName, "apm-server") {
-					// Cloud explicitly looks for an ID of "apm-server" to determine if APM is in managed mode.
-					// Ensure that this is the ID we use, at the time of writing it is "apm-default".
-					// Otherwise apm-server won't be routable/accessible in cloud.
-					// https://github.com/elastic/elastic-agent/issues/1731#issuecomment-1325862913
-					displayID = "apm-server"
-				}
 				procs = append(procs, process{
-					ID:     displayID,
+					ID:     expectedCloudProcessID(&c.Component),
 					PID:    c.LegacyPID,
 					Binary: c.Component.InputSpec.BinaryName,
 					Source: sourceFromComponentID(c.Component.ID),

--- a/internal/pkg/agent/application/monitoring/processes_cloud.go
+++ b/internal/pkg/agent/application/monitoring/processes_cloud.go
@@ -1,0 +1,32 @@
+package monitoring
+
+import (
+	"strings"
+
+	"github.com/elastic/elastic-agent/pkg/component"
+)
+
+func expectedCloudProcessID(c *component.Component) string {
+	// Cloud explicitly looks for an ID of "apm-server" to determine if APM is in managed mode.
+	// Ensure that this is the ID we use, in agent v2 the ID is usually "apm-default".
+	// Otherwise apm-server won't be routable/accessible in cloud.
+	// https://github.com/elastic/elastic-agent/issues/1731#issuecomment-1325862913
+	if strings.Contains(c.InputSpec.BinaryName, "apm-server") {
+		return "apm-server"
+	}
+
+	return c.ID
+}
+
+func matchesCloudProcessID(c *component.Component, id string) bool {
+	// Similar to the case above, cloud currently makes a call to /processes/apm-server
+	// to find the APM server address. Rather than change all of the monitoring in cloud,
+	// it is easier to just make sure the existing ID maps to the APM server component.
+	if strings.Contains(id, "apm-server") {
+		if strings.Contains(c.InputSpec.BinaryName, "apm-server") {
+			return true
+		}
+	}
+
+	return id == c.ID
+}

--- a/internal/pkg/agent/application/monitoring/processes_cloud_test.go
+++ b/internal/pkg/agent/application/monitoring/processes_cloud_test.go
@@ -3,8 +3,9 @@ package monitoring
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/elastic-agent/pkg/component"
-	"gotest.tools/assert"
 )
 
 func TestExpectedCloudProcessID(t *testing.T) {

--- a/internal/pkg/agent/application/monitoring/processes_cloud_test.go
+++ b/internal/pkg/agent/application/monitoring/processes_cloud_test.go
@@ -1,0 +1,99 @@
+package monitoring
+
+import (
+	"testing"
+
+	"github.com/elastic/elastic-agent/pkg/component"
+	"gotest.tools/assert"
+)
+
+func TestExpectedCloudProcessID(t *testing.T) {
+	testcases := []struct {
+		name      string
+		component component.Component
+		id        string
+	}{
+		{
+			"APM",
+			component.Component{
+				ID:        "apm-default",
+				InputSpec: &component.InputRuntimeSpec{BinaryName: "apm-server"},
+			},
+			"apm-server",
+		},
+		{
+			"NotAPM",
+			component.Component{
+				ID:        "filestream-default",
+				InputSpec: &component.InputRuntimeSpec{BinaryName: "filebeat"},
+			},
+			"filestream-default",
+		},
+		{
+			"AlmostAPM",
+			component.Component{
+				ID:        "apm-java-attacher-default",
+				InputSpec: &component.InputRuntimeSpec{BinaryName: "apm-java-attacher"},
+			},
+			"apm-java-attacher-default",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.id, expectedCloudProcessID(&tc.component))
+		})
+	}
+}
+
+func TestMatchesCloudProcessID(t *testing.T) {
+	testcases := []struct {
+		name      string
+		processID string
+		component component.Component
+		matches   bool
+	}{
+		{
+			"MatchesAPMServer",
+			"apm-server",
+			component.Component{
+				ID:        "apm-default",
+				InputSpec: &component.InputRuntimeSpec{BinaryName: "apm-server"},
+			},
+			true,
+		},
+		{
+			"MatchesAPMDefault",
+			"apm-default",
+			component.Component{
+				ID:        "apm-default",
+				InputSpec: &component.InputRuntimeSpec{BinaryName: "apm-server"},
+			},
+			true,
+		},
+		{
+			"MatchesFilestream",
+			"filestream-default",
+			component.Component{
+				ID:        "filestream-default",
+				InputSpec: &component.InputRuntimeSpec{BinaryName: "filebeat"},
+			},
+			true,
+		},
+		{
+			"DoesNotMatch",
+			"filestream-default",
+			component.Component{
+				ID:        "metricbeat-default",
+				InputSpec: &component.InputRuntimeSpec{BinaryName: "metricbeat"},
+			},
+			false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.matches, matchesCloudProcessID(&tc.component, tc.processID))
+		})
+	}
+}


### PR DESCRIPTION
Add special handling for the apm-server process ID for the /processes/$ID route as well as the /processes response body.

V2 changed the process IDs used for these APIs, which has broken health checks in the cloud provisioning infrastructure. It is much faster to add a few lines of code to special case this in the agent than it is to update all of the cloud monitoring infrastructure.

- Relates https://github.com/elastic/ingest-dev/issues/1418
