### PR TITLE
Comment out cloud-defend caps

### DIFF
--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -64,13 +64,13 @@ spec:
                   fieldPath: metadata.name
           securityContext:
             runAsUser: 0
-            capabilities:
-              add:
-                # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
-                # If you are not using this integration, then these capabilites can be removed.
-                - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
-                - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
-                - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for Containers' to modify 'rlimit_memlock'
+            # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
+            # If you are using this integration, please uncomment these lines before applying.
+            #capabilities:
+            #  add:
+            #    - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
+            #    - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
+            #    - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for Containers' to modify 'rlimit_memlock'
           resources:
             limits:
               memory: 700Mi

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -64,13 +64,13 @@ spec:
                   fieldPath: metadata.name
           securityContext:
             runAsUser: 0
-            capabilities:
-              add:
-                # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
-                # If you are not using this integration, then these capabilites can be removed.
-                - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
-                - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
-                - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for Containers' to modify 'rlimit_memlock'
+            # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
+            # If you are using this integration, please uncomment these lines before applying.
+            #capabilities:
+            #  add:
+            #    - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
+            #    - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
+            #    - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for Containers' to modify 'rlimit_memlock'
           resources:
             limits:
               memory: 700Mi

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -732,13 +732,13 @@ spec:
               value: "/etc/elastic-agent"
           securityContext:
             runAsUser: 0
-            capabilities:
-              add:
-                # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
-                # If you are not using this integration, then these capabilites can be removed.
-                - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
-                - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
-                - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for containers' to modify 'rlimit_memlock'
+            # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
+            # If you are using this integration, please uncomment these lines before applying.
+            #capabilities:
+            #  add:
+            #    - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
+            #    - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
+            #    - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for Containers' to modify 'rlimit_memlock'
           resources:
             limits:
               memory: 700Mi

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
@@ -65,13 +65,13 @@ spec:
               value: "/etc/elastic-agent"
           securityContext:
             runAsUser: 0
-            capabilities:
-              add:
-                # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
-                # If you are not using this integration, then these capabilites can be removed.
-                - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
-                - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
-                - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for containers' to modify 'rlimit_memlock'
+            # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
+            # If you are using this integration, please uncomment these lines before applying.
+            #capabilities:
+            #  add:
+            #    - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
+            #    - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
+            #    - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for Containers' to modify 'rlimit_memlock'
           resources:
             limits:
               memory: 700Mi


### PR DESCRIPTION
## What does this PR do?
This PR comments out the additional capabilities required to run cloud-defend. 

## Why is it important?
The BPF and PERFMON capabilities are not compatible with some older system dependencies. This includes Kubernetes 1.23 and Docker Engine v20. 

See [this](https://github.com/elastic/security-team/issues/6538) conversation for further background 

This patch removes the capabilities by default until we can deprecate support for some older depedencies or introduce a templating mechanism. 


