### PR TITLE
Restore downloads directory before downloading

### DIFF
--- a/internal/pkg/agent/application/upgrade/cleanup.go
+++ b/internal/pkg/agent/application/upgrade/cleanup.go
@@ -22,6 +22,11 @@ func cleanNonMatchingVersionsFromDownloads(log *logger.Logger, version string) e
 	log.Debugw("Cleaning up non-matching downloaded versions", "version", version, "downloads.path", downloadsPath)
 
 	files, err := os.ReadDir(downloadsPath)
+	if os.IsNotExist(err) {
+		// nothing to clean up
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("unable to read directory %q: %w", paths.Downloads(), err)
 	}

--- a/internal/pkg/agent/application/upgrade/step_download.go
+++ b/internal/pkg/agent/application/upgrade/step_download.go
@@ -57,7 +57,7 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 		return "", errors.New(err, "initiating fetcher")
 	}
 
-	if err := os.MkdirAll(paths.Downloads(), 0755); err != nil {
+	if err := os.MkdirAll(paths.Downloads(), 0750); err != nil {
 		return "", errors.New(err, fmt.Sprintf("failed to create download directory at %s", paths.Downloads()))
 	}
 

--- a/internal/pkg/agent/application/upgrade/step_download.go
+++ b/internal/pkg/agent/application/upgrade/step_download.go
@@ -6,10 +6,13 @@ package upgrade
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strings"
 
 	"go.elastic.co/apm"
 
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact/download"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact/download/composed"
@@ -52,6 +55,10 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 	fetcher, err := newDownloader(version, u.log, &settings)
 	if err != nil {
 		return "", errors.New(err, "initiating fetcher")
+	}
+
+	if err := os.MkdirAll(paths.Downloads(), 0755); err != nil {
+		return "", errors.New(err, fmt.Sprintf("failed to create download directory at %s", paths.Downloads()))
 	}
 
 	path, err := fetcher.Download(ctx, agentArtifact, version)


### PR DESCRIPTION
## What does this PR do?

During upgrade we cleanup `downloads` directory after ourselves. 
This makes troubles when upgrade is fine or rolled back, and then next upgrade needs to happen. 
Downloads directory does not exist and upgrade fails

Related PR here: https://github.com/elastic/elastic-agent/pull/752

## Why is it important?

Running multiple upgrades not possible

Logs from an example failure

```json
{"log.level":"info","@timestamp":"2023-01-13T10:03:54.035+0100","log.origin":{"file.name":"upgrade/upgrade.go","file.line":111},"message":"Upgrading agent","version":"8.6.0","source_uri":"","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2023-01-13T10:03:54.035+0100","log.origin":{"file.name":"upgrade/upgrade.go","file.line":132},"message":"Unable to clean downloads before update","error":{"message":"unable to read directory \"/opt/Elastic/Agent/data/elastic-agent-026915/downloads\": open /opt/Elastic/Agent/data/elastic-agent-026915/downloads: no such file or directory"},"downloads.path":"/opt/Elastic/Agent/data/elastic-agent-026915/downloads","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2023-01-13T10:03:54.035+0100","log.origin":{"file.name":"log/reporter.go","file.line":40},"message":"2023-01-13T10:03:54+01:00 - message: Application: [4535d1a9-c7b9-4913-86f8-808dabeb8fe1]: State changed to UPDATING: Update to version '8.6.0' started - type: 'STATE' - sub_type: 'UPDATING'","ecs.version":"1.6.0"}
{"log.level":"warn","@timestamp":"2023-01-13T10:03:54.035+0100","log.origin":{"file.name":"http/downloader.go","file.line":100},"message":"failed to cleanup : remove : no such file or directory","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2023-01-13T10:03:54.035+0100","log.origin":{"file.name":"upgrade/upgrade.go","file.line":149},"message":"Unable to remove file after verification failure","error":{"message":"unable to read directory \"/opt/Elastic/Agent/data/elastic-agent-026915/downloads\": open /opt/Elastic/Agent/data/elastic-agent-026915/downloads: no such file or directory"},"ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2023-01-13T10:03:55.196+0100","log.origin":{"file.name":"log/reporter.go","file.line":36},"message":"2023-01-13T10:03:55+01:00 - message: Application: [4535d1a9-c7b9-4913-86f8-808dabeb8fe1]: State changed to FAILED: failed upgrade of agent binary: 2 errors occurred:\n\t* package '/opt/Elastic/Agent/data/elastic-agent-026915/downloads/elastic-agent-8.6.0-linux-x86_64.tar.gz' not found: open /opt/Elastic/Agent/data/elastic-agent-026915/downloads/elastic-agent-8.6.0-linux-x86_64.tar.gz: no such file or directory\n\t* creating package file failed: open /opt/Elastic/Agent/data/elastic-agent-026915/downloads/elastic-agent-8.6.0-linux-x86_64.tar.gz: no such file or directory\n\n - type: 'ERROR' - sub_type: 'FAILED'","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2023-01-13T10:03:55.196+0100","log.origin":{"file.name":"handlers/handler_action_upgrade.go","file.line":45},"message":"Upgrade action failed","error":{"message":"failed upgrade of agent binary: 2 errors occurred:\n\t* package '/opt/Elastic/Agent/data/elastic-agent-026915/downloads/elastic-agent-8.6.0-linux-x86_64.tar.gz' not found: open /opt/Elastic/Agent/data/elastic-agent-026915/downloads/elastic-agent-8.6.0-linux-x86_64.tar.gz: no such file or directory\n\t* creating package file failed: open /opt/Elastic/Agent/data/elastic-agent-026915/downloads/elastic-agent-8.6.0-linux-x86_64.tar.gz: no such file or directory\n\n"},"action.version":"8.6.0","action.source_uri":"","action.id":"cb140906-3dee-4948-89d8-3757c3d66c34","action.start_timeError":"json: unsupported type: func() (time.Time, error)","action.expiration":"2023-01-13T10:33:32.339Z","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2023-01-13T10:03:55.197+0100","log.origin":{"file.name":"fleet/fleet_gateway.go","file.line":204},"message":"failed to dispatch actions, error: failed upgrade of agent binary: 2 errors occurred:\n\t* package '/opt/Elastic/Agent/data/elastic-agent-026915/downloads/elastic-agent-8.6.0-linux-x86_64.tar.gz' not found: open /opt/Elastic/Agent/data/elastic-agent-026915/downloads/elastic-agent-8.6.0-linux-x86_64.tar.gz: no such file or directory\n\t* creating package file failed: open /opt/Elastic/Agent/data/elastic-agent-026915/downloads/elastic-agent-8.6.0-linux-x86_64.tar.gz: no such file or directory\n\n","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2023-01-13T10:03:55.197+0100","log.origin":{"file.name":"status/reporter.go","file.line":326},"message":"Elastic Agent status changed to \"error\": \"component gateway-b0fe7321: failed to dispatch actions, error: failed upgrade of agent binary: 2 errors occurred:\\n\\t* package '/opt/Elastic/Agent/data/elastic-agent-026915/downloads/elastic-agent-8.6.0-linux-x86_64.tar.gz' not found: open /opt/Elastic/Agent/data/elastic-agent-026915/downloads/elastic-agent-8.6.0-linux-x86_64.tar.gz: no such file or directory\\n\\t* creating package file failed: open /opt/Elastic/Agent/data/elastic-agent-026915/downloads/elastic-agent-8.6.0-linux-x86_64.tar.gz: no such file or directory\\n\\n\"","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2023-01-13T10:04:13.688+0100","log.origin":{"file.name":"artifact/config.go","file.line":138},"message":"Source URI changed from \"https://artifacts.elastic.co/downloads/\" to \"https://artifacts.elastic.co/downloads/\"","ecs.version":"1.6.0"}
```

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)


Not fixing an actual issue, just one of the issues related to upgrade to 8.6