### PR TITLE
Fix deadlock in RuntimeManager

### DIFF
--- a/changelog/fragments/1685029627-Fix-deadlock-condition-in-RuntimeManager.yaml
+++ b/changelog/fragments/1685029627-Fix-deadlock-condition-in-RuntimeManager.yaml
@@ -1,0 +1,36 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix deadlock condition in RuntimeManager
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  In some cases it was possible that a running component would lose connection to the Elastic Agent and
+  unable to re-connect because of a concurrent updated component model. With it being unable to re-connect
+  and the Elastic Agent unable to send it latest component model it results in the Elastic Agent hitting
+  a deadlock where it cannot run properly.
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/2729
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/2691

--- a/pkg/component/fake/component/comp/component.go
+++ b/pkg/component/fake/component/comp/component.go
@@ -427,10 +427,8 @@ func (f *fakeInput) parseConfig(config *proto.UnitExpectedConfig) {
 	_, killOnInterval := cfg["kill_on_interval"]
 	f.logger.Trace().Bool("kill_on_interval", killOnInterval).Msg("kill_on_interval config set value")
 	if killOnInterval {
-		f.logger.Info().Msg("starting interval killer")
 		f.runKiller()
 	} else {
-		f.logger.Info().Msg("stopping interval killer")
 		f.stopKiller()
 	}
 }
@@ -451,6 +449,7 @@ func (f *fakeInput) runKiller() {
 		// already running
 		return
 	}
