### PR TITLE
runtime/manager: make error message human readable

### DIFF
--- a/pkg/component/runtime/manager.go
+++ b/pkg/component/runtime/manager.go
@@ -179,7 +179,7 @@ func (m *Manager) Run(ctx context.Context) error {
 		for {
 			err := server.Serve(lis)
 			if err != nil {
-				m.logger.Errorf("control protocol failed: %w", err)
+				m.logger.Errorf("control protocol failed: %s", err)
 			}
 			if ctx.Err() != nil {
 				// context has an error don't start again


### PR DESCRIPTION
Signed-off-by: Florian Lehner <florian.lehner@elastic.co>

The  `%w` verb is intended for error operands but not for human readable error messages. Therefore the `%s` verb should be preferred for logging over `%w`.

```
control protocol failed: %!w(*errors.errorString=&{grpc: the server has been stopped})
```

to 
```
control protocol failed: grpc: the server has been stopped
```
