### PR TITLE
Do not always fail on copy

### DIFF
--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -273,7 +273,11 @@ func copyRunDirectory(log *logger.Logger, newHash string) error {
 		log.Debugw("Run directory not present", "old_run_path", oldRunPath)
 		return nil
 	}
-	return errors.New(err, "failed to copy %q to %q", oldRunPath, newRunPath)
+	if err != nil {
+		return errors.New(err, "failed to copy %q to %q", oldRunPath, newRunPath)
+	}
+
+	return nil
 }
 
 // shutdownCallback returns a callback function to be executing during shutdown once all processes are closed.


### PR DESCRIPTION
## What does this PR do?

returns nil error when failure is not there

## Why is it important?

Upgrade scenario wont work