### PR TITLE
Support only HTTPS for remote upgrade PGP

### DIFF
--- a/_meta/config/common.p2.yml.tmpl
+++ b/_meta/config/common.p2.yml.tmpl
@@ -114,9 +114,6 @@ inputs:
 #   target_directory: "${path.data}/downloads"
 #   # timeout for downloading package
 #   timeout: 120s
-#   # file path to a public key used for verifying downloaded artifacts
-#   # if not file is present agent will try to load public key from elastic.co website.
-#   pgpfile: "${path.data}/elastic.pgp"
 #   # install_path describes the location of installed packages/programs. It is also used
 #   # for reading program specifications.
 #   install_path: "${path.data}/install"

--- a/_meta/config/common.reference.p2.yml.tmpl
+++ b/_meta/config/common.reference.p2.yml.tmpl
@@ -65,9 +65,6 @@ inputs:
 #   target_directory: "${path.data}/downloads"
 #   # timeout for downloading package
 #   timeout: 120s
-#   # file path to a public key used for verifying downloaded artifacts
-#   # if not file is present agent will try to load public key from elastic.co website.
-#   pgpfile: "${path.data}/elastic.pgp"
 #   # install_path describes the location of installed packages/programs. It is also used
 #   # for reading program specifications.
 #   install_path: "${path.data}/install"

--- a/_meta/config/elastic-agent.docker.yml.tmpl
+++ b/_meta/config/elastic-agent.docker.yml.tmpl
@@ -64,9 +64,6 @@ inputs:
 #   target_directory: "${path.data}/downloads"
 #   # timeout for downloading package
 #   timeout: 120s
-#   # file path to a public key used for verifying downloaded artifacts
-#   # if not file is present agent will try to load public key from elastic.co website.
-#   pgpfile: "${path.data}/elastic.pgp"
 #   # install_path describes the location of installed packages/programs. It is also used
 #   # for reading program specifications.
 #   install_path: "${path.data}/install"

--- a/_meta/elastic-agent.fleet.yml
+++ b/_meta/elastic-agent.fleet.yml
@@ -13,9 +13,6 @@ fleet:
 #   target_directory: "${path.data}/downloads"
 #   # timeout for downloading package
 #   timeout: 120s
-#   # file path to a public key used for verifying downloaded artifacts
-#   # if not file is present Elastic Agent will try to load public key from elastic.co website.
-#   pgpfile: "${path.data}/elastic.pgp"
 #   # install_path describes the location of installed packages/programs. It is also used
 #   # for reading program specifications.
 #   install_path: "${path.data}/install"

--- a/_meta/elastic-agent.yml
+++ b/_meta/elastic-agent.yml
@@ -64,9 +64,6 @@ inputs:
 #   target_directory: "${path.data}/downloads"
 #   # timeout for downloading package
 #   timeout: 120s
-#   # file path to a public key used for verifying downloaded artifacts
-#   # if not file is present agent will try to load public key from elastic.co website.
-#   pgpfile: "${path.data}/elastic.pgp"
 #   # install_path describes the location of installed packages/programs. It is also used
 #   # for reading program specifications.
 #   install_path: "${path.data}/install"

--- a/elastic-agent.docker.yml
+++ b/elastic-agent.docker.yml
@@ -64,9 +64,6 @@ inputs:
 #   target_directory: "${path.data}/downloads"
 #   # timeout for downloading package
 #   timeout: 120s
-#   # file path to a public key used for verifying downloaded artifacts
-#   # if not file is present agent will try to load public key from elastic.co website.
-#   pgpfile: "${path.data}/elastic.pgp"
 #   # install_path describes the location of installed packages/programs. It is also used
 #   # for reading program specifications.
 #   install_path: "${path.data}/install"

--- a/elastic-agent.reference.yml
+++ b/elastic-agent.reference.yml
@@ -71,9 +71,6 @@ inputs:
 #   target_directory: "${path.data}/downloads"
 #   # timeout for downloading package
 #   timeout: 120s
-#   # file path to a public key used for verifying downloaded artifacts
-#   # if not file is present agent will try to load public key from elastic.co website.
-#   pgpfile: "${path.data}/elastic.pgp"
 #   # install_path describes the location of installed packages/programs. It is also used
 #   # for reading program specifications.
 #   install_path: "${path.data}/install"

--- a/elastic-agent.yml
+++ b/elastic-agent.yml
@@ -120,9 +120,6 @@ inputs:
 #   target_directory: "${path.data}/downloads"
 #   # timeout for downloading package
 #   timeout: 120s
