### PR TITLE
Allow empty redirect for processes endpoint

### DIFF
--- a/internal/pkg/agent/application/monitoring/process.go
+++ b/internal/pkg/agent/application/monitoring/process.go
@@ -56,12 +56,6 @@ func processHandler(coord *coordinator.Coordinator, statsHandler func(http.Respo
 			return statsHandler(w, r)
 		}
 
-		if strings.HasPrefix(componentID, fleetServerPrefix) {
-			// special case, fleet server is expected to return stats right away
-			// removing this would be breaking
-			return redirectToPath(w, r, componentID, "stats", operatingSystem)
-		}
-
 		if isProcessRedirectable(componentID) {
 			// special handling for redirectable processes
 			// apm needs its own output even for no path
@@ -69,6 +63,12 @@ func processHandler(coord *coordinator.Coordinator, statsHandler func(http.Respo
 			_, ok := redirectPathAllowlist[metricsPath]
 			if !ok {
 				return errorfWithStatus(http.StatusNotFound, "process specified does not expose metrics")
+			}
+
+			if strings.HasPrefix(componentID, fleetServerPrefix) && metricsPathKey == "" {
+				// special case, fleet server is expected to return stats right away
+				// removing this would be breaking
+				metricsPath = "stats"
 			}
 
 			return redirectToPath(w, r, componentID, metricsPath, operatingSystem)

--- a/internal/pkg/agent/application/monitoring/process.go
+++ b/internal/pkg/agent/application/monitoring/process.go
@@ -37,7 +37,7 @@ var redirectPathAllowlist = map[string]struct{}{
 }
 
 var redirectableProcesses = []string{
-	apmPrefix,
+	apmTypePrefix,
 	fleetServerPrefix,
 }
 
@@ -57,6 +57,8 @@ func processHandler(coord *coordinator.Coordinator, statsHandler func(http.Respo
 			return statsHandler(w, r)
 		}
 
+		componentID = cloudComponentIDToAgentInputType(componentID)
+
 		if isProcessRedirectable(componentID) {
 			// special handling for redirectable processes
 			// apm needs its own output even for no path
@@ -70,10 +72,6 @@ func processHandler(coord *coordinator.Coordinator, statsHandler func(http.Respo
 				// special case, fleet server is expected to return stats right away
 				// removing this would be breaking
 				metricsPath = "stats"
-			}
-			if strings.HasPrefix(componentID, apmPrefix) {
-				// from binary name back to input type, keep the output name as is (apm-default)
-				componentID = strings.Replace(componentID, apmPrefix, apmTypePrefix, -1)
 			}
 
 			return redirectToPath(w, r, componentID, metricsPath, operatingSystem)

--- a/internal/pkg/agent/application/monitoring/process.go
+++ b/internal/pkg/agent/application/monitoring/process.go
@@ -26,6 +26,7 @@ const (
 	metricsPathKey    = "metricsPath"
 	timeout           = 10 * time.Second
 	apmPrefix         = "apm-server"
+	apmTypePrefix     = "apm"
 	fleetServerPrefix = "fleet-server"
 )
 
@@ -69,6 +70,10 @@ func processHandler(coord *coordinator.Coordinator, statsHandler func(http.Respo
 				// special case, fleet server is expected to return stats right away
 				// removing this would be breaking
 				metricsPath = "stats"
+			}
+			if strings.HasPrefix(componentID, apmPrefix) {
+				// from binary name back to input type, keep the output name as is (apm-default)
+				componentID = strings.Replace(componentID, apmPrefix, apmTypePrefix, -1)
 			}
 
 			return redirectToPath(w, r, componentID, metricsPath, operatingSystem)

--- a/internal/pkg/agent/application/monitoring/processes_cloud.go
+++ b/internal/pkg/agent/application/monitoring/processes_cloud.go
@@ -12,7 +12,8 @@ func expectedCloudProcessID(c *component.Component) string {
 	// Otherwise apm-server won't be routable/accessible in cloud.
 	// https://github.com/elastic/elastic-agent/issues/1731#issuecomment-1325862913
 	if strings.Contains(c.InputSpec.BinaryName, "apm-server") {
-		return "apm-server"
+		// cloud understands `apm-server-default` and does not understand `apm-default`
+		return strings.Replace(c.ID, "apm-", "apm-server-", 1)
 	}
 
 	return c.ID

--- a/internal/pkg/agent/application/monitoring/processes_cloud.go
+++ b/internal/pkg/agent/application/monitoring/processes_cloud.go
@@ -6,6 +6,14 @@ import (
 	"github.com/elastic/elastic-agent/pkg/component"
 )
 
+func cloudComponentIDToAgentInputType(componentID string) string {
+	if strings.HasPrefix(componentID, apmPrefix) {
+		// from binary name back to input type, keep the output name as is (apm-default)
+		return strings.Replace(componentID, apmPrefix, apmTypePrefix, 1)
+	}
+	return componentID
+}
+
 func expectedCloudProcessID(c *component.Component) string {
 	// Cloud explicitly looks for an ID of "apm-server" to determine if APM is in managed mode.
 	// Ensure that this is the ID we use, in agent v2 the ID is usually "apm-default".

--- a/internal/pkg/agent/application/monitoring/processes_cloud_test.go
+++ b/internal/pkg/agent/application/monitoring/processes_cloud_test.go
@@ -8,6 +8,51 @@ import (
 	"github.com/elastic/elastic-agent/pkg/component"
 )
 
+func TestCloudComponentIDToAgentInputType(t *testing.T) {
+	testcases := []struct {
+		name        string
+		componentID string
+		expectedID  string
+	}{
+		{
+			"apm server",
+			"apm-server-default",
+			"apm-default",
+		},
+		{
+			"not apm",
+			"filestream-default",
+			"filestream-default",
+		},
+		{
+			"almost apm",
+			"apm-java-attacher-default",
+			"apm-java-attacher-default",
+		},
+		{
+			"apm in output name",
+			"endpoint-apm-output",
+			"endpoint-apm-output",
+		},
+		{
+			"apm-server in output name",
+			"endpoint-apm-server-output",
+			"endpoint-apm-server-output",
+		},
+		{
+			"apm-server everywhere",
+			"apm-server-with-apm-server-output",
+			"apm-with-apm-server-output",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedID, cloudComponentIDToAgentInputType(tc.componentID))
+		})
+	}
+}
+
 func TestExpectedCloudProcessID(t *testing.T) {
 	testcases := []struct {
 		name      string

--- a/internal/pkg/agent/application/monitoring/processes_cloud_test.go
+++ b/internal/pkg/agent/application/monitoring/processes_cloud_test.go
@@ -20,7 +20,7 @@ func TestExpectedCloudProcessID(t *testing.T) {
 				ID:        "apm-default",
 				InputSpec: &component.InputRuntimeSpec{BinaryName: "apm-server"},
 			},
-			"apm-server",
+			"apm-server-default",
 		},
 		{
 			"NotAPM",


### PR DESCRIPTION
fixed apm naming weirdness and empty path redirect handling.

in processes we need to return `apm-server-{outputName}` instead of our representation where we replaced binary name with input type.

then on process handler we need to translate it back from `apm-server-{outputName}` to `apm-{outputName}` so we find correct socket with endpoint.
 
<img width="605" alt="image" src="https://user-images.githubusercontent.com/1522652/205106073-079fde9a-4e51-4c2b-ba9e-fcc618364923.png">

<img width="760" alt="image" src="https://user-images.githubusercontent.com/1522652/205106181-38bb6b79-30ba-42e7-8f4a-09f8fd883237.png">

