### PR TITLE
Enable policy and actions signature verification with more unit tests

### DIFF
--- a/internal/pkg/agent/application/actions/handlers/handler_action_application_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_application_test.go
@@ -1,0 +1,149 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator/state"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/protection"
+	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
+	"github.com/elastic/elastic-agent/pkg/component"
+	"github.com/elastic/elastic-agent/pkg/component/runtime"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+)
+
+type MockActionProtectionCoordinator struct {
+	signatureValidationKey []byte
+}
+
+var signatureValidationKey []byte
+
+func init() {
+	var err error
+	signatureValidationKey, err = base64.StdEncoding.DecodeString(`MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEuaakkgkOQlVh78UOZuT8fOcocIMXAp01azX5ZK4LkLiMe8BjENTF/tT8rf3nlu5mqBvlePc/IJMXMYiN5YJo4A==`)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (c *MockActionProtectionCoordinator) Protection() protection.Config {
+	return protection.Config{
+		SignatureValidationKey: signatureValidationKey,
+	}
+}
+
+func (c *MockActionProtectionCoordinator) State() state.State {
+	return state.State{
+		Components: []runtime.ComponentComponentState{
+			{
+				Component: component.Component{
+					Units: []component.Unit{
+						{
+							Type:   client.UnitTypeInput,
+							Config: &proto.UnitExpectedConfig{Type: "endpoint"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *MockActionProtectionCoordinator) PerformAction(ctx context.Context, comp component.Component, unit component.Unit, name string, params map[string]interface{}) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+type MockAcker struct {
+	Acked []fleetapi.Action
+}
+
+func (m *MockAcker) Ack(_ context.Context, action fleetapi.Action) error {
+	m.Acked = append(m.Acked, action)
+	return nil
+}
+
+func (m *MockAcker) Commit(_ context.Context) error {
+	return nil
+}
+
+func (m *MockAcker) Clear() {
+	m.Acked = nil
+}
+
+func TestActionHandler(t *testing.T) {
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
+	log, _ := logger.New("", false)
+	coord := &MockActionProtectionCoordinator{signatureValidationKey: signatureValidationKey}
+	agentID := "bafdd485-104b-41e8-acd7-65a21d4105d0"
+
+	acker := &MockAcker{}
+
+	action := &fleetapi.ActionApp{
+		ActionID:   "c80e9219-70bf-43d3-b8cd-b5131a771751",
+		ActionType: "INPUT_ACTION",
+		InputType:  "endpoint",
+		Data:       json.RawMessage(`{"command": "isolate"}`),
+	}
+	goodSigned := &fleetapi.Signed{
+		Data:      "eyJhY3Rpb25faWQiOiJjODBlOTIxOS03MGJmLTQzZDMtYjhjZC1iNTEzMWE3NzE3NTEiLCJleHBpcmF0aW9uIjoiMjAyMy0wNS0xNVQxNjo0NTozMi43NzZaIiwidHlwZSI6IklOUFVUX0FDVElPTiIsImlucHV0X3R5cGUiOiJlbmRwb2ludCIsImRhdGEiOnsiY29tbWFuZCI6Imlzb2xhdGUifSwiQHRpbWVzdGFtcCI6IjIwMjMtMDUtMDFUMTY6NDU6MzIuNzc2WiIsImFnZW50cyI6WyJiYWZkZDQ4NS0xMDRiLTQxZTgtYWNkNy02NWEyMWQ0MTA1ZDAiXSwidGltZW91dCI6MzAwLCJ1c2VyX2lkIjoiMzg0NDExMDU0MSJ9",
+		Signature: "MEUCIQDlOSEm5YtJgg70nMQUhNIUIxi4fL1xo+gHzzypefk7bgIgLyn1wVi1urM2VZM2rxOMIN+hao/LWft7in5ZXnZmwy0=",
+	}
+
+	handler := NewAppAction(log, coord, agentID)
+
+	tests := []struct {
+		name          string
+		action        *fleetapi.ActionApp
+		wantErr       error  // Handler error
+		wantActionErr string // Action result error
+	}{
+		{
+			name:   "not signed", // Should succeed. Not signed actions are acceptable. Agent doesn't enforce actions signing
+			action: action,
+		},
+		{
+			name: "empty data or signature", // Should fail if "signed" property is present
+			action: func() *fleetapi.ActionApp {
+				a := *action // Copy
+				a.Signed = &fleetapi.Signed{}
+				return &a
+			}(),
+			wantActionErr: "action failed validation: " + action.InputType,
+		},
+		{
+			name: "valid signature", // Valid signature should succeed
+			action: func() *fleetapi.ActionApp {
+				a := *action // Copy
+				a.Signed = goodSigned
+				return &a
+			}(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer acker.Clear()
+			err := handler.Handle(ctx, tc.action, acker)
+			require.ErrorIs(t, err, tc.wantErr)
+			if tc.wantErr == nil {
+				require.Len(t, acker.Acked, 1)
+				actionAck := acker.Acked[0].(*fleetapi.ActionApp)
+				if tc.wantActionErr != "" {
+					require.EqualValues(t, tc.wantActionErr, actionAck.Error)
+				}
+			}
+		})
+	}
+}

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -20,6 +21,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator/state"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/reexec"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/protection"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/transpiler"
 	"github.com/elastic/elastic-agent/internal/pkg/capabilities"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
@@ -181,11 +183,8 @@ type Coordinator struct {
 	ast    *transpiler.AST
 	vars   []*transpiler.Vars
 
-	// Disabled for 8.8.0 release in order to limit the surface
-	// https://github.com/elastic/security-team/issues/6501
-
-	// mx         sync.RWMutex
-	// protection protection.Config
+	mx         sync.RWMutex
+	protection protection.Config
 }
 
 // ErrFatalCoordinator is returned when a coordinator sub-component returns an error, as opposed to a simple context-cancelled.
@@ -233,23 +232,20 @@ func (c *Coordinator) StateSubscribe(ctx context.Context) *state.StateSubscripti
 	return c.state.Subscribe(ctx)
 }
 
-// Disabled for 8.8.0 release in order to limit the surface
-// https://github.com/elastic/security-team/issues/6501
+// Protection returns the current agent protection configuration
+// This is needed to be able to access the protection configuration for actions validation
+func (c *Coordinator) Protection() protection.Config {
+	c.mx.RLock()
+	defer c.mx.RUnlock()
+	return c.protection
+}
 
-// // Protection returns the current agent protection configuration
-// // This is needed to be able to access the protection configuration for actions validation
-// func (c *Coordinator) Protection() protection.Config {
-// 	c.mx.RLock()
-// 	defer c.mx.RUnlock()
-// 	return c.protection
-// }
-
-// // setProtection sets protection configuration
-// func (c *Coordinator) setProtection(protectionConfig protection.Config) {
-// 	c.mx.Lock()
-// 	c.protection = protectionConfig
-// 	c.mx.Unlock()
-// }
+// setProtection sets protection configuration
+func (c *Coordinator) setProtection(protectionConfig protection.Config) {
+	c.mx.Lock()
+	c.protection = protectionConfig
+	c.mx.Unlock()
+}
 
 // ReExec performs the re-execution.
 func (c *Coordinator) ReExec(callback reexec.ShutdownCallbackFn, argOverrides ...string) {
@@ -705,12 +701,10 @@ func (c *Coordinator) processConfig(ctx context.Context, cfg *config.Config) (er
 		return fmt.Errorf("could not create the map from the configuration: %w", err)
 	}
 
-	// Disabled for 8.8.0 release in order to limit the surface
-	// https://github.com/elastic/security-team/issues/6501
-	// protectionConfig, err := protection.GetAgentProtectionConfig(m)
-	// if err != nil && !errors.Is(err, protection.ErrNotFound) {
-	// 	return fmt.Errorf("could not read the agent protection configuration: %w", err)
-	// }
+	protectionConfig, err := protection.GetAgentProtectionConfig(m)
+	if err != nil && !errors.Is(err, protection.ErrNotFound) {
+		return fmt.Errorf("could not read the agent protection configuration: %w", err)
+	}
 
 	rawAst, err := transpiler.NewAST(m)
 	if err != nil {
@@ -745,10 +739,7 @@ func (c *Coordinator) processConfig(ctx context.Context, cfg *config.Config) (er
 	c.config = cfg
 	c.ast = rawAst
 
-	// Disabled for 8.8.0 release in order to limit the surface
-	// https://github.com/elastic/security-team/issues/6501
-
-	// c.setProtection(protectionConfig)
+	c.setProtection(protectionConfig)
 
 	if c.vars != nil {
 		return c.process(ctx)


### PR DESCRIPTION
## What does this PR do?

Enabled the Agent policy and actions signature verification back for 8.9.0 releases.
Added more unit tests for the policy change and the app action handlers that were missing in the previous iteration.
This relates to the previous PR https://github.com/elastic/elastic-agent/pull/2348, the functionality was disabled for 8.8.0 release in order to reduce the surface.

## Why is it important?

This a part of Agent tamper protection.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Related issues

- Relates to the previous PR https://github.com/elastic/elastic-agent/pull/2348

