### PR TITLE
Migrate unencrypted config if fleet.enc does not exist

### DIFF
--- a/changelog/fragments/1676358802-migrate-unencrypted-config.yaml
+++ b/changelog/fragments/1676358802-migrate-unencrypted-config.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Migrate unencrypted fleet.yml and state.yml when encryption is introduced
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -38,6 +38,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/control/v2/server"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/migration"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/storage"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
@@ -139,6 +140,20 @@ func run(override cfgOverrider, modifiers ...component.PlatformModifier) error {
 	err = secret.CreateAgentSecret()
 	if err != nil {
 		return fmt.Errorf("failed to read/write secrets: %w", err)
+	}
+
+	// Migrate .yml files if the corresponding .enc does not exist
+
+	// the encrypted config does not exist but the unencrypted file does
+	err = migration.MigrateToEncryptedConfig(l, paths.AgentConfigYmlFile(), paths.AgentConfigFile())
+	if err != nil {
+		return errors.New(err, "error migrating fleet config")
+	}
+
+	// the encrypted state does not exist but the unencrypted file does
+	err = migration.MigrateToEncryptedConfig(l, paths.AgentStateStoreYmlFile(), paths.AgentStateStoreFile())
+	if err != nil {
+		return errors.New(err, "error migrating agent state")
 	}
 
 	agentInfo, err := info.NewAgentInfoWithLog(defaultLogLevel(cfg), createAgentID)

--- a/internal/pkg/agent/migration/migrate_config.go
+++ b/internal/pkg/agent/migration/migrate_config.go
@@ -1,0 +1,64 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package migration
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/storage"
+)
+
+// MigrateToEncryptedConfig will copy content from the store specified in unencryptedConfigPath
+// to the encrypted store specified in encryptedConfigPath if it doesn't exist already.
+// This function is intended to be called during startup when *.yml files exist from a previous version
+// but no corresponding *.enc file has been generated yet.
+// Notes:
+//   - The contents from the unencrypted file will be copied as a byte stream without any transformation.
+//   - The function will not perform any operation if the encryptedConfigPath already exists and it's not empty to avoid overwrites.
+//   - If neither the encrypted file nor the unencrypted file exist this call is a no-op
+func MigrateToEncryptedConfig(l *logp.Logger, unencryptedConfigPath string, encryptedConfigPath string) error {
+	encStat, encFileErr := os.Stat(encryptedConfigPath)
+
+	if encFileErr != nil && !errors.Is(encFileErr, fs.ErrNotExist) {
+		return errors.New("error checking for existence of %s: %v", encryptedConfigPath, encFileErr)
+	}
+
+	unencStat, unencFileErr := os.Stat(unencryptedConfigPath)
+
+	l.Debugf("checking stat of enc config %s: %+v, err: %v", encryptedConfigPath, encStat, encFileErr)
+	l.Debugf("checking stat of unenc config %s: %+v, err: %v", unencryptedConfigPath, unencStat, unencFileErr)
+
+	isEncryptedConfigEmpty := errors.Is(encFileErr, fs.ErrNotExist) || encStat.Size() == 0
+	isUnencryptedConfigPresent := unencFileErr == nil && unencStat.Size() > 0
+
+	if !isEncryptedConfigEmpty || !isUnencryptedConfigPresent {
+		return nil
+	}
+
+	l.Info("Initiating migration of %s to %s", unencryptedConfigPath, encryptedConfigPath)
+	legacyStore := storage.NewDiskStore(unencryptedConfigPath)
+	reader, err := legacyStore.Load()
+	if err != nil {
+		return errors.New(err, fmt.Sprintf("loading of unencrypted config from file %s failed", unencryptedConfigPath))
+	}
+	defer func() {
+		err = reader.Close()
+		if err != nil {
+			l.Errorf("Error closing unencrypted store reader for %s: %v", unencryptedConfigPath, err)
+		}
+	}()
+	store := storage.NewEncryptedDiskStore(encryptedConfigPath)
+	err = store.Save(reader)
+	if err != nil {
+		return errors.New(err, fmt.Sprintf("error writing encrypted config from file %s to file %s", unencryptedConfigPath, encryptedConfigPath))
+	}
+	l.Info("Migration of %s to %s complete", unencryptedConfigPath, encryptedConfigPath)
+
+	return nil
+}

