### PR TITLE
change code owners of dev-tools/kubernetes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,4 @@
 * @elastic/elastic-agent-control-plane
 
 /deploy/kubernetes @elastic/obs-cloudnative-monitoring
+/dev-tools/kubernetes @elastic/obs-cloudnative-monitoring


### PR DESCRIPTION
## What does this PR do?

Change codeowners for the path /dev-tools/kubernetes to the cloud-native monitoring team since it contains k8s manifests and scripts

## Why is it important?

So that we don't ping the Elastic Agent Control Plane when it is not necessary
