### PR TITLE
Set the build settings for the elastc-agent

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -37,6 +37,13 @@ spec:
     spec:
       repository: elastic/elastic-agent
       pipeline_file: ".buildkite/pipeline.yml"
+      provider_settings:
+        build_pull_request_forks: false
+        build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
+        build_tags: true
+        filter_enabled: true
+        filter_condition: |
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
## What does this PR do?

Sets the build settings for the elastic-agent repo. 

## Why is it important?

This is part of the Buildkite migration and it is required so we trigger properly Buildkite only using the bot.

This change does not affect the elastic-agent product.