### PR TITLE
add enterprisesearch input to metricbeat spec

### DIFF
--- a/specs/metricbeat.spec.yml
+++ b/specs/metricbeat.spec.yml
@@ -51,6 +51,12 @@ inputs:
     outputs: *outputs
     shippers: *shippers
     command: *command
+  - name: enterprisesearch/metrics
+    description: "Enterprise search metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command: *command
   - name: kibana/metrics
     description: "Kibana metrics"
     platforms: *platforms


### PR DESCRIPTION
## What does this PR do?

Adds the `enterprisesearch/metrics` input to the metricbeat spec. 

## Why is it important?

This is necessary for the [related package](https://github.com/elastic/integrations/pull/4926) to work. If not agent will throw an `input not supported` error starting 8.6.0

```
{"log.level":"error","@timestamp":"2023-01-16T22:21:10.953Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":833},"message":"Spawned new unit enterprisesearch/metrics-default-enterprisesearch/metrics-enterprisesearch-3ac61e2c-dfa1-4d5b-af90-4ab353a576cb: input not supported","component":{"id":"enterprisesearch/metrics-default","state":"FAILED"},"unit":{"id":"enterprisesearch/metrics-default-enterprisesearch/metrics-enterprisesearch-3ac61e2c-dfa1-4d5b-af90-4ab353a576cb","type":"input","state":"FAILED"},"ecs.version":"1.6.0"}
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

