### PR TITLE
Enable auto-updates of github.com/elastic/* dependencies.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - automation
+      - Team:Elastic-Agent-Control-Plane
+    allow:
+      - dependency-name: "github.com/elastic/*"
+    reviewers:
+      - "elastic/elastic-agent-control-plane"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "daily"
     labels:
       - automation
+      - skip-changelog
       - Team:Elastic-Agent-Control-Plane
     allow:
       - dependency-name: "github.com/elastic/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     labels:
       - automation
       - skip-changelog
-      - Team:Elastic-Agent-Control-Plane
+      - Team:Elastic-Agent
     allow:
       - dependency-name: "github.com/elastic/*"
     reviewers:

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -1,0 +1,40 @@
+# Follow-on actions relating to dependabot PRs. In elastic/elastic-agent, any changes to
+# dependencies contained in go.mod requires the change to be reflected in the
+# NOTICE.txt file. When dependabot creates a branch for a go_modules change this
+# will update the NOTICE.txt file for that change.
+name: post-dependabot
+
+on:
+  push:
+    branches:
+      - 'dependabot/go_modules/**'
+
+jobs:
+  update-notice:
+    permissions:
+      # Allow job to write to the branch.
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: .go-version
+
+      - name: update NOTICE.txt
+        run: make notice
+
+      - name: check for modified NOTICE.txt
+        id: notice-check
+        run: echo "modified=$(if git diff-index --quiet HEAD -- NOTICE.txt; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
+
+      - name: commit NOTICE.txt
+        if: steps.notice-check.outputs.modified == 'true'
+        run: |
+          git config --global user.name 'dependabot[bot]'
+          git config --global user.email 'dependabot[bot]@users.noreply.github.com'
+          git add NOTICE.txt
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git commit -m "Update NOTICE.txt"
+          git push


### PR DESCRIPTION
Configures dependabot to automatically keep internal dependencies up to date. This was recently enabled for Beats with reasonable results. 

Example PR: 
- https://github.com/elastic/beats/pull/35533

Related:
- https://github.com/elastic/beats/pull/35525
- https://github.com/elastic/beats/pull/35538