### PR TITLE
actions: use go-version-file: .go-version

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,11 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: check pr-has-fragment
       run: |
         GOBIN=$PWD/bin go install github.com/elastic/elastic-agent-changelog-tool@latest

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,14 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # Uses Go version from the repository.
-      - name: Read .go-version file
-        id: goversion
-        run: echo "::set-output name=version::$(cat .go-version)"
-
       - uses: actions/setup-go@v3
         with:
-          go-version: "${{ steps.goversion.outputs.version }}"
+          go-version-file: .go-version
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,11 +12,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Install dependencies
       run:  go install github.com/magefile/mage
     - name: Run build


### PR DESCRIPTION
 ## What does this PR do?

Use the `setup-go` action with the `go-version-file` input so it reads the file `.go-version`

## Why is it important?

Avoid the logic to read and create env variables and use the undocumented `.go-version-file` 

See https://github.com/actions/setup-go/pull/295