### PR TITLE
[automation] update elastic stack version for testing 8.7.0-1b0dc867

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.7.0-11ac5926-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.7.0-1b0dc867-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.7.0-11ac5926-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.7.0-1b0dc867-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Fri, 2 Dec 2022 00:15:08 GMT, release_branch:master, prefix:, end_time:Fri, 2 Dec 2022 04:30:28 GMT, manifest_version:2.1.0, version:8.7.0-SNAPSHOT, branch:master, build_id:8.7.0-1b0dc867, build_duration_seconds:15320]