### PR TITLE
Fix actions acks delay

### DIFF
--- a/changelog/fragments/1680101776-Fix-actions-acks-delay.yaml
+++ b/changelog/fragments/1680101776-Fix-actions-acks-delay.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix actions acks delay
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/2406
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/2410

--- a/internal/pkg/remote/client.go
+++ b/internal/pkg/remote/client.go
@@ -39,6 +39,16 @@ type requestClient struct {
 	lastErrOcc time.Time
 }
 
+func (c *requestClient) SetLastError(err error) {
+	c.lastUsed = time.Now().UTC()
+	c.lastErr = err
+	if err != nil {
+		c.lastErrOcc = c.lastUsed
+	} else {
+		c.lastErrOcc = time.Time{}
+	}
+}
+
 // Client wraps a http.Client and takes care of making the raw calls, the client should
 // stay simple and specifics should be implemented in external action instead of adding new methods
 // to the client. For authenticated calls or sending fields on every request, create a custom RoundTripper
@@ -160,14 +170,13 @@ func (c *Client) Send(
 	}
 
 	c.log.Debugf("Request method: %s, path: %s, reqID: %s", method, path, reqID)
-	c.clientLock.Lock()
-	defer c.clientLock.Unlock()
 
 	var resp *http.Response
 	var multiErr error
 
