### PR TITLE
Drop events from monitoring components

### DIFF
--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -311,7 +311,7 @@ func (b *BeatsMonitor) injectLogsInput(cfg map[string]interface{}, componentIDTo
 				},
 			},
 			"processors": []interface{}{
-				// drop all events from filestream monitoring component (do it early; no need for extra processing)
+				// drop all events from monitoring components (do it early)
 				// without dropping these events the filestream gets stuck in an infinite loop
 				// if filestream hits an issue publishing the events it logs an error which then filestream monitor
 				// will read from the logs and try to also publish that new log message (thus the infinite loop)
@@ -322,6 +322,18 @@ func (b *BeatsMonitor) injectLogsInput(cfg map[string]interface{}, componentIDTo
 								map[string]interface{}{
 									"equals": map[string]interface{}{
 										"component.dataset": fmt.Sprintf("elastic_agent.filestream_%s", monitoringOutput),
+									},
+								},
+								// for consistency this monitor is also not shipped (fetch-able with diagnostics)
+								map[string]interface{}{
+									"equals": map[string]interface{}{
+										"component.dataset": fmt.Sprintf("elastic_agent.beats_metrics_%s", monitoringOutput),
+									},
+								},
+								// for consistency with this monitor is also not shipped (fetch-able with diagnostics)
+								map[string]interface{}{
+									"equals": map[string]interface{}{
+										"component.dataset": fmt.Sprintf("elastic_agent.http_metrics_%s", monitoringOutput),
 									},
 								},
 							},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Drops all events from being published from the `component.dataset: elastic_agent.filestream_monitoring`,  `component.dataset: elastic_agent.beats_metrics_monitoring`, and  `component.dataset: elastic_agent.http_metrics_monitoring`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without dropping these events the filestream gets stuck in an infinite loop. If filestream hits an issue publishing the events it logs an error which then filestream monitor will read from the logs and try to also publish that new log message (thus the infinite loop).

This means that no logs from the monitoring components will be made available in Fleet UI. They will still be retrievable with diagnostics as well as included in the unified elastic-agent log.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
