### PR TITLE
Fix permissions on default state sub-directories when Agent runs as container

### DIFF
--- a/internal/pkg/agent/application/paths/common.go
+++ b/internal/pkg/agent/application/paths/common.go
@@ -22,6 +22,7 @@ const (
 	// AgentLockFileName is the name of the overall Elastic Agent file lock.
 	AgentLockFileName = "agent.lock"
 	tempSubdir        = "tmp"
+	tempSubdirPerms   = 0770
 
 	darwin = "darwin"
 )
@@ -85,7 +86,7 @@ func TempDir() string {
 	tmpDir := filepath.Join(Data(), tempSubdir)
 	tmpCreator.Do(func() {
 		// create tempdir as it probably don't exists
-		_ = os.MkdirAll(tmpDir, 0750)
+		_ = os.MkdirAll(tmpDir, tempSubdirPerms)
 	})
 	return tmpDir
 }

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -43,6 +43,8 @@ const (
 	defaultRequestRetrySleep = "1s"                             // sleep 1 sec between retries for HTTP requests
 	defaultMaxRequestRetries = "30"                             // maximum number of retries for HTTP requests
 	defaultStateDirectory    = "/usr/share/elastic-agent/state" // directory that will hold the state data
+
+	logsPathPerms = 0775
 )
 
 var (
@@ -150,7 +152,7 @@ func logContainerCmd(streams *cli.IOStreams) error {
 	logsPath := envWithDefault("", "LOGS_PATH")
 	if logsPath != "" {
 		// log this entire command to a file as well as to the passed streams
-		if err := os.MkdirAll(logsPath, 0755); err != nil {
+		if err := os.MkdirAll(logsPath, logsPathPerms); err != nil {
 			return fmt.Errorf("preparing LOGS_PATH(%s) failed: %w", logsPath, err)
 		}
 		logPath := filepath.Join(logsPath, "elastic-agent-startup.log")
@@ -795,14 +797,14 @@ func setPaths(statePath, configPath, logsPath string, writePaths bool) error {
 	if logsPath != "" {
 		paths.SetLogs(logsPath)
 		// ensure that the logs directory exists
-		if err := os.MkdirAll(filepath.Join(logsPath), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(logsPath), logsPathPerms); err != nil {
 			return fmt.Errorf("preparing LOGS_PATH(%s) failed: %w", logsPath, err)
 		}
 	}
 
 	// ensure that the internal logger directory exists
 	loggerPath := filepath.Join(paths.Home(), logger.DefaultLogDirectory)
-	if err := os.MkdirAll(loggerPath, 0755); err != nil {
+	if err := os.MkdirAll(loggerPath, logsPathPerms); err != nil {
 		return fmt.Errorf("preparing internal log path(%s) failed: %w", loggerPath, err)
 	}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR fixes the permissions of the `state/data/tmp` and `state/data/logs` folders when they're setup as part of `elastic-agent container` running.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
To allow processes within the same group as `elastic-agent` to write to the `state/data/tmp` and `state/data/logs` folders.  

Note that there is another folder that's a sibling of those two, `state/data/run` but it already has the correct permissions, so this PR doesn't do anything with it.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Author's Checklist

### Before this PR

<img width="1367" alt="Screenshot 2023-02-28 at 10 45 04" src="https://user-images.githubusercontent.com/51061/221905702-682e4451-1a4f-4976-9456-22e330b5c57d.png">

### After this PR

<img width="1620" alt="Screenshot 2023-02-28 at 10 27 06" src="https://user-images.githubusercontent.com/51061/221905724-58df2b46-27e1-4575-8d35-ceb4b8c95d6a.png">


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Rebuild the docker images for Elastic Agent.
2. Run the docker container for Elastic Agent from the freshly-built image.
3. Check the paths of sub-folders under `/usr/share/elastic-agent/state/data`.  Verify that all of them are group-writeable.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #2315 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
