### PR TITLE
specs/filebeat.spec.yml - Re-add lumberjack input

### DIFF
--- a/changelog/fragments/1681842199-re-add-lumberjack-input-spec.yaml
+++ b/changelog/fragments/1681842199-re-add-lumberjack-input-spec.yaml
@@ -1,0 +1,4 @@
+kind: bug-fix
+summary: Re-add lumberjack input to the Filebeat spec.
+component: spec
+pr: https://github.com/elastic/elastic-agent/pull/2511

--- a/specs/filebeat.spec.yml
+++ b/specs/filebeat.spec.yml
@@ -140,6 +140,12 @@ inputs:
     outputs: *outputs
     shippers: *shippers
     command: *command
+  - name: lumberjack
+    description: "Lumberjack"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command: *command
   - name: mqtt
     description: "MQTT"
     platforms: *platforms


### PR DESCRIPTION
## What does this PR do?

Between v8.5.3 and v8.6.0 the lumberjack input was lost from the filebeat spec file.

From v8.5.3:
https://github.com/elastic/elastic-agent/blob/c0367b97a255484c3414995f32cefe6de3a12f17/internal/spec/filebeat.yml#L49

## Why is it important?

The barracuda_cloudgen_firewall integration depends on this input type.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Related issues

- Relates https://github.com/elastic/integrations/issues/5912

## Logs

From v8.6.0 when running https://docs.elastic.co/integrations/barracuda_cloudgen_firewall.
```
{
  "@timestamp": "2023-04-18T17:03:46.412Z",
  "component": {
    "id": "lumberjack-default",
    "state": "FAILED"
  },
  "ecs.version": "1.6.0",
  "log.level": "error",
  "log.origin": {
    "file.line": 833,
    "file.name": "coordinator/coordinator.go"
  },
  "message": "Spawned new unit lumberjack-default: input not supported",
  "unit": {
    "id": "lumberjack-default",
    "state": "FAILED",
    "type": "output"
  }
}
```
