### PR TITLE
Log the binary and platform on build failure.

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -677,7 +677,7 @@ func packageAgent(platforms []string, packagingFn func()) {
 						if strings.Contains(err.Error(), "object not found") {
 							fmt.Printf("Downloading %s: unsupported on %s, skipping\n", binary, platform)
 						} else {
-							panic(fmt.Sprintf("fetchBinaryFromArtifactsApi failed: %v", err))
+							panic(fmt.Sprintf("fetchBinaryFromArtifactsApi failed for %s on %s: %v", binary, platform, err))
 						}
 					}
 				}


### PR DESCRIPTION
When we fail to download an artifact from the artifact API, log the affected binary and platform to make debugging easier.

Before:

```
❯ DEV=true EXTERNAL=true SNAPSHOT=true PLATFORMS=darwin/arm64 PACKAGES=tar.gz mage -v package
Running target: Package
package ran for 56.499300208s
Error: fetchBinaryFromArtifactsApi failed: the artifact was not found
```

After:

```
❯ DEV=true EXTERNAL=true SNAPSHOT=true PLATFORMS=darwin/arm64 PACKAGES=tar.gz mage -v package
Running target: Package
package ran for 56.44111175s
Error: fetchBinaryFromArtifactsApi failed for auditbeat on darwin/arm64: the artifact was not found
```

This is currently failing because the unified release snapshot for main is failing, see 7