### PR TITLE
Add statsd metricbeat input.

### DIFF
--- a/specs/metricbeat.spec.yml
+++ b/specs/metricbeat.spec.yml
@@ -287,6 +287,13 @@ inputs:
     shippers: *shippers
     command:
       args: *args
+  - name: statsd/metrics
+    description: "Statsd metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command:
+      args: *args
   - name: traefik/metrics
     description: "Traefik metrics"
     platforms: *platforms


### PR DESCRIPTION
## What does this PR do?

Add **statsd/metrics** missing input. We are working on **integrations/input package** using **statsd/metrics** In both the cases we noticed:

- Some issues in the new agent, where **statsd** metrics were not pushed to ES.
- Working for older agents but not in new agents.
-  statsd entry to be missing in the recently added metricbeat spec file in V2 elastic-agent.

CC: @ishleenk17 

## Why is it important?

- Gating the development of new statsd input package, while using latest V2 elastic-agent.

## Checklist

NA

-->

- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
