### PR TITLE
Remove forcing localhost for insecure bootstrap

### DIFF
--- a/changelog/fragments/1674766899-fix-insecure-fleet-server-bootstrap.yaml
+++ b/changelog/fragments/1674766899-fix-insecure-fleet-server-bootstrap.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: fix insecure fleet-server bootstrap
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: Disable passing `localhost` when bootstrapping an insecure fleet-server instance.
+
+# Affected component; a word indicating the component this changeset affects.
+component: fleet-server
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: 1234
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 2197

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -395,10 +395,6 @@ func (c *enrollCmd) prepareFleetTLS() error {
 	}
 	if c.options.FleetServer.Cert == "" && c.options.FleetServer.CertKey == "" {
 		if c.options.FleetServer.Insecure {
-			// running insecure, force the binding to localhost (unless specified)
-			if c.options.FleetServer.Host == "" {
-				c.options.FleetServer.Host = defaultFleetServerInternalHost
-			}
 			c.options.URL = fmt.Sprintf("http://%s:%d", host, port)
 			c.options.Insecure = true
 			return nil

--- a/internal/pkg/agent/cmd/enroll_cmd_test.go
+++ b/internal/pkg/agent/cmd/enroll_cmd_test.go
@@ -423,7 +423,7 @@ func TestPrepareFleetTLS(t *testing.T) {
 		assert.NotEmpty(t, cmd.options.FleetServer.Cert)
 		assert.NotEmpty(t, cmd.options.FleetServer.CertKey)
 		assert.Equal(t, "https://localhost:8220", cmd.options.URL)
-		assert.NotEmpty(t, cmd.options.FleetServer.CAs)
+		assert.NotEmpty(t, cmd.options.CAs)
 		assert.Equal(t, "localhost:8221", cmd.options.InternalURL)
 
 		assert.Equal(t, "", cmd.options.FleetServer.Host)


### PR DESCRIPTION
## What does this PR do?

Remove the forced use of `localhost` as the host when bootstrapping and insecure fleet-server instance.

## Why is it important?

Bootstrapping process on 8.6.0+ forces a bind to localhost, this does not allow other agents to enroll with the server.

## Checklist

- [x] My code follows the style guidelines of this project
- ~I have commented my code, particularly in hard-to-understand areas~
- ~I have made corresponding changes to the documentation~
- ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## How to test this PR locally

1. Start ES + Kibana, specify `xpack.fleet.agents.fleet_server.hosts: [ http://HOSTNAME:8220 ]` in the kibana config
2. Enroll a fleet-server agent with the command that Kibana provides and append the `--fleet-server-insecure-http` flag
3. After enrollment run `sudo lsof | grep 8220` -> verify that something like `TCP *:8220 (LISTEN)` appears in the output. Elastic agent logs will also contain:
```json
{"log.level":"info","@timestamp":"2023-01-26T20:58:42.791Z","message":"server listening","component":{"binary":"fleet-server","dataset":"elastic_agent.fleet_server","id":"fleet-server-default","type":"fleet-server"},"log":{"source":"fleet-server-default"},"ecs.version":"1.6.0","service.name":"fleet-server","bind":"0.0.0.0:8220","rdTimeout":60000,"wrTimeout":600000,"ecs.version":"1.6.0"}
```

You can also test with a docker container:
```
docker run --name elastic-agent --rm --env FLEET_SERVER_ENABLE=1 --env FLEET_SERVER_ELASTICSEARCH_HOST=$ELASTICSEARCH_HOSTS --env FLEET_SERVER_INSECURE_HTTP=true --env FLEET_SERVER_POLICY_ID=fleet-server-policy --env FLEET_SERVER_SERVICE_TOKEN=$SERVICE_TOKEN  docker.elastic.co/beats/elastic-agent-complete:8.7.0-SNAPSHOT container
```

The same log line will appear.

## Related issues

- Closes #2197 