### PR TITLE
Start/stop components in a more synchronised manner

### DIFF
--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -1866,13 +1866,13 @@ func TestManager_FakeInput_MultiComponent(t *testing.T) {
 				return
 			case state := <-sub0.Ch():
 				t.Logf("component fake-0 state changed: %+v", state)
-				signalState(subErrCh0, &state)
+				signalState(subErrCh0, &state, []client.UnitState{client.UnitStateHealthy})
 			case state := <-sub1.Ch():
 				t.Logf("component fake-1 state changed: %+v", state)
-				signalState(subErrCh1, &state)
+				signalState(subErrCh1, &state, []client.UnitState{client.UnitStateHealthy})
 			case state := <-sub2.Ch():
 				t.Logf("component fake-2 state changed: %+v", state)
-				signalState(subErrCh2, &state)
+				signalState(subErrCh2, &state, []client.UnitState{client.UnitStateHealthy})
 			}
 		}
 	}()
@@ -2344,6 +2344,214 @@ LOOP:
 	require.NoError(t, err)
 }
 
+func TestManager_FakeInput_OutputChange(t *testing.T) {
+	testPaths(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ai, _ := info.NewAgentInfo(true)
+	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), "localhost:0", ai, apmtest.DiscardTracer, newTestMonitoringMgr(), configuration.DefaultGRPCConfig())
+	require.NoError(t, err)
+	errCh := make(chan error)
+	go func() {
+		err := m.Run(ctx)
+		if errors.Is(err, context.Canceled) {
+			err = nil
+		}
+		errCh <- err
+	}()
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
+	defer waitCancel()
+	if err := m.WaitForReady(waitCtx); err != nil {
+		require.NoError(t, err)
+	}
+
+	binaryPath := testBinary(t, "component")
+	runtimeSpec := component.InputRuntimeSpec{
+		InputType:  "fake",
+		BinaryName: "",
+		BinaryPath: binaryPath,
+		Spec:       fakeInputSpec,
+	}
+	components := []component.Component{
+		{
+			ID:        "fake-0",
+			InputSpec: &runtimeSpec,
+			Units: []component.Unit{
+				{
+					ID:   "fake-input-0-0",
+					Type: client.UnitTypeInput,
+					Config: component.MustExpectedConfig(map[string]interface{}{
+						"type":    "fake",
+						"state":   int(client.UnitStateHealthy),
+						"message": "Fake Healthy 0-0",
+					}),
+				},
+				{
+					ID:   "fake-input-0-1",
+					Type: client.UnitTypeInput,
+					Config: component.MustExpectedConfig(map[string]interface{}{
+						"type":    "fake",
+						"state":   int(client.UnitStateHealthy),
+						"message": "Fake Healthy 0-1",
+					}),
+				},
+				{
+					ID:   "fake-input-0-2",
+					Type: client.UnitTypeInput,
+					Config: component.MustExpectedConfig(map[string]interface{}{
+						"type":    "fake",
+						"state":   int(client.UnitStateHealthy),
+						"message": "Fake Healthy 0-1",
+					}),
+				},
+			},
+		},
+	}
+
+	components2 := []component.Component{
+		{
+			ID:        "fake-1",
+			InputSpec: &runtimeSpec,
+			Units: []component.Unit{
+				{
+					ID:   "fake-input-1-0",
+					Type: client.UnitTypeInput,
+					Config: component.MustExpectedConfig(map[string]interface{}{
+						"type":    "fake",
+						"state":   int(client.UnitStateHealthy),
+						"message": "Fake Healthy 0-0",
+					}),
+				},
+				{
+					ID:   "fake-input-1-1",
+					Type: client.UnitTypeInput,
+					Config: component.MustExpectedConfig(map[string]interface{}{
+						"type":    "fake",
+						"state":   int(client.UnitStateHealthy),
+						"message": "Fake Healthy 0-1",
+					}),
+				},
+				{
+					ID:   "fake-input-1-1",
+					Type: client.UnitTypeInput,
+					Config: component.MustExpectedConfig(map[string]interface{}{
+						"type":    "fake",
+						"state":   int(client.UnitStateHealthy),
+						"message": "Fake Healthy 0-1",
+					}),
+				},
+			},
+		},
+	}
+
+	type progressionStep struct {
+		componentID string
+		state       ComponentState
+	}
+	stateProgression := make([]progressionStep, 0)
+
+	subCtx, subCancel := context.WithCancel(context.Background())
+	defer subCancel()
+	stateProgCh := make(chan progressionStep)
+	subErrCh0 := make(chan error)
+	subErrCh1 := make(chan error)
+	go func() {
+		sub0 := m.Subscribe(subCtx, "fake-0")
+		sub1 := m.Subscribe(subCtx, "fake-1")
+		for {
+			select {
+			case <-subCtx.Done():
+				close(stateProgCh)
+				return
+			case state := <-sub0.Ch():
+				t.Logf("component fake-0 state changed: %+v", state)
+				signalState(subErrCh0, &state, []client.UnitState{client.UnitStateHealthy, client.UnitStateStopped})
+				stateProgCh <- progressionStep{"fake-o", state}
+			case state := <-sub1.Ch():
+				t.Logf("component fake-1 state changed: %+v", state)
+				signalState(subErrCh1, &state, []client.UnitState{client.UnitStateHealthy})
+				stateProgCh <- progressionStep{"fake-o", state}
+			}
+		}
+	}()
+
+	go func() {
+		for step := range stateProgCh {
+			stateProgression = append(stateProgression, step)
+		}
+	}()
+
+	defer drainErrChan(errCh)
+	defer drainErrChan(subErrCh0)
+	defer drainErrChan(subErrCh1)
+
+	startTimer := time.NewTimer(100 * time.Millisecond)
+	defer startTimer.Stop()
+	select {
+	case <-startTimer.C:
+		err = m.Update(components)
+		require.NoError(t, err)
+	case err := <-errCh:
+		t.Fatalf("failed early: %s", err)
+	}
+
+	updateTimer := time.NewTimer(300 * time.Millisecond)
+	defer updateTimer.Stop()
+	select {
+	case <-updateTimer.C:
+		err = m.Update(components2)
+		require.NoError(t, err)
+	case err := <-errCh:
+		t.Fatalf("failed early: %s", err)
+	}
+
+	count := 0
+	endTimer := time.NewTimer(30 * time.Second)
+	defer endTimer.Stop()
+LOOP:
+	for {
+		select {
+		case <-endTimer.C:
+			t.Fatalf("timed out after 30 seconds")
+		case err := <-errCh:
+			require.NoError(t, err)
+		case err := <-subErrCh0:
+			require.NoError(t, err)
+			count++
+			if count >= 2 {
+				break LOOP
+			}
+		case err := <-subErrCh1:
+			require.NoError(t, err)
+			count++
+			if count >= 2 {
+				break LOOP
+			}
+		}
+	}
+
+	subCancel()
+	cancel()
+
+	// check progresstion, require stop fake-0 before start fake-1
+	wasStopped := false
+	for _, step := range stateProgression {
+		if step.componentID == "fake-0" && step.state.State == client.UnitStateStopped {
+			wasStopped = true
+		}
+		if step.componentID == "fake-1" && step.state.State == client.UnitStateStarting {
+			require.True(t, wasStopped)
+			break
+		}
+	}
+
+	err = <-errCh
+	require.NoError(t, err)
+}
+
 func newDebugLogger(t *testing.T) *logger.Logger {
 	t.Helper()
 
@@ -2366,7 +2574,7 @@ func drainErrChan(ch chan error) {
 	}
 }
 
