### PR TITLE
Report errors when parsing EQL conditions

### DIFF
--- a/internal/pkg/eql/eql_test.go
+++ b/internal/pkg/eql/eql_test.go
@@ -305,6 +305,9 @@ func TestEql(t *testing.T) {
 		{expression: "length('hello')", err: true},
 		{expression: "length()", err: true},
 		{expression: "donotexist()", err: true},
+		{expression: "${***} != ${~~~}", err: true},
+		{expression: "false asdf!@#$", err: true},
+		{expression: "length('something' 345) > 1000", err: true},
 	}
 
 	store := &testVarStore{


### PR DESCRIPTION
[This is a draft, so I can see what the CI thinks. I also want to add some additional tests exercising `eql.New` in isolation: many invalid expressions do produce errors in the current test code, but only because they produce nil pointer errors on evaluation, and I want a test that confirms `eql.New` itself produces an error in that case.]

This PR fixes the issue reported in https://github.com/elastic/elastic-agent/issues/2608 where Agent silently ignores errors encountered while parsing EQL expressions. All invalid expressions added to the unit tests in this PR failed (producing no error) prior to this change, whereas now they all produce an appropriate error message when `eql.New` is called.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] I have added an integration test or an E2E test

## Related issues

- Closes #2608.
