### PR TITLE
Avoid using slash in named pipe ID

### DIFF
--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -701,12 +701,18 @@ func loggingPath(id, operatingSystem string) string {
 }
 
 func endpointPath(id, operatingSystem string) (endpointPath string) {
-	id = strings.ReplaceAll(id, string(filepath.Separator), "-")
+	return endpointPathWithDir(id, operatingSystem, paths.TempDir(), string(filepath.Separator))
+}
+
+func endpointPathWithDir(id, operatingSystem, tempDir, separator string) (endpointPath string) {
+	id = strings.ReplaceAll(id, separator, "-")
 	if operatingSystem == windowsOS {
+		// on windows named pipe `/` separates pipe name from a computer/server name
+		id = strings.ReplaceAll(id, "/", "-")
 		return fmt.Sprintf(mbEndpointFileFormatWin, id)
 	}
 	// unix socket path must be less than 104 characters
-	path := fmt.Sprintf("unix://%s.sock", filepath.Join(paths.TempDir(), id))
+	path := fmt.Sprintf("unix://%s.sock", filepath.Join(tempDir, id))
 	if len(path) < 104 {
 		return path
 	}

--- a/internal/pkg/agent/application/monitoring/v1_monitor_test.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor_test.go
@@ -1,0 +1,51 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package monitoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpointPath(t *testing.T) {
+	testCases := []struct {
+		Name       string
+		OS         string
+		ID         string
+		ExpectedID string
+	}{
+		// simple
+		{"simple linux", "linux", "simple", "unix:///tmp/elastic-agent/simple.sock"},
+		{"simple windows", "windows", "simple", "npipe:///simple"},
+		{"simple darwin", "darwin", "simple", "unix:///tmp/elastic-agent/simple.sock"},
+
+		// special chars
+		{"simple linux", "linux", "complex43@#$", "unix:///tmp/elastic-agent/complex43@#$.sock"},
+		{"simple windows", "windows", "complex43@#$", "npipe:///complex43@#$"},
+		{"simple darwin", "darwin", "complex43@#$", "unix:///tmp/elastic-agent/complex43@#$.sock"},
+
+		// slash
+		{"simple linux", "linux", "slash/sample", "unix:///tmp/elastic-agent/slash-sample.sock"},
+		{"simple windows", "windows", "slash/sample", "npipe:///slash-sample"},
+		{"simple darwin", "darwin", "slash/sample", "unix:///tmp/elastic-agent/slash-sample.sock"},
+
+		// backslash
+		{"simple linux", "linux", "back\\slash", "unix:///tmp/elastic-agent/back\\slash.sock"},
+		{"simple windows", "windows", "back\\slash", "npipe:///back-slash"},
+		{"simple darwin", "darwin", "back\\slash", "unix:///tmp/elastic-agent/back\\slash.sock"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			separator := "/"
+			if tc.OS == windowsOS {
+				separator = "\\"
+			}
+			endpointPath := endpointPathWithDir(tc.ID, tc.OS, "/tmp/elastic-agent", separator)
+			require.Equal(t, tc.ExpectedID, endpointPath)
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Due to some funny issues winio does not like system/whatever in a named pipe identifier.
Changing logic to avoid using slashes .

## Why is it important?

When querying metrics for system metrics we run into


```json
{"log.level":"error","@timestamp":"2022-12-12T11:48:29.245Z","message":"Error fetching data for metricset beat.stats:
 error making http request: Get \"http://npipe/metrics-default\": open \\\\.\\pipe\\system: The system cannot find the file 
specified."}
```

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test

Start windows machine and run ./elastic-agent run with default config. 
let it run for couple of minutes. you should not see any npipe not found errors.
as a sanity check you can use unfixed version error will pop up within 2 minutes.