### PR TITLE
Enhancement: Adding required mounts and capabilities for `Defend for containers`

### DIFF
--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -65,13 +65,12 @@ spec:
           securityContext:
             runAsUser: 0
             capabilities:
-              drop:
-                - all
               add:
-              # Needed for 'Defend for containers' integration (cloud-defend)
-                - BPF
-                - PERFMON
-                - SYS_RESOURCE
+              # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
+              # If you are not using this integration, then these capabilites can be removed.
+                - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
+                - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
+                - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by `Defend for Containers` to modify `rlimit_memlock`
           resources:
             limits:
               memory: 500Mi
@@ -100,7 +99,6 @@ spec:
             - name: etc-mid
               mountPath: /etc/machine-id
               readOnly: true
-            # Needed for 'Defend for containers' integration (cloud-defend)
             - name: sys-kernel-debug
               mountPath: /sys/kernel/debug
       volumes:
@@ -132,6 +130,8 @@ spec:
             path: /etc/machine-id
             type: File
         # Needed for 'Defend for containers' integration (cloud-defend)
+        # If you are not using this integration, then these volumes and the corresponding
+        # mounts can be removed.
         - name: sys-kernel-debug
           hostPath:
             path: /sys/kernel/debug

--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -64,6 +64,8 @@ spec:
                   fieldPath: metadata.name
           securityContext:
             runAsUser: 0
+            # Needed for 'Defend for containers' integration (cloud-defend)
+            #privileged: true
           resources:
             limits:
               memory: 500Mi
@@ -92,6 +94,17 @@ spec:
             - name: etc-mid
               mountPath: /etc/machine-id
               readOnly: true
+            # Needed for 'Defend for containers' integration (cloud-defend)
+            #- name: boot
+            #  mountPath: /boot
+            #  readOnly: true
+            #- name: sys-kernel-debug
+            #  mountPath: /sys/kernel/debug
+            #- name: sys-fs-bpf
+            #  mountPath: /sys/fs/bpf
+            #- name: sys-kernel-security
+            #  mountPath: /sys/kernel/security
+            #  readOnly: true
       volumes:
         - name: proc
           hostPath:
@@ -120,6 +133,19 @@ spec:
           hostPath:
             path: /etc/machine-id
             type: File
+        # Needed for 'Defend for containers' integration (cloud-defend)
+        #- name: boot
+        #  hostPath:
+        #    path: /boot
+        #- name: sys-kernel-debug
+        #  hostPath:
+        #    path: /sys/kernel/debug
+        #- name: sys-fs-bpf
+        #  hostPath:
+        #    path: /sys/fs/bpf
+        #- name: sys-kernel-security
+        #  hostPath:
+        #    path: /sys/kernel/security
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -101,16 +101,8 @@ spec:
               mountPath: /etc/machine-id
               readOnly: true
             # Needed for 'Defend for containers' integration (cloud-defend)
-            - name: boot
-              mountPath: /boot
-              readOnly: true
             - name: sys-kernel-debug
               mountPath: /sys/kernel/debug
-            - name: sys-fs-bpf
-              mountPath: /sys/fs/bpf
-            - name: sys-kernel-security
-              mountPath: /sys/kernel/security
-              readOnly: true
       volumes:
         - name: proc
           hostPath:
@@ -140,18 +132,9 @@ spec:
             path: /etc/machine-id
             type: File
         # Needed for 'Defend for containers' integration (cloud-defend)
-        - name: boot
-          hostPath:
-            path: /boot
         - name: sys-kernel-debug
           hostPath:
             path: /sys/kernel/debug
-        - name: sys-fs-bpf
-          hostPath:
-            path: /sys/fs/bpf
-        - name: sys-kernel-security
-          hostPath:
-            path: /sys/kernel/security
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -64,8 +64,14 @@ spec:
                   fieldPath: metadata.name
           securityContext:
             runAsUser: 0
-            # Needed for 'Defend for containers' integration (cloud-defend)
-            #privileged: true
+            capabilities:
+              drop:
+                - all
+              add:
+              # Needed for 'Defend for containers' integration (cloud-defend)
+                - BPF
+                - PERFMON
+                - SYS_RESOURCE
           resources:
             limits:
               memory: 500Mi
