### PR TITLE
Fix changelog checklist item in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,7 +33,7 @@ List here all the items you have verified BEFORE sending this PR. Please DO NOT 
 - [ ] I have made corresponding changes to the documentation
 - [ ] I have made corresponding change to the default configuration files
 - [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
+- [ ] I have added an entry in `./changelogs/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
 
 ## Author's Checklist
 


### PR DESCRIPTION
## What does this PR do?

Changelog tool has changed, but the checklist in the PR template was still the old way.