### PR TITLE
Preserve component state on upgrade

### DIFF
--- a/changelog/fragments/1675085396-preserve-state-on-upgrade.yaml
+++ b/changelog/fragments/1675085396-preserve-state-on-upgrade.yaml
@@ -24,7 +24,7 @@ component:
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: 1234
+pr: 2207
 
 # Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.

--- a/changelog/fragments/1675085396-preserve-state-on-upgrade.yaml
+++ b/changelog/fragments/1675085396-preserve-state-on-upgrade.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug
+
+# Change summary; a 80ish characters long description of the change.
+summary: Preserve component state on upgrade
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: 1234
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 2136

--- a/version/version.go
+++ b/version/version.go
@@ -4,4 +4,4 @@
 
 package version
 
-const defaultBeatVersion = "8.7.0"
+const defaultBeatVersion = "8.6.0"

--- a/version/version.go
+++ b/version/version.go
@@ -4,4 +4,4 @@
 
 package version
 
-const defaultBeatVersion = "8.6.0"
+const defaultBeatVersion = "8.7.0"


### PR DESCRIPTION
## What does this PR do?

This PR copies run directory from stale agent to a new version of agent. Component can then pick up the state and continue where it was interrupted. This prevents creating duplicate events. 

## Why is it important?

Without this component loses state and can process whole file (in case of logs) again generating a lot of duplicate entries

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

Fixes: #2136