### PR TITLE
Add a new job for Sonar only on push on main

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,6 +1,10 @@
 name: SonarCloud
 
 on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
   workflow_run:
     workflows: ["CodeCoverage Build"]
     types:
@@ -83,3 +87,34 @@ jobs:
             -Dsonar.pullrequest.key=${{ steps.pr-number.outputs.result }}
             -Dsonar.pullrequest.branch=${{ steps.pr-branch.outputs.result }}
             -Dsonar.pullrequest.base=${{ steps.pr-base.outputs.result }}
+
+  branch-coverage:
+    name: Branch SonarCloud
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Run Mage
+        uses: magefile/mage-action@v2
+        env:
+          TEST_COVERAGE: 'true'
+        with:
+          version: latest
+          args: unitTest
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This commit adds a new job in the sonarcloud workflow that will be executed on push events.

Additionally, add a push trigger for the main branch, so when new code is merged on main this will be triggered and send the results into SonarCloud.

Adding also a workflow_dispatch to be able to trigger it manually


## Why is it important?

This is going to keep the main branch up-to-date in sonarcloud and the badge updated.
