### PR TITLE
add container platforms to endpoint spec

### DIFF
--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -321,58 +321,6 @@ func TestToComponents(t *testing.T) {
 			},
 		},
 		{
-			Name: "Invalid: inputs endpoint not support on container platform",
-			Platform: PlatformDetail{
-				Platform: Platform{
-					OS:   Container,
-					Arch: AMD64,
-					GOOS: Linux,
-				},
-			},
-			Policy: map[string]interface{}{
-				"outputs": map[string]interface{}{
-					"default": map[string]interface{}{
-						"type":    "elasticsearch",
-						"enabled": true,
-					},
-				},
-				"inputs": []interface{}{
-					map[string]interface{}{
-						"type":       "endpoint",
-						"id":         "endpoint-0",
-						"use_output": "default",
-						"enabled":    true,
-					},
-				},
-			},
-			Result: []Component{
-				{
-					ID:        "endpoint-default",
-					InputSpec: &InputRuntimeSpec{},
-					Err:       ErrInputNotSupportedOnPlatform,
-					Units: []Unit{
-						{
-							ID:       "endpoint-default",
-							Type:     client.UnitTypeOutput,
-							LogLevel: defaultUnitLogLevel,
-							Config: MustExpectedConfig(map[string]interface{}{
-								"type": "elasticsearch",
-							}),
-						},
-						{
-							ID:       "endpoint-default-endpoint-0",
-							Type:     client.UnitTypeInput,
-							LogLevel: defaultUnitLogLevel,
-							Config: MustExpectedConfig(map[string]interface{}{
-								"type": "endpoint",
-								"id":   "endpoint-0",
-							}),
-						},
-					},
-				},
-			},
-		},
-		{
 			Name:     "Invalid: inputs endpoint doesn't support logstash",
 			Platform: linuxAMD64Platform,
 			Policy: map[string]interface{}{

--- a/pkg/component/load_test.go
+++ b/pkg/component/load_test.go
@@ -32,12 +32,6 @@ func TestLoadRuntimeSpecs(t *testing.T) {
 			// unknown input
 			_, err = runtime.GetInput("unknown")
 			require.ErrorIs(t, err, ErrInputNotSupported)
-
-			// endpoint not support on container platforms
-			if platform.OS == "container" {
-				_, err = runtime.GetInput("endpoint")
-				assert.ErrorIs(t, err, ErrInputNotSupportedOnPlatform)
-			}
 		})
 	}
 }

--- a/specs/endpoint-security.spec.yml
+++ b/specs/endpoint-security.spec.yml
@@ -5,6 +5,8 @@ inputs:
     platforms:
       - linux/amd64
       - linux/arm64
+      - container/amd64
+      - container/arm64
     outputs:
       - elasticsearch
     runtime:


### PR DESCRIPTION
## What does this PR do?

Allows endpoint to run in a kubernetes cluster. The spec.yml wasn't updated correctly for the new v2 changes.

## Testing

This was tested manually on kubernetes, before there would not be any policy response for the integration, and now the policy response is received, and the kubernetes security dashboard is populated.

## Related issues

- Closes https://github.com/elastic/endpoint-dev/issues/12195

Apologies that this is not as thorough as the template showed. I'm at the end of my day, want CI to run, and will fill in more details tomorrow.