-	c.sortClients()
-	for i, requester := range c.clients {
+	clients := c.sortClients()
+
+	for i, requester := range clients {
 		req, err := requester.newRequest(method, path, params, body)
 		if err != nil {
 			return nil, fmt.Errorf(
@@ -195,15 +204,16 @@ func (c *Client) Send(
 			}
 		}
 
-		requester.lastUsed = time.Now().UTC()
-
 		resp, err = requester.client.Do(req.WithContext(ctx))
-		if err != nil {
-			requester.lastErr = err
-			requester.lastErrOcc = time.Now().UTC()
 
+		// Using the same lock that was used for sorting above
+		c.clientLock.Lock()
+		requester.SetLastError(err)
+		c.clientLock.Unlock()
+
+		if err != nil {
 			msg := fmt.Sprintf("requester %d/%d to host %s errored",
-				i, len(c.clients), requester.host)
+				i, len(clients), requester.host)
 			multiErr = multierror.Append(multiErr, fmt.Errorf("%s: %w", msg, err))
 
 			// Using debug level as the error is only relevant if all clients fail.
@@ -211,8 +221,6 @@ func (c *Client) Send(
 			continue
 		}
 
-		requester.lastErr = nil
-		requester.lastErrOcc = time.Time{}
 		return resp, nil
 	}
 
@@ -250,7 +258,10 @@ func newClient(
 //   - last errored.
 //
 // It also removes the last error after retryOnBadConnTimeout has elapsed.
-func (c *Client) sortClients() {
+func (c *Client) sortClients() []*requestClient {
+	c.clientLock.Lock()
+	defer c.clientLock.Unlock()
+
 	now := time.Now().UTC()
 
 	sort.Slice(c.clients, func(i, j int) bool {
@@ -293,6 +304,11 @@ func (c *Client) sortClients() {
 		// Lastly, the one that errored last
 		return c.clients[i].lastUsed.Before(c.clients[j].lastUsed)
 	})
+
+	// return a copy of the slice so we can iterate over it without the lock
+	res := make([]*requestClient, len(c.clients))
+	copy(res, c.clients)
+	return res
 }
 
 func (r requestClient) newRequest(method string, path string, params url.Values, body io.Reader) (*http.Request, error) {

--- a/internal/pkg/remote/client.go
+++ b/internal/pkg/remote/client.go
@@ -39,13 +39,13 @@ type requestClient struct {
 	lastErrOcc time.Time
 }
 
-func (c *requestClient) SetLastError(err error) {
-	c.lastUsed = time.Now().UTC()
-	c.lastErr = err
+func (r *requestClient) SetLastError(err error) {
+	r.lastUsed = time.Now().UTC()
+	r.lastErr = err
 	if err != nil {
-		c.lastErrOcc = c.lastUsed
+		r.lastErrOcc = r.lastUsed
 	} else {
-		c.lastErrOcc = time.Time{}
+		r.lastErrOcc = time.Time{}
 	}
 }
 

--- a/internal/pkg/remote/client_test.go
+++ b/internal/pkg/remote/client_test.go
@@ -58,8 +58,8 @@ func TestPortDefaults(t *testing.T) {
 			c, err := NewWithConfig(l, cfg, nil)
 			require.NoError(t, err)
 
-			c.sortClients()
-			r, err := c.clients[0].newRequest(http.MethodGet, "/", nil, strings.NewReader(""))
+			clients := c.sortClients()
+			r, err := clients[0].newRequest(http.MethodGet, "/", nil, strings.NewReader(""))
 			require.NoError(t, err)
 
 			if tc.ExpectedPort > 0 {
@@ -299,9 +299,9 @@ func TestSortClients(t *testing.T) {
 		client, err := newClient(nil, Config{}, one, two)
 		require.NoError(t, err)
 
-		client.sortClients()
+		clients := client.sortClients()
 
-		assert.Equal(t, one, client.clients[0])
+		assert.Equal(t, one, clients[0])
 	})
 
 	t.Run("Picks second requester when first has error", func(t *testing.T) {
@@ -314,9 +314,9 @@ func TestSortClients(t *testing.T) {
 		client, err := newClient(nil, Config{}, one, two)
 		require.NoError(t, err)
 
-		client.sortClients()
+		clients := client.sortClients()
 
-		assert.Equal(t, two, client.clients[0])
+		assert.Equal(t, two, clients[0])
 	})
 
 	t.Run("Picks second requester when first has been used", func(t *testing.T) {
@@ -327,9 +327,9 @@ func TestSortClients(t *testing.T) {
 		client, err := newClient(nil, Config{}, one, two)
 		require.NoError(t, err)
 
-		client.sortClients()
+		clients := client.sortClients()
 
-		assert.Equal(t, two, client.clients[0])
+		assert.Equal(t, two, clients[0])
 	})
 
 	t.Run("Picks second requester when it's the oldest", func(t *testing.T) {
@@ -345,9 +345,9 @@ func TestSortClients(t *testing.T) {
 		client, err := newClient(nil, Config{}, one, two, three)
 		require.NoError(t, err)
 
-		client.sortClients()
+		clients := client.sortClients()
 
-		assert.Equal(t, two, client.clients[0])
+		assert.Equal(t, two, clients[0])
 	})
 
 	t.Run("Picks third requester when second has error and first is last used", func(t *testing.T) {
@@ -364,9 +364,9 @@ func TestSortClients(t *testing.T) {
 		}
 		client := &Client{clients: []*requestClient{one, two, three}}
 
-		client.sortClients()
+		clients := client.sortClients()
 
-		assert.Equal(t, three, client.clients[0])
+		assert.Equal(t, three, clients[0])
 	})
 
 	t.Run("Picks second requester when its oldest and all have old errors", func(t *testing.T) {
@@ -388,9 +388,9 @@ func TestSortClients(t *testing.T) {
 		client, err := newClient(nil, Config{}, one, two, three)
 		require.NoError(t, err)
 
-		client.sortClients()
+		clients := client.sortClients()
 
-		assert.Equal(t, two, client.clients[0])
+		assert.Equal(t, two, clients[0])
 	})
 }
 

--- a/internal/pkg/remote/client_test.go
+++ b/internal/pkg/remote/client_test.go
@@ -194,8 +194,8 @@ func TestHTTPClient(t *testing.T) {
 				{host: "http://must.fail-3.co/"},
 			}}
 
-		resp, err := client.Send(ctx, http.MethodGet, "/echo-hello", nil, nil, nil)
-		assert.Contains(t, err.Error(), "http://must.fail-3.co/") // error contains last host
+		resp, err := client.Send(ctx, http.MethodGet, "/echo-hello", nil, nil, nil) //nolint:bodyclose // wad
+		assert.Contains(t, err.Error(), "http://must.fail-3.co/")                   // error contains last host
 		assert.Nil(t, resp)
 	})
 


### PR DESCRIPTION
## What does this PR do?

Fixes the issue with acks being delayed by the agent.

The cause of the issue is the shared fleet server "client" being locked here
https://github.com/elastic/elastic-agent/blob/018bc0bcd2412fbd357fac2f28140b1543f63456/internal/pkg/remote/client.go#L164
preventing any fleet server requests until the existing requests is finished.

The problem is exacerbated by the fact that there the long poll request doesn't return until there is any new action or timeout which as far as I remember was 5 minutes or possibly longer.
In such cases the acks request will be awaiting to acquire that which can only happens when the user either changes the policy or executes the action.

Depending on the timing the checkins and the actions dispatching loops, they competed with each other for one single shared client.

Here is a little bit more details/comments on the investigation:
https://github.com/elastic/elastic-agent/issues/2410
https://github.com/elastic/elastic-agent/issues/2410

As far as I understand this problem was introduced in 8.6 as a result of separation of the checkin and the actions dispatching loops which lead to the concurrent access to the http "client" and competition for the "clients lock" in the current implementation.

This is the "minimal viable" fix for this problem.

## Why is it important?

Fixes a huge issue with the actions execution/acking.
This affects any action acking, but most of all osquery that relies on .fleet-action-results to be delivered in timely manner.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## How to test this PR locally

Run the agent with osquery, execute live pack of 30-40 queries.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/2410

## Screenshots

The live packs work as expected with the fix

<img width="1305" alt="Screenshot 2023-03-27 at 6 03 01 PM" src="https://user-images.githubusercontent.com/872351/228081708-e5391eda-85b8-4642-9793-17bc822ac1f5.png">


