### PR TITLE
Improve state change messages

### DIFF
--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -343,14 +343,14 @@ func (c *Coordinator) Run(ctx context.Context) error {
 						ID:    s.Component.ID,
 						State: s.State.State.String(),
 					}
-					logBasedOnState(c.logger, s.State.State, fmt.Sprintf("Spawned new %s: %s", s.Component.ID, s.State.Message), "component", componentLog)
+					logBasedOnState(c.logger, s.State.State, fmt.Sprintf("Spawned new component %s: %s", s.Component.ID, s.State.Message), "component", componentLog)
 					for ui, us := range s.State.Units {
 						unitLog := coordinatorUnitLog{
 							ID:    ui.UnitID,
 							Type:  ui.UnitType.String(),
 							State: us.State.String(),
 						}
-						logBasedOnState(c.logger, us.State, fmt.Sprintf("Spawned new %s: %s", ui.UnitID, us.Message), "component", componentLog, "unit", unitLog)
+						logBasedOnState(c.logger, us.State, fmt.Sprintf("Spawned new unit %s: %s", ui.UnitID, us.Message), "component", componentLog, "unit", unitLog)
 					}
 				} else {
 					componentLog := coordinatorComponentLog{
@@ -363,7 +363,7 @@ func (c *Coordinator) Run(ctx context.Context) error {
 							State:    s.State.State.String(),
 							OldState: oldState.State.String(),
 						}
-						logBasedOnState(c.logger, s.State.State, fmt.Sprintf("State changed %s (%s->%s): %s", s.Component.ID, oldState.State.String(), s.State.State.String(), s.State.Message), "component", cl)
+						logBasedOnState(c.logger, s.State.State, fmt.Sprintf("Component state changed %s (%s->%s): %s", s.Component.ID, oldState.State.String(), s.State.State.String(), s.State.Message), "component", cl)
 					}
 					for ui, us := range s.State.Units {
 						oldUS, ok := oldState.Units[ui]
@@ -373,7 +373,7 @@ func (c *Coordinator) Run(ctx context.Context) error {
 								Type:  ui.UnitType.String(),
 								State: us.State.String(),
 							}
-							logBasedOnState(c.logger, us.State, fmt.Sprintf("Spawned new %s: %s", ui.UnitID, us.Message), "component", componentLog, "unit", unitLog)
+							logBasedOnState(c.logger, us.State, fmt.Sprintf("Spawned new unit %s: %s", ui.UnitID, us.Message), "component", componentLog, "unit", unitLog)
 						} else if oldUS.State != us.State {
 							unitLog := coordinatorUnitLog{
 								ID:       ui.UnitID,
@@ -381,7 +381,7 @@ func (c *Coordinator) Run(ctx context.Context) error {
 								State:    us.State.String(),
 								OldState: oldUS.State.String(),
 							}
-							logBasedOnState(c.logger, us.State, fmt.Sprintf("State changed %s (%s->%s): %s", ui.UnitID, oldUS.State.String(), us.State.String(), us.Message), "component", componentLog, "unit", unitLog)
+							logBasedOnState(c.logger, us.State, fmt.Sprintf("Unit state changed %s (%s->%s): %s", ui.UnitID, oldUS.State.String(), us.State.String(), us.Message), "component", componentLog, "unit", unitLog)
 						}
 					}
 				}

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -835,6 +835,7 @@ func logBasedOnState(l *logger.Logger, state client.UnitState, msg string, args 
 		l.With(args...).Info(msg)
 	case client.UnitStateStopped:
 		l.With(args...).Info(msg)
+    default:
+        l.With(args...).Info(msg)
 	}
-	l.With(args...).Info(msg)
 }

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -343,14 +343,14 @@ func (c *Coordinator) Run(ctx context.Context) error {
 						ID:    s.Component.ID,
 						State: s.State.State.String(),
 					}
