### PR TITLE
Fix TestManager_FakeShipper flakiness.

### DIFF
--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -2307,8 +2307,6 @@ func TestManager_FakeShipper(t *testing.T) {
 		5. Send `send_event` action to the component fake input (GRPC client); returns once sent.
 		6. Wait for `record_event` action to return from the shipper input (GRPC server).
 	*/
-	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/2301")
-
 	testPaths(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -2412,14 +2410,21 @@ func TestManager_FakeShipper(t *testing.T) {
 	defer subCancel()
 	subErrCh := make(chan error)
 	go func() {
-		shipperOn := false
+		shipperInputOn := false
+		shipperOutputOn := false
 		compConnected := false
+		eventSent := false
 
 		sendEvent := func() (bool, error) {
-			if !shipperOn || !compConnected {
+			if !shipperInputOn || !shipperOutputOn || !compConnected {
 				// wait until connected
 				return false, nil
 			}
+			if eventSent {
+				// other path already sent event
+				return false, nil
+			}
+			eventSent = true
 
 			// send an event between component and the fake shipper
 			eventID, err := uuid.NewV4()
@@ -2471,7 +2476,7 @@ func TestManager_FakeShipper(t *testing.T) {
 						if unit.State == client.UnitStateFailed {
 							subErrCh <- fmt.Errorf("unit failed: %s", unit.Message)
 						} else if unit.State == client.UnitStateHealthy {
-							shipperOn = true
+							shipperInputOn = true
 							ok, err := sendEvent()
 							if ok {
 								if err != nil {
@@ -2493,7 +2498,36 @@ func TestManager_FakeShipper(t *testing.T) {
 							subErrCh <- fmt.Errorf("unit reported unexpected state: %v", unit.State)
 						}
 					} else {
-						subErrCh <- errors.New("unit missing: fake-input")
+						subErrCh <- errors.New("input unit missing: fake-input")
+					}
+					unit, ok = state.Units[ComponentUnitKey{UnitType: client.UnitTypeOutput, UnitID: "fake-default"}]
+					if ok {
+						if unit.State == client.UnitStateFailed {
+							subErrCh <- fmt.Errorf("unit failed: %s", unit.Message)
+						} else if unit.State == client.UnitStateHealthy {
+							shipperOutputOn = true
+							ok, err := sendEvent()
+							if ok {
+								if err != nil {
+									subErrCh <- err
+								} else {
+									// successful; turn it all off
+									err := m.Update([]component.Component{})
+									if err != nil {
+										subErrCh <- err
+									}
+								}
+							}
+						} else if unit.State == client.UnitStateStopped {
+							subErrCh <- nil
+						} else if unit.State == client.UnitStateStarting {
+							// acceptable
+						} else {
+							// unknown state that should not have occurred
+							subErrCh <- fmt.Errorf("unit reported unexpected state: %v", unit.State)
+						}
+					} else {
+						subErrCh <- errors.New("output unit missing: fake-input")
 					}
 				}
 			case state := <-compSub.Ch():

--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -2498,7 +2498,7 @@ func TestManager_FakeShipper(t *testing.T) {
 							subErrCh <- fmt.Errorf("unit reported unexpected state: %v", unit.State)
 						}
 					} else {
-						subErrCh <- errors.New("input unit missing: fake-input")
+						subErrCh <- errors.New("input unit missing: fake-default")
 					}
 					unit, ok = state.Units[ComponentUnitKey{UnitType: client.UnitTypeOutput, UnitID: "fake-default"}]
 					if ok {
@@ -2527,7 +2527,7 @@ func TestManager_FakeShipper(t *testing.T) {
 							subErrCh <- fmt.Errorf("unit reported unexpected state: %v", unit.State)
 						}
 					} else {
-						subErrCh <- errors.New("output unit missing: fake-input")
+						subErrCh <- errors.New("output unit missing: fake-default")
 					}
 				}
 			case state := <-compSub.Ch():


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Removes skip on the `TestManager_FakeShipper` and fixes the flakiness of the test. The issue was the test didn't wait for the shippers input and output unit to be healthy before performing the sending of the event test.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Ensures that testing and configuration of a component and shipper works correctly.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [x] I have added an integration test or an E2E test

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #2301 

