### PR TITLE
Fix osqueryd and osquery-extension.ext permissions

### DIFF
--- a/changelog/fragments/1669739947-fix-osqueryd-and-osquery-extension.ext-permissions.yaml
+++ b/changelog/fragments/1669739947-fix-osqueryd-and-osquery-extension.ext-permissions.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix osqueryd and osquery-extension.ext permissions
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 1829
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: 1234

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -18,6 +18,7 @@ RUN mkdir -p {{ $beatHome }}/data {{ $beatHome }}/data/elastic-agent-{{ commit_s
     ln -s {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/elastic-agent {{ $beatBinary }} && \
     chmod 0755 {{ $beatHome }}/data/elastic-agent-*/elastic-agent && \
     chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/*beat && \
+    (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/osquery* || true) && \
     (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/apm-server || true) && \
     (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/endpoint-security || true) && \
     (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/fleet-server || true) && \


### PR DESCRIPTION
## What does this PR do?

Fixes permissions for osqueryd and osquery-extension.ext

Was:
<img width="592" alt="Screen Shot 2022-11-29 at 10 48 43 AM" src="https://user-images.githubusercontent.com/872351/204587337-bc2980e2-9291-49ef-b16a-17a3ab379ea0.png">

Should be:
<img width="634" alt="Screen Shot 2022-11-29 at 11 27 19 AM" src="https://user-images.githubusercontent.com/872351/204587400-551ba393-4f10-4739-a7a5-d27bdf2b0257.png">


## Why is it important?

Fixes the agent going unhealthy when osquery integration is added to the policy (Not linking to the issue since it is in the private repo). Osquerybeat is unable to run the osqueryd 
```
Exiting: fork/exec /usr/share/elastic-agent/data/elastic-agent-0e669f/components/osqueryd: operation not permitted
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation


