### PR TITLE
Removing debugging statements

### DIFF
--- a/internal/pkg/agent/application/info/agent_metadata.go
+++ b/internal/pkg/agent/application/info/agent_metadata.go
@@ -146,7 +146,6 @@ func (i *AgentInfo) ECSMetadata(l *logger.Logger) (*ECSMeta, error) {
 
 	info := sysInfo.Info()
 	hostname := info.Hostname
-	l.Debugf("in ECSMetadata, hostname = %s", hostname)
 	if features.FQDN() {
 		fqdn, err := sysInfo.FQDN()
 		if err != nil {
@@ -202,7 +201,6 @@ func (i *AgentInfo) ECSMetadataFlatMap(l *logger.Logger) (map[string]interface{}
 
 	info := sysInfo.Info()
 	hostname := info.Hostname
-	l.Debugf("in ECSMetadataFlatMap, hostname = %s", hostname)
 	if features.FQDN() {
 		fqdn, err := sysInfo.FQDN()
 		if err != nil {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Removes two statements introduced in https://github.com/elastic/elastic-agent/pull/2218 for debugging-only purposes.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

The statements should've been removed before https://github.com/elastic/elastic-agent/pull/2218 was merged but I forgot to do that in my excitement to merge that PR.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

