### PR TITLE
Replace input alias with real name in config source

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -132,7 +132,7 @@ func (r *RuntimeSpecs) ToComponents(policy map[string]interface{}, monitoringInj
 // PolicyToComponents takes the policy and generated a component model along with providing a mapping between component
 // and the running binary.
 func (r *RuntimeSpecs) PolicyToComponents(policy map[string]interface{}) ([]Component, map[string]string, error) {
-	outputsMap, err := toIntermediate(policy)
+	outputsMap, err := toIntermediate(policy, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -419,7 +419,7 @@ func getSupportedShipper(r *RuntimeSpecs, output outputI, inputSpec InputRuntime
 
 // toIntermediate takes the policy and returns it into an intermediate representation that is easier to map into a set
 // of components.
-func toIntermediate(policy map[string]interface{}) (map[string]outputI, error) {
+func toIntermediate(policy map[string]interface{}, aliasMapping map[string]string) (map[string]outputI, error) {
 	const (
 		outputsKey = "outputs"
 		enabledKey = "enabled"
@@ -500,6 +500,11 @@ func toIntermediate(policy map[string]interface{}) (map[string]outputI, error) {
 		t, ok := typeRaw.(string)
 		if !ok {
 			return nil, fmt.Errorf("invalid 'inputs.%d.type', expected a string not a %T", idx, typeRaw)
+		}
+		if realInputType, found := aliasMapping[t]; found {
+			t = realInputType
+			// by replacing type we make sure component understands aliasing
+			input[typeKey] = t
 		}
 		idRaw, ok := input[idKey]
 		if !ok {


### PR DESCRIPTION
## What does this PR do?

Adding alias translation to input config itself. 
Change is visible here, all other values are kept as they are.
Sample is a system integration with only syslog collection enabled.
On the left we have configuration generated with fix, on the right without fix. 
Resulting config is not enabled to contain `logfile` keyword in this example

![image](https://user-images.githubusercontent.com/1522652/207035181-28a2db67-01f0-481b-9e6f-654e2144761a.png)

## Why is it important?

Components do not understand aliases and we need to make sure they are translated, otherwise input won't start

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Fixes: https://github.com/elastic/elastic-agent/issues/1897
