### PR TITLE
filebeat.spec: Add new Entity Analytics input

### DIFF
--- a/changelog/fragments/1674757194-entity-analytics-input.yaml
+++ b/changelog/fragments/1674757194-entity-analytics-input.yaml
@@ -25,7 +25,7 @@ component: spec
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/elastic-agent/pull/2196
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.

--- a/changelog/fragments/1674757194-entity-analytics-input.yaml
+++ b/changelog/fragments/1674757194-entity-analytics-input.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add Entity Analytics input mapping to the Filebeat spec.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: spec
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/specs/filebeat.spec.yml
+++ b/specs/filebeat.spec.yml
@@ -22,7 +22,7 @@ inputs:
       maximum_restarts_per_period: 1
       timeouts:
         restart: 1s
-      args: 
+      args:
         - "-E"
         - "setup.ilm.enabled=false"
         - "-E"
@@ -85,6 +85,12 @@ inputs:
     aliases:
       - log/docker
     description: "Docker logs"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command: *command
+  - name: entity-analytics
+    description: "Entity Analytics"
     platforms: *platforms
     outputs: *outputs
     shippers: *shippers


### PR DESCRIPTION
## What does this PR do?

Adds the new Entity Analytics Filebeat input to elastic-agent added in elastic/beats#34305.

## Why is it important?

This makes that input available to be used as an integration.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Related issues

- Relates elastic/beats#34305
