### PR TITLE
Adding developer guide for integration and E2E testing framework

### DIFF
--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -1,0 +1,55 @@
+# Developer Guide for the Integration and E2E Testing Framework
+
+## Writing tests
+
+Write integration and E2E tests by adding them to the `testing/integration`
+folder.
+
+// TODO: Replace with a comprehensive write up of `define.*` directives,
+// environment variables, etc. useful when writing tests. Until then...
+
+Look at existing tests under the `testing/integration` for examples of how
+to write tests using the integration and E2E testing framework. Also look at
+the `github.com/elastic/elastic-agent/pkg/testing/define` package for the test
+framework's API and the `github.com/elastic/elastic-agent/pkg/testing/tools`
+package for helper utilities.
+
+## Running tests
+
+Some one-time setup is required to run any integration and E2E tests. Run
+`mage integration:auth` to perform this setup.
+
+Some integration and E2E tests are safe to run locally. These tests set
+`Local: true` in their test functions' `define.Require` directive. Tests that
+don't set `Local: true` or explicitly set `Local: false` are not considered
+safe to run locally and will be executed on remote VMs instead.
+
+Run `mage integration:test` to execute all tests under the `testing/integration`
+folder. All tests are executed on remote VMs, including those that set `Local: true`.
+
+Run `mage integration:local` to execute only those tests under the
+`testing/integration` folder that set `Local: true`. These tests are executed
+on your local machine.
+
+## Troubleshooting Tips
+
+### Error: GCE service token missing; run 'mage integration:auth'
+If you encounter this error when running `mage integration:test`, it's because
+the test runner is unable to create VMs on GCP to execute the tests.
+
+As the error message suggests, run `mage integration:auth` to resolve this error.
+
+### Error: missing required Elastic Agent package builds for integration runner to execute: ...
+If you encounter this error when running `mage integration:test` or
+`mage integration:local`, it's because the test runner couldn't find the appropriate
+Agent packages in the `build/distributions` folder.
+
+Run `mage package` with the appropriate value(s) in `PLATFORMS`, as suggested by the
+error message, to build the necessary Agent packages first.
+
+If the issue is that the built Agent packages contain `-SNAPSHOT` in their versions,
+whereas the package names in the error message do not, either omit `SNAPSHOT=true` from
+the `mage package` command OR set the `AGENT_VERSION` environment variable to a version
+that includes the `-SNAPSHOT` suffix when running `mage integration:test` or
+`mage integration:local`.
+


### PR DESCRIPTION
This PR starts to add a developer guide for the integration and E2E testing framework.

Closes #2640
