### PR TITLE
Remove inputs when all streams are removed

### DIFF
--- a/changelog/fragments/1669940990-Remove-inputs-when-all-streams-are-removed.yaml
+++ b/changelog/fragments/1669940990-Remove-inputs-when-all-streams-are-removed.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Remove inputs when all streams are removed
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 1869
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 1868

--- a/internal/pkg/agent/transpiler/utils_test.go
+++ b/internal/pkg/agent/transpiler/utils_test.go
@@ -759,32 +759,14 @@ func TestRenderInputs(t *testing.T) {
 					},
 				},
 					"var1",
-					[]map[string]interface{}{
-						{
-							"add_fields": map[string]interface{}{
-								"fields": map[string]interface{}{
-									"custom": "value1",
-								},
-								"to": "dynamic",
-							},
-						},
-					}),
+					nil),
 				mustMakeVarsP("value2", map[string]interface{}{
 					"var1": map[string]interface{}{
 						"name": "value1",
 					},
 				},
 					"var1",
-					[]map[string]interface{}{
-						{
-							"add_fields": map[string]interface{}{
-								"fields": map[string]interface{}{
-									"custom": "value2",
-								},
-								"to": "dynamic",
-							},
-						},
-					}),
+					nil),
 			},
 		},
 	}

--- a/internal/pkg/agent/transpiler/utils_test.go
+++ b/internal/pkg/agent/transpiler/utils_test.go
@@ -721,6 +721,62 @@ func TestRenderInputs(t *testing.T) {
 					}),
 			},
 		},
+		"input removal with stream conditions": {
+			input: NewKey("inputs", NewList([]Node{
+				NewDict([]Node{
+					NewKey("type", NewStrVal("logfile")),
+					NewKey("streams", NewList([]Node{
+						NewDict([]Node{
+							NewKey("paths", NewList([]Node{
+								NewStrVal("/var/log/${var1.name}.log"),
+							})),
+							NewKey("condition", NewStrVal("${var1.name} != 'value1'")),
+						}),
+						NewDict([]Node{
+							NewKey("paths", NewList([]Node{
+								NewStrVal("/var/log/${var1.name}.log"),
+							})),
+							NewKey("condition", NewStrVal("${var1.name} != 'value1'")),
+						}),
+					})),
+				}),
+			})),
+			expected: NewList([]Node{}),
+			varsArray: []*Vars{
+				mustMakeVarsP(map[string]interface{}{
+					"var1": map[string]interface{}{
+						"name": "value1",
+					},
+				},
+					"var1",
+					[]map[string]interface{}{
+						{
+							"add_fields": map[string]interface{}{
+								"fields": map[string]interface{}{
+									"custom": "value1",
+								},
+								"to": "dynamic",
+							},
+						},
+					}),
+				mustMakeVarsP(map[string]interface{}{
+					"var1": map[string]interface{}{
+						"name": "value1",
+					},
+				},
+					"var1",
+					[]map[string]interface{}{
+						{
+							"add_fields": map[string]interface{}{
+								"fields": map[string]interface{}{
+									"custom": "value2",
+								},
+								"to": "dynamic",
+							},
+						},
+					}),
+			},
+		},
 	}
 
 	for name, test := range testcases {

--- a/internal/pkg/agent/transpiler/utils_test.go
+++ b/internal/pkg/agent/transpiler/utils_test.go
@@ -753,7 +753,7 @@ func TestRenderInputs(t *testing.T) {
 			})),
 			expected: NewList([]Node{}),
 			varsArray: []*Vars{
-				mustMakeVarsP(map[string]interface{}{
+				mustMakeVarsP("value1", map[string]interface{}{
 					"var1": map[string]interface{}{
 						"name": "value1",
 					},
@@ -769,7 +769,7 @@ func TestRenderInputs(t *testing.T) {
 							},
 						},
 					}),
-				mustMakeVarsP(map[string]interface{}{
+				mustMakeVarsP("value2", map[string]interface{}{
 					"var1": map[string]interface{}{
 						"name": "value1",
 					},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

When an input has conditions on all of its streams and the conditions result in all streams being removed from the input the entire input is removed. 

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This solves the issue described here https://github.com/elastic/integrations/issues/4725 without having to change the integration. I think it provides a better experience than also having a condition on the input.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #1868
