### PR TITLE
Add pre-hook to load paths overrides in container

### DIFF
--- a/internal/pkg/agent/cmd/common.go
+++ b/internal/pkg/agent/cmd/common.go
@@ -35,6 +35,9 @@ func NewCommand() *cobra.Command {
 func NewCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "elastic-agent [subcommand]",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return tryContainerLoadPaths()
+		},
 	}
 
 	// path flags

--- a/internal/pkg/agent/cmd/diagnostics.go
+++ b/internal/pkg/agent/cmd/diagnostics.go
@@ -50,15 +50,10 @@ func diagnosticCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		fileName = "elastic-agent-diagnostics-" + ts.Format("2006-01-02T15-04-05Z07-00") + ".zip" // RFC3339 format that replaces : with -, so it will work on Windows
 	}
 
-	err := tryContainerLoadPaths()
-	if err != nil {
-		return err
-	}
-
 	ctx := handleSignal(context.Background())
 
 	daemon := client.New()
-	err = daemon.Connect(ctx)
+	err := daemon.Connect(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to connect to daemon: %w", err)
 	}

--- a/internal/pkg/agent/cmd/inspect.go
+++ b/internal/pkg/agent/cmd/inspect.go
@@ -126,11 +126,6 @@ type inspectConfigOpts struct {
 }
 
 func inspectConfig(ctx context.Context, cfgPath string, opts inspectConfigOpts, streams *cli.IOStreams) error {
-	err := tryContainerLoadPaths()
-	if err != nil {
-		return err
-	}
-
 	l, err := newErrorLogger()
 	if err != nil {
 		return err
@@ -232,12 +227,6 @@ type inspectComponentsOpts struct {
 
 func inspectComponents(ctx context.Context, cfgPath string, opts inspectComponentsOpts, streams *cli.IOStreams) error {
 	l, err := newErrorLogger()
-	if err != nil {
-		return err
-	}
-
-	// Ensure that when running inside a container that the correct paths are used.
-	err = tryContainerLoadPaths()
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/agent/cmd/status.go
+++ b/internal/pkg/agent/cmd/status.go
@@ -49,11 +49,6 @@ func newStatusCommand(_ []string, streams *cli.IOStreams) *cobra.Command {
 }
 
 func statusCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error {
-	err := tryContainerLoadPaths()
-	if err != nil {
-		return err
-	}
-
 	output, _ := cmd.Flags().GetString("output")
 	outputFunc, ok := statusOutputs[output]
 	if !ok {


### PR DESCRIPTION
## What does this PR do?

We're loading path overrides in every command and few of them were left unnoticed. 
This PR moves the logic to Prehook so paths are always updated in all cases.

## Why is it important?

Restart and version does not work in a container
Fixes https://github.com/elastic/elastic-agent/issues/1713


## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
