### PR TITLE
Fix log collection with hints when missing container ports or annotations

### DIFF
--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -355,6 +355,28 @@ data:
               #     match: after
             paths:
               - /var/log/containers/*${kubernetes.container.id}.log
+      - name: filestream-generic
+        id: hints-container-logs-${kubernetes.hints.container_id}
+        type: filestream
+        use_output: default
+        streams:
+          - condition: ${kubernetes.hints.generic_logs.container_logs.enabled} == true
+            data_stream:
+              dataset: kubernetes.hints.container_logs
+              type: logs
+            exclude_files: [ ]
+            exclude_lines: [ ]
+            parsers:
+              - container:
+                  format: auto
+                  stream: ${kubernetes.hints.generic_logs.stream|'all'}
+            paths:
+              - /var/log/containers/*${kubernetes.hints.container_id}.log
+            prospector:
+              scanner:
+                symlinks: true
+            tags: [ ]
+        data_stream.namespace: default
       - id: audit-log
         type: filestream
         use_output: default

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
@@ -355,6 +355,28 @@ data:
               #     match: after
             paths:
               - /var/log/containers/*${kubernetes.container.id}.log
+      - name: filestream-generic
+        id: hints-container-logs-${kubernetes.hints.container_id}
+        type: filestream
+        use_output: default
+        streams:
+          - condition: ${kubernetes.hints.generic_logs.container_logs.enabled} == true
+            data_stream:
+              dataset: kubernetes.hints.container_logs
+              type: logs
+            exclude_files: [ ]
+            exclude_lines: [ ]
+            parsers:
+              - container:
+                  format: auto
+                  stream: ${kubernetes.hints.generic_logs.stream|'all'}
+            paths:
+              - /var/log/containers/*${kubernetes.hints.container_id}.log
+            prospector:
+              scanner:
+                symlinks: true
+            tags: [ ]
+        data_stream.namespace: default
       - id: audit-log
         type: filestream
         use_output: default

--- a/internal/pkg/composable/providers/kubernetes/config.go
+++ b/internal/pkg/composable/providers/kubernetes/config.go
@@ -7,8 +7,6 @@ package kubernetes
 import (
 	"time"
 
-	"github.com/elastic/elastic-agent-libs/config"
-
 	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
 	"github.com/elastic/elastic-agent-autodiscover/kubernetes/metadata"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -37,8 +35,8 @@ type Config struct {
 	LabelsDedot      bool `config:"labels.dedot"`
 	AnnotationsDedot bool `config:"annotations.dedot"`
 
-	Hints  *config.C `config:"hints"`
-	Prefix string    `config:"prefix"`
+	Hints  Hints  `config:"hints"`
+	Prefix string `config:"prefix"`
 }
 
 // Resources config section for resources' config blocks
@@ -46,6 +44,12 @@ type Resources struct {
 	Pod     Enabled `config:"pod"`
 	Node    Enabled `config:"node"`
 	Service Enabled `config:"service"`
+}
+
+// Hints config section for hints' config blocks
+type Hints struct {
+	Enabled              bool `config:"enabled"`
+	DefaultContainerLogs bool `config:"default_container_logs"`
 }
 
 // Enabled config section for resources' config blocks
@@ -62,6 +66,7 @@ func (c *Config) InitDefaults() {
 	c.AnnotationsDedot = true
 	c.AddResourceMetadata = metadata.GetDefaultResourceMetadataConfig()
 	c.Prefix = "co.elastic"
+	c.Hints.DefaultContainerLogs = true
 }
 
 // Validate ensures correctness of config

--- a/internal/pkg/composable/providers/kubernetes/kubernetes.go
+++ b/internal/pkg/composable/providers/kubernetes/kubernetes.go
@@ -57,7 +57,7 @@ func DynamicProviderBuilder(logger *logger.Logger, c *config.Config, managed boo
 
 // Run runs the kubernetes context provider.
 func (p *dynamicProvider) Run(comm composable.DynamicProviderComm) error {
-	if p.config.Hints.Enabled() {
+	if p.config.Hints.Enabled {
 		betalogger := logp.NewLogger("cfgwarn")
 		betalogger.Warnf("BETA: Hints' feature is beta.")
 	}

--- a/internal/pkg/composable/providers/kubernetes/pod.go
+++ b/internal/pkg/composable/providers/kubernetes/pod.go
@@ -390,20 +390,14 @@ func generateContainerData(
 
 				if config.Hints.Enabled() { // This is "hints based autodiscovery flow"
 					if !managed {
-						if ann, ok := k8sMapping["annotations"]; ok {
-							annotations, _ := ann.(mapstr.M)
-							hints := utils.GenerateHints(annotations, "", config.Prefix)
-							if len(hints) > 0 {
-								logger.Debugf("Extracted hints are :%v", hints)
-								hintsMapping := GenerateHintsMapping(hints, k8sMapping, logger, c.ID)
-								logger.Debugf("Generated hints mappings are :%v", hintsMapping)
-								_ = comm.AddOrUpdate(
-									eventID,
-									PodPriority,
-									map[string]interface{}{"hints": hintsMapping},
-									processors,
-								)
-							}
+						hintsMapping := getHintsMapping(k8sMapping, logger, config.Prefix, c.ID)
+						if len(hintsMapping) > 0 {
+							_ = comm.AddOrUpdate(
+								eventID,
+								PodPriority,
+								map[string]interface{}{"hints": hintsMapping},
+								processors,
+							)
 						}
 					}
 				} else { // This is the "template-based autodiscovery" flow
@@ -414,20 +408,14 @@ func generateContainerData(
 			k8sMapping["container"] = containerMeta
 			if config.Hints.Enabled() { // This is "hints based autodiscovery flow"
 				if !managed {
-					if ann, ok := k8sMapping["annotations"]; ok {
-						annotations, _ := ann.(mapstr.M)
-						hints := utils.GenerateHints(annotations, "", config.Prefix)
-						if len(hints) > 0 {
-							logger.Debugf("Extracted hints are :%v", hints)
-							hintsMapping := GenerateHintsMapping(hints, k8sMapping, logger, c.ID)
-							logger.Debugf("Generated hints mappings are :%v", hintsMapping)
-							_ = comm.AddOrUpdate(
-								eventID,
-								PodPriority,
-								map[string]interface{}{"hints": hintsMapping},
-								processors,
-							)
-						}
+					hintsMapping := getHintsMapping(k8sMapping, logger, config.Prefix, c.ID)
+					if len(hintsMapping) > 0 {
+						_ = comm.AddOrUpdate(
+							eventID,
+							PodPriority,
+							map[string]interface{}{"hints": hintsMapping},
+							processors,
+						)
 					}
 				}
 			} else { // This is the "template-based autodiscovery" flow
@@ -435,4 +423,18 @@ func generateContainerData(
 			}
 		}
 	}
+}
+
+func getHintsMapping(k8sMapping map[string]interface{}, logger *logp.Logger, prefix string, cID string) mapstr.M {
+	hintsMapping := mapstr.M{}
+	if ann, ok := k8sMapping["annotations"]; ok {
+		annotations, _ := ann.(mapstr.M)
+		hints := utils.GenerateHints(annotations, "", prefix)
+		if len(hints) > 0 {
+			logger.Debugf("Extracted hints are :%v", hints)
+			hintsMapping = GenerateHintsMapping(hints, k8sMapping, logger, cID)
+			logger.Debugf("Generated hints mappings are :%v", hintsMapping)
+		}
+	}
+	return hintsMapping
 }


### PR DESCRIPTION
## What does this PR do?
This PR enhances hints mechanism for logging use cases by adding the following:

1. emit mapping for all of the containers that belong to a discovered Pod and not only those that have defined Ports. This is needed so as to ensure that logs from all containers will be collected.
2. if no hints are detected then emit a generic_logs mapping so as to start collecting logs for all the discovered containers even if those are not annotated properly. This can be disabled with  `hints.default_container_logs: false`


## How to test this PR manaully

### Multiple containers case

Define the following Agent config:
```yml
providers:
  kubernetes:
    kube_config: /home/chrismark/.kube/config
    node: "kind-control-plane"
    hints.enabled: true

inputs:
  - name: filestream-redis
    type: filestream
    use_output: default
    streams:
      - condition: ${kubernetes.hints.redis.log.enabled} == true or ${kubernetes.hints.redis.enabled} == true
        data_stream:
          dataset: redis.log
          type: logs
        exclude_files:
          - .gz$
        exclude_lines:
          - ^\s+[\-`('.|_]
        parsers:
          - container:
              format: auto
              stream: ${kubernetes.hints.redis.log.stream|'all'}
        paths:
          - /var/log/containers/*${kubernetes.hints.container_id}.log
        prospector:
          scanner:
            symlinks: true
        tags:
          - redis-log
```

Run a target pod with hints annotations:
```yml
apiVersion: v1
kind: Pod
metadata:
  name: redis
  annotations:
    co.elastic.hints/package: redis
    co.elastic.hints/data_streams: info, log
    co.elastic.hints/host: '${kubernetes.pod.ip}:6379'
    co.elastic.hints/info.period: 1m
    co.elastic.hints/info.password: myred1sp@ss
  labels:
    k8s-app: redis
    app: redis
spec:
  initContainers:
  - name: init-container42
    image: busybox
    command: ["echo","I am init-conatiner"]
  containers:
  - image: redis
    imagePullPolicy: IfNotPresent
    name: redis42
    ports:
    - name: redis
      containerPort: 6379
      protocol: TCP
    command:
      - redis-server
      - "--requirepass 'myred1sp@ss'"
```

Execute the `inspect` command to produce to populate the inputs:
`./elastic-agent inspect -v --variables --variables-wait 2s`true

The expected outcome will be 2 filestream inputs, one per container, ie:

```
...
inputs:
- id: kubernetes-ccd46902-cd37-4180-8fd3-9cfeec4ebc38.init-container42
  name: filestream-redis
  processors:
  - add_fields:
      fields:
        id: 97dafa6d905c4679e24207a3ed2b7e08ed9f1dd5d3af5e77807fa124e4a5f72e
        image:
          name: busybox
        runtime: containerd
      target: container
  - add_fields:
      fields:
        container:
          name: init-container42
        labels:
          app: redis
          k8s-app: redis
        namespace: default
        namespace_labels:
          kubernetes_io/metadata_name: default
        namespace_uid: a5692398-e32f-4332-979f-97f6f040faa3
        node:
          hostname: kind-control-plane
          labels:
            beta_kubernetes_io/arch: amd64
            beta_kubernetes_io/os: linux
            kubernetes_io/arch: amd64
            kubernetes_io/hostname: kind-control-plane
            kubernetes_io/os: linux
            node-role_kubernetes_io/control-plane: ""
            node_kubernetes_io/exclude-from-external-load-balancers: ""
          name: kind-control-plane
          uid: 1e3c36d2-f3e7-4d1f-ba66-75f72102cf22
        pod:
          ip: 10.244.0.7
          name: redis
          uid: ccd46902-cd37-4180-8fd3-9cfeec4ebc38
      target: kubernetes
  - add_fields:
      fields:
        cluster:
          name: kind-kind
          url: https://127.0.0.1:35435
      target: orchestrator
  streams:
  - data_stream:
      dataset: redis.log
      type: logs
    exclude_files:
    - .gz$
    exclude_lines:
    - ^\s+[\-`('.|_]
    parsers:
    - container:
        format: auto
        stream: all
    paths:
    - /var/log/containers/*97dafa6d905c4679e24207a3ed2b7e08ed9f1dd5d3af5e77807fa124e4a5f72e.log
    prospector:
      scanner:
        symlinks: true
    tags:
    - redis-log
  type: filestream
  use_output: default
- id: kubernetes-ccd46902-cd37-4180-8fd3-9cfeec4ebc38.redis42
  name: filestream-redis
  processors:
  - add_fields:
      fields:
        id: 64b605be45dfe470234994f282efb59332a43bae6e21d9f2876f59d7b24ebcad
        image:
          name: redis
        runtime: containerd
      target: container
  - add_fields:
      fields:
        container:
          name: redis42
        labels:
          app: redis
          k8s-app: redis
        namespace: default
        namespace_labels:
          kubernetes_io/metadata_name: default
        namespace_uid: a5692398-e32f-4332-979f-97f6f040faa3
        node:
          hostname: kind-control-plane
          labels:
            beta_kubernetes_io/arch: amd64
            beta_kubernetes_io/os: linux
            kubernetes_io/arch: amd64
            kubernetes_io/hostname: kind-control-plane
            kubernetes_io/os: linux
            node-role_kubernetes_io/control-plane: ""
            node_kubernetes_io/exclude-from-external-load-balancers: ""
          name: kind-control-plane
          uid: 1e3c36d2-f3e7-4d1f-ba66-75f72102cf22
        pod:
          ip: 10.244.0.7
          name: redis
          uid: ccd46902-cd37-4180-8fd3-9cfeec4ebc38
      target: kubernetes
  - add_fields:
      fields:
        cluster:
          name: kind-kind
          url: https://127.0.0.1:35435
      target: orchestrator
  streams:
  - data_stream:
      dataset: redis.log
      type: logs
    exclude_files:
    - .gz$
    exclude_lines:
    - ^\s+[\-`('.|_]
    parsers:
    - container:
        format: auto
        stream: all
    paths:
    - /var/log/containers/*64b605be45dfe470234994f282efb59332a43bae6e21d9f2876f59d7b24ebcad.log
    prospector:
      scanner:
        symlinks: true
    tags:
    - redis-log
  type: filestream
  use_output: default
...
```


### Generic logs collection for all non annotated containers

Use the following agent config:

```yml
providers:
  kubernetes:
    kube_config: /home/chrismark/.kube/config
    node: "kind-control-plane"
    hints.enabled: true
    #hints.default_container_logs: false

inputs:
  - name: filestream-generic
    id: hints-container-logs-${kubernetes.hints.container_id}
    type: filestream
    use_output: default
    streams:
      - condition: ${kubernetes.hints.generic_logs.container_logs.enabled} == true
        data_stream:
          dataset: kubernetes.container_logs
          type: logs
        exclude_files: [ ]
        exclude_lines: [ ]
        parsers:
          - container:
              format: auto
              stream: ${kubernetes.hints.redis.generic_logs.stream|'all'}
        paths:
          - /var/log/containers/*${kubernetes.hints.container_id}.log
        prospector:
          scanner:
            symlinks: true
        tags: [ ]
    data_stream.namespace: default
```

Execute the `inspect` command to populate the inputs:
`./elastic-agent inspect -v --variables --variables-wait 2s`true

The expected outcome will be filestream inputs for all the discovered containers, one per container.

Uncomment the `hints.default_container_logs: false` and run again to see that no generic log inputs are populated.