### PR TITLE
Fix issue with service token path in fleet-server bootstrap of container

### DIFF
--- a/changelog/fragments/1682953274-Fix-container-service-token-path-issue.yaml
+++ b/changelog/fragments/1682953274-Fix-container-service-token-path-issue.yaml
@@ -8,7 +8,7 @@
 # - security: impacts on the security of a product or a user’s deployment.
 # - upgrade: important information for someone upgrading from a prior version
 # - other: does not fit into any of the other categories
-kind: feature
+kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
 summary: Fix container service token path issue
@@ -28,7 +28,7 @@ component:
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/elastic-agent/pull/2576
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.

--- a/changelog/fragments/1682953274-Fix-container-service-token-path-issue.yaml
+++ b/changelog/fragments/1682953274-Fix-container-service-token-path-issue.yaml
@@ -1,0 +1,35 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix container service token path issue
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Fix issue that occurs when specifing a FLEET_SERVER_SERVICE_TOKEN_PATH with
+  the agent running in a Docker container where both the token value and path
+  are passed in the enroll section of the agent setup.
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -427,8 +427,7 @@ func buildEnrollArgs(cfg setupConfig, token string, policyID string) ([]string, 
 		args = append(args, "--fleet-server-es", connStr)
 		if cfg.FleetServer.Elasticsearch.ServiceTokenPath != "" {
 			args = append(args, "--fleet-server-service-token-path", cfg.FleetServer.Elasticsearch.ServiceTokenPath)
-		}
-		if cfg.FleetServer.Elasticsearch.ServiceTokenPath == "" && cfg.FleetServer.Elasticsearch.ServiceToken != "" {
+		} else if cfg.FleetServer.Elasticsearch.ServiceTokenPath == "" && cfg.FleetServer.Elasticsearch.ServiceToken != "" {
 			args = append(args, "--fleet-server-service-token", cfg.FleetServer.Elasticsearch.ServiceToken)
 		}
 		if policyID != "" {

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -425,11 +425,11 @@ func buildEnrollArgs(cfg setupConfig, token string, policyID string) ([]string, 
 			return nil, err
 		}
 		args = append(args, "--fleet-server-es", connStr)
-		if cfg.FleetServer.Elasticsearch.ServiceToken != "" {
-			args = append(args, "--fleet-server-service-token", cfg.FleetServer.Elasticsearch.ServiceToken)
-		}
 		if cfg.FleetServer.Elasticsearch.ServiceTokenPath != "" {
 			args = append(args, "--fleet-server-service-token-path", cfg.FleetServer.Elasticsearch.ServiceTokenPath)
+		}
+		if cfg.FleetServer.Elasticsearch.ServiceTokenPath == "" && cfg.FleetServer.Elasticsearch.ServiceToken != "" {
+			args = append(args, "--fleet-server-service-token", cfg.FleetServer.Elasticsearch.ServiceToken)
 		}
 		if policyID != "" {
 			args = append(args, "--fleet-server-policy", policyID)

--- a/internal/pkg/agent/cmd/container_test.go
+++ b/internal/pkg/agent/cmd/container_test.go
@@ -56,3 +56,66 @@ func TestContainerTestPaths(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildEnrollArgs(t *testing.T) {
+	cases := []struct {
+		name   string
+		cfg    setupConfig
+		expect []string
+		err    error
+	}{{
+		name: "service token passes",
+		cfg: setupConfig{
+			FleetServer: fleetServerConfig{
+				Enable: true,
+				Elasticsearch: elasticsearchConfig{
+					Host:         "http://localhost:9200",
+					ServiceToken: "token-val",
+				},
+			},
+		},
+		expect: []string{"--fleet-server-service-token", "token-val"},
+		err:    nil,
+	}, {
+		name: "service token path passes",
+		cfg: setupConfig{
+			FleetServer: fleetServerConfig{
+				Enable: true,
+				Elasticsearch: elasticsearchConfig{
+					Host:             "http://localhost:9200",
+					ServiceTokenPath: "/path/to/token",
+				},
+			},
+		},
+		expect: []string{"--fleet-server-service-token-path", "/path/to/token"},
+		err:    nil,
+	}, {
+		name: "service token path preffered",
+		cfg: setupConfig{
+			FleetServer: fleetServerConfig{
+				Enable: true,
+				Elasticsearch: elasticsearchConfig{
+					Host:             "http://localhost:9200",
+					ServiceTokenPath: "/path/to/token",
+					ServiceToken:     "token-val",
+				},
+			},
+		},
+		expect: []string{"--fleet-server-service-token-path", "/path/to/token"},
+		err:    nil,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args, err := buildEnrollArgs(tc.cfg, "", "")
+			if tc.err != nil {
+				require.EqualError(t, err, tc.err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			for _, arg := range tc.expect {
+				require.Contains(t, args, arg)
+			}
+		})
+	}
+}

--- a/internal/pkg/agent/cmd/container_test.go
+++ b/internal/pkg/agent/cmd/container_test.go
@@ -58,55 +58,55 @@ func TestContainerTestPaths(t *testing.T) {
 }
 
 func TestBuildEnrollArgs(t *testing.T) {
-	cases := []struct {
-		name   string
+	cases := map[string]struct {
 		cfg    setupConfig
 		expect []string
 		err    error
-	}{{
-		name: "service token passes",
-		cfg: setupConfig{
-			FleetServer: fleetServerConfig{
-				Enable: true,
-				Elasticsearch: elasticsearchConfig{
-					Host:         "http://localhost:9200",
-					ServiceToken: "token-val",
+	}{
+		"service token passes": {
+			cfg: setupConfig{
+				FleetServer: fleetServerConfig{
+					Enable: true,
+					Elasticsearch: elasticsearchConfig{
+						Host:         "http://localhost:9200",
+						ServiceToken: "token-val",
+					},
 				},
 			},
+			expect: []string{"--fleet-server-service-token", "token-val"},
+			err:    nil,
 		},
-		expect: []string{"--fleet-server-service-token", "token-val"},
-		err:    nil,
-	}, {
-		name: "service token path passes",
-		cfg: setupConfig{
-			FleetServer: fleetServerConfig{
-				Enable: true,
-				Elasticsearch: elasticsearchConfig{
-					Host:             "http://localhost:9200",
-					ServiceTokenPath: "/path/to/token",
+		"service token path passes": {
+			cfg: setupConfig{
+				FleetServer: fleetServerConfig{
+					Enable: true,
+					Elasticsearch: elasticsearchConfig{
+						Host:             "http://localhost:9200",
+						ServiceTokenPath: "/path/to/token",
+					},
 				},
 			},
+			expect: []string{"--fleet-server-service-token-path", "/path/to/token"},
+			err:    nil,
 		},
-		expect: []string{"--fleet-server-service-token-path", "/path/to/token"},
-		err:    nil,
-	}, {
-		name: "service token path preffered",
-		cfg: setupConfig{
-			FleetServer: fleetServerConfig{
-				Enable: true,
-				Elasticsearch: elasticsearchConfig{
-					Host:             "http://localhost:9200",
-					ServiceTokenPath: "/path/to/token",
-					ServiceToken:     "token-val",
+		"service token path preferred": {
+			cfg: setupConfig{
+				FleetServer: fleetServerConfig{
+					Enable: true,
+					Elasticsearch: elasticsearchConfig{
+						Host:             "http://localhost:9200",
+						ServiceTokenPath: "/path/to/token",
+						ServiceToken:     "token-val",
+					},
 				},
 			},
+			expect: []string{"--fleet-server-service-token-path", "/path/to/token"},
+			err:    nil,
 		},
-		expect: []string{"--fleet-server-service-token-path", "/path/to/token"},
-		err:    nil,
-	}}
+	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
 			args, err := buildEnrollArgs(tc.cfg, "", "")
 			if tc.err != nil {
 				require.EqualError(t, err, tc.err.Error())


### PR DESCRIPTION
## What does this PR do?

Part of the bootstrap code in container will read the service token file in order to make requests against Kibana. When the file is read the fleet.Elasticsearch.ServiceToken attribute is set and as a result both --service-token and --service-token-path flags are sent to the enroll command. This changes the flags to send only --service-token-path if both attributes are defined.

## Why is it important?

using the service token secret file is currently broken for containers

## Checklist

- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~I have added an integration test or an E2E test~~ e2e tests added as part of fleet-server pr: https://github.com/elastic/fleet-server/pull/2538