### PR TITLE
ci: use ubuntu:22 workers

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -3,7 +3,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'ubuntu-20.04 && immutable' }
+  agent { label 'ubuntu-22 && immutable' }
   environment {
     REPO = "elastic-agent"
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -92,7 +92,7 @@ pipeline {
           axis {
             name 'PLATFORM'
             // Orka workers are not healthy (memory and connectivity issues)
-            values 'ubuntu-20.04 && immutable', 'aws && aarch64 && gobld/diskSizeGb:200', 'windows-2016 && windows-immutable', 'windows-2022 && windows-immutable' //, 'macos12 && x86_64'
+            values 'ubuntu-22 && immutable', 'aws && aarch64 && gobld/diskSizeGb:200', 'windows-2016 && windows-immutable', 'windows-2022 && windows-immutable' //, 'macos12 && x86_64'
           }
         }
         stages {
@@ -152,7 +152,7 @@ pipeline {
               // Always when running builds on branches/tags
               // Enable if k8s related changes.
               allOf {
-                expression { return env.PLATFORM == 'ubuntu-20.04 && immutable' }
+                expression { return env.PLATFORM == 'ubuntu-22 && immutable' }
                 anyOf {
                   not { changeRequest() }                           // If no PR
                   expression { return env.K8S_CHANGES == "true" }
@@ -227,7 +227,7 @@ pipeline {
       }
       failFast false
       matrix {
-        agent {label 'ubuntu-20.04 && immutable'}
+        agent {label 'ubuntu-22 && immutable'}
         options { skipDefaultCheckout() }
         axes {
           axis {
@@ -261,7 +261,7 @@ pipeline {
         }
       }
       failFast false
-        agent {label 'ubuntu-20.04 && immutable'}
+        agent {label 'ubuntu-22 && immutable'}
         options { skipDefaultCheckout() }
         stages {
           stage('OpenKibanaPR') {


### PR DESCRIPTION
## What does this PR do?

Use ubuntu:22 workers in the CI

## Why is it important?

Ubuntu 18 is a kind of old

## Issues


Similar to https://github.com/elastic/beats/pull/34315