### PR TITLE
[Release] Update version to 8.6.3

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -4,4 +4,4 @@
 
 package version
 
-const defaultBeatVersion = "8.6.2"
+const defaultBeatVersion = "8.6.3"


### PR DESCRIPTION
Updates references to the new release 8.6.3.

Merge after the release 8.6.2.