### PR TITLE
[Fleet] Fix backticks in k8's manifests

### DIFF
--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -66,11 +66,11 @@ spec:
             runAsUser: 0
             capabilities:
               add:
-              # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
-              # If you are not using this integration, then these capabilites can be removed.
+                # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
+                # If you are not using this integration, then these capabilites can be removed.
                 - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
                 - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
-                - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by `Defend for Containers` to modify `rlimit_memlock`
+                - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for Containers' to modify 'rlimit_memlock'
           resources:
             limits:
               memory: 700Mi

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -66,11 +66,11 @@ spec:
             runAsUser: 0
             capabilities:
               add:
-              # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
-              # If you are not using this integration, then these capabilites can be removed.
+                # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
+                # If you are not using this integration, then these capabilites can be removed.
                 - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
                 - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
-                - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by `Defend for Containers` to modify `rlimit_memlock`
+                - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for Containers' to modify 'rlimit_memlock'
           resources:
             limits:
               memory: 700Mi


### PR DESCRIPTION
## What does this PR do?

Removes backticks (`) from the Elastic Agent manifests as they break the JS build when the manifests are ported to Kibana, e.g. https://github.com/elastic/kibana/pull/152936. I've opted to replace the backticks with single quotes (') to maintain the intended effect. 

There's also some autoformatting that ran on these files and improved indentation/spacing for some of the explanatory comments included in the diff.

## Why is it important?

Change allows automation for K8's manifest syncing to continue functioning. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
