### PR TITLE
Support Shipper monitoring in elastic-agent

### DIFF
--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -57,7 +57,7 @@ const (
 
 var (
 	errNoOuputPresent          = errors.New("outputs not part of the config")
-	supportedMetricsComponents = []string{"filebeat", "metricbeat", "apm-server", "auditbeat", "cloudbeat", "fleet-server", "heartbeat", "osquerybeat", "packetbeat"}
+	supportedMetricsComponents = []string{"filebeat", "metricbeat", "apm-server", "auditbeat", "cloudbeat", "fleet-server", "heartbeat", "osquerybeat", "packetbeat", "shipper"}
 	supportedBeatsComponents   = []string{"filebeat", "metricbeat", "apm-server", "fleet-server", "auditbeat", "cloudbeat", "heartbeat", "osquerybeat", "packetbeat"}
 )
 
@@ -149,7 +149,7 @@ func (b *BeatsMonitor) MonitoringConfig(
 	}
 
 	if b.config.C.MonitorMetrics {
-		if err := b.injectMetricsInput(cfg, componentIDToBinary, monitoringOutput); err != nil {
+		if err := b.injectMetricsInput(cfg, componentIDToBinary, monitoringOutput, components); err != nil {
 			return nil, errors.New(err, "failed to inject monitoring output")
 		}
 	}
@@ -165,8 +165,8 @@ func (b *BeatsMonitor) EnrichArgs(unit, binary string, args []string) []string {
 		return args
 	}
 
-	// only beats understands these flags
-	if !isSupportedBeatsBinary(binary) {
+	// only beats & shipper understand these flags
+	if !isSupportedBeatsBinary(binary) && binary != "shipper" {
 		return args
 	}
 
@@ -524,7 +524,7 @@ func (b *BeatsMonitor) monitoringNamespace() string {
 	}
 	return defaultMonitoringNamespace
 }
-func (b *BeatsMonitor) injectMetricsInput(cfg map[string]interface{}, componentIDToBinary map[string]string, monitoringOutputName string) error {
+func (b *BeatsMonitor) injectMetricsInput(cfg map[string]interface{}, componentIDToBinary map[string]string, monitoringOutputName string, componentList []component.Component) error {
 	monitoringNamespace := b.monitoringNamespace()
 	fixedAgentName := strings.ReplaceAll(agentName, "-", "_")
 	beatsStreams := make([]interface{}, 0, len(componentIDToBinary))
@@ -781,6 +781,50 @@ func (b *BeatsMonitor) injectMetricsInput(cfg map[string]interface{}, componentI
 				},
 			})
 		}
+
+	}
+
+	shipperHTTPStreams := []interface{}{}
+	// the shipper is listed in componentList, but not componentIDToBinary
+	// iterate over the full component list, adding a monitoring output for every shipper binary.
+	for _, comp := range componentList {
+		if comp.ShipperSpec != nil { // a shipper unit
+			endpoints := []interface{}{prefixedEndpoint(endpointPath(comp.ID, b.operatingSystem))}
+			name := "shipper" // in other beats this is the binary name, but we can hard-code it here.
+			// note: this doesn't fetch anything from the /state endpoint, as it doesn't report much beyond name/version,
+			// the equivelent of the beat /state metrics end up in /shipper
+			shipperHTTPStreams = append(shipperHTTPStreams, map[string]interface{}{
+				idKey: "metrics-monitoring-shipper",
+				"data_stream": map[string]interface{}{
+					"type":      "metrics",
+					"dataset":   fmt.Sprintf("elastic_agent.%s", name),
+					"namespace": monitoringNamespace,
+				},
+				"metricsets": []interface{}{"json"},
+				"path":       "/shipper",
+				"hosts":      endpoints,
+				"namespace":  "application",
+				"period":     "10s",
+				"index":      fmt.Sprintf("metrics-elastic_agent.%s-%s", name, "application"),
+				"processors": createProcessorsForJSONInput(name, monitoringNamespace, b.agentInfo),
+			},
+				map[string]interface{}{
+					idKey: "metrics-monitoring-shipper-stats",
+					"data_stream": map[string]interface{}{
+						"type":      "metrics",
+						"dataset":   fmt.Sprintf("elastic_agent.%s", name),
+						"namespace": monitoringNamespace,
+					},
+					"metricsets": []interface{}{"json"},
+					"path":       "/stats",
+					"hosts":      endpoints,
+					"namespace":  "agent",
+					"period":     "10s",
+					"index":      fmt.Sprintf("metrics-elastic_agent.%s-%s", name, "resources"),
+					"processors": createProcessorsForJSONInput(name, monitoringNamespace, b.agentInfo),
+				})
+		}
+
 	}
 
 	inputs := []interface{}{
@@ -806,6 +850,20 @@ func (b *BeatsMonitor) injectMetricsInput(cfg map[string]interface{}, componentI
 		},
 	}
 
