### PR TITLE
Cleanup in preparation for #2500

### DIFF
--- a/internal/pkg/agent/application/upgrade/service.go
+++ b/internal/pkg/agent/application/upgrade/service.go
@@ -136,7 +136,8 @@ func (p *sysvPidProvider) PID(ctx context.Context) (int, error) {
 		return 0, errors.New(fmt.Sprintf("'%v' is not running", paths.ServiceName))
 	}
 
-	pidofLine, err := exec.Command("pidof", filepath.Join(paths.InstallPath, paths.BinaryName)).Output()
+	cmdArgs := filepath.Join(paths.InstallPath, paths.BinaryName)
+	pidofLine, err := exec.Command("pidof", cmdArgs).Output()
 	if err != nil {
 		return 0, errors.New(fmt.Sprintf("PID not found for'%v': %v", paths.ServiceName, err))
 	}

--- a/internal/pkg/agent/application/upgrade/service.go
+++ b/internal/pkg/agent/application/upgrade/service.go
@@ -43,7 +43,9 @@ type pidProvider interface {
 // Init initializes os dependent properties.
 func (ch *CrashChecker) Init(ctx context.Context, _ *logger.Logger) error {
 	pp := relevantPidProvider()
-	pp.Init()
+	if err := pp.Init(); err != nil {
+		return fmt.Errorf("unable to initialize relevant PID provider: %w", err)
+	}
 
 	ch.sc = pp
 

--- a/internal/pkg/agent/application/upgrade/service.go
+++ b/internal/pkg/agent/application/upgrade/service.go
@@ -178,7 +178,7 @@ func (p *dbusPidProvider) PID(ctx context.Context) (int, error) {
 		sn += ".service"
 	}
 
-	prop, err := p.dbusConn.GetServiceProperty(sn, "MainPID")
+	prop, err := p.dbusConn.GetServicePropertyContext(ctx, sn, "MainPID")
 	if err != nil {
 		return 0, errors.New("failed to read service", err)
 	}

--- a/internal/pkg/agent/application/upgrade/service.go
+++ b/internal/pkg/agent/application/upgrade/service.go
@@ -240,7 +240,9 @@ func isSystemd() bool {
 		defer filerc.Close()
 
 		buf := new(bytes.Buffer)
-		buf.ReadFrom(filerc)
+		if _, err := buf.ReadFrom(filerc); err != nil {
+			return false
+		}
 		contents := buf.String()
 
 		if strings.Trim(contents, " \r\n") == "systemd" {

--- a/internal/pkg/agent/application/upgrade/service.go
+++ b/internal/pkg/agent/application/upgrade/service.go
@@ -157,7 +157,7 @@ type dbusPidProvider struct {
 }
 
 func (p *dbusPidProvider) Init() error {
-	dbusConn, err := dbus.New()
+	dbusConn, err := dbus.NewWithContext(context.Background())
 	if err != nil {
 		return errors.New("failed to create dbus connection", err)
 	}

--- a/internal/pkg/agent/install/install_unix.go
+++ b/internal/pkg/agent/install/install_unix.go
@@ -26,6 +26,8 @@ func checkPackageInstall() bool {
 		return false
 	}
 
+	binaryName := paths.BinaryName
+
 	// NOTE searching for english words might not be a great idea as far as portability goes.
 	// list all installed packages then search for paths.BinaryName?
 	// dpkg is strange as the remove and purge processes leads to the package bing isted after a remove, but not after a purge
@@ -35,7 +37,7 @@ func checkPackageInstall() bool {
 	// If the package has been removed (but not pruged) status starts with "deinstall"
 	// If purged or never installed, rc is 1
 	if _, err := exec.Command("which", "dpkg-query").Output(); err == nil {
-		out, err := exec.Command("dpkg-query", "-W", "-f", "${Status}", paths.BinaryName).Output()
+		out, err := exec.Command("dpkg-query", "-W", "-f", "${Status}", binaryName).Output()
 		if err != nil {
 			return false
 		}
@@ -49,7 +51,7 @@ func checkPackageInstall() bool {
 	// if package has been installed the query will returns the list of associated files.
 	// otherwise if uninstalled, or has never been installled status ends with "not installed"
 	if _, err := exec.Command("which", "rpm").Output(); err == nil {
-		out, err := exec.Command("rpm", "-q", paths.BinaryName, "--state").Output()
+		out, err := exec.Command("rpm", "-q", binaryName, "--state").Output()
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR performs a bunch of cleanup, as suggested by golangci-lint.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

When https://github.com/elastic/elastic-agent/pull/2500 was created, the `golangci-lint` linter made several suggestions in files touched by the PR, but not on lines related to the changes in that PR.  This created unnecessary noise in the PR.  To reduce that noise, I've extracted the changes to address those linter suggestions into this separate PR here.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~

