### PR TITLE
Pass uninstall token from Agent uninstall command to Endpoint uninstall command

### DIFF
--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -188,7 +188,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 
 		defer func() {
 			if err != nil {
-				_ = install.Uninstall(cfgFile, topPath)
+				_ = install.Uninstall(cfgFile, topPath, "")
 			}
 		}()
 
@@ -222,7 +222,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		if err != nil {
 			if status != install.PackageInstall {
 				var exitErr *exec.ExitError
-				_ = install.Uninstall(cfgFile, topPath)
+				_ = install.Uninstall(cfgFile, topPath, "")
 				if err != nil && errors.As(err, &exitErr) {
 					return fmt.Errorf("enroll command failed with exit code: %d", exitErr.ExitCode())
 				}

--- a/internal/pkg/agent/cmd/uninstall.go
+++ b/internal/pkg/agent/cmd/uninstall.go
@@ -34,6 +34,7 @@ Unless -f is used this command will ask confirmation before performing removal.
 	}
 
 	cmd.Flags().BoolP("force", "f", false, "Force overwrite the current and do not prompt for confirmation")
+	cmd.Flags().String("uninstall-token", "", "Uninstall protection token")
 
 	return cmd
 }
@@ -55,6 +56,7 @@ func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 	}
 
 	force, _ := cmd.Flags().GetBool("force")
+	uninstallToken, _ := cmd.Flags().GetString("uninstall-token")
 	if status == install.Broken {
 		if !force {
 			fmt.Fprintf(streams.Out, "Elastic Agent is installed but currently broken: %s\n", reason)
@@ -78,7 +80,7 @@ func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		}
 	}
 
-	err = install.Uninstall(paths.ConfigFile(), paths.Top())
+	err = install.Uninstall(paths.ConfigFile(), paths.Top(), uninstallToken)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/agent/install/install.go
+++ b/internal/pkg/agent/install/install.go
@@ -28,10 +28,17 @@ func Install(cfgFile, topPath string) error {
 		return errors.New(err, "failed to discover the source directory for installation", errors.TypeFilesystem)
 	}
 
