### PR TITLE
Disable signature validation for policy and actions

### DIFF
--- a/changelog/fragments/1682599444-Disable-policy-and-action-signature-validation-in-the-Agent.yaml
+++ b/changelog/fragments/1682599444-Disable-policy-and-action-signature-validation-in-the-Agent.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Disable policy and action signature validation in the Agent for 8.8.0 release
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/2562
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/actions/handlers/handler_action_application.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_application.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
-	"github.com/elastic/elastic-agent/internal/pkg/agent/protection"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/acker"
 	"github.com/elastic/elastic-agent/pkg/component"
@@ -54,16 +53,19 @@ func (h *AppAction) Handle(ctx context.Context, a fleetapi.Action, acker acker.A
 	}
 
 	// Validate action
-	h.log.Debugf("handlerAppAction: validate action '%+v', for agentID %s", a, h.agentID)
-	validated, err := protection.ValidateAction(*action, h.coord.Protection().SignatureValidationKey, h.agentID)
-	if err != nil {
-		action.StartedAt = time.Now().UTC().Format(time.RFC3339Nano)
-		action.CompletedAt = action.StartedAt
-		h.log.Errorf("handlerAppAction: action '%+v' failed validation: %v", action, err) // error details are logged
-		action.Error = fmt.Sprintf("action failed validation: %s", action.InputType)      // generic error message for the action response
-		return acker.Ack(ctx, action)
-	}
-	action = &validated
+	// Disabled for 8.8.0 release in order to limit the surface
+	// https://github.com/elastic/security-team/issues/6501
+	//
+	// h.log.Debugf("handlerAppAction: validate action '%+v', for agentID %s", a, h.agentID)
+	// validated, err := protection.ValidateAction(*action, h.coord.Protection().SignatureValidationKey, h.agentID)
+	// if err != nil {
+	// 	action.StartedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	// 	action.CompletedAt = action.StartedAt
+	// 	h.log.Errorf("handlerAppAction: action '%+v' failed validation: %v", action, err) // error details are logged
+	// 	action.Error = fmt.Sprintf("action failed validation: %s", action.InputType)      // generic error message for the action response
+	// 	return acker.Ack(ctx, action)
+	// }
+	// action = &validated
 
 	state := h.coord.State()
 	comp, unit, ok := findUnitFromInputType(state, action.InputType)

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -44,8 +44,10 @@ type PolicyChangeHandler struct {
 	ch        chan coordinator.ConfigChange
 	setters   []actions.ClientSetter
 
-	// Last known valid signature validation key
-	signatureValidationKey []byte
+	// Disabled for 8.8.0 release in order to limit the surface
+	// https://github.com/elastic/security-team/issues/6501
+	// // Last known valid signature validation key
+	// signatureValidationKey []byte
 }
 
 // NewPolicyChangeHandler creates a new PolicyChange handler.

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -22,7 +22,6 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
-	"github.com/elastic/elastic-agent/internal/pkg/agent/protection"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/storage"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
@@ -85,17 +84,20 @@ func (h *PolicyChangeHandler) Handle(ctx context.Context, a fleetapi.Action, ack
 		return fmt.Errorf("invalid type, expected ActionPolicyChange and received %T", a)
 	}
 
-	// Validate policy signature and overlay signed configuration
-	policy, signatureValidationKey, err := protection.ValidatePolicySignature(h.log, action.Policy, h.signatureValidationKey)
-	if err != nil {
-		return errors.New(err, "could not validate the policy signed configuration", errors.TypeConfig)
-	}
-	h.log.Debugf("handlerPolicyChange: policy validation result: signature validation key length: %v, err: %v", len(signatureValidationKey), err)
+	// Disabled for 8.8.0 release in order to limit the surface
+	// https://github.com/elastic/security-team/issues/6501
 
-	// Cache signature validation key for the next policy handling
-	h.signatureValidationKey = signatureValidationKey
+	// // Validate policy signature and overlay signed configuration
+	// policy, signatureValidationKey, err := protection.ValidatePolicySignature(h.log, action.Policy, h.signatureValidationKey)
+	// if err != nil {
+	// 	return errors.New(err, "could not validate the policy signed configuration", errors.TypeConfig)
+	// }
+	// h.log.Debugf("handlerPolicyChange: policy validation result: signature validation key length: %v, err: %v", len(signatureValidationKey), err)
 
