### PR TITLE
Disable monitoring in bootstrap mode

### DIFF
--- a/internal/pkg/agent/application/application.go
+++ b/internal/pkg/agent/application/application.go
@@ -31,6 +31,7 @@ func New(
 	agentInfo *info.AgentInfo,
 	reexec coordinator.ReExecManager,
 	tracer *apm.Tracer,
+	disableMonitoring bool,
 	modifiers ...component.PlatformModifier,
 ) (*coordinator.Coordinator, error) {
 	platform, err := component.LoadPlatformDetail(modifiers...)
@@ -64,8 +65,10 @@ func New(
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
 
+	// monitoring is not supported in bootstrap mode https://github.com/elastic/elastic-agent/issues/1761
+	isMonitoringSupported := !disableMonitoring && cfg.Settings.V1MonitoringEnabled
 	upgrader := upgrade.NewUpgrader(log, cfg.Settings.DownloadConfig, agentInfo)
-	monitor := monitoring.New(cfg.Settings.V1MonitoringEnabled, cfg.Settings.DownloadConfig.OS(), cfg.Settings.MonitoringConfig, agentInfo)
+	monitor := monitoring.New(isMonitoringSupported, cfg.Settings.DownloadConfig.OS(), cfg.Settings.MonitoringConfig, agentInfo)
 
 	runtime, err := runtime.NewManager(log, cfg.Settings.GRPC.String(), agentInfo, tracer, monitor, cfg.Settings.GRPC)
 	if err != nil {

--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -90,7 +90,8 @@ func (b *BeatsMonitor) Enabled() bool {
 
 // Reload refreshes monitoring configuration.
 func (b *BeatsMonitor) Reload(rawConfig *config.Config) error {
-	if !b.Enabled() {
+	if !b.enabled {
+		// it's disabled regardless of config
 		return nil
 	}
 
@@ -127,6 +128,9 @@ func (b *BeatsMonitor) MonitoringConfig(policy map[string]interface{}, component
 
 	if err := b.injectMonitoringOutput(policy, cfg, monitoringOutputName); err != nil && !errors.Is(err, errNoOuputPresent) {
 		return nil, errors.New(err, "failed to inject monitoring output")
+	} else if errors.Is(err, errNoOuputPresent) {
+		// nothing to inject, no monitoring output
+		return nil, nil
 	}
 
 	// initializes inputs collection so injectors don't have to deal with it

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -166,7 +166,7 @@ func run(override cfgOverrider, modifiers ...component.PlatformModifier) error {
 		logger.Info("APM instrumentation disabled")
 	}
 
-	coord, err := application.New(logger, agentInfo, rex, tracer, modifiers...)
+	coord, err := application.New(logger, agentInfo, rex, tracer, configuration.IsFleetServerBootstrap(cfg.Fleet), modifiers...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What does this PR do?

This PR checks upon run whether or not we're in bootstrap mode and if so we initiate application with disable monitoring override. 
We do this by passing override to avoid loading fleet config in case of standalone in `application.go`

## Why is it important?

During bootstrap monitoring is not needed and it causes some confusing logs

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Fixes: https://github.com/elastic/elastic-agent/issues/1761