### PR TITLE
Fix formatting of system metricsets in example elastic-agent config

### DIFF
--- a/_meta/config/common.p2.yml.tmpl
+++ b/_meta/config/common.p2.yml.tmpl
@@ -18,14 +18,18 @@ inputs:
     data_stream.namespace: default
     use_output: default
     streams:
-      - metricset: cpu
+      - metricsets: 
+        - cpu
         # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
-      - metricset: memory
+      - metricsets: 
+        - memory
         data_stream.dataset: system.memory
-      - metricset: network
+      - metricsets: 
+        - network
         data_stream.dataset: system.network
-      - metricset: filesystem
+      - metricsets: 
+        - filesystem
         data_stream.dataset: system.filesystem
 
 # agent.monitoring:

--- a/_meta/config/common.reference.p2.yml.tmpl
+++ b/_meta/config/common.reference.p2.yml.tmpl
@@ -18,14 +18,18 @@ inputs:
     data_stream.namespace: default
     use_output: default
     streams:
-      - metricset: cpu
+      - metricsets: 
+        - cpu
         # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
-      - metricset: memory
+      - metricsets: 
+        - memory
         data_stream.dataset: system.memory
-      - metricset: network
+      - metricsets: 
+        - network
         data_stream.dataset: system.network
-      - metricset: filesystem
+      - metricsets: 
+        - filesystem
         data_stream.dataset: system.filesystem
 
 # management:

--- a/_meta/config/elastic-agent.docker.yml.tmpl
+++ b/_meta/config/elastic-agent.docker.yml.tmpl
@@ -17,14 +17,18 @@ inputs:
     data_stream.namespace: default
     use_output: default
     streams:
-      - metricset: cpu
+      - metricsets: 
+        - cpu
         # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
-      - metricset: memory
+      - metricsets: 
+        - memory
         data_stream.dataset: system.memory
-      - metricset: network
+      - metricsets: 
+        - network
         data_stream.dataset: system.network
-      - metricset: filesystem
+      - metricsets: 
+        - filesystem
         data_stream.dataset: system.filesystem
 
 # management:

--- a/_meta/elastic-agent.yml
+++ b/_meta/elastic-agent.yml
@@ -17,14 +17,18 @@ inputs:
     data_stream.namespace: default
     use_output: default
     streams:
-      - metricset: cpu
+      - metricsets: 
+        - cpu
         # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
-      - metricset: memory
+      - metricsets: 
+        - memory
         data_stream.dataset: system.memory
-      - metricset: network
+      - metricsets: 
+        - network
         data_stream.dataset: system.network
-      - metricset: filesystem
+      - metricsets: 
+        - filesystem
         data_stream.dataset: system.filesystem
 
 # management:

--- a/changelog/fragments/1677711770-fix-standalone-system-config.yaml
+++ b/changelog/fragments/1677711770-fix-standalone-system-config.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix system config in example standalone config file
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: config
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/elastic-agent.docker.yml
+++ b/elastic-agent.docker.yml
@@ -17,14 +17,18 @@ inputs:
     data_stream.namespace: default
     use_output: default
     streams:
-      - metricset: cpu
+      - metricsets: 
+        - cpu
         # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
-      - metricset: memory
+      - metricsets: 
+        - memory
         data_stream.dataset: system.memory
-      - metricset: network
+      - metricsets: 
+        - network
         data_stream.dataset: system.network
-      - metricset: filesystem
+      - metricsets: 
+        - filesystem
         data_stream.dataset: system.filesystem
 
 # management:

--- a/elastic-agent.reference.yml
+++ b/elastic-agent.reference.yml
@@ -24,14 +24,18 @@ inputs:
     data_stream.namespace: default
     use_output: default
     streams:
-      - metricset: cpu
+      - metricsets: 
+        - cpu
         # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
-      - metricset: memory
+      - metricsets: 
+        - memory
         data_stream.dataset: system.memory
-      - metricset: network
+      - metricsets: 
+        - network
         data_stream.dataset: system.network
-      - metricset: filesystem
+      - metricsets: 
+        - filesystem
         data_stream.dataset: system.filesystem
 
 # management:

--- a/elastic-agent.yml
+++ b/elastic-agent.yml
@@ -24,14 +24,18 @@ inputs:
     data_stream.namespace: default
     use_output: default
     streams:
-      - metricset: cpu
+      - metricsets: 
+        - cpu
         # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
-      - metricset: memory
+      - metricsets: 
+        - memory
         data_stream.dataset: system.memory
-      - metricset: network
+      - metricsets: 
+        - network
         data_stream.dataset: system.network
-      - metricset: filesystem
+      - metricsets: 
+        - filesystem
         data_stream.dataset: system.filesystem
 
 # agent.monitoring:


### PR DESCRIPTION
## What does this PR do?

This fixes the config in the standalone example elastic-agent.yml files; the key should be `metricsets` not `metricset`. 
Quickly looked around some of the other k8s/docker configs, and it looks to be correct elsewhere.

## Why is it important?

The config is currently invalid in the example file.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding change to the default configuration files
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