@@ -95,16 +101,16 @@ spec:
               mountPath: /etc/machine-id
               readOnly: true
             # Needed for 'Defend for containers' integration (cloud-defend)
-            #- name: boot
-            #  mountPath: /boot
-            #  readOnly: true
-            #- name: sys-kernel-debug
-            #  mountPath: /sys/kernel/debug
-            #- name: sys-fs-bpf
-            #  mountPath: /sys/fs/bpf
-            #- name: sys-kernel-security
-            #  mountPath: /sys/kernel/security
-            #  readOnly: true
+            - name: boot
+              mountPath: /boot
+              readOnly: true
+            - name: sys-kernel-debug
+              mountPath: /sys/kernel/debug
+            - name: sys-fs-bpf
+              mountPath: /sys/fs/bpf
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
       volumes:
         - name: proc
           hostPath:
@@ -134,18 +140,18 @@ spec:
             path: /etc/machine-id
             type: File
         # Needed for 'Defend for containers' integration (cloud-defend)
-        #- name: boot
-        #  hostPath:
-        #    path: /boot
-        #- name: sys-kernel-debug
-        #  hostPath:
-        #    path: /sys/kernel/debug
-        #- name: sys-fs-bpf
-        #  hostPath:
-        #    path: /sys/fs/bpf
-        #- name: sys-kernel-security
-        #  hostPath:
-        #    path: /sys/kernel/security
+        - name: boot
+          hostPath:
+            path: /boot
+        - name: sys-kernel-debug
+          hostPath:
+            path: /sys/kernel/debug
+        - name: sys-fs-bpf
+          hostPath:
+            path: /sys/fs/bpf
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -65,13 +65,12 @@ spec:
           securityContext:
             runAsUser: 0
             capabilities:
-              drop:
-                - all
               add:
-              # Needed for 'Defend for containers' integration (cloud-defend)
-                - BPF
-                - PERFMON
-                - SYS_RESOURCE
+              # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
+              # If you are not using this integration, then these capabilites can be removed.
+                - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
+                - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
+                - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by `Defend for Containers` to modify `rlimit_memlock`
           resources:
             limits:
               memory: 500Mi
@@ -100,7 +99,6 @@ spec:
             - name: etc-mid
               mountPath: /etc/machine-id
               readOnly: true
-            # Needed for 'Defend for containers' integration (cloud-defend)
             - name: sys-kernel-debug
               mountPath: /sys/kernel/debug
       volumes:
@@ -132,6 +130,8 @@ spec:
             path: /etc/machine-id
             type: File
         # Needed for 'Defend for containers' integration (cloud-defend)
+        # If you are not using this integration, then these volumes and the corresponding
+        # mounts can be removed.
         - name: sys-kernel-debug
           hostPath:
             path: /sys/kernel/debug

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -101,16 +101,8 @@ spec:
               mountPath: /etc/machine-id
               readOnly: true
             # Needed for 'Defend for containers' integration (cloud-defend)
-            - name: boot
-              mountPath: /boot
-              readOnly: true
             - name: sys-kernel-debug
               mountPath: /sys/kernel/debug
-            - name: sys-fs-bpf
-              mountPath: /sys/fs/bpf
-            - name: sys-kernel-security
-              mountPath: /sys/kernel/security
-              readOnly: true
       volumes:
         - name: proc
           hostPath:
@@ -140,15 +132,6 @@ spec:
             path: /etc/machine-id
             type: File
         # Needed for 'Defend for containers' integration (cloud-defend)
-        - name: boot
-          hostPath:
-            path: /boot
         - name: sys-kernel-debug
           hostPath:
             path: /sys/kernel/debug
-        - name: sys-fs-bpf
-          hostPath:
-            path: /sys/fs/bpf
-        - name: sys-kernel-security
-          hostPath:
-            path: /sys/kernel/security

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -64,6 +64,8 @@ spec:
                   fieldPath: metadata.name
           securityContext:
             runAsUser: 0
