### PR TITLE
Add the `logs` subcommand to the CLI

### DIFF
--- a/changelog/fragments/1685442237-add-logs-subcommand.yaml
+++ b/changelog/fragments/1685442237-add-logs-subcommand.yaml
@@ -1,0 +1,5 @@
+kind: feature
+summary: Add the logs subcommand to the agent CLI
+component: CLI
+pr: https://github.com/elastic/elastic-agent/pull/2745
+issue: https://github.com/elastic/elastic-agent/issues/114

--- a/internal/pkg/agent/cmd/common.go
+++ b/internal/pkg/agent/cmd/common.go
@@ -71,6 +71,7 @@ func NewCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Command {
 	cmd.AddCommand(newStatusCommand(args, streams))
 	cmd.AddCommand(newDiagnosticsCommand(args, streams))
 	cmd.AddCommand(newComponentCommandWithArgs(args, streams))
+	cmd.AddCommand(newLogsCommandWithArgs(args, streams))
 
 	// windows special hidden sub-command (only added on Windows)
 	reexec := newReExecWindowsCommand(args, streams)

--- a/internal/pkg/agent/cmd/logs.go
+++ b/internal/pkg/agent/cmd/logs.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"time"
@@ -20,6 +20,7 @@ import (
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
 const (
@@ -117,7 +118,11 @@ func logsCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		filter = createComponentFilter(component)
 	}
 
-	err := printLogs(cmd.Context(), streams.Out, paths.Logs(), lines, follow, filter)
+	logsDir := filepath.Join(paths.Home(), logger.DefaultLogDirectory)
+	// uncomment for debugging
+	// fmt.Fprintf(streams.Err, "logs dir: %q", logsDir)
+
+	err := printLogs(cmd.Context(), streams.Out, logsDir, lines, follow, filter)
 	if err != nil {
 		return fmt.Errorf("failed to get logs: %w", err)
 	}
@@ -298,7 +303,7 @@ func getLogFilenames(dir string) ([]string, error) {
 		if e.IsDir() || !logFilePattern.MatchString(e.Name()) {
 			continue
 		}
-		paths = append(paths, path.Join(dir, e.Name()))
+		paths = append(paths, filepath.Join(dir, e.Name()))
 	}
 
 	sortLogFilenames(paths)

--- a/internal/pkg/agent/cmd/logs.go
+++ b/internal/pkg/agent/cmd/logs.go
@@ -1,0 +1,402 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"regexp"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/internal/pkg/cli"
+)
+
+const (
+	// 1KB, it's a size of the file chunk we read for searching lines starting
+	// from the end of the file
+	logBufferSize = 1024
+	// when follow logs, on each interval we check log file updates and if a new file appeared
+	watchInterval = 500 * time.Millisecond
+)
+
+var (
+	firstLogFilePattern   = regexp.MustCompile(`^elastic-agent-\d+\.ndjson$`)
+	rotatedLogFilePattern = regexp.MustCompile(`^elastic-agent-\d+-\d+\.ndjson$`)
+)
+
+// filter for each log line, returns `true` if we print the line
+type filterFunc func([]byte) bool
+
+// logEntry represents a part of the elastic agent log entry
+type logEntry struct {
+	Component struct {
+		ID string `json:"id"`
+	} `json:"component"`
+}
+
+// createComponentFilter creates a new log line filter that
+// lets print only the log lines that contain the given component ID.
+func createComponentFilter(id string) filterFunc {
+	return func(line []byte) bool {
+		var entry logEntry
+		err := json.Unmarshal(line, &entry)
+		if err != nil {
+			return false
+		}
+		return entry.Component.ID == id
+	}
+}
+
+// stackWriter collects written byte slices and then pops them in
+// the reversed (LIFO) order.
+type stackWriter struct {
+	lines [][]byte
+}
+
+// Write implements `io.Writer`
+func (s *stackWriter) Write(line []byte) (int, error) {
+	// we must allocate and copy to preserve the state,
+	// `line` is normally a slice on the reading buffer which
+	// gets overwritten
+	l := make([]byte, len(line))
+	copy(l, line)
+	s.lines = append(s.lines, l)
+	return len(l), nil
+}
+
+// PopAll pops every line from the stack and writes into `w` in LIFO order.
+func (s stackWriter) PopAll(w io.Writer) error {
+	for i := len(s.lines) - 1; i >= 0; i-- {
+		_, err := w.Write(s.lines[i])
+		if err != nil {
+			return fmt.Errorf("failed to print the log line to the writer: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func newLogsCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logs",
+		Short: "Output Elastic Agent logs",
+		Long:  "This command allows to output, watch and filter Elastic Agent logs.",
+		Run: func(c *cobra.Command, _ []string) {
+			if err := logsCmd(streams, c); err != nil {
+				fmt.Fprintf(streams.Err, "Error: %v\n%s\n", err, troubleshootMessage())
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().BoolP("follow", "f", false, "Do not stop when end of file is reached, but rather to wait for additional data to be appended to the log file.")
+	cmd.Flags().IntP("number", "n", 10, "Maximum number of lines at the end of logs to output.")
+	cmd.Flags().StringP("component", "C", "", "Filter logs and output only logs for the given component ID.")
+
+	return cmd
+}
+
+func logsCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
+	component, _ := cmd.Flags().GetString("component")
+	lines, _ := cmd.Flags().GetInt("number")
+	follow, _ := cmd.Flags().GetBool("follow")
+
+	var filter filterFunc
+
+	if component != "" {
+		filter = createComponentFilter(component)
+	}
+
+	err := printLogs(cmd.Context(), streams.Out, paths.Logs(), lines, follow, filter)
+	if err != nil {
+		return fmt.Errorf("failed to get logs: %w", err)
+	}
+
+	return nil
+}
+
+// printLogs prints the last `lines` number of log lines from the log files in `dir`
+// applying the `filter` and printing all the log lines to `w`.
+// if `follow` is true it will keep printing all the log updates afterwards.
+func printLogs(ctx context.Context, w io.Writer, dir string, lines int, follow bool, filter filterFunc) error {
+	files, err := getLogFilenames(dir)
+	if err != nil {
+		return fmt.Errorf("failed to fetch log filenames: %w", err)
+	}
+	if len(files) == 0 {
+		return nil
+	}
+
+	stackWriter := &stackWriter{}
+
+	var (
+		fileIndex = len(files) - 1
+		printed   = 0
+	)
+
+	buf := make([]byte, logBufferSize)
+
+	// we need to store the file size ASAP before it changes by new lines
+	// but right before we start looking for the last N lines in this file
+	// to minimize likelihood of corrupted output
+	fileToFollow := files[fileIndex]
+	followOffset, err := getFileSize(fileToFollow)
+	if err != nil {
+		return fmt.Errorf("failed to prepare for watching file %q: %w", fileToFollow, err)
+	}
+
+	// start looking for the N lines among all log files started with the most recent one
+	for {
+		filename := files[fileIndex]
+		// try to read the requested amount of lines from the end of the file
+		justPrinted, err := printLogFile(filename, lines-printed, stackWriter, buf, filter)
+		if err != nil {
+			return fmt.Errorf("failed to print log file %q: %w", filename, err)
+		}
+		// account for what we've read in total, to stop once we reached the given number
+		printed += justPrinted
+		if printed >= lines {
+			break
+		}
+		// if we have not read/printed enough lines, we switch to the previous file and repeat
+		fileIndex--
+		if fileIndex < 0 {
+			break
+		}
+	}
+
+	// all log lines written above were written in LIFO order, we need to invert that
+	// while writing to the destination writer
+	err = stackWriter.PopAll(w)
+	if err != nil {
+		return fmt.Errorf("failed to write the requested number of lines: %w", err)
+	}
+
+	if follow {
+		err = watchLogsDir(ctx, dir, fileToFollow, followOffset, w)
+		if err != nil {
+			return fmt.Errorf("failed to follow the logs: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// printLogFile reads the target file defined by the absolute path `filename` backwards in chunks
+// defined by the size of the given `buf`  until it finds enough lines defined by `maxLines`
+// or the whole file is read. Prints all found lines to `w` in LIFO order.
+func printLogFile(filename string, maxLines int, w io.Writer, buf []byte, filter filterFunc) (linesWritten int, err error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open log file %q for reading: %w", filename, err)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("failed to stat log file %q: %w", filename, err)
+	}
+	offset := info.Size()
+	bufferSize := int64(len(buf))
+
+	var leftOverBuf []byte
+
+	// reading chunks starting with the end of the file and try to find
+	// lines up to the requested amount, once found - stop
+	for {
+		offset -= bufferSize
+		if offset < 0 {
+			// this chunk is smaller than the buffer
+			offset = 0
+		}
+
+		bytesRead, err := file.ReadAt(buf, offset)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return linesWritten, fmt.Errorf("failed to read from log file %q: %w", filename, err)
+		}
+
+		chunk := buf[:bytesRead]
+
+		// the current chunk must contains leftovers (incomplete line) from the previous chunk
+		if len(leftOverBuf) != 0 {
+			chunk = append(chunk, leftOverBuf...)
+			leftOverBuf = nil
+		}
+
+		// the first line ends at the end for the current chunk
+		lineEnd := len(chunk)
+		for i := len(chunk) - 1; i >= 0; i-- {
+			if chunk[i] != '\n' {
+				continue
+			}
+
+			line := chunk[i+1 : lineEnd]
+
+			// if it's a trailing new line
+			if len(line) == 0 {
+				continue
+			}
+
+			// the next line will end where this line starts
+			lineEnd = i + 1
+
+			if filter != nil && !filter(line) {
+				continue
+			}
+
+			_, err := w.Write(line)
+			if err != nil {
+				return linesWritten, fmt.Errorf("failed to print log line: %w", err)
+			}
+
+			linesWritten++
+			if linesWritten == maxLines {
+				return linesWritten, nil
+			}
+		}
+
+		if lineEnd != 0 {
+			leftOverBuf = make([]byte, lineEnd)
+			copy(leftOverBuf, chunk[:lineEnd])
+		}
+
+		if offset == 0 {
+			break
+		}
+	}
+
+	if len(leftOverBuf) != 0 && (filter == nil || filter(leftOverBuf)) {
+		_, err := w.Write(leftOverBuf)
+		if err != nil {
+			err = fmt.Errorf("failed to print log line: %w", err)
+			return linesWritten, err
+		}
+		linesWritten++
+	}
+	return linesWritten, nil
+}
+
+// getLogFilenames returns absolute paths to all log files in `dir` sorted in the log rotation order.
+func getLogFilenames(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list logs directory: %w", err)
+	}
+
+	// the first index is reserved for the initial file (without `-xxx` suffix),
+	// so we don't have to sort the entire slice again
+	paths := make([]string, len(entries)+1)
+	i := 1
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if firstLogFilePattern.MatchString(e.Name()) {
+			paths[0] = path.Join(dir, e.Name())
+		}
+		if rotatedLogFilePattern.MatchString(e.Name()) {
+			paths[i] = path.Join(dir, e.Name())
+			i++
+		}
+	}
+
+	paths = paths[:i]
+
+	if paths[0] == "" {
+		paths = paths[1:]
+	}
+
+	return paths, nil
+}
+
+// watchLogsDir watches the log directory `dir` for new log lines, starting with the given `startFile` at
+// its `startOffset` printing all new content to `w` until the `ctx` is cancelled.
+// Once new log lines are written to `startFile` they are printed to `w`.
+// Once a new log file is created it switches to watching the new file instead.
+// The new state is checked every `watchInterval`.
+func watchLogsDir(ctx context.Context, dir, startFile string, startOffset int64, w io.Writer) (err error) {
+	curFile := startFile
+	curOffset := startOffset
+
+	ticker := time.NewTicker(watchInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("watching %s interrupted: %w", startFile, ctx.Err())
+		case <-ticker.C:
+			size, err := getFileSize(curFile)
+			if err != nil {
+				return fmt.Errorf("failed to watch the logs dir %q: %w", dir, err)
+			}
+			if curOffset != size {
+				curOffset, err = tailFile(curFile, curOffset, w)
+				if err != nil {
+					return fmt.Errorf("failed to watch the logs dir %q: %w", dir, err)
+				}
+			}
+
+			files, err := getLogFilenames(dir)
+			if err != nil {
+				return fmt.Errorf("failed to watch the logs dir %q: %w", dir, err)
+			}
+
+			i := len(files) - 1
+			for ; i >= 0; i-- {
+				if files[i] == curFile {
+					break
+				}
+			}
+			if i == len(files)-1 {
+				continue
+			}
+			curFile = files[i+1]
+			curOffset = 0
+		}
+	}
+}
+
+// getFileSize returns a file size of the given file.
+func getFileSize(file string) (int64, error) {
+	info, err := os.Stat(file)
+	if err != nil {
+		return 0, fmt.Errorf("failed to stat file %q: %w", file, err)
+	}
+	return info.Size(), nil
+}
+
+// tailFile prints the tail of the `file` to `w` starting from `offset`.
+func tailFile(file string, offset int64, w io.Writer) (size int64, err error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open file %q: %w", file, err)
+	}
+	defer f.Close()
+
+	_, err = f.Seek(offset, io.SeekStart)
+	if err != nil {
+		return 0, fmt.Errorf("failed to seek to %d in file %q: %w", offset, file, err)
+	}
+
+	_, err = io.Copy(w, f)
+	if err != nil {
+		return size, fmt.Errorf("failed to print file %s: %w", file, err)
+	}
+
+	size, err = getFileSize(file)
+	if err != nil {
+		return size, fmt.Errorf("failed to get file size %s: %w", file, err)
+	}
+
+	return size, nil
+}

--- a/internal/pkg/agent/cmd/logs_test.go
+++ b/internal/pkg/agent/cmd/logs_test.go
@@ -1,0 +1,421 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+)
+
+const (
+	line1 = "first"
+	line2 = "second"
+	line3 = "third"
+	file  = "elastic-agent-20230530.ndjson"
+	file1 = "elastic-agent-20230530-1.ndjson"
+	file2 = "elastic-agent-20230530-2.ndjson"
+	file3 = "elastic-agent-20230530-3.ndjson"
+)
+
+type testFile struct {
+	name    string
+	content string
+}
+
+func TestGetLogFilenames(t *testing.T) {
+	t.Run("returns the correct sorted filelist", func(t *testing.T) {
+		dir := t.TempDir()
+
+		createFile(t, dir, file2)
+		createFile(t, dir, file)
+		createFile(t, dir, file1)
+		createFile(t, dir, file3)
+
+		names, err := getLogFilenames(dir)
+		require.NoError(t, err)
+		expected := []string{
+			path.Join(dir, file),
+			path.Join(dir, file1),
+			path.Join(dir, file2),
+			path.Join(dir, file3),
+		}
+		require.Equal(t, expected, names)
+	})
+
+	t.Run("does not return directory entries", func(t *testing.T) {
+		dir := t.TempDir()
+		err := os.Mkdir(path.Join(dir, "should_exclude"), 0777)
+		require.NoError(t, err)
+
+		names, err := getLogFilenames(dir)
+		require.NoError(t, err)
+		expected := []string{}
+		require.Equal(t, expected, names)
+	})
+
+	t.Run("does not return non-log entries", func(t *testing.T) {
+		dir := t.TempDir()
+		createFile(t, dir, "excluded")
+
+		names, err := getLogFilenames(dir)
+		require.NoError(t, err)
+		expected := []string{}
+		require.Equal(t, expected, names)
+	})
+
+	t.Run("returns a list of one", func(t *testing.T) {
+		dir := t.TempDir()
+		createFile(t, dir, file1)
+
+		names, err := getLogFilenames(dir)
+		require.NoError(t, err)
+		expected := []string{
+			path.Join(dir, file1),
+		}
+		require.Equal(t, expected, names)
+	})
+}
+
+func TestPrintLogs(t *testing.T) {
+	cases := []struct {
+		name     string
+		files    []testFile
+		lines    int
+		expected string
+	}{
+		{
+			name:     "outputs no lines if there are no log files",
+			lines:    100,
+			expected: "",
+		},
+		{
+			name: "outputs max number of lines from a single file",
+			files: []testFile{
+				{
+					name:    file1,
+					content: generateLines(line1, 1, 20),
+				},
+			},
+			lines:    100,
+			expected: generateLines(line1, 1, 20),
+		},
+		{
+			name: "outputs last N lines from the last file only",
+			files: []testFile{
+				// not ordered on purpose
+				{
+					name:    file2,
+					content: generateLines(line2, 1, 20),
+				},
+				{
+					name:    file3,
+					content: generateLines(line3, 1, 30),
+				},
+				{
+					name:    file1,
+					content: generateLines(line1, 1, 10),
+				},
+			},
+			lines:    15,
+			expected: generateLines(line3, 16, 30),
+		},
+		{
+			name: "outputs last N lines from 2 files gluing them together",
+			files: []testFile{
+				// not ordered on purpose
+				{
+					name:    file2,
+					content: generateLines(line2, 1, 20),
+				},
+				{
+					name:    file3,
+					content: generateLines(line3, 1, 30),
+				},
+				{
+					name:    file1,
+					content: generateLines(line1, 1, 10),
+				},
+			},
+			lines:    40,
+			expected: generateLines(line2, 11, 20) + generateLines(line3, 1, 30),
+		},
+		{
+			name: "outputs all lines from all files gluing them together",
+			files: []testFile{
+				// not ordered on purpose
+				{
+					name:    file2,
+					content: generateLines(line2, 1, 20),
+				},
+				{
+					name:    file3,
+					content: generateLines(line3, 1, 30),
+				},
+				{
+					name:    file1,
+					content: generateLines(line1, 1, 10),
+				},
+			},
+			lines:    100,
+			expected: generateLines(line1, 1, 10) + generateLines(line2, 1, 20) + generateLines(line3, 1, 30),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, f := range tc.files {
+				createFileContent(t, dir, f.name, bytes.NewBuffer([]byte(f.content)))
+			}
+			result := bytes.NewBuffer(nil)
+			err := printLogs(context.Background(), result, dir, tc.lines, false, nil)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, result.String())
+		})
+	}
+
+	t.Run("returns tail and then follows the logs", func(t *testing.T) {
+		dir := t.TempDir()
+		createFileContent(t, dir, file1, bytes.NewBuffer([]byte(generateLines(line1, 1, 10))))
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		result := bytes.NewBuffer(nil)
+		var printErr error
+		go func() {
+			printErr = printLogs(ctx, result, dir, 5, true, nil)
+		}()
+
+		var expected string
+
+		t.Run("tails the file", func(t *testing.T) {
+			expected = generateLines(line1, 6, 10)
+			require.Eventuallyf(t, func() bool {
+				return result.String() == expected
+			}, time.Second, 10*time.Millisecond, "output %q does not match expected %q", result.String(), expected)
+		})
+
+		t.Run("detects new lines and prints them", func(t *testing.T) {
+			f, err := os.OpenFile(path.Join(dir, file1), os.O_WRONLY|os.O_APPEND, 0)
+			require.NoError(t, err)
+			_, err = f.WriteString(generateLines(line1, 11, 20))
+			require.NoError(t, err)
+			f.Close()
+
+			time.Sleep(watchInterval)
+
+			expected += generateLines(line1, 11, 20)
+			require.Eventuallyf(t, func() bool {
+				return result.String() == expected
+			}, 2*watchInterval, 10*time.Millisecond, "output %q does not match expected %q", result.String(), expected)
+		})
+
+		t.Run("detects a new file and switches to it", func(t *testing.T) {
+			createFileContent(t, dir, file2, bytes.NewBuffer([]byte(generateLines(line2, 1, 20))))
+
+			time.Sleep(watchInterval)
+
+			expected += generateLines(line2, 1, 20)
+			require.Eventuallyf(t, func() bool {
+				return result.String() == expected
+			}, 2*watchInterval, 10*time.Millisecond, "output %q does not match expected %q", result.String(), expected)
+		})
+
+		t.Run("detects another file and switches to it", func(t *testing.T) {
+			createFileContent(t, dir, file3, bytes.NewBuffer([]byte(generateLines(line3, 1, 30))))
+
+			time.Sleep(watchInterval)
+
+			expected += generateLines(line3, 1, 30)
+			require.Eventuallyf(t, func() bool {
+				return result.String() == expected
+			}, 2*watchInterval, 10*time.Millisecond, "output %q does not match expected %q", result.String(), expected)
+		})
+
+		t.Run("handles interruption correctly", func(t *testing.T) {
+			cancel()
+			require.Eventuallyf(t, func() bool { return printErr != nil }, time.Second, time.Millisecond, "context must stop logs following")
+			require.ErrorIs(t, printErr, context.Canceled)
+		})
+	})
+}
+
+func TestPrintLogFile(t *testing.T) {
+	testBufferSize := 64
+	cases := []struct {
+		name      string
+		fileLines int
+		lines     int
+		expLines  int
+		expected  string
+	}{
+		{
+			name:      "outputs no lines if the file is empty",
+			fileLines: 0,
+			lines:     100,
+			expLines:  0,
+			expected:  "",
+		},
+		{
+			name:      "outputs max number lines from a single file that fits in the buffer",
+			fileLines: 5,
+			lines:     100,
+			expLines:  5,
+			expected:  generateLines(line1, 1, 5),
+		},
+		{
+			name:      "outputs number lines from a single file that fits in the buffer",
+			fileLines: 5,
+			lines:     3,
+			expLines:  3,
+			expected:  generateLines(line1, 3, 5),
+		},
+		{
+			name:      "outputs number lines from a single file that does not fit in the buffer",
+			fileLines: 500,
+			lines:     400,
+			expLines:  400,
+			expected:  generateLines(line1, 101, 500),
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			content := ""
+			if tc.fileLines > 0 {
+				content = generateLines(line1, 1, tc.fileLines)
+			}
+
+			filename := fmt.Sprintf("test-%d", i)
+			createFileContent(t, dir, filename, bytes.NewBuffer([]byte(content)))
+
+			sw := &stackWriter{}
+
+			buf := make([]byte, testBufferSize)
+
+			printed, err := printLogFile(path.Join(dir, filename), tc.lines, sw, buf, nil)
+			require.NoError(t, err)
+
+			result := bytes.NewBuffer(nil)
+			err = sw.PopAll(result)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result.String())
+			assert.Equal(t, tc.expLines, printed)
+		})
+	}
+
+	matchingEntry := []byte(`{"component":{"id":"testID"}}` + "\n")
+	nonMatchingEntry := []byte(`{"component":{"id":"NO_MATCH"}}` + "\n")
+	matchingID := "testID"
+
+	t.Run("filter entries with the given filter", func(t *testing.T) {
+		dir := t.TempDir()
+		var entries []byte
+
+		entries = append(entries, matchingEntry...)
+		entries = append(entries, matchingEntry...)
+		entries = append(entries, nonMatchingEntry...)
+		entries = append(entries, matchingEntry...)
+
+		createFileContent(t, dir, "test.ndjson", bytes.NewBuffer(entries))
+
+		result := bytes.NewBuffer(nil)
+		testBuffer := make([]byte, 16) // so the buffer is not aligned
+		_, err := printLogFile(path.Join(dir, "test.ndjson"), 2, result, testBuffer, createComponentFilter(matchingID))
+		require.NoError(t, err)
+
+		var expected []byte
+		expected = append(expected, matchingEntry...)
+		expected = append(expected, matchingEntry...)
+		require.Equal(t, string(expected), result.String())
+	})
+
+	t.Run("filters out all entries", func(t *testing.T) {
+		dir := t.TempDir()
+		var entries []byte
+
+		entries = append(entries, nonMatchingEntry...)
+		entries = append(entries, nonMatchingEntry...)
+		entries = append(entries, nonMatchingEntry...)
+
+		createFileContent(t, dir, "test.ndjson", bytes.NewBuffer(entries))
+
+		result := bytes.NewBuffer(nil)
+		testBuffer := make([]byte, 16) // so the buffer is not aligned
+		_, err := printLogFile(path.Join(dir, "test.ndjson"), 2, result, testBuffer, createComponentFilter(matchingID))
+		require.NoError(t, err)
+
+		var expected []byte
+		require.Equal(t, string(expected), result.String())
+	})
+}
+
+func TestCreateComponentFilter(t *testing.T) {
+	cases := []struct {
+		name        string
+		componentID string
+		entry       []byte
+		exp         bool
+	}{
+		{
+			name:        "returns false if the component ID does not match",
+			componentID: "requiredID",
+			entry:       []byte(`{"component":{"id":"doesNotMatch"}}`),
+			exp:         false,
+		},
+		{
+			name:        "returns false if the entry is not valid JSON",
+			componentID: "requiredID",
+			entry:       []byte(`{"}`),
+			exp:         false,
+		},
+		{
+			name:        "returns true if the entry has matching component ID",
+			componentID: "requiredID",
+			entry:       []byte(`{"component":{"id":"requiredID"}}`),
+			exp:         true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := createComponentFilter(tc.componentID)
+			require.Equal(t, tc.exp, filter(tc.entry))
+		})
+	}
+}
+
+func generateLines(prefix string, start, end int) string {
+	b := strings.Builder{}
+	for i := start; i <= end; i++ {
+		b.WriteString(fmt.Sprintf("%s: %d\n", prefix, i))
+	}
+	return b.String()
+}
+
+func createFile(t *testing.T, dir, name string) {
+	createFileContent(t, dir, name, nil)
+}
+
+func createFileContent(t *testing.T, dir, name string, content io.Reader) {
+	f, err := os.Create(path.Join(dir, name))
+	require.NoError(t, err)
+	defer f.Close()
+	if content != nil {
+		_, err = io.Copy(f, content)
+		require.NoError(t, err)
+	}
+}

