### PR TITLE
[Cloud Defend] removing these commented mounts as this feature is not going out until 8.8

### DIFF
--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -64,8 +64,6 @@ spec:
                   fieldPath: metadata.name
           securityContext:
             runAsUser: 0
-            # Needed for 'Defend for containers' integration (cloud-defend)
-            #privileged: true
           resources:
             limits:
               memory: 500Mi
@@ -94,17 +92,6 @@ spec:
             - name: etc-mid
               mountPath: /etc/machine-id
               readOnly: true
-            # Needed for 'Defend for containers' integration (cloud-defend)
-            #- name: boot
-            #  mountPath: /boot
-            #  readOnly: true
-            #- name: sys-kernel-debug
-            #  mountPath: /sys/kernel/debug
-            #- name: sys-fs-bpf
-            #  mountPath: /sys/fs/bpf
-            #- name: sys-kernel-security
-            #  mountPath: /sys/kernel/security
-            #  readOnly: true
       volumes:
         - name: proc
           hostPath:
@@ -133,19 +120,6 @@ spec:
           hostPath:
             path: /etc/machine-id
             type: File
-        # Needed for 'Defend for containers' integration (cloud-defend)
-        #- name: boot
-        #  hostPath:
-        #    path: /boot
-        #- name: sys-kernel-debug
-        #  hostPath:
-        #    path: /sys/kernel/debug
-        #- name: sys-fs-bpf
-        #  hostPath:
-        #    path: /sys/fs/bpf
-        #- name: sys-kernel-security
-        #  hostPath:
-        #    path: /sys/kernel/security
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -64,8 +64,6 @@ spec:
                   fieldPath: metadata.name
           securityContext:
             runAsUser: 0
-            # Needed for 'Defend for containers' integration (cloud-defend)
-            #privileged: true
           resources:
             limits:
               memory: 500Mi
@@ -94,17 +92,6 @@ spec:
             - name: etc-mid
               mountPath: /etc/machine-id
               readOnly: true
-            # Needed for 'Defend for containers' integration (cloud-defend)
-            #- name: boot
-            #  mountPath: /boot
-            #  readOnly: true
-            #- name: sys-kernel-debug
-            #  mountPath: /sys/kernel/debug
-            #- name: sys-fs-bpf
-            #  mountPath: /sys/fs/bpf
-            #- name: sys-kernel-security
-            #  mountPath: /sys/kernel/security
-            #  readOnly: true
       volumes:
         - name: proc
           hostPath:
@@ -133,16 +120,3 @@ spec:
           hostPath:
             path: /etc/machine-id
             type: File
-        # Needed for 'Defend for containers' integration (cloud-defend)
-        #- name: boot
-        #  hostPath:
-        #    path: /boot
-        #- name: sys-kernel-debug
-        #  hostPath:
-        #    path: /sys/kernel/debug
-        #- name: sys-fs-bpf
-        #  hostPath:
-        #    path: /sys/fs/bpf
-        #- name: sys-kernel-security
-        #  hostPath:
-        #    path: /sys/kernel/security

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -713,8 +713,6 @@ spec:
               value: "/etc/elastic-agent"
           securityContext:
             runAsUser: 0
-            # Needed for 'Defend for containers' integration (cloud-defend)
-            #privileged: true
           resources:
             limits:
               memory: 700Mi
@@ -747,17 +745,6 @@ spec:
             - name: var-lib
               mountPath: /hostfs/var/lib
               readOnly: true
-            # Needed for 'Defend for containers' integration (cloud-defend)
-            #- name: boot
-            #  mountPath: /boot
-            #  readOnly: true
-            #- name: sys-kernel-debug
-            #  mountPath: /sys/kernel/debug
-            #- name: sys-fs-bpf
-            #  mountPath: /sys/fs/bpf
-            #- name: sys-kernel-security
-            #  mountPath: /sys/kernel/security
-            #  readOnly: true
       volumes:
         - name: datastreams
           configMap:
@@ -787,19 +774,6 @@ spec:
         - name: var-lib
           hostPath:
             path: /var/lib
-        # Needed for 'Defend for containers' integration (cloud-defend)
-        #- name: boot
-        #  hostPath:
-        #    path: /boot
-        #- name: sys-kernel-debug
-        #  hostPath:
-        #    path: /sys/kernel/debug
-        #- name: sys-fs-bpf
-        #  hostPath:
-        #    path: /sys/fs/bpf
-        #- name: sys-kernel-security
-        #  hostPath:
-        #    path: /sys/kernel/security
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
@@ -68,8 +68,6 @@ spec:
               value: "/etc/elastic-agent"
           securityContext:
             runAsUser: 0
-            # Needed for 'Defend for containers' integration (cloud-defend)
-            #privileged: true
           resources:
             limits:
               memory: 700Mi
@@ -102,17 +100,6 @@ spec:
             - name: var-lib
               mountPath: /hostfs/var/lib
               readOnly: true
-            # Needed for 'Defend for containers' integration (cloud-defend)
-            #- name: boot
-            #  mountPath: /boot
-            #  readOnly: true
-            #- name: sys-kernel-debug
-            #  mountPath: /sys/kernel/debug
-            #- name: sys-fs-bpf
-            #  mountPath: /sys/fs/bpf
-            #- name: sys-kernel-security
-            #  mountPath: /sys/kernel/security
-            #  readOnly: true
       volumes:
         - name: datastreams
           configMap:
@@ -142,16 +129,3 @@ spec:
         - name: var-lib
           hostPath:
             path: /var/lib
-        # Needed for 'Defend for containers' integration (cloud-defend)
-        #- name: boot
-        #  hostPath:
-        #    path: /boot
-        #- name: sys-kernel-debug
-        #  hostPath:
-        #    path: /sys/kernel/debug
-        #- name: sys-fs-bpf
-        #  hostPath:
-        #    path: /sys/fs/bpf
-        #- name: sys-kernel-security
-        #  hostPath:
-        #    path: /sys/kernel/security


### PR DESCRIPTION
## What does this PR do?

There are still some unresolved questions around how we plan to get these mount points into the agent yaml (as well as the privileged flag). The cloud_defend integration won't be released until 8.8, so we are removing these commented out mount points to avoid any confusion.

## Why is it important?

As to not confuse the user or reveal details around an unfinished feature set in 8.7

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~