+            # Needed for 'Defend for containers' integration (cloud-defend)
+            #privileged: true
           resources:
             limits:
               memory: 500Mi
@@ -92,6 +94,17 @@ spec:
             - name: etc-mid
               mountPath: /etc/machine-id
               readOnly: true
+            # Needed for 'Defend for containers' integration (cloud-defend)
+            #- name: boot
+            #  mountPath: /boot
+            #  readOnly: true
+            #- name: sys-kernel-debug
+            #  mountPath: /sys/kernel/debug
+            #- name: sys-fs-bpf
+            #  mountPath: /sys/fs/bpf
+            #- name: sys-kernel-security
+            #  mountPath: /sys/kernel/security
+            #  readOnly: true
       volumes:
         - name: proc
           hostPath:
@@ -120,3 +133,16 @@ spec:
           hostPath:
             path: /etc/machine-id
             type: File
+        # Needed for 'Defend for containers' integration (cloud-defend)
+        #- name: boot
+        #  hostPath:
+        #    path: /boot
+        #- name: sys-kernel-debug
+        #  hostPath:
+        #    path: /sys/kernel/debug
+        #- name: sys-fs-bpf
+        #  hostPath:
+        #    path: /sys/fs/bpf
+        #- name: sys-kernel-security
+        #  hostPath:
+        #    path: /sys/kernel/security

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -64,8 +64,14 @@ spec:
                   fieldPath: metadata.name
           securityContext:
             runAsUser: 0
-            # Needed for 'Defend for containers' integration (cloud-defend)
-            #privileged: true
+            capabilities:
+              drop:
+                - all
+              add:
+              # Needed for 'Defend for containers' integration (cloud-defend)
+                - BPF
+                - PERFMON
+                - SYS_RESOURCE
           resources:
             limits:
               memory: 500Mi
@@ -95,16 +101,16 @@ spec:
               mountPath: /etc/machine-id
               readOnly: true
             # Needed for 'Defend for containers' integration (cloud-defend)
-            #- name: boot
-            #  mountPath: /boot
-            #  readOnly: true
-            #- name: sys-kernel-debug
-            #  mountPath: /sys/kernel/debug
-            #- name: sys-fs-bpf
-            #  mountPath: /sys/fs/bpf
-            #- name: sys-kernel-security
-            #  mountPath: /sys/kernel/security
-            #  readOnly: true
+            - name: boot
+              mountPath: /boot
+              readOnly: true
+            - name: sys-kernel-debug
+              mountPath: /sys/kernel/debug
+            - name: sys-fs-bpf
+              mountPath: /sys/fs/bpf
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
       volumes:
         - name: proc
           hostPath:
@@ -134,15 +140,15 @@ spec:
             path: /etc/machine-id
             type: File
         # Needed for 'Defend for containers' integration (cloud-defend)
-        #- name: boot
-        #  hostPath:
-        #    path: /boot
-        #- name: sys-kernel-debug
-        #  hostPath:
-        #    path: /sys/kernel/debug
-        #- name: sys-fs-bpf
-        #  hostPath:
-        #    path: /sys/fs/bpf
-        #- name: sys-kernel-security
-        #  hostPath:
-        #    path: /sys/kernel/security
+        - name: boot
+          hostPath:
+            path: /boot
+        - name: sys-kernel-debug
+          hostPath:
+            path: /sys/kernel/debug
+        - name: sys-fs-bpf
+          hostPath:
+            path: /sys/fs/bpf
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -713,6 +713,8 @@ spec:
               value: "/etc/elastic-agent"
           securityContext:
             runAsUser: 0
+            # Needed for 'Defend for containers' integration (cloud-defend)
+            #privileged: true
           resources:
             limits:
               memory: 700Mi
@@ -745,6 +747,17 @@ spec:
             - name: var-lib
               mountPath: /hostfs/var/lib
               readOnly: true
+            # Needed for 'Defend for containers' integration (cloud-defend)
+            #- name: boot
+            #  mountPath: /boot
+            #  readOnly: true
+            #- name: sys-kernel-debug
+            #  mountPath: /sys/kernel/debug
+            #- name: sys-fs-bpf
+            #  mountPath: /sys/fs/bpf
+            #- name: sys-kernel-security
+            #  mountPath: /sys/kernel/security
+            #  readOnly: true
       volumes:
         - name: datastreams
           configMap:
