### PR TITLE
Map State.STARTING as "starting" at fleet checkin to avoid presenting the agent as unhealthy at startup

### DIFF
--- a/changelog/fragments/1677572502-add-fleet-checkin-starting-state.yaml
+++ b/changelog/fragments/1677572502-add-fleet-checkin-starting-state.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: add-fleet-checkin-starting-state
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/2325
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/2272

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -26,8 +26,11 @@ import (
 // Max number of times an invalid API Key is checked
 const maxUnauthCounter int = 6
 
-// Const for decraded state or linter complains
-const degraded = "DEGRADED"
+// Consts for states at fleet checkin
+const fleetStateDegraded = "DEGRADED"
+const fleetStateOnline = "online"
+const fleetStateError = "error"
+const fleetStateStarting = "starting"
 
 // Default Configuration for the Fleet Gateway.
 var defaultGatewaySettings = &fleetGatewaySettings{
@@ -241,7 +244,7 @@ func (f *fleetGateway) convertToCheckinComponents(components []runtime.Component
 		case eaclient.UnitStateHealthy:
 			return "HEALTHY"
 		case eaclient.UnitStateDegraded:
-			return degraded
+			return fleetStateDegraded
 		case eaclient.UnitStateFailed:
 			return "FAILED"
 		case eaclient.UnitStateStopping:
@@ -378,9 +381,11 @@ func (f *fleetGateway) SetClient(c client.Sender) {
 func agentStateToString(state agentclient.State) string {
 	switch state {
 	case agentclient.Healthy:
-		return "online"
+		return fleetStateOnline
 	case agentclient.Failed:
-		return "error"
+		return fleetStateError
+	case agentclient.Starting:
+		return fleetStateStarting
 	}
-	return degraded
+	return fleetStateDegraded
 }

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -19,9 +19,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/gateway"
+	agentclient "github.com/elastic/elastic-agent/internal/pkg/agent/control/v2/client"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/storage"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/storage/store"
@@ -442,4 +444,56 @@ func newStateStore(t *testing.T, log *logger.Logger) *store.StateStore {
 	})
 
 	return stateStore
+}
+
+func TestAgentStateToString(t *testing.T) {
+	testcases := []struct {
+		agentState         agentclient.State
+		expectedFleetState string
+	}{
+		{
+			agentState:         agentclient.Healthy,
+			expectedFleetState: fleetStateOnline,
+		},
+		{
+			agentState:         agentclient.Failed,
+			expectedFleetState: fleetStateError,
+		},
+		{
+			agentState:         agentclient.Starting,
+			expectedFleetState: fleetStateStarting,
+		},
+		// everything else maps to degraded
+		{
+			agentState:         agentclient.Configuring,
+			expectedFleetState: fleetStateDegraded,
+		},
+		{
+			agentState:         agentclient.Degraded,
+			expectedFleetState: fleetStateDegraded,
+		},
+		{
+			agentState:         agentclient.Stopping,
+			expectedFleetState: fleetStateDegraded,
+		},
+		{
+			agentState:         agentclient.Stopped,
+			expectedFleetState: fleetStateDegraded,
+		},
+		{
+			agentState:         agentclient.Upgrading,
+			expectedFleetState: fleetStateDegraded,
+		},
+		{
+			agentState:         agentclient.Rollback,
+			expectedFleetState: fleetStateDegraded,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(fmt.Sprintf("%s -> %s", tc.agentState, tc.expectedFleetState), func(t *testing.T) {
+			actualFleetState := agentStateToString(tc.agentState)
+			assert.Equal(t, tc.expectedFleetState, actualFleetState)
+		})
+	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->
## What does this PR do?

This PR maps the State.STARTING into "starting" string sent to fleet during checkin.
This will prevent a starting agent to be flagged as unhealthy in fleet UI until the next checkin.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

This should avoid confusion in the users when they see a starting agent with unhealthy state just after enrolling only to become healthy at next checkin
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #2272 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots
We need to add an additional log call at checkin time to see what's going on:

```
diff --git a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
index 9d9024ef5..748bf73f4 100644
--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -325,6 +325,12 @@ func (f *fleetGateway) execute(ctx context.Context) (*fleetapi.CheckinResponse,
 	components := f.convertToCheckinComponents(state.Components)
 
 	// checkin
+
+	f.log.Infow("Checking In", "state", state.State, "mappedState", agentStateToString(state.State), "state_message", state.Message,
+		"fleetState", state.FleetState, "fleetMessage", state.FleetMessage,
+		"components", components,
+	)
+
 	cmd := fleetapi.NewCheckinCmd(f.agentInfo, f.client)
 	req := &fleetapi.CheckinRequest{
 		AckToken:   ackToken,
```

(mappedState is the status string the agent is sending to the fleet server)

Here's the log for the agent without the fix:
![image (2)](https://user-images.githubusercontent.com/96178987/221567829-4e464f2c-97b5-4a2d-bb54-12493750b204.png)

And this is with the fix:
![image](https://user-images.githubusercontent.com/96178987/221568944-63e46ff3-4609-4adb-a48a-d302fa6a10b0.png)


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
