### PR TITLE
[Enhancement] Adding GCS and ABS to allowed inputs in filebeat spec

### DIFF
--- a/specs/filebeat.spec.yml
+++ b/specs/filebeat.spec.yml
@@ -45,6 +45,12 @@ inputs:
     outputs: *outputs
     shippers: *shippers
     command: *command
+  - name: azure-blob-storage
+    description: "Azure Blob Storage"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command: *command
   - name: azure-eventhub
     description: "Azure Eventhub"
     platforms: *platforms
@@ -85,6 +91,12 @@ inputs:
     command: *command
   - name: gcp-pubsub
     description: "GCP Pub-Sub"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command: *command
+  - name: gcs
+    description: "Google Cloud Storage"
     platforms: *platforms
     outputs: *outputs
     shippers: *shippers


### PR DESCRIPTION
## What does this PR do?

Filebeat have two newer inputs that have yet to be added to integration packages. To be able to add these we need to first update the filebeat spec file so they are allowed to run.

## Why is it important?

Change is needed to run these new inputs in elastic-agent, and is currently a blocker for us to use them in integration packages.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)


## Related issues

- Relates https://github.com/elastic/integrations/pull/4692
- Relates https://github.com/elastic/integrations/pull/4693

