### PR TITLE
Cleanup: Remove `// +build` lines

### DIFF
--- a/dev-tools/mage/keychain_test.go
+++ b/dev-tools/mage/keychain_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build darwin
-// +build darwin
 
 package mage
 

--- a/internal/pkg/agent/application/info/svc_unix.go
+++ b/internal/pkg/agent/application/info/svc_unix.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package info
 

--- a/internal/pkg/agent/application/info/svc_windows.go
+++ b/internal/pkg/agent/application/info/svc_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package info
 

--- a/internal/pkg/agent/application/paths/paths.go
+++ b/internal/pkg/agent/application/paths/paths.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !darwin && !windows
-// +build !darwin,!windows
 
 package paths
 

--- a/internal/pkg/agent/application/paths/paths_darwin.go
+++ b/internal/pkg/agent/application/paths/paths_darwin.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build darwin
-// +build darwin
 
 package paths
 

--- a/internal/pkg/agent/application/paths/paths_linux.go
+++ b/internal/pkg/agent/application/paths/paths_linux.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build linux
-// +build linux
 
 package paths
 

--- a/internal/pkg/agent/application/paths/paths_windows.go
+++ b/internal/pkg/agent/application/paths/paths_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package paths
 

--- a/internal/pkg/agent/application/reexec/reexec.go
+++ b/internal/pkg/agent/application/reexec/reexec.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package reexec
 

--- a/internal/pkg/agent/application/reexec/reexec_windows.go
+++ b/internal/pkg/agent/application/reexec/reexec_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package reexec
 

--- a/internal/pkg/agent/application/secret/secret_test.go
+++ b/internal/pkg/agent/application/secret/secret_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build linux || windows
-// +build linux windows
 
 package secret
 

--- a/internal/pkg/agent/application/upgrade/service.go
+++ b/internal/pkg/agent/application/upgrade/service.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !darwin && !windows
-// +build !darwin,!windows
 
 package upgrade
 

--- a/internal/pkg/agent/application/upgrade/service_darwin.go
+++ b/internal/pkg/agent/application/upgrade/service_darwin.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build darwin
-// +build darwin
 
 package upgrade
 

--- a/internal/pkg/agent/application/upgrade/service_windows.go
+++ b/internal/pkg/agent/application/upgrade/service_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package upgrade
 

--- a/internal/pkg/agent/cmd/install_test.go
+++ b/internal/pkg/agent/cmd/install_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package cmd
 

--- a/internal/pkg/agent/cmd/install_windows_test.go
+++ b/internal/pkg/agent/cmd/install_windows_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package cmd
 

--- a/internal/pkg/agent/cmd/platformcheck.go
+++ b/internal/pkg/agent/cmd/platformcheck.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build linux || windows
-// +build linux windows
 
 package cmd
 

--- a/internal/pkg/agent/cmd/platformcheck_other.go
+++ b/internal/pkg/agent/cmd/platformcheck_other.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !linux && !windows
-// +build !linux,!windows
 
 package cmd
 

--- a/internal/pkg/agent/cmd/reexec.go
+++ b/internal/pkg/agent/cmd/reexec.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package cmd
 

--- a/internal/pkg/agent/cmd/reexec_windows.go
+++ b/internal/pkg/agent/cmd/reexec_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package cmd
 

--- a/internal/pkg/agent/install/install_unix.go
+++ b/internal/pkg/agent/install/install_unix.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package install
 

--- a/internal/pkg/agent/install/install_windows.go
+++ b/internal/pkg/agent/install/install_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package install
 

--- a/internal/pkg/agent/install/perms_unix.go
+++ b/internal/pkg/agent/install/perms_unix.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package install
 

--- a/internal/pkg/agent/install/perms_windows.go
+++ b/internal/pkg/agent/install/perms_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package install
 

--- a/internal/pkg/agent/migration/migrate_config_test.go
+++ b/internal/pkg/agent/migration/migrate_config_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build linux || windows
-// +build linux windows
 
 package migration
 

--- a/internal/pkg/agent/migration/migrate_secret_test.go
+++ b/internal/pkg/agent/migration/migrate_secret_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build linux || windows
-// +build linux windows
 
 package migration
 

--- a/internal/pkg/agent/storage/encrypted_disk_storage_windows_linux_test.go
+++ b/internal/pkg/agent/storage/encrypted_disk_storage_windows_linux_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build linux || windows
-// +build linux windows
 
 package storage
 

--- a/internal/pkg/agent/vault/seed.go
+++ b/internal/pkg/agent/vault/seed.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build linux || windows
-// +build linux windows
 
 package vault
 

--- a/internal/pkg/agent/vault/seed_test.go
+++ b/internal/pkg/agent/vault/seed_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build linux || windows
-// +build linux windows
 
 package vault
 

