### PR TITLE
Monitoring: add Universal Profiling components to supportedBeatsCompo…

### DIFF
--- a/internal/pkg/agent/application/monitoring/process.go
+++ b/internal/pkg/agent/application/monitoring/process.go
@@ -22,12 +22,13 @@ import (
 )
 
 const (
-	componentIDKey    = "componentID"
-	metricsPathKey    = "metricsPath"
-	timeout           = 10 * time.Second
-	apmPrefix         = "apm-server"
-	apmTypePrefix     = "apm"
-	fleetServerPrefix = "fleet-server"
+	componentIDKey         = "componentID"
+	metricsPathKey         = "metricsPath"
+	timeout                = 10 * time.Second
+	apmPrefix              = "apm-server"
+	apmTypePrefix          = "apm"
+	fleetServerPrefix      = "fleet-server"
+	profilingServicePrefix = "pf-elastic-"
 )
 
 var redirectPathAllowlist = map[string]struct{}{
@@ -39,6 +40,7 @@ var redirectPathAllowlist = map[string]struct{}{
 var redirectableProcesses = []string{
 	apmTypePrefix,
 	fleetServerPrefix,
+	profilingServicePrefix,
 }
 
 func processHandler(coord *coordinator.Coordinator, statsHandler func(http.ResponseWriter, *http.Request) error, operatingSystem string) func(http.ResponseWriter, *http.Request) error {

--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -58,7 +58,7 @@ const (
 var (
 	errNoOuputPresent          = errors.New("outputs not part of the config")
 	supportedMetricsComponents = []string{"filebeat", "metricbeat", "apm-server", "auditbeat", "cloudbeat", "fleet-server", "heartbeat", "osquerybeat", "packetbeat", "shipper"}
-	supportedBeatsComponents   = []string{"filebeat", "metricbeat", "apm-server", "fleet-server", "auditbeat", "cloudbeat", "heartbeat", "osquerybeat", "packetbeat", "pf-host-agent", "pf-elastic-collecor", "pf-elastic-symbolizer"}
+	supportedBeatsComponents   = []string{"filebeat", "metricbeat", "apm-server", "fleet-server", "auditbeat", "cloudbeat", "heartbeat", "osquerybeat", "packetbeat", "pf-host-agent", "pf-elastic-collector", "pf-elastic-symbolizer"}
 )
 
 // BeatsMonitor is providing V1 monitoring support for metrics and logs for endpoint-security only.

--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -57,8 +57,8 @@ const (
 
 var (
 	errNoOuputPresent          = errors.New("outputs not part of the config")
-	supportedMetricsComponents = []string{"filebeat", "metricbeat", "apm-server", "auditbeat", "cloudbeat", "fleet-server", "heartbeat", "osquerybeat", "packetbeat", "shipper"}
-	supportedBeatsComponents   = []string{"filebeat", "metricbeat", "apm-server", "fleet-server", "auditbeat", "cloudbeat", "heartbeat", "osquerybeat", "packetbeat", "pf-host-agent", "pf-elastic-collector", "pf-elastic-symbolizer"}
+	supportedMetricsComponents = []string{"filebeat", "metricbeat", "apm-server", "auditbeat", "cloudbeat", "fleet-server", "heartbeat", "osquerybeat", "packetbeat", "pf-elastic-collector", "pf-elastic-symbolizer", "shipper"}
+	supportedBeatsComponents   = []string{"filebeat", "metricbeat", "apm-server", "fleet-server", "auditbeat", "cloudbeat", "heartbeat", "osquerybeat", "packetbeat", "pf-elastic-collector", "pf-elastic-symbolizer"}
 )
 
 // BeatsMonitor is providing V1 monitoring support for metrics and logs for endpoint-security only.

--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -58,7 +58,7 @@ const (
 var (
 	errNoOuputPresent          = errors.New("outputs not part of the config")
 	supportedMetricsComponents = []string{"filebeat", "metricbeat", "apm-server", "auditbeat", "cloudbeat", "fleet-server", "heartbeat", "osquerybeat", "packetbeat", "shipper"}
-	supportedBeatsComponents   = []string{"filebeat", "metricbeat", "apm-server", "fleet-server", "auditbeat", "cloudbeat", "heartbeat", "osquerybeat", "packetbeat"}
+	supportedBeatsComponents   = []string{"filebeat", "metricbeat", "apm-server", "fleet-server", "auditbeat", "cloudbeat", "heartbeat", "osquerybeat", "packetbeat", "pf-host-agent", "pf-elastic-collecor", "pf-elastic-symbolizer"}
 )
 
 // BeatsMonitor is providing V1 monitoring support for metrics and logs for endpoint-security only.


### PR DESCRIPTION
…nents

## What does this PR do?


To be able to properly configure monitoring the Universal Profiling components require the information from Elastic Agent on how to configure everything.


