### PR TITLE
Fixed ack of unenroll action

### DIFF
--- a/internal/pkg/agent/application/actions/handlers/handler_action_unenroll.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_unenroll.go
@@ -7,12 +7,17 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/acker"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
+)
+
+const (
+	unenrollTimeout = 15 * time.Second
 )
 
 type stateStore interface {
@@ -60,19 +65,19 @@ func (h *Unenroll) Handle(ctx context.Context, a fleetapi.Action, acker acker.Ac
 		a = nil
 	}
 
-	h.ch <- &policyChange{
-		ctx:    ctx,
-		cfg:    config.New(),
-		action: a,
-		acker:  acker,
-		commit: true,
-	}
+	unenrollPolicy := newPolicyChange(ctx, config.New(), a, acker, true)
+	h.ch <- unenrollPolicy
 
 	if h.stateStore != nil {
 		// backup action for future start to avoid starting fleet gateway loop
 		h.stateStore.Add(a)
 		h.stateStore.Save()
 	}
+
+	unenrollCtx, cancel := context.WithTimeout(ctx, unenrollTimeout)
+	defer cancel()
+
+	unenrollPolicy.WaitAck(unenrollCtx)
 
 	// close fleet gateway loop
 	for _, c := range h.closers {

--- a/internal/pkg/agent/application/managed_mode.go
+++ b/internal/pkg/agent/application/managed_mode.go
@@ -297,8 +297,8 @@ func fleetServerRunning(state runtime.ComponentState) bool {
 	return false
 }
 
-func (m *managedConfigManager) initDispatcher(canceller context.CancelFunc) *handlers.PolicyChange {
-	policyChanger := handlers.NewPolicyChange(
+func (m *managedConfigManager) initDispatcher(canceller context.CancelFunc) *handlers.PolicyChangeHandler {
+	policyChanger := handlers.NewPolicyChangeHandler(
 		m.log,
 		m.agentInfo,
 		m.cfg,

--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -54,6 +54,7 @@ const (
 )
 
 var (
+	errNoOuputPresent        = errors.New("outputs not part of the config")
 	supportedComponents      = []string{"filebeat", "metricbeat", "apm-server", "auditbeat", "cloudbeat", "cloud-defend", "endpoint-security", "fleet-server", "heartbeat", "osquerybeat", "packetbeat"}
 	supportedBeatsComponents = []string{"filebeat", "metricbeat", "apm-server", "fleet-server", "auditbeat", "cloudbeat", "heartbeat", "osquerybeat", "packetbeat"}
 )
@@ -124,7 +125,7 @@ func (b *BeatsMonitor) MonitoringConfig(policy map[string]interface{}, component
 
 	cfg := make(map[string]interface{})
 
-	if err := b.injectMonitoringOutput(policy, cfg, monitoringOutputName); err != nil {
+	if err := b.injectMonitoringOutput(policy, cfg, monitoringOutputName); err != nil && !errors.Is(err, errNoOuputPresent) {
 		return nil, errors.New(err, "failed to inject monitoring output")
 	}
 
@@ -256,7 +257,7 @@ func (b *BeatsMonitor) initInputs(cfg map[string]interface{}) {
 func (b *BeatsMonitor) injectMonitoringOutput(source, dest map[string]interface{}, monitoringOutputName string) error {
 	outputsNode, found := source[outputsKey]
 	if !found {
-		return fmt.Errorf("outputs not part of the config")
+		return errNoOuputPresent
 	}
 
 	outputs, ok := outputsNode.(map[string]interface{})


### PR DESCRIPTION
## What does this PR do?

Two problems actually
First one is monitoring injector. it tries to duplicate default output. but in case of unenroll there's no output so we're not failing hard if there;s no output anymore and accept this as a valid config in monitoring injector leading to premature termination of config injection.

The other is a race. We do not await `ack` to be completed. I added awaiting mechanism used purely for this policy change. we could work on using it for other use cases later but for now this is enough.

## Why is it important?

Unenrolled agents are still shown in a list until they are forcefully unenrolled.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Fixes https://github.com/elastic/kibana/issues/146774