### PR TITLE
Adding `integration:auth` target

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -72,8 +72,6 @@ var Aliases = map[string]interface{}{
 	"demo":  Demo.Enroll,
 }
 
-var essAPIKeyFile string
-
 func init() {
 	common.RegisterCheckDeps(Update, Check.All)
 	test.RegisterDeps(UnitTest)
@@ -82,12 +80,6 @@ func init() {
 
 	devtools.Platforms = devtools.Platforms.Filter("!linux/386")
 	devtools.Platforms = devtools.Platforms.Filter("!windows/386")
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		panic(fmt.Errorf("unable to determine user's home directory: %w", err))
-	}
-	essAPIKeyFile = filepath.Join(homeDir, ".config", "ess", "api_key.txt")
 }
 
 // Default set to build everything by default.
@@ -1373,7 +1365,13 @@ func authGCP(ctx context.Context) error {
 }
 
 func authESS(ctx context.Context) error {
-	_, err := os.Stat(essAPIKeyFile)
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("unable to determine user's home directory: %w", err)
+	}
+	essAPIKeyFile := filepath.Join(homeDir, ".config", "ess", "api_key.txt")
+
+	_, err = os.Stat(essAPIKeyFile)
 	if os.IsNotExist(err) {
 		if err := os.MkdirAll(filepath.Dir(essAPIKeyFile), 0700); err != nil {
 			return fmt.Errorf("unable to create ESS config directory: %w", err)

--- a/magefile.go
+++ b/magefile.go
@@ -1301,7 +1301,6 @@ func (Integration) Auth(ctx context.Context) error {
 
 	// TODO: Authenticate user to Azure
 
-	// TODO: Authenticate user to ESS
 	if err := authESS(ctx); err != nil {
 		return fmt.Errorf("unable to authenticate to ESS: %w", err)
 	}

--- a/magefile.go
+++ b/magefile.go
@@ -1323,9 +1323,15 @@ func shouldBuildAgent() bool {
 
 // Pre-requisite: user must have the gcloud CLI installed
 func authGCP(ctx context.Context) error {
+	// Use OS-appropriate command to find executables
+	execFindCmd := "which"
+	if runtime.GOOS == "windows" {
+		execFindCmd = "where"
+	}
+
 	// Check if gcloud CLI is installed
 	const cliName = "gcloud"
-	cmd := exec.CommandContext(ctx, "which", cliName)
+	cmd := exec.CommandContext(ctx, execFindCmd, cliName)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("%s CLI is not installed: %w", cliName, err)
 	}

--- a/magefile.go
+++ b/magefile.go
@@ -1360,6 +1360,21 @@ func authGCP(ctx context.Context) error {
 		}
 	}
 
+	// Skip additional Elastic-specific checks if so requested
+	const skipEnvVar = "TEST_INTEG_AUTH_GCP_SKIP_ELASTIC_CHECK"
+	skipElasticChecks := os.Getenv(skipEnvVar)
+	if skipElasticChecks != "" {
+		shouldSkip, err := strconv.ParseBool(skipElasticChecks)
+		if err != nil {
+			return fmt.Errorf("unable to parse environment variable %s as boolean: %w", skipEnvVar, err)
+		}
+
+		if shouldSkip {
+			// We're all set, no further checks to do.
+			return nil
+		}
+	}
+
 	// Check that authenticated account's email domain name
 	const expectedEmailDomain = "elastic.co"
 	email := authList[0].Account

--- a/magefile.go
+++ b/magefile.go
@@ -1401,7 +1401,7 @@ func authESS(ctx context.Context) error {
 		}
 
 		if u.User.UserID != 0 {
-			// We have a user. All set!
+			// We have a user. It indicates that the API key works. All set!
 			authSuccess = true
 			continue
 		}

--- a/magefile.go
+++ b/magefile.go
@@ -1375,10 +1375,21 @@ func authGCP(ctx context.Context) error {
 		return fmt.Errorf("unable to get project: %w", err)
 	}
 
-	const expectedProject = "elastic-obs-integrations-dev"
+	const expectedProject = "elastic-platform-ingest"
 	project := strings.TrimSpace(string(output))
-	if project != expectedProject {
-		return fmt.Errorf("please configure %s to use the %s project (currently using the %s project)", cliName, expectedProject, project)
+	if project == expectedProject {
+		// We're all set!
+		return nil
+	}
+
+	// Attempt to select correct GCP project
+	fmt.Printf("Attempting to switch GCP project from [%s] to [%s]...\n", project, expectedProject)
+	cmd = exec.CommandContext(ctx, cliName, "config", "set", "core/project", expectedProject)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	if err = cmd.Run(); err != nil {
+		return fmt.Errorf("unable to switch project from [%s] to [%s]: %w", project, expectedProject, err)
 	}
 
 	return nil

--- a/magefile.go
+++ b/magefile.go
@@ -1416,7 +1416,7 @@ func authESS(ctx context.Context) error {
 
 	// Write API key to file for future use
 	if err := os.WriteFile(essAPIKeyFile, []byte(essAPIKey), 0600); err != nil {
-		return fmt.Errorf("unable to persiste ESS API key for future use: %w", err)
+		return fmt.Errorf("unable to persist ESS API key for future use: %w", err)
 	}
 
 	return nil

--- a/magefile.go
+++ b/magefile.go
@@ -1324,12 +1324,13 @@ func shouldBuildAgent() bool {
 func authGCP(ctx context.Context) error {
 	// Use OS-appropriate command to find executables
 	execFindCmd := "which"
+	cliName := "gcloud"
 	if runtime.GOOS == "windows" {
 		execFindCmd = "where"
+		cliName += ".exe"
 	}
 
 	// Check if gcloud CLI is installed
-	const cliName = "gcloud"
 	cmd := exec.CommandContext(ctx, execFindCmd, cliName)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("%s CLI is not installed: %w", cliName, err)

--- a/pkg/testing/ess/users.go
+++ b/pkg/testing/ess/users.go
@@ -1,0 +1,37 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package ess
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type GetUserRequest struct {
+	// For future use
+}
+
+type GetUserResponse struct {
+	User struct {
+		UserID int `json:"user_id"`
+	} `json:"user"`
+}
+
+// GetUser returns information about the authenticated user
+func (c *Client) GetUser(ctx context.Context, req GetUserRequest) (*GetUserResponse, error) {
+	resp, err := c.doGet(ctx, "users")
+	if err != nil {
+		return nil, fmt.Errorf("error calling get user API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var respBody GetUserResponse
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		return nil, fmt.Errorf("error parsing get user response: %w", err)
+	}
+
+	return &respBody, nil
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR adds a `mage integration:auth` target.  For starters, it just implements authentication against GCP and ESS (QA).

## Why is it important?

This target will be invoked either directly by the user or indirectly by the integration testing framework to authenticate the user to various IaaS CSPs (GCP, AWS, Azure) and ESS (QA).   The framework will need this authentication so it can provision the necessary resources (VMs, Elastic stack deployments) as needed for the integration/E2E tests.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

### Pre-requisites

* [Install](https://cloud.google.com/sdk/docs/install) the `gcloud` CLI.

### Without being authenticated to either `gcp` or ESS

1. Run `mage integration:auth`
2. First, you should be taken through the GCP authentication workflow, which includes opening your browser and signing in with your `@elastic.co` Google account.  When you are done in the browser, return to your terminal.
3. Next, you should be taken through the ESS authentication workflow, which includes being prompted on the command-line for your ESS API key.  If you don't have one already, [create one](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) in the [ESS **QA** User Console UI](https://console.qa.cld.elstc.co/).

### After being authenticated to both `gcp` and ESS

1. Run `mage integration:auth`
2. You should not be taken through any authentication workflows.  Instead, you should just see messages on STDOUT saying you are authenticated to GCP and ESS.

### Being authenticated to either `gcp` or ESS but not both
1. Run `mage integration:auth`
2. For the service you are not authenticated to, you should be taken through the authentication workflow as described in the first scenario above.
3. For the service you are authenticated to, you should not be taken through any authentication workflows.  Instead, you should just see a message on STDOUT saying you are authenticated to that service.

#### Tips 
* To un-authenticate with GCP, run `gcloud auth revoke`
* To un-authenticate with ESS, run one of these:
   * `rm ~/.config/ess/api_key.txt` — simulates the "first use" scenario
   * `echo -n $RANDOM$RANDOM > ~/.config/ess/api_key.txt` — simulates the ESS API key being bogus or revoked
