### PR TITLE
Change local fleet-server connection to localhost:8221

### DIFF
--- a/changelog/fragments/1669929902-fix-local-fleet-server-port.yaml
+++ b/changelog/fragments/1669929902-fix-local-fleet-server-port.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: elastic-agent will use local port when running fleet-server
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: The elastic-agent will now use the 8221 locally bound port when running fleet-server instead of the external port (8220).
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: 1234
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: 1234

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -552,8 +552,8 @@ func (c *enrollCmd) enroll(ctx context.Context, persistentConfig map[string]inte
 		if c.options.InternalURL != "" {
 			fleetConfig.Client.Host = c.options.InternalURL
 			// fleet-server will bind the internal listenter to localhost:8221
-			// InternalURL is localhost:8221, however cert uses $HOSTNAME, so we need to disable verification.
-			fleetConfig.Client.Transport.TLS.VerificationMode = tlscommon.VerifyNone
+			// InternalURL is localhost:8221, however cert uses $HOSTNAME, so we need to disable hostname verification.
+			fleetConfig.Client.Transport.TLS.VerificationMode = tlscommon.VerifyCertificate
 		}
 	}
 

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -305,7 +305,7 @@ func (c *enrollCmd) fleetServerBootstrap(ctx context.Context, persistentConfig m
 	if c.options.FleetServer.InternalPort == 0 {
 		c.options.FleetServer.InternalPort = defaultFleetServerInternalPort
 	}
-	_, err := getDaemonStatus(ctx)
+	_, err := getDaemonState(ctx)
 	if err != nil {
 		if !c.options.FleetServer.SpawnAgent {
 			// wait longer to try and communicate with the Elastic Agent

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -230,7 +230,8 @@ func (c *enrollCmd) Execute(ctx context.Context, streams *cli.IOStreams) error {
 	if localFleetServer {
 		// Ensure that the agent does not use a proxy configuration
 		// when connecting to the local fleet server.
-		// TODO At this point remote config has $HOSTNAME:8220 - is that expected or do we part port 8221?
+		// Note that when running fleet-server the enroll request will be sent to :8220,
+		// however when the agent is running afterwards requests will be sent to :8221
 		c.remoteConfig.Transport.Proxy.Disable = true
 	}
 

--- a/internal/pkg/remote/client.go
+++ b/internal/pkg/remote/client.go
@@ -174,6 +174,7 @@ func (c *Client) Send(
 				"fail to create HTTP request using method %s to %s: %w",
 				method, path, err)
 		}
+		c.log.Debugf("Creating new request to request URL %s", req.URL.String())
 
 		// Add generals headers to the request, we are dealing exclusively with JSON.
 		// Content-Type / Accepted type can be overridden by the caller.


### PR DESCRIPTION
## What does this PR do?

Fix an issue where the local fleet-server port was not properly used by the elastic-agent when running an instance of fleet-server.

## Why is it important?

When running a large scale of agents, the fleet-server may hit the connection limit if it's running on the same port as the other agents. this causes the elastic-agent running the fleet-server to be marked as degraded.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
