### PR TITLE
Fix stale checkin expected messages being sent on process restart

### DIFF
--- a/pkg/component/runtime/conn_info_server_test.go
+++ b/pkg/component/runtime/conn_info_server_test.go
@@ -60,6 +60,9 @@ func (c *mockCommunicator) WriteConnInfo(w io.Writer, services ...client.Service
 func (c *mockCommunicator) CheckinExpected(expected *proto.CheckinExpected) {
 }
 
+func (c *mockCommunicator) ClearPendingCheckinExpected() {
+}
+
 func (c *mockCommunicator) CheckinObserved() <-chan *proto.CheckinObserved {
 	return c.ch
 }

--- a/pkg/component/runtime/service.go
+++ b/pkg/component/runtime/service.go
@@ -114,6 +114,7 @@ func (s *ServiceRuntime) Run(ctx context.Context, comm Communicator) (err error)
 				// Initial state on start
 				lastCheckin = time.Time{}
 				missedCheckins = 0
+				comm.ClearPendingCheckinExpected()
 				checkinTimer.Stop()
 				cisStop()
 


### PR DESCRIPTION
When a previously running process exits, it is possible that the most recent checkin expected message for that process was queued to be sent in the communicator checkin expected channel but never sent.

When the process is restarted, this stale previous checkin expected message  would then be sent to the new process as the first checkin.

This can lead to invalid or unexpected initial checkin expected messages being sent to component processes, for example the config index can be set to the correct value but the actual configuration set to nil because the stale message was for a process that was already up to date. This can lead to component processes ignoring the actual initial configuration that is sent later because the config index was the same as it was in the stale initial checkin message.

Component processes that don't expect this invalid state can then fail at startup, see https://github.com/elastic/beats/issues/34137 for example.

To fix this the agent now clears out any pending checkin expected messages before starting new processes or services.

Closes https://github.com/elastic/beats/issues/34137

I haven't added a test for this because it would be difficult to orchestrate but it is easy to verify this fixes the problem manually. Each time an output setting (for example bulk_max_size) is changed the Beats restart, which would almost always trigger a panic due to nil dereference in one of the Beats. With this fix this panic no longer occurs.