### PR TITLE
Add spec for Universal Profiling Agent

### DIFF
--- a/changelog/fragments/1675151497-Add-Universal-Profiling-Agent.yaml
+++ b/changelog/fragments/1675151497-Add-Universal-Profiling-Agent.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add Universal Profiling Agent
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: spec
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 2210
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -23,7 +23,7 @@ RUN mkdir -p {{ $beatHome }}/data {{ $beatHome }}/data/elastic-agent-{{ commit_s
     (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/endpoint-security || true) && \
     (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/fleet-server || true) && \
     (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/elastic-agent-shipper || true) && \
-    (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/prodfiler || true) && \
+    (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/pf-host-agent || true) && \
     find {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/components -name "*.yml*" -type f -exec chown root:root {} \; && \
     find {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/components -name "*.yml*" -type f -exec chmod 0644 {} \; && \
 {{- range $i, $modulesd := .ModulesDirs }}

--- a/magefile.go
+++ b/magefile.go
@@ -662,6 +662,7 @@ func packageAgent(platforms []string, packagingFn func()) {
 				"apm-server",
 				"endpoint-security",
 				"fleet-server",
+				"pf-host-agent",
 			}
 
 			ctx := context.Background()

--- a/pkg/component/load_test.go
+++ b/pkg/component/load_test.go
@@ -85,6 +85,10 @@ func TestLoadSpec_Components(t *testing.T) {
 			Name: "Packetbeat",
 			Path: "packetbeat.spec.yml",
 		},
+		{
+			Name: "Universal Profiling Agent",
+			Path: "pf-host-agent.spec.yml",
+		},
 	}
 
 	for _, scenario := range scenarios {

--- a/specs/pf-host-agent.spec.yml
+++ b/specs/pf-host-agent.spec.yml
@@ -1,0 +1,16 @@
+version: 2
+inputs:
+  - name: pf-host-agent
+    description: "Universal Profiling Agent"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    outputs:
+      - elasticsearch
+    runtime:
+      preventions:
+        - condition: ${runtime.user.root} == false
+          message: "Elastic Agent must be running as root"
+    command:
+      args:
+        - "-elastic"


### PR DESCRIPTION
Signed-off-by: Florian Lehner <florian.lehner@elastic.co>

## What does this PR do?

Add specification file for the [Universal Profiling Agent](https://www.elastic.co/observability/universal-profiling).

## Why is it important?

This change will allow elastic/elastic-agent to deploy, run and manage the [Universal Profiling Agent](https://www.elastic.co/observability/universal-profiling).

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

