### PR TITLE
Add specs to Sonar exclusions

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.projectKey=elastic_elastic-agent
 sonar.host.url=https://sonarcloud.io
 
 sonar.sources=.
-sonar.exclusions=**/*_test.go, .git/**, dev-tools/**, /magefile.go, changelog/**, _meta/**, deploy/**, docs/**, img/**
+sonar.exclusions=**/*_test.go, .git/**, dev-tools/**, /magefile.go, changelog/**, _meta/**, deploy/**, docs/**, img/** specs/**
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.projectKey=elastic_elastic-agent
 sonar.host.url=https://sonarcloud.io
 
 sonar.sources=.
-sonar.exclusions=**/*_test.go, .git/**, dev-tools/**, /magefile.go, changelog/**, _meta/**, deploy/**, docs/**, img/** specs/**
+sonar.exclusions=**/*_test.go, .git/**, dev-tools/**, /magefile.go, changelog/**, _meta/**, deploy/**, docs/**, img/**, specs/**
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 


### PR DESCRIPTION

## What does this PR do?

Add specs folder to the sonar exclusions list

## Why is it important?

So changes in this folder are not accounted into the sonar report.

cc @cmacknz in case you have any objections and think we should include them.
