### PR TITLE
fix spec file for shipper

### DIFF
--- a/changelog/fragments/1677713178-fix-spec-shipper-logging.yaml
+++ b/changelog/fragments/1677713178-fix-spec-shipper-logging.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: fix-spec-shipper-logging
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: specfiles
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/specs/shipper.spec.yml
+++ b/specs/shipper.spec.yml
@@ -18,4 +18,9 @@ shippers:
       - kafka
       - logstash
       - redis
-    command: {}
+    command:
+      args:
+        - "-E"
+        - "logging.level=info"
+        - "-E"
+        - "logging.to_stderr=true"


### PR DESCRIPTION
## What does this PR do?

Small change, this adds `logging.level` and `logging.to_stderr` flags for the shipper's spec file, to bring it in line with the CLI flags used by rest of the beats

## Why is it important?

The log settings at startup should be consistent across beats

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding change to the default configuration files
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)