### PR TITLE
Increase timeout, add config for timeout in fleet setup

### DIFF
--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -72,6 +72,7 @@ The following actions are possible and grouped based on the actions.
   FLEET_ENROLLMENT_TOKEN - token to use for enrollment. This is not needed in case FLEET_SERVER_ENABLED and FLEET_ENROLL is set. Then the token is fetched from Kibana.
   FLEET_CA - path to certificate authority to use with communicate with Fleet Server [$KIBANA_CA]
   FLEET_INSECURE - communicate with Fleet with either insecure HTTP or unverified HTTPS
+  FLEET_TIMEOUT - Sets the initial timeout when starting up the fleet server under agent. Default: 30s.
 
   The following vars are need in the scenario that Elastic Agent should automatically fetch its own token.
 

--- a/internal/pkg/agent/configuration/fleet_server.go
+++ b/internal/pkg/agent/configuration/fleet_server.go
@@ -15,7 +15,7 @@ import (
 // FleetServerConfig is the configuration written so Elastic Agent can run Fleet Server.
 type FleetServerConfig struct {
 	Bootstrap    bool                     `config:"bootstrap" yaml:"bootstrap,omitempty"`
-	InitTimeout  *time.Duration           `config:"init_timeout" yaml:"init_timeout"`
+	InitTimeout  *time.Duration           `config:"fleet_timeout" yaml:"fleet_timeout"`
 	Policy       *FleetServerPolicyConfig `config:"policy" yaml:"policy,omitempty"`
 	Output       FleetServerOutputConfig  `config:"output" yaml:"output,omitempty"`
 	Host         string                   `config:"host" yaml:"host,omitempty"`

--- a/internal/pkg/agent/configuration/fleet_server.go
+++ b/internal/pkg/agent/configuration/fleet_server.go
@@ -6,6 +6,7 @@ package configuration
 
 import (
 	"net/url"
+	"time"
 
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
@@ -14,6 +15,7 @@ import (
 // FleetServerConfig is the configuration written so Elastic Agent can run Fleet Server.
 type FleetServerConfig struct {
 	Bootstrap    bool                     `config:"bootstrap" yaml:"bootstrap,omitempty"`
+	InitTimeout  *time.Duration           `config:"init_timeout" yaml:"init_timeout"`
 	Policy       *FleetServerPolicyConfig `config:"policy" yaml:"policy,omitempty"`
 	Output       FleetServerOutputConfig  `config:"output" yaml:"output,omitempty"`
 	Host         string                   `config:"host" yaml:"host,omitempty"`


### PR DESCRIPTION
## What does this PR do?

Meant to help address https://github.com/elastic/elastic-agent/issues/2440

This does a few things: 
- Increase the default timeout when elastic-agent is waiting for fleet to start to 30s
- Add a `fleet_timeout` config variable under the fleet server config
- Add a `FLEET_TIMEOUT` environment variable for the same

This is a bit of a pain to reproduce and test. This timeout will only happen in cases where elastic-agent starts its own fleet server, and within that, there needs to be a condition that causes fleet setup to take longer than 15 seconds. In addition, it seems like we only reach this codepath during initial startup, before we have an encrypted .enc config. Right now I've just tested to make sure the timeout logic works, if anyone has an example of how to get elastic-agent to start up a test fleet-server instance, tell me.

Also not sure if there's anywhere we should add documentation for this.

## Why is it important?

There's been a few issues with the default value timing out under k8s, presumably due to resource limit issues.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

