### PR TITLE
Restore support for the memcached/metrics input.

### DIFF
--- a/changelog/fragments/1677000534-Restore-support-for-memcached-metrics-inputs.yaml
+++ b/changelog/fragments/1677000534-Restore-support-for-memcached-metrics-inputs.yaml
@@ -20,8 +20,8 @@ component: Elastic agent.
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/elastic-agent/pull/2298
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.
-#issue: https://github.com/owner/repo/1234
+issue: https://github.com/elastic/elastic-agent/issues/2293

--- a/changelog/fragments/1677000534-Restore-support-for-memcached-metrics-inputs.yaml
+++ b/changelog/fragments/1677000534-Restore-support-for-memcached-metrics-inputs.yaml
@@ -1,0 +1,27 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Restore support for memcached/metrics inputs.
+
+# Affected component; a word indicating the component this changeset affects.
+component: Elastic agent.
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/specs/metricbeat.spec.yml
+++ b/specs/metricbeat.spec.yml
@@ -225,6 +225,12 @@ inputs:
     outputs: *outputs
     shippers: *shippers
     command: *command
+  - name: memcached/metrics
+    description: "Memcached metrics"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command: *command
   - name: nats/metrics
     description: "NATS metrics"
     platforms: *platforms


### PR DESCRIPTION
- Closes #2293

We lost support for the memcached/metrics input in 8.6 when we introduced the new specification file syntax. This PR adds it back.

@elastic/obs-service-integrations FYI since it looks like this integration is yours 
https://github.com/elastic/integrations/blob/cde97a82070665c8e2e0780401f6d4c5ceafb734/.github/CODEOWNERS#L128