### PR TITLE
Add the file extension in unit diagnostics again.

### DIFF
--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -195,7 +195,7 @@ func ZipArchive(errOut, w io.Writer, agentDiag []client.DiagnosticFileResult, un
 				continue
 			}
 			for _, fr := range ud.Results {
-				filePath := fmt.Sprintf("components/%s/%s/%s", dirName, unitDir, fr.Name)
+				filePath := fmt.Sprintf("components/%s/%s/%s", dirName, unitDir, fr.Filename)
 				w, err := zw.CreateHeader(&zip.FileHeader{
 					Name:     filePath,
 					Method:   zip.Deflate,


### PR DESCRIPTION
Re-apply the changes from https://github.com/elastic/elastic-agent/pull/2047 again since they somehow got lost on main again.

I think this was lost during merge conflict resolution in https://github.com/elastic/elastic-agent/pull/1703 and so this only applies to 8.7 and main
