### PR TITLE
Adjust the workflows for SonarCloud

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: CodeCoverage Build
 on:
   pull_request:
+
 jobs:
   coverage:
     name: CodeCoverage
@@ -9,11 +10,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Go cache
         uses: actions/cache@v3
         with:
@@ -25,6 +28,7 @@ jobs:
           key: ${{ runner.os }}-go-cache-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-cache
+
       - name: Run Mage
         uses: magefile/mage-action@v2
         env:
@@ -32,10 +36,18 @@ jobs:
         with:
           version: latest
           args: unitTest
+
+      - name: Save PR information
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./build/pull_request_number
+          echo ${{ github.event.pull_request.base.ref }} > ./build/pull_request_base
+          echo ${{ github.event.pull_request.head.ref }} > ./build/pull_request_branch
+
       - uses: actions/upload-artifact@v3
         with:
           name: test-coverage
           path: |
             build/TEST-*
-            sonar-project.properties
+            build/pull_request*
           if-no-files-found: error

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -16,7 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
+          repository: '${{ github.event.workflow_run.head_repository.full_name }}'
+          ref: '${{ github.event.workflow_run.head_branch }}'
 
       - name: 'Download artifact'
         uses: actions/github-script@v3.1.0
@@ -38,11 +40,46 @@ jobs:
             });
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/test-coverage.zip', Buffer.from(download.data));
-      - run: unzip test-coverage.zip
+      - run: unzip -o test-coverage.zip
+
+      - name: Retrieve the pr number
+        id: pr-number
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            var fs = require('fs');
+            var pr_number = Number(fs.readFileSync('./build/pull_request_number'));
+            return pr_number;
+
+      - name: Retrieve the pr base
+        id: pr-base
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            var fs = require('fs');
+            var pr_base = fs.readFileSync('./build/pull_request_base');
+            return pr_base;
+
+      - name: Retrieve the pr branch
+        id: pr-branch
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            var fs = require('fs');
+            var pr_base = fs.readFileSync('./build/pull_request_branch');
+            return pr_base;
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
+        with:
+          args: >
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+            -Dsonar.pullrequest.key=${{ steps.pr-number.outputs.result }}
+            -Dsonar.pullrequest.branch=${{ steps.pr-branch.outputs.result }}
+            -Dsonar.pullrequest.base=${{ steps.pr-base.outputs.result }}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This change adjusts the workflows so that the first one will build and generate the required file of a PR and archive and the second will be triggered to upload the results into the sonar cloud.

## Why is it important?

This will allow pull_requests from forks to be analyzed before merging.
