### PR TITLE
internal/pkg/diagnostics - Fix creation of sub-directories in logs/

### DIFF
--- a/changelog/fragments/1681942680-fix-diag-zip-file.yaml
+++ b/changelog/fragments/1681942680-fix-diag-zip-file.yaml
@@ -1,0 +1,4 @@
+kind: bug-fix
+summary: Fix diagnostic zip file handling of sub-directories in logs/.
+component: diagnostics
+pr: https://github.com/elastic/elastic-agent/pull/2523

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -348,7 +348,7 @@ func zipLogsWithPath(pathsHome, commitName string, collectServices bool, zw *zip
 
 		if d.IsDir() {
 			_, err := zw.CreateHeader(&zip.FileHeader{
-				Name:     "logs/" + name + "/",
+				Name:     "logs/" + filepath.ToSlash(name) + "/",
 				Method:   zip.Deflate,
 				Modified: ts,
 			})
@@ -416,7 +416,7 @@ func saveLogs(name string, logPath string, zw *zip.Writer) error {
 		ts = li.ModTime()
 	}
 	zf, err := zw.CreateHeader(&zip.FileHeader{
-		Name:     "logs/" + name,
+		Name:     "logs/" + filepath.ToSlash(name),
 		Method:   zip.Deflate,
 		Modified: ts,
 	})

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -305,7 +305,7 @@ func zipLogs(zw *zip.Writer, ts time.Time) error {
 
 		if d.IsDir() {
 			_, err := zw.CreateHeader(&zip.FileHeader{
-				Name:     "logs" + name + "/",
+				Name:     "logs/" + name + "/",
 				Method:   zip.Deflate,
 				Modified: ts,
 			})

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -318,6 +318,15 @@ func zipLogsWithPath(pathsHome, commitName string, collectServices bool, zw *zip
 		}
 	}
 
+	_, err = zw.CreateHeader(&zip.FileHeader{
+		Name:     "logs/" + commitName + "/",
+		Method:   zip.Deflate,
+		Modified: ts,
+	})
+	if err != nil {
+		return err
+	}
+
 	// using Data() + "/logs", for some reason default paths/Logs() is the home dir...
 	logPath := filepath.Join(pathsHome, "logs") + string(filepath.Separator)
 	return filepath.WalkDir(logPath, func(path string, d fs.DirEntry, fErr error) error {

--- a/internal/pkg/diagnostics/dianostics_test.go
+++ b/internal/pkg/diagnostics/dianostics_test.go
@@ -49,6 +49,7 @@ func TestZipLogs(t *testing.T) {
 	// Verify the results.
 	expected := []zippedItem{
 		{"logs/", true},
+		{"logs/elastic-agent-unknow/", true},
 		{"logs/elastic-agent-unknow/sub-dir/", true},
 		{"logs/elastic-agent-unknow/sub-dir/log.ndjson", false},
 	}

--- a/internal/pkg/diagnostics/dianostics_test.go
+++ b/internal/pkg/diagnostics/dianostics_test.go
@@ -49,8 +49,8 @@ func TestZipLogs(t *testing.T) {
 	// Verify the results.
 	expected := []zippedItem{
 		{"logs/", true},
-		{"logs/sub-dir/", true},
-		{"logs/sub-dir/log.ndjson", false},
+		{"logs/elastic-agent-unknow/sub-dir/", true},
+		{"logs/elastic-agent-unknow/sub-dir/log.ndjson", false},
 	}
 	assert.Equal(t, expected, observed)
 }

--- a/internal/pkg/diagnostics/dianostics_test.go
+++ b/internal/pkg/diagnostics/dianostics_test.go
@@ -1,0 +1,56 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package diagnostics
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+)
+
+func TestZipLogs(t *testing.T) {
+	// Setup a directory structure of: logs/httpjson/log.ndjson
+	{
+		paths.SetTop(t.TempDir())
+		dir := filepath.Join(paths.Home(), "logs/sub-dir")
+		require.NoError(t, os.MkdirAll(dir, 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "log.ndjson"), []byte(".\n"), 0o600))
+	}
+
+	// Zip the logs directory.
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+	require.NoError(t, zipLogs(w, time.Now()))
+	require.NoError(t, w.Close())
+
+	type zippedItem struct {
+		Name  string
+		IsDir bool
+	}
+
+	// Read back the contents.
+	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+	var observed []zippedItem
+	for _, f := range r.File {
+		observed = append(observed, zippedItem{Name: f.Name, IsDir: f.FileInfo().IsDir()})
+	}
+
+	// Verify the results.
+	expected := []zippedItem{
+		{"logs/", true},
+		{"logs/sub-dir/", true},
+		{"logs/sub-dir/log.ndjson", false},
+	}
+	assert.Equal(t, expected, observed)
+}


### PR DESCRIPTION
## What does this PR do?

Prior to this change sub-directories within `logs/` were not created properly and resulted in unexpected directories within diagnostics files. A path separator was missing. Before the change the new test was failing with

    -  Name: (string) (len=13) "logs/sub-dir/",
    +  Name: (string) (len=12) "logssub-dir/",

## Why is it important?

It makes the diag zip file layout match what's on the agent host filesystem. The diag file should be correct to be trustworthy.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

