### PR TITLE
[8.6] Use v1 data stream names for log shipping

### DIFF
--- a/pkg/component/runtime/command.go
+++ b/pkg/component/runtime/command.go
@@ -462,7 +462,7 @@ func (c *CommandRuntime) getCommandSpec() *component.CommandSpec {
 
 func attachOutErr(comp component.Component, cmdSpec *component.CommandSpec, typeStr string, binaryName string) process.CmdOption {
 	return func(cmd *exec.Cmd) error {
-		dataset := fmt.Sprintf("elastic_agent.%s", strings.ReplaceAll(strings.ReplaceAll(comp.ID, "-", "_"), "/", "_"))
+		dataset := fmt.Sprintf("elastic_agent.%s", strings.ReplaceAll(strings.ReplaceAll(binaryName, "-", "_"), "/", "_"))
 		logger := logger.NewWithoutConfig("").With("component", map[string]interface{}{
 			"id":      comp.ID,
 			"type":    typeStr,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Changes the elastic-agent log monitoring to use the old names that match v1. This is for 8.6 only!

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So no fixes are required on Fleet side for new v2 architecture to work with 8.6.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

- Relates https://github.com/elastic/elastic-agent/issues/1814
- Closes https://github.com/elastic/elastic-agent/issues/1847