### PR TITLE
[V2] Do not collect endpoint metrics on /stats endpoint

### DIFF
--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -56,9 +56,9 @@ const (
 )
 
 var (
-	errNoOuputPresent        = errors.New("outputs not part of the config")
-	supportedComponents      = []string{"filebeat", "metricbeat", "apm-server", "auditbeat", "cloudbeat", "cloud-defend", "endpoint-security", "fleet-server", "heartbeat", "osquerybeat", "packetbeat"}
-	supportedBeatsComponents = []string{"filebeat", "metricbeat", "apm-server", "fleet-server", "auditbeat", "cloudbeat", "heartbeat", "osquerybeat", "packetbeat"}
+	errNoOuputPresent          = errors.New("outputs not part of the config")
+	supportedMetricsComponents = []string{"filebeat", "metricbeat", "apm-server", "auditbeat", "cloudbeat", "cloud-defend", "fleet-server", "heartbeat", "osquerybeat", "packetbeat"}
+	supportedBeatsComponents   = []string{"filebeat", "metricbeat", "apm-server", "fleet-server", "auditbeat", "cloudbeat", "heartbeat", "osquerybeat", "packetbeat"}
 )
 
 // BeatsMonitor is providing V1 monitoring support for metrics and logs for endpoint-security only.
@@ -584,7 +584,7 @@ func (b *BeatsMonitor) injectMetricsInput(cfg map[string]interface{}, componentI
 		},
 	}
 	for unit, binaryName := range componentIDToBinary {
-		if !isSupportedBinary(binaryName) {
+		if !isSupportedMetricsBinary(binaryName) {
 			continue
 		}
 
@@ -889,8 +889,8 @@ func httpCopyRules() []interface{} {
 	return fromToMap
 }
 
-func isSupportedBinary(binaryName string) bool {
-	for _, supportedBinary := range supportedComponents {
+func isSupportedMetricsBinary(binaryName string) bool {
+	for _, supportedBinary := range supportedMetricsComponents {
 		if strings.EqualFold(supportedBinary, binaryName) {
 			return true
 		}


### PR DESCRIPTION
## What does this PR do?

Removes endpoint from supported binaries for metrics collection. 


## Why is it important?

Reduces logs by not hitting 
```
Error fetching data for metricset http.json: error making http request: 
Get \"http://unix/stats\": dial unix /opt/Elastic/Agent/data/tmp/endpoint-default.sock: connect: no such file or directory" 
```

as endpoint does not expose metrics on used path.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Fixes: #1965 