### PR TITLE
Add support for excluded paths in packaging

### DIFF
--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -39,6 +39,7 @@ const (
 )
 
 var (
+	excludedPathsPattern   = regexp.MustCompile(`node_modules`)
 	configFilePattern      = regexp.MustCompile(`.*beat\.spec.yml$|.*beat\.yml$|apm-server\.yml|elastic-agent\.yml$$`)
 	manifestFilePattern    = regexp.MustCompile(`manifest.yml`)
 	modulesDirPattern      = regexp.MustCompile(`module/.+`)
@@ -560,6 +561,9 @@ func readRPM(rpmFile string) (*packageFile, *rpm.PackageFile, error) {
 	pf := &packageFile{Name: filepath.Base(rpmFile), Contents: map[string]packageEntry{}}
 
 	for _, file := range contents {
+		if excludedPathsPattern.MatchString(file.Name()) {
+			continue
+		}
 		pe := packageEntry{
 			File: file.Name(),
 			Mode: file.Mode(),
@@ -643,7 +647,9 @@ func readTarContents(tarName string, data io.Reader) (*packageFile, error) {
 			}
 			return nil, err
 		}
-
+		if excludedPathsPattern.MatchString(header.Name) {
+			continue
+		}
 		p.Contents[header.Name] = packageEntry{
 			File: header.Name,
 			UID:  header.Uid,
@@ -668,6 +674,9 @@ func readZip(t *testing.T, zipFile string, inspectors ...inspector) (*packageFil
 
 	p := &packageFile{Name: filepath.Base(zipFile), Contents: map[string]packageEntry{}}
 	for _, f := range r.File {
+		if excludedPathsPattern.MatchString(f.Name) {
+			continue
+		}
 		p.Contents[f.Name] = packageEntry{
 			File: f.Name,
 			Mode: f.Mode(),
@@ -753,6 +762,9 @@ func readDocker(dockerFile string) (*packageFile, *dockerInfo, error) {
 			return nil, nil, fmt.Errorf("layer not found: %s", layerID)
 		}
 		for name, entry := range layerFile.Contents {
+			if excludedPathsPattern.MatchString(name) {
+				continue
+			}
 			// Check only files in working dir and entrypoint
 			if strings.HasPrefix("/"+name, workingDir) || "/"+name == entrypoint {
 				p.Contents[name] = entry


### PR DESCRIPTION
## What does this PR do?

Adds support for excluded paths when testing the packaging.

## Why is it important?

After an update in heartbeat we have have a path like `usr/share/heartbeat/.node/node/lib/node_modules/@elastic/synthetics/templates/lightweight/heartbeat.yml` which matches the `configFilePattern` which causes a permission check which the file does not satisfy. It has nothing to do with the actual heartbeat configuration file.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```sh
cd ./dev-tools/packaging
go test package_test.go
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/beats/pull/33894