-	c, err := config.NewConfigFrom(policy)
+	// // Cache signature validation key for the next policy handling
+	// h.signatureValidationKey = signatureValidationKey
+
+	c, err := config.NewConfigFrom(action.Policy)
 	if err != nil {
 		return errors.New(err, "could not parse the configuration from the policy", errors.TypeConfig)
 	}

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -21,7 +20,6 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator/state"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/reexec"
-	"github.com/elastic/elastic-agent/internal/pkg/agent/protection"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/transpiler"
 	"github.com/elastic/elastic-agent/internal/pkg/capabilities"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
@@ -183,8 +181,11 @@ type Coordinator struct {
 	ast    *transpiler.AST
 	vars   []*transpiler.Vars
 
-	mx         sync.RWMutex
-	protection protection.Config
+	// Disabled for 8.8.0 release in order to limit the surface
+	// https://github.com/elastic/security-team/issues/6501
+
+	// mx         sync.RWMutex
+	// protection protection.Config
 }
 
 // ErrFatalCoordinator is returned when a coordinator sub-component returns an error, as opposed to a simple context-cancelled.
@@ -232,20 +233,23 @@ func (c *Coordinator) StateSubscribe(ctx context.Context) *state.StateSubscripti
 	return c.state.Subscribe(ctx)
 }
 
-// Protection returns the current agent protection configuration
-// This is needed to be able to access the protection configuration for actions validation
-func (c *Coordinator) Protection() protection.Config {
-	c.mx.RLock()
-	defer c.mx.RUnlock()
-	return c.protection
-}
+// Disabled for 8.8.0 release in order to limit the surface
+// https://github.com/elastic/security-team/issues/6501
 
-// setProtection sets protection configuration
-func (c *Coordinator) setProtection(protectionConfig protection.Config) {
-	c.mx.Lock()
-	c.protection = protectionConfig
-	c.mx.Unlock()
-}
+// // Protection returns the current agent protection configuration
+// // This is needed to be able to access the protection configuration for actions validation
+// func (c *Coordinator) Protection() protection.Config {
+// 	c.mx.RLock()
+// 	defer c.mx.RUnlock()
+// 	return c.protection
+// }
+
+// // setProtection sets protection configuration
+// func (c *Coordinator) setProtection(protectionConfig protection.Config) {
+// 	c.mx.Lock()
+// 	c.protection = protectionConfig
+// 	c.mx.Unlock()
+// }
 
 // ReExec performs the re-execution.
 func (c *Coordinator) ReExec(callback reexec.ShutdownCallbackFn, argOverrides ...string) {
@@ -701,10 +705,12 @@ func (c *Coordinator) processConfig(ctx context.Context, cfg *config.Config) (er
 		return fmt.Errorf("could not create the map from the configuration: %w", err)
 	}
 
-	protectionConfig, err := protection.GetAgentProtectionConfig(m)
-	if err != nil && !errors.Is(err, protection.ErrNotFound) {
-		return fmt.Errorf("could not read the agent protection configuration: %w", err)
-	}
+	// Disabled for 8.8.0 release in order to limit the surface
+	// https://github.com/elastic/security-team/issues/6501
+	// protectionConfig, err := protection.GetAgentProtectionConfig(m)
+	// if err != nil && !errors.Is(err, protection.ErrNotFound) {
+	// 	return fmt.Errorf("could not read the agent protection configuration: %w", err)
+	// }
 
 	rawAst, err := transpiler.NewAST(m)
 	if err != nil {
@@ -739,7 +745,10 @@ func (c *Coordinator) processConfig(ctx context.Context, cfg *config.Config) (er
 	c.config = cfg
 	c.ast = rawAst
 
-	c.setProtection(protectionConfig)
+	// Disabled for 8.8.0 release in order to limit the surface
+	// https://github.com/elastic/security-team/issues/6501
+
+	// c.setProtection(protectionConfig)
 
 	if c.vars != nil {
 		return c.process(ctx)


### PR DESCRIPTION
## What does this PR do?

This disables the policy and the agent validation for 8.8.0 release as requested in the 
https://github.com/elastic/security-team/issues/6501

The policy and the action signature validation is handled by Endpoint only in order to reduce the impact and the scope of the release of the new feature.

## Why is it important?

The change is requested for 8.8.0 in order to reduce the impact of the completely new feature.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test


## How to test this PR locally

Full regression testing. The agent can install/enroll, receive policy, osquery and endpoint actions continue working.

## Related issues

- Closes https://github.com/elastic/security-team/issues/6501

