### PR TITLE
Include host in hosts

### DIFF
--- a/internal/pkg/agent/application/fleet_server_bootstrap.go
+++ b/internal/pkg/agent/application/fleet_server_bootstrap.go
@@ -88,6 +88,12 @@ func FleetServerComponentModifier(serverCfg *configuration.FleetServerConfig) co
 // that need to be able to connect to fleet server.
 func InjectFleetConfigComponentModifier(fleetCfg *configuration.FleetAgentConfig) coordinator.ComponentsModifier {
 	return func(comps []component.Component, cfg map[string]interface{}) ([]component.Component, error) {
+		hostsStr := fleetCfg.Client.GetHosts()
+		fleetHosts := make([]interface{}, 0, len(hostsStr))
+		for _, host := range hostsStr {
+			fleetHosts = append(fleetHosts, host)
+		}
+
 		for i, comp := range comps {
 			if comp.InputSpec != nil && (comp.InputSpec.InputType == endpoint || comp.InputSpec.InputType == apmServer) {
 				for j, unit := range comp.Units {
@@ -104,6 +110,7 @@ func InjectFleetConfigComponentModifier(fleetCfg *configuration.FleetAgentConfig
 						if v, ok := unitCfgMap["fleet"]; ok {
 							if m, ok := v.(map[string]interface{}); ok {
 								m["host"] = cfg["host"]
+								m["hosts"] = fleetHosts
 							}
 						}
 						unitCfg, err := component.ExpectedConfig(unitCfgMap)

--- a/internal/pkg/agent/application/fleet_server_bootstrap_test.go
+++ b/internal/pkg/agent/application/fleet_server_bootstrap_test.go
@@ -7,7 +7,6 @@ package application
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -78,8 +77,17 @@ func TestInjectFleetConfigComponentModifier(t *testing.T) {
 	hostsRaw, found := fleetMap["hosts"]
 	require.True(t, found)
 
-	fmt.Println(hostRaw)
-	fmt.Println(hostsRaw)
+	hostMap, ok := hostRaw.(map[string]interface{})
+	require.True(t, ok)
+
+	idRaw, found := hostMap["id"]
+	require.True(t, found)
+	require.Equal(t, "agent-id", idRaw.(string))
+
+	hostsSlice, ok := hostsRaw.([]interface{})
+	require.True(t, ok)
+	require.Equal(t, 1, len(hostsSlice))
+	require.Equal(t, "sample.host", hostsSlice[0].(string))
 
 }
 

--- a/internal/pkg/agent/application/fleet_server_bootstrap_test.go
+++ b/internal/pkg/agent/application/fleet_server_bootstrap_test.go
@@ -7,16 +7,81 @@ package application
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
+	"github.com/elastic/elastic-agent/internal/pkg/remote"
 	"github.com/elastic/elastic-agent/internal/pkg/testutils"
+	"github.com/elastic/elastic-agent/pkg/component"
 )
+
+func TestInjectFleetConfigComponentModifier(t *testing.T) {
+	fleetConfig := &configuration.FleetAgentConfig{
+		Enabled: true,
+		Client: remote.Config{
+			Host: "sample.host",
+		},
+	}
+
+	cfg := map[string]interface{}{
+		"host": map[string]interface{}{
+			"id": "agent-id",
+		},
+	}
+
+	modifier := InjectFleetConfigComponentModifier(fleetConfig)
+	apmSource, err := structpb.NewStruct(map[string]interface{}{
+		"sample": "config",
+	})
+	require.NoError(t, err)
+
+	apmComponent := component.Component{
+		InputSpec: &component.InputRuntimeSpec{
+			InputType: "apm",
+		},
+		Units: []component.Unit{
+			{
+				Type: client.UnitTypeInput,
+				Config: &proto.UnitExpectedConfig{
+					Type:   "apm",
+					Source: apmSource,
+				},
+			},
+		},
+	}
+	comps := []component.Component{apmComponent}
+	resComps, err := modifier(comps, cfg)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(resComps))
+	require.Equal(t, 1, len(resComps[0].Units))
+	resConfig := resComps[0].Units[0].Config.Source.AsMap()
+	fleet, ok := resConfig["fleet"]
+	require.True(t, ok)
+
+	fleetMap, ok := fleet.(map[string]interface{})
+	require.True(t, ok)
+
+	hostRaw, found := fleetMap["host"]
+	require.True(t, found)
+
+	hostsRaw, found := fleetMap["hosts"]
+	require.True(t, found)
+
+	fmt.Println(hostRaw)
+	fmt.Println(hostsRaw)
+
+}
 
 func TestFleetServerBootstrapManager(t *testing.T) {
 	l := testutils.NewErrorLogger(t)


### PR DESCRIPTION
## What does this PR do?

In case host has a value and hosts is omitted injected config is without hosts information.
this pr copies host into hosts if needed.

## Why is it important?

`fleet.hosts` is omitted when only `fleet.host` is specified. 
when we inject config  we replace `fleet.host` with information about id e.g
```
"fleet": {
        "access_api_key": "xxxxxxdvUUJITm80OFQyb1YwOU86clBNalZ2ZjNUM0M5a0U2SEgzc2N4Zw==",
        ...
        "host": {
            "id": "2628AB39-F770-5FC3-B7F1-8CC95E506B0D"
        },
        "hosts": [
            "https://ffffe9b5f47d409099163e5e8e5e4f4e.fleet.us-west2.gcp.elastic-cloud.com:443"
        ],
    },
```

in case we have input config:
```json
"fleet": {
        "access_api_key": "xxxxxxdvUUJITm80OFQyb1YwOU86clBNalZ2ZjNUM0M5a0U2SEgzc2N4Zw==",
        ...
        "host":  "https://ffffe9b5f47d409099163e5e8e5e4f4e.fleet.us-west2.gcp.elastic-cloud.com:443",
        "hosts":  {
                "https://ffffe9b5f47d409099163e5e8e5e4f4e.fleet.us-west2.gcp.elastic-cloud.com:443"
         }
    },
```

everything is fine

but in case we have 
```json
"fleet": {
        "access_api_key": "xxxxxxdvUUJITm80OFQyb1YwOU86clBNalZ2ZjNUM0M5a0U2SEgzc2N4Zw==",
        ...
        "host":  "https://ffffe9b5f47d409099163e5e8e5e4f4e.fleet.us-west2.gcp.elastic-cloud.com:443",
    },
```

we end up with 
```
"fleet": {
        "access_api_key": "xxxxxxdvUUJITm80OFQyb1YwOU86clBNalZ2ZjNUM0M5a0U2SEgzc2N4Zw==",
        ...
        "host": {
            "id": "2628AB39-F770-5FC3-B7F1-8CC95E506B0D"
        },
       /// "hosts" is missing
    },
```