--- a/internal/pkg/agent/vault/vault_darwin.go
+++ b/internal/pkg/agent/vault/vault_darwin.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build darwin
-// +build darwin
 
 package vault
 

--- a/internal/pkg/agent/vault/vault_key.go
+++ b/internal/pkg/agent/vault/vault_key.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build linux || windows
-// +build linux windows
 
 package vault
 

--- a/internal/pkg/agent/vault/vault_linux.go
+++ b/internal/pkg/agent/vault/vault_linux.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build linux
-// +build linux
 
 package vault
 

--- a/internal/pkg/agent/vault/vault_test.go
+++ b/internal/pkg/agent/vault/vault_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build linux || windows
-// +build linux windows
 
 package vault
 

--- a/internal/pkg/agent/vault/vault_windows.go
+++ b/internal/pkg/agent/vault/vault_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package vault
 

--- a/internal/pkg/config/operations/svc_unix.go
+++ b/internal/pkg/config/operations/svc_unix.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package operations
 

--- a/internal/pkg/config/operations/svc_windows.go
+++ b/internal/pkg/config/operations/svc_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package operations
 

--- a/internal/pkg/core/socket/dial.go
+++ b/internal/pkg/core/socket/dial.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package socket
 

--- a/internal/pkg/core/socket/dial_windows.go
+++ b/internal/pkg/core/socket/dial_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package socket
 

--- a/magefile.go
+++ b/magefile.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build mage
-// +build mage
 
 package main
 

--- a/pkg/component/fake/component/comp/dialer.go
+++ b/pkg/component/fake/component/comp/dialer.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package comp
 

--- a/pkg/component/fake/component/comp/dialer_windows.go
+++ b/pkg/component/fake/component/comp/dialer_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package comp
 

--- a/pkg/component/runtime/manager_shipper_unix.go
+++ b/pkg/component/runtime/manager_shipper_unix.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package runtime
 

--- a/pkg/component/runtime/manager_shipper_windows.go
+++ b/pkg/component/runtime/manager_shipper_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package runtime
 

--- a/pkg/control/addr.go
+++ b/pkg/control/addr.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package control
 

--- a/pkg/control/addr_windows.go
+++ b/pkg/control/addr_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package control
 

--- a/pkg/control/v1/client/dial.go
+++ b/pkg/control/v1/client/dial.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package client
 

--- a/pkg/control/v1/client/dial_windows.go
+++ b/pkg/control/v1/client/dial_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package client
 

--- a/pkg/control/v2/client/dial.go
+++ b/pkg/control/v2/client/dial.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package client
 

--- a/pkg/control/v2/client/dial_windows.go
+++ b/pkg/control/v2/client/dial_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package client
 

--- a/pkg/control/v2/server/listener.go
+++ b/pkg/control/v2/server/listener.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package server
 

--- a/pkg/control/v2/server/listener_windows.go
+++ b/pkg/control/v2/server/listener_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package server
 

--- a/pkg/core/process/cmd.go
+++ b/pkg/core/process/cmd.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !linux && !darwin
-// +build !linux,!darwin
 
 package process
 

--- a/pkg/core/process/cmd_darwin.go
+++ b/pkg/core/process/cmd_darwin.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build darwin
-// +build darwin
 
 package process
 

--- a/pkg/core/process/cmd_linux.go
+++ b/pkg/core/process/cmd_linux.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build linux
-// +build linux
 
 package process
 

--- a/pkg/core/process/external_unix.go
+++ b/pkg/core/process/external_unix.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package process
 

--- a/pkg/core/process/external_windows.go
+++ b/pkg/core/process/external_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package process
 

--- a/pkg/core/process/job_unix.go
+++ b/pkg/core/process/job_unix.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package process
 

--- a/pkg/core/process/job_windows.go
+++ b/pkg/core/process/job_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package process
 

--- a/pkg/utils/perm_unix.go
+++ b/pkg/utils/perm_unix.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package utils
 

--- a/pkg/utils/perm_windows.go
+++ b/pkg/utils/perm_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package utils
 

--- a/pkg/utils/root_unix.go
+++ b/pkg/utils/root_unix.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !windows
-// +build !windows
 
 package utils
 

--- a/pkg/utils/root_windows.go
+++ b/pkg/utils/root_windows.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package utils
 

--- a/pkg/utils/root_windows_test.go
+++ b/pkg/utils/root_windows_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package utils
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR runs `go fix -fix buildtag ./...` on the Elastic Agent codebase to remove the deprecated `// +build` build tags from `.go` source files.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Starting with Go 1.17, `//go:build` tags are preferred over the more bespoke `// +build` tags, for consistency with other `//go:` directives.  Starting with Go 1.18, `go fix` is able to remove the deprecated `// +build` tags and only leave the corresponding `//go:build` tags in their place.

More here: https://go.dev/doc/go1.18#go-build-lines

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
