### PR TITLE
Use `require.Eventually` instead of `time.Sleep` in unit test

### DIFF
--- a/internal/pkg/composable/providers/host/host_test.go
+++ b/internal/pkg/composable/providers/host/host_test.go
@@ -124,7 +124,10 @@ func TestFQDNFeatureFlagToggle(t *testing.T) {
 
 	// Wait long enough for provider.Run to register
 	// the FQDN feature flag onChange callback.
-	time.Sleep(20 * time.Millisecond)
+	numCallbacks := features.NumFQDNOnChangeCallbacks()
+	require.Eventually(t, func() bool {
+		return features.NumFQDNOnChangeCallbacks() == numCallbacks+1
+	}, 100*time.Millisecond, 10*time.Millisecond)
 
 	// Trigger the FQDN feature flag callback by
 	// toggling the FQDN feature flag
@@ -133,14 +136,14 @@ func TestFQDNFeatureFlagToggle(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	// hostProvider.fetcher should be called twice:
-	// - once, right after the provider is run, and
-	// - once again, when the FQDN feature flag callback is triggered
 	// Wait long enough for the FQDN feature flag onChange
 	// callback to be called.
-	assert.Eventually(t,
-		func() bool { return numCalled == 2 },
-		time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		// hostProvider.fetcher should be called twice:
+		// - once, right after the provider is run, and
+		// - once again, when the FQDN feature flag callback is triggered
+		return numCalled == 2
+	}, 100*time.Millisecond, 10*time.Millisecond)
 }
 
 func returnHostMapping(log *logger.Logger) infoFetcher {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -81,6 +81,15 @@ func RemoveFQDNOnChangeCallback(id string) {
 	delete(current.fqdnCallbacks, id)
 }
 
+// NumFQDNOnChangeCallbacks returns the number of FQDN onChange
+// callbacks currently registered.  Useful for testing.
+func NumFQDNOnChangeCallbacks() int {
+	current.mu.RLock()
+	defer current.mu.RUnlock()
+
+	return len(current.fqdnCallbacks)
+}
+
 // setFQDN sets the value of the FQDN flag in Flags.
 func (f *Flags) setFQDN(newValue bool) {
 	f.mu.Lock()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR uses `require.Eventually` instead of `time.Sleep` in a unit test.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

It makes the test's timing less dependent on the speed of the system the test is being executed on, thus making the test less likely to be flaky.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Follow up to https://github.com/elastic/elastic-agent/pull/2473.