@@ -774,6 +787,19 @@ spec:
         - name: var-lib
           hostPath:
             path: /var/lib
+        # Needed for 'Defend for containers' integration (cloud-defend)
+        #- name: boot
+        #  hostPath:
+        #    path: /boot
+        #- name: sys-kernel-debug
+        #  hostPath:
+        #    path: /sys/kernel/debug
+        #- name: sys-fs-bpf
+        #  hostPath:
+        #    path: /sys/fs/bpf
+        #- name: sys-kernel-security
+        #  hostPath:
+        #    path: /sys/kernel/security
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -714,6 +714,13 @@ spec:
           securityContext:
             runAsUser: 0
             capabilities:
+              add:
+              # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
+              # If you are not using this integration, then these capabilites can be removed.
+                - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
+                - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
+                - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by `Defend for Containers` to modify `rlimit_memlock`
+            capabilities:
               drop:
                 - all
               add:
@@ -753,7 +760,6 @@ spec:
             - name: var-lib
               mountPath: /hostfs/var/lib
               readOnly: true
-            # Needed for 'Defend for containers' integration (cloud-defend)
             - name: sys-kernel-debug
               mountPath: /sys/kernel/debug
       volumes:
@@ -786,6 +792,8 @@ spec:
           hostPath:
             path: /var/lib
         # Needed for 'Defend for containers' integration (cloud-defend)
+        # If you are not using this integration, then these volumes and the corresponding
+        # mounts can be removed.
         - name: sys-kernel-debug
           hostPath:
             path: /sys/kernel/debug

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -713,8 +713,14 @@ spec:
               value: "/etc/elastic-agent"
           securityContext:
             runAsUser: 0
-            # Needed for 'Defend for containers' integration (cloud-defend)
-            #privileged: true
+            capabilities:
+              drop:
+                - all
+              add:
+              # Needed for 'Defend for containers' integration (cloud-defend)
+                - BPF
+                - PERFMON
+                - SYS_RESOURCE
           resources:
             limits:
               memory: 700Mi
@@ -748,16 +754,16 @@ spec:
               mountPath: /hostfs/var/lib
               readOnly: true
             # Needed for 'Defend for containers' integration (cloud-defend)
-            #- name: boot
-            #  mountPath: /boot
-            #  readOnly: true
-            #- name: sys-kernel-debug
-            #  mountPath: /sys/kernel/debug
-            #- name: sys-fs-bpf
-            #  mountPath: /sys/fs/bpf
-            #- name: sys-kernel-security
-            #  mountPath: /sys/kernel/security
-            #  readOnly: true
+            - name: boot
+              mountPath: /boot
+              readOnly: true
+            - name: sys-kernel-debug
+              mountPath: /sys/kernel/debug
+            - name: sys-fs-bpf
+              mountPath: /sys/fs/bpf
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
       volumes:
         - name: datastreams
           configMap:
@@ -788,18 +794,18 @@ spec:
           hostPath:
             path: /var/lib
         # Needed for 'Defend for containers' integration (cloud-defend)
-        #- name: boot
-        #  hostPath:
-        #    path: /boot
-        #- name: sys-kernel-debug
-        #  hostPath:
-        #    path: /sys/kernel/debug
-        #- name: sys-fs-bpf
-        #  hostPath:
-        #    path: /sys/fs/bpf
-        #- name: sys-kernel-security
-        #  hostPath:
-        #    path: /sys/kernel/security
+        - name: boot
+          hostPath:
+            path: /boot
+        - name: sys-kernel-debug
+          hostPath:
+            path: /sys/kernel/debug
+        - name: sys-fs-bpf
+          hostPath:
+            path: /sys/fs/bpf
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -720,14 +720,6 @@ spec:
                 - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
                 - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
                 - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by `Defend for Containers` to modify `rlimit_memlock`
