### PR TITLE
Migrate docker provider to ECS fields: container.image -> container.image.name

### DIFF
--- a/internal/pkg/composable/providers/docker/docker.go
+++ b/internal/pkg/composable/providers/docker/docker.go
@@ -131,9 +131,11 @@ func generateData(event bus.Event) (*dockerContainerData, error) {
 		container: container,
 		mapping: map[string]interface{}{
 			"container": map[string]interface{}{
-				"id":     container.ID,
-				"name":   container.Name,
-				"image":  container.Image,
+				"id":   container.ID,
+				"name": container.Name,
+				"image": map[string]interface{}{
+					"name": container.Image,
+				},
 				"labels": labelMap,
 			},
 		},
@@ -141,10 +143,10 @@ func generateData(event bus.Event) (*dockerContainerData, error) {
 			{
 				"add_fields": map[string]interface{}{
 					"fields": map[string]interface{}{
-						"id":     container.ID,
-						"name":   container.Name,
-						"image":  container.Image,
-						"labels": processorLabelMap,
+						"id":         container.ID,
+						"name":       container.Name,
+						"image.name": container.Image,
+						"labels":     processorLabelMap,
 					},
 					"target": "container",
 				},

--- a/internal/pkg/composable/providers/docker/docker_test.go
+++ b/internal/pkg/composable/providers/docker/docker_test.go
@@ -17,8 +17,9 @@ import (
 
 func TestGenerateData(t *testing.T) {
 	container := &docker.Container{
-		ID:   "abc",
-		Name: "foobar",
+		ID:    "abc",
+		Name:  "foobar",
+		Image: "busybox:latest",
 		Labels: map[string]string{
 			"do.not.include":          "true",
 			"co.elastic.logs/disable": "true",
@@ -32,9 +33,11 @@ func TestGenerateData(t *testing.T) {
 	require.NoError(t, err)
 	mapping := map[string]interface{}{
 		"container": map[string]interface{}{
-			"id":    container.ID,
-			"name":  container.Name,
-			"image": container.Image,
+			"id":   container.ID,
+			"name": container.Name,
+			"image": map[string]interface{}{
+				"name": container.Image,
+			},
 			"labels": mapstr.M{
 				"do": mapstr.M{"not": mapstr.M{"include": "true"}},
 				"co": mapstr.M{"elastic": mapstr.M{"logs/disable": "true"}},
@@ -45,9 +48,9 @@ func TestGenerateData(t *testing.T) {
 		{
 			"add_fields": map[string]interface{}{
 				"fields": map[string]interface{}{
-					"id":    container.ID,
-					"name":  container.Name,
-					"image": container.Image,
+					"id":         container.ID,
+					"name":       container.Name,
+					"image.name": container.Image,
 					"labels": mapstr.M{
 						"do_not_include":          "true",
 						"co_elastic_logs/disable": "true",


### PR DESCRIPTION
## What does this PR do?

Docker integration fails processing logs with the error:
```
object mapping for [container.image] tried to parse field [image] as object, but found a concrete value" 
```
in beats this field was migrated to the new ECS format a long time ago - `add_docker_metadata` https://github.com/elastic/beats/pull/9412

## Why is it important?

docker logs can't be processed, and event are dropped

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to reproduce the error:
1. Create the elastic cloud of version 8.8.0-SNAPSHOT
2. run
```
sudo docker run --env FLEET_ENROLL=1 --env FLEET_URL=<URL>  --env FLEET_ENROLLMENT_TOKEN=<TOKEN> --user=root --volume="/var/run/docker.sock:/var/run/docker.sock:ro" --volume="/:/docker:ro" --rm docker.elastic.co/beats/elastic-agent:8.8.0-SNAPSHOT
```

-> see the error `{\"type\":\"mapper_parsing_exception\",\"reason\":\"object mapping for [container.image] tried to parse field [image] as object, but found a concrete value\"}, dropping event!"`

## How to test this PR locally
1. `DEV=true PLATFORMS=linux/amd64 PACKAGES=docker mage package`
2. `cd build/package/elastic-agent/elastic-agent-linux-amd64.docker/docker-build`
3. `docker build -t custom-elastic-agent-docker-logs-parsing-6 .`
4.
```
sudo docker run --env FLEET_ENROLL=1 --env FLEET_URL=<URL> --env FLEET_ENROLLMENT_TOKEN=<TOKEN> --user=root --volume="/var/run/docker.sock:/var/run/docker.sock:ro" --volume="/:/docker:ro" --rm custom-elastic-agent-docker-logs-parsing-6:latest
```
result:
logs are parsed, `container.image.name` field is available:
<img width="1785" alt="Screenshot 2023-03-28 at 19 07 04" src="https://user-images.githubusercontent.com/28299531/228318806-ea57eb07-8c7e-4efa-895b-252494261407.png">


## Related issues

- Closes https://github.com/elastic/integrations/issues/5450

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
