### PR TITLE
Fix logging of service based components (aka. endpoint)

### DIFF
--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -68,7 +68,7 @@ type MonitorManager interface {
 	Reload(rawConfig *config.Config) error
 
 	// InjectMonitoring injects monitoring configuration into resolved ast tree.
-	MonitoringConfig(map[string]interface{}, map[string]string) (map[string]interface{}, error)
+	MonitoringConfig(map[string]interface{}, []component.Component, map[string]string) (map[string]interface{}, error)
 }
 
 // Runner provides interface to run a manager and receive running errors.

--- a/internal/pkg/agent/cmd/inspect.go
+++ b/internal/pkg/agent/cmd/inspect.go
@@ -160,11 +160,11 @@ func inspectConfig(ctx context.Context, cfgPath string, opts inspectConfigOpts, 
 		if err != nil {
 			return fmt.Errorf("failed to get monitoring: %w", err)
 		}
-		_, binaryMapping, err := specs.PolicyToComponents(cfg, lvl)
+		components, binaryMapping, err := specs.PolicyToComponents(cfg, lvl)
 		if err != nil {
 			return fmt.Errorf("failed to get binary mappings: %w", err)
 		}
-		monitorCfg, err := monitorFn(cfg, binaryMapping)
+		monitorCfg, err := monitorFn(cfg, components, binaryMapping)
 		if err != nil {
 			return fmt.Errorf("failed to get monitoring config: %w", err)
 		}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -21,7 +21,7 @@ import (
 )
 
 // GenerateMonitoringCfgFn is a function that can inject information into the model generation process.
-type GenerateMonitoringCfgFn func(map[string]interface{}, map[string]string) (map[string]interface{}, error)
+type GenerateMonitoringCfgFn func(map[string]interface{}, []Component, map[string]string) (map[string]interface{}, error)
 
 const (
 	// defaultUnitLogLevel is the default log level that a unit will get if one is not defined.
@@ -112,7 +112,7 @@ func (r *RuntimeSpecs) ToComponents(policy map[string]interface{}, monitoringInj
 	}
 
 	if monitoringInjector != nil {
-		monitoringCfg, err := monitoringInjector(policy, binaryMapping)
+		monitoringCfg, err := monitoringInjector(policy, components, binaryMapping)
 		if err != nil {
 			return nil, fmt.Errorf("failed to inject monitoring: %w", err)
 		}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This adds to the filestream monitor so it can gather log files from any service based component that defined a log path to be used in its specification.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This fixes the issue where 8.6 was not shipping log information for Endpoint Security.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #1939 