--- a/internal/pkg/agent/migration/migrate_config.go
+++ b/internal/pkg/agent/migration/migrate_config.go
@@ -31,8 +31,8 @@ func MigrateToEncryptedConfig(l *logp.Logger, unencryptedConfigPath string, encr
 
 	unencStat, unencFileErr := os.Stat(unencryptedConfigPath)
 
-	l.Debugf("checking stat of enc config %s: %+v, err: %v", encryptedConfigPath, encStat, encFileErr)
-	l.Debugf("checking stat of unenc config %s: %+v, err: %v", unencryptedConfigPath, unencStat, unencFileErr)
+	l.Debugf("checking stat of enc config %q: %+v, err: %v", encryptedConfigPath, encStat, encFileErr)
+	l.Debugf("checking stat of unenc config %q: %+v, err: %v", unencryptedConfigPath, unencStat, unencFileErr)
 
 	isEncryptedConfigEmpty := errors.Is(encFileErr, fs.ErrNotExist) || encStat.Size() == 0
 	isUnencryptedConfigPresent := unencFileErr == nil && unencStat.Size() > 0
@@ -41,24 +41,24 @@ func MigrateToEncryptedConfig(l *logp.Logger, unencryptedConfigPath string, encr
 		return nil
 	}
 
-	l.Info("Initiating migration of %s to %s", unencryptedConfigPath, encryptedConfigPath)
+	l.Info("Initiating migration of %q to %q", unencryptedConfigPath, encryptedConfigPath)
 	legacyStore := storage.NewDiskStore(unencryptedConfigPath)
 	reader, err := legacyStore.Load()
 	if err != nil {
-		return errors.New(err, fmt.Sprintf("loading of unencrypted config from file %s failed", unencryptedConfigPath))
+		return errors.New(err, fmt.Sprintf("loading of unencrypted config from file %q failed", unencryptedConfigPath))
 	}
 	defer func() {
 		err = reader.Close()
 		if err != nil {
-			l.Errorf("Error closing unencrypted store reader for %s: %v", unencryptedConfigPath, err)
+			l.Errorf("Error closing unencrypted store reader for %q: %v", unencryptedConfigPath, err)
 		}
 	}()
 	store := storage.NewEncryptedDiskStore(encryptedConfigPath)
 	err = store.Save(reader)
 	if err != nil {
-		return errors.New(err, fmt.Sprintf("error writing encrypted config from file %s to file %s", unencryptedConfigPath, encryptedConfigPath))
+		return errors.New(err, fmt.Sprintf("error writing encrypted config from file %q to file %q", unencryptedConfigPath, encryptedConfigPath))
 	}
-	l.Info("Migration of %s to %s complete", unencryptedConfigPath, encryptedConfigPath)
+	l.Info("Migration of %q to %q complete", unencryptedConfigPath, encryptedConfigPath)
 
 	return nil
 }

--- a/internal/pkg/agent/migration/migrate_config_test.go
+++ b/internal/pkg/agent/migration/migrate_config_test.go
@@ -33,7 +33,6 @@ type configfile struct {
 }
 
 func TestMigrateToEncryptedConfig(t *testing.T) {
-
 	testcases := []struct {
 		name                     string
 		unencryptedConfig        configfile
@@ -104,7 +103,6 @@ func TestMigrateToEncryptedConfig(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			//setup begin
 			top := t.TempDir()
 			paths.SetTop(top)
@@ -153,14 +151,11 @@ func TestMigrateToEncryptedConfig(t *testing.T) {
 			for _, filename := range tc.expectedFiles {
 				assert.FileExistsf(t, path.Join(top, filename), "file %s should exist", filename)
 			}
-
 		})
 	}
-
 }
 
 func TestErrorMigrateToEncryptedConfig(t *testing.T) {
-
 	if runtime.GOOS == "windows" {
 		t.Skip("cannot reliably reproduce permission errors on windows")
 	}
@@ -198,10 +193,8 @@ func TestErrorMigrateToEncryptedConfig(t *testing.T) {
 			},
 		},
 	}
-
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			//setup begin
 			top := t.TempDir()
 			paths.SetTop(top)
