### PR TITLE
Validate install base path

### DIFF
--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -56,7 +56,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 
 	basePath, _ := cmd.Flags().GetString(flagInstallBasePath)
 	if !filepath.IsAbs(basePath) {
-		return fmt.Errorf("base path %q is not absolute", basePath)
+		return fmt.Errorf("base path [%s] is not absolute", basePath)
 	}
 
 	isAdmin, err := utils.HasRoot()

--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -54,17 +54,17 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		return err
 	}
 
+	basePath, _ := cmd.Flags().GetString(flagInstallBasePath)
+	if !filepath.IsAbs(basePath) {
+		return fmt.Errorf("base path %q is not absolute", basePath)
+	}
+
 	isAdmin, err := utils.HasRoot()
 	if err != nil {
 		return fmt.Errorf("unable to perform install command while checking for administrator rights, %w", err)
 	}
 	if !isAdmin {
 		return fmt.Errorf("unable to perform install command, not executed with %s permissions", utils.PermissionUser)
-	}
-
-	basePath, _ := cmd.Flags().GetString(flagInstallBasePath)
-	if err := validateBasePath(basePath); err != nil {
-		return err
 	}
 
 	topPath := installPath(basePath)
@@ -230,14 +230,6 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 	}
 
 	fmt.Fprint(streams.Out, "Elastic Agent has been successfully installed.\n")
-	return nil
-}
-
-func validateBasePath(basePath string) error {
-	if !filepath.IsAbs(basePath) {
-		return fmt.Errorf("base path %q is not absolute", basePath)
-	}
-
 	return nil
 }
 

--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -42,7 +42,7 @@ would like the Agent to operate.
 
 	cmd.Flags().BoolP("force", "f", false, "Force overwrite the current and do not prompt for confirmation")
 	cmd.Flags().BoolP("non-interactive", "n", false, "Install Elastic Agent in non-interactive mode which will not prompt on missing parameters but fails instead.")
-	cmd.Flags().String(flagInstallBasePath, paths.DefaultBasePath, "Base path (absolute) for installing Elastic Agent's files.")
+	cmd.Flags().String(flagInstallBasePath, paths.DefaultBasePath, "The path where the Elastic Agent will be installed. It must be an absolute path.")
 	addEnrollFlags(cmd)
 
 	return cmd

--- a/internal/pkg/agent/cmd/install_test.go
+++ b/internal/pkg/agent/cmd/install_test.go
@@ -36,15 +36,15 @@ func TestInvalidBasePath(t *testing.T) {
 	}{
 		"relative_path_1": {
 			basePath:      "relative/path",
-			expectedError: `base path "relative/path" is not absolute`,
+			expectedError: `base path [relative/path] is not absolute`,
 		},
 		"relative_path_2": {
 			basePath:      "./relative/path",
-			expectedError: `base path "./relative/path" is not absolute`,
+			expectedError: `base path [./relative/path] is not absolute`,
 		},
 		"empty_path": {
 			basePath:      "",
-			expectedError: `base path "" is not absolute`,
+			expectedError: `base path [] is not absolute`,
 		},
 	}
 

--- a/internal/pkg/agent/cmd/install_test.go
+++ b/internal/pkg/agent/cmd/install_test.go
@@ -35,9 +35,13 @@ func TestValidateBasePath(t *testing.T) {
 			basePath:      "/absolute/path",
 			expectedError: "",
 		},