--- a/internal/pkg/agent/cmd/logs_test.go
+++ b/internal/pkg/agent/cmd/logs_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -46,10 +46,10 @@ func TestGetLogFilenames(t *testing.T) {
 		names, err := getLogFilenames(dir)
 		require.NoError(t, err)
 		expected := []string{
-			path.Join(dir, file),
-			path.Join(dir, file1),
-			path.Join(dir, file2),
-			path.Join(dir, file3),
+			filepath.Join(dir, file),
+			filepath.Join(dir, file1),
+			filepath.Join(dir, file2),
+			filepath.Join(dir, file3),
 		}
 		require.Equal(t, expected, names)
 	})
@@ -74,21 +74,21 @@ func TestGetLogFilenames(t *testing.T) {
 		names, err := getLogFilenames(dir)
 		require.NoError(t, err)
 		expected := []string{
-			path.Join(dir, prevDayFile),
-			path.Join(dir, prevDayFile1),
-			path.Join(dir, prevDayFile2),
-			path.Join(dir, prevDayFile3),
-			path.Join(dir, file),
-			path.Join(dir, file1),
-			path.Join(dir, file2),
-			path.Join(dir, file3),
+			filepath.Join(dir, prevDayFile),
+			filepath.Join(dir, prevDayFile1),
+			filepath.Join(dir, prevDayFile2),
+			filepath.Join(dir, prevDayFile3),
+			filepath.Join(dir, file),
+			filepath.Join(dir, file1),
+			filepath.Join(dir, file2),
+			filepath.Join(dir, file3),
 		}
 		require.Equal(t, expected, names)
 	})
 
 	t.Run("does not return directory entries", func(t *testing.T) {
 		dir := t.TempDir()
-		err := os.Mkdir(path.Join(dir, "should_exclude"), 0777)
+		err := os.Mkdir(filepath.Join(dir, "should_exclude"), 0777)
 		require.NoError(t, err)
 
 		names, err := getLogFilenames(dir)
@@ -114,7 +114,7 @@ func TestGetLogFilenames(t *testing.T) {
 		names, err := getLogFilenames(dir)
 		require.NoError(t, err)
 		expected := []string{
-			path.Join(dir, file1),
+			filepath.Join(dir, file1),
 		}
 		require.Equal(t, expected, names)
 	})
@@ -267,7 +267,7 @@ func TestPrintLogs(t *testing.T) {
 		})
 
 		t.Run("detects new lines and prints them", func(t *testing.T) {
-			f, err := os.OpenFile(path.Join(dir, file1), os.O_WRONLY|os.O_APPEND, 0)
+			f, err := os.OpenFile(filepath.Join(dir, file1), os.O_WRONLY|os.O_APPEND, 0)
 			require.NoError(t, err)
 			_, err = f.WriteString(generateLines(line1, 11, 20))
 			require.NoError(t, err)
@@ -365,7 +365,7 @@ func TestPrintLogFile(t *testing.T) {
 
 			buf := make([]byte, testBufferSize)
 
-			printed, err := printLogFile(path.Join(dir, filename), tc.lines, sw, buf, nil)
+			printed, err := printLogFile(filepath.Join(dir, filename), tc.lines, sw, buf, nil)
 			require.NoError(t, err)
 
 			result := bytes.NewBuffer(nil)
@@ -393,7 +393,7 @@ func TestPrintLogFile(t *testing.T) {
 
 		result := bytes.NewBuffer(nil)
 		testBuffer := make([]byte, 16) // so the buffer is not aligned
-		_, err := printLogFile(path.Join(dir, "test.ndjson"), 2, result, testBuffer, createComponentFilter(matchingID))
+		_, err := printLogFile(filepath.Join(dir, "test.ndjson"), 2, result, testBuffer, createComponentFilter(matchingID))
 		require.NoError(t, err)
 
 		var expected []byte
@@ -414,7 +414,7 @@ func TestPrintLogFile(t *testing.T) {
 
 		result := bytes.NewBuffer(nil)
 		testBuffer := make([]byte, 16) // so the buffer is not aligned
-		_, err := printLogFile(path.Join(dir, "test.ndjson"), 2, result, testBuffer, createComponentFilter(matchingID))
+		_, err := printLogFile(filepath.Join(dir, "test.ndjson"), 2, result, testBuffer, createComponentFilter(matchingID))
 		require.NoError(t, err)
 
 		var expected []byte
@@ -470,7 +470,7 @@ func createFile(t *testing.T, dir, name string) {
 }
 
 func createFileContent(t *testing.T, dir, name string, content io.Reader) {
-	f, err := os.Create(path.Join(dir, name))
+	f, err := os.Create(filepath.Join(dir, name))
 	require.NoError(t, err)
 	defer f.Close()
 	if content != nil {


### PR DESCRIPTION
## What does this PR do?

It adds the `logs` subcommand.

Following is supported:

* Print the last `-n` lines of the logs (10 by default)
* Follow the logs after printing
* Filter logs by a component ID

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->



<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Improves development and troubleshooting experience.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
~~- [ ] I have added an integration test or an E2E test~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
* Unit tests with a very good coverage (all the successful paths and edge cases are covered)
* Install the agent built from this branch and then use `elastic-agent logs -f`

## Related issues

- Fixes #114

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


https://github.com/elastic/elastic-agent/assets/887952/d74fe794-25e6-493b-8045-6539e048f761

