### PR TITLE
Uplifting Kubernetes Standalone Manifest 

### DIFF
--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -35,7 +35,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.9.0
+            version: 1.29.2
         data_stream:
           namespace: default
         streams:
@@ -273,7 +273,7 @@ data:
         meta:
           package:
             name: system
-            version: 0.10.7
+            version: 1.20.4
         data_stream:
           namespace: default
         streams:
@@ -289,10 +289,8 @@ data:
               pattern: ^\s
               match: after
             processors:
-              - add_fields:
-                  target: ''
-                  fields:
-                    ecs.version: 1.12.0
+              - add_locale: null
+            ignore_older: 72h
           - data_stream:
               dataset: system.syslog
               type: logs
@@ -305,17 +303,40 @@ data:
               pattern: ^\s
               match: after
             processors:
-              - add_fields:
-                  target: ''
-                  fields:
-                    ecs.version: 1.12.0
+              - add_locale: null
+            ignore_older: 72h
+      - id: windows-event-log
+        type: winlog
+        use_output: default
+        meta:
+          package:
+            name: system
+            version: 1.20.4
+        data_stream:
+          namespace: default
+        streams:
+          - data_stream:
+              type: logs
+              dataset: system.application
+            condition: '${host.platform} == ''windows'''
+            ignore_older: 72h
+          - data_stream:
+              type: logs
+              dataset: system.security
+            condition: '${host.platform} == ''windows'''
+            ignore_older: 72h
+          - data_stream:
+              type: logs
+              dataset: system.system
+            condition: '${host.platform} == ''windows'''
+            ignore_older: 72h
       - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
         type: filestream
         use_output: default
         meta:
           package:
             name: kubernetes
-            version: 1.9.0
+            version: 1.29.2
         data_stream:
           namespace: default
         streams:
@@ -340,7 +361,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.9.0
+            version: 1.29.2
         data_stream:
           namespace: default
         streams:
@@ -385,17 +406,10 @@ data:
         meta:
           package:
             name: system
-            version: 0.10.9
+            version: 1.20.4
         data_stream:
           namespace: default
         streams:
-          - data_stream:
-              dataset: system.core
-              type: metrics
-            metricsets:
-              - core
-            core.metrics:
-              - percentages
           - data_stream:
               dataset: system.cpu
               type: metrics
@@ -433,6 +447,7 @@ data:
           - data_stream:
               dataset: system.load
               type: metrics
+            condition: '${host.platform} != ''windows'''
             period: 10s
             metricsets:
               - load
@@ -452,38 +467,42 @@ data:
           - data_stream:
               dataset: system.process
               type: metrics
-            process.include_top_n.by_memory: 5
             period: 10s
             processes:
               - .*
             process.include_top_n.by_cpu: 5
-            process.cgroups.enabled: false
+            process.include_top_n.by_memory: 5
             process.cmdline.cache.enabled: true
+            process.cgroups.enabled: false
+            process.include_cpu_ticks: false
             metricsets:
               - process
             process.include_cpu_ticks: false
-            system.hostfs: /hostfs
           - data_stream:
               dataset: system.process_summary
               type: metrics
             period: 10s
             metricsets:
               - process_summary
-            system.hostfs: /hostfs
           - data_stream:
               dataset: system.socket_summary
               type: metrics
             period: 10s
             metricsets:
               - socket_summary
-            system.hostfs: /hostfs
+          - data_stream:
+              type: metrics
+              dataset: system.uptime
+            metricsets:
+              - uptime
+            period: 10s
       - id: kubernetes-node-metrics
         type: kubernetes/metrics
         use_output: default
         meta:
           package:
             name: kubernetes
-            version: 1.9.0
+            version: 1.29.2
         data_stream:
           namespace: default
         streams:

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
@@ -35,7 +35,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.9.0
+            version: 1.29.2
         data_stream:
           namespace: default
         streams:
@@ -273,7 +273,7 @@ data:
         meta:
           package:
             name: system
