### PR TITLE
Correct api-key to api_key in example configurations

### DIFF
--- a/_meta/config/common.p2.yml.tmpl
+++ b/_meta/config/common.p2.yml.tmpl
@@ -5,7 +5,7 @@ outputs:
   default:
     type: elasticsearch
     hosts: [127.0.0.1:9200]
-    api-key: "example-key"
+    api_key: "example-key"
     # username: "elastic"
     # password: "changeme"
 
@@ -18,17 +18,17 @@ inputs:
     data_stream.namespace: default
     use_output: default
     streams:
-      - metricsets: 
+      - metricsets:
         - cpu
         # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
-      - metricsets: 
+      - metricsets:
         - memory
         data_stream.dataset: system.memory
-      - metricsets: 
+      - metricsets:
         - network
         data_stream.dataset: system.network
-      - metricsets: 
+      - metricsets:
         - filesystem
         data_stream.dataset: system.filesystem
 

--- a/_meta/config/common.reference.p2.yml.tmpl
+++ b/_meta/config/common.reference.p2.yml.tmpl
@@ -5,7 +5,7 @@ outputs:
   default:
     type: elasticsearch
     hosts: [127.0.0.1:9200]
-    api-key: "example-key"
+    api_key: "example-key"
     # username: "elastic"
     # password: "changeme"
 
@@ -18,17 +18,17 @@ inputs:
     data_stream.namespace: default
     use_output: default
     streams:
-      - metricsets: 
+      - metricsets:
         - cpu
         # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
-      - metricsets: 
+      - metricsets:
         - memory
         data_stream.dataset: system.memory
-      - metricsets: 
+      - metricsets:
         - network
         data_stream.dataset: system.network
-      - metricsets: 
+      - metricsets:
         - filesystem
         data_stream.dataset: system.filesystem
 

--- a/elastic-agent.reference.yml
+++ b/elastic-agent.reference.yml
@@ -11,7 +11,7 @@ outputs:
   default:
     type: elasticsearch
     hosts: [127.0.0.1:9200]
-    api-key: "example-key"
+    api_key: "example-key"
     # username: "elastic"
     # password: "changeme"
 
@@ -24,17 +24,17 @@ inputs:
     data_stream.namespace: default
     use_output: default
     streams:
-      - metricsets: 
+      - metricsets:
         - cpu
         # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
-      - metricsets: 
+      - metricsets:
         - memory
         data_stream.dataset: system.memory
-      - metricsets: 
+      - metricsets:
         - network
         data_stream.dataset: system.network
-      - metricsets: 
+      - metricsets:
         - filesystem
         data_stream.dataset: system.filesystem
 

--- a/elastic-agent.yml
+++ b/elastic-agent.yml
@@ -11,7 +11,7 @@ outputs:
   default:
     type: elasticsearch
     hosts: [127.0.0.1:9200]
-    api-key: "example-key"
+    api_key: "example-key"
     # username: "elastic"
     # password: "changeme"
 
@@ -24,17 +24,17 @@ inputs:
     data_stream.namespace: default
     use_output: default
     streams:
-      - metricsets: 
+      - metricsets:
         - cpu
         # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
-      - metricsets: 
+      - metricsets:
         - memory
         data_stream.dataset: system.memory
-      - metricsets: 
+      - metricsets:
         - network
         data_stream.dataset: system.network
-      - metricsets: 
+      - metricsets:
         - filesystem
         data_stream.dataset: system.filesystem
 

--- a/internal/pkg/config/loader_test.go
+++ b/internal/pkg/config/loader_test.go
@@ -42,7 +42,7 @@ func TestExternalConfigLoading(t *testing.T) {
 					"default": map[string]interface{}{
 						"type":    "elasticsearch",
 						"hosts":   []interface{}{"127.0.0.1:9201"},
-						"api-key": "my-secret-key",
+						"api_key": "my-secret-key",
 					},
 				},
 				"agent": map[string]interface{}{
@@ -67,7 +67,7 @@ func TestExternalConfigLoading(t *testing.T) {
 					"default": map[string]interface{}{
 						"type":    "elasticsearch",
 						"hosts":   []interface{}{"127.0.0.1:9201"},
-						"api-key": "my-secret-key",
+						"api_key": "my-secret-key",
 					},
 				},
 				"inputs": []interface{}{
@@ -125,7 +125,7 @@ func TestExternalConfigLoading(t *testing.T) {
 					"default": map[string]interface{}{
 						"type":    "elasticsearch",
 						"hosts":   []interface{}{"127.0.0.1:9201"},
-						"api-key": "my-secret-key",
+						"api_key": "my-secret-key",
 					},
 				},
 				"inputs": []interface{}{

--- a/internal/pkg/config/testdata/standalone-with-inputs.yml
+++ b/internal/pkg/config/testdata/standalone-with-inputs.yml
@@ -2,7 +2,7 @@ outputs:
   default:
     type: elasticsearch
     hosts: [127.0.0.1:9201]
-    api-key: "my-secret-key"
+    api_key: "my-secret-key"
 
 inputs:
   - type: system/metrics

--- a/internal/pkg/config/testdata/standalone1.yml
+++ b/internal/pkg/config/testdata/standalone1.yml
@@ -2,5 +2,5 @@ outputs:
   default:
     type: elasticsearch
     hosts: [127.0.0.1:9201]
-    api-key: "my-secret-key"
+    api_key: "my-secret-key"
 


### PR DESCRIPTION
`api_key` is the correct syntax and is what is actually used in most of our example documentation. I wasted some time today starting from the reference config in the repository without noticing this.

For examples see https://www.elastic.co/guide/en/fleet/current/grant-access-to-elasticsearch.html

We should probably be using our reference examples to drive integration tests.