-					logBasedOnState(c.logger, s.State.State, fmt.Sprintf("Spawned new component %s: %s", s.Component.ID, s.State.Message), "component", componentLog)
+					logBasedOnState(c.logger, s.State.State, fmt.Sprintf("Spawned new %s: %s", s.Component.ID, s.State.Message), "component", componentLog)
 					for ui, us := range s.State.Units {
 						unitLog := coordinatorUnitLog{
 							ID:    ui.UnitID,
 							Type:  ui.UnitType.String(),
 							State: us.State.String(),
 						}
-						logBasedOnState(c.logger, us.State, fmt.Sprintf("Spawned new component/unit %s/%s: %s", s.Component.ID, ui.UnitID, us.Message), "component", componentLog, "unit", unitLog)
+						logBasedOnState(c.logger, us.State, fmt.Sprintf("Spawned new %s: %s", ui.UnitID, us.Message), "component", componentLog, "unit", unitLog)
 					}
 				} else {
 					componentLog := coordinatorComponentLog{
@@ -363,7 +363,7 @@ func (c *Coordinator) Run(ctx context.Context) error {
 							State:    s.State.State.String(),
 							OldState: oldState.State.String(),
 						}
-						logBasedOnState(c.logger, s.State.State, fmt.Sprintf("Component state changed %s (%s->%s): %s", s.Component.ID, oldState.State.String(), s.State.State.String(), s.State.Message), "component", cl)
+						logBasedOnState(c.logger, s.State.State, fmt.Sprintf("State changed %s (%s->%s): %s", s.Component.ID, oldState.State.String(), s.State.State.String(), s.State.Message), "component", cl)
 					}
 					for ui, us := range s.State.Units {
 						oldUS, ok := oldState.Units[ui]
@@ -373,15 +373,15 @@ func (c *Coordinator) Run(ctx context.Context) error {
 								Type:  ui.UnitType.String(),
 								State: us.State.String(),
 							}
-							logBasedOnState(c.logger, us.State, fmt.Sprintf("Spawned new component/unit %s/%s: %s", s.Component.ID, ui.UnitID, us.Message), "component", componentLog, "unit", unitLog)
-						} else {
+							logBasedOnState(c.logger, us.State, fmt.Sprintf("Spawned new %s: %s", ui.UnitID, us.Message), "component", componentLog, "unit", unitLog)
+						} else if oldUS.State != us.State {
 							unitLog := coordinatorUnitLog{
 								ID:       ui.UnitID,
 								Type:     ui.UnitType.String(),
 								State:    us.State.String(),
 								OldState: oldUS.State.String(),
 							}
-							logBasedOnState(c.logger, us.State, fmt.Sprintf("Component/unit state changed %s/%s (%s->%s): %s", s.Component.ID, ui.UnitID, oldState.State.String(), us.State.String(), us.Message), "component", componentLog, "unit", unitLog)
+							logBasedOnState(c.logger, us.State, fmt.Sprintf("State changed %s (%s->%s): %s", ui.UnitID, oldState.State.String(), us.State.String(), us.Message), "component", componentLog, "unit", unitLog)
 						}
 					}
 				}

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -835,7 +835,7 @@ func logBasedOnState(l *logger.Logger, state client.UnitState, msg string, args 
 		l.With(args...).Info(msg)
 	case client.UnitStateStopped:
 		l.With(args...).Info(msg)
-    default:
-        l.With(args...).Info(msg)
+	default:
+		l.With(args...).Info(msg)
 	}
 }

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -381,7 +381,7 @@ func (c *Coordinator) Run(ctx context.Context) error {
 								State:    us.State.String(),
 								OldState: oldUS.State.String(),
 							}
-							logBasedOnState(c.logger, us.State, fmt.Sprintf("State changed %s (%s->%s): %s", ui.UnitID, oldState.State.String(), us.State.String(), us.Message), "component", componentLog, "unit", unitLog)
+							logBasedOnState(c.logger, us.State, fmt.Sprintf("State changed %s (%s->%s): %s", ui.UnitID, oldUS.State.String(), us.State.String(), us.Message), "component", componentLog, "unit", unitLog)
 						}
 					}
 				}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

It updates the logging messages for component and unit state changes to be easier to understand and read.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without this change viewing state change information in the logs is hard to read and doesn't show properly when the logs are rendered in the Fleet UI.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #1954

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

```
{"log.level":"info","@timestamp":"2022-12-23T09:04:07.182-0500","log.origin":{"file.name":"coordinator/coordinator.go","file.line":831},"message":"State changed system/metrics-default-system/metrics-system-e2699079-2004-4ee0-8916-e8614031c65e (STARTING->HEALTHY): Healthy","component":{"id":"system/metrics-default","state":"HEALTHY"},"unit":{"id":"system/metrics-default-system/metrics-system-e2699079-2004-4ee0-8916-e8614031c65e","type":"input","state":"HEALTHY","old_state":"STARTING"},"ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-12-23T09:04:07.182-0500","log.origin":{"file.name":"coordinator/coordinator.go","file.line":839},"message":"State changed system/metrics-default-system/metrics-system-e2699079-2004-4ee0-8916-e8614031c65e (STARTING->HEALTHY): Healthy","component":{"id":"system/metrics-default","state":"HEALTHY"},"unit":{"id":"system/metrics-default-system/metrics-system-e2699079-2004-4ee0-8916-e8614031c65e","type":"input","state":"HEALTHY","old_state":"STARTING"},"ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-12-23T09:04:07.182-0500","log.origin":{"file.name":"coordinator/coordinator.go","file.line":831},"message":"State changed system/metrics-default (STARTING->HEALTHY): Healthy","component":{"id":"system/metrics-default","state":"HEALTHY"},"unit":{"id":"system/metrics-default","type":"output","state":"HEALTHY","old_state":"STARTING"},"ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-12-23T09:04:07.182-0500","log.origin":{"file.name":"coordinator/coordinator.go","file.line":839},"message":"State changed system/metrics-default (STARTING->HEALTHY): Healthy","component":{"id":"system/metrics-default","state":"HEALTHY"},"unit":{"id":"system/metrics-default","type":"output","state":"HEALTHY","old_state":"STARTING"},"ecs.version":"1.6.0"}
```