### PR TITLE
Prevent losing Headers

### DIFF
--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -207,6 +207,7 @@ func fleetToReader(agentInfo *info.AgentInfo, cfg *configuration.Configuration) 
 		"fleet": cfg.Fleet,
 		"agent": map[string]interface{}{
 			"id":               agentInfo.AgentID(),
+			"headers":          agentInfo.Headers(),
 			"logging.level":    cfg.Settings.LoggingConfig.Level,
 			"monitoring.http":  cfg.Settings.MonitoringConfig.HTTP,
 			"monitoring.pprof": cfg.Settings.MonitoringConfig.Pprof,

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -1025,6 +1025,7 @@ func getPersistentConfig(pathConfigFile string) (map[string]interface{}, error) 
 	}
 
 	pc := &struct {
+		Headers        map[string]string                      `json:"agent.headers,omitempty" yaml:"agent.headers,omitempty" config:"agent.headers,omitempty"`
 		LogLevel       string                                 `json:"agent.logging.level,omitempty" yaml:"agent.logging.level,omitempty" config:"agent.logging.level,omitempty"`
 		MonitoringHTTP *monitoringConfig.MonitoringHTTPConfig `json:"agent.monitoring.http,omitempty" yaml:"agent.monitoring.http,omitempty" config:"agent.monitoring.http,omitempty"`
 	}{


### PR DESCRIPTION
## What does this PR do?

This PR prevents headers to disappear when policy is fetched and stored

## Why is it important?

So headers from enrollment time can be applied to outputs later on.

##  How to test
- Build 
- Install and Enroll to fleet (default policy with system integration) with ` --header="custom=header"` flag
- run `sudo elastic-agent inspect components log-default --show-config`
- header is part of output config ✅ 