### PR TITLE
Fix: Elastic-Agent fails to re-start during upgrade

### DIFF
--- a/changelog/fragments/1669665017-fix-nil-action-ack-crash-after-local-upgrade.yaml
+++ b/changelog/fragments/1669665017-fix-nil-action-ack-crash-after-local-upgrade.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix Elastic-Agent fails to re-start during upgrade
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 1805
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 1788

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -195,12 +195,17 @@ func (u *Upgrader) Ack(ctx context.Context, acker acker.Acker) error {
 		return nil
 	}
 
-	if err := acker.Ack(ctx, marker.Action); err != nil {
-		return err
-	}
+	// Action can be nil if the upgrade was called locally.
+	// Should handle gracefully
+	// https://github.com/elastic/elastic-agent/issues/1788
+	if marker.Action != nil {
+		if err := acker.Ack(ctx, marker.Action); err != nil {
+			return err
+		}
 
-	if err := acker.Commit(ctx); err != nil {
-		return err
+		if err := acker.Commit(ctx); err != nil {
+			return err
+		}
 	}
 
 	marker.Acked = true


### PR DESCRIPTION
## What does this PR do?

Fixes the crash on agent restart after local upgrade, when the upgrade action is missing (nil)

## Why is it important?

Fixed crash https://github.com/elastic/elastic-agent/issues/1788

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation


## How to test this PR locally

Check the original issue for the repro steps.
One update is that the ```dropPath``` has two different configuration and yml tags and issue  step uses the yml tag ```dropPath```, while it should be ```drop_path```.

```
agent.download:
  dropPath: /your/drop/path
  drop_path: /your/drop/path  
```

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/1788

## Screenshots

The agent is restarted after upgrade 
<img width="1628" alt="Screen Shot 2022-11-28 at 1 54 56 PM" src="https://user-images.githubusercontent.com/872351/204359918-03ffcde4-a320-45a1-af50-7215f336e173.png">

Content of the ```.update-marker``` after upgrade
<img width="668" alt="Screen Shot 2022-11-28 at 1 56 10 PM" src="https://user-images.githubusercontent.com/872351/204359962-5be5a09c-0a23-4655-b32a-32349cabc78d.png">