@@ -248,7 +241,6 @@ func TestErrorMigrateToEncryptedConfig(t *testing.T) {
 }
 
 func createAndPersistStore(t *testing.T, baseDir string, cf configfile, encrypted bool) storage.Storage {
-
 	var store storage.Storage
 
 	asbFilePath := path.Join(baseDir, cf.name)

--- a/internal/pkg/agent/migration/migrate_config_test.go
+++ b/internal/pkg/agent/migration/migrate_config_test.go
@@ -1,0 +1,273 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build linux || windows
+// +build linux windows
+
+package migration
+
+import (
+	"bytes"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/secret"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/storage"
+)
+
+type configfile struct {
+	name        string
+	create      bool
+	permissions fs.FileMode
+	content     []byte
+}
+
+func TestMigrateToEncryptedConfig(t *testing.T) {
+
+	testcases := []struct {
+		name                     string
+		unencryptedConfig        configfile
+		encryptedConfig          configfile
+		expectedFiles            []string
+		expectedEncryptedContent []byte
+	}{
+		{
+			name: "no files, no migration",
+			unencryptedConfig: configfile{
+				name:   "fleet.yml",
+				create: false,
+			},
+			encryptedConfig: configfile{
+				name:   "fleet.enc",
+				create: false,
+			},
+			expectedFiles: []string{},
+		},
+		{
+			name: "unencrypted exists encrypted does not -> migrated",
+			unencryptedConfig: configfile{
+				name:        "fleet.yml",
+				create:      true,
+				content:     []byte("some legacy fleet config here"),
+				permissions: 0644,
+			},
+			encryptedConfig: configfile{
+				name: "fleet.enc",
+			},
+			expectedFiles:            []string{"fleet.enc"},
+			expectedEncryptedContent: []byte("some legacy fleet config here"),
+		},
+		{
+			name: "unencrypted exists encrypted is empty -> migrated",
+			unencryptedConfig: configfile{
+				name:        "fleet.yml",
+				create:      true,
+				content:     []byte("some legacy fleet config here"),
+				permissions: 0644,
+			},
+			encryptedConfig: configfile{
+				name:        "fleet.enc",
+				create:      true,
+				permissions: 0644,
+			},
+			expectedFiles:            []string{"fleet.enc"},
+			expectedEncryptedContent: []byte("some legacy fleet config here"),
+		},
+		{
+			name: "both unencrypted and encrypted exist and not empty -> not migrated",
+			unencryptedConfig: configfile{
+				name:        "fleet.yml",
+				create:      true,
+				content:     []byte("some legacy fleet config here"),
+				permissions: 0644,
+			},
+			encryptedConfig: configfile{
+				name:        "fleet.enc",
+				create:      true,
+				content:     []byte("some new shiny fleet config here"),
+				permissions: 0644,
+			},
+			expectedFiles:            []string{"fleet.enc"},
+			expectedEncryptedContent: []byte("some new shiny fleet config here"),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			//setup begin
+			top := t.TempDir()
+			paths.SetTop(top)
+
+			vaultPath := paths.AgentVaultPath()
+			err := secret.CreateAgentSecret(secret.WithVaultPath(vaultPath))
+
+			require.NoError(t, err)
+
+			createAndPersistStore(t, top, tc.unencryptedConfig, false)
+			encryptedStore := createAndPersistStore(t, top, tc.encryptedConfig, true)
+
+			absUnencryptedFile := path.Join(top, tc.unencryptedConfig.name)
+			absEncryptedFile := path.Join(top, tc.encryptedConfig.name)
+
+			defer func() {
+				// make sure we can delete all the stuff in the temp dir
+				err = os.Chmod(absUnencryptedFile, 0777&os.ModePerm)
+				if err != nil {
+					t.Logf("error setting file permission for %s: %v", absUnencryptedFile, err)
+				}
+				err = os.Chmod(absEncryptedFile, 0777&os.ModePerm)
+				if err != nil {
+					t.Logf("error setting file permission for %s: %v", absEncryptedFile, err)
+				}
+			}()
+
+			log := logp.NewLogger("test_migrate_config")
+			// setup end
+
+			err = MigrateToEncryptedConfig(log, absUnencryptedFile, absEncryptedFile)
+
+			assert.NoError(t, err)
+			if len(tc.expectedEncryptedContent) > 0 {
+				readCloser, err := encryptedStore.Load()
+				require.NoError(t, err)
+				defer func() {
+					err = readCloser.Close()
+					assert.NoError(t, err)
+				}()
+				actualEncryptedContent, err := io.ReadAll(readCloser)
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedEncryptedContent, actualEncryptedContent)
+			}
+
+			for _, filename := range tc.expectedFiles {
+				assert.FileExistsf(t, path.Join(top, filename), "file %s should exist", filename)
+			}
+
+		})
+	}
+
+}
+
+func TestErrorMigrateToEncryptedConfig(t *testing.T) {
+
+	if runtime.GOOS == "windows" {
+		t.Skip("cannot reliably reproduce permission errors on windows")
+	}
+
+	testcases := []struct {
+		name              string
+		unencryptedConfig configfile
+		encryptedConfig   configfile
+	}{
+		{
+			name: "unencrypted present, encrypted not writable -> error",
+			unencryptedConfig: configfile{
+				name:        "fleet.yml",
+				create:      true,
+				content:     []byte("some legacy fleet config here"),
+				permissions: 0644,
+			},
+			encryptedConfig: configfile{
+				name:        "fleet.enc",
+				create:      true,
+				permissions: 0400,
+			},
+		},
+		{
+			name: "unencrypted not readable, encrypted does not exist -> error",
+			unencryptedConfig: configfile{
+				name:        "fleet.yml",
+				create:      true,
+				content:     []byte("some legacy fleet config here"),
+				permissions: 0200,
+			},
+			encryptedConfig: configfile{
+				name:        "fleet.enc",
+				permissions: 0644,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			//setup begin
+			top := t.TempDir()
+			paths.SetTop(top)
+
+			vaultPath := paths.AgentVaultPath()
+			err := secret.CreateAgentSecret(secret.WithVaultPath(vaultPath))
+
+			require.NoError(t, err)
+
+			createAndPersistStore(t, top, tc.unencryptedConfig, false)
+			createAndPersistStore(t, top, tc.encryptedConfig, true)
+
+			err = os.Chmod(top, 0555&os.ModePerm)
+			require.NoError(t, err)
+
+			absUnencryptedFile := path.Join(top, tc.unencryptedConfig.name)
+			absEncryptedFile := path.Join(top, tc.encryptedConfig.name)
+
+			defer func() {
+				// make sure we can delete all the stuff in the temp dir
+				err = os.Chmod(absUnencryptedFile, 0777&os.ModePerm)
+				if err != nil {
+					t.Logf("error setting file permission for %s: %v", absUnencryptedFile, err)
+				}
+				err = os.Chmod(absEncryptedFile, 0777&os.ModePerm)
+				if err != nil {
+					t.Logf("error setting file permission for %s: %v", absEncryptedFile, err)
+				}
+				err = os.Chmod(top, 0777&os.ModePerm)
+				if err != nil {
+					t.Logf("error setting permissions for directory %s: %v", top, err)
+				}
+			}()
+
+			log := logp.NewLogger("test_migrate_config")
+			// setup end
+
+			err = MigrateToEncryptedConfig(log, absUnencryptedFile, absEncryptedFile)
+
+			assert.Error(t, err)
+		})
+	}
+
+}
+
+func createAndPersistStore(t *testing.T, baseDir string, cf configfile, encrypted bool) storage.Storage {
+
+	var store storage.Storage
+
+	asbFilePath := path.Join(baseDir, cf.name)
+
+	if encrypted {
+		store = storage.NewEncryptedDiskStore(asbFilePath)
+	} else {
+		store = storage.NewDiskStore(asbFilePath)
+	}
+
+	if !cf.create {
+		return store
+	}
+
+	err := store.Save(bytes.NewReader(cf.content))
+	require.NoError(t, err)
+
+	err = os.Chmod(asbFilePath, cf.permissions&fs.ModePerm)
+	require.NoError(t, err)
+
+	return store
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
Fix upgrading from 7.17 where the unencrypted configuration contained in `fleet.yml` and `state.yml` is not copied into the corresponding encrypted stores `fleet.enc` and `state.enc`. This would cause the agent to fail reconnecting to fleet in a healthy state after upgrade.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
We need to make sure that agent reconnects to fleet after upgrade.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

- Install an old version of agent that does not use encrypted configuration and enroll it to a fleet server.
- Upgrade to a recent agent version that expects to find encrypted config
-  Check the health of the corresponding agent

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #2249 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
