### PR TITLE
Remove input private key from config shared with shipper

### DIFF
--- a/pkg/component/runtime/manager_shipper.go
+++ b/pkg/component/runtime/manager_shipper.go
@@ -121,7 +121,6 @@ func injectShipperConn(cfg *proto.UnitExpectedConfig, addr string, ca *authority
 			string(ca.Crt()),
 		},
 		"certificate": string(pair.Crt),
-		"key":         string(pair.Key),
 	}
 	return component.ExpectedConfig(source)
 }

--- a/pkg/component/runtime/manager_shipper.go
+++ b/pkg/component/runtime/manager_shipper.go
@@ -52,8 +52,7 @@ func (m *Manager) connectShippers(components []component.Component) error {
 
 			// cleanup any pairs that are no-longer used
 			for pairID := range conn.pairs {
-				touch, _ := pairsTouched[pairID]
-				if !touch {
+				if !pairsTouched[pairID] {
 					delete(conn.pairs, pairID)
 				}
 			}
@@ -63,8 +62,7 @@ func (m *Manager) connectShippers(components []component.Component) error {
 
 	// cleanup any shippers that are no-longer used
 	for shipperID := range m.shipperConns {
-		touch, _ := shippersTouched[shipperID]
-		if !touch {
+		if !shippersTouched[shipperID] {
 			delete(m.shipperConns, shipperID)
 		}
 	}


### PR DESCRIPTION
## What does this PR do?

The shipper is currently given all key data from the input units, including the private key, but only the input unit itself should have the private key.