-            version: 0.10.7
+            version: 1.20.4
         data_stream:
           namespace: default
         streams:
@@ -289,10 +289,8 @@ data:
               pattern: ^\s
               match: after
             processors:
-              - add_fields:
-                  target: ''
-                  fields:
-                    ecs.version: 1.12.0
+              - add_locale: null
+            ignore_older: 72h
           - data_stream:
               dataset: system.syslog
               type: logs
@@ -305,17 +303,40 @@ data:
               pattern: ^\s
               match: after
             processors:
-              - add_fields:
-                  target: ''
-                  fields:
-                    ecs.version: 1.12.0
+              - add_locale: null
+            ignore_older: 72h
+      - id: windows-event-log
+        type: winlog
+        use_output: default
+        meta:
+          package:
+            name: system
+            version: 1.20.4
+        data_stream:
+          namespace: default
+        streams:
+          - data_stream:
+              type: logs
+              dataset: system.application
+            condition: '${host.platform} == ''windows'''
+            ignore_older: 72h
+          - data_stream:
+              type: logs
+              dataset: system.security
+            condition: '${host.platform} == ''windows'''
+            ignore_older: 72h
+          - data_stream:
+              type: logs
+              dataset: system.system
+            condition: '${host.platform} == ''windows'''
+            ignore_older: 72h
       - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
         type: filestream
         use_output: default
         meta:
           package:
             name: kubernetes
-            version: 1.9.0
+            version: 1.29.2
         data_stream:
           namespace: default
         streams:
@@ -340,7 +361,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.9.0
+            version: 1.29.2
         data_stream:
           namespace: default
         streams:
@@ -385,17 +406,10 @@ data:
         meta:
           package:
             name: system
-            version: 0.10.9
+            version: 1.20.4
         data_stream:
           namespace: default
         streams:
-          - data_stream:
-              dataset: system.core
-              type: metrics
-            metricsets:
-              - core
-            core.metrics:
-              - percentages
           - data_stream:
               dataset: system.cpu
               type: metrics
@@ -433,6 +447,7 @@ data:
           - data_stream:
               dataset: system.load
               type: metrics
+            condition: '${host.platform} != ''windows'''
             period: 10s
             metricsets:
               - load
@@ -452,38 +467,42 @@ data:
           - data_stream:
               dataset: system.process
               type: metrics
-            process.include_top_n.by_memory: 5
             period: 10s
             processes:
               - .*
             process.include_top_n.by_cpu: 5
-            process.cgroups.enabled: false
+            process.include_top_n.by_memory: 5
             process.cmdline.cache.enabled: true
+            process.cgroups.enabled: false
+            process.include_cpu_ticks: false
             metricsets:
               - process
             process.include_cpu_ticks: false
-            system.hostfs: /hostfs
           - data_stream:
               dataset: system.process_summary
               type: metrics
             period: 10s
             metricsets:
               - process_summary
-            system.hostfs: /hostfs
           - data_stream:
               dataset: system.socket_summary
               type: metrics
             period: 10s
             metricsets:
               - socket_summary
-            system.hostfs: /hostfs
+          - data_stream:
+              type: metrics
+              dataset: system.uptime
+            metricsets:
+              - uptime
+            period: 10s
       - id: kubernetes-node-metrics
         type: kubernetes/metrics
         use_output: default
         meta:
           package:
             name: kubernetes
-            version: 1.9.0
+            version: 1.29.2
         data_stream:
           namespace: default
         streams:


### PR DESCRIPTION
Cloudantive team hosts and is responsible to housekeep the standalone version of https://github.com/elastic/elastic-agent/blob/main/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml.
As part of this continuous effort we uplifted the Stanadlone Manifest in order to include latest changes for System and Kubernetes Integration

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Uplifting versions of System Integration and Kubernetes Integration into our manifest. Releavant changes to conditions and missing datastreams added

## Why is it important?

In order to keep standalone manifest consistent with latest changes of our integration pacakges.
## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

