### PR TITLE
Support singed UNENROLL action and UNENROLL forwarding to Endpoint

### DIFF
--- a/internal/pkg/agent/application/actions/handlers/handler_action_unenroll_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_unenroll_test.go
@@ -1,0 +1,169 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator/state"
+	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
+	"github.com/elastic/elastic-agent/pkg/component"
+	"github.com/elastic/elastic-agent/pkg/component/runtime"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func makeComponentState(name string, agentActions []string) runtime.ComponentComponentState {
+	return runtime.ComponentComponentState{
+		Component: component.Component{
+			Units: []component.Unit{
+				{
+					Type:   client.UnitTypeInput,
+					Config: &proto.UnitExpectedConfig{Type: name},
+				},
+			},
+			InputSpec: &component.InputRuntimeSpec{
+				Spec: component.InputSpec{
+					Name:         name,
+					AgentActions: agentActions,
+				},
+			},
+		},
+	}
+}
+
+type MockActionCoordinator struct {
+	st               state.State
+	performedActions int
+}
+
+func (c *MockActionCoordinator) State() state.State {
+	return c.st
+}
+
+func (c *MockActionCoordinator) PerformAction(ctx context.Context, comp component.Component, unit component.Unit, name string, params map[string]interface{}) (map[string]interface{}, error) {
+	c.performedActions++
+	return nil, nil
+}
+
+func (c *MockActionCoordinator) Clear() {
+	c.performedActions = 0
+}
+
+type MockAcker struct {
+	Acked []fleetapi.Action
+}
+
+func (m *MockAcker) Ack(_ context.Context, action fleetapi.Action) error {
+	m.Acked = append(m.Acked, action)
+	return nil
+}
+
+func (m *MockAcker) Commit(_ context.Context) error {
+	return nil
+}
+
+func (m *MockAcker) Clear() {
+	m.Acked = nil
+}
+
+func TestActionUnenrollHandler(t *testing.T) {
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
+	log, _ := logger.New("", false)
+	coord := &MockActionCoordinator{}
+	acker := &MockAcker{}
+
+	action := &fleetapi.ActionUnenroll{
+		ActionID:   "c80e9219-70bf-43d3-b8cd-b5131a771751",
+		ActionType: "UNENROLL",
+	}
+	goodSigned := &fleetapi.Signed{
+		Data:      "eyJAdGltZXN0YW1wIjoiMjAyMy0wNS0yMlQxNzoxOToyOC40NjNaIiwiZXhwaXJhdGlvbiI6IjIwMjMtMDYtMjFUMTc6MTk6MjguNDYzWiIsImFnZW50cyI6WyI3ZjY0YWI2NC1hNmM0LTQ2ZTMtODIyYS0zODUxZGVkYTJmY2UiXSwiYWN0aW9uX2lkIjoiNGYwODQ2MGYtMDE0Yy00ZDllLWJmOGEtY2FhNjQyNzRhZGU0IiwidHlwZSI6IlVORU5ST0xMIiwidHJhY2VwYXJlbnQiOiIwMC1iOTBkYTlmOGNjNzdhODk0OTc0ZWIxZTIzMGNmNjc2Yy1lOTNlNzk4YTU4ODg2MDVhLTAxIn0=",
+		Signature: "MEUCIAxxsi9ff1zyV0+4fsJLqbP8Qb83tedU5iIFldtxEzEfAiEA0KUsrL7q+Fv7z6Boux3dY2P4emGi71jsMGanIZ552bM=",
+	}
+	action.Signed = goodSigned
+
+	ch := make(chan coordinator.ConfigChange, 1)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case policyChange := <-ch:
+				policyChange.Ack()
+			}
+		}
+	}()
+
+	handler := NewUnenroll(log, coord, ch, nil, nil)
+
+	tests := []struct {
+		name                 string
+		st                   state.State
+		wantErr              error // Handler error
+		wantPerformedActions int
+	}{
+		{
+			name: "no running components",
+		},
+		{
+			name: "endpoint no dispatch",
+			st: func() state.State {
+				return state.State{
+					Components: []runtime.ComponentComponentState{
+						makeComponentState("endpoint", nil),
+					},
+				}
+			}(),
+		},
+		{
+			name: "endpoint with UNENROLL",
+			st: func() state.State {
+				return state.State{
+					Components: []runtime.ComponentComponentState{
+						makeComponentState("endpoint", []string{"UNENROLL"}),
+						makeComponentState("osquery", nil),
+					},
+				}
+			}(),
+			wantPerformedActions: 1,
+		},
+		{
+			name: "more than one UNENROLL dispatch",
+			st: func() state.State {
+				return state.State{
+					Components: []runtime.ComponentComponentState{
+						makeComponentState("endpoint", []string{"UNENROLL"}),
+						makeComponentState("foobar", []string{"UNENROLL", "FOOBAR"}),
+						makeComponentState("osquery", nil),
+					},
+				}
+			}(),
+			wantPerformedActions: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer acker.Clear()
+			defer coord.Clear()
+
+			coord.st = tc.st
+
+			err := handler.Handle(ctx, action, acker)
+			require.ErrorIs(t, err, tc.wantErr)
+			if tc.wantErr == nil {
+				require.Len(t, acker.Acked, 1)
+			}
+			require.Equal(t, tc.wantPerformedActions, coord.performedActions)
+		})
+	}
+}

