### PR TITLE
Add osquery and endpoint security logstash output support

### DIFF
--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -334,19 +334,19 @@ func TestToComponents(t *testing.T) {
 				},
 				"inputs": []interface{}{
 					map[string]interface{}{
-						"type": "endpoint",
-						"id":   "endpoint-0",
+						"type": "fleet-server",
+						"id":   "fleet-server-0",
 					},
 				},
 			},
 			Result: []Component{
 				{
-					ID:        "endpoint-default",
+					ID:        "fleet-server-default",
 					InputSpec: &InputRuntimeSpec{},
 					Err:       ErrOutputNotSupported,
 					Units: []Unit{
 						{
-							ID:       "endpoint-default",
+							ID:       "fleet-server-default",
 							Type:     client.UnitTypeOutput,
 							LogLevel: defaultUnitLogLevel,
 							Config: MustExpectedConfig(map[string]interface{}{
@@ -354,12 +354,12 @@ func TestToComponents(t *testing.T) {
 							}),
 						},
 						{
-							ID:       "endpoint-default-endpoint-0",
+							ID:       "fleet-server-default-fleet-server-0",
 							Type:     client.UnitTypeInput,
 							LogLevel: defaultUnitLogLevel,
 							Config: MustExpectedConfig(map[string]interface{}{
-								"type": "endpoint",
-								"id":   "endpoint-0",
+								"type": "fleet-server",
+								"id":   "fleet-server-0",
 							}),
 						},
 					},

--- a/specs/endpoint-security.spec.yml
+++ b/specs/endpoint-security.spec.yml
@@ -9,6 +9,7 @@ inputs:
       - container/arm64
     outputs:
       - elasticsearch
+      - logstash
     runtime:
       preventions:
         - condition: ${runtime.user.root} == false
@@ -48,6 +49,7 @@ inputs:
       - darwin/arm64
     outputs:
       - elasticsearch
+      - logstash
     service:
       cport: 6788
       log:
@@ -59,6 +61,7 @@ inputs:
       - windows/amd64
     outputs:
       - elasticsearch
+      - logstash
     runtime:
       preventions:
         - condition: ${runtime.user.root} == false

--- a/specs/osquerybeat.spec.yml
+++ b/specs/osquerybeat.spec.yml
@@ -12,6 +12,7 @@ inputs:
       - container/arm64
     outputs:
       - elasticsearch
+      - logstash
     command:
       restart_monitoring_period: 5s
       maximum_restarts_per_period: 1


### PR DESCRIPTION
- Closes https://github.com/elastic/security-team/issues/5572

Osquerybeat support for Logstash was removed when it should not have been. Put it back.
