### PR TITLE
Split GH workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,9 @@
-name: Build
-on: workflow_dispatch
+name: CodeCoverage Build
+on:
+  pull_request:
 jobs:
-  sonarcloud:
-    name: SonarCloud
+  coverage:
+    name: CodeCoverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -31,10 +32,8 @@ jobs:
         with:
           version: latest
           args: unitTest
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-          
+      - uses: actions/upload-artifact@v3
+        with:
+          name: test-coverage
+          path: build/TEST-*
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,5 +35,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: test-coverage
-          path: build/TEST-*
+          path: |
+            build/TEST-*
+            sonar-project.properties
           if-no-files-found: error

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,31 @@
+name: SonarCloud
+
+on:
+  workflow_run:
+    workflows: ["CodeCoverage Build"]
+    types:
+      - completed
+
+jobs:
+  coverage:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: test-coverage
+          path: build
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+


### PR DESCRIPTION
Split the GH workflow into 2 workflows. 

Using `workflow_run` the job is going to be triggered from the scope of the upstream repository.