### PR TITLE
Address flakey dispatcher flush test

### DIFF
--- a/internal/pkg/agent/application/managed_mode_test.go
+++ b/internal/pkg/agent/application/managed_mode_test.go
@@ -102,8 +102,7 @@ func Test_runDispatcher(t *testing.T) {
 		},
 		interval: time.Second,
 	}, {
-		name:                "no gateway actions, dispatcher is flushed",
-		skipOnWindowsReason: "Flaky test: https://github.com/elastic/elastic-agent/issues/2585",
+		name: "no gateway actions, dispatcher is flushed",
 		mockGateway: func(ch chan []fleetapi.Action) *mockGateway {
 			gateway := &mockGateway{}
 			gateway.On("Actions").Return((<-chan []fleetapi.Action)(ch))
@@ -112,6 +111,7 @@ func Test_runDispatcher(t *testing.T) {
 		mockDispatcher: func() *mockDispatcher {
 			dispatcher := &mockDispatcher{}
 			dispatcher.On("Dispatch", mock.Anything, mock.Anything, mock.Anything).Once()
+			dispatcher.On("Dispatch", mock.Anything, mock.Anything, mock.Anything).Maybe() // allow a second call in case there are timing issues in the CI pipeline
 			return dispatcher
 		},
 		interval: time.Millisecond * 60,


### PR DESCRIPTION
## What does this PR do?

Allow the dispatcher to be called multiple times in a flakey test case. Ensure that is called at least once by the periodic timer.

## Why is it important?

Fix flakey test on windows CI instances.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~I have added an integration test or an E2E test~~


## Related issues

- Closes #2585 