### PR TITLE
Fix metrics destination index and dataset to match v1

### DIFF
--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -596,20 +596,20 @@ func (b *BeatsMonitor) injectMetricsInput(cfg map[string]interface{}, componentI
 				idKey: "metrics-monitoring-" + name,
 				"data_stream": map[string]interface{}{
 					"type":      "metrics",
-					"dataset":   fmt.Sprintf("elastic_agent.%s", name),
+					"dataset":   fmt.Sprintf("elastic_agent.%s", binaryName),
 					"namespace": monitoringNamespace,
 				},
 				"metricsets": []interface{}{"stats", "state"},
 				"hosts":      endpoints,
 				"period":     "10s",
-				"index":      fmt.Sprintf("metrics-elastic_agent.%s-%s", name, monitoringNamespace),
+				"index":      fmt.Sprintf("metrics-elastic_agent.%s-%s", binaryName, monitoringNamespace),
 				"processors": []interface{}{
 					map[string]interface{}{
 						"add_fields": map[string]interface{}{
 							"target": "data_stream",
 							"fields": map[string]interface{}{
 								"type":      "metrics",
-								"dataset":   fmt.Sprintf("elastic_agent.%s", name),
+								"dataset":   fmt.Sprintf("elastic_agent.%s", binaryName),
 								"namespace": monitoringNamespace,
 							},
 						},
@@ -618,7 +618,7 @@ func (b *BeatsMonitor) injectMetricsInput(cfg map[string]interface{}, componentI
 						"add_fields": map[string]interface{}{
 							"target": "event",
 							"fields": map[string]interface{}{
-								"dataset": fmt.Sprintf("elastic_agent.%s", name),
+								"dataset": fmt.Sprintf("elastic_agent.%s", binaryName),
 							},
 						},
 					},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fixes the data streams that we send agent monitoring metrics to use the `elastic_agent.<binary name>` pattern from v1 instead of `elastic_agent.<unit id>`

## Why is it important?

We need to be sure agent's monitoring metrics get delivered so they must match what's defined by the elastic_agent package. Also, having a data stream per unique unit will cause an explosion of data streams without user benefit. Without this change, metrics from individual binaries are being dropped with errors like:

```
{"type":"security_exception","reason":"action [indices:admin/auto_create] is unauthorized for API key id [OgRsP4UBpJowysjwmQ1H] of user [elastic/fleet-server] on indices [metrics-elastic_agent.system_metrics_8c767cd0_82cf_11ed_a802_7913b47c3a5f-default], this action is granted by the index privileges [auto_configure,create_index,manage,all]"}, dropping event!
```

This is the same change we did for logging in https://github.com/elastic/elastic-agent/pull/1845 and the long-term plan for v2 logs and metrics will be discussed in:
- https://github.com/elastic/elastic-agent/issues/1814

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

## How to test this PR locally

Enroll an agent with monitoring enabled, verify that none of the error logs above show up in `logs-elastic_agent.metricbeat-default` and verify that metrics are available in `metrics-elastic_agent.metricbeat-default`
