### PR TITLE
Integration input name updated for new cloud-defend service

### DIFF
--- a/specs/cloud-defend.spec.yml
+++ b/specs/cloud-defend.spec.yml
@@ -1,7 +1,7 @@
 version: 2
 inputs:
-  - name: cloud_defend
-    description: "Cloud defend for containers"
+  - name: cloud_defend/control
+    description: "Defend for containers"
     platforms: &platforms
       - container/amd64
       - container/arm64


### PR DESCRIPTION
## What does this PR do?

Renames the integration input of a new "wip" integration called cloud_defend (for containers). 
Also, creates a distinct input for metrics data stream config.

## Why is it important?

To ensure everything hooks up correctly.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/integrations/pull/4680 