-            capabilities:
-              drop:
-                - all
-              add:
-              # Needed for 'Defend for containers' integration (cloud-defend)
-                - BPF
-                - PERFMON
-                - SYS_RESOURCE
           resources:
             limits:
               memory: 700Mi

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -754,16 +754,8 @@ spec:
               mountPath: /hostfs/var/lib
               readOnly: true
             # Needed for 'Defend for containers' integration (cloud-defend)
-            - name: boot
-              mountPath: /boot
-              readOnly: true
             - name: sys-kernel-debug
               mountPath: /sys/kernel/debug
-            - name: sys-fs-bpf
-              mountPath: /sys/fs/bpf
-            - name: sys-kernel-security
-              mountPath: /sys/kernel/security
-              readOnly: true
       volumes:
         - name: datastreams
           configMap:
@@ -794,18 +786,9 @@ spec:
           hostPath:
             path: /var/lib
         # Needed for 'Defend for containers' integration (cloud-defend)
-        - name: boot
-          hostPath:
-            path: /boot
         - name: sys-kernel-debug
           hostPath:
             path: /sys/kernel/debug
-        - name: sys-fs-bpf
-          hostPath:
-            path: /sys/fs/bpf
-        - name: sys-kernel-security
-          hostPath:
-            path: /sys/kernel/security
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
@@ -69,13 +69,12 @@ spec:
           securityContext:
             runAsUser: 0
             capabilities:
-              drop:
-                - all
               add:
-              # Needed for 'Defend for containers' integration (cloud-defend)
-                - BPF
-                - PERFMON
-                - SYS_RESOURCE
+              # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
+              # If you are not using this integration, then these capabilites can be removed.
+                - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
+                - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
+                - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by `Defend for Containers` to modify `rlimit_memlock`
           resources:
             limits:
               memory: 700Mi

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
@@ -108,7 +108,6 @@ spec:
             - name: var-lib
               mountPath: /hostfs/var/lib
               readOnly: true
-            # Needed for 'Defend for containers' integration (cloud-defend)
             - name: sys-kernel-debug
               mountPath: /sys/kernel/debug
       volumes:
@@ -141,6 +140,8 @@ spec:
           hostPath:
             path: /var/lib
         # Needed for 'Defend for containers' integration (cloud-defend)
+        # If you are not using this integration, then these volumes and the corresponding
+        # mounts can be removed.
         - name: sys-kernel-debug
           hostPath:
             path: /sys/kernel/debug

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
@@ -68,8 +68,14 @@ spec:
               value: "/etc/elastic-agent"
           securityContext:
             runAsUser: 0
-            # Needed for 'Defend for containers' integration (cloud-defend)
-            #privileged: true
+            capabilities:
+              drop:
+                - all
+              add:
+              # Needed for 'Defend for containers' integration (cloud-defend)
+                - BPF
+                - PERFMON
+                - SYS_RESOURCE
           resources:
             limits:
               memory: 700Mi
@@ -103,16 +109,16 @@ spec:
               mountPath: /hostfs/var/lib
               readOnly: true
             # Needed for 'Defend for containers' integration (cloud-defend)
-            #- name: boot
-            #  mountPath: /boot
-            #  readOnly: true
-            #- name: sys-kernel-debug
-            #  mountPath: /sys/kernel/debug
-            #- name: sys-fs-bpf
-            #  mountPath: /sys/fs/bpf
-            #- name: sys-kernel-security
-            #  mountPath: /sys/kernel/security
-            #  readOnly: true
+            - name: boot
+              mountPath: /boot
+              readOnly: true
+            - name: sys-kernel-debug
+              mountPath: /sys/kernel/debug
+            - name: sys-fs-bpf
+              mountPath: /sys/fs/bpf
+            - name: sys-kernel-security
+              mountPath: /sys/kernel/security
+              readOnly: true
       volumes:
         - name: datastreams
           configMap:
@@ -143,15 +149,15 @@ spec:
           hostPath:
             path: /var/lib
         # Needed for 'Defend for containers' integration (cloud-defend)
