### PR TITLE
Better callback registration/deregistration in host provider's lifecycle

### DIFF
--- a/internal/pkg/agent/application/application.go
+++ b/internal/pkg/agent/application/application.go
@@ -7,6 +7,8 @@ package application
 import (
 	"fmt"
 
+	"github.com/elastic/elastic-agent/pkg/features"
+
 	"go.elastic.co/apm"
 
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -24,7 +26,6 @@ import (
 	"github.com/elastic/elastic-agent/pkg/component"
 	"github.com/elastic/elastic-agent/pkg/component/runtime"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
-	"github.com/elastic/elastic-agent/pkg/features"
 )
 
 // New creates a new Agent and bootstrap the required subsystem.

--- a/internal/pkg/agent/application/application.go
+++ b/internal/pkg/agent/application/application.go
@@ -39,22 +39,22 @@ func New(
 	testingMode bool,
 	disableMonitoring bool,
 	modifiers ...component.PlatformModifier,
-) (*coordinator.Coordinator, coordinator.ConfigManager, error) {
+) (*coordinator.Coordinator, coordinator.ConfigManager, composable.Controller, error) {
 	platform, err := component.LoadPlatformDetail(modifiers...)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to gather system information: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to gather system information: %w", err)
 	}
 	log.Info("Gathered system information")
 
 	specs, err := component.LoadRuntimeSpecs(paths.Components(), platform)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to detect inputs and outputs: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to detect inputs and outputs: %w", err)
 	}
 	log.With("inputs", specs.Inputs()).Info("Detected available inputs and outputs")
 
 	caps, err := capabilities.Load(paths.AgentCapabilitiesPath(), log)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to determine capabilities: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to determine capabilities: %w", err)
 	}
 	log.Info("Determined allowed capabilities")
 
@@ -65,7 +65,7 @@ func New(
 		// testing mode doesn't read any configuration from the disk
 		rawConfig, err = config.NewConfigFrom("")
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to load configuration: %w", err)
+			return nil, nil, nil, fmt.Errorf("failed to load configuration: %w", err)
 		}
 
 		// monitoring is always disabled in testing mode
