### PR TITLE
All inputs in an agent policy must have a unique ID

### DIFF
--- a/_meta/config/common.p2.yml.tmpl
+++ b/_meta/config/common.p2.yml.tmpl
@@ -11,7 +11,8 @@ outputs:
 
 inputs:
   - type: system/metrics
-
+    # Each input must have a unique ID.
+    id: unique-system-metrics-input
     # Namespace name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
     # For index naming restrictions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params
     data_stream.namespace: default
@@ -118,7 +119,7 @@ inputs:
 #   # port for the GRPC server that spawned processes connect back to.
 #   port: 6789
 #   # max_message_size limits the message size in agent internal communication
-#   # default is 100MB 
+#   # default is 100MB
 #   max_message_size: 104857600
 
 # agent.retry:

--- a/_meta/config/common.reference.p2.yml.tmpl
+++ b/_meta/config/common.reference.p2.yml.tmpl
@@ -11,7 +11,8 @@ outputs:
 
 inputs:
   - type: system/metrics
-
+    # Each input must have a unique ID.
+    id: unique-system-metrics-input
     # Namespace name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
     # For index naming restrictions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params
     data_stream.namespace: default
@@ -85,7 +86,7 @@ inputs:
 #   # port for the GRPC server that spawned processes connect back to.
 #   port: 6789
 #   # max_message_size limits the message size in agent internal communication
-#   # default is 100MB 
+#   # default is 100MB
 #   max_message_size: 104857600
 
 # agent.retry:

--- a/_meta/config/elastic-agent.docker.yml.tmpl
+++ b/_meta/config/elastic-agent.docker.yml.tmpl
@@ -10,7 +10,8 @@ outputs:
 
 inputs:
   - type: system/metrics
-
+    # Each input must have a unique ID.
+    id: unique-system-metrics-input
     # Namespace name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
     # For index naming restrictions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params
     data_stream.namespace: default
@@ -84,7 +85,7 @@ inputs:
 #   # port for the GRPC server that spawned processes connect back to.
 #   port: 6789
 #   # max_message_size limits the message size in agent internal communication
-#   # default is 100MB 
+#   # default is 100MB
 #   max_message_size: 104857600
 
 # agent.retry:

--- a/_meta/elastic-agent.yml
+++ b/_meta/elastic-agent.yml
@@ -10,7 +10,8 @@ outputs:
 
 inputs:
   - type: system/metrics
-
+    # Each input must have a unique ID.
+    id: unique-system-metrics-input
     # Namespace name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
     # For index naming restrictions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params
     data_stream.namespace: default

--- a/changelog/fragments/1671748292-input-ids-are-required.yaml
+++ b/changelog/fragments/1671748292-input-ids-are-required.yaml
@@ -1,0 +1,34 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: breaking-change
+
+# Change summary; a 80ish characters long description of the change.
+summary: Each input in an agent policy must have a unique ID.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  Each input in an agent policy must have a unique ID, like "id: my-unique-input-id".
+  This only applies to standalone agents. Unique IDs are automatically generated in
+  agent policies managed by Fleet.
+
+# Affected component; a word indicating the component this changeset affects.
+component: agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1671748292-input-ids-are-required.yaml
+++ b/changelog/fragments/1671748292-input-ids-are-required.yaml
@@ -17,7 +17,7 @@ summary: Each input in an agent policy must have a unique ID.
 # this field accommodate a description without length limits.
 description: |
   Each input in an agent policy must have a unique ID, like "id: my-unique-input-id".
-  This only applies to standalone agents. Unique IDs are automatically generated in
+  This only affects standalone agents. Unique IDs are automatically generated in
   agent policies managed by Fleet.
 
 # Affected component; a word indicating the component this changeset affects.

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -28,8 +28,7 @@ data:
       #Uncomment to enable hints' support
       #hints.enabled: true
     inputs:
-      - name: kubernetes-cluster-metrics
-        id: kubernetes-cluster-metrics
+      - id: kubernetes-cluster-metrics
         condition: ${kubernetes_leaderelection.leader} == true
         type: kubernetes/metrics
         use_output: default
