### PR TITLE
Add `integration:matrix` and `integration:single` mage targets

### DIFF
--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -31,6 +31,10 @@ Run `mage integration:local` to execute only those tests under the
 `testing/integration` folder that set `Local: true`. These tests are executed
 on your local machine.
 
+Run `mage integration:single [testName]` to execute a single test under the `testing/integration` folder. Only the selected test will be executed on remote VMs.
+
+Run `mage integration:matrix` to run all tests on the complete matrix of supported operating systems and architectures of the Elastic Agent.
+
 ## Troubleshooting Tips
 
 ### Error: GCE service token missing; run 'mage integration:auth'

--- a/magefile.go
+++ b/magefile.go
@@ -1263,12 +1263,13 @@ func majorMinor() string {
 	return ""
 }
 
+// cleans up the integration testing leftovers
 func (Integration) Clean() error {
 	_ = os.RemoveAll(".agent-testing")
 	_, err := os.Stat(".ogc-cache")
 	if err == nil {
 		// .ogc-cache exists; need to run `Clean` from the runner
-		r, err := createTestRunner()
+		r, err := createTestRunner(false, "")
 		if err != nil {
 			return err
 		}
@@ -1281,11 +1282,13 @@ func (Integration) Clean() error {
 	return nil
 }
 
+// checks that integration tests are using define.Require
 func (Integration) Check() error {
 	fmt.Println(">> check: Checking for define.Require in integration tests") // nolint:forbidigo // it's ok to use fmt.println in mage
 	return define.ValidateDir("testing/integration")
 }
 
+// runs only the integration tests that support local mode
 func (Integration) Local(ctx context.Context) error {
 	if shouldBuildAgent() {
 		// need only local package for current platform
@@ -1326,44 +1329,27 @@ func (Integration) Auth(ctx context.Context) error {
 // run integration tests on remote hosts
 func (Integration) Test(ctx context.Context) error {
 	mg.CtxDeps(ctx, Integration.Clean)
-	batches, err := define.DetermineBatches("testing/integration", "integration")
-	if err != nil {
-		return fmt.Errorf("failed to detemine batches: %w", err)
-	}
-	r, err := createTestRunner(batches...)
-	if err != nil {
-		return err
-	}
-	results, err := r.Run(ctx)
-	if err != nil {
-		return err
-	}
-	_ = os.Remove("build/TEST-go-integration.out")
-	_ = os.Remove("build/TEST-go-integration.out.json")
-	_ = os.Remove("build/TEST-go-integration.xml")
-	err = writeFile("build/TEST-go-integration.out", results.Output, 0644)
-	if err != nil {
-		return err
-	}
-	err = writeFile("build/TEST-go-integration.out.json", results.Output, 0644)
-	if err != nil {
-		return err
-	}
-	err = writeFile("build/TEST-go-integration.xml", results.XMLOutput, 0644)
-	if err != nil {
-		return err
-	}
-	fmt.Printf(">>> Testing completed\n")
-	fmt.Printf(">>> Console output written here: build/TEST-go-integration.out\n")
-	fmt.Printf(">>> Console JSON output written here: build/TEST-go-integration.out.json\n")
-	fmt.Printf(">>> JUnit XML written here: build/TEST-go-integration.xml\n")
-	return nil
+	return integRunner(ctx, false, "")
 }
 
+// run integration tests on a matrix of all supported remote hosts
+func (Integration) Matrix(ctx context.Context) error {
+	mg.CtxDeps(ctx, Integration.Clean)
+	return integRunner(ctx, true, "")
+}
+
+// run single integration test on remote host
+func (Integration) Single(ctx context.Context, testName string) error {
+	mg.CtxDeps(ctx, Integration.Clean)
+	return integRunner(ctx, false, testName)
+}
+
+// don't call locally (called on remote host to prepare it for testing)
 func (Integration) PrepareOnRemote() {
 	mg.Deps(mage.InstallGoTestTools)
 }
 
+// don't call locally (called on remote host to perform testing)
 func (Integration) TestOnRemote(ctx context.Context) error {
 	mg.Deps(Build.TestBinaries)
 	version := os.Getenv("AGENT_VERSION")
@@ -1423,7 +1409,49 @@ func (Integration) TestOnRemote(ctx context.Context) error {
 	return nil
 }
 
-func createTestRunner(batches ...define.Batch) (*runner.Runner, error) {
+func integRunner(ctx context.Context, matrix bool, singleTest string) error {
+	batches, err := define.DetermineBatches("testing/integration", "integration")
+	if err != nil {
+		return fmt.Errorf("failed to detemine batches: %w", err)
+	}
+	r, err := createTestRunner(matrix, singleTest, batches...)
+	if err != nil {
+		return err
+	}
+	results, err := r.Run(ctx)
+	if err != nil {
+		return err
+	}
+	_ = os.Remove("build/TEST-go-integration.out")
+	_ = os.Remove("build/TEST-go-integration.out.json")
+	_ = os.Remove("build/TEST-go-integration.xml")
+	err = writeFile("build/TEST-go-integration.out", results.Output, 0644)
+	if err != nil {
+		return err
+	}
+	err = writeFile("build/TEST-go-integration.out.json", results.Output, 0644)
+	if err != nil {
+		return err
+	}
+	err = writeFile("build/TEST-go-integration.xml", results.XMLOutput, 0644)
+	if err != nil {
+		return err
+	}
+	if results.Failures > 0 {
+		fmt.Printf(">>> Testing completed (%d failures)\n", results.Failures)
+	} else {
+		fmt.Printf(">>> Testing completed (%d successful)\n", results.Tests)
+	}
+	fmt.Printf(">>> Console output written here: build/TEST-go-integration.out\n")
+	fmt.Printf(">>> Console JSON output written here: build/TEST-go-integration.out.json\n")
+	fmt.Printf(">>> JUnit XML written here: build/TEST-go-integration.xml\n")
+	if results.Failures > 0 {
+		os.Exit(1)
+	}
+	return nil
+}
+
+func createTestRunner(matrix bool, singleTest string, batches ...define.Batch) (*runner.Runner, error) {
 	goVersion, err := mage.DefaultBeatBuildVariableSources.GetGoVersion()
 	if err != nil {
 		return nil, err
@@ -1482,6 +1510,8 @@ func createTestRunner(batches ...define.Batch) (*runner.Runner, error) {
 			ServiceTokenPath: serviceTokenPath,
 			Datacenter:       datacenter,
 		},
+		Matrix:     matrix,
+		SingleTest: singleTest,
 	}, batches...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create runner: %w", err)

--- a/magefile.go
+++ b/magefile.go
@@ -1438,7 +1438,7 @@ func integRunner(ctx context.Context, matrix bool, singleTest string) error {
 		return err
 	}
 	if results.Failures > 0 {
-		fmt.Printf(">>> Testing completed (%d failures)\n", results.Failures)
+		fmt.Printf(">>> Testing completed (%d failures, %d successful)\n", results.Failures, results.Tests-results.Failures)
 	} else {
 		fmt.Printf(">>> Testing completed (%d successful)\n", results.Tests)
 	}

--- a/pkg/testing/runner/config.go
+++ b/pkg/testing/runner/config.go
@@ -20,6 +20,13 @@ type Config struct {
 	RepoDir           string
 	ESS               *ESSConfig
 	GCE               *GCEConfig
+
+	// Matrix enables matrix testing. This explodes each test to
+	// run on all supported platforms the runner supports.
+	Matrix bool
+
+	// SingleTest only has the runner run that specific test.
+	SingleTest string
 }
 
 // Validate returns an error if the information is invalid.

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -839,8 +839,8 @@ func findLayoutBatchByID(id string, batches []LayoutBatch) (LayoutBatch, bool) {
 }
 
 func createBatches(batch define.Batch, matrix bool) ([]LayoutBatch, error) {
-	specifics, err := getSupported(batch.OS)
 	var batches []LayoutBatch
+	specifics, err := getSupported(batch.OS)
 	if errors.Is(err, ErrOSNotSupported) {
 		var s LayoutOS
 		s.OS.Type = batch.OS.Type

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -203,12 +203,13 @@ func (r *Runner) runMachines(ctx context.Context, sshAuth ssh.AuthMethod, repoAr
 					return fmt.Errorf("unable to find layout batch with ID: %s", m.Layout.Name)
 				}
 				loggerPrefix := fmt.Sprintf(
-					"%s[%s/%s/%s/%s]",
-					batch.ID[len(batch.ID)-5:len(batch.ID)-1],
+					"%s/%s/%s/%s[%s]",
 					batch.LayoutOS.OS.Type,
 					batch.LayoutOS.OS.Arch,
 					batch.LayoutOS.OS.Distro,
-					batch.LayoutOS.OS.Version)
+					batch.LayoutOS.OS.Version,
+					batch.ID[len(batch.ID)-5:len(batch.ID)-1],
+				)
 				logger := &batchLogger{prefix: loggerPrefix}
 				result, err := r.runMachine(ctx, sshAuth, logger, repoArchive, batch, m)
 				if err != nil {

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -52,13 +52,25 @@ type OSRunnerResult struct {
 // OSRunner provides an interface to run the tests on the OS.
 type OSRunner interface {
 	// Prepare prepares the runner to actual run on the host.
-	Prepare(ctx context.Context, c *ssh.Client, instanceName string, arch string, goVersion string, repoArchive string, buildPath string) error
+	Prepare(ctx context.Context, c *ssh.Client, logger Logger, arch string, goVersion string, repoArchive string, buildPath string) error
 	// Run runs the actual tests and provides the result.
-	Run(ctx context.Context, c *ssh.Client, instanceName string, agentVersion string, prefix string, batch define.Batch, env map[string]string) (OSRunnerResult, error)
+	Run(ctx context.Context, c *ssh.Client, logger Logger, agentVersion string, prefix string, batch define.Batch, env map[string]string) (OSRunnerResult, error)
+}
+
+// Logger is a simple logging interface used by each runner type.
+type Logger interface {
+	// Prefix returns the prefix used for logging.
+	Prefix() string
+	// Logf logs the message for this runner.
+	Logf(format string, args ...any)
 }
 
 // Result is the complete result from the runner.
 type Result struct {
+	// Tests is the number of tests ran.
+	Tests int
+	// Failures is the number of tests that failed.
+	Failures int
 	// Output is the raw test output.
 	Output []byte
 	// XMLOutput is the XML Junit output.
@@ -83,11 +95,19 @@ func NewRunner(cfg Config, batches ...define.Batch) (*Runner, error) {
 	}
 	var layoutBatches []LayoutBatch
 	for _, b := range batches {
-		lb, err := createBatch(b)
+		lbs, err := createBatches(b, cfg.Matrix)
 		if err != nil {
 			return nil, err
 		}
-		layoutBatches = append(layoutBatches, lb)
+		for _, lb := range lbs {
+			layoutBatches = append(layoutBatches, lb)
+		}
+	}
+	if cfg.SingleTest != "" {
+		layoutBatches, err = filterSingleTest(layoutBatches, cfg.SingleTest)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &Runner{
 		cfg:          cfg,
@@ -182,9 +202,17 @@ func (r *Runner) runMachines(ctx context.Context, sshAuth ssh.AuthMethod, repoAr
 				if !ok {
 					return fmt.Errorf("unable to find layout batch with ID: %s", m.Layout.Name)
 				}
-				result, err := r.runMachine(ctx, sshAuth, repoArchive, batch, m)
+				loggerPrefix := fmt.Sprintf(
+					"%s[%s/%s/%s/%s]",
+					batch.ID[len(batch.ID)-5:len(batch.ID)-1],
+					batch.LayoutOS.OS.Type,
+					batch.LayoutOS.OS.Arch,
+					batch.LayoutOS.OS.Distro,
+					batch.LayoutOS.OS.Version)
+				logger := &batchLogger{prefix: loggerPrefix}
+				result, err := r.runMachine(ctx, sshAuth, logger, repoArchive, batch, m)
 				if err != nil {
-					fmt.Printf(">>> Failed for instance %s @ %s: %s\n", m.InstanceName, m.PublicIP, err)
+					logger.Logf("Failed for instance %s: %s\n", m.PublicIP, err)
 					return err
 				}
 				resultsMx.Lock()
@@ -202,23 +230,23 @@ func (r *Runner) runMachines(ctx context.Context, sshAuth ssh.AuthMethod, repoAr
 }
 
 // runMachine runs the batch on the machine.
-func (r *Runner) runMachine(ctx context.Context, sshAuth ssh.AuthMethod, repoArchive string, batch LayoutBatch, machine OGCMachine) (OSRunnerResult, error) {
-	fmt.Printf(">>> Starting SSH connection to instance %s @ %s\n", machine.InstanceName, machine.PublicIP)
+func (r *Runner) runMachine(ctx context.Context, sshAuth ssh.AuthMethod, logger Logger, repoArchive string, batch LayoutBatch, machine OGCMachine) (OSRunnerResult, error) {
+	logger.Logf("Starting SSH connection to %s", machine.PublicIP)
 	connectCtx, connectCancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer connectCancel()
 	client, err := sshConnect(connectCtx, machine.PublicIP, machine.Layout.Username, sshAuth)
 	if err != nil {
-		fmt.Printf(">>> Failed to connect to instance %s @ %s: %s\n", machine.InstanceName, machine.PublicIP, err)
+		logger.Logf("Failed to connect to instance %s: %s", machine.PublicIP, err)
 		return OSRunnerResult{}, fmt.Errorf("failed to connect to instance %s: %w", machine.InstanceName, err)
 	}
 	defer client.Close()
-	fmt.Printf(">>> Connected over SSH to instance %s\n", machine.InstanceName)
+	logger.Logf("Connected over SSH")
 
 	// prepare the host to run the tests
-	fmt.Printf(">>> Preparing instance %s\n", machine.InstanceName)
-	err = batch.LayoutOS.Runner.Prepare(ctx, client, machine.InstanceName, batch.LayoutOS.OS.Arch, r.cfg.GOVersion, repoArchive, r.getBuildPath(batch))
+	logger.Logf("Preparing instance")
+	err = batch.LayoutOS.Runner.Prepare(ctx, client, logger, batch.LayoutOS.OS.Arch, r.cfg.GOVersion, repoArchive, r.getBuildPath(batch))
 	if err != nil {
-		fmt.Printf(">>> Failed to prepare instance %s: %s\n", machine.InstanceName, err)
+		logger.Logf("Failed to prepare instance: %s", err)
 		return OSRunnerResult{}, fmt.Errorf("failed to prepare instance %s: %w", machine.InstanceName, err)
 	}
 
@@ -229,12 +257,12 @@ func (r *Runner) runMachine(ctx context.Context, sshAuth ssh.AuthMethod, repoArc
 		if err != nil {
 			return OSRunnerResult{}, err
 		}
-		fmt.Printf(">>> Instance %s waiting for stack to be ready\n", machine.InstanceName)
+		logger.Logf("Waiting for stack to be ready")
 		resp := <-ch
 		if resp == nil {
-			fmt.Printf(">>> Instance %s cannot continue because stack never became ready\n", machine.InstanceName)
+			logger.Logf("Cannot continue because stack never became ready")
 		} else {
-			fmt.Printf(">>> Instance %s will continue stack is ready\n", machine.InstanceName)
+			logger.Logf("Will continue stack is ready")
 			env = map[string]string{
 				"ELASTICSEARCH_HOST":     resp.ElasticsearchEndpoint,
 				"ELASTICSEARCH_USERNAME": resp.Username,
@@ -248,9 +276,9 @@ func (r *Runner) runMachine(ctx context.Context, sshAuth ssh.AuthMethod, repoArc
 
 	// run the actual tests on the host
 	prefix := fmt.Sprintf("%s-%s-%s-%s", batch.LayoutOS.OS.Type, batch.LayoutOS.OS.Arch, batch.LayoutOS.OS.Distro, strings.Replace(batch.LayoutOS.OS.Version, ".", "", -1))
-	result, err := batch.LayoutOS.Runner.Run(ctx, client, machine.InstanceName, r.cfg.AgentVersion, prefix, batch.Batch, env)
+	result, err := batch.LayoutOS.Runner.Run(ctx, client, logger, r.cfg.AgentVersion, prefix, batch.Batch, env)
 	if err != nil {
-		fmt.Printf(">>> Failed to execute tests on instance %s: %s\n", machine.InstanceName, err)
+		logger.Logf("Failed to execute tests on instance: %s", err)
 		return OSRunnerResult{}, fmt.Errorf("failed to execute tests on instance %s: %w", machine.InstanceName, err)
 	}
 	return result, nil
@@ -733,6 +761,10 @@ func (r *Runner) mergeResults(results map[string]OSRunnerResult) (Result, error)
 	}
 
 	var complete Result
+	for _, suite := range suites.Suites {
+		complete.Tests += suite.Tests
+		complete.Failures += suite.Failures
+	}
 	complete.Output = rawOutput.Bytes()
 	complete.JSONOutput = jsonOutput.Bytes()
 	complete.XMLOutput = junitBytes.Bytes()
@@ -807,29 +839,96 @@ func findLayoutBatchByID(id string, batches []LayoutBatch) (LayoutBatch, bool) {
 	return LayoutBatch{}, false
 }
 
-func createBatch(batch define.Batch) (LayoutBatch, error) {
-	skip := false
-	specific, err := getSupported(batch.OS)
+func createBatches(batch define.Batch, matrix bool) ([]LayoutBatch, error) {
+	specifics, err := getSupported(batch.OS)
+	var batches []LayoutBatch
 	if errors.Is(err, ErrOSNotSupported) {
-		skip = true
-		specific.OS.Type = batch.OS.Type
-		specific.OS.Arch = batch.OS.Arch
-		specific.OS.Distro = batch.OS.Distro
-		if specific.OS.Distro == "" {
-			specific.OS.Distro = "unknown"
+		var s LayoutOS
+		s.OS.Type = batch.OS.Type
+		s.OS.Arch = batch.OS.Arch
+		s.OS.Distro = batch.OS.Distro
+		if s.OS.Distro == "" {
+			s.OS.Distro = "unknown"
 		}
-		if specific.OS.Version == "" {
-			specific.OS.Version = "unknown"
+		if s.OS.Version == "" {
+			s.OS.Version = "unknown"
 		}
+		batches = append(batches, LayoutBatch{
+			ID:       xid.New().String(),
+			LayoutOS: s,
+			Batch:    batch,
+			Skip:     true,
+		})
+		return batches, nil
 	} else if err != nil {
-		return LayoutBatch{}, err
+		return nil, err
 	}
-	return LayoutBatch{
-		ID:       xid.New().String(),
-		LayoutOS: specific,
-		Batch:    batch,
-		Skip:     skip,
-	}, nil
+	if matrix {
+		for _, s := range specifics {
+			batches = append(batches, LayoutBatch{
+				ID:       xid.New().String(),
+				LayoutOS: s,
+				Batch:    batch,
+				Skip:     false,
+			})
+		}
+	} else {
+		batches = append(batches, LayoutBatch{
+			ID:       xid.New().String(),
+			LayoutOS: specifics[0],
+			Batch:    batch,
+			Skip:     false,
+		})
+	}
+	return batches, nil
+}
+
+func filterSingleTest(batches []LayoutBatch, singleTest string) ([]LayoutBatch, error) {
+	var filtered []LayoutBatch
+	for _, batch := range batches {
+		batch, ok := filterSingleTestBatch(batch, singleTest)
+		if ok {
+			filtered = append(filtered, batch)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil, fmt.Errorf("test not found: %s", singleTest)
+	}
+	return filtered, nil
+}
+
+func filterSingleTestBatch(batch LayoutBatch, testName string) (LayoutBatch, bool) {
+	for _, pt := range batch.Batch.Tests {
+		for _, t := range pt.Tests {
+			if t == testName {
+				// filter batch to only run one test
+				batch.Batch.Tests = []define.BatchPackageTests{
+					{
+						Name:  pt.Name,
+						Tests: []string{testName},
+					},
+				}
+				batch.Batch.SudoTests = nil
+				return batch, true
+			}
+		}
+	}
+	for _, pt := range batch.Batch.SudoTests {
+		for _, t := range pt.Tests {
+			if t == testName {
+				// filter batch to only run one test
+				batch.Batch.SudoTests = []define.BatchPackageTests{
+					{
+						Name:  pt.Name,
+						Tests: []string{testName},
+					},
+				}
+				batch.Batch.Tests = nil
+				return batch, true
+			}
+		}
+	}
+	return batch, false
 }
 
 type essCloudResponse struct {
@@ -838,4 +937,16 @@ type essCloudResponse struct {
 	done  bool
 	subCh []chan *ess.CreateDeploymentResponse
 	subMx sync.RWMutex
+}
+
+type batchLogger struct {
+	prefix string
+}
+
+func (b *batchLogger) Prefix() string {
+	return b.prefix
+}
+
+func (b *batchLogger) Logf(format string, args ...any) {
+	fmt.Printf(">>> (%s) %s\n", b.prefix, fmt.Sprintf(format, args...))
 }

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -99,9 +99,7 @@ func NewRunner(cfg Config, batches ...define.Batch) (*Runner, error) {
 		if err != nil {
 			return nil, err
 		}
-		for _, lb := range lbs {
-			layoutBatches = append(layoutBatches, lb)
-		}
+		layoutBatches = append(layoutBatches, lbs...)
 	}
 	if cfg.SingleTest != "" {
 		layoutBatches, err = filterSingleTest(layoutBatches, cfg.SingleTest)

--- a/pkg/testing/runner/supported.go
+++ b/pkg/testing/runner/supported.go
@@ -100,14 +100,18 @@ var supported = []LayoutOS{
 	},
 }
 
-// getSupported returns the supported layout based on the provided OS profile.
-func getSupported(os define.OS) (LayoutOS, error) {
+// getSupported returns all the supported layout based on the provided OS profile.
+func getSupported(os define.OS) ([]LayoutOS, error) {
+	var match []LayoutOS
 	for _, s := range supported {
 		if osMatch(s.OS, os) {
-			return s, nil
+			match = append(match, s)
 		}
 	}
-	return LayoutOS{}, fmt.Errorf("%w: %s/%s", ErrOSNotSupported, os.Type, os.Arch)
+	if len(match) > 0 {
+		return match, nil
+	}
+	return nil, fmt.Errorf("%w: %s/%s", ErrOSNotSupported, os.Type, os.Arch)
 }
 
 // osMatch returns true when the specific OS is a match for a non-specific OS.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds a new `integration:matrix` target that explodes the possible instances to run tests on to include all possible combinations. `integration:test` always just picks the first for each OS type, the `integration:matrix` will run it on the same OS type if the runner supports different distros and versions of that type. Currently running `integration:test` the tests only run on Ubuntu 22.04, running `integration:matrix` the tests are run on Ubuntu 22.04 and Ubuntu 20.04.

Adds a new `integration:single [testName]` target that allows the selection of only a single integration test to run. This makes it easier on the developer to work and fix a single test without having to run all tests.

Fixes issue where the mage target would not return a bad exit code in the case of test failures. This now will exit 1 if any tests fails, exit 0 if all are successful.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

`integration:matrix` is important so we can get complete test coverage across our entire support matrix.

`integration:single [testName` is needed for developers to write and fix a single test.

Exit code change is required by CI to allow the CI to know if the test run was successful.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #2714 
- Closes #2716
