### PR TITLE
Removing unused field from subscription structs

### DIFF
--- a/internal/pkg/agent/application/coordinator/diagnostics_test.go
+++ b/internal/pkg/agent/application/coordinator/diagnostics_test.go
@@ -218,7 +218,7 @@ func TestCoordinatorDiagnosticHooks(t *testing.T) {
 
 			ctx, cancelFunc := context.WithCancel(context.Background())
 			componentsUpdateChannel := make(chan runtime.ComponentComponentState)
-			subscriptionAll := runtime.NewSubscriptionAllWithChannel(ctx, nil, componentsUpdateChannel)
+			subscriptionAll := runtime.NewSubscriptionAllWithChannel(ctx, componentsUpdateChannel)
 			helper.runtimeManager.EXPECT().SubscribeAll(mock.Anything).Return(subscriptionAll)
 			helper.runtimeManager.EXPECT().Update(mock.AnythingOfType("[]component.Component")).Return(nil)
 

--- a/pkg/component/runtime/manager.go
+++ b/pkg/component/runtime/manager.go
@@ -454,7 +454,7 @@ func (m *Manager) PerformDiagnostics(ctx context.Context, req ...ComponentUnitDi
 //
 // Note: Not reading from a subscription channel will cause the Manager to block.
 func (m *Manager) Subscribe(ctx context.Context, componentID string) *Subscription {
-	sub := newSubscription(ctx, m)
+	sub := newSubscription(ctx)
 
 	// add latestState to channel
 	m.mx.RLock()
@@ -503,7 +503,7 @@ func (m *Manager) Subscribe(ctx context.Context, componentID string) *Subscripti
 //
 // Note: Not reading from a subscription channel will cause the Manager to block.
 func (m *Manager) SubscribeAll(ctx context.Context) *SubscriptionAll {
-	sub := newSubscriptionAll(ctx, m)
+	sub := newSubscriptionAll(ctx)
 
 	// add the latest states
 	m.mx.RLock()

--- a/pkg/component/runtime/subscription.go
+++ b/pkg/component/runtime/subscription.go
@@ -10,16 +10,14 @@ import (
 
 // Subscription provides a channel for notifications on a component state.
 type Subscription struct {
-	ctx     context.Context
-	manager *Manager
-	ch      chan ComponentState
+	ctx context.Context
+	ch  chan ComponentState
 }
 
-func newSubscription(ctx context.Context, manager *Manager) *Subscription {
+func newSubscription(ctx context.Context) *Subscription {
 	return &Subscription{
-		ctx:     ctx,
-		manager: manager,
-		ch:      make(chan ComponentState),
+		ctx: ctx,
+		ch:  make(chan ComponentState),
 	}
 }
 
@@ -30,26 +28,23 @@ func (s *Subscription) Ch() <-chan ComponentState {
 
 // SubscriptionAll provides a channel for notifications on all component state changes.
 type SubscriptionAll struct {
-	ctx     context.Context
-	manager *Manager
-	ch      chan ComponentComponentState
+	ctx context.Context
+	ch  chan ComponentComponentState
 }
 
-func newSubscriptionAll(ctx context.Context, manager *Manager) *SubscriptionAll {
+func newSubscriptionAll(ctx context.Context) *SubscriptionAll {
 	return &SubscriptionAll{
-		ctx:     ctx,
-		manager: manager,
-		ch:      make(chan ComponentComponentState),
+		ctx: ctx,
+		ch:  make(chan ComponentComponentState),
 	}
 }
 
 // NewSubscriptionAllWithChannel creates a SubscriptionAll using an existing channel
 // For Test purposes ONLY.
-func NewSubscriptionAllWithChannel(ctx context.Context, manager *Manager, evtChan chan ComponentComponentState) *SubscriptionAll {
+func NewSubscriptionAllWithChannel(ctx context.Context, evtChan chan ComponentComponentState) *SubscriptionAll {
 	return &SubscriptionAll{
-		ctx:     ctx,
-		manager: manager,
-		ch:      evtChan,
+		ctx: ctx,
+		ch:  evtChan,
 	}
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR removes the `manager` field from the `runtime.Subscription` and `runtime.SubscriptionAll` structs.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

The field is no longer being used.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
