### PR TITLE
Fix TestAddToBucket flakiness on Windows

### DIFF
--- a/pkg/component/runtime/command.go
+++ b/pkg/component/runtime/command.go
@@ -553,11 +553,11 @@ func newRateLimiter(restartMonitoringPeriod time.Duration, maxEventsPerPeriod in
 		return nil
 	}
 
-	freq := restartMonitoringPeriod.Seconds()
+	period := restartMonitoringPeriod.Seconds()
 	events := float64(maxEventsPerPeriod)
-	perSecond := events / freq
-	if perSecond > 0 {
-		bucketSize := rate.Limit(perSecond)
+	frequency := events / period
+	if frequency > 0 {
+		bucketSize := rate.Limit(frequency)
 		return rate.NewLimiter(bucketSize, maxEventsPerPeriod)
 	}
 

--- a/pkg/component/runtime/command_test.go
+++ b/pkg/component/runtime/command_test.go
@@ -13,29 +13,33 @@ import (
 
 func TestAddToBucket(t *testing.T) {
 	testCases := map[string]struct {
-		bucketSize  int
-		add         int
+		bucketSize int
+		dropRate   time.Duration
+		add        int
+		// Warning: this sleep duration is not very precise on Windows machines as the system clock ticks only every 15ms
 		addSleep    time.Duration
 		shouldBlock bool
 	}{
-		"no error":           {1, 0, 1 * time.Millisecond, false},
-		"error within limit": {1, 1, 1 * time.Millisecond, false},
-		"errors > than limit but across timespans":                {1, 2, 80 * time.Millisecond, false},
-		"errors > than limit within timespans, exact bucket size": {2, 2, 2 * time.Millisecond, false},
-		"errors > than limit within timespans, off by one":        {2, 3, 2 * time.Millisecond, true},
-		"errors > than limit within timespans":                    {2, 4, 2 * time.Millisecond, true},
+		"no error":           {1, 50 * time.Millisecond, 0, 1 * time.Millisecond, false},
+		"error within limit": {1, 50 * time.Millisecond, 1, 1 * time.Millisecond, false},
+		"errors > than limit but across timespans":                {1, 50 * time.Millisecond, 2, 80 * time.Millisecond, false},
+		"errors > than limit within timespans, exact bucket size": {2, 50 * time.Millisecond, 2, 2 * time.Millisecond, false},
+		// These testcases use a longer duration as dropRate to make sure that on Windows machine we don't drop any old events
+		"errors > than limit within timespans, off by one": {2, 150 * time.Millisecond, 3, 2 * time.Millisecond, true},
+		"errors > than limit within timespans":             {2, 150 * time.Millisecond, 4, 2 * time.Millisecond, true},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			dropRate := 50 * time.Millisecond
-			b := newRateLimiter(dropRate, tc.bucketSize)
+
+			b := newRateLimiter(tc.dropRate, tc.bucketSize)
 
 			blocked := false
 			b.Allow()
-			<-time.After(dropRate + 20*time.Millisecond) // init ticker
+			<-time.After(tc.dropRate + 20*time.Millisecond) // init ticker
 
 			for i := 0; i < tc.add; i++ {
+				t.Logf("%v : add 1 element when there are %f tokens available", time.Now(), b.Tokens())
 				wasBlocked := !b.Allow()
 				blocked = blocked || wasBlocked
 				<-time.After(tc.addSleep)

--- a/pkg/component/runtime/command_test.go
+++ b/pkg/component/runtime/command_test.go
@@ -31,7 +31,6 @@ func TestAddToBucket(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-
 			b := newRateLimiter(tc.dropRate, tc.bucketSize)
 
 			blocked := false


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
Some testcases insert 3 or more events in a loop to test the rate limiter.
On windows machines system clock ticks every 15ms so the loop we use to add events to the rate limiter run slower (we set the timer to 2 ms which translates to ~20 ms between iterations on windows). 
Using a timeframe of 50ms for the rate limiter makes the unit tests flaky when running on windows (there's a growing chance of the loop running for longer than that the more items we add)
This commit extends the timeframe of the rate limiter from 50ms to 150ms in such testcases to make sure that all the events we use in the unit tests are kept into account of a single timeframe.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
This eliminates flakiness of unit tests run on CI.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

To test this we can simply run the tests for a few times (10 in the example below)
```
go test ./pkg/component/runtime -run TestAddToBucket -count 10
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes  #2146 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