-#   # file path to a public key used for verifying downloaded artifacts
-#   # if not file is present agent will try to load public key from elastic.co website.
-#   pgpfile: "${path.data}/elastic.pgp"
 #   # install_path describes the location of installed packages/programs. It is also used
 #   # for reading program specifications.
 #   install_path: "${path.data}/install"

--- a/internal/pkg/agent/application/upgrade/artifact/download/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/verifier.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -176,7 +177,24 @@ func PgpBytesFromSource(source string, client http.Client) ([]byte, error) {
 	return nil, errors.New("unknown pgp source")
 }
 
+func CheckValidDownloadUri(rawURI string) error {
+	uri, err := url.Parse(rawURI)
+	if err != nil {
+		return err
+	}
+
+	if !strings.EqualFold(uri.Scheme, "https") {
+		return fmt.Errorf("failed to check URI %q: HTTPS is required", rawURI)
+	}
+
+	return nil
+}
+
 func fetchPgpFromURI(uri string, client http.Client) ([]byte, error) {
+	if err := CheckValidDownloadUri(uri); err != nil {
+		return nil, err
+	}
+
 	resp, err := client.Get(uri)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/agent/cmd/upgrade.go
+++ b/internal/pkg/agent/cmd/upgrade.go
@@ -27,6 +27,8 @@ const (
 	flagPGPBytes     = "pgp"
 	flagPGPBytesPath = "pgp-path"
 	flagPGPBytesURI  = "pgp-uri"
+
+	remoteElasticPubKey = download.PgpSourceURIPrefix + "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
 )
 
 func newUpgradeCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
@@ -91,6 +93,9 @@ func upgradeCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error
 			// URI is parsed later with proper TLS and Proxy config within downloader
 			pgpChecks = append(pgpChecks, download.PgpSourceURIPrefix+pgpUri)
 		}
+
+		// add Elastic remote Public key as last option for fallback
+		pgpChecks = append(pgpChecks, remoteElasticPubKey)
 	}
 
 	version, err = c.Upgrade(context.Background(), version, sourceURI, skipVerification, pgpChecks...)

--- a/internal/pkg/agent/cmd/upgrade.go
+++ b/internal/pkg/agent/cmd/upgrade.go
@@ -27,8 +27,6 @@ const (
 	flagPGPBytes     = "pgp"
 	flagPGPBytesPath = "pgp-path"
 	flagPGPBytesURI  = "pgp-uri"
-
-	remoteElasticPubKey = download.PgpSourceURIPrefix + "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
 )
 
 func newUpgradeCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
@@ -93,9 +91,6 @@ func upgradeCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error
 			// URI is parsed later with proper TLS and Proxy config within downloader
 			pgpChecks = append(pgpChecks, download.PgpSourceURIPrefix+pgpUri)
 		}
-
-		// add Elastic remote Public key as last option for fallback
-		pgpChecks = append(pgpChecks, remoteElasticPubKey)
 	}
 
 	version, err = c.Upgrade(context.Background(), version, sourceURI, skipVerification, pgpChecks...)

--- a/internal/pkg/agent/cmd/upgrade.go
+++ b/internal/pkg/agent/cmd/upgrade.go
@@ -8,9 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"net/url"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -84,7 +82,7 @@ func upgradeCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error
 
 		pgpUri, _ := cmd.Flags().GetString(flagPGPBytesURI)
 		if len(pgpUri) > 0 {
-			if uriErr := checkValidUri(pgpUri); uriErr != nil {
+			if uriErr := download.CheckValidDownloadUri(pgpUri); uriErr != nil {
 				return uriErr
 			}
 
@@ -98,18 +96,5 @@ func upgradeCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error
 		return errors.New(err, "Failed trigger upgrade of daemon")
 	}
 	fmt.Fprintf(streams.Out, "Upgrade triggered to version %s, Elastic Agent is currently restarting\n", version)
-	return nil
-}
-
-func checkValidUri(rawURI string) error {
-	uri, err := url.Parse(rawURI)
-	if err != nil {
-		return err
-	}
-
-	if !strings.EqualFold(uri.Scheme, "https") {
-		return fmt.Errorf("failed to check URI %q: HTTPS is required", rawURI)
-	}
-
 	return nil
 }


### PR DESCRIPTION
## What does this PR do?

Followup to #2246
- restricts URI to be HTTPS
- ~~adds Elastic GPG as a backup~~

!! Manual backport to 7.17