### PR TITLE
Fix erroneously created http url directory path for monitoring

### DIFF
--- a/changelog/fragments/1669668741-fix-erroneous-http-url-directory-created-for-monitoring.yaml
+++ b/changelog/fragments/1669668741-fix-erroneous-http-url-directory-created-for-monitoring.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: fix erroneous http url directory created for monitoring
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 1811
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: 1234

--- a/internal/pkg/agent/application/monitoring/server.go
+++ b/internal/pkg/agent/application/monitoring/server.go
@@ -6,6 +6,7 @@ package monitoring
 
 import (
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -75,7 +76,7 @@ func exposeMetricsEndpoint(
 }
 
 func createAgentMonitoringDrop(drop string) error {
-	if drop == "" || runtime.GOOS == "windows" {
+	if drop == "" || runtime.GOOS == "windows" || isHttpUrl(drop) {
 		return nil
 	}
 
@@ -97,4 +98,9 @@ func createAgentMonitoringDrop(drop string) error {
 	}
 
 	return os.Chown(path, os.Geteuid(), os.Getegid())
+}
+
+func isHttpUrl(s string) bool {
+	u, err := url.Parse(strings.TrimSpace(s))
+	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
 }

--- a/internal/pkg/agent/application/monitoring/server_test.go
+++ b/internal/pkg/agent/application/monitoring/server_test.go
@@ -1,0 +1,65 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package monitoring
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestIsHTTPUrl(t *testing.T) {
+
+	tests := []struct {
+		name string
+		s    string
+		res  bool
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "/",
+			s:    "/",
+		},
+		{
+			name: "relative",
+			s:    "foo/bar",
+		},
+		{
+			name: "absolute",
+			s:    "/foo/bar",
+		},
+		{
+			name: "file",
+			s:    "file://foo/bar",
+		},
+		{
+			name: "http",
+			s:    "http://localhost:5691",
+			res:  true,
+		},
+		{
+			name: "https",
+			s:    "https://localhost:5691",
+			res:  true,
+		},
+		{
+			name: "http space prefix",
+			s:    " http://localhost:5691",
+			res:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res := isHttpUrl(tc.s)
+			diff := cmp.Diff(tc.res, res)
+			if diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Fixes erroneously created http url directory path for monitoring when the agent runs. 
Added a check if the url is passed in the path.

```
➜ sudo ls -la /Library/Elastic/Agent/http\:/localhost\:6791
total 0
drwxr-x---  2 root  wheel  64 Nov 28 11:12 .
drwxr-x---  3 root  wheel  96 Nov 28 11:12 ..
```

## Why is it important?

No erroneous directories should be created during the agent execution.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation


## How to test this PR locally

1. Install the agent
2. Make sure the agent create "http" directory, something like: ``` /Library/Elastic/Agent/http\:/localhost\:6791``` 

- Closes https://github.com/elastic/elastic-agent/issues/1806
