### PR TITLE
chore: Update template to new configuration format

### DIFF
--- a/testing/e2e/Makefile
+++ b/testing/e2e/Makefile
@@ -1,11 +1,10 @@
-STACK_VERSION ?= 8.6.1
-AGENT_VERSION ?= 8.6.0
+STACK_VERSION ?= 8.7.1
+AGENT_VERSION ?= 8.7.0
+ELASTIC_AGENT_DOCKER_IMAGE ?= docker.elastic.co/observability-ci/elastic-agent-cloud:$(STACK_VERSION)
 GO_VERSION ?= $(shell cat ../../.go-version)
 CLUSTER_DIGEST_FILE ?= cluster-digest.yml
 CLUSTER_INFO_FILE ?= cluster-info.json
-CLUSTER_NAME ?= e2e-elasic-agent-$(shell date +%s)
 TEMPLATE_FILE ?= test-cluster.yml.tpl
-SLACK_CHANNEL ?= @U0396725PSN
 # The directory where the pre-downloaded agent binary is stored.
 ARTIFACTS_DIR := e2e_artifacts
 LOCAL_SSH_KEY ?= ~/.ssh/id_rsa
@@ -40,9 +39,11 @@ download-agent: set-arch
 
 .PHONY: create-cluster
 create-cluster:
-	@$(call check_defined, SLACK_CHANNEL, SLACK_CHANNEL is not defined. Specify a slack channel to send notifications to.)
 	@$(call check_defined, GITHUB_TOKEN, GITHUB_TOKEN is not defined. Specify a github token to use for the cluster.)
-	oblt-cli cluster create custom --template-file $(CURDIR)/$(TEMPLATE_FILE) --output-file $(CURDIR)/$(CLUSTER_INFO_FILE) --parameters '{"StackVersion": "$(STACK_VERSION)", "ClusterName": "$(CLUSTER_NAME)", "SlackChannel": "$(SLACK_CHANNEL)"}' --wait 15
+	oblt-cli cluster create custom --template-file $(CURDIR)/$(TEMPLATE_FILE) \
+		--output-file $(CURDIR)/$(CLUSTER_INFO_FILE) \
+		--parameters '{"StackVersion": "$(STACK_VERSION)", "ElasticAgentDockerImage": "$(ELASTIC_AGENT_DOCKER_IMAGE)"}' \
+		--wait 15
 	sync $(CURDIR)/$(CLUSTER_INFO_FILE)
 	oblt-cli cluster secrets digest-yml --cluster-name $$(cat $(CURDIR)/$(CLUSTER_INFO_FILE) | jq -r '.ClusterName') --output-file $(CURDIR)/$(CLUSTER_DIGEST_FILE)
 

--- a/testing/e2e/test-cluster.yml.tpl
+++ b/testing/e2e/test-cluster.yml.tpl
@@ -1,39 +1,32 @@
 ---
-cluster_name: "{{ .ClusterName }}"
 template_name: "elastic-agent-e2e"
-create_users: false
-grab_cluster_info: false
-create_ilm: false
-certificate_issuer: letsencrypt-staging
+template_description: |
+  elastic-agent-e2e is a template for deploying ESS cluster with elastic-agent on a specific version.
+  Parameters:
+    - ClusterName: Name for the new oblt cluster (automatic).
+    - SlackChannel: SlackChannel name or Slack member ID to send the credentials of the cluster (#my-channel, @MIDNUM)(automatic)
+    - StackVersion: Elastic Stack Pack version to be use on ESS (required).
+    - ElasticAgentDockerImage: Docker image to use for Elastic Agent (Optional).
+    - StackBuild: Elastic Stack build version used for the Elastic Agent Docker image (optional).
+  Usage:
+    oblt-cli cluster create custom --template elastic-agent-e2e --parameters '{"StackVersion": "8.7.1"}'
+    oblt-cli cluster create custom --template elastic-agent-e2e --parameters '{"StackVersion":"8.7.1", "ElasticAgentDockerImage": "docker.elastic.co/observability-ci/elastic-agent-cloud:8.7.1-08adc761"}'
+
+
+#{{ $elasticAgentDockerImage := (printf "%s:%s" "docker.elastic.co/observability-ci/elastic-agent-cloud" .StackVersion) }}
+#{{- if .ElasticAgentDockerImage }}
+#{{ $elasticAgentDockerImage = .ElasticAgentDockerImage }}
+#{{- end }}
+
+cluster_name: "{{ .ClusterName }}"
 slack_channel: "{{ .SlackChannel }}"
 digest_secrets_enabled: true
-secret_ec_user: "observability-team/ci/elastic-cloud/observability-pro"
 
-elastic_cloud:
-  provider: gcp
-  region: gcp-us-west2
-  endpoint: https://cloud.elastic.co
-  zones: 1
-  template: gcp-io-optimized-v2
-
-elasticsearch:
-  enabled: true
+stack:
+  mode: ess
+  template: observability
   version: "{{ .StackVersion }}"
-  type: tf
-
-kibana:
-  version: "{{ .StackVersion }}"
-  enabled: true
-  type: tf
-  mem: 1
-  apm_enabled: false
-
-apm:
-  enabled: true
-  version: "{{ .StackVersion }}"
-  image: "docker.elastic.co/observability-ci/elastic-agent-cloud:{{ .StackVersion }}"
-  type: tf
-  mem: 2
-
-k8s:
-  enabled: false
+  observability: true
+  ess:
+    integrations:
+      image: "{{ $elasticAgentDockerImage }}"


### PR DESCRIPTION
## What does this PR do?

* Updates the oblt-cli template to new configuration format
* Adds some help comments to the oblt-cli template
* Allow to change the Elastic Agent Docker image in the oblt-cli tempate
* Updates the Elastic Stack versions

## Why is it important?

The old template format is deprecated, the new format is clean and more human ready, most of the values are set by default.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```bash
export STACK_VERSION=8.8.0-SNAPSHOT
make -C testing/e2e create-cluster GITHUB_TOKEN=$(gh auth token) 
make -C testing/e2e destroy-cluster
```

```bash
export  STACK_VERSION=8.8.0-SNAPSHOT
export ELASTIC_AGENT_DOCKER_IMAGE=docker.elastic.co/cloud-release/elastic-agent-cloud:8.8.0-c26f78b8-SNAPSHOT
make -C testing/e2e create-cluster GITHUB_TOKEN=$(gh auth token)
make -C testing/e2e destroy-cluster
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