-func signalState(subErrCh chan error, state *ComponentState) {
+func signalState(subErrCh chan error, state *ComponentState, acceptableStates []client.UnitState) {
 	if state.State == client.UnitStateFailed {
 		subErrCh <- fmt.Errorf("component failed: %s", state.Message)
 	} else {
@@ -2375,7 +2583,7 @@ func signalState(subErrCh chan error, state *ComponentState) {
 		for key, unit := range state.Units {
 			if unit.State == client.UnitStateStarting {
 				// acceptable
-			} else if unit.State == client.UnitStateHealthy {
+			} else if isAcceptableState(unit.State, acceptableStates) {
 				healthy++
 			} else if issue == "" {
 				issue = fmt.Sprintf("unit %s in invalid state %v", key.UnitID, unit.State)
@@ -2388,6 +2596,15 @@ func signalState(subErrCh chan error, state *ComponentState) {
 			subErrCh <- nil
 		}
 	}
+}
+
+func isAcceptableState(state client.UnitState, acceptableStates []client.UnitState) bool {
+	for _, s := range acceptableStates {
+		if s == state {
+			return true
+		}
+	}
+	return false
 }
 
 func testPaths(t *testing.T) {

--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -2498,7 +2498,12 @@ func TestManager_FakeInput_OutputChange(t *testing.T) {
 		t.Fatalf("failed early: %s", err)
 	}
 
-	updateTimer := time.NewTimer(300 * time.Millisecond)
+	updateTimeout := 300 * time.Millisecond
+	if runtime.GOOS == windows {
+		// windows is slow, preventing flakyness
+		updateTimeout = 550 * time.Millisecond
+	}
+	updateTimer := time.NewTimer(updateTimeout)
 	defer updateTimer.Stop()
 	select {
 	case <-updateTimer.C:

--- a/pkg/component/runtime/service.go
+++ b/pkg/component/runtime/service.go
@@ -211,7 +211,7 @@ func (s *ServiceRuntime) stop(ctx context.Context, comm Communicator, lastChecki
 			}
 		}
 
-		s.log.Debug("uninstall %s service", name)
+		s.log.Debugf("uninstall %s service", name)
 		err := s.uninstall(ctx)
 		if err != nil {
 			s.log.Errorf("failed %s service uninstall, err: %v", name, err)


### PR DESCRIPTION
## What does this PR do?

Two things being fixed here:

First one is order of start/stop. 
Currently we start new components before stopping old. This is usually fine unless component is a service (start/stop is slower).
When new service is started old one can be still running and using resources needed for new service to start. 
We can than see something like `bind port already in use`.

Second thing fixed here is waiting for uninstall to finish.
Again problem is when we change output and we try to uninstall component `service-output-one` and start `service-output-two`
We kick off uninstall of `service-output-one` and we actually don't wait for operation to finish. Then we start `service-output-two`
This may be fine as `service-output-one` may already be stopped but uninstall may be still in progress and this uninstall will remove service even though it's needed for `service-output-two`  

## Why is it important?

Service failures when
- we swap outputs
- we upgrade agent.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)