### PR TITLE
Disable E2E testing stage for branch/tags

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -400,11 +400,12 @@ pipeline {
     }
     stage('e2e tests') {
       when {
-        // Always when running builds on branches/tags
+        // Disable until we fix the e2e test.
+        // This should be always running when builds on branches/tags
         // Enable if e2e related changes.
         beforeAgent true
         anyOf {
-          not { changeRequest() }
+          //not { changeRequest() }
           // package artifacts are not generated if ONLY_DOCS, therefore e2e should not run if ONLY_DOCS
           expression { return isE2eEnabled() && env.ONLY_DOCS == "false"}
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -401,11 +401,9 @@ pipeline {
     stage('e2e tests') {
       when {
         // Disable until we fix the e2e test.
-        // This should be always running when builds on branches/tags
-        // Enable if e2e related changes.
+        // This should be running when there is a comment or the e2e label
         beforeAgent true
         anyOf {
-          //not { changeRequest() }
           // package artifacts are not generated if ONLY_DOCS, therefore e2e should not run if ONLY_DOCS
           expression { return isE2eEnabled() && env.ONLY_DOCS == "false"}
         }

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -39,7 +39,8 @@ def runBuilds(Map args = [:]) {
           job: "elastic-agent/elastic-agent-mbp/${branch}",
           parameters: [
             booleanParam(name: 'integration_tests_ci', value: true),
-            booleanParam(name: 'end_to_end_tests_ci', value: true)
+            // Disable running e2e until we fix this
+            booleanParam(name: 'end_to_end_tests_ci', value: false)
           ],
           wait: false, propagate: false)
     quietPeriod += args.quietPeriodFactor

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -39,7 +39,7 @@ def runBuilds(Map args = [:]) {
           job: "elastic-agent/elastic-agent-mbp/${branch}",
           parameters: [
             booleanParam(name: 'integration_tests_ci', value: true),
-            // Disable running e2e until we fix this
+            // Disable running e2e until we fix the 2e2 testing suite
             booleanParam(name: 'end_to_end_tests_ci', value: false)
           ],
           wait: false, propagate: false)


### PR DESCRIPTION
## What does this PR do?

This change is going to disable triggering the stage of e2e testing when
running from the context of a branch or tag. 

It also disabled the scheduled job from running them constantly.

We would be still able to 
trigger it by commenting `e2e tests` or putting the label `ci:end-to-end`

Signed-off-by: Alexandros, Sapranidis <alexandros@elastic.co>

## Why is it important?

The existing e2e tests are failing always. Until we fix this change disables 
them from being triggered always.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added an integration test or an E2E test


## How to test this PR locally

This change is affecting the CI, thus requires to setup the local elastic Jenkins setup to test this change.

## Related issues

- #2457


cc @cmacknz @pierrehilbert 