### PR TITLE
[automation] update elastic stack version for testing 8.5.4-cade095d

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.4-2ce7df52-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.4-cade095d-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.5.4-2ce7df52-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.5.4-cade095d-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Thu, 5 Jan 2023 12:15:59 GMT, release_branch:8.5, prefix:, end_time:Thu, 5 Jan 2023 16:31:46 GMT, manifest_version:2.1.0, version:8.5.4-SNAPSHOT, branch:8.5, build_id:8.5.4-cade095d, build_duration_seconds:15347]