### PR TITLE
Do not persist action error with new action batch

### DIFF
--- a/internal/pkg/agent/application/dispatcher/dispatcher_test.go
+++ b/internal/pkg/agent/application/dispatcher/dispatcher_test.go
@@ -411,17 +411,23 @@ func TestActionDispatcher(t *testing.T) {
 		dispatchCtx1, cancelFn1 := context.WithCancel(context.Background())
 		defer cancelFn1()
 		go d.Dispatch(dispatchCtx1, ack, action1)
-		time.Sleep(time.Millisecond * 300)
-		if err := <-d.Errors(); err == nil {
-			t.Fatal("Expecting error")
+		select {
+		case err := <-d.Errors():
+			if err == nil {
+				t.Fatal("Expecting error")
+			}
+		case <-time.After(300 * time.Millisecond):
 		}
 
 		dispatchCtx2, cancelFn2 := context.WithCancel(context.Background())
 		defer cancelFn2()
 		go d.Dispatch(dispatchCtx2, ack, action2)
-		time.Sleep(time.Millisecond * 300)
-		if err := <-d.Errors(); err != nil {
-			t.Fatal("Unexpected error")
+		select {
+		case err := <-d.Errors():
+			if err != nil {
+				t.Fatal("Unexpected error")
+			}
+		case <-time.After(300 * time.Millisecond):
 		}
 
 		def.AssertExpectations(t)


### PR DESCRIPTION
## What does this PR do?

This PR resets last error coupled with action batch in dispatcher. when action comes and is invalid last error is set. we never reset this value. even when new config comes and is ok.
resetting this before actions are processed will cause some interesting side effect. agent won't get into failed state.
setting fail/succ conditionally like in this PR works better within these loops

## Why is it important?

Whenever action fails error will persist forever until agent restarts.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Fixes: #1926 