+	// if we have shipper data, inject the extra inputs
+	if len(shipperHTTPStreams) > 0 {
+		inputs = append(inputs, map[string]interface{}{
+			idKey:        "metrics-monitoring-shipper",
+			"name":       "metrics-monitoring-shipper",
+			"type":       "http/metrics",
+			useOutputKey: monitoringOutput,
+			"data_stream": map[string]interface{}{
+				"namespace": monitoringNamespace,
+			},
+			"streams": shipperHTTPStreams,
+		})
+	}
+
 	inputsNode, found := cfg[inputsKey]
 	if !found {
 		return fmt.Errorf("no inputs in config")
@@ -819,6 +877,63 @@ func (b *BeatsMonitor) injectMetricsInput(cfg map[string]interface{}, componentI
 	inputsCfg = append(inputsCfg, inputs...)
 	cfg[inputsKey] = inputsCfg
 	return nil
+}
+
+func createProcessorsForJSONInput(name string, monitoringNamespace string, agentInfo *info.AgentInfo) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"add_fields": map[string]interface{}{
+				"target": "data_stream",
+				"fields": map[string]interface{}{
+					"type":      "metrics",
+					"dataset":   fmt.Sprintf("elastic_agent.%s", name),
+					"namespace": monitoringNamespace,
+				},
+			},
+		},
+		map[string]interface{}{
+			"add_fields": map[string]interface{}{
+				"target": "event",
+				"fields": map[string]interface{}{
+					"dataset": fmt.Sprintf("elastic_agent.%s", name),
+				},
+			},
+		},
+		map[string]interface{}{
+			"add_fields": map[string]interface{}{
+				"target": "elastic_agent",
+				"fields": map[string]interface{}{
+					"id":       agentInfo.AgentID(),
+					"version":  agentInfo.Version(),
+					"snapshot": agentInfo.Snapshot(),
+					"process":  name,
+				},
+			},
+		},
+		map[string]interface{}{
+			"add_fields": map[string]interface{}{
+				"target": "agent",
+				"fields": map[string]interface{}{
+					"id": agentInfo.AgentID(),
+				},
+			},
+		},
+		map[string]interface{}{
+			"copy_fields": map[string]interface{}{
+				"fields":         httpCopyRules(),
+				"ignore_missing": true,
+				"fail_on_error":  false,
+			},
+		},
+		map[string]interface{}{
+			"drop_fields": map[string]interface{}{
+				"fields": []interface{}{
+					"http",
+				},
+				"ignore_missing": true,
+			},
+		},
+	}
 }
 
 func loggingPath(id, operatingSystem string) string {
@@ -967,6 +1082,12 @@ func httpCopyRules() []interface{} {
 		map[string]interface{}{
 			"from": "http.filebeat_input",
 			"to":   "filebeat_input",
+		},
+
+		// shipper specific metrics
+		map[string]interface{}{
+			"from": "http.application.shipper",
+			"to":   "shipper",
 		},
 	}
 

--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -791,6 +791,9 @@ func (b *BeatsMonitor) injectMetricsInput(cfg map[string]interface{}, componentI
 		if comp.ShipperSpec != nil { // a shipper unit
 			endpoints := []interface{}{prefixedEndpoint(endpointPath(comp.ID, b.operatingSystem))}
 			name := "shipper" // in other beats this is the binary name, but we can hard-code it here.
+			if comp.ShipperSpec.Spec.Name != "" {
+				name = comp.ShipperSpec.Spec.Name
+			}
 			// note: this doesn't fetch anything from the /state endpoint, as it doesn't report much beyond name/version,
 			// the equivalent of the beat /state metrics end up in /shipper
 			shipperHTTPStreams = append(shipperHTTPStreams, map[string]interface{}{
@@ -805,7 +808,6 @@ func (b *BeatsMonitor) injectMetricsInput(cfg map[string]interface{}, componentI
 				"hosts":      endpoints,
 				"namespace":  "application",
 				"period":     "10s",
-				"index":      fmt.Sprintf("metrics-elastic_agent.%s-%s", name, "application"),
 				"processors": createProcessorsForJSONInput(name, monitoringNamespace, b.agentInfo),
 			},
 				map[string]interface{}{
@@ -820,7 +822,6 @@ func (b *BeatsMonitor) injectMetricsInput(cfg map[string]interface{}, componentI
 					"hosts":      endpoints,
 					"namespace":  "agent",
 					"period":     "10s",
-					"index":      fmt.Sprintf("metrics-elastic_agent.%s-%s", name, "resources"),
 					"processors": createProcessorsForJSONInput(name, monitoringNamespace, b.agentInfo),
 				})
 		}

--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -792,7 +792,7 @@ func (b *BeatsMonitor) injectMetricsInput(cfg map[string]interface{}, componentI
 			endpoints := []interface{}{prefixedEndpoint(endpointPath(comp.ID, b.operatingSystem))}
 			name := "shipper" // in other beats this is the binary name, but we can hard-code it here.
 			// note: this doesn't fetch anything from the /state endpoint, as it doesn't report much beyond name/version,
-			// the equivelent of the beat /state metrics end up in /shipper
+			// the equivalent of the beat /state metrics end up in /shipper
 			shipperHTTPStreams = append(shipperHTTPStreams, map[string]interface{}{
 				idKey: "metrics-monitoring-shipper",
 				"data_stream": map[string]interface{}{


### PR DESCRIPTION
## What does this PR do?

See https://github.com/elastic/elastic-agent-shipper/issues/267

This requires https://github.com/elastic/elastic-agent-shipper/pull/289

This adds shipper  monitoring support to elastic-agent. Right now I'm opening this as a draft PR for a few reasons:

- the `index` field in the config doesn't seem to do anything, and we just create a datastream, and I'm not sure if it needs to be there at all
- I'm not 100% sure the `dataset` and various `id` fields are set correctly.

Right now, when run with monitoring enabled, this results in two documents-per-period: one with queue metrics, and one with system resource metrics

<details>
<summary> The complete document for resource metrics</summary>

```
{
  "_index": ".ds-metrics-elastic_agent.shipper-default-2023.03.29-000001",
  "_id": "QaoANIcBsNMa2qX4bRHy",
  "_version": 1,
  "_score": 0,
  "_source": {
    "@timestamp": "2023-03-30T19:30:48.071663908Z",
    "event": {
      "duration": 7959499,
      "dataset": "elastic_agent.shipper",
      "module": "http"
    },
    "agent": {
      "name": "shoebill.nest",
      "type": "metricbeat",
      "version": "8.8.0",
      "id": "90c33586-728c-406a-b9a9-0e0eb52a2a81",
      "ephemeral_id": "1388106b-11a9-4c02-94fd-bb07715ab947"
    },
    "metricset": {
      "name": "json",
      "period": 10000
    },
    "host": {
      "mac": [
        "02-42-1E-01-77-4F",
      ],
      "hostname": "shoebill.nest",
      "name": "shoebill.nest",
      "architecture": "x86_64",
      "os": {
        "type": "linux",
        "platform": "fedora",
        "version": "36 (Server Edition)",
        "family": "redhat",
        "name": "Fedora Linux",
        "kernel": "6.0.7-200.fc36.x86_64",
        "codename": "Thirty Six"
      },
      "id": "f1d831c8916f41339bd9b4fc73c6de97",
      "containerized": false,
      "ip": [
        "192.168.1.96",
      ]
    },
    "service": {
      "address": "http://unix/stats",
      "type": "http"
    },
    "data_stream": {
      "namespace": "default",
      "type": "metrics",
      "dataset": "elastic_agent.shipper"
    },
    "system": {
      "process": {
        "cpu": {
          "user": {
            "time": {
              "ms": 1280
            },
            "ticks": 1280
          },
          "system": {
            "time": {
              "ms": 1230
            },
            "ticks": 1230
          },
          "total": {
            "time": {
              "ms": 2510
            },
            "value": 2510,
            "ticks": 2510
          }
        },
        "memory": {
          "size": 90620184
        },
        "fd": {
          "open": 23,
          "limit": {
            "soft": 524288,
            "hard": 524288
          }
        },
        "cgroup": {
          "memory": {
            "id": "session-1749.scope",
            "mem": {
              "usage": {
                "bytes": 14167662592
              }
            }
          },
          "cpu": {
            "id": "session-1749.scope",
            "stats": {
              "throttled": {
                "ns": 0,
                "periods": 0
              },
              "periods": 0
            }
          }
        }
      }
    },
    "ecs": {
      "version": "8.0.0"
    },
    "elastic_agent": {
      "id": "90c33586-728c-406a-b9a9-0e0eb52a2a81",
      "snapshot": false,
      "version": "8.8.0",
      "process": "shipper"
    }
  },
  "fields": {
    "system.process.cpu.system.ticks": [
      1230
    ],
    "elastic_agent.version": [
      "8.8.0"
    ],
    "elastic_agent.process": [
      "shipper"
    ],
    "system.process.cpu.total.value": [
      2510
    ],
    "host.hostname": [
      "shoebill.nest"
    ],
    "host.mac": [
      "02-42-1E-01-77-4F",
      "02-42-A3-24-5B-D0",
      "02-42-BC-C0-AC-20",
      "0A-00-27-00-00-00",
      "0A-00-27-00-00-01",
      "0A-00-27-00-00-02",
      "5E-B3-C9-E0-AD-96",
      "6E-80-26-76-B5-A4",
      "74-86-7A-F0-D9-44",
      "74-86-7A-F0-D9-45",
      "74-86-7A-F0-D9-46",
      "74-86-7A-F0-D9-47",
      "E2-79-4F-36-E2-DD"
    ],
    "service.type": [
      "http"
    ],
    "system.process.memory.size": [
      90620184
    ],
    "host.os.version": [
      "36 (Server Edition)"
    ],
    "system.process.cgroup.cpu.stats.periods": [
      0
    ],
    "system.process.fd.open": [
      23
    ],
    "system.process.fd.limit.soft": [
      524288
    ],
    "host.os.name": [
      "Fedora Linux"
    ],
    "system.process.cgroup.cpu.stats.throttled.ns": [
      0
    ],
    "system.process.cgroup.cpu.stats.throttled.periods": [
      0
    ],
    "agent.name": [
      "shoebill.nest"
    ],
    "host.name": [
      "shoebill.nest"
    ],
    "system.process.cgroup.cpu.id": [
      "session-1749.scope"
    ],
    "host.os.type": [
      "linux"
    ],
    "data_stream.type": [
      "metrics"
    ],
    "host.architecture": [
      "x86_64"
    ],
    "agent.id": [
      "90c33586-728c-406a-b9a9-0e0eb52a2a81"
    ],
    "host.containerized": [
      false
    ],
    "ecs.version": [
      "8.0.0"
    ],
    "service.address": [
      "http://unix/stats"
    ],
    "agent.version": [
      "8.8.0"
    ],
    "host.os.family": [
      "redhat"
    ],
    "system.process.cgroup.memory.id": [
      "session-1749.scope"
    ],
    "system.process.fd.limit.hard": [
      524288
    ],
    "system.process.cpu.user.ticks": [
      1280
    ],
    "system.process.cpu.system.time.ms": [
      1230
    ],
    "system.process.cgroup.memory.mem.usage.bytes": [
      14167663000
    ],
    "host.ip": [
      "192.168.1.96",
      "fe80::7686:7aff:fef0:d944",
      "192.168.49.1",
      "172.17.0.1",
      "fe80::42:1eff:fe01:774f",
      "172.24.0.1",
      "fe80::42:bcff:fec0:ac20",
      "fe80::5cb3:c9ff:fee0:ad96",
      "fe80::e079:4fff:fe36:e2dd",
      "fe80::6c80:26ff:fe76:b5a4"
    ],
    "agent.type": [
      "metricbeat"
    ],
    "event.module": [
      "http"
    ],
    "host.os.kernel": [
      "6.0.7-200.fc36.x86_64"
    ],
    "elastic_agent.snapshot": [
      false
    ],
    "host.id": [
      "f1d831c8916f41339bd9b4fc73c6de97"
    ],
    "system.process.cpu.user.time.ms": [
      1280
    ],
    "system.process.cpu.total.time.ms": [
      2510
    ],
    "system.process.cpu.total.ticks": [
      2510
    ],
    "elastic_agent.id": [
      "90c33586-728c-406a-b9a9-0e0eb52a2a81"
    ],
    "data_stream.namespace": [
      "default"
    ],
    "metricset.period": [
      10000
    ],
    "host.os.codename": [
      "Thirty Six"
    ],
    "event.duration": [
      7959499
    ],
    "metricset.name": [
      "json"
    ],
    "@timestamp": [
      "2023-03-30T19:30:48.071Z"
    ],
    "host.os.platform": [
      "fedora"
    ],
    "data_stream.dataset": [
      "elastic_agent.shipper"
    ],
    "agent.ephemeral_id": [
      "1388106b-11a9-4c02-94fd-bb07715ab947"
    ],
    "event.dataset": [
      "elastic_agent.shipper"
    ]
  }
}
```
</details>

<details>
<summary>The complete document for shipper metrics </summary>

```
{
  "_index": ".ds-metrics-elastic_agent.shipper-default-2023.03.29-000001",
  "_id": "raoANIcBsNMa2qX4bRCM",
  "_version": 1,
  "_score": 0,
  "_source": {
    "@timestamp": "2023-03-30T19:30:45.056506183Z",
    "event": {
      "dataset": "elastic_agent.shipper",
      "module": "http",
      "duration": 907153
    },
    "elastic_agent": {
      "snapshot": false,
      "version": "8.8.0",
      "id": "90c33586-728c-406a-b9a9-0e0eb52a2a81",
      "process": "shipper"
    },
    "shipper": {
      "queue": {
        "is_full": false,
        "limit_reached_count": 0,
        "max_level": 4096,
        "unacked_read": 4,
        "current_level": 4
      }
    },
    "service": {
      "type": "http",
      "address": "http://unix/shipper"
    },
    "host": {
      "name": "shoebill.nest",
      "ip": [
        "192.168.1.96",
      ],
      "mac": [
        "02-42-1E-01-77-4F",
      ],
      "hostname": "shoebill.nest",
      "architecture": "x86_64",
      "os": {
        "version": "36 (Server Edition)",
        "family": "redhat",
        "name": "Fedora Linux",
        "kernel": "6.0.7-200.fc36.x86_64",
        "codename": "Thirty Six",
        "type": "linux",
        "platform": "fedora"
      },
      "id": "f1d831c8916f41339bd9b4fc73c6de97",
      "containerized": false
    },
    "data_stream": {
      "namespace": "default",
      "type": "metrics",
      "dataset": "elastic_agent.shipper"
    },
    "metricset": {
      "period": 10000,
      "name": "json"
    },
    "agent": {
      "version": "8.8.0",
      "id": "90c33586-728c-406a-b9a9-0e0eb52a2a81",
      "ephemeral_id": "1388106b-11a9-4c02-94fd-bb07715ab947",
      "name": "shoebill.nest",
      "type": "metricbeat"
    },
    "ecs": {
      "version": "8.0.0"
    }
  },
  "fields": {
    "shipper.queue.max_level": [
      4096
    ],
    "elastic_agent.version": [
      "8.8.0"
    ],
    "elastic_agent.process": [
      "shipper"
    ],
    "host.hostname": [
      "shoebill.nest"
    ],
    "host.mac": [
      "02-42-1E-01-77-4F",
    ],
    "service.type": [
      "http"
    ],
    "host.ip": [
      "192.168.1.96",
    ],
    "agent.type": [
      "metricbeat"
    ],
    "event.module": [
      "http"
    ],
    "host.os.version": [
      "36 (Server Edition)"
    ],
    "host.os.kernel": [
      "6.0.7-200.fc36.x86_64"
    ],
    "host.os.name": [
      "Fedora Linux"
    ],
    "shipper.queue.limit_reached_count": [
      0
    ],
    "agent.name": [
      "shoebill.nest"
    ],
    "shipper.queue.current_level": [
      4
    ],
    "elastic_agent.snapshot": [
      false
    ],
    "host.name": [
      "shoebill.nest"
    ],
    "host.id": [
      "f1d831c8916f41339bd9b4fc73c6de97"
    ],
    "shipper.queue.unacked_read": [
      4
    ],
    "host.os.type": [
      "linux"
    ],
    "elastic_agent.id": [
      "90c33586-728c-406a-b9a9-0e0eb52a2a81"
    ],
    "data_stream.namespace": [
      "default"
    ],
    "metricset.period": [
      10000
    ],
    "host.os.codename": [
      "Thirty Six"
    ],
    "data_stream.type": [
      "metrics"
    ],
    "shipper.queue.is_full": [
      false
    ],
    "host.architecture": [
      "x86_64"
    ],
    "event.duration": [
      907153
    ],
    "metricset.name": [
      "json"
    ],
    "@timestamp": [
      "2023-03-30T19:30:45.056Z"
    ],
    "agent.id": [
      "90c33586-728c-406a-b9a9-0e0eb52a2a81"
    ],
    "host.containerized": [
      false
    ],
    "host.os.platform": [
      "fedora"
    ],
    "ecs.version": [
      "8.0.0"
    ],
    "service.address": [
      "http://unix/shipper"
    ],
    "data_stream.dataset": [
      "elastic_agent.shipper"
    ],
    "agent.ephemeral_id": [
      "1388106b-11a9-4c02-94fd-bb07715ab947"
    ],
    "agent.version": [
      "8.8.0"
    ],
    "host.os.family": [
      "redhat"
    ],
    "event.dataset": [
      "elastic_agent.shipper"
    ]
  }
}
```
</details>

## Why is it important?

We need monitoring for the shipper

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test



## How to test this PR locally

- Pull down this PR
- Pull down and build https://github.com/elastic/elastic-agent-shipper/pull/289
- Build the agent with ` EXTERNAL=false mage dev:package`
- Unpack the tarball
- Copy over the shipper binary and `shipper.spec.yml` file from `specs/` over to the `components/` subdirectory in the unpacked tarball
- rename `elastic-agent-shipper` to `shipper`
- Configure/enroll elastic-agent however you like
- `agent.monitoring.enabled` must be set to `true`
- run 
- Wait for `.ds-metrics-elastic_agent.shipper-default-*` events to ingest

