### PR TITLE
Respect context cancellation when waiting for Vars

### DIFF
--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -589,7 +589,7 @@ func (b *BeatsMonitor) injectMetricsInput(cfg map[string]interface{}, componentI
 		}
 
 		endpoints := []interface{}{prefixedEndpoint(endpointPath(unit, b.operatingSystem))}
-		name := strings.ReplaceAll(strings.ReplaceAll(unit, "-", "_"), "/", "_") // conform with index naming policy
+		name := strings.ReplaceAll(strings.ReplaceAll(binaryName, "-", "_"), "/", "_") // conform with index naming policy
 
 		if isSupportedBeatsBinary(binaryName) {
 			beatsStreams = append(beatsStreams, map[string]interface{}{

--- a/internal/pkg/composable/controller.go
+++ b/internal/pkg/composable/controller.go
@@ -173,6 +173,7 @@ func (c *controller) Run(ctx context.Context) error {
 					}
 				}()
 
+				close(c.ch)
 				wg.Wait()
 				return ctx.Err()
 			case <-notify:
@@ -207,7 +208,11 @@ func (c *controller) Run(ctx context.Context) error {
 			}
 		}
 
-		c.ch <- vars
+		select {
+		case c.ch <- vars:
+		case <-ctx.Done():
+			// coordinator is handling cancellation it won't drain the channel
+		}
 	}
 }
 

--- a/internal/pkg/composable/controller_test.go
+++ b/internal/pkg/composable/controller_test.go
@@ -201,4 +201,16 @@ func TestCancellation(t *testing.T) {
 		})
 		timeout += 10 * time.Millisecond
 	}
+
+	t.Run("immediate cancellation", func(t *testing.T) {
+		c, err := composable.New(log, cfg, false)
+		require.NoError(t, err)
+		ctx, cancelFn := context.WithTimeout(context.Background(), 0)
+		cancelFn()
+		err = c.Run(ctx)
+		// test will time out and fail if cancellation is not proper
+		if err != nil {
+			require.True(t, errors.Is(err, context.DeadlineExceeded))
+		}
+	})
 }

--- a/internal/pkg/composable/controller_test.go
+++ b/internal/pkg/composable/controller_test.go
@@ -7,6 +7,7 @@ package composable_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -130,4 +131,74 @@ func TestController(t *testing.T) {
 	localMap, ok = local.(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "value2", localMap["key1"])
+}
+
+func TestCancellation(t *testing.T) {
+	cfg, err := config.NewConfigFrom(map[string]interface{}{
+		"providers": map[string]interface{}{
+			"env": map[string]interface{}{
+				"enabled": "false",
+			},
+			"local": map[string]interface{}{
+				"vars": map[string]interface{}{
+					"key1": "value1",
+				},
+			},
+			"local_dynamic": map[string]interface{}{
+				"items": []map[string]interface{}{
+					{
+						"vars": map[string]interface{}{
+							"key1": "value1",
+						},
+						"processors": []map[string]interface{}{
+							{
+								"add_fields": map[string]interface{}{
+									"fields": map[string]interface{}{
+										"add": "value1",
+									},
+									"to": "dynamic",
+								},
+							},
+						},
+					},
+					{
+						"vars": map[string]interface{}{
+							"key1": "value2",
+						},
+						"processors": []map[string]interface{}{
+							{
+								"add_fields": map[string]interface{}{
+									"fields": map[string]interface{}{
+										"add": "value2",
+									},
+									"to": "dynamic",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	log, err := logger.New("", false)
+	require.NoError(t, err)
+
+	// try with variable deadlines
+	timeout := 50 * time.Millisecond
+	for i := 1; i <= 10; i++ {
+		t.Run(fmt.Sprintf("test run %d", i), func(t *testing.T) {
+			c, err := composable.New(log, cfg, false)
+			require.NoError(t, err)
+			ctx, cancelFn := context.WithTimeout(context.Background(), timeout)
+			defer cancelFn()
+			err = c.Run(ctx)
+			// test will time out and fail if cancellation is not proper
+			if err != nil {
+				require.True(t, errors.Is(err, context.DeadlineExceeded))
+			}
+		})
+		timeout += 10 * time.Millisecond
+	}
 }


### PR DESCRIPTION
## What does this PR do?

This PR adds a context cancellation check in controller.
It can happen that controllers will hang on `c.ch <- vars` because coordinator is handling cancellation already and never gets to handling `case vars := <-varsWatcher.Watch():` part of the loop and never drains the channel.

Including also fix for index name generation for monitoring metricbeat

## Why is it important?

Sometimes very occasionally we're experiencing agent stuck in REEXECuting (unhealthy in UI)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Related: https://github.com/elastic/elastic-agent/issues/1861
it should fix it but i'd rather wait for test results. I haven't run into the situation after this fix in place