### PR TITLE
Update arguments in cloud_defend spec file

### DIFF
--- a/specs/cloud-defend.spec.yml
+++ b/specs/cloud-defend.spec.yml
@@ -15,5 +15,4 @@ inputs:
           message: "Elastic Agent must be running as root"
     command: &args
       args:
-        - "--fleet-managed"
-        - "--process-managed"
+        - "--agent-managed"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Updates the arguments passed to the `cloud_defend` binary. The `--fleet-managed` and `--process-managed` arguments were recently replaced with `--agent-managed`, causing cloud_defend to error-out on startup when launched by agent.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Cloud defend will not work at all without this change.