### PR TITLE
Write internal logs under versioned home logs folder

### DIFF
--- a/pkg/core/logger/logger.go
+++ b/pkg/core/logger/logger.go
@@ -126,7 +126,7 @@ func DefaultLoggingConfig() *Config {
 	cfg.Beat = agentName
 	cfg.Level = DefaultLogLevel
 	cfg.ToFiles = true
-	cfg.Files.Path = filepath.Join(paths.Home(), DefaultLogDirectory)
+	cfg.Files.Path = paths.Logs()
 	cfg.Files.Name = agentName
 	cfg.Files.MaxSize = 20 * 1024 * 1024
 

--- a/pkg/core/logger/logger.go
+++ b/pkg/core/logger/logger.go
@@ -140,7 +140,7 @@ func makeInternalFileOutput(cfg *Config) (zapcore.Core, error) {
 	// defaultCfg is used to set the defaults for the file rotation of the internal logging
 	// these settings cannot be changed by a user configuration
 	defaultCfg := logp.DefaultConfig(logp.DefaultEnvironment)
-	filename := filepath.Join(paths.Logs(), cfg.Beat)
+	filename := filepath.Join(paths.Home(), DefaultLogDirectory, cfg.Beat)
 	al := zap.NewAtomicLevelAt(cfg.Level.ZapLevel())
 	internalLevelEnabler = &al // directly persisting struct will panic on accessing unitialized backing pointer
 	rotator, err := file.NewFileRotator(filename,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR ensures that Elastic Agent writes its internal logs to its versioned home's `logs` folder.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

When `elastic-agent diagnostics` is run, it tries to collect logs from the versioned home logs folder.  Before this PR logs were not being written to this folder so `elastic-agent diagnostics` was not collecting any Elastic Agent logs. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~ Will be covered by https://github.com/elastic/elastic-agent/issues/1789#issuecomment-1499998621.

## Author's Checklist

Since this PR is a follow up to https://github.com/elastic/elastic-agent/pull/2456, I did test with this PR that enrolling the Elastic Agent in Fleet and changing the log level there still works as expected.  In other words, I verified that the change in this PR will not cause a regression in the bug fixed by https://github.com/elastic/elastic-agent/pull/2456.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Install Agent in Standalone mode.
   ```
   sudo ./elastic-agent install
   ```

2. Get diagnostics bundle.
   ```
   sudo ./elastic-agent diagnostics
   ```
3. Look at the logs folder in the diagnostics bundle. It should contain at least one `.ndjson` log file but it is empty.
   ```
   unzip elastic-agent-diagnostics-*.zip -d diag
   ls -al diag/logs
   ```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #2470
- Follow up to https://github.com/elastic/elastic-agent/pull/2456
