### PR TITLE
Add missing metrics input types.

### DIFF
--- a/specs/metricbeat.spec.yml
+++ b/specs/metricbeat.spec.yml
@@ -187,3 +187,122 @@ inputs:
     shippers: *shippers
     command:
       args: *args
+  - name: activemq/metrics
+    description: "ActiveMQ metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
+  - name: apache/metrics
+    description: "Apache metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
+  - name: etcd/metrics
+    description: "Etcd metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
+  - name: gcp/metrics
+    description: "GCP metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
+  - name: haproxy/metrics
+    description: "HAProxy metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
+  - name: iis/metrics
+    description: "IIS metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
+  - name: jolokia/metrics
+    description: "Jolokia metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
+  - name: kafka/metrics
+    description: "Kafka metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
+  - name: nats/metrics
+    description: "NATS metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
+  - name: nginx/metrics
+    description: "NGINX metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
+  - name: prometheus/metrics
+    description: "Prometheus metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
+  - name: rabbitmq/metrics
+    description: "RabbitMQ metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
+  - name: sql/metrics
+    description: "SQL metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
+  - name: stan/metrics
+    description: "Stan metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
+  - name: traefik/metrics
+    description: "Traefik metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
+  - name: vsphere/metrics
+    description: "VSphere metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
+  - name: zookeeper/metrics
+    description: "ZooKeeper metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args


### PR DESCRIPTION
- Closes https://github.com/elastic/elastic-agent/issues/1828

We are missing several of the Metricbeat input metrics typed. I just searched the integrations repository for the list of every metrics input and added the ones that were missing. See https://github.com/elastic/elastic-agent/issues/1828#issuecomment-1330943678