### PR TITLE
Increase Agent logfile size

### DIFF
--- a/_meta/config/common.p2.yml.tmpl
+++ b/_meta/config/common.p2.yml.tmpl
@@ -182,7 +182,7 @@ agent.logging.to_stderr: true
 
   # Configure log file size limit. If limit is reached, log file will be
   # automatically rotated
-  #rotateeverybytes: 10485760 # = 10MB
+  #rotateeverybytes: 20971520 # = 20MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
   #keepfiles: 7

--- a/_meta/config/common.reference.p2.yml.tmpl
+++ b/_meta/config/common.reference.p2.yml.tmpl
@@ -182,7 +182,7 @@ agent.logging.to_stderr: true
 
   # Configure log file size limit. If limit is reached, log file will be
   # automatically rotated
-  #rotateeverybytes: 10485760 # = 10MB
+  #rotateeverybytes: 20971520 # = 20MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
   #keepfiles: 7

--- a/_meta/config/elastic-agent.docker.yml.tmpl
+++ b/_meta/config/elastic-agent.docker.yml.tmpl
@@ -181,7 +181,7 @@ agent.logging.to_stderr: true
 
   # Configure log file size limit. If limit is reached, log file will be
   # automatically rotated
-  #rotateeverybytes: 10485760 # = 10MB
+  #rotateeverybytes: 20971520 # = 20MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
   #keepfiles: 7

--- a/_meta/elastic-agent.yml
+++ b/_meta/elastic-agent.yml
@@ -170,7 +170,7 @@ agent.logging.to_stderr: true
 
   # Configure log file size limit. If limit is reached, log file will be
   # automatically rotated
-  #rotateeverybytes: 10485760 # = 10MB
+  #rotateeverybytes: 20971520 # = 20MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
   #keepfiles: 7

--- a/elastic-agent.docker.yml
+++ b/elastic-agent.docker.yml
@@ -181,7 +181,7 @@ agent.logging.to_stderr: true
 
   # Configure log file size limit. If limit is reached, log file will be
   # automatically rotated
-  #rotateeverybytes: 10485760 # = 10MB
+  #rotateeverybytes: 20971520 # = 20MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
   #keepfiles: 7

--- a/elastic-agent.reference.yml
+++ b/elastic-agent.reference.yml
@@ -188,7 +188,7 @@ agent.logging.to_stderr: true
 
   # Configure log file size limit. If limit is reached, log file will be
   # automatically rotated
-  #rotateeverybytes: 10485760 # = 10MB
+  #rotateeverybytes: 20971520 # = 20MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
   #keepfiles: 7

--- a/elastic-agent.yml
+++ b/elastic-agent.yml
@@ -188,7 +188,7 @@ agent.logging.to_stderr: true
 
   # Configure log file size limit. If limit is reached, log file will be
   # automatically rotated
-  #rotateeverybytes: 10485760 # = 10MB
+  #rotateeverybytes: 20971520 # = 20MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
   #keepfiles: 7

--- a/pkg/core/logger/logger.go
+++ b/pkg/core/logger/logger.go
@@ -121,6 +121,7 @@ func DefaultLoggingConfig() *Config {
 	cfg.ToFiles = true
 	cfg.Files.Path = paths.Logs()
 	cfg.Files.Name = agentName
+	cfg.Files.MaxSize = 20 * 1024 * 1024
 
 	return &cfg
 }


### PR DESCRIPTION
## What does this PR do?

This PR increases logfile size limit from `10MB` to `20MB`

## Why is it important?

As log files of processes are removed and events are persisted in agent log file we need to increase agent logfile size to keep capacity of the logs.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Fixes: #1992 