### PR TITLE
Fix flaky test: Add missing timeout value in unit test

### DIFF
--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -1791,6 +1791,7 @@ func TestManager_FakeInput_RestartsOnMissedCheckins(t *testing.T) {
 					Timeouts: component.CommandTimeoutSpec{
 						// very low checkin timeout so we can cause missed check-ins
 						Checkin: 100 * time.Millisecond,
+						Restart: 10 * time.Second,
 						Stop:    30 * time.Second,
 					},
 				},


### PR DESCRIPTION
Add a positive value for the restart timeout in `TestManager_FakeInput_RestartsOnMissedCheckins`.

An omitted timeout value in this test led to timer intervals of zero, which caused a panic unpredictably depending on whether the test completed before the problematic code path was invoked.

This timeout value isn't zero in live code because the timeouts are initialized to default values during deserialization, but because the unit test created this config struct explicitly (skippining deserialization), a zero value was allowed through.

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~
