### PR TITLE
Fixed Monitoring.Prepare for IDs exceeding filepath length limit

### DIFF
--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -193,18 +193,18 @@ func (b *BeatsMonitor) EnrichArgs(unit, binary string, args []string) []string {
 }
 
 // Prepare executes steps in order for monitoring to work correctly
-func (b *BeatsMonitor) Prepare() error {
+func (b *BeatsMonitor) Prepare(unit string) error {
 	if !b.Enabled() {
 		return nil
 	}
 	drops := make([]string, 0, 2)
 	if b.config.C.MonitorLogs {
-		logsDrop := loggingPath("unit", b.operatingSystem)
+		logsDrop := loggingPath(unit, b.operatingSystem)
 		drops = append(drops, filepath.Dir(logsDrop))
 	}
 
 	if b.config.C.MonitorMetrics {
-		metricsDrop := monitoringDrop(endpointPath("unit", b.operatingSystem))
+		metricsDrop := monitoringDrop(endpointPath(unit, b.operatingSystem))
 		drops = append(drops, metricsDrop)
 	}
 

--- a/pkg/component/runtime/command.go
+++ b/pkg/component/runtime/command.go
@@ -41,7 +41,7 @@ const (
 
 type MonitoringManager interface {
 	EnrichArgs(string, string, []string) []string
-	Prepare() error
+	Prepare(string) error
 	Cleanup(string) error
 }
 
@@ -301,7 +301,7 @@ func (c *CommandRuntime) start(comm Communicator) error {
 		return fmt.Errorf("execution of component prevented: %w", err)
 	}
 
-	if err := c.monitor.Prepare(); err != nil {
+	if err := c.monitor.Prepare(c.current.ID); err != nil {
 		return err
 	}
 	args := c.monitor.EnrichArgs(c.current.ID, c.getSpecBinaryName(), cmdSpec.Args)

--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -2127,5 +2127,5 @@ type testMonitoringManager struct{}
 func newTestMonitoringMgr() *testMonitoringManager { return &testMonitoringManager{} }
 
 func (*testMonitoringManager) EnrichArgs(_ string, _ string, args []string) []string { return args }
-func (*testMonitoringManager) Prepare() error                                        { return nil }
+func (*testMonitoringManager) Prepare(_ string) error                                { return nil }
 func (*testMonitoringManager) Cleanup(string) error                                  { return nil }


### PR DESCRIPTION
## What does this PR do?

Coming from #1894
when unit ID is longer than limit we plan on placing HTTP socket to `/tmp/elastic-agent` 
We should create this directory when calling `Prepare()`
Prepare is although unaware of exceeding limit and prepares structure for normal length ID which is within elastic agent directory layout. 

This PR fixes `Prepare()` to accept unit ID so it can properly target directory holding HTTP socket

_note: we need to think about testing filesystem operations, either integration tests or wrapping these behind interface and refactoring._

## Why is it important?

No metrics are collected for unit IDs longer than 106 characters

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
