### PR TITLE
Remove race detector platform restrictions and enable it in CI

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -114,7 +114,7 @@ pipeline {
               withGithubNotify(context: "Test-${PLATFORM}") {
                 withMageEnv(){
                   dir("${BASE_DIR}"){
-                    withEnv(["TEST_COVERAGE=${isCodeCoverageEnabled()}"]) {
+                    withEnv(["RACE_DETECTOR=true", "TEST_COVERAGE=${isCodeCoverageEnabled()}"]) {
                       cmd(label: 'Go unitTest', script: 'mage unitTest')
                     }
                   }
@@ -330,7 +330,7 @@ pipeline {
               withGithubNotify(context: "Test-${PLATFORM}") {
                 withMageEnv(){
                   dir("${BASE_DIR}"){
-                    withEnv(["TEST_COVERAGE=${isCodeCoverageEnabled()}"]) {
+                    withEnv(["RACE_DETECTOR=true", "TEST_COVERAGE=${isCodeCoverageEnabled()}"]) {
                       cmd(label: 'Go unitTest', script: 'mage unitTest')
                     }
                   }
@@ -380,7 +380,7 @@ pipeline {
             withGithubNotify(context: "Test-darwin-aarch64") {
               withMageEnv(){
                 dir("${BASE_DIR}"){
-                  withEnv(["TEST_COVERAGE=${isCodeCoverageEnabled()}"]) {
+                  withEnv(["RACE_DETECTOR=true", "TEST_COVERAGE=${isCodeCoverageEnabled()}"]) {
                     cmd(label: 'Go unitTest', script: 'mage unitTest')
                   }
                 }

--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -213,12 +213,10 @@ func GoTest(ctx context.Context, params GoTestArgs) error {
 
 	var testArgs []string
 
-	// -race is only supported on */amd64
-	if os.Getenv("DEV_ARCH") == "amd64" {
-		if params.Race {
-			testArgs = append(testArgs, "-race")
-		}
+	if params.Race {
+		testArgs = append(testArgs, "-race")
 	}
+
 	if len(params.Tags) > 0 {
 		params := strings.Join(params.Tags, " ")
 		if params != "" {

--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -170,8 +170,8 @@ func GoTestIntegrationForModule(ctx context.Context) error {
 }
 
 // InstallGoTestTools installs additional tools that are required to run unit and integration tests.
-func InstallGoTestTools() {
-	gotool.Install(
+func InstallGoTestTools() error {
+	return gotool.Install(
 		gotool.Install.Package("gotest.tools/gotestsum"),
 	)
 }


### PR DESCRIPTION
We discovered in a recent PR that the RACE_DETECTOR environment variable seemingly was not having any effect (https://github.com/elastic/elastic-agent/pull/2729#issuecomment-1563320866), it turns out it is ignored on arm64. This is now an unnecessary restriction.

I've also enabled the race detector in CI, I'll need to see what this does to the test time on each platform first though. We will keep it at least for Linux.