--- a/internal/pkg/agent/application/managed_mode.go
+++ b/internal/pkg/agent/application/managed_mode.go
@@ -341,6 +341,7 @@ func (m *managedConfigManager) initDispatcher(canceller context.CancelFunc) *han
 		&fleetapi.ActionUnenroll{},
 		handlers.NewUnenroll(
 			m.log,
+			m.coord,
 			m.ch,
 			[]context.CancelFunc{canceller},
 			m.stateStore,

--- a/internal/pkg/agent/storage/store/action_store.go
+++ b/internal/pkg/agent/storage/store/action_store.go
@@ -33,6 +33,7 @@ func newActionStore(log *logger.Logger, store storeLoad) (*actionStore, error) {
 	// persisted and we return an empty store.
 	reader, err := store.Load()
 	if err != nil {
+		//nolint:nilerr // ignore the error, this is expected
 		return &actionStore{log: log, store: store}, nil
 	}
 	defer reader.Close()
@@ -144,9 +145,10 @@ var _ actionPolicyChangeSerializer = actionPolicyChangeSerializer(fleetapi.Actio
 
 // actionUnenrollSerializer is a struct that adds a YAML serialization,
 type actionUnenrollSerializer struct {
-	ActionID   string `yaml:"action_id"`
-	ActionType string `yaml:"action_type"`
-	IsDetected bool   `yaml:"is_detected"`
+	ActionID   string           `yaml:"action_id"`
+	ActionType string           `yaml:"action_type"`
+	IsDetected bool             `yaml:"is_detected"`
+	Signed     *fleetapi.Signed `yaml:"signed,omitempty"`
 }
 
 // add a guards between the serializer structs and the original struct.

--- a/internal/pkg/fleetapi/action.go
+++ b/internal/pkg/fleetapi/action.go
@@ -324,9 +324,10 @@ func (a *ActionUpgrade) SetStartTime(t time.Time) {
 
 // ActionUnenroll is a request for agent to unhook from fleet.
 type ActionUnenroll struct {
-	ActionID   string `yaml:"action_id"`
-	ActionType string `yaml:"type"`
-	IsDetected bool   `json:"is_detected,omitempty" yaml:"is_detected,omitempty"`
+	ActionID   string  `yaml:"action_id"`
+	ActionType string  `yaml:"type"`
+	IsDetected bool    `json:"is_detected,omitempty" yaml:"is_detected,omitempty"`
+	Signed     *Signed `json:"signed,omitempty" mapstructure:"signed,omitempty"`
 }
 
 func (a *ActionUnenroll) String() string {
@@ -350,6 +351,13 @@ func (a *ActionUnenroll) ID() string {
 
 func (a *ActionUnenroll) AckEvent() AckEvent {
 	return newAckEvent(a.ActionID, a.ActionType)
+}
+
+// MarshalMap marshals ActionUnenroll into a corresponding map
+func (a *ActionUnenroll) MarshalMap() (map[string]interface{}, error) {
+	var res map[string]interface{}
+	err := mapstructure.Decode(a, &res)
+	return res, err
 }
 
 // ActionSettings is a request to change agent settings.
@@ -562,6 +570,7 @@ func (a *Actions) UnmarshalJSON(data []byte) error {
 			action = &ActionUnenroll{
 				ActionID:   response.ActionID,
 				ActionType: response.ActionType,
+				Signed:     response.Signed,
 			}
 		case ActionTypeUpgrade:
 			action = &ActionUpgrade{
@@ -656,11 +665,13 @@ func (a *Actions) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				InputType:  n.InputType,
 				Timeout:    n.Timeout,
 				Data:       n.Data,
+				Signed:     n.Signed,
 			}
 		case ActionTypeUnenroll:
 			action = &ActionUnenroll{
 				ActionID:   n.ActionID,
 				ActionType: n.ActionType,
+				Signed:     n.Signed,
 			}
 		case ActionTypeUpgrade:
 			action = &ActionUpgrade{

--- a/pkg/component/input_spec.go
+++ b/pkg/component/input_spec.go
@@ -12,13 +12,14 @@ import (
 
 // InputSpec is the specification for an input type.
 type InputSpec struct {
-	Name        string      `config:"name" yaml:"name"  validate:"required"`
-	Aliases     []string    `config:"aliases,omitempty" yaml:"aliases,omitempty"`
-	Description string      `config:"description" yaml:"description" validate:"required"`
-	Platforms   []string    `config:"platforms" yaml:"platforms" validate:"required,min=1"`
-	Outputs     []string    `config:"outputs,omitempty" yaml:"outputs,omitempty"`
-	Shippers    []string    `config:"shippers,omitempty" yaml:"shippers,omitempty"`
-	Runtime     RuntimeSpec `config:"runtime,omitempty" yaml:"runtime,omitempty"`
+	Name         string      `config:"name" yaml:"name"  validate:"required"`
+	Aliases      []string    `config:"aliases,omitempty" yaml:"aliases,omitempty"`
+	Description  string      `config:"description" yaml:"description" validate:"required"`
+	Platforms    []string    `config:"platforms" yaml:"platforms" validate:"required,min=1"`
+	Outputs      []string    `config:"outputs,omitempty" yaml:"outputs,omitempty"`
+	AgentActions []string    `config:"agent_actions,omitempty" yaml:"agent_actions,omitempty"`
+	Shippers     []string    `config:"shippers,omitempty" yaml:"shippers,omitempty"`
+	Runtime      RuntimeSpec `config:"runtime,omitempty" yaml:"runtime,omitempty"`
 
 	Command *CommandSpec `config:"command,omitempty" yaml:"command,omitempty"`
 	Service *ServiceSpec `config:"service,omitempty" yaml:"service,omitempty"`

--- a/specs/endpoint-security.spec.yml
+++ b/specs/endpoint-security.spec.yml
@@ -10,6 +10,8 @@ inputs:
     outputs:
       - elasticsearch
       - logstash
+    agent_actions:
+      - UNENROLL
     runtime:
       preventions:
         - condition: ${runtime.arch} == 'arm64' and ${runtime.family} == 'redhat' and ${runtime.major} == '7'
@@ -50,6 +52,8 @@ inputs:
     outputs:
       - elasticsearch
       - logstash
+    agent_actions:
+      - UNENROLL
     service:
       cport: 6788
       log:
@@ -62,6 +66,8 @@ inputs:
     outputs:
       - elasticsearch
       - logstash
+    agent_actions:
+      - UNENROLL
     runtime:
       preventions:
         - condition: ${user.root} == false


### PR DESCRIPTION
## What does this PR do?

Implements UNENROLL action dispatching to the Endpoint (or any other matching spec) as described in
https://github.com/elastic/ingest-dev/issues/1882

```
UNEROLL
For the UNENROLL action the solution could utilize the actions signing.
Currently the Agent converts UNENROLL action into empty policy that causes the Agent to stop/uninstall all the running integrations.
The proposal is:

1. Kibana signs the UNENROLL action (the same way the Endpoint actions are signed)
2. Agent dispatches the UNENROLL action with the signed data and signature to Endpoint or any integration that indicates in the it's spec that it needs to receive UNENROLL action.
3. Endpoint unprotects itself
4. Agent awaits successful acks from all dispatched UNENROLL actions before it proceeds to uninstall step.
5. Agent stops/uninstalls integrations.
```

This is tested with Kibana branch that implements the UNENROLL action signed:
https://github.com/joeypoon/kibana/pull/new/feature/sign-unenroll

The signed UNENROLL action example:
```
{
    "@timestamp": "2023-05-22T17:19:28.463Z",
    "expiration": "2023-06-21T17:19:28.463Z",
    "agents": [
        "7f64ab64-a6c4-46e3-822a-3851deda2fce"
    ],
    "action_id": "4f08460f-014c-4d9e-bf8a-caa64274ade4",
    "type": "UNENROLL",
    "traceparent": "00-b90da9f8cc77a894974eb1e230cf676c-e93e798a5888605a-01",
    "signed": {
        "data": "eyJAdGltZXN0YW1wIjoiMjAyMy0wNS0yMlQxNzoxOToyOC40NjNaIiwiZXhwaXJhdGlvbiI6IjIwMjMtMDYtMjFUMTc6MTk6MjguNDYzWiIsImFnZW50cyI6WyI3ZjY0YWI2NC1hNmM0LTQ2ZTMtODIyYS0zODUxZGVkYTJmY2UiXSwiYWN0aW9uX2lkIjoiNGYwODQ2MGYtMDE0Yy00ZDllLWJmOGEtY2FhNjQyNzRhZGU0IiwidHlwZSI6IlVORU5ST0xMIiwidHJhY2VwYXJlbnQiOiIwMC1iOTBkYTlmOGNjNzdhODk0OTc0ZWIxZTIzMGNmNjc2Yy1lOTNlNzk4YTU4ODg2MDVhLTAxIn0=",
        "signature": "MEUCIAxxsi9ff1zyV0+4fsJLqbP8Qb83tedU5iIFldtxEzEfAiEA0KUsrL7q+Fv7z6Boux3dY2P4emGi71jsMGanIZ552bM="
    }
}
```

The Endpoint currently doesn't handle UNENROLL action implemented yet. @intxgo is planning to update Endpoint soon to handle UNENROLL action.

## Why is it important?

Enables tamper protection for Endpoint UNENROLL.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)


## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/1882

