### PR TITLE
Add agent logging level to fleet configuration

### DIFF
--- a/changelog/fragments/1669845868-add-agent-logging-level-to-fleet-configuration.yaml
+++ b/changelog/fragments/1669845868-add-agent-logging-level-to-fleet-configuration.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add agent logging level to fleet configuration
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 1856
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 1853

--- a/internal/pkg/agent/application/application.go
+++ b/internal/pkg/agent/application/application.go
@@ -105,7 +105,7 @@ func New(
 
 			composableManaged = true
 			compModifiers = append(compModifiers, FleetServerComponentModifier(cfg.Fleet.Server),
-				InjectFleetConfigComponentModifier(cfg.Fleet))
+				InjectFleetConfigComponentModifier(cfg.Fleet, agentInfo))
 
 			managed, err = newManagedConfigManager(log, agentInfo, cfg, store, runtime)
 			if err != nil {


### PR DESCRIPTION
## What does this PR do?

Adds missing agent logging level to fleet configuration. 
The Endpoint expects as
```
fleet:
  agent:
    logging:
      level: info
```
Refer for more details to https://github.com/elastic/elastic-agent/issues/1853

The fleet configuration example after this change:
```
    "fleet": {
        "access_api_key": "xXxXYnlvUUJPYzlfZ1A4X0ZlWnk6ZGVEQ2RaR3ZUWWV6UldrbDd4VUJ2QQ==",
        "agent": {
            "id": "88e91b22-2f3a-4047-a951-48255c5b3026",
            "logging": {
                "level": "debug"
            }
        },
        "enabled": true,
        "host": {
            "id": "b62e91be682a4108bbb080152cc5eeac"
        },
        "hosts": [
            "https://ccccc998d3c74a64890381fdcc38c9c9.fleet.us-central1.gcp.foundit.no:443"
        ],
        "protocol": "http",
        "ssl": {
            "renegotiation": "never",
            "verification_mode": "full"
        },
        "timeout": "10m0s"
    }
```

## Why is it important?

Fixed the issue for Endpoint missing logging configuration https://github.com/elastic/elastic-agent/issues/1853

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/1853