+	f.logger.Info().Msg("starting interval killer")
 	ctx, canceller := context.WithCancel(context.Background())
 	f.killerCanceller = canceller
 	go func() {
@@ -468,6 +467,7 @@ func (f *fakeInput) runKiller() {
 
 func (f *fakeInput) stopKiller() {
 	if f.killerCanceller != nil {
+		f.logger.Trace().Msg("stopping interval killer")
 		f.killerCanceller()
 		f.killerCanceller = nil
 	}

--- a/pkg/component/runtime/command.go
+++ b/pkg/component/runtime/command.go
@@ -81,9 +81,9 @@ func NewCommandRuntime(comp component.Component, log *logger.Logger, monitor Mon
 		current:     comp,
 		monitor:     monitor,
 		ch:          make(chan ComponentState),
-		actionCh:    make(chan actionMode),
+		actionCh:    make(chan actionMode, 1),
 		procCh:      make(chan procState),
-		compCh:      make(chan component.Component),
+		compCh:      make(chan component.Component, 1),
 		actionState: actionStop,
 		state:       newComponentState(&comp),
 	}
@@ -231,6 +231,11 @@ func (c *CommandRuntime) Watch() <-chan ComponentState {
 //
 // Non-blocking and never returns an error.
 func (c *CommandRuntime) Start() error {
+	// clear channel so it's the latest action
+	select {
+	case <-c.actionCh:
+	default:
+	}
 	c.actionCh <- actionStart
 	return nil
 }
@@ -239,6 +244,11 @@ func (c *CommandRuntime) Start() error {
 //
 // Non-blocking and never returns an error.
 func (c *CommandRuntime) Update(comp component.Component) error {
+	// clear channel so it's the latest component
+	select {
+	case <-c.compCh:
+	default:
+	}
 	c.compCh <- comp
 	return nil
 }
@@ -247,6 +257,11 @@ func (c *CommandRuntime) Update(comp component.Component) error {
 //
 // Non-blocking and never returns an error.
 func (c *CommandRuntime) Stop() error {
+	// clear channel so it's the latest action
+	select {
+	case <-c.actionCh:
+	default:
+	}
 	c.actionCh <- actionStop
 	return nil
 }
@@ -255,6 +270,11 @@ func (c *CommandRuntime) Stop() error {
 //
 // Non-blocking and never returns an error.
 func (c *CommandRuntime) Teardown() error {
+	// clear channel so it's the latest action
+	select {
+	case <-c.actionCh:
+	default:
+	}
 	c.actionCh <- actionTeardown
 	return nil
 }

--- a/pkg/component/runtime/manager.go
+++ b/pkg/component/runtime/manager.go
@@ -88,16 +88,23 @@ type Manager struct {
 	monitor    MonitoringManager
 	grpcConfig *configuration.GRPCConfig
 
+	// netMx synchronizes the access to listener and server only
 	netMx    sync.RWMutex
 	listener net.Listener
 	server   *grpc.Server
 
+	// waitMx synchronizes the access to waitReady only
 	waitMx    sync.RWMutex
 	waitReady map[string]waitForReady
 
-	updateMx     sync.Mutex
-	currentMx    sync.RWMutex
-	current      map[string]*componentRuntimeState
+	// updateMx protects the call to update to ensure that
+	// only one call to update occurs at a time
+	updateMx sync.Mutex
+
+	// currentMx protects access to the current map only
+	currentMx sync.RWMutex
+	current   map[string]*componentRuntimeState
+
 	shipperConns map[string]*shipperConn
 
 	subMx         sync.RWMutex

--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -140,15 +140,8 @@ func TestManager_SimpleComponentErr(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	startTimer := time.NewTimer(100 * time.Millisecond)
-	defer startTimer.Stop()
-	select {
-	case <-startTimer.C:
-		err = m.Update([]component.Component{comp})
-		require.NoError(t, err)
-	case err := <-errCh:
-		t.Fatalf("failed early: %s", err)
-	}
+	err = m.Update([]component.Component{comp})
+	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
 	defer endTimer.Stop()
@@ -262,15 +255,8 @@ func TestManager_FakeInput_StartStop(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	startTimer := time.NewTimer(100 * time.Millisecond)
-	defer startTimer.Stop()
-	select {
-	case <-startTimer.C:
-		err = m.Update([]component.Component{comp})
-		require.NoError(t, err)
-	case err := <-errCh:
-		t.Fatalf("failed early: %s", err)
-	}
+	err = m.Update([]component.Component{comp})
+	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
 	defer endTimer.Stop()
@@ -468,16 +454,8 @@ func TestManager_FakeInput_Features(t *testing.T) {
 	defer drainErrChan(managerErrCh)
 	defer drainErrChan(subscriptionErrCh)
 
-	startTimer := time.NewTimer(100 * time.Millisecond)
-	defer startTimer.Stop()
-
-	select {
-	case <-startTimer.C:
-		err = m.Update([]component.Component{comp})
-		require.NoError(t, err)
-	case err := <-managerErrCh:
-		t.Fatalf("manager failed early: %s", err)
-	}
+	err = m.Update([]component.Component{comp})
+	require.NoError(t, err)
 
 	timeout := 30 * time.Second
 	timeoutTimer := time.NewTimer(timeout)
@@ -644,15 +622,8 @@ func TestManager_FakeInput_BadUnitToGood(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	startTimer := time.NewTimer(100 * time.Millisecond)
-	defer startTimer.Stop()
-	select {
-	case <-startTimer.C:
-		err = m.Update([]component.Component{comp})
-		require.NoError(t, err)
-	case err := <-errCh:
-		t.Fatalf("failed early: %s", err)
-	}
+	err = m.Update([]component.Component{comp})
+	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
 	defer endTimer.Stop()
@@ -801,15 +772,8 @@ func TestManager_FakeInput_GoodUnitToBad(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	startTimer := time.NewTimer(100 * time.Millisecond)
-	defer startTimer.Stop()
-	select {
-	case <-startTimer.C:
-		err = m.Update([]component.Component{comp})
-		require.NoError(t, err)
-	case err := <-errCh:
-		t.Fatalf("failed early: %s", err)
-	}
+	err = m.Update([]component.Component{comp})
+	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
 	defer endTimer.Stop()
@@ -827,6 +791,146 @@ LOOP:
 	}
 
 	subCancel()
+	cancel()
+
+	err = <-errCh
+	require.NoError(t, err)
+}
+
+func TestManager_FakeInput_NoDeadlock(t *testing.T) {
+	/*
+		NOTE: This is a long-running test that spams the runtime managers `Update` function to try and
+		trigger a deadlock. This test takes 2 minutes to run trying to re-produce issue:
+
+		https://github.com/elastic/elastic-agent/issues/2691
+	*/
+	testPaths(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ai, _ := info.NewAgentInfo(true)
+	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), "localhost:0", ai, apmtest.DiscardTracer, newTestMonitoringMgr(), configuration.DefaultGRPCConfig())
+	require.NoError(t, err)
+	errCh := make(chan error)
+	go func() {
+		err := m.Run(ctx)
+		if errors.Is(err, context.Canceled) {
+			err = nil
+		}
+		errCh <- err
+	}()
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
+	defer waitCancel()
+	if err := m.WaitForReady(waitCtx); err != nil {
+		require.NoError(t, err)
+	}
+
+	binaryPath := testBinary(t, "component")
+	comp := component.Component{
+		ID: "fake-default",
+		InputSpec: &component.InputRuntimeSpec{
+			InputType:  "fake",
+			BinaryName: "",
+			BinaryPath: binaryPath,
+			Spec:       fakeInputSpec,
+		},
+		Units: []component.Unit{
+			{
+				ID:       "fake-input",
+				Type:     client.UnitTypeInput,
+				LogLevel: client.UnitLogLevelError, // test log will get spammed with the constant updates (error to prevent spam)
+				Config: component.MustExpectedConfig(map[string]interface{}{
+					"type":    "fake",
+					"state":   int(client.UnitStateHealthy),
+					"message": "Fake Healthy",
+				}),
+			},
+		},
+	}
+
+	updatedCh := make(chan time.Time)
+	updatedErr := make(chan error)
+	updatedCtx, updatedCancel := context.WithCancel(context.Background())
+	defer updatedCancel()
+	go func() {
+		// spam update on component trying to cause a deadlock
+		comp := comp
+		i := 0
+		for {
+			if updatedCtx.Err() != nil {
+				return
+			}
+			updatedComp := comp
+			updatedComp.Units = make([]component.Unit, 1)
+			updatedComp.Units[0] = component.Unit{
+				ID:       "fake-input",
+				Type:     client.UnitTypeInput,
+				LogLevel: client.UnitLogLevelError, // test log will get spammed with the constant updates (error to prevent spam)
+				Config: component.MustExpectedConfig(map[string]interface{}{
+					"type":    "fake",
+					"state":   int(client.UnitStateHealthy),
+					"message": fmt.Sprintf("Fake Healthy %d", i),
+				}),
+			}
+			i += 1
+			comp = updatedComp
+			err := m.Update([]component.Component{updatedComp})
+			if err != nil {
+				updatedErr <- err
+				return
+			}
+			updatedCh <- time.Now()
+		}
+	}()
+
+	deadlockErr := make(chan error)
+	go func() {
+		t := time.NewTimer(15 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-updatedCtx.Done():
+				return
+			case <-updatedCh:
+				// update did occur
+				t.Reset(15 * time.Second)
+			case <-t.C:
+				// timeout hit waiting for another update to work
+				deadlockErr <- errors.New("hit deadlock")
+				return
+			}
+		}
+	}()
+
+	defer drainErrChan(errCh)
+	defer drainErrChan(updatedErr)
+	defer drainErrChan(deadlockErr)
+
+	// wait 2 minutes for a deadlock to occur
+	endTimer := time.NewTimer(2 * time.Minute)
+	defer endTimer.Stop()
+LOOP:
+	for {
+		select {
+		case <-endTimer.C:
+			// no deadlock after timeout (all good stop the component)
+			updatedCancel()
+			_ = m.Update([]component.Component{})
+			break LOOP
+		case err := <-errCh:
+			require.NoError(t, err)
+		case err := <-updatedErr:
+			require.NoError(t, err)
+			break LOOP
+		case err := <-deadlockErr:
+			require.NoError(t, err)
+			break LOOP
+		}
+	}
+
+	updatedCancel()
 	cancel()
 
 	err = <-errCh
@@ -928,15 +1032,8 @@ func TestManager_FakeInput_Configure(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	startTimer := time.NewTimer(100 * time.Millisecond)
-	defer startTimer.Stop()
-	select {
-	case <-startTimer.C:
-		err = m.Update([]component.Component{comp})
-		require.NoError(t, err)
-	case err := <-errCh:
-		t.Fatalf("failed early: %s", err)
-	}
+	err = m.Update([]component.Component{comp})
+	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
 	defer endTimer.Stop()
@@ -1088,15 +1185,8 @@ func TestManager_FakeInput_RemoveUnit(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	startTimer := time.NewTimer(100 * time.Millisecond)
-	defer startTimer.Stop()
-	select {
-	case <-startTimer.C:
-		err = m.Update([]component.Component{comp})
-		require.NoError(t, err)
-	case err := <-errCh:
-		t.Fatalf("failed early: %s", err)
-	}
+	err = m.Update([]component.Component{comp})
+	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
 	defer endTimer.Stop()
@@ -1219,15 +1309,8 @@ func TestManager_FakeInput_ActionState(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	startTimer := time.NewTimer(100 * time.Millisecond)
-	defer startTimer.Stop()
-	select {
-	case <-startTimer.C:
-		err = m.Update([]component.Component{comp})
-		require.NoError(t, err)
-	case err := <-errCh:
-		t.Fatalf("failed early: %s", err)
-	}
+	err = m.Update([]component.Component{comp})
+	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
 	defer endTimer.Stop()
@@ -1361,15 +1444,8 @@ func TestManager_FakeInput_Restarts(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	startTimer := time.NewTimer(100 * time.Millisecond)
-	defer startTimer.Stop()
-	select {
-	case <-startTimer.C:
-		err = m.Update([]component.Component{comp})
-		require.NoError(t, err)
-	case err := <-errCh:
-		t.Fatalf("failed early: %s", err)
-	}
+	err = m.Update([]component.Component{comp})
+	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
 	defer endTimer.Stop()
@@ -1510,15 +1586,8 @@ func TestManager_FakeInput_Restarts_ConfigKill(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	startTimer := time.NewTimer(100 * time.Millisecond)
-	defer startTimer.Stop()
-	select {
-	case <-startTimer.C:
-		err = m.Update([]component.Component{comp})
-		require.NoError(t, err)
-	case err := <-errCh:
-		t.Fatalf("failed early: %s", err)
-	}
+	err = m.Update([]component.Component{comp})
+	require.NoError(t, err)
 
 	endTimer := time.NewTimer(1 * time.Minute)
 	defer endTimer.Stop()
@@ -1659,15 +1728,8 @@ func TestManager_FakeInput_KeepsRestarting(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	startTimer := time.NewTimer(100 * time.Millisecond)
-	defer startTimer.Stop()
-	select {
-	case <-startTimer.C:
-		err = m.Update([]component.Component{comp})
-		require.NoError(t, err)
-	case err := <-errCh:
-		t.Fatalf("failed early: %s", err)
-	}
+	err = m.Update([]component.Component{comp})
+	require.NoError(t, err)
 
 	endTimer := time.NewTimer(1 * time.Minute)
 	defer endTimer.Stop()
@@ -1780,15 +1842,8 @@ func TestManager_FakeInput_RestartsOnMissedCheckins(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	startTimer := time.NewTimer(100 * time.Millisecond)
-	defer startTimer.Stop()
-	select {
-	case <-startTimer.C:
-		err = m.Update([]component.Component{comp})
-		require.NoError(t, err)
-	case err := <-errCh:
-		t.Fatalf("failed early: %s", err)
-	}
+	err = m.Update([]component.Component{comp})
+	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
 	defer endTimer.Stop()
@@ -1904,15 +1959,8 @@ func TestManager_FakeInput_InvalidAction(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	startTimer := time.NewTimer(100 * time.Millisecond)
-	defer startTimer.Stop()
-	select {
-	case <-startTimer.C:
-		err = m.Update([]component.Component{comp})
-		require.NoError(t, err)
-	case err := <-errCh:
-		t.Fatalf("failed early: %s", err)
-	}
+	err = m.Update([]component.Component{comp})
+	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
 	defer endTimer.Stop()
@@ -2108,15 +2156,8 @@ func TestManager_FakeInput_MultiComponent(t *testing.T) {
 	defer drainErrChan(subErrCh1)
 	defer drainErrChan(subErrCh2)
 
-	startTimer := time.NewTimer(100 * time.Millisecond)
-	defer startTimer.Stop()
-	select {
-	case <-startTimer.C:
-		err = m.Update(components)
-		require.NoError(t, err)
-	case err := <-errCh:
-		t.Fatalf("failed early: %s", err)
-	}
+	err = m.Update(components)
+	require.NoError(t, err)
 
 	count := 0
 	endTimer := time.NewTimer(30 * time.Second)
@@ -2271,15 +2312,8 @@ func TestManager_FakeInput_LogLevel(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	startTimer := time.NewTimer(100 * time.Millisecond)
-	defer startTimer.Stop()
-	select {
-	case <-startTimer.C:
-		err = m.Update([]component.Component{comp})
-		require.NoError(t, err)
-	case err := <-errCh:
-		t.Fatalf("failed early: %s", err)
-	}
+	err = m.Update([]component.Component{comp})
+	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
 	defer endTimer.Stop()
@@ -2581,15 +2615,8 @@ func TestManager_FakeShipper(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	startTimer := time.NewTimer(100 * time.Millisecond)
-	defer startTimer.Stop()
-	select {
-	case <-startTimer.C:
-		err = m.Update(comps)
-		require.NoError(t, err)
-	case err := <-errCh:
-		t.Fatalf("failed early: %s", err)
-	}
+	err = m.Update(comps)
+	require.NoError(t, err)
 
 	timeout := 2 * time.Minute
 	endTimer := time.NewTimer(timeout)

--- a/pkg/component/runtime/runtime.go
+++ b/pkg/component/runtime/runtime.go
@@ -85,8 +85,10 @@ type componentRuntimeState struct {
 	logger  *logger.Logger
 	comm    *runtimeComm
 
-	currComp component.Component
-	runtime  ComponentRuntime
+	id         string
+	currCompMx sync.RWMutex
+	currComp   component.Component
+	runtime    ComponentRuntime
 
 	shuttingDown atomic.Bool
 
@@ -111,6 +113,7 @@ func newComponentRuntimeState(m *Manager, logger *logger.Logger, monitor Monitor
 		manager:  m,
 		logger:   logger,
 		comm:     comm,
+		id:       comp.ID,
 		currComp: comp,
 		runtime:  runtime,
 		latestState: ComponentState{
@@ -160,6 +163,18 @@ func newComponentRuntimeState(m *Manager, logger *logger.Logger, monitor Monitor
 	})
 
 	return state, nil
+}
+
+func (s *componentRuntimeState) getCurrent() component.Component {
+	s.currCompMx.RLock()
+	defer s.currCompMx.RUnlock()
+	return s.currComp
+}
+
+func (s *componentRuntimeState) setCurrent(current component.Component) {
+	s.currCompMx.Lock()
+	s.currComp = current
+	s.currCompMx.Unlock()
 }
 
 func (s *componentRuntimeState) start() error {

--- a/pkg/component/runtime/runtime_comm.go
+++ b/pkg/component/runtime/runtime_comm.go
@@ -89,7 +89,7 @@ func newRuntimeComm(logger *logger.Logger, listenAddr string, ca *authority.Cert
 		token:           token.String(),
 		cert:            pair,
 		checkinConn:     true,
-		checkinExpected: make(chan *proto.CheckinExpected, 10), // size of 10 gives a buffer for expected, only last is used
+		checkinExpected: make(chan *proto.CheckinExpected, 1),
 		checkinObserved: make(chan *proto.CheckinObserved),
 		actionsConn:     true,
 		actionsRequest:  make(chan *proto.ActionRequest),
@@ -169,23 +169,16 @@ func (c *runtimeComm) CheckinExpected(
 	c.initCheckinObservedMx.Unlock()
 
 	// not in the initial observed message path; send it over the standard channel
+	// clear channel making it the latest expected message
+	select {
+	case <-c.checkinExpected:
+	default:
+	}
 	c.checkinExpected <- expected
 }
 
 func (c *runtimeComm) CheckinObserved() <-chan *proto.CheckinObserved {
 	return c.checkinObserved
-}
-
-// latestCheckinExpected ensures that the latest expected checkin is used
-func (c *runtimeComm) latestCheckinExpected(exp *proto.CheckinExpected) *proto.CheckinExpected {
-	latest := exp
-	for {
-		select {
-		case latest = <-c.checkinExpected:
-		default:
-			return latest
-		}
-	}
 }
 
 func (c *runtimeComm) checkin(server proto.ElasticAgent_CheckinV2Server, init *proto.CheckinObserved) error {
@@ -245,7 +238,6 @@ func (c *runtimeComm) checkin(server proto.ElasticAgent_CheckinV2Server, init *p
 			case <-recvDone:
 				return
 			case expected = <-c.checkinExpected:
-				expected = c.latestCheckinExpected(expected)
 			}
 
 			err := server.Send(expected)
@@ -266,7 +258,11 @@ func (c *runtimeComm) checkin(server proto.ElasticAgent_CheckinV2Server, init *p
 	c.initCheckinObservedMx.Lock()
 	c.initCheckinObserved = init
 	c.initCheckinExpectedCh = initExp
-	c.latestCheckinExpected(nil) // clears all queued expected messages
+	// clears the latest queued expected message
+	select {
+	case <-c.checkinExpected:
+	default:
+	}
 	c.initCheckinObservedMx.Unlock()
 
 	// send the initial message (manager then calls `CheckinExpected` method with the result)

--- a/pkg/component/runtime/service.go
+++ b/pkg/component/runtime/service.go
@@ -64,8 +64,8 @@ func NewServiceRuntime(comp component.Component, logger *logger.Logger) (Compone
 		comp:                      comp,
 		log:                       logger.Named("service_runtime"),
 		ch:                        make(chan ComponentState),
-		actionCh:                  make(chan actionMode),
-		compCh:                    make(chan component.Component),
+		actionCh:                  make(chan actionMode, 1),
+		compCh:                    make(chan component.Component, 1),
 		statusCh:                  make(chan service.Status),
 		state:                     state,
 		executeServiceCommandImpl: executeServiceCommand,
@@ -347,6 +347,11 @@ func (s *ServiceRuntime) Watch() <-chan ComponentState {
 //
 // Non-blocking and never returns an error.
 func (s *ServiceRuntime) Start() error {
+	// clear channel so it's the latest action
+	select {
+	case <-s.actionCh:
+	default:
+	}
 	s.actionCh <- actionStart
 	return nil
 }
@@ -355,6 +360,11 @@ func (s *ServiceRuntime) Start() error {
 //
 // Non-blocking and never returns an error.
 func (s *ServiceRuntime) Update(comp component.Component) error {
+	// clear channel so it's the latest component
+	select {
+	case <-s.compCh:
+	default:
+	}
 	s.compCh <- comp
 	return nil
 }
@@ -363,6 +373,11 @@ func (s *ServiceRuntime) Update(comp component.Component) error {
 //
 // Non-blocking and never returns an error.
 func (s *ServiceRuntime) Stop() error {
+	// clear channel so it's the latest action
+	select {
+	case <-s.actionCh:
+	default:
+	}
 	s.actionCh <- actionStop
 	return nil
 }
@@ -371,6 +386,11 @@ func (s *ServiceRuntime) Stop() error {
 //
 // Non-blocking and never returns an error.
 func (s *ServiceRuntime) Teardown() error {
+	// clear channel so it's the latest action
+	select {
+	case <-s.actionCh:
+	default:
+	}
 	s.actionCh <- actionTeardown
 	return nil
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes a deadlock issue that can occur in the communication of updated components with the `RuntimeManager` and each of the `CommandRuntime` and `ServiceRuntime` component managers.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

It is possible for a component to become disconnected from the Elastic Agent control protocol and unable to complete re-connection because a concurrent update of the component model was occurring.

This change also allows for the runtime manager to not need to settle before calling the initial `m.Update`. You can see that I was able to remove the initial delay in the existing runtime manager tests.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Only way to really verify is to remove the changes in this PR, except for the `TestManager_FakeInput_NoDeadlock` test. Run the `TestManager_FakeInput_NoDeadlock` test and see that it fails. Then re-add the changes and see that it causes the test to pass.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #2691
