### PR TITLE
Adding Label in CI of cloudnative automation for autoapprove

### DIFF
--- a/deploy/kubernetes/Makefile
+++ b/deploy/kubernetes/Makefile
@@ -75,6 +75,7 @@ else
 		--title "Update kubernetes templates for elastic-agent" \
 		--body "Automated by ${BUILD_URL}" \
 		--label automation \
+		--label release_note:skip \
 		--base main \
 		--head $(ELASTIC_AGENT_BRANCH) \
 		--reviewer elastic/obs-cloudnative-monitoring


### PR DESCRIPTION


## What does this PR do?

This PR adds an additional label to the CI Job of elastic-agent in order to allow auto merging from Fleet team side

See relevant info [here](https://github.com/elastic/kibana/pull/151500#issuecomment-1477846238)

