### PR TITLE
Fix install on Mac OS to ensure that the /usr/local/bin exists

### DIFF
--- a/changelog/fragments/1681311024-Ensure-local-bin-directory-exists-on-Mac-OS-during-installation..yaml
+++ b/changelog/fragments/1681311024-Ensure-local-bin-directory-exists-on-Mac-OS-during-installation..yaml
@@ -1,0 +1,34 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Ensure local bin directory exists on Mac OS during installation.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  During installation of the Elatic Agent on Mac OS ensure that the /usr/local/bin path exists before
+  creating the /usr/local/bin/elastic-agent symlink.
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/2490
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1681311024-Ensure-local-bin-directory-exists-on-Mac-OS-during-installation..yaml
+++ b/changelog/fragments/1681311024-Ensure-local-bin-directory-exists-on-Mac-OS-during-installation..yaml
@@ -8,7 +8,7 @@
 # - security: impacts on the security of a product or a user’s deployment.
 # - upgrade: important information for someone upgrading from a prior version
 # - other: does not fit into any of the other categories
-kind: feature
+kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
 summary: Ensure local bin directory exists on Mac OS during installation.

--- a/internal/pkg/agent/install/install.go
+++ b/internal/pkg/agent/install/install.go
@@ -70,7 +70,10 @@ func Install(cfgFile string) error {
 						errors.M("destination", paths.ShellWrapperPath))
 				}
 			}
-			err = os.Symlink("/Library/Elastic/Agent/elastic-agent", paths.ShellWrapperPath)
+			err = os.MkdirAll(filepath.Dir(paths.ShellWrapperPath), 0755)
+			if err == nil {
+				err = os.Symlink("/Library/Elastic/Agent/elastic-agent", paths.ShellWrapperPath)
+			}
 			if err != nil {
 				return errors.New(
 					err,

--- a/internal/pkg/agent/install/install.go
+++ b/internal/pkg/agent/install/install.go
@@ -56,6 +56,14 @@ func Install(cfgFile string) error {
 
 	// place shell wrapper, if present on platform
 	if paths.ShellWrapperPath != "" {
+		pathDir := filepath.Dir(paths.ShellWrapperPath)
+		err = os.MkdirAll(pathDir, 0755)
+		if err != nil {
+			return errors.New(
+				err,
+				fmt.Sprintf("failed to create directory (%s) for shell wrapper (%s)", pathDir, paths.ShellWrapperPath),
+				errors.M("directory", pathDir))
+		}
 		// Install symlink for darwin instead of the wrapper script.
 		// Elastic-agent should be first process that launchd starts in order to be able to grant
 		// the Full-Disk Access (FDA) to the agent and it's child processes.
@@ -70,10 +78,7 @@ func Install(cfgFile string) error {
 						errors.M("destination", paths.ShellWrapperPath))
 				}
 			}
-			err = os.MkdirAll(filepath.Dir(paths.ShellWrapperPath), 0755)
-			if err == nil {
-				err = os.Symlink("/Library/Elastic/Agent/elastic-agent", paths.ShellWrapperPath)
-			}
+			err = os.Symlink("/Library/Elastic/Agent/elastic-agent", paths.ShellWrapperPath)
 			if err != nil {
 				return errors.New(
 					err,
@@ -81,11 +86,8 @@ func Install(cfgFile string) error {
 					errors.M("destination", paths.ShellWrapperPath))
 			}
 		} else {
-			err = os.MkdirAll(filepath.Dir(paths.ShellWrapperPath), 0755)
-			if err == nil {
-				//nolint: gosec // this is intended to be an executable shell script, not chaning the permissions for the linter
-				err = os.WriteFile(paths.ShellWrapperPath, []byte(paths.ShellWrapper), 0755)
-			}
+			//nolint: gosec // this is intended to be an executable shell script, not changing the permissions for the linter
+			err = os.WriteFile(paths.ShellWrapperPath, []byte(paths.ShellWrapper), 0755)
 			if err != nil {
 				return errors.New(
 					err,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Ensures that the `/usr/local/bin` directory exists on Mac OS before it places the `/usr/local/bin/elastic-agent` symlink.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

On a fresh installation of Mac OS the `/usr/local/bin` doesn't exist causing the `install` subcommand to fail to complete installation.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #2487