-        #- name: boot
-        #  hostPath:
-        #    path: /boot
-        #- name: sys-kernel-debug
-        #  hostPath:
-        #    path: /sys/kernel/debug
-        #- name: sys-fs-bpf
-        #  hostPath:
-        #    path: /sys/fs/bpf
-        #- name: sys-kernel-security
-        #  hostPath:
-        #    path: /sys/kernel/security
+        - name: boot
+          hostPath:
+            path: /boot
+        - name: sys-kernel-debug
+          hostPath:
+            path: /sys/kernel/debug
+        - name: sys-fs-bpf
+          hostPath:
+            path: /sys/fs/bpf
+        - name: sys-kernel-security
+          hostPath:
+            path: /sys/kernel/security

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
@@ -109,16 +109,8 @@ spec:
               mountPath: /hostfs/var/lib
               readOnly: true
             # Needed for 'Defend for containers' integration (cloud-defend)
-            - name: boot
-              mountPath: /boot
-              readOnly: true
             - name: sys-kernel-debug
               mountPath: /sys/kernel/debug
-            - name: sys-fs-bpf
-              mountPath: /sys/fs/bpf
-            - name: sys-kernel-security
-              mountPath: /sys/kernel/security
-              readOnly: true
       volumes:
         - name: datastreams
           configMap:
@@ -149,15 +141,6 @@ spec:
           hostPath:
             path: /var/lib
         # Needed for 'Defend for containers' integration (cloud-defend)
-        - name: boot
-          hostPath:
-            path: /boot
         - name: sys-kernel-debug
           hostPath:
             path: /sys/kernel/debug
-        - name: sys-fs-bpf
-          hostPath:
-            path: /sys/fs/bpf
-        - name: sys-kernel-security
-          hostPath:
-            path: /sys/kernel/security

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
@@ -68,6 +68,8 @@ spec:
               value: "/etc/elastic-agent"
           securityContext:
             runAsUser: 0
+            # Needed for 'Defend for containers' integration (cloud-defend)
+            #privileged: true
           resources:
             limits:
               memory: 700Mi
@@ -100,6 +102,17 @@ spec:
             - name: var-lib
               mountPath: /hostfs/var/lib
               readOnly: true
+            # Needed for 'Defend for containers' integration (cloud-defend)
+            #- name: boot
+            #  mountPath: /boot
+            #  readOnly: true
+            #- name: sys-kernel-debug
+            #  mountPath: /sys/kernel/debug
+            #- name: sys-fs-bpf
+            #  mountPath: /sys/fs/bpf
+            #- name: sys-kernel-security
+            #  mountPath: /sys/kernel/security
+            #  readOnly: true
       volumes:
         - name: datastreams
           configMap:
@@ -129,3 +142,16 @@ spec:
         - name: var-lib
           hostPath:
             path: /var/lib
+        # Needed for 'Defend for containers' integration (cloud-defend)
+        #- name: boot
+        #  hostPath:
+        #    path: /boot
+        #- name: sys-kernel-debug
+        #  hostPath:
+        #    path: /sys/kernel/debug
+        #- name: sys-fs-bpf
+        #  hostPath:
+        #    path: /sys/fs/bpf
+        #- name: sys-kernel-security
+        #  hostPath:
+        #    path: /sys/kernel/security


### PR DESCRIPTION
## What does this PR do?
This PR adds the required mounts and capabilities for Defend for Containers. 

## Why is it important?
`Defend for Containers` uses BPF to provide runtime security for a user's containerized workloads. The changes grant it the minimum set of privileges for these operations. 

## Caviats
1. I have also added the `dropall` flag with the goal of further increasing the security posture of this container. This may interfere with other integrations. I would be glad to remove this or, even better, work with other teams to help identify a reduced set of caps as needed. (Part of me is hoping that this addition will cause CI/CD to fail.) I found a great Brendan Gregg [tool](https://github.com/iovisor/bcc/blob/master/tools/capable.py) to audit the required caps of a running process. 
2. I understand that a Kustomize overlay may be coming https://github.com/elastic/elastic-agent/issues/2175 to add these extra mount points, but I am not sure that it will be available for the timeframe in which we wish to ship this integration. I am more than happy to revisit this work once Kustomize is available. 