-		"relative_path": {
+		"relative_path_1": {
 			basePath:      "relative/path",
 			expectedError: `base path "relative/path" is not absolute`,
+		},
+		"relative_path_2": {
+			basePath:      "./relative/path",
+			expectedError: `base path "./relative/path" is not absolute`,
 		},
 		"empty_path": {
 			basePath:      "",

--- a/internal/pkg/agent/cmd/install_test.go
+++ b/internal/pkg/agent/cmd/install_test.go
@@ -9,10 +9,10 @@ package cmd
 import (
 	"testing"
 
-	"github.com/elastic/elastic-agent/internal/pkg/cli"
 	"github.com/spf13/cobra"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/internal/pkg/cli"
 )
 
 func TestInstallPath(t *testing.T) {

--- a/internal/pkg/agent/cmd/install_test.go
+++ b/internal/pkg/agent/cmd/install_test.go
@@ -25,3 +25,22 @@ func TestInstallPath(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateBasePath(t *testing.T) {
+	tests := map[string]string{
+		"/absolute/path": "",
+		"relative/path":  `base path "relative/path" is not absolute`,
+	}
+
+	for basePath, expectedError := range tests {
+		t.Run(basePath, func(t *testing.T) {
+			err := validateBasePath(basePath)
+
+			if expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Equal(t, expectedError, err.Error())
+			}
+		})
+	}
+}

--- a/internal/pkg/agent/cmd/install_test.go
+++ b/internal/pkg/agent/cmd/install_test.go
@@ -9,6 +9,9 @@ package cmd
 import (
 	"testing"
 
+	"github.com/elastic/elastic-agent/internal/pkg/cli"
+	"github.com/spf13/cobra"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,15 +29,11 @@ func TestInstallPath(t *testing.T) {
 	}
 }
 
-func TestValidateBasePath(t *testing.T) {
+func TestInvalidBasePath(t *testing.T) {
 	tests := map[string]struct {
 		basePath      string
 		expectedError string
 	}{
-		"absolute_path": {
-			basePath:      "/absolute/path",
-			expectedError: "",
-		},
 		"relative_path_1": {
 			basePath:      "relative/path",
 			expectedError: `base path "relative/path" is not absolute`,
@@ -51,7 +50,11 @@ func TestValidateBasePath(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := validateBasePath(test.basePath)
+			streams := cli.NewIOStreams()
+			cmd := cobra.Command{}
+			cmd.Flags().String(flagInstallBasePath, test.basePath, "")
+
+			err := installCmd(streams, &cmd)
 
 			if test.expectedError == "" {
 				require.NoError(t, err)

--- a/internal/pkg/agent/cmd/install_test.go
+++ b/internal/pkg/agent/cmd/install_test.go
@@ -27,19 +27,32 @@ func TestInstallPath(t *testing.T) {
 }
 
 func TestValidateBasePath(t *testing.T) {
-	tests := map[string]string{
-		"/absolute/path": "",
-		"relative/path":  `base path "relative/path" is not absolute`,
+	tests := map[string]struct {
+		basePath      string
+		expectedError string
+	}{
+		"absolute_path": {
+			basePath:      "/absolute/path",
+			expectedError: "",
+		},
+		"relative_path": {
+			basePath:      "relative/path",
+			expectedError: `base path "relative/path" is not absolute`,
+		},
+		"empty_path": {
+			basePath:      "",
+			expectedError: `base path "" is not absolute`,
+		},
 	}
 
-	for basePath, expectedError := range tests {
-		t.Run(basePath, func(t *testing.T) {
-			err := validateBasePath(basePath)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateBasePath(test.basePath)
 
-			if expectedError == "" {
+			if test.expectedError == "" {
 				require.NoError(t, err)
 			} else {
-				require.Equal(t, expectedError, err.Error())
+				require.Equal(t, test.expectedError, err.Error())
 			}
 		})
 	}

--- a/internal/pkg/agent/cmd/install_windows_test.go
+++ b/internal/pkg/agent/cmd/install_windows_test.go
@@ -26,22 +26,18 @@ func TestInstallPath(t *testing.T) {
 	}
 }
 
-func TestValidateBasePath(t *testing.T) {
+func TestInvalidBasePath(t *testing.T) {
 	tests := map[string]struct {
 		basePath      string
 		expectedError string
 	}{
-		"absolute_path": {
-			basePath:      `D:\absolute\path`,
-			expectedError: "",
-		},
 		"relative_path_1": {
 			basePath:      `relative\path`,
-			expectedError: `base path "relative\path" is not absolute`,
+			expectedError: `base path "relative/path" is not absolute`,
 		},
 		"relative_path_2": {
 			basePath:      `.\relative\path`,
-			expectedError: `base path ".\relative\path" is not absolute`,
+			expectedError: `base path "./relative/path" is not absolute`,
 		},
 		"empty_path": {
 			basePath:      "",
@@ -51,7 +47,11 @@ func TestValidateBasePath(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := validateBasePath(test.basePath)
+			streams := cli.NewIOStreams()
+			cmd := cobra.Command{}
+			cmd.Flags().String(flagInstallBasePath, test.basePath, "")
+
+			err := installCmd(streams, &cmd)
 
 			if test.expectedError == "" {
 				require.NoError(t, err)

--- a/internal/pkg/agent/cmd/install_windows_test.go
+++ b/internal/pkg/agent/cmd/install_windows_test.go
@@ -7,7 +7,6 @@
 package cmd
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -36,16 +35,16 @@ func TestInvalidBasePath(t *testing.T) {
 		expectedError string
 	}{
 		"relative_path_1": {
-			basePath:      filepath.Join("relative", "path"),
-			expectedError: "base path \"" + filepath.Join("relative", "path") + "\" is not absolute",
+			basePath:      `relative\path`,
+			expectedError: `base path [relative\path] is not absolute`,
 		},
 		"relative_path_2": {
-			basePath:      filepath.Join(".", "relative", "path"),
-			expectedError: "base path \"" + filepath.Join(".", "relative", "path") + "\" is not absolute",
+			basePath:      `.\relative\path`,
+			expectedError: `base path [.\relative\path] is not absolute`,
 		},
 		"empty_path": {
 			basePath:      "",
-			expectedError: `base path "" is not absolute`,
+			expectedError: `base path [] is not absolute`,
 		},
 	}
 

--- a/internal/pkg/agent/cmd/install_windows_test.go
+++ b/internal/pkg/agent/cmd/install_windows_test.go
@@ -35,12 +35,12 @@ func TestInvalidBasePath(t *testing.T) {
 		expectedError string
 	}{
 		"relative_path_1": {
-			basePath:      `relative\path`,
-			expectedError: `base path "relative\path" is not absolute`,
+			basePath:      "relative\\path",
+			expectedError: "base path \"relative\\path\" is not absolute",
 		},
 		"relative_path_2": {
-			basePath:      `.\relative\path`,
-			expectedError: `base path ".\relative\path" is not absolute`,
+			basePath:      ".\\relative\\path",
+			expectedError: "base path \".\\relative\\path\" is not absolute",
 		},
 		"empty_path": {
 			basePath:      "",

--- a/internal/pkg/agent/cmd/install_windows_test.go
+++ b/internal/pkg/agent/cmd/install_windows_test.go
@@ -36,11 +36,11 @@ func TestInvalidBasePath(t *testing.T) {
 	}{
 		"relative_path_1": {
 			basePath:      `relative\path`,
-			expectedError: `base path "relative/path" is not absolute`,
+			expectedError: `base path "relative\path" is not absolute`,
 		},
 		"relative_path_2": {
 			basePath:      `.\relative\path`,
-			expectedError: `base path "./relative/path" is not absolute`,
+			expectedError: `base path ".\relative\path" is not absolute`,
 		},
 		"empty_path": {
 			basePath:      "",

--- a/internal/pkg/agent/cmd/install_windows_test.go
+++ b/internal/pkg/agent/cmd/install_windows_test.go
@@ -25,3 +25,39 @@ func TestInstallPath(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateBasePath(t *testing.T) {
+	tests := map[string]struct {
+		basePath      string
+		expectedError string
+	}{
+		"absolute_path": {
+			basePath:      `D:\absolute\path`,
+			expectedError: "",
+		},
+		"relative_path_1": {
+			basePath:      `relative\path`,
+			expectedError: `base path "relative\path" is not absolute`,
+		},
+		"relative_path_2": {
+			basePath:      `.\relative\path`,
+			expectedError: `base path ".\relative\path" is not absolute`,
+		},
+		"empty_path": {
+			basePath:      "",
+			expectedError: `base path "" is not absolute`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateBasePath(test.basePath)
+
+			if test.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Equal(t, test.expectedError, err.Error())
+			}
+		})
+	}
+}

--- a/internal/pkg/agent/cmd/install_windows_test.go
+++ b/internal/pkg/agent/cmd/install_windows_test.go
@@ -7,6 +7,7 @@
 package cmd
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -35,12 +36,12 @@ func TestInvalidBasePath(t *testing.T) {
 		expectedError string
 	}{
 		"relative_path_1": {
-			basePath:      "relative\\path",
-			expectedError: "base path \"relative\\path\" is not absolute",
+			basePath:      filepath.Join("relative", "path"),
+			expectedError: "base path \"" + filepath.Join("relative", "path") + "\" is not absolute",
 		},
 		"relative_path_2": {
-			basePath:      ".\\relative\\path",
-			expectedError: "base path \".\\relative\\path\" is not absolute",
+			basePath:      filepath.Join(".", "relative", "path"),
+			expectedError: "base path \"" + filepath.Join(".", "relative", "path") + "\" is not absolute",
 		},
 		"empty_path": {
 			basePath:      "",

--- a/internal/pkg/agent/cmd/install_windows_test.go
+++ b/internal/pkg/agent/cmd/install_windows_test.go
@@ -9,7 +9,10 @@ package cmd
 import (
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/internal/pkg/cli"
 )
 
 func TestInstallPath(t *testing.T) {

--- a/version/version.go
+++ b/version/version.go
@@ -4,4 +4,4 @@
 
 package version
 
-const defaultBeatVersion = "8.9.0"
+const defaultBeatVersion = "8.8.0"

--- a/version/version.go
+++ b/version/version.go
@@ -4,4 +4,4 @@
 
 package version
 
-const defaultBeatVersion = "8.8.0"
+const defaultBeatVersion = "8.9.0"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR validates the value of the `--base-path` CLI option of the `elastic-agent install` command.  If the value is not an absolute path, it returns an error. 

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To prevent users accidentally attempting to install Elastic Agent in the same folder where they extracted the downloaded Elastic Agent archive, and corrupting the contents of the folder in the process.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation: https://github.com/elastic/ingest-docs/pull/180
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~ Not needed as bug fix is in same release when the feature was introduced
- [ ] ~I have added an integration test or an E2E test~ Added unit tests


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #2558
