### PR TITLE
[automation] update elastic stack version for testing 8.5.4-6280647c

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.4-2ce7df52-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.4-6280647c-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.5.4-2ce7df52-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.5.4-6280647c-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Wed, 11 Jan 2023 00:17:01 GMT, release_branch:8.5, prefix:, end_time:Wed, 11 Jan 2023 04:27:47 GMT, manifest_version:2.1.0, version:8.5.4-SNAPSHOT, branch:8.5, build_id:8.5.4-6280647c, build_duration_seconds:15046]