### PR TITLE
Ventura Permissions Issue

### DIFF
--- a/changelog/fragments/1678553750-ventura-permission-issue.yaml
+++ b/changelog/fragments/1678553750-ventura-permission-issue.yaml
@@ -11,7 +11,7 @@
 kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
-summary: Fix permission issue on MacOS when enrolling is part of the installation
+summary: Fix permission issue on MacOS Ventura and above when enrolling as part of the installation.
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.

--- a/changelog/fragments/1678553750-ventura-permission-issue.yaml
+++ b/changelog/fragments/1678553750-ventura-permission-issue.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix permission issue on MacOS when enrolling is part of the installation
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/2314
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/2103

--- a/internal/pkg/agent/cmd/enroll.go
+++ b/internal/pkg/agent/cmd/enroll.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -320,6 +321,13 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command) error {
 
 	ctx := handleSignal(context.Background())
 
+	// On MacOS, enrolling during installation won't work as expected if we are triggering the FixPermissions() func.
+	// Forcing to set fixPermissions to false in case the agent is running on Mac
+	var fixPermissions bool = fromInstall
+	if runtime.GOOS == "darwin" {
+		fixPermissions = false
+	}
+
 	options := enrollCmdOption{
 		EnrollAPIKey:         enrollmentToken,
 		URL:                  url,
@@ -328,7 +336,7 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command) error {
 		Insecure:             insecure,
 		UserProvidedMetadata: make(map[string]interface{}),
 		Staging:              staging,
-		FixPermissions:       false,
+		FixPermissions:       fixPermissions,
 		ProxyURL:             proxyURL,
 		ProxyDisabled:        proxyDisabled,
 		ProxyHeaders:         mapFromEnvList(proxyHeaders),

--- a/internal/pkg/agent/cmd/enroll.go
+++ b/internal/pkg/agent/cmd/enroll.go
@@ -321,8 +321,10 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command) error {
 
 	ctx := handleSignal(context.Background())
 
-	// On MacOS, enrolling during installation won't work as expected if we are triggering the FixPermissions() func.
-	// Forcing to set fixPermissions to false in case the agent is running on Mac
+// On MacOS Ventura and above, fixing the permissions on enrollment during installation fails with the error:
+//  Error: failed to fix permissions: chown /Library/Elastic/Agent/data/elastic-agent-c13f91/elastic-agent.app: operation not permitted
+// This is because we are fixing permissions twice, once during installation and again during the enrollment step.
+// When we are enrolling as part of installation on MacOS, skip the second attempt to fix permissions.
 	var fixPermissions bool = fromInstall
 	if runtime.GOOS == "darwin" {
 		fixPermissions = false

--- a/internal/pkg/agent/cmd/enroll.go
+++ b/internal/pkg/agent/cmd/enroll.go
@@ -328,7 +328,7 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command) error {
 		Insecure:             insecure,
 		UserProvidedMetadata: make(map[string]interface{}),
 		Staging:              staging,
-		FixPermissions:       fromInstall,
+		FixPermissions:       false,
 		ProxyURL:             proxyURL,
 		ProxyDisabled:        proxyDisabled,
 		ProxyHeaders:         mapFromEnvList(proxyHeaders),


### PR DESCRIPTION
## What does this PR do?

Monkey patch to fix the Ventura permission problem.
My PR needs to be reviewed by someone with more understanding about why it has been implemented that way (https://github.com/elastic/elastic-agent/commit/48a4703cf28ba7fd05d8f2cb1680438514a78736)

During my investigation time, I discovered that installing Elastic Agent and then Enroll it was working.
`sudo ./elastic-agent install -f`
`sudo ./elastic-agent enroll --url= --enrollment-token= `

The problem happens only when we are doing both in the same time
`sudo ./elastic-agent install --url= --enrollment-token=`

By investigating into the code, I discovered that during enrollment in the same time than installation, we are triggering two times the  FixPermissions() func

According to me, there is no reason to trigger this function during enrollment time and we should do it only when installing the binaries.

## Why is it important?

We can install or upgrade Elastic Agent on Mac OS Ventura.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/2103