@@ -268,8 +267,7 @@ data:
             # bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
             # ssl.certificate_authorities:
             #   - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
-      - name: system-logs
-        id: system-logs
+      - id: system-logs
         type: logfile
         use_output: default
         meta:
@@ -311,8 +309,7 @@ data:
                   target: ''
                   fields:
                     ecs.version: 1.12.0
-      - name: container-log
-        id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
+      - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
         type: filestream
         use_output: default
         meta:
@@ -337,8 +334,7 @@ data:
               #     match: after
             paths:
               - /var/log/containers/*${kubernetes.container.id}.log
-      - name: audit-log
-        id: audit-log
+      - id: audit-log
         type: filestream
         use_output: default
         meta:
@@ -383,8 +379,7 @@ data:
                         throw "expected kubernetes.audit.annotations.authorization_k8s_io/decision === allow";
                     }
                   }
-      - name: system-metrics
-        id: system-metrics
+      - id: system-metrics
         type: system/metrics
         use_output: default
         meta:
@@ -482,8 +477,7 @@ data:
             metricsets:
               - socket_summary
             system.hostfs: /hostfs
-      - name: kubernetes-node-metrics
-        id: kubernetes-node-metrics
+      - id: kubernetes-node-metrics
         type: kubernetes/metrics
         use_output: default
         meta:
@@ -607,8 +601,7 @@ data:
       # Add extra input blocks here, based on conditions
       # so as to automatically identify targeted Pods and start monitoring them
       # using a predefined integration. For instance:
-      #- name: redis-metrics
-      #  id: redis-metrics
+      #- id: redis-metrics
       #  type: redis/metrics
       #  use_output: default
       #  meta:

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -29,6 +29,7 @@ data:
       #hints.enabled: true
     inputs:
       - name: kubernetes-cluster-metrics
+        id: kubernetes-cluster-metrics
         condition: ${kubernetes_leaderelection.leader} == true
         type: kubernetes/metrics
         use_output: default
@@ -268,6 +269,7 @@ data:
             # ssl.certificate_authorities:
             #   - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
       - name: system-logs
+        id: system-logs
         type: logfile
         use_output: default
         meta:
@@ -382,6 +384,7 @@ data:
                     }
                   }
       - name: system-metrics
+        id: system-metrics
         type: system/metrics
         use_output: default
         meta:
@@ -480,6 +483,7 @@ data:
               - socket_summary
             system.hostfs: /hostfs
       - name: kubernetes-node-metrics
+        id: kubernetes-node-metrics
         type: kubernetes/metrics
         use_output: default
         meta:
@@ -603,7 +607,8 @@ data:
       # Add extra input blocks here, based on conditions
       # so as to automatically identify targeted Pods and start monitoring them
       # using a predefined integration. For instance:
-      #- name: redis
+      #- name: redis-metrics
+      #  id: redis-metrics
       #  type: redis/metrics
       #  use_output: default
       #  meta:

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
@@ -28,8 +28,7 @@ data:
       #Uncomment to enable hints' support
       #hints.enabled: true
     inputs:
-      - name: kubernetes-cluster-metrics
-        id: kubernetes-cluster-metrics
+      - id: kubernetes-cluster-metrics
         condition: ${kubernetes_leaderelection.leader} == true
         type: kubernetes/metrics
         use_output: default
@@ -268,8 +267,7 @@ data:
             # bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
             # ssl.certificate_authorities:
             #   - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
-      - name: system-logs
-        id: system-logs
+      - id: system-logs
         type: logfile
         use_output: default
         meta:
@@ -311,8 +309,7 @@ data:
                   target: ''
                   fields:
                     ecs.version: 1.12.0
-      - name: container-log
-        id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
+      - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
         type: filestream
         use_output: default
         meta:
@@ -337,8 +334,7 @@ data:
               #     match: after
             paths:
               - /var/log/containers/*${kubernetes.container.id}.log
-      - name: audit-log
-        id: audit-log
+      - id: audit-log
         type: filestream
         use_output: default
         meta:
@@ -383,8 +379,7 @@ data:
                         throw "expected kubernetes.audit.annotations.authorization_k8s_io/decision === allow";
                     }
                   }
-      - name: system-metrics
-        id: system-metrics
+      - id: system-metrics
         type: system/metrics
         use_output: default
         meta:
@@ -482,8 +477,7 @@ data:
             metricsets:
               - socket_summary
             system.hostfs: /hostfs
-      - name: kubernetes-node-metrics
-        id: kubernetes-node-metrics
+      - id: kubernetes-node-metrics
         type: kubernetes/metrics
         use_output: default
         meta:
@@ -607,8 +601,7 @@ data:
       # Add extra input blocks here, based on conditions
       # so as to automatically identify targeted Pods and start monitoring them
       # using a predefined integration. For instance:
-      #- name: redis-metrics
-      #  id: redis-metrics
+      #- id: redis-metrics
       #  type: redis/metrics
       #  use_output: default
       #  meta:

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
@@ -29,6 +29,7 @@ data:
       #hints.enabled: true
     inputs:
       - name: kubernetes-cluster-metrics
+        id: kubernetes-cluster-metrics
         condition: ${kubernetes_leaderelection.leader} == true
         type: kubernetes/metrics
         use_output: default
@@ -268,6 +269,7 @@ data:
             # ssl.certificate_authorities:
             #   - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
       - name: system-logs
+        id: system-logs
         type: logfile
         use_output: default
         meta:
@@ -382,6 +384,7 @@ data:
                     }
                   }
       - name: system-metrics
+        id: system-metrics
         type: system/metrics
         use_output: default
         meta:
@@ -480,6 +483,7 @@ data:
               - socket_summary
             system.hostfs: /hostfs
       - name: kubernetes-node-metrics
+        id: kubernetes-node-metrics
         type: kubernetes/metrics
         use_output: default
         meta:
@@ -603,7 +607,8 @@ data:
       # Add extra input blocks here, based on conditions
       # so as to automatically identify targeted Pods and start monitoring them
       # using a predefined integration. For instance:
-      #- name: redis
+      #- name: redis-metrics
+      #  id: redis-metrics
       #  type: redis/metrics
       #  use_output: default
       #  meta:

--- a/elastic-agent.docker.yml
+++ b/elastic-agent.docker.yml
@@ -10,7 +10,8 @@ outputs:
 
 inputs:
   - type: system/metrics
-
+    # Each input must have a unique ID.
+    id: unique-system-metrics-input
     # Namespace name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
     # For index naming restrictions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params
     data_stream.namespace: default
@@ -84,7 +85,7 @@ inputs:
 #   # port for the GRPC server that spawned processes connect back to.
 #   port: 6789
 #   # max_message_size limits the message size in agent internal communication
-#   # default is 100MB 
+#   # default is 100MB
 #   max_message_size: 104857600
 
 # agent.retry:

--- a/elastic-agent.reference.yml
+++ b/elastic-agent.reference.yml
@@ -17,7 +17,8 @@ outputs:
 
 inputs:
   - type: system/metrics
-
+    # Each input must have a unique ID.
+    id: unique-system-metrics-input
     # Namespace name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
     # For index naming restrictions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params
     data_stream.namespace: default
@@ -91,7 +92,7 @@ inputs:
 #   # port for the GRPC server that spawned processes connect back to.
 #   port: 6789
 #   # max_message_size limits the message size in agent internal communication
-#   # default is 100MB 
+#   # default is 100MB
 #   max_message_size: 104857600
 
 # agent.retry:

--- a/elastic-agent.yml
+++ b/elastic-agent.yml
@@ -17,7 +17,7 @@ outputs:
 
 inputs:
   - type: system/metrics
-    # Each input listed in the agent policy must have a unique ID.
+    # Each input must have a unique ID.
     id: unique-system-metrics-input
     # Namespace name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
     # For index naming restrictions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params

--- a/elastic-agent.yml
+++ b/elastic-agent.yml
@@ -17,7 +17,8 @@ outputs:
 
 inputs:
   - type: system/metrics
-
+    # Each input listed in the agent policy must have a unique ID.
+    id: unique-system-metrics-input
     # Namespace name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
     # For index naming restrictions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params
     data_stream.namespace: default
@@ -124,7 +125,7 @@ inputs:
 #   # port for the GRPC server that spawned processes connect back to.
 #   port: 6789
 #   # max_message_size limits the message size in agent internal communication
-#   # default is 100MB 
+#   # default is 100MB
 #   max_message_size: 104857600
 
 # agent.retry:

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -518,7 +518,7 @@ func toIntermediate(policy map[string]interface{}, aliasMapping map[string]strin
 			return nil, fmt.Errorf("invalid 'inputs.%d.id', expected a string not a %T", idx, idRaw)
 		}
 		if hasDuplicate(outputsMap, id) {
-			return nil, fmt.Errorf("invalid 'inputs.%d.id', has a duplicate id %q. Please add a unique value for the 'id' field to each input in the agent policy.", idx, id)
+			return nil, fmt.Errorf("invalid 'inputs.%d.id', has a duplicate id %q. Please add a unique value for the 'id' field to each input in the agent policy", idx, id)
 		}
 		outputName := "default"
 		if outputRaw, ok := input[useKey]; ok {

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -518,7 +518,7 @@ func toIntermediate(policy map[string]interface{}, aliasMapping map[string]strin
 			return nil, fmt.Errorf("invalid 'inputs.%d.id', expected a string not a %T", idx, idRaw)
 		}
 		if hasDuplicate(outputsMap, id) {
-			return nil, fmt.Errorf("invalid 'inputs.%d.id', has a duplicate id %q (id is required to be unique)", idx, id)
+			return nil, fmt.Errorf("invalid 'inputs.%d.id', has a duplicate id %q. Please add a unique value for the 'id' field to each input in the agent policy.", idx, id)
 		}
 		outputName := "default"
 		if outputRaw, ok := input[useKey]; ok {

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -518,7 +518,7 @@ func toIntermediate(policy map[string]interface{}, aliasMapping map[string]strin
 			return nil, fmt.Errorf("invalid 'inputs.%d.id', expected a string not a %T", idx, idRaw)
 		}
 		if hasDuplicate(outputsMap, id) {
-			return nil, fmt.Errorf("invalid 'inputs.%d.id', has a duplicate id %q. Please add a unique value for the 'id' field to each input in the agent policy", idx, id)
+			return nil, fmt.Errorf("invalid 'inputs.%d.id', has a duplicate id %q. Please add a unique value for the 'id' key to each input in the agent policy", idx, id)
 		}
 		outputName := "default"
 		if outputRaw, ok := input[useKey]; ok {

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -195,7 +195,7 @@ func TestToComponents(t *testing.T) {
 					},
 				},
 			},
-			Err: `invalid 'inputs.1.id', has a duplicate id "filestream" (id is required to be unique)`,
+			Err: `invalid 'inputs.1.id', has a duplicate id "filestream". Please add a unique value for the 'id' field to each input in the agent policy.`,
 		},
 		{
 			Name:     "Invalid: inputs entry id not a string",

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -195,7 +195,7 @@ func TestToComponents(t *testing.T) {
 					},
 				},
 			},
-			Err: `invalid 'inputs.1.id', has a duplicate id "filestream". Please add a unique value for the 'id' field to each input in the agent policy.`,
+			Err: `invalid 'inputs.1.id', has a duplicate id "filestream". Please add a unique value for the 'id' field to each input in the agent policy`,
 		},
 		{
 			Name:     "Invalid: inputs entry id not a string",

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -195,7 +195,7 @@ func TestToComponents(t *testing.T) {
 					},
 				},
 			},
-			Err: `invalid 'inputs.1.id', has a duplicate id "filestream". Please add a unique value for the 'id' field to each input in the agent policy`,
+			Err: `invalid 'inputs.1.id', has a duplicate id "filestream". Please add a unique value for the 'id' key to each input in the agent policy`,
 		},
 		{
 			Name:     "Invalid: inputs entry id not a string",


### PR DESCRIPTION
As part of the agent V2 change, unique input IDs are mandatory. Add a changelog fragment for this, and update the example agent policies to include IDs where necessary.

I made this fairly quickly and may have missed an update to a reference file.

- Relates https://github.com/elastic/elastic-agent/issues/1991