### PR TITLE
Add link to ESS QA API keys page

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -1455,7 +1455,9 @@ func authESS(ctx context.Context) error {
 
 		fmt.Fprintln(os.Stderr, "❌  ESS authentication unsuccessful. Retrying...")
 
-		essAPIKey, err = stringPrompt("Please provide a ESS (QA) API key:")
+		prompt := "Please provide a ESS (QA) API key. To get your API key, " +
+			"visit https://console.qa.cld.elstc.co/deployment-features/keys:"
+		essAPIKey, err = stringPrompt(prompt)
 		if err != nil {
 			return fmt.Errorf("unable to read ESS API key from prompt: %w", err)
 		}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR enhances the `mage integration:auth` target to include a link to the ESS QA API keys page.

```
$ mage integration:auth
✔️  GCP authentication successful
❌  ESS authentication unsuccessful. Retrying...
Please provide a ESS (QA) API key. To get your API key, visit https://console.qa.cld.elstc.co/deployment-features/keys:
```

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To make it easy for developers to find their ESS QA API key.  Thanks @blakerouse for the suggestion.
