### PR TITLE
Fix up 8.7.1 release notes

### DIFF
--- a/changelog/8.7.1.yaml
+++ b/changelog/8.7.1.yaml
@@ -110,7 +110,7 @@ entries:
         name: 1681942680-fix-diag-zip-file.yaml
         checksum: ff3bd63aa3dfa8d9c7d8f708cf7d3febde4e5bae
     - kind: bug-fix
-      summary: Make best effort in copying the run directory on upgrades
+      summary: Make best effort in copying the run directory on upgrades to avoid unnecessary failures.
       description: ""
       component: agent
       pr:

--- a/changelog/8.7.1.yaml
+++ b/changelog/8.7.1.yaml
@@ -109,3 +109,15 @@ entries:
       file:
         name: 1681942680-fix-diag-zip-file.yaml
         checksum: ff3bd63aa3dfa8d9c7d8f708cf7d3febde4e5bae
+    - kind: bug-fix
+      summary: Make best effort in copying the run directory on upgrades
+      description: ""
+      component: agent
+      pr:
+        - https://github.com/elastic/elastic-agent/pull/2448
+      issue:
+        - https://github.com/elastic/elastic-agent/issues/2433
+      timestamp: 1682721331
+      file:
+        name: 1682721331-Make-best-effort-in-copying-the-run-directory-on-upgrades.yaml
+        checksum: 7753fe110c81503074dbcb7ca0c4acd33ccfa267

--- a/changelog/fragments/1681942680-fix-diag-zip-file.yaml
+++ b/changelog/fragments/1681942680-fix-diag-zip-file.yaml
@@ -1,4 +1,0 @@
-kind: bug-fix
-summary: Fix diagnostic zip file handling of sub-directories in logs/.
-component: diagnostics
-pr: https://github.com/elastic/elastic-agent/pull/2523


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR adds an entry we missed (for https://github.com/elastic/elastic-agent/pull/2448) to the `8.7.1` release notes.  It also deletes a fragment file whose entry (for https://github.com/elastic/elastic-agent/pull/2523) had already been merged into the `8.7.1` release notes.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

So that `8.7.1` release notes are accurate + cleaning out the `changelog/fragments/` folder for the `8.7.2` release's CHANGELOG fragments. 

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->