### PR TITLE
Update sonarcloud workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,10 +18,27 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
-      - uses: actions/download-artifact@v3
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
         with:
-          name: test-coverage
-          path: build
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "test-coverage"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/test-coverage.zip', Buffer.from(download.data));
+      - run: unzip test-coverage.zip
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master


### PR DESCRIPTION
!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Update the sonarcloud workflow as the GH download step was not able to fetch the artifacts that were created from the forks workflow.

This is following the same instructions as https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

## Why is it important?

We want to be able to run the sonar workflow in the scope of the upstream repository and not the forks.
