### PR TITLE
Update cloud defend args to run as tested in `https://github.com/elastic/elastic-agent/cloud-defend`

### DIFF
--- a/specs/cloud-defend.spec.yml
+++ b/specs/cloud-defend.spec.yml
@@ -12,9 +12,8 @@ inputs:
     runtime:
       preventions:
         - condition: ${runtime.user.root} == false
-          message: "Elastic agent must be running as root"
-    command:
-      args: &args
-        - "run"
+          message: "Elastic Agent must be running as root"
+    command: &args
+      args:
         - "--fleet-managed"
         - "--process-managed"


### PR DESCRIPTION

## What does this PR do?

This PR updates the args being passed to the `cloud-defend` binary on startup. 

## Why is it important?
The `run` argument was acting as a terminator. This meant that the `fleet-managed` parameter was not being parsed. 

