### PR TITLE
Fix mapping of Fleet status and message in protobuf StateResponse

### DIFF
--- a/pkg/control/v2/server/server.go
+++ b/pkg/control/v2/server/server.go
@@ -308,8 +308,10 @@ func stateToProto(state *state.State, agentInfo *info.AgentInfo) (*cproto.StateR
 			BuildTime: release.BuildTime().Format(control.TimeFormat()),
 			Snapshot:  release.Snapshot(),
 		},
-		State:      state.State,
-		Message:    state.Message,
-		Components: components,
+		State:        state.State,
+		Message:      state.Message,
+		FleetState:   state.FleetState,
+		FleetMessage: state.FleetMessage,
+		Components:   components,
 	}, nil
 }

--- a/pkg/control/v2/server/server_test.go
+++ b/pkg/control/v2/server/server_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
 )
 
-func TestFleetStateMapping(t *testing.T) {
+func TestStateMapping(t *testing.T) {
 
 	testcases := []struct {
 		name         string

--- a/pkg/control/v2/server/server_test.go
+++ b/pkg/control/v2/server/server_test.go
@@ -1,0 +1,58 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator/state"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
+	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
+)
+
+func TestFleetStateMapping(t *testing.T) {
+
+	testcases := []struct {
+		name    string
+		state   cproto.State
+		message string
+	}{
+		{
+			name:    "waiting first checkin response",
+			state:   cproto.State_STARTING,
+			message: "",
+		},
+		{
+			name:    "last checkin successful",
+			state:   cproto.State_HEALTHY,
+			message: "Connected",
+		},
+		{
+			name:    "last checkin failed",
+			state:   cproto.State_FAILED,
+			message: "<error value coming from fleet gateway>",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputState := new(state.State)
+			inputState.FleetState = tc.state
+			inputState.FleetMessage = tc.message
+
+			agentInfo := new(info.AgentInfo)
+
+			stateResponse, err := stateToProto(inputState, agentInfo)
+			require.NoError(t, err)
+
+			assert.Equal(t, stateResponse.FleetState, tc.state)
+			assert.Equal(t, stateResponse.FleetMessage, tc.message)
+		})
+	}
+
+}

--- a/pkg/control/v2/server/server_test.go
+++ b/pkg/control/v2/server/server_test.go
@@ -7,51 +7,133 @@ package server
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gotest.tools/assert"
 
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator/state"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
+	"github.com/elastic/elastic-agent/pkg/component"
+	"github.com/elastic/elastic-agent/pkg/component/runtime"
 	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
 )
 
 func TestFleetStateMapping(t *testing.T) {
 
 	testcases := []struct {
-		name    string
-		state   cproto.State
-		message string
+		name         string
+		agentState   cproto.State
+		agentMessage string
+		fleetState   cproto.State
+		fleetMessage string
 	}{
 		{
-			name:    "waiting first checkin response",
-			state:   cproto.State_STARTING,
-			message: "",
+			name:         "waiting first checkin response",
+			agentState:   cproto.State_HEALTHY,
+			agentMessage: "Healthy",
+			fleetState:   cproto.State_STARTING,
+			fleetMessage: "",
 		},
 		{
-			name:    "last checkin successful",
-			state:   cproto.State_HEALTHY,
-			message: "Connected",
+			name:         "last checkin successful",
+			agentState:   cproto.State_HEALTHY,
+			agentMessage: "Healthy",
+			fleetState:   cproto.State_HEALTHY,
+			fleetMessage: "Connected",
 		},
 		{
-			name:    "last checkin failed",
-			state:   cproto.State_FAILED,
-			message: "<error value coming from fleet gateway>",
+			name:         "last checkin failed",
+			agentState:   cproto.State_HEALTHY,
+			agentMessage: "Healthy",
+			fleetState:   cproto.State_FAILED,
+			fleetMessage: "<error value coming from fleet gateway>",
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			inputState := new(state.State)
-			inputState.FleetState = tc.state
-			inputState.FleetMessage = tc.message
+			inputState := &state.State{
+				State:        tc.agentState,
+				Message:      tc.agentMessage,
+				FleetState:   tc.fleetState,
+				FleetMessage: tc.fleetMessage,
+				LogLevel:     logp.ErrorLevel,
+				Components: []runtime.ComponentComponentState{
+					{
+						Component: component.Component{
+							ID: "some-component",
+							InputSpec: &component.InputRuntimeSpec{
+								InputType: "some-component-input-type",
+							},
+							Units: []component.Unit{
+								{
+									ID:   "some-input-unit",
+									Type: client.UnitTypeInput,
+								},
+							},
+						},
+						State: runtime.ComponentState{
+							State:   client.UnitStateHealthy,
+							Message: "component healthy",
+							VersionInfo: runtime.ComponentVersionInfo{
+								Name:    "awesome-comp",
+								Version: "0.0.1",
+								Meta: map[string]string{
+									"foo": "bar",
+								},
+							},
+							Units: map[runtime.ComponentUnitKey]runtime.ComponentUnitState{
+								{
+									UnitType: client.UnitTypeInput,
+									UnitID:   "some-input-unit",
+								}: {
+									State:   client.UnitStateHealthy,
+									Message: "unit healthy",
+									Payload: map[string]any{
+										"foo": map[string]any{
+											"bar": "baz"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
 
 			agentInfo := new(info.AgentInfo)
 
 			stateResponse, err := stateToProto(inputState, agentInfo)
 			require.NoError(t, err)
 
-			assert.Equal(t, stateResponse.FleetState, tc.state)
-			assert.Equal(t, stateResponse.FleetMessage, tc.message)
+			assert.Equal(t, stateResponse.State, tc.agentState)
+			assert.Equal(t, stateResponse.Message, tc.agentMessage)
+			assert.Equal(t, stateResponse.FleetState, tc.fleetState)
+			assert.Equal(t, stateResponse.FleetMessage, tc.fleetMessage)
+			if assert.Len(t, stateResponse.Components, 1) {
+				expectedCompState := &cproto.ComponentState{
+					Id:      "some-component",
+					State:   cproto.State_HEALTHY,
+					Name:    "some-component-input-type",
+					Message: "component healthy",
+					Units: []*cproto.ComponentUnitState{
+						{
+							UnitId:   "some-input-unit",
+							UnitType: cproto.UnitType_INPUT,
+							State:    cproto.State_HEALTHY,
+							Message:  "unit healthy",
+							Payload:  "{\"foo\":{\"bar\":\"baz\"}}",
+						},
+					},
+					VersionInfo: &cproto.ComponentVersionInfo{
+						Name:    "awesome-comp",
+						Version: "0.0.1",
+						Meta:    map[string]string{"foo": "bar"},
+					},
+				}
+				assert.Equal(t, expectedCompState, stateResponse.Components[0])
+			}
+
 		})
 	}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fix mapping of fleet state and message in the `StateResponse`

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

To avoid having always Fleet state: STARTING in `elastic-agent status` output
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #2528 
## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
