### PR TITLE
Lazy Acker print actions as string so indeed prints them

### DIFF
--- a/internal/pkg/fleetapi/acker/lazy/lazy_acker.go
+++ b/internal/pkg/fleetapi/acker/lazy/lazy_acker.go
@@ -80,18 +80,18 @@ func (f *Acker) Commit(ctx context.Context) (err error) {
 	actions := f.queue
 	f.queue = make([]fleetapi.Action, 0)
 
-	f.log.Debugf("lazy acker: ackbatch: %#v", actions)
+	f.log.Debugf("lazy acker: ack batch: %s", actions)
 	var resp *fleetapi.AckResponse
 	resp, err = f.acker.AckBatch(ctx, actions)
 
 	// If request failed enqueue all actions with retrier if it is set
 	if err != nil {
 		if f.retrier != nil {
-			f.log.Errorf("lazy acker: failed ack batch, enqueue for retry: %#v", actions)
+			f.log.Errorf("lazy acker: failed ack batch, enqueue for retry: %s", actions)
 			f.retrier.Enqueue(actions)
 			return nil
 		}
-		f.log.Errorf("lazy acker: failed ack batch, no retrier set, fail with err: %v", err)
+		f.log.Errorf("lazy acker: failed ack batch, no retrier set, fail with err: %s", err)
 		return err
 	}
 
@@ -107,7 +107,7 @@ func (f *Acker) Commit(ctx context.Context) (err error) {
 			}
 		}
 		if len(failed) > 0 {
-			f.log.Infof("lazy acker: partially failed ack batch, enqueue for retry: %#v", failed)
+			f.log.Infof("lazy acker: partially failed ack batch, enqueue for retry: %s", failed)
 			f.retrier.Enqueue(failed)
 		}
 	}

--- a/internal/pkg/fleetapi/acker/lazy/lazy_acker_test.go
+++ b/internal/pkg/fleetapi/acker/lazy/lazy_acker_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
@@ -82,7 +83,11 @@ func TestLazyAcker(t *testing.T) {
 	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 
-	log, _ := logger.New("", false)
+	cfg := logger.DefaultLoggingConfig()
+	cfg.Level = logp.DebugLevel
+	// cfg.ToFiles = false
+	cfg.ToStderr = true
+	log, _ := logger.NewFromConfig("", cfg, true)
 
 	// Tests
 	tests := []struct {

--- a/internal/pkg/fleetapi/acker/lazy/lazy_acker_test.go
+++ b/internal/pkg/fleetapi/acker/lazy/lazy_acker_test.go
@@ -10,9 +10,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

It uses `%s` instead of `%#v` to print actions, that way the `String()` method is called and the pointers are dereferenced.


## Why is it important?

The actual values of the pointers are printed instead of the memory address the pointers are pointing to.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## How to test this PR locally

From the root run:
```
go test -v github.com/elastic/elastic-agent/internal/pkg/fleetapi/acker/lazy
```

if run without the fix, the pointers will print the memory address they point to

## Logs

- Before:
```
{[...],"message":"lazy acker: failed ack batch, enqueue for retry: []fleetapi.Action{(*fleetapi.ActionPolicyChange)(0xc00018f440)}","ecs.version":"1.6.0"}
```

- After:
```
{[...],"message":"lazy acker: failed ack batch, enqueue for retry: [action_id: 1, type:  (original type: )]","ecs.version":"1.6.0"}

```