-	// uninstall current installation
-	err = Uninstall(cfgFile, topPath)
+	// Uninstall current installation
+	//
+	// There is no uninstall token for "install" command.
+	// Uninstall will fail on protected agent.
+	// The protected Agent will need to be uninstalled first before it can be installed.
+	err = Uninstall(cfgFile, topPath, "")
 	if err != nil {
-		return err
+		return errors.New(
+			err,
+			fmt.Sprintf("failed to uninstall Agent at (%s)", filepath.Dir(topPath)),
+			errors.M("directory", filepath.Dir(topPath)))
 	}
 
 	// ensure parent directory exists, copy source into install path

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Uninstall uninstalls persistently Elastic Agent on the system.
-func Uninstall(cfgFile, topPath string) error {
+func Uninstall(cfgFile, topPath, uninstallToken string) error {
 	// uninstall the current service
 	svc, err := newService(topPath)
 	if err != nil {
@@ -47,7 +47,7 @@ func Uninstall(cfgFile, topPath string) error {
 	}
 	_ = svc.Uninstall()
 
-	if err := uninstallComponents(context.Background(), cfgFile); err != nil {
+	if err := uninstallComponents(context.Background(), cfgFile, uninstallToken); err != nil {
 		return err
 	}
 
@@ -152,7 +152,7 @@ func delayedRemoval(path string) {
 
 }
 
-func uninstallComponents(ctx context.Context, cfgFile string) error {
+func uninstallComponents(ctx context.Context, cfgFile, uninstallToken string) error {
 	log, err := logger.NewWithLogpLevel("", logp.ErrorLevel, false)
 	if err != nil {
 		return err
@@ -190,7 +190,7 @@ func uninstallComponents(ctx context.Context, cfgFile string) error {
 
 	// remove each service component
 	for _, comp := range comps {
-		if err := uninstallComponent(ctx, log, comp); err != nil {
+		if err := uninstallComponent(ctx, log, comp, uninstallToken); err != nil {
 			os.Stderr.WriteString(fmt.Sprintf("failed to uninstall component %q: %s\n", comp.ID, err))
 		}
 	}
@@ -198,8 +198,8 @@ func uninstallComponents(ctx context.Context, cfgFile string) error {
 	return nil
 }
 
-func uninstallComponent(ctx context.Context, log *logp.Logger, comp component.Component) error {
-	return comprt.UninstallService(ctx, log, comp)
+func uninstallComponent(ctx context.Context, log *logp.Logger, comp component.Component, uninstallToken string) error {
+	return comprt.UninstallService(ctx, log, comp, uninstallToken)
 }
 
 func serviceComponentsFromConfig(specs component.RuntimeSpecs, cfg *config.Config) ([]component.Component, error) {

--- a/pkg/component/runtime/service_test.go
+++ b/pkg/component/runtime/service_test.go
@@ -1,0 +1,59 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/elastic/elastic-agent/pkg/component"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestResolveUninstallTokenArg(t *testing.T) {
+	tests := []struct {
+		name              string
+		uninstallSpec     *component.ServiceOperationsCommandSpec
+		uninstallToken    string
+		wantUninstallSpec *component.ServiceOperationsCommandSpec
+	}{
+		{
+			name: "nil uninstall spec",
+		},
+		{
+			name: "no uninstall token",
+			uninstallSpec: &component.ServiceOperationsCommandSpec{
+				Args: []string{"uninstall", "--log", "stderr"},
+			},
+			wantUninstallSpec: &component.ServiceOperationsCommandSpec{
+				Args: []string{"uninstall", "--log", "stderr"},
+			},
+		},
+		{
+			name: "with uninstall token arg and empty token value",
+			uninstallSpec: &component.ServiceOperationsCommandSpec{
+				Args: []string{"uninstall", "--log", "stderr", "--uninstall-token"},
+			},
+			wantUninstallSpec: &component.ServiceOperationsCommandSpec{
+				Args: []string{"uninstall", "--log", "stderr"},
+			},
+		},
+		{
+			name: "with uninstall token arg and non-empty token value",
+			uninstallSpec: &component.ServiceOperationsCommandSpec{
+				Args: []string{"uninstall", "--log", "stderr", "--uninstall-token"},
+			},
+			uninstallToken: "EQo1ML2T95pdcH",
+			wantUninstallSpec: &component.ServiceOperationsCommandSpec{
+				Args: []string{"uninstall", "--log", "stderr", "--uninstall-token", "EQo1ML2T95pdcH"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := resolveUninstallTokenArg(tc.uninstallSpec, tc.uninstallToken)
+			diff := cmp.Diff(tc.wantUninstallSpec, spec)
+			if diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/specs/endpoint-security.spec.yml
+++ b/specs/endpoint-security.spec.yml
@@ -41,6 +41,7 @@ inputs:
             - "uninstall"
             - "--log"
             - "stderr"
+            - "--uninstall-token"
           timeout: 600
   - name: endpoint
     description: "Endpoint Security"


### PR DESCRIPTION
## What does this PR do?

This is an initial cut of the implementation, might require some iterations based on the feedback.

As a part of Agent tamper protection for the local agent uninstall:
1. Introduce ```--uninstall_token``` argument  to pass down to Endpoint for the local uninstalls.
2. Leaving/preserving the same behavour as the current Agent for uninstall: The Agent still uninstalls if there was a error uninstalling endpoint.  The endpoint remains installed on the machine.
```
$ sudo elastic-agent uninstall --uninstall-token adfasdfasdfasd
Elastic Agent will be uninstalled from your system at /opt/Elastic/Agent. Do you want to continue? [Y/n]:Y
failed to uninstall component "endpoint-default": Error: Unknown option for uninstall command: --uninstall-token: exit status 3
Elastic Agent has been uninstalled.
```

Tested the Agent reinstall of the existing Agent, the user gets the error:
```
Error: already installed at: /opt/Elastic/Agent
For help, please see our troubleshooting guide at https://www.elastic.co/guide/en/fleet/8.9/fleet-troubleshooting.html
```

## Why is it important?

This is a part of the Agent/Endpoint tamper/uninstall protection effort.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## How to test this PR locally

The Endpoint implementation for this is not merged yet at the moment.
Kibana also doesn't show the uninstall command with the uninstall token yet.

1. Install the Agent with Endpoint. 
2. Have the Endpoint protected 
2. Call uninstall without token or the wrong token the Endpoint should fail to uninstall.
3. Call uninstall with the matching token value. The Endpoint should uninstall successfully.

## Related issues

- Relates https://github.com/elastic/security-team/issues/5798

