### PR TITLE
Add generic diagnostic redactor back to v2

### DIFF
--- a/internal/pkg/agent/cmd/diagnostics.go
+++ b/internal/pkg/agent/cmd/diagnostics.go
@@ -170,15 +170,14 @@ func writeRedacted(streams *cli.IOStreams, fullFilePath string, fr client.Diagno
 	if fr.ContentType == "application/yaml" {
 		unmarshalled := map[string]interface{}{}
 		err := yaml.Unmarshal(fr.Content, &unmarshalled)
-
 		if err != nil {
 			// Best effort, output a warning but still include the file
-			fmt.Fprintf(streams.Err, "[warning] Could not redact %s due to unmarshalling error: %s\n", fullFilePath, err)
+			fmt.Fprintf(streams.Err, "[WARNING] Could not redact %s due to unmarshalling error: %s\n", fullFilePath, err)
 		} else {
 			redacted, err := yaml.Marshal(redactMap(unmarshalled))
 			if err != nil {
 				// Best effort, output a warning but still include the file
-				fmt.Fprintf(streams.Err, "[warning] Could not redact %s due to marshalling error: %s\n", fullFilePath, err)
+				fmt.Fprintf(streams.Err, "[WARNING] Could not redact %s due to marshalling error: %s\n", fullFilePath, err)
 			} else {
 				out = &redacted
 			}

--- a/internal/pkg/agent/cmd/diagnostics.go
+++ b/internal/pkg/agent/cmd/diagnostics.go
@@ -179,9 +179,9 @@ func writeRedacted(streams *cli.IOStreams, fullFilePath string, fr client.Diagno
 			if err != nil {
 				// Best effort, output a warning but still include the file
 				fmt.Fprintf(streams.Err, "[warning] Could not redact %s due to marshalling error: %s\n", fullFilePath, err)
+			} else {
+				out = &redacted
 			}
-
-			out = &redacted
 		}
 	}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Restores the redaction step from https://github.com/elastic/elastic-agent/pull/566 during diagnostic building to ensure that most secrets in configuration are not included in the diag.

There are situations where the YAML is not always unmarshallable https://github.com/elastic/elastic-agent/issues/1907#issuecomment-1363224642 which limits the ability to redact the agent's `state.yml` diag file. This will need to be fixed by either a smarter generic redaction implementation that can selectively unmarshall/redact parts of the file or by redacting the state.yml file before it's serialized in `coordinator.go`.

In the meantime, I have made redaction best-effort and will allow any file that cannot be successfully unmarshalled to be written to the diag as-is with secrets in place. A warning log is written to stderr with details about which files were not redacted when this happens.

~~This also fixes a bug where diagnostic files that provided by components were written to the diag bundle without the file extension.~~ Got fixed in https://github.com/elastic/elastic-agent/pull/2047

## Why is it important?

We do not want users to include any secrets in the diagnostics that they end to us. We have had this feature since 8.4 and do not want to regress on it

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates to https://github.com/elastic/elastic-agent/issues/1907

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