@@ -73,15 +73,15 @@ func New(
 	} else {
 		rawConfig, err = config.LoadFile(pathConfigFile)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to load configuration: %w", err)
+			return nil, nil, nil, fmt.Errorf("failed to load configuration: %w", err)
 		}
 	}
 	if err := info.InjectAgentConfig(rawConfig); err != nil {
-		return nil, nil, fmt.Errorf("failed to load configuration: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
 	cfg, err := configuration.NewFromConfig(rawConfig)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load configuration: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
 
 	// monitoring is not supported in bootstrap mode https://github.com/elastic/elastic-agent/issues/1761
@@ -99,7 +99,7 @@ func New(
 		cfg.Settings.GRPC,
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to initialize runtime manager: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to initialize runtime manager: %w", err)
 	}
 
 	var configMgr coordinator.ConfigManager
@@ -129,7 +129,7 @@ func New(
 		var store storage.Store
 		store, cfg, err = mergeFleetConfig(rawConfig)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		if configuration.IsFleetServerBootstrap(cfg.Fleet) {
@@ -148,7 +148,7 @@ func New(
 
 			managed, err = newManagedConfigManager(log, agentInfo, cfg, store, runtime)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			configMgr = managed
 		}
@@ -156,7 +156,7 @@ func New(
 
 	composable, err := composable.New(log, rawConfig, composableManaged)
 	if err != nil {
-		return nil, nil, errors.New(err, "failed to initialize composable controller")
+		return nil, nil, nil, errors.New(err, "failed to initialize composable controller")
 	}
 
 	coord := coordinator.New(log, logLevel, agentInfo, specs, reexec, upgrader, runtime, configMgr, composable, caps, monitor, isManaged, compModifiers...)
@@ -169,10 +169,10 @@ func New(
 	// It is important that feature flags from configuration are applied as late as possible.  This will ensure that
 	// any feature flag change callbacks are registered before they get called by `features.Apply`.
 	if err := features.Apply(rawConfig); err != nil {
-		return nil, nil, fmt.Errorf("could not parse and apply feature flags config: %w", err)
+		return nil, nil, nil, fmt.Errorf("could not parse and apply feature flags config: %w", err)
 	}
 
-	return coord, configMgr, nil
+	return coord, configMgr, composable, nil
 }
 
 func mergeFleetConfig(rawConfig *config.Config) (storage.Store, *configuration.Configuration, error) {

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -229,10 +229,11 @@ func run(override cfgOverrider, testingMode bool, modifiers ...component.Platfor
 		l.Info("APM instrumentation disabled")
 	}
 
-	coord, configMgr, err := application.New(l, baseLogger, logLvl, agentInfo, rex, tracer, testingMode, configuration.IsFleetServerBootstrap(cfg.Fleet), modifiers...)
+	coord, configMgr, composable, err := application.New(l, baseLogger, logLvl, agentInfo, rex, tracer, testingMode, configuration.IsFleetServerBootstrap(cfg.Fleet), modifiers...)
 	if err != nil {
 		return err
 	}
+	defer composable.Close()
 
 	serverStopFn, err := setupMetrics(l, cfg.Settings.DownloadConfig.OS(), cfg.Settings.MonitoringConfig, tracer, coord)
 	if err != nil {

--- a/internal/pkg/agent/vars/vars.go
+++ b/internal/pkg/agent/vars/vars.go
@@ -26,6 +26,7 @@ func WaitForVariables(ctx context.Context, l *logger.Logger, cfg *config.Config,
 	if err != nil {
 		return nil, fmt.Errorf("failed to create composable controller: %w", err)
 	}
+	defer composable.Close()
 
 	hasTimeout := false
 	if wait > time.Duration(0) {

--- a/internal/pkg/composable/controller.go
+++ b/internal/pkg/composable/controller.go
@@ -115,6 +115,9 @@ func (c *controller) Run(ctx context.Context) error {
 	var wg sync.WaitGroup
 	wg.Add(len(c.contextProviders) + len(c.dynamicProviders))
 
+	// This function will attempt to close a provider if that provider is
+	// closeable, i.e. implements the `CloseableProvider` interface.  It must
+	// be called after a provider has been run.
 	closeProvider := func(name string, provider any) {
 		defer wg.Done()
 

--- a/internal/pkg/composable/controller_test.go
+++ b/internal/pkg/composable/controller_test.go
@@ -191,6 +191,8 @@ func TestCancellation(t *testing.T) {
 		t.Run(fmt.Sprintf("test run %d", i), func(t *testing.T) {
 			c, err := composable.New(log, cfg, false)
 			require.NoError(t, err)
+			defer c.Close()
+
 			ctx, cancelFn := context.WithTimeout(context.Background(), timeout)
 			defer cancelFn()
 			err = c.Run(ctx)
@@ -205,6 +207,8 @@ func TestCancellation(t *testing.T) {
 	t.Run("immediate cancellation", func(t *testing.T) {
 		c, err := composable.New(log, cfg, false)
 		require.NoError(t, err)
+		defer c.Close()
+
 		ctx, cancelFn := context.WithTimeout(context.Background(), 0)
 		cancelFn()
 		err = c.Run(ctx)

--- a/internal/pkg/composable/providers/host/host.go
+++ b/internal/pkg/composable/providers/host/host.go
@@ -87,7 +87,10 @@ func (c *contextProvider) Run(comm corecomp.ContextProviderComm) error {
 
 func (c *contextProvider) onFQDNFeatureFlagChange(new, old bool) {
 	// FQDN feature flag was toggled, so notify on channel
-	c.fqdnFFChangeCh <- struct{}{}
+	select {
+	case c.fqdnFFChangeCh <- struct{}{}:
+	default:
+	}
 }
 
 func (c *contextProvider) Close() error {

--- a/internal/pkg/composable/providers/host/host.go
+++ b/internal/pkg/composable/providers/host/host.go
@@ -113,7 +113,7 @@ func ContextProviderBuilder(log *logger.Logger, c *config.Config, _ bool) (corec
 		p.CheckInterval = DefaultCheckInterval
 	}
 
-	p.fqdnFFChangeCh = make(chan struct{})
+	p.fqdnFFChangeCh = make(chan struct{}, 1)
 	err := features.AddFQDNOnChangeCallback(
 		p.onFQDNFeatureFlagChange,
 		fqdnFeatureFlagCallbackID,

--- a/internal/pkg/composable/providers/host/host.go
+++ b/internal/pkg/composable/providers/host/host.go
@@ -20,8 +20,12 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
-// DefaultCheckInterval is the default timeout used to check if any host information has changed.
-const DefaultCheckInterval = 5 * time.Minute
+const (
+	// DefaultCheckInterval is the default timeout used to check if any host information has changed.
+	DefaultCheckInterval = 5 * time.Minute
+
+	fqdnFeatureFlagCallbackID = "host_provider"
+)
 
 func init() {
 	composable.Providers.MustAddContextProvider("host", ContextProviderBuilder)
@@ -33,6 +37,10 @@ type contextProvider struct {
 	logger *logger.Logger
 
 	CheckInterval time.Duration `config:"check_interval"`
+
+	// fqdnFFChangeCh is used to signal when the FQDN
+	// feature flag has changed
+	fqdnFFChangeCh chan struct{}
 
 	// used by testing
 	fetcher infoFetcher
@@ -49,21 +57,6 @@ func (c *contextProvider) Run(comm corecomp.ContextProviderComm) error {
 		return errors.New(err, "failed to set mapping", errors.TypeUnexpected)
 	}
 
-	const fqdnFeatureFlagCallbackID = "host_provider"
-	fqdnFFChangeCh := make(chan struct{})
-	err = features.AddFQDNOnChangeCallback(
-		onFQDNFeatureFlagChange(fqdnFFChangeCh),
-		fqdnFeatureFlagCallbackID,
-	)
-	if err != nil {
-		return fmt.Errorf("unable to add FQDN onChange callback in host provider: %w", err)
-	}
-
-	defer func() {
-		features.RemoveFQDNOnChangeCallback(fqdnFeatureFlagCallbackID)
-		close(fqdnFFChangeCh)
-	}()
-
 	// Update context when any host information changes.
 	for {
 		t := time.NewTimer(c.CheckInterval)
@@ -71,7 +64,7 @@ func (c *contextProvider) Run(comm corecomp.ContextProviderComm) error {
 		case <-comm.Done():
 			t.Stop()
 			return comm.Err()
-		case <-fqdnFFChangeCh:
+		case <-c.fqdnFFChangeCh:
 		case <-t.C:
 		}
 
@@ -92,11 +85,16 @@ func (c *contextProvider) Run(comm corecomp.ContextProviderComm) error {
 	}
 }
 
-func onFQDNFeatureFlagChange(fqdnFFChangeCh chan struct{}) features.BoolValueOnChangeCallback {
-	return func(new, old bool) {
-		// FQDN feature flag was toggled, so notify on channel
-		fqdnFFChangeCh <- struct{}{}
-	}
+func (c *contextProvider) onFQDNFeatureFlagChange(new, old bool) {
+	// FQDN feature flag was toggled, so notify on channel
+	c.fqdnFFChangeCh <- struct{}{}
+}
+
+func (c *contextProvider) Close() error {
+	features.RemoveFQDNOnChangeCallback(fqdnFeatureFlagCallbackID)
+	close(c.fqdnFFChangeCh)
+
+	return nil
 }
 
 // ContextProviderBuilder builds the context provider.
@@ -114,6 +112,16 @@ func ContextProviderBuilder(log *logger.Logger, c *config.Config, _ bool) (corec
 	if p.CheckInterval <= 0 {
 		p.CheckInterval = DefaultCheckInterval
 	}
+
+	p.fqdnFFChangeCh = make(chan struct{})
+	err := features.AddFQDNOnChangeCallback(
+		p.onFQDNFeatureFlagChange,
+		fqdnFeatureFlagCallbackID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to add FQDN onChange callback in host provider: %w", err)
+	}
+
 	return p, nil
 }
 

--- a/internal/pkg/core/composable/providers.go
+++ b/internal/pkg/core/composable/providers.go
@@ -28,3 +28,11 @@ type ContextProvider interface {
 	// Run runs the context provider.
 	Run(ContextProviderComm) error
 }
+
+// CloseableProvider is an interface that providers may choose to implement
+// if it makes sense for them, e.g. if they have any resources that need
+// cleaning up after the provider's (final) run.
+type CloseableProvider interface {
+	// Close is called after all runs of the provider have finished.
+	Close() error
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -81,15 +81,6 @@ func RemoveFQDNOnChangeCallback(id string) {
 	delete(current.fqdnCallbacks, id)
 }
 
-// NumFQDNOnChangeCallbacks returns the number of FQDN onChange
-// callbacks currently registered.  Useful for testing.
-func NumFQDNOnChangeCallbacks() int {
-	current.mu.RLock()
-	defer current.mu.RUnlock()
-
-	return len(current.fqdnCallbacks)
-}
-
 // setFQDN sets the value of the FQDN flag in Flags.
 func (f *Flags) setFQDN(newValue bool) {
 	f.mu.Lock()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR makes the following changes to the host provider:
* It moves the registration of the FQDN feature flag change callback function to the host provider's constructor.  
* It introduces a new `CloseableProvider` interface and updates the host provider to use this new interface. Specifically, the `Close()` method on the host provider is used to deregister the FQDN feature flag change callback.

It also changes when the feature flags from a standalone configuration are applied - at the very end of the Agent's construction process (`application.New()`).

## Why is it important?

Prior to this PR, callback registration (and deregistration) were happening inside the host provider's `Run()` method.  This introduced a race condition between when the FQDN feature flag change callback registration happened and when the same callback might be called due to a change in the FQDN feature flag:
* When the timing is just right,  the host provider would've registered the callback prior to a change in the FQDN feature flag, and thus the host provider would get notified of the change correctly.
* When the timing is just wrong, a change in the FQDN feature flag would happen prior to the host provider registering the callack, and thus the host provider would miss the notification of the change.

By moving the callback registration to the host provider's constructor (and, less relevantly but symmetrically, the callback deregistration to the host provider's new `Close()` method), we now ensure that the callback will be registered when the provider is constructed.  Providers are constructed in the controller's constructor, which is now called before feature flags from standalone configuration or fleet-managed configuration are applied and any callbacks are called.

A secondary benefit of these changes is that the `host.TestFQDNFeatureFlagToggle` unit test is now no longer flaky. 
 It was the flakiness that pointed to the race condition in the implementation prior to this PR.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

To check that the `host.TestFQDNFeatureFlagToggle` unit test is no longer flaky, run it a 1000 times:

```
time go test github.com/elastic/elastic-agent/internal/pkg/composable/providers/host -test.run ^TestFQDNFeatureFlagToggle$ -test.count 1000
ok  	github.com/elastic/elastic-agent/internal/pkg/composable/providers/host	103.303s
go test  -test.run ^TestFQDNFeatureFlagToggle$ -test.count 1000  3.39s user 1.89s system 5% cpu 1:44.45 total
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Follow up to #2473 
- Follow up to #2480

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
