### PR TITLE
Compile pkg/component/fake binaries on TestMain

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,8 +18,8 @@ issues:
     - text: "ST1003:"
       linters:
         - stylecheck
-    # From mage we are priting to the console to ourselves
-    - path: (.*magefile.go|.*dev-tools/mage/.*)
+    # From mage and tests we are printing to the console to ourselves
+    - path: (.*magefile.go|.*dev-tools/mage/.*|_test\.go)
       linters:
        - forbidigo
 

--- a/internal/pkg/agent/application/coordinator/coordinator_test_main_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_test_main_test.go
@@ -1,4 +1,4 @@
-package runtime
+package coordinator
 
 import (
 	"flag"

--- a/magefile.go
+++ b/magefile.go
@@ -243,25 +243,20 @@ func (Build) Clean() {
 
 // TestBinaries build the required binaries for the test suite.
 func (Build) TestBinaries() error {
-	wd, _ := os.Getwd()
-	p := filepath.Join(wd, "pkg", "component", "fake")
-	for _, name := range []string{"component", "shipper"} {
-		binary := name
-		if runtime.GOOS == "windows" {
-			binary += ".exe"
-		}
-
-		fakeDir := filepath.Join(p, name)
-		outputName := filepath.Join(fakeDir, binary)
-		err := RunGo("build", "-o", outputName, filepath.Join(fakeDir))
-		if err != nil {
-			return err
-		}
-		err = os.Chmod(outputName, 0755)
-		if err != nil {
-			return err
-		}
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
 	}
+	// p := filepath.Join(wd, "pkg", "component", "fake")
+	env := map[string]string{"REMOVE_FAKE_BINARIES": "false"}
+	err = sh.RunWithV(env, mg.GoCmd(),
+		"test",
+		"-run", "no-test", "-count", "1",
+		filepath.Join(wd, "pkg", "component", "runtime"))
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/magefile.go
+++ b/magefile.go
@@ -247,7 +247,7 @@ func (Build) TestBinaries() error {
 	if err != nil {
 		return err
 	}
-	// p := filepath.Join(wd, "pkg", "component", "fake")
+
 	env := map[string]string{"REMOVE_FAKE_BINARIES": "false"}
 	err = sh.RunWithV(env, mg.GoCmd(),
 		"test",

--- a/magefile.go
+++ b/magefile.go
@@ -318,14 +318,14 @@ func (Test) All() {
 
 // Unit runs all the unit tests.
 func (Test) Unit(ctx context.Context) error {
-	mg.Deps(Prepare.Env, Build.TestBinaries)
+	mg.Deps(Prepare.Env)
 	params := devtools.DefaultGoTestUnitArgs()
 	return devtools.GoTest(ctx, params)
 }
 
 // Coverage takes the coverages report from running all the tests and display the results in the browser.
 func (Test) Coverage() error {
-	mg.Deps(Prepare.Env, Build.TestBinaries)
+	mg.Deps(Prepare.Env)
 	return RunGo("tool", "cover", "-html="+filepath.Join(buildDir, "coverage.out"))
 }
 
@@ -1267,7 +1267,6 @@ func (Integration) Local(ctx context.Context) error {
 		devtools.Platforms = devtools.Platforms.Select(fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH))
 		mg.Deps(Package)
 	}
-	mg.Deps(Build.TestBinaries)
 
 	// clean the .agent-testing/local so this run will use the latest build
 	_ = os.RemoveAll(".agent-testing/local")

--- a/magefile.go
+++ b/magefile.go
@@ -248,7 +248,7 @@ func (Build) TestBinaries() error {
 		return err
 	}
 
-	env := map[string]string{"REMOVE_FAKE_BINARIES": "false"}
+	env := map[string]string{"KEEP_FAKE_BINARIES": "true"}
 	err = sh.RunWith(env, mg.GoCmd(),
 		"test",
 		"-run", "no-test", "-count", "1",

--- a/magefile.go
+++ b/magefile.go
@@ -249,7 +249,7 @@ func (Build) TestBinaries() error {
 	}
 
 	env := map[string]string{"REMOVE_FAKE_BINARIES": "false"}
-	err = sh.RunWithV(env, mg.GoCmd(),
+	err = sh.RunWith(env, mg.GoCmd(),
 		"test",
 		"-run", "no-test", "-count", "1",
 		filepath.Join(wd, "pkg", "component", "runtime"))

--- a/pkg/component/fake/bintools/bintools.go
+++ b/pkg/component/fake/bintools/bintools.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -23,8 +22,8 @@ var (
 	PathBinShipper   = BinaryPath("shipper")
 	PathBinComponent = BinaryPath("component")
 
-	PathPkgShipper, _   = path.Split(PathBinShipper)
-	PathPkgComponent, _ = path.Split(PathBinComponent)
+	PathPkgShipper, _   = filepath.Split(PathBinShipper)
+	PathPkgComponent, _ = filepath.Split(PathBinComponent)
 )
 
 func RemoveBinaries(binaries ...string) error {
@@ -79,6 +78,7 @@ func CompileBinary(out string, packagePath string) {
 		"go",
 		"build",
 		"-gcflags=all=-N -l",
+		"-buildvcs=false",
 		"-o", out,
 		packagePath)
 	cmd.Stdout = &outBuff

--- a/pkg/component/fake/bintools/bintools.go
+++ b/pkg/component/fake/bintools/bintools.go
@@ -1,0 +1,113 @@
+package bintools
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strconv"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/elastic-agent/pkg/component"
+)
+
+const ExtExe = ".exe"
+
+var (
+	PathBinShipper   = BinaryPath("shipper")
+	PathBinComponent = BinaryPath("component")
+
+	PathPkgShipper, _   = path.Split("shipper")
+	PathPkgComponent, _ = path.Split("component")
+)
+
+func RemoveBinaries(binaries ...string) error {
+	const envVarRemoveBinaries = "REMOVE_FAKE_BINARIES"
+	removeBinaries := os.Getenv(envVarRemoveBinaries)
+
+	remove, err := strconv.ParseBool(removeBinaries)
+	if err != nil {
+		remove = true // if anything fails, keep the default
+		fmt.Printf("could not parse %s: %v", envVarRemoveBinaries, err)
+	}
+
+	if !remove {
+		fmt.Println("not removing binaries")
+	}
+
+	var multErr *multierror.Error
+	for _, b := range binaries {
+		err := os.Remove(PathBinComponent)
+		if err != nil {
+			multErr = multierror.Append(multErr, fmt.Errorf(
+				"failed to remove %s: %q: %v", b, err))
+
+		}
+
+	}
+
+	return multErr
+}
+
+func BinaryPath(name string) string {
+	binaryPath := filepath.Join("..", "fake", name, name)
+
+	if runtime.GOOS == component.Windows {
+		binaryPath += ExtExe
+	}
+
+	return binaryPath
+}
+
+func CompileBinary(out string, packagePath string) {
+	var outBuff bytes.Buffer
+	var errBuff bytes.Buffer
+
+	cmd := exec.Command(
+		"go",
+		"build",
+		"-gcflags=all=-N -l",
+		"-o", out,
+		packagePath)
+	cmd.Stdout = &outBuff
+	cmd.Stderr = &errBuff
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			fmt.Printf("could not compile binary: %s: %v",
+				exitErr.String(),
+				string(exitErr.Stderr))
+			fmt.Println("the command run was:", cmd.String())
+
+			if outBuff.Len() > 0 {
+				fmt.Println("stdOut:", outBuff.String())
+			}
+			if errBuff.Len() > 0 {
+				fmt.Println("stdErr:", errBuff.String())
+			}
+
+			os.Exit(1)
+		}
+
+		fmt.Printf("failed compiling binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	if runtime.GOOS != component.Windows {
+		err := os.Chown(out, os.Geteuid(), os.Getgid())
+		if err != nil {
+			fmt.Printf("failed chown %s: %s\n", out, err)
+			os.Exit(1)
+		}
+		err = os.Chmod(out, 0755)
+		if err != nil {
+			fmt.Printf("failed chmod %s: %s\n", out, err)
+			os.Exit(1)
+		}
+	}
+}

--- a/pkg/component/fake/bintools/bintools.go
+++ b/pkg/component/fake/bintools/bintools.go
@@ -89,8 +89,10 @@ func RemoveBinaries(binaries ...string) error {
 }
 
 func BinaryPath(name string) string {
-	binaryPath := filepath.Join("..", "fake", name, name)
+	_, b, _, _ := runtime.Caller(0)
+	pathPkg := filepath.Dir(b)
 
+	binaryPath := filepath.Join(pathPkg, "..", name, name)
 	if runtime.GOOS == component.Windows {
 		binaryPath += ExtExe
 	}

--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/elastic-agent/pkg/component/fake/bintools"
 	fakecmp "github.com/elastic/elastic-agent/pkg/component/fake/component/comp"
 
 	"github.com/gofrs/uuid"
@@ -35,7 +36,6 @@ import (
 )
 
 const (
-	exeExt             = ".exe"
 	errActionUndefined = "action undefined"
 )
 
@@ -2898,7 +2898,7 @@ func testBinary(t *testing.T, name string) string {
 	t.Helper()
 
 	var err error
-	binaryPath := fakeBinaryPath(name)
+	binaryPath := bintools.BinaryPath(name)
 
 	binaryPath, err = filepath.Abs(binaryPath)
 	if err != nil {

--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -2908,16 +2908,6 @@ func testBinary(t *testing.T, name string) string {
 	return binaryPath
 }
 
-func fakeBinaryPath(name string) string {
-	binaryPath := filepath.Join("..", "fake", name, name)
-
-	if runtime.GOOS == component.Windows {
-		binaryPath += exeExt
-	}
-
-	return binaryPath
-}
-
 type testMonitoringManager struct{}
 
 func newTestMonitoringMgr() *testMonitoringManager { return &testMonitoringManager{} }

--- a/pkg/component/runtime/test_main_test.go
+++ b/pkg/component/runtime/test_main_test.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/elastic/elastic-agent/pkg/component"
@@ -23,6 +24,8 @@ var (
 func TestMain(m *testing.M) {
 	flag.Parse()
 
+	removeBinaries := os.Getenv("REMOVE_FAKE_BINARIES")
+
 	fakeCompPackage := path.Join("..", "fake", "component")
 	fakeShipperPackage := path.Join("..", "fake", "shipper")
 
@@ -31,29 +34,31 @@ func TestMain(m *testing.M) {
 
 	exitCode := m.Run()
 
-	errRmFakeComp := os.Remove(fakeCompBinPath)
-	if errRmFakeComp != nil {
-		fmt.Printf("failed to remove fake/component: %q: %v\n",
-			fakeShipperBinPath, errRmFakeComp)
-	}
+	if strings.ToLower(removeBinaries) != "false" {
+		errRmFakeComp := os.Remove(fakeCompBinPath)
+		if errRmFakeComp != nil {
+			fmt.Printf("failed to remove fake/component: %q: %v\n",
+				fakeShipperBinPath, errRmFakeComp)
+		}
 
-	errRmFakeshipper := os.Remove(fakeShipperBinPath)
-	if errRmFakeComp != nil {
-		fmt.Printf("failed to remove fake/shipper: %q: %v\n",
-			fakeShipperBinPath, errRmFakeshipper)
-	}
+		errRmFakeshipper := os.Remove(fakeShipperBinPath)
+		if errRmFakeComp != nil {
+			fmt.Printf("failed to remove fake/shipper: %q: %v\n",
+				fakeShipperBinPath, errRmFakeshipper)
+		}
 
-	switch {
-	case exitCode != 0 && errRmFakeComp == nil && errRmFakeshipper == nil:
-		fmt.Printf("tests exited with code %d, but clean up succeeded\n",
-			exitCode)
-	case exitCode == 0 && (errRmFakeComp != nil || errRmFakeshipper != nil):
-		fmt.Printf("test clean up failed: fake/component err:%v, fake/shipper err: %v\n",
-			errRmFakeComp, errRmFakeshipper)
-		exitCode = 1
-	case exitCode != 0 && (errRmFakeComp != nil || errRmFakeshipper != nil):
-		fmt.Printf("test exited with code %d. clean up failed: fake/component err:%v, fake/shipper err: %v\n",
-			exitCode, errRmFakeComp, errRmFakeshipper)
+		switch {
+		case exitCode != 0 && errRmFakeComp == nil && errRmFakeshipper == nil:
+			fmt.Printf("tests exited with code %d, but clean up succeeded\n",
+				exitCode)
+		case exitCode == 0 && (errRmFakeComp != nil || errRmFakeshipper != nil):
+			fmt.Printf("test clean up failed: fake/component err:%v, fake/shipper err: %v\n",
+				errRmFakeComp, errRmFakeshipper)
+			exitCode = 1
+		case exitCode != 0 && (errRmFakeComp != nil || errRmFakeshipper != nil):
+			fmt.Printf("test exited with code %d. clean up failed: fake/component err:%v, fake/shipper err: %v\n",
+				exitCode, errRmFakeComp, errRmFakeshipper)
+		}
 	}
 
 	os.Exit(exitCode)

--- a/pkg/component/runtime/test_main_test.go
+++ b/pkg/component/runtime/test_main_test.go
@@ -1,0 +1,120 @@
+package runtime
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/elastic/elastic-agent/pkg/component"
+)
+
+var (
+	fakeCompBinPath    = fakeBinaryPath("component")
+	fakeShipperBinPath = fakeBinaryPath("shipper")
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	fakeCompPackage := path.Join("..", "fake", "component")
+	fakeShipperPackage := path.Join("..", "fake", "shipper")
+
+	compileBinary(fakeCompBinPath, fakeCompPackage)
+	compileBinary(fakeShipperBinPath, fakeShipperPackage)
+
+	exitCode := m.Run()
+
+	errRmFakeComp := os.Remove(fakeCompBinPath)
+	if errRmFakeComp != nil {
+		fmt.Printf("failed to remove fake/component: %q: %v\n",
+			fakeShipperBinPath, errRmFakeComp)
+	}
+
+	errRmFakeshipper := os.Remove(fakeShipperBinPath)
+	if errRmFakeComp != nil {
+		fmt.Printf("failed to remove fake/shipper: %q: %v\n",
+			fakeShipperBinPath, errRmFakeshipper)
+	}
+
+	switch {
+	case exitCode != 0 && errRmFakeComp == nil && errRmFakeshipper == nil:
+		fmt.Printf("tests exited with code %d, but clean up succeeded\n",
+			exitCode)
+	case exitCode == 0 && (errRmFakeComp != nil || errRmFakeshipper != nil):
+		fmt.Printf("test clean up failed: fake/component err:%v, fake/shipper err: %v\n",
+			errRmFakeComp, errRmFakeshipper)
+		exitCode = 1
+	case exitCode != 0 && (errRmFakeComp != nil || errRmFakeshipper != nil):
+		fmt.Printf("test exited with code %d. clean up failed: fake/component err:%v, fake/shipper err: %v\n",
+			exitCode, errRmFakeComp, errRmFakeshipper)
+	}
+
+	os.Exit(exitCode)
+}
+
+func fakeBinaryPath(name string) string {
+	binaryPath := filepath.Join("..", "fake", name, name)
+
+	if runtime.GOOS == component.Windows {
+		binaryPath += exeExt
+	}
+
+	return binaryPath
+}
+
+func compileBinary(out string, packagePath string) {
+	var outBuff bytes.Buffer
+	var errBuff bytes.Buffer
+
+	cmd := exec.Command(
+		"go",
+		"build",
+		"-gcflags=all=-N -l",
+		"-o", out,
+		packagePath)
+	cmd.Stdout = &outBuff
+	cmd.Stderr = &errBuff
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			fmt.Printf("could not compile binary: %s: %v",
+				exitErr.String(),
+				string(exitErr.Stderr))
+			fmt.Println("the command run was:", cmd.String())
+
+			if outBuff.Len() > 0 {
+				fmt.Println("stdOut:", outBuff.String())
+			}
+			if errBuff.Len() > 0 {
+				fmt.Println("stdErr:", errBuff.String())
+			}
+
+			os.Exit(1)
+		}
+
+		fmt.Printf("failed compiling binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	if runtime.GOOS != component.Windows {
+		err := os.Chown(out, os.Geteuid(), os.Getgid())
+		if err != nil {
+			fmt.Printf("failed chown %s: %s\n", out, err)
+			os.Exit(1)
+		}
+		err = os.Chmod(out, 0755)
+		if err != nil {
+			fmt.Printf("failed chmod %s: %s\n", out, err)
+			os.Exit(1)
+		}
+	}
+
+	return
+}

--- a/pkg/component/runtime/test_main_test.go
+++ b/pkg/component/runtime/test_main_test.go
@@ -1,125 +1,34 @@
 package runtime
 
 import (
-	"bytes"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
-	"path"
-	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
 
-	"github.com/elastic/elastic-agent/pkg/component"
-)
-
-var (
-	fakeCompBinPath    = fakeBinaryPath("component")
-	fakeShipperBinPath = fakeBinaryPath("shipper")
+	"github.com/elastic/elastic-agent/pkg/component/fake/bintools"
 )
 
 func TestMain(m *testing.M) {
 	flag.Parse()
 
-	removeBinaries := os.Getenv("REMOVE_FAKE_BINARIES")
-
-	fakeCompPackage := path.Join("..", "fake", "component")
-	fakeShipperPackage := path.Join("..", "fake", "shipper")
-
-	compileBinary(fakeCompBinPath, fakeCompPackage)
-	compileBinary(fakeShipperBinPath, fakeShipperPackage)
+	bintools.CompileBinary(bintools.PathBinComponent, bintools.PathPkgComponent)
+	bintools.CompileBinary(bintools.PathBinShipper, bintools.PathPkgShipper)
 
 	exitCode := m.Run()
 
-	if strings.ToLower(removeBinaries) != "false" {
-		errRmFakeComp := os.Remove(fakeCompBinPath)
-		if errRmFakeComp != nil {
-			fmt.Printf("failed to remove fake/component: %q: %v\n",
-				fakeShipperBinPath, errRmFakeComp)
-		}
+	err := bintools.RemoveBinaries(bintools.PathBinComponent, bintools.PathBinShipper)
 
-		errRmFakeshipper := os.Remove(fakeShipperBinPath)
-		if errRmFakeComp != nil {
-			fmt.Printf("failed to remove fake/shipper: %q: %v\n",
-				fakeShipperBinPath, errRmFakeshipper)
-		}
-
-		switch {
-		case exitCode != 0 && errRmFakeComp == nil && errRmFakeshipper == nil:
-			fmt.Printf("tests exited with code %d, but clean up succeeded\n",
-				exitCode)
-		case exitCode == 0 && (errRmFakeComp != nil || errRmFakeshipper != nil):
-			fmt.Printf("test clean up failed: fake/component err:%v, fake/shipper err: %v\n",
-				errRmFakeComp, errRmFakeshipper)
-			exitCode = 1
-		case exitCode != 0 && (errRmFakeComp != nil || errRmFakeshipper != nil):
-			fmt.Printf("test exited with code %d. clean up failed: fake/component err:%v, fake/shipper err: %v\n",
-				exitCode, errRmFakeComp, errRmFakeshipper)
-		}
+	switch {
+	case exitCode == 0 && err != nil:
+		fmt.Printf("test clean up failed: %v\n", err)
+	case exitCode != 0 && err == nil:
+		fmt.Printf("test exited with code %d but clean up succeeded: %v\n",
+			exitCode, err)
+	case exitCode != 0 && err != nil:
+		fmt.Printf("test exited with code %d and clean up failed: %v\n",
+			exitCode, err)
 	}
 
 	os.Exit(exitCode)
-}
-
-func fakeBinaryPath(name string) string {
-	binaryPath := filepath.Join("..", "fake", name, name)
-
-	if runtime.GOOS == component.Windows {
-		binaryPath += exeExt
-	}
-
-	return binaryPath
-}
-
-func compileBinary(out string, packagePath string) {
-	var outBuff bytes.Buffer
-	var errBuff bytes.Buffer
-
-	cmd := exec.Command(
-		"go",
-		"build",
-		"-gcflags=all=-N -l",
-		"-o", out,
-		packagePath)
-	cmd.Stdout = &outBuff
-	cmd.Stderr = &errBuff
-	if err := cmd.Run(); err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			fmt.Printf("could not compile binary: %s: %v",
-				exitErr.String(),
-				string(exitErr.Stderr))
-			fmt.Println("the command run was:", cmd.String())
-
-			if outBuff.Len() > 0 {
-				fmt.Println("stdOut:", outBuff.String())
-			}
-			if errBuff.Len() > 0 {
-				fmt.Println("stdErr:", errBuff.String())
-			}
-
-			os.Exit(1)
-		}
-
-		fmt.Printf("failed compiling binary: %v\n", err)
-		os.Exit(1)
-	}
-
-	if runtime.GOOS != component.Windows {
-		err := os.Chown(out, os.Geteuid(), os.Getgid())
-		if err != nil {
-			fmt.Printf("failed chown %s: %s\n", out, err)
-			os.Exit(1)
-		}
-		err = os.Chmod(out, 0755)
-		if err != nil {
-			fmt.Printf("failed chmod %s: %s\n", out, err)
-			os.Exit(1)
-		}
-	}
-
-	return
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Makes the fake components to be compiled on `TestMain`.

## Why is it important?

Every time the tests run it'll use the most up to date version of the fake binaries. It's particularly important when modifying those binaries.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~


## How to test this PR locally

 - Delete the pkg/component/fake binaries if you have any of them
 - run the tests, they should succeed
```
go test ./pkg/component/runtime
```
## Related issues

N/A