### PR TITLE
Fleet managed K8S resources should match standalone resources

### DIFF
--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -66,10 +66,10 @@ spec:
             runAsUser: 0
           resources:
             limits:
-              memory: 500Mi
+              memory: 700Mi
             requests:
               cpu: 100m
-              memory: 200Mi
+              memory: 400Mi
           volumeMounts:
             - name: proc
               mountPath: /hostfs/proc

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -66,10 +66,10 @@ spec:
             runAsUser: 0
           resources:
             limits:
-              memory: 500Mi
+              memory: 700Mi
             requests:
               cpu: 100m
-              memory: 200Mi
+              memory: 400Mi
           volumeMounts:
             - name: proc
               mountPath: /hostfs/proc

--- a/dev-tools/kubernetes/base/elastic-agent-managed/daemonset.yaml
+++ b/dev-tools/kubernetes/base/elastic-agent-managed/daemonset.yaml
@@ -38,10 +38,10 @@ spec:
             runAsUser: 0
           resources:
             limits:
-              memory: 500Mi
+              memory: 700Mi
             requests:
               cpu: 100m
-              memory: 200Mi
+              memory: 400Mi
           volumeMounts:
             - name: proc
               mountPath: /hostfs/proc


### PR DESCRIPTION
The CPU and memory requests for a standalone agent were updated to higher values than what is currently used for Fleet managed agents. Update the managed configuration to match the standalone configuration there is no reason for them to be different.
