### PR TITLE
fix checkout under windows for golangci-lint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@ CHANGELOG-developer.next.asciidoc  merge=union
 # Keep these file types as CRLF (Windows).
 *.bat    text eol=crlf
 *.cmd    text eol=crlf
+*.go     text eol=lf


### PR DESCRIPTION
## What does this PR do?

Adds

```
*.go text eol=lf
```

to `.gitattributes` as recommended by https://github.com/golangci/golangci-lint-action so `golangci-lint` works correctly under windows

## Why is it important?

golangci-lint checks aren't working without it

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
