### PR TITLE
Do not propagate gateway errors.

### DIFF
--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -73,7 +73,6 @@ type fleetGateway struct {
 	checkinFailCounter int
 	stateFetcher       coordinator.StateFetcher
 	stateStore         stateStore
-	errCh              chan error
 	actionCh           chan []fleetapi.Action
 }
 
@@ -119,7 +118,6 @@ func newFleetGatewayWithScheduler(
 		acker:        acker,
 		stateFetcher: stateFetcher,
 		stateStore:   stateStore,
-		errCh:        make(chan error),
 		actionCh:     make(chan []fleetapi.Action, 1),
 	}, nil
 }
@@ -169,11 +167,6 @@ func (f *fleetGateway) Run(ctx context.Context) error {
 	}
 }
 
-// Errors returns the channel to watch for reported errors.
-func (f *fleetGateway) Errors() <-chan error {
-	return f.errCh
-}
-
 func (f *fleetGateway) doExecute(ctx context.Context, bo backoff.Backoff) (*fleetapi.CheckinResponse, error) {
 	bo.Reset()
 
@@ -205,10 +198,8 @@ func (f *fleetGateway) doExecute(ctx context.Context, bo backoff.Backoff) (*flee
 				)
 
 				f.log.Error(err)
-				f.errCh <- err
 				return nil, err
 			}
-			f.errCh <- err
 			continue
 		}
 

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -404,19 +404,14 @@ func (e *emptyStateFetcher) State(_ bool) coordinator.State {
 }
 
 func runFleetGateway(ctx context.Context, g gateway.FleetGateway) <-chan error {
-	done := make(chan bool)
 	errCh := make(chan error, 1)
 	go func() {
 		err := g.Run(ctx)
-		close(done)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			errCh <- err
 		} else {
 			errCh <- nil
 		}
-	}()
-	go func() {
-		<-done
 	}()
 	return errCh
 }

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -7,6 +7,7 @@ package fleet
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -18,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -416,14 +416,7 @@ func runFleetGateway(ctx context.Context, g gateway.FleetGateway) <-chan error {
 		}
 	}()
 	go func() {
-		for {
-			select {
-			case <-done:
-				return
-			case <-g.Errors():
-				// ignore errors here
-			}
-		}
+		<-done
 	}()
 	return errCh
 }

--- a/internal/pkg/agent/application/gateway/gateway.go
+++ b/internal/pkg/agent/application/gateway/gateway.go
@@ -19,9 +19,6 @@ type FleetGateway interface {
 	// Run runs the gateway.
 	Run(ctx context.Context) error
 
-	// Errors returns the channel to watch for reported errors.
-	Errors() <-chan error
-
 	// Actions returns the channel to watch for new actions from the fleet-server.
 	Actions() <-chan []fleetapi.Action
 

--- a/internal/pkg/agent/application/managed_mode.go
+++ b/internal/pkg/agent/application/managed_mode.go
@@ -188,21 +188,8 @@ func (m *managedConfigManager) Run(ctx context.Context) error {
 		policyChanger.AddSetter(ack)
 	}
 
-	// Proxy errors from the gateway to our own channel.
-	gatewayErrorsRunner := runner.Start(context.Background(), func(ctx context.Context) error {
-		for {
-			select {
-			case <-ctx.Done():
-				return nil
-			case err := <-gateway.Errors():
-				m.errCh <- err
-			}
-		}
-	})
-
 	// Run the gateway.
 	gatewayRunner := runner.Start(gatewayCtx, func(ctx context.Context) error {
-		defer gatewayErrorsRunner.Stop()
 		return gateway.Run(ctx)
 	})
 


### PR DESCRIPTION
## What does this PR do?

This PR removes reporting of errors to status reporter. We keep logs.

## Why is it important?

This was agreed https://github.com/elastic/elastic-agent/issues/1148
and implemented https://github.com/elastic/elastic-agent/pull/1152 in V1.
Change got lost in migration to V2 architecture

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

Fixes: #2194 