### PR TITLE
Use full filename for component diagnostic files.

### DIFF
--- a/internal/pkg/agent/cmd/diagnostics.go
+++ b/internal/pkg/agent/cmd/diagnostics.go
@@ -137,7 +137,7 @@ func createZip(fileName string, agentDiag []client.DiagnosticFileResult, unitDia
 				continue
 			}
 			for _, fr := range ud.Results {
-				w, err := zw.Create(fmt.Sprintf("components/%s/%s/%s", dirName, unitDir, fr.Name))
+				w, err := zw.Create(fmt.Sprintf("components/%s/%s/%s", dirName, unitDir, fr.Filename))
 				if err != nil {
 					return closeHandlers(err, zw, f)
 				}


### PR DESCRIPTION
Fixes omitting the file extensions when writing per component diagnostic files to disk.

Picked this change out of https://github.com/elastic/elastic-agent/pull/2005.

Before:
```
ls diag/components/system-metrics-default/system-metrics-default
allocs               block.txt            heap                 threadcreate
beat-rendered-config goroutine            mutex
```

After:

```
ls diag/components/system-metrics-default/system-metrics-default
allocs.txt               block.txt                heap.txt                 threadcreate.txt
beat-rendered-config.yml goroutine.txt            mutex.txt
```
