### PR TITLE
[Kubernetes] Add support to 1.26 k8s version

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -160,7 +160,7 @@ pipeline {
               }
             }
             steps {
-              runK8s(k8sVersion: 'v1.25.0-beta.0', kindVersion: 'v0.14.0', context: "K8s-${PLATFORM}")
+              runK8s(k8sVersion: 'v1.26.0', kindVersion: 'v0.17.0', context: "K8s-${PLATFORM}")
             }
           }
           stage('Package') {
@@ -232,7 +232,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_VERSION'
-            values "v1.25.0","v1.24.3", "v1.23.6", "v1.22.9"
+            values "v1.26.0","v1.25.0","v1.24.3", "v1.23.6"
           }
         }
         stages {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -240,7 +240,7 @@ pipeline {
             steps {
               deleteDir()
               unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
-              runK8s(k8sVersion: K8S_VERSION, kindVersion: 'v0.14.0', context: "K8s-${K8S_VERSION}")
+              runK8s(k8sVersion: K8S_VERSION, kindVersion: 'v0.17.0', context: "K8s-${K8S_VERSION}")
             }
             post {
               always {


### PR DESCRIPTION
## What does this PR do?
Adds support for Kubernetes 1.26.x version and update kind version to 0.17.0


## Related issues

- Relates to https://github.com/elastic/observability-dev/issues/2345
