### PR TITLE
Add documentation around inputs.d to config file

### DIFF
--- a/_meta/config/common.p2.yml.tmpl
+++ b/_meta/config/common.p2.yml.tmpl
@@ -9,6 +9,9 @@ outputs:
     # username: "elastic"
     # password: "changeme"
 
+# Here you can configure your list of inputs. You can either configure all the inputs as a list of arrays
+# or create an "inputs.d" directory and put a yaml file inside for each input. If you use the inputs.d
+# directory, it is important that each .yml file repeats the `inputs:` top level array part.
 inputs:
   - type: system/metrics
     # Each input must have a unique ID.

--- a/_meta/config/common.p2.yml.tmpl
+++ b/_meta/config/common.p2.yml.tmpl
@@ -9,9 +9,11 @@ outputs:
     # username: "elastic"
     # password: "changeme"
 
+
+
 # Here you can configure your list of inputs. You can either configure all the inputs as a list of arrays
-# or create an "inputs.d" directory and put a yaml file inside for each input. If you use the inputs.d
-# directory, it is important that each .yml file repeats the `inputs:` top level array part.
+# or create an "inputs.d" directory containing your input configurations. 
+# See https://www.elastic.co/guide/en/fleet/current/elastic-agent-configuration.html for how to structure the "inputs.d" directory.
 inputs:
   - type: system/metrics
     # Each input must have a unique ID.

--- a/elastic-agent.yml
+++ b/elastic-agent.yml
@@ -15,6 +15,9 @@ outputs:
     # username: "elastic"
     # password: "changeme"
 
+# Here you can configure your list of inputs. You can either configure all the inputs as a list of arrays
+# or create an "inputs.d" directory and put a yaml file inside for each input. If you use the inputs.d
+# directory, it is important that each .yml file repeats the `inputs:` top level array part.
 inputs:
   - type: system/metrics
     # Each input must have a unique ID.

--- a/elastic-agent.yml
+++ b/elastic-agent.yml
@@ -15,9 +15,11 @@ outputs:
     # username: "elastic"
     # password: "changeme"
 
+
+
 # Here you can configure your list of inputs. You can either configure all the inputs as a list of arrays
-# or create an "inputs.d" directory and put a yaml file inside for each input. If you use the inputs.d
-# directory, it is important that each .yml file repeats the `inputs:` top level array part.
+# or create an "inputs.d" directory containing your input configurations. 
+# See https://www.elastic.co/guide/en/fleet/current/elastic-agent-configuration.html for how to structure the "inputs.d" directory.
 inputs:
   - type: system/metrics
     # Each input must have a unique ID.


### PR DESCRIPTION
The inputs.d feature was added in https://github.com/elastic/beats/pull/30087 for elastic agent but unfortunately without any documentation. inputs.d directory is especially useful in the elastic-agent standalone mode. The close the first gap around documentation, I added it to the elastic-agent.yml file.

For awareness, this is an open issue around inputs.d directory: https://github.com/elastic/elastic-agent/issues/622
