### PR TITLE
Tamper protected Endpoint integration removal

### DIFF
--- a/internal/pkg/agent/application/coordinator/mocks/runtime_manager.go
+++ b/internal/pkg/agent/application/coordinator/mocks/runtime_manager.go
@@ -323,11 +323,11 @@ func (_c *RuntimeManager_SubscribeAll_Call) RunAndReturn(run func(context.Contex
 }
 
 // Update provides a mock function with given fields: _a0
-func (_m *RuntimeManager) Update(_a0 []component.Component) error {
+func (_m *RuntimeManager) Update(_a0 component.Model) error {
 	ret := _m.Called(_a0)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func([]component.Component) error); ok {
+	if rf, ok := ret.Get(0).(func(component.Model) error); ok {
 		r0 = rf(_a0)
 	} else {
 		r0 = ret.Error(0)

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -15,8 +15,10 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/transpiler"
 	"github.com/elastic/elastic-agent/internal/pkg/eql"
+	"gopkg.in/yaml.v2"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -2030,4 +2032,150 @@ type testHeadersProvider struct {
 
 func (h *testHeadersProvider) Headers() map[string]string {
 	return h.headers
+}
+
+// TestSignedMarshalUnmarshal will catch if the yaml library will get updated to v3 for example
+func TestSignedMarshalUnmarshal(t *testing.T) {
+	const data = "eyJAdGltZXN0YW1wIjoiMjAyMy0wNS0yMlQxNzoxOToyOC40NjNaIiwiZXhwaXJhdGlvbiI6IjIwMjMtMDYtMjFUMTc6MTk6MjguNDYzWiIsImFnZW50cyI6WyI3ZjY0YWI2NC1hNmM0LTQ2ZTMtODIyYS0zODUxZGVkYTJmY2UiXSwiYWN0aW9uX2lkIjoiNGYwODQ2MGYtMDE0Yy00ZDllLWJmOGEtY2FhNjQyNzRhZGU0IiwidHlwZSI6IlVORU5ST0xMIiwidHJhY2VwYXJlbnQiOiIwMC1iOTBkYTlmOGNjNzdhODk0OTc0ZWIxZTIzMGNmNjc2Yy1lOTNlNzk4YTU4ODg2MDVhLTAxIn0="
+	const signature = "MEUCIAxxsi9ff1zyV0+4fsJLqbP8Qb83tedU5iIFldtxEzEfAiEA0KUsrL7q+Fv7z6Boux3dY2P4emGi71jsMGanIZ552bM="
+
+	signed := Signed{
+		Data:      data,
+		Signature: signature,
+	}
+
+	b, err := yaml.Marshal(signed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var newSigned Signed
+	err = yaml.Unmarshal(b, &newSigned)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diff := cmp.Diff(signed, newSigned)
+	if diff != "" {
+		t.Fatal(diff)
+	}
+
+	diff = cmp.Diff(true, signed.IsSigned())
+	if diff != "" {
+		t.Fatal(diff)
+	}
+
+	var nilSigned *Signed
+	diff = cmp.Diff(false, nilSigned.IsSigned())
+	if diff != "" {
+		t.Fatal(diff)
+	}
+
+	unsigned := Signed{}
+	diff = cmp.Diff(false, unsigned.IsSigned())
+	if diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestSignedFromPolicy(t *testing.T) {
+	const data = "eyJAdGltZXN0YW1wIjoiMjAyMy0wNS0yMlQxNzoxOToyOC40NjNaIiwiZXhwaXJhdGlvbiI6IjIwMjMtMDYtMjFUMTc6MTk6MjguNDYzWiIsImFnZW50cyI6WyI3ZjY0YWI2NC1hNmM0LTQ2ZTMtODIyYS0zODUxZGVkYTJmY2UiXSwiYWN0aW9uX2lkIjoiNGYwODQ2MGYtMDE0Yy00ZDllLWJmOGEtY2FhNjQyNzRhZGU0IiwidHlwZSI6IlVORU5ST0xMIiwidHJhY2VwYXJlbnQiOiIwMC1iOTBkYTlmOGNjNzdhODk0OTc0ZWIxZTIzMGNmNjc2Yy1lOTNlNzk4YTU4ODg2MDVhLTAxIn0="
+	const signature = "MEUCIAxxsi9ff1zyV0+4fsJLqbP8Qb83tedU5iIFldtxEzEfAiEA0KUsrL7q+Fv7z6Boux3dY2P4emGi71jsMGanIZ552bM="
+
+	tests := []struct {
+		name       string
+		policy     map[string]interface{}
+		wantSigned *Signed
+		wantErr    error
+	}{
+		{
+			name:    "not signed",
+			wantErr: ErrNotFound,
+		},
+		{
+			name: "signed nil",
+			policy: map[string]interface{}{
+				"signed": nil,
+			},
+			wantErr: ErrNotFound,
+		},
+		{
+			name: "signed not map",
+			policy: map[string]interface{}{
+				"signed": "",
+			},
+			wantErr: ErrNotFound,
+		},
+		{
+			name: "signed empty",
+			policy: map[string]interface{}{
+				"signed": map[string]interface{}{},
+			},
+			wantErr: ErrNotFound,
+		},
+		{
+			name: "signed missing signature",
+			policy: map[string]interface{}{
+				"signed": map[string]interface{}{
+					"data": data,
+				},
+			},
+			wantErr: ErrNotFound,
+		},
+		{
+			name: "signed missing data",
+			policy: map[string]interface{}{
+				"signed": map[string]interface{}{
+					"signaure": signature,
+				},
+			},
+			wantErr: ErrNotFound,
+		},
+		{
+			name: "signed data invalid data type",
+			policy: map[string]interface{}{
+				"signed": map[string]interface{}{
+					"data": 1,
+				},
+			},
+			wantErr: ErrNotFound,
+		},
+		{
+			name: "signed signature invalid data type",
+			policy: map[string]interface{}{
+				"signed": map[string]interface{}{
+					"signature": 1,
+				},
+			},
+			wantErr: ErrNotFound,
+		},
+		{
+			name: "signed correct",
+			policy: map[string]interface{}{
+				"signed": map[string]interface{}{
+					"data":      data,
+					"signature": signature,
+				},
+			},
+			wantSigned: &Signed{
+				Data:      data,
+				Signature: signature,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			signed, err := SignedFromPolicy(tc.policy)
+			diff := cmp.Diff(tc.wantSigned, signed)
+			if diff != "" {
+				t.Fatal(diff)
+			}
+
+			diff = cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors())
+			if diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
 }

--- a/pkg/component/runtime/command.go
+++ b/pkg/component/runtime/command.go
@@ -269,7 +269,7 @@ func (c *CommandRuntime) Stop() error {
 // Teardown tears down the component.
 //
 // Non-blocking and never returns an error.
-func (c *CommandRuntime) Teardown() error {
+func (c *CommandRuntime) Teardown(_ *component.Signed) error {
 	// clear channel so it's the latest action
 	select {
 	case <-c.actionCh:

--- a/pkg/component/runtime/failed.go
+++ b/pkg/component/runtime/failed.go
@@ -75,7 +75,7 @@ func (c *FailedRuntime) Stop() error {
 }
 
 // Teardown marks it stopped.
-func (c *FailedRuntime) Teardown() error {
+func (c *FailedRuntime) Teardown(_ *component.Signed) error {
 	return c.Stop()
 }
 

--- a/pkg/component/runtime/manager.go
+++ b/pkg/component/runtime/manager.go
@@ -302,7 +302,7 @@ func (m *Manager) Errors() <-chan error {
 // Update updates the currComp state of the running components.
 //
 // This returns as soon as possible, the work is performed in the background.
-func (m *Manager) Update(components []component.Component) error {
+func (m *Manager) Update(model component.Model) error {
 	shuttingDown := m.shuttingDown.Load()
 	if shuttingDown {
 		// ignore any updates once shutdown started
@@ -310,7 +310,7 @@ func (m *Manager) Update(components []component.Component) error {
 	}
 	// teardown is true because the public `Update` method would be coming directly from
 	// policy so if a component was removed it needs to be torn down.
-	return m.update(components, true)
+	return m.update(model, true)
 }
 
 // State returns the current component states.
@@ -661,21 +661,21 @@ func (m *Manager) Actions(server proto.ElasticAgent_ActionsServer) error {
 // update updates the current state of the running components.
 //
 // This returns as soon as possible, work is performed in the background.
-func (m *Manager) update(components []component.Component, teardown bool) error {
+func (m *Manager) update(model component.Model, teardown bool) error {
 	// ensure that only one `update` can occur at the same time
 	m.updateMx.Lock()
 	defer m.updateMx.Unlock()
 
 	// prepare the components to add consistent shipper connection information between
 	// the connected components in the model
-	err := m.connectShippers(components)
+	err := m.connectShippers(model.Components)
 	if err != nil {
 		return err
 	}
 
 	touched := make(map[string]bool)
-	newComponents := make([]component.Component, 0, len(components))
-	for _, comp := range components {
+	newComponents := make([]component.Component, 0, len(model.Components))
+	for _, comp := range model.Components {
 		touched[comp.ID] = true
 		m.currentMx.RLock()
 		existing, ok := m.current[comp.ID]
@@ -706,7 +706,7 @@ func (m *Manager) update(components []component.Component, teardown bool) error 
 		var stoppedWg sync.WaitGroup
 		stoppedWg.Add(len(stop))
 		for _, existing := range stop {
-			_ = existing.stop(teardown)
+			_ = existing.stop(teardown, model.Signed)
 			// stop is async, wait for operation to finish,
 			// otherwise new instance may be started and components
 			// may fight for resources (e.g ports, files, locks)
@@ -780,7 +780,7 @@ func (m *Manager) shutdown() {
 
 	// don't tear down as this is just a shutdown, so components most likely will come back
 	// on next start of the manager
-	_ = m.update([]component.Component{}, false)
+	_ = m.update(component.Model{Components: []component.Component{}}, false)
 
 	// wait until all components are removed
 	for {

--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -141,7 +141,7 @@ func TestManager_SimpleComponentErr(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	err = m.Update([]component.Component{comp})
+	err = m.Update(component.Model{Components: []component.Component{comp}})
 	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
@@ -233,7 +233,7 @@ func TestManager_FakeInput_StartStop(t *testing.T) {
 							subErrCh <- fmt.Errorf("unit failed: %s", unit.Message)
 						} else if unit.State == client.UnitStateHealthy {
 							// remove the component which will stop it
-							err := m.Update([]component.Component{})
+							err := m.Update(component.Model{Components: []component.Component{}})
 							if err != nil {
 								subErrCh <- err
 							}
@@ -256,7 +256,7 @@ func TestManager_FakeInput_StartStop(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	err = m.Update([]component.Component{comp})
+	err = m.Update(component.Model{Components: []component.Component{comp}})
 	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
@@ -380,7 +380,7 @@ func TestManager_FakeInput_Features(t *testing.T) {
 							Fqdn: &proto.FQDNFeature{Enabled: true},
 						}
 
-						err := m.Update([]component.Component{comp})
+						err := m.Update(component.Model{Components: []component.Component{comp}})
 						if err != nil {
 							subscriptionErrCh <- fmt.Errorf("[case %d]: failed to update component: %w",
 								healthIteration, err)
@@ -435,7 +435,7 @@ func TestManager_FakeInput_Features(t *testing.T) {
 						"message": "Fake Healthy",
 					})
 
-					err := m.Update([]component.Component{comp})
+					err := m.Update(component.Model{Components: []component.Component{comp}})
 					if err != nil {
 						t.Logf("error updating component state to health: %v", err)
 
@@ -455,7 +455,7 @@ func TestManager_FakeInput_Features(t *testing.T) {
 	defer drainErrChan(managerErrCh)
 	defer drainErrChan(subscriptionErrCh)
 
-	err = m.Update([]component.Component{comp})
+	err = m.Update(component.Model{Components: []component.Component{comp}})
 	require.NoError(t, err)
 
 	timeout := 30 * time.Second
@@ -571,7 +571,7 @@ func TestManager_FakeInput_BadUnitToGood(t *testing.T) {
 							}
 
 							unitBad = false
-							err := m.Update([]component.Component{updatedComp})
+							err := m.Update(component.Model{Components: []component.Component{updatedComp}})
 							if err != nil {
 								subErrCh <- err
 							}
@@ -599,7 +599,7 @@ func TestManager_FakeInput_BadUnitToGood(t *testing.T) {
 								}
 							} else if unit.State == client.UnitStateHealthy {
 								// bad unit is now healthy; stop the component
-								err := m.Update([]component.Component{})
+								err := m.Update(component.Model{Components: []component.Component{}})
 								if err != nil {
 									subErrCh <- err
 								}
@@ -623,7 +623,7 @@ func TestManager_FakeInput_BadUnitToGood(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	err = m.Update([]component.Component{comp})
+	err = m.Update(component.Model{Components: []component.Component{comp}})
 	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
@@ -738,7 +738,7 @@ func TestManager_FakeInput_GoodUnitToBad(t *testing.T) {
 									Err:  errors.New("hard-error for config"),
 								}
 								unitGood = false
-								err := m.Update([]component.Component{updatedComp})
+								err := m.Update(component.Model{Components: []component.Component{updatedComp}})
 								if err != nil {
 									subErrCh <- err
 								}
@@ -751,7 +751,7 @@ func TestManager_FakeInput_GoodUnitToBad(t *testing.T) {
 						} else {
 							if unit.State == client.UnitStateFailed {
 								// went to failed; stop whole component
-								err := m.Update([]component.Component{})
+								err := m.Update(component.Model{Components: []component.Component{}})
 								if err != nil {
 									subErrCh <- err
 								}
@@ -773,7 +773,7 @@ func TestManager_FakeInput_GoodUnitToBad(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	err = m.Update([]component.Component{comp})
+	err = m.Update(component.Model{Components: []component.Component{comp}})
 	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
@@ -1010,7 +1010,7 @@ func TestManager_FakeInput_Configure(t *testing.T) {
 								"state":   int(client.UnitStateDegraded),
 								"message": "Fake Degraded",
 							})
-							err := m.Update([]component.Component{comp})
+							err := m.Update(component.Model{Components: []component.Component{comp}})
 							if err != nil {
 								subErrCh <- err
 							}
@@ -1033,7 +1033,7 @@ func TestManager_FakeInput_Configure(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	err = m.Update([]component.Component{comp})
+	err = m.Update(component.Model{Components: []component.Component{comp}})
 	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
@@ -1151,7 +1151,7 @@ func TestManager_FakeInput_RemoveUnit(t *testing.T) {
 						} else if unit1.State == client.UnitStateHealthy {
 							// unit1 is healthy lets remove it from the component
 							comp.Units = comp.Units[0:1]
-							err := m.Update([]component.Component{comp})
+							err := m.Update(component.Model{Components: []component.Component{comp}})
 							if err != nil {
 								subErrCh <- err
 							}
@@ -1186,7 +1186,7 @@ func TestManager_FakeInput_RemoveUnit(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	err = m.Update([]component.Component{comp})
+	err = m.Update(component.Model{Components: []component.Component{comp}})
 	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
@@ -1310,7 +1310,7 @@ func TestManager_FakeInput_ActionState(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	err = m.Update([]component.Component{comp})
+	err = m.Update(component.Model{Components: []component.Component{comp}})
 	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
@@ -1445,7 +1445,7 @@ func TestManager_FakeInput_Restarts(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	err = m.Update([]component.Component{comp})
+	err = m.Update(component.Model{Components: []component.Component{comp}})
 	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
@@ -1562,7 +1562,7 @@ func TestManager_FakeInput_Restarts_ConfigKill(t *testing.T) {
 									"message": "Fake Healthy",
 									"kill":    rp[1],
 								})
-								err := m.Update([]component.Component{comp})
+								err := m.Update(component.Model{Components: []component.Component{comp}})
 								if err != nil {
 									subErrCh <- err
 								}
@@ -1587,7 +1587,7 @@ func TestManager_FakeInput_Restarts_ConfigKill(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	err = m.Update([]component.Component{comp})
+	err = m.Update(component.Model{Components: []component.Component{comp}})
 	require.NoError(t, err)
 
 	endTimer := time.NewTimer(1 * time.Minute)
@@ -1701,7 +1701,7 @@ func TestManager_FakeInput_KeepsRestarting(t *testing.T) {
 									"message":          fmt.Sprintf("Fake Healthy %d", lastStoppedCount),
 									"kill_on_interval": true,
 								})
-								err := m.Update([]component.Component{comp})
+								err := m.Update(component.Model{Components: []component.Component{comp}})
 								if err != nil {
 									subErrCh <- err
 								}
@@ -1729,7 +1729,7 @@ func TestManager_FakeInput_KeepsRestarting(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	err = m.Update([]component.Component{comp})
+	err = m.Update(component.Model{Components: []component.Component{comp}})
 	require.NoError(t, err)
 
 	endTimer := time.NewTimer(1 * time.Minute)
@@ -1844,7 +1844,7 @@ func TestManager_FakeInput_RestartsOnMissedCheckins(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	err = m.Update([]component.Component{comp})
+	err = m.Update(component.Model{Components: []component.Component{comp}})
 	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
@@ -1961,7 +1961,7 @@ func TestManager_FakeInput_InvalidAction(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	err = m.Update([]component.Component{comp})
+	err = m.Update(component.Model{Components: []component.Component{comp}})
 	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
@@ -2158,7 +2158,7 @@ func TestManager_FakeInput_MultiComponent(t *testing.T) {
 	defer drainErrChan(subErrCh1)
 	defer drainErrChan(subErrCh2)
 
-	err = m.Update(components)
+	err = m.Update(component.Model{Components: components})
 	require.NoError(t, err)
 
 	count := 0
@@ -2314,7 +2314,7 @@ func TestManager_FakeInput_LogLevel(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	err = m.Update([]component.Component{comp})
+	err = m.Update(component.Model{Components: []component.Component{comp}})
 	require.NoError(t, err)
 
 	endTimer := time.NewTimer(30 * time.Second)
@@ -2528,7 +2528,7 @@ func TestManager_FakeShipper(t *testing.T) {
 									subErrCh <- err
 								} else {
 									// successful; turn it all off
-									err := m.Update([]component.Component{})
+									err := m.Update(component.Model{Components: []component.Component{}})
 									if err != nil {
 										subErrCh <- err
 									}
@@ -2557,7 +2557,7 @@ func TestManager_FakeShipper(t *testing.T) {
 									subErrCh <- err
 								} else {
 									// successful; turn it all off
-									err := m.Update([]component.Component{})
+									err := m.Update(component.Model{Components: []component.Component{}})
 									if err != nil {
 										subErrCh <- err
 									}
@@ -2592,7 +2592,7 @@ func TestManager_FakeShipper(t *testing.T) {
 									subErrCh <- err
 								} else {
 									// successful; turn it all off
-									err := m.Update([]component.Component{})
+									err := m.Update(component.Model{Components: []component.Component{}})
 									if err != nil {
 										subErrCh <- err
 									}
@@ -2617,7 +2617,7 @@ func TestManager_FakeShipper(t *testing.T) {
 	defer drainErrChan(errCh)
 	defer drainErrChan(subErrCh)
 
-	err = m.Update(comps)
+	err = m.Update(component.Model{Components: comps})
 	require.NoError(t, err)
 
 	timeout := 2 * time.Minute
@@ -2822,7 +2822,7 @@ func TestManager_FakeInput_OutputChange(t *testing.T) {
 	}
 
 	time.Sleep(100 * time.Millisecond)
-	err = m.Update(components)
+	err = m.Update(component.Model{Components: components})
 	require.NoError(t, err)
 
 	updateSleep := 300 * time.Millisecond
@@ -2831,7 +2831,7 @@ func TestManager_FakeInput_OutputChange(t *testing.T) {
 		updateSleep = time.Second
 	}
 	time.Sleep(updateSleep)
-	err = m.Update(components2)
+	err = m.Update(component.Model{Components: components2})
 	require.NoError(t, err)
 
 	count := 0

--- a/pkg/component/runtime/runtime.go
+++ b/pkg/component/runtime/runtime.go
@@ -50,7 +50,7 @@ type ComponentRuntime interface {
 	//
 	// Used to tell control the difference between stopping a component to restart it or upgrade it, versus
 	// the component being completely removed.
-	Teardown() error
+	Teardown(signed *component.Signed) error
 }
 
 // NewComponentRuntime creates the proper runtime based on the input specification for the component.
@@ -181,10 +181,10 @@ func (s *componentRuntimeState) start() error {
 	return s.runtime.Start()
 }
 
-func (s *componentRuntimeState) stop(teardown bool) error {
+func (s *componentRuntimeState) stop(teardown bool, signed *component.Signed) error {
 	s.shuttingDown.Store(true)
 	if teardown {
-		return s.runtime.Teardown()
+		return s.runtime.Teardown(signed)
 	}
 	return s.runtime.Stop()
 }

--- a/pkg/component/runtime/service_test.go
+++ b/pkg/component/runtime/service_test.go
@@ -1,0 +1,95 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+	"github.com/elastic/elastic-agent/pkg/component"
+	"github.com/google/go-cmp/cmp"
+)
+
+func makeComponent(name string, config map[string]interface{}) (component.Component, error) {
+	c := component.Component{
+		Units: []component.Unit{
+			{
+				Type:   client.UnitTypeInput,
+				Config: &proto.UnitExpectedConfig{Type: name},
+			},
+		},
+		InputSpec: &component.InputRuntimeSpec{
+			Spec: component.InputSpec{
+				Name: name,
+			},
+		},
+	}
+	unitCfg, err := component.ExpectedConfig(config)
+	if err != nil {
+		return c, nil
+	}
+	c.Units[0].Config = unitCfg
+	return c, nil
+}
+
+func makeEndpointComponent(t *testing.T, config map[string]interface{}) component.Component {
+	comp, err := makeComponent("endpoint", config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return comp
+}
+
+func compareCompsConfigs(t *testing.T, comp component.Component, cfg map[string]interface{}) {
+	for _, unit := range comp.Units {
+		if unit.Type == client.UnitTypeInput {
+			unitCfgMap := unit.Config.Source.AsMap()
+			diff := cmp.Diff(cfg, unitCfgMap)
+			if diff != "" {
+				t.Fatal(diff)
+			}
+		}
+	}
+}
+
+func TestInjectSigned(t *testing.T) {
+	signed := &component.Signed{
+		Data:      "eyJAdGltZXN0YW1wIjoiMjAyMy0wNS0yMlQxNzoxOToyOC40NjNaIiwiZXhwaXJhdGlvbiI6IjIwMjMtMDYtMjFUMTc6MTk6MjguNDYzWiIsImFnZW50cyI6WyI3ZjY0YWI2NC1hNmM0LTQ2ZTMtODIyYS0zODUxZGVkYTJmY2UiXSwiYWN0aW9uX2lkIjoiNGYwODQ2MGYtMDE0Yy00ZDllLWJmOGEtY2FhNjQyNzRhZGU0IiwidHlwZSI6IlVORU5ST0xMIiwidHJhY2VwYXJlbnQiOiIwMC1iOTBkYTlmOGNjNzdhODk0OTc0ZWIxZTIzMGNmNjc2Yy1lOTNlNzk4YTU4ODg2MDVhLTAxIn0=",
+		Signature: "MEUCIAxxsi9ff1zyV0+4fsJLqbP8Qb83tedU5iIFldtxEzEfAiEA0KUsrL7q+Fv7z6Boux3dY2P4emGi71jsMGanIZ552bM=",
+	}
+
+	tests := []struct {
+		name    string
+		cfg     map[string]interface{}
+		signed  *component.Signed
+		wantCfg map[string]interface{}
+	}{
+		{
+			name:    "nil signed",
+			cfg:     map[string]interface{}{},
+			wantCfg: map[string]interface{}{},
+		},
+		{
+			name:   "signed",
+			cfg:    map[string]interface{}{},
+			signed: signed,
+			wantCfg: map[string]interface{}{
+				"signed": map[string]interface{}{
+					"data":      "eyJAdGltZXN0YW1wIjoiMjAyMy0wNS0yMlQxNzoxOToyOC40NjNaIiwiZXhwaXJhdGlvbiI6IjIwMjMtMDYtMjFUMTc6MTk6MjguNDYzWiIsImFnZW50cyI6WyI3ZjY0YWI2NC1hNmM0LTQ2ZTMtODIyYS0zODUxZGVkYTJmY2UiXSwiYWN0aW9uX2lkIjoiNGYwODQ2MGYtMDE0Yy00ZDllLWJmOGEtY2FhNjQyNzRhZGU0IiwidHlwZSI6IlVORU5ST0xMIiwidHJhY2VwYXJlbnQiOiIwMC1iOTBkYTlmOGNjNzdhODk0OTc0ZWIxZTIzMGNmNjc2Yy1lOTNlNzk4YTU4ODg2MDVhLTAxIn0=",
+					"signature": "MEUCIAxxsi9ff1zyV0+4fsJLqbP8Qb83tedU5iIFldtxEzEfAiEA0KUsrL7q+Fv7z6Boux3dY2P4emGi71jsMGanIZ552bM=",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			newComp, err := injectSigned(makeEndpointComponent(t, tc.cfg), tc.signed)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			compareCompsConfigs(t, newComp, tc.wantCfg)
+		})
+	}
+
+}


### PR DESCRIPTION
## What does this PR do?

Implements the Tamper protected Endpoint integration removal
as described in the first part of https://github.com/elastic/ingest-dev/issues/1882

I discussed this approach with @blakerouse last week. The idea is to not introduce any agent state dependency on a particular order of the policy updates, the agent can still configure itself from any policy revision. The trust is maintained between Kibana and Endpoint through the signed policy payload, that's why the Endpoint would have to know more about the original structure of the policy, because that's what Kibana knows about and that's what it signs.
The surface of the change is limited to to the service runtime teardown implementation, which currently affects only Endpoint.

Here is what's done here:

* Change the runtime manager Update signature in order to pass the component.Model instead, thus allowing to pass the optional ```Signed``` struct as discussed with @blakerouse.

* Change the Teardown to pass ```Signed```

* Change the teardown sequence for the service runtime, which affects only Endpoint at the moment. 
The teardown is now performed in two steps, first the new policy ```Signed``` object is passed down to Endpoint with the component update.

The signed data now has all the inputs included with some minimal set of properties that allows Endpoint
to validate the signature and unprotect itself if the there is no corresponding ```endpoint``` input in the policy.
Here is and example decoded from base64 encoded ```signed.data``` payload:
```
{
  "id": "6314e110-f8c2-11ed-ab07-d3e4064cb6ee",
  "agent": {
    "protection": {
      "enabled": false,
      "uninstall_token_hash": "tx/Vht5/TVZ7gE8LcuX0NiV9azGfpX3BkrF0/wRjFsY=",
      "signing_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENxwK08uYPM8D5yTmoA/emoxK5s5lQFyt/6E4LpMmpxbukMBN3/rNfjodisQBPyVQmE/ENuTbE42G5K8iXXvBRA=="
    }
  },
  "inputs": [
    {
      "id": "5be5a402-b3cb-456a-92e7-5ca5ac9204af",
      "name": "EP",
      "revision": 1,
      "type": "endpoint"
    }
  ]
}
```

The agent expects Endpoint to checkin after that or uses the teardown timeout, and proceeds with stopping and uninstalling the service.


This was tested against Kibana changes on @joeypoon branch
https://github.com/joeypoon/kibana/pull/new/feature/sign-unenroll

This will need to be tested and possibly adjusted once Endpoint implements this functionality, will work with @intxgo on validating it end-to-end once the Endpoint is ready.


## Why is it important?

Completes the requirements for the tamper protection the 8.10 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/1882


