### PR TITLE
Increase timeouts in TestManager_FakeShipper for slower CI nodes

### DIFF
--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -2204,7 +2204,7 @@ func TestManager_FakeShipper(t *testing.T) {
 			// wait for the event on the shipper side
 			gotEvt := make(chan error)
 			go func() {
-				actionCtx, actionCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				actionCtx, actionCancel := context.WithTimeout(context.Background(), 30*time.Second)
 				_, err := m.PerformAction(actionCtx, comps[1], comps[1].Units[1], "record_event", map[string]interface{}{
 					"id": eventID.String(),
 				})
@@ -2213,7 +2213,7 @@ func TestManager_FakeShipper(t *testing.T) {
 			}()
 
 			// send the fake event
-			actionCtx, actionCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			actionCtx, actionCancel := context.WithTimeout(context.Background(), 15*time.Second)
 			_, err = m.PerformAction(actionCtx, comps[0], comps[0].Units[0], "send_event", map[string]interface{}{
 				"id": eventID.String(),
 			})
@@ -2322,13 +2322,13 @@ func TestManager_FakeShipper(t *testing.T) {
 		t.Fatalf("failed early: %s", err)
 	}
 
-	endTimer := time.NewTimer(30 * time.Second)
+	endTimer := time.NewTimer(2 * time.Minute)
 	defer endTimer.Stop()
 LOOP:
 	for {
 		select {
 		case <-endTimer.C:
-			t.Fatalf("timed out after 30 seconds")
+			t.Fatalf("timed out after 2 minutes")
 		case err := <-errCh:
 			require.NoError(t, err)
 		case err := <-subErrCh:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Increases timeouts for `TestManager_FakeShipper`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Sometimes the test fails with `context deadline exceeded` because not enough time is given on slower CI nodes.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #1725 

