### PR TITLE
Fix possible blocking in the Coordinator and out-of-order state reporting in CoordinatorState

### DIFF
--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -232,7 +232,7 @@ func (c *Coordinator) State() state.State {
 // results in the subscription being unsubscribed.
 //
 // Note: Not reading from a subscription channel will cause the Coordinator to block.
-func (c *Coordinator) StateSubscribe(ctx context.Context) *state.StateSubscription {
+func (c *Coordinator) StateSubscribe(ctx context.Context) state.StateSubscription {
 	return c.state.Subscribe(ctx)
 }
 

--- a/internal/pkg/agent/application/coordinator/coordinator_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_test.go
@@ -341,6 +341,8 @@ func TestCoordinator_StateSubscribe_BlockedSubscriber(t *testing.T) {
 		// active subscriber that will. This is to test that congestion in some
 		// subscribers will not block state updates to others.
 		coord.StateSubscribe(ctx)
+		coord.StateSubscribe(ctx)
+		coord.StateSubscribe(ctx)
 		activeSub := coord.StateSubscribe(ctx)
 		stateChangeCount := 0
 		for {

--- a/internal/pkg/agent/application/coordinator/state/state.go
+++ b/internal/pkg/agent/application/coordinator/state/state.go
@@ -342,6 +342,7 @@ func (cs *CoordinatorState) stateReporter() {
 			reflect.SelectCase{
 				Dir:  reflect.SelectSend,
 				Chan: reflect.ValueOf(subscriber.ch),
+				Send: reflect.ValueOf(currentState),
 			})
 	}
 

--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -1791,6 +1791,7 @@ func TestManager_FakeInput_RestartsOnMissedCheckins(t *testing.T) {
 					Timeouts: component.CommandTimeoutSpec{
 						// very low checkin timeout so we can cause missed check-ins
 						Checkin: 100 * time.Millisecond,
+						Restart: 10 * time.Second,
 						Stop:    30 * time.Second,
 					},
 				},


### PR DESCRIPTION
Fix the issues discussed in https://github.com/elastic/elastic-agent/issues/2735 by reimplementing the `CoordinatorState` state subscription with `reflect.Select`. The new design can't be blocked by idle subscribers, even for a short period, and values sent to subscribers always reflect the most current state, not a possibly queued / out-of-order earlier state.

Fixes #2735.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~

