### PR TITLE
`TestFQDNFeatureFlagToggle` unit test: Increase sleep to avoid flakiness

### DIFF
--- a/internal/pkg/composable/providers/host/host_test.go
+++ b/internal/pkg/composable/providers/host/host_test.go
@@ -125,7 +125,7 @@ func TestFQDNFeatureFlagToggle(t *testing.T) {
 
 	// Wait long enough for provider.Run to register
 	// the FQDN feature flag onChange callback.
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	// Trigger the FQDN feature flag callback by
 	// toggling the FQDN feature flag
@@ -136,7 +136,7 @@ func TestFQDNFeatureFlagToggle(t *testing.T) {
 
 	// Wait long enough for the FQDN feature flag onChange
 	// callback to be called.
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	// hostProvider.fetcher should be called twice:
 	// - once, right after the provider is run, and


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR doubles the sleep periods used in the `TestFQDNFeatureFlagToggle` unit test from `10ms` to `20ms`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The `TestFQDNFeatureFlagToggle` unit test failed in CI when it ran on https://github.com/elastic/elastic-agent/pull/2472 (a PR that contains an unrelated change to this test).  When CI was re-run on the same PR without any changes, the same unit test passed.  This indicates that the test might be flaky.

I suspect the flakiness comes from not waiting long enough at critical points in the test for asynchronous operations to "catch up".  So this PR here increases those waits.

