### PR TITLE
Document goroutine call patterns, cleanup

### DIFF
--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -420,8 +420,8 @@ func (c *Coordinator) watchRuntimeComponents(ctx context.Context) {
 func (c *Coordinator) Run(ctx context.Context) error {
 	// log all changes in the state of the runtime and update the coordinator state
 	// TODO: nothing cancels this listener goroutine when Run returns.
-        watchCtx, watchCanceller := context.WithCancel(ctx)
-        defer watchCanceller()
+	watchCtx, watchCanceller := context.WithCancel(ctx)
+	defer watchCanceller()
 	go c.watchRuntimeComponents(watchCtx)
 
 	for {

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -419,7 +419,6 @@ func (c *Coordinator) watchRuntimeComponents(ctx context.Context) {
 // In the case that either of the above managers fail, they will all be restarted unless the context was explicitly cancelled or timed out.
 func (c *Coordinator) Run(ctx context.Context) error {
 	// log all changes in the state of the runtime and update the coordinator state
-	// TODO: nothing cancels this listener goroutine when Run returns.
 	watchCtx, watchCanceller := context.WithCancel(ctx)
 	defer watchCanceller()
 	go c.watchRuntimeComponents(watchCtx)

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -420,7 +420,9 @@ func (c *Coordinator) watchRuntimeComponents(ctx context.Context) {
 func (c *Coordinator) Run(ctx context.Context) error {
 	// log all changes in the state of the runtime and update the coordinator state
 	// TODO: nothing cancels this listener goroutine when Run returns.
-	go c.watchRuntimeComponents(ctx)
+        watchCtx, watchCanceller := context.WithCancel(ctx)
+        defer watchCanceller()
+	go c.watchRuntimeComponents(watchCtx)
 
 	for {
 		c.state.UpdateState(state.WithState(agentclient.Starting, "Waiting for initial configuration and composable variables"))

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -222,11 +222,13 @@ func New(logger *logger.Logger, cfg *configuration.Configuration, logLevel logp.
 }
 
 // State returns the current state for the coordinator.
+// Called by external goroutines.
 func (c *Coordinator) State() state.State {
 	return c.state.State()
 }
 
 // StateSubscribe subscribes to changes in the coordinator state.
+// Called by external goroutines (currently just from the StateWatch RPC).
 //
 // This provides the current state at the time of first subscription. Cancelling the context
 // results in the subscription being unsubscribed.
@@ -255,6 +257,7 @@ func (c *Coordinator) StateSubscribe(ctx context.Context) *state.StateSubscripti
 // }
 
 // ReExec performs the re-execution.
+// Called from external goroutines.
 func (c *Coordinator) ReExec(callback reexec.ShutdownCallbackFn, argOverrides ...string) {
 	// override the overall state to stopping until the re-execution is complete
 	c.state.SetOverrideState(agentclient.Stopping, "Re-executing")
@@ -262,6 +265,7 @@ func (c *Coordinator) ReExec(callback reexec.ShutdownCallbackFn, argOverrides ..
 }
 
 // Upgrade runs the upgrade process.
+// Called from external goroutines.
 func (c *Coordinator) Upgrade(ctx context.Context, version string, sourceURI string, action *fleetapi.ActionUpgrade, skipVerifyOverride bool, pgpBytes ...string) error {
 	// early check outside of upgrader before overridding the state
 	if !c.upgradeMgr.Upgradeable() {
@@ -308,22 +312,26 @@ func (c *Coordinator) Upgrade(ctx context.Context, version string, sourceURI str
 }
 
 // AckUpgrade is the method used on startup to ack a previously successful upgrade action.
+// Called from external goroutines.
 func (c *Coordinator) AckUpgrade(ctx context.Context, acker acker.Acker) error {
 	return c.upgradeMgr.Ack(ctx, acker)
 }
 
 // PerformAction executes an action on a unit.
+// Called from external goroutines.
 func (c *Coordinator) PerformAction(ctx context.Context, comp component.Component, unit component.Unit, name string, params map[string]interface{}) (map[string]interface{}, error) {
 	return c.runtimeMgr.PerformAction(ctx, comp, unit, name, params)
 }
 
 // PerformDiagnostics executes the diagnostic action for the provided units. If no units are provided then
 // it performs diagnostics for all current units.
+// Called from external goroutines.
 func (c *Coordinator) PerformDiagnostics(ctx context.Context, req ...runtime.ComponentUnitDiagnosticRequest) []runtime.ComponentUnitDiagnostic {
 	return c.runtimeMgr.PerformDiagnostics(ctx, req...)
 }
 
 // SetLogLevel changes the entire log level for the running Elastic Agent.
+// Called from external goroutines.
 func (c *Coordinator) SetLogLevel(ctx context.Context, lvl logp.Level) error {
 	select {
 	case <-ctx.Done():
@@ -335,78 +343,84 @@ func (c *Coordinator) SetLogLevel(ctx context.Context, lvl logp.Level) error {
 	}
 }
 
-// Run runs the coordinator.
-//
-// The RuntimeManager, ConfigManager and VarsManager that is passed into NewCoordinator are also ran and lifecycle controlled by the Run.
-//
-// In the case that either of the above managers fail, they will all be restarted unless the context was explicitly cancelled or timed out.
-func (c *Coordinator) Run(ctx context.Context) error {
-	// log all changes in the state of the runtime and update the coordinator state
-	go func() {
-		state := make(map[string]runtime.ComponentState)
+// watchRuntimeComponents listens for state updates from the runtime
+// manager, logs them, and forwards them to CoordinatorState.
+// Runs in its own goroutine created in Coordinator.Run.
+func (c *Coordinator) watchRuntimeComponents(ctx context.Context) {
+	state := make(map[string]runtime.ComponentState)
 
-		sub := c.runtimeMgr.SubscribeAll(ctx)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case s := <-sub.Ch():
-				oldState, ok := state[s.Component.ID]
-				if !ok {
-					componentLog := coordinatorComponentLog{
-						ID:    s.Component.ID,
-						State: s.State.State.String(),
+	sub := c.runtimeMgr.SubscribeAll(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case s := <-sub.Ch():
+			oldState, ok := state[s.Component.ID]
+			if !ok {
+				componentLog := coordinatorComponentLog{
+					ID:    s.Component.ID,
+					State: s.State.State.String(),
+				}
+				logBasedOnState(c.logger, s.State.State, fmt.Sprintf("Spawned new component %s: %s", s.Component.ID, s.State.Message), "component", componentLog)
+				for ui, us := range s.State.Units {
+					unitLog := coordinatorUnitLog{
+						ID:    ui.UnitID,
+						Type:  ui.UnitType.String(),
+						State: us.State.String(),
 					}
-					logBasedOnState(c.logger, s.State.State, fmt.Sprintf("Spawned new component %s: %s", s.Component.ID, s.State.Message), "component", componentLog)
-					for ui, us := range s.State.Units {
+					logBasedOnState(c.logger, us.State, fmt.Sprintf("Spawned new unit %s: %s", ui.UnitID, us.Message), "component", componentLog, "unit", unitLog)
+				}
+			} else {
+				componentLog := coordinatorComponentLog{
+					ID:    s.Component.ID,
+					State: s.State.State.String(),
+				}
+				if oldState.State != s.State.State {
+					cl := coordinatorComponentLog{
+						ID:       s.Component.ID,
+						State:    s.State.State.String(),
+						OldState: oldState.State.String(),
+					}
+					logBasedOnState(c.logger, s.State.State, fmt.Sprintf("Component state changed %s (%s->%s): %s", s.Component.ID, oldState.State.String(), s.State.State.String(), s.State.Message), "component", cl)
+				}
+				for ui, us := range s.State.Units {
+					oldUS, ok := oldState.Units[ui]
+					if !ok {
 						unitLog := coordinatorUnitLog{
 							ID:    ui.UnitID,
 							Type:  ui.UnitType.String(),
 							State: us.State.String(),
 						}
 						logBasedOnState(c.logger, us.State, fmt.Sprintf("Spawned new unit %s: %s", ui.UnitID, us.Message), "component", componentLog, "unit", unitLog)
-					}
-				} else {
-					componentLog := coordinatorComponentLog{
-						ID:    s.Component.ID,
-						State: s.State.State.String(),
-					}
-					if oldState.State != s.State.State {
-						cl := coordinatorComponentLog{
-							ID:       s.Component.ID,
-							State:    s.State.State.String(),
-							OldState: oldState.State.String(),
+					} else if oldUS.State != us.State {
+						unitLog := coordinatorUnitLog{
+							ID:       ui.UnitID,
+							Type:     ui.UnitType.String(),
+							State:    us.State.String(),
+							OldState: oldUS.State.String(),
 						}
-						logBasedOnState(c.logger, s.State.State, fmt.Sprintf("Component state changed %s (%s->%s): %s", s.Component.ID, oldState.State.String(), s.State.State.String(), s.State.Message), "component", cl)
-					}
-					for ui, us := range s.State.Units {
-						oldUS, ok := oldState.Units[ui]
-						if !ok {
-							unitLog := coordinatorUnitLog{
-								ID:    ui.UnitID,
-								Type:  ui.UnitType.String(),
-								State: us.State.String(),
-							}
-							logBasedOnState(c.logger, us.State, fmt.Sprintf("Spawned new unit %s: %s", ui.UnitID, us.Message), "component", componentLog, "unit", unitLog)
-						} else if oldUS.State != us.State {
-							unitLog := coordinatorUnitLog{
-								ID:       ui.UnitID,
-								Type:     ui.UnitType.String(),
-								State:    us.State.String(),
-								OldState: oldUS.State.String(),
-							}
-							logBasedOnState(c.logger, us.State, fmt.Sprintf("Unit state changed %s (%s->%s): %s", ui.UnitID, oldUS.State.String(), us.State.String(), us.Message), "component", componentLog, "unit", unitLog)
-						}
+						logBasedOnState(c.logger, us.State, fmt.Sprintf("Unit state changed %s (%s->%s): %s", ui.UnitID, oldUS.State.String(), us.State.String(), us.Message), "component", componentLog, "unit", unitLog)
 					}
 				}
-				state[s.Component.ID] = s.State
-				if s.State.State == client.UnitStateStopped {
-					delete(state, s.Component.ID)
-				}
-				c.state.UpdateComponentState(s)
 			}
+			state[s.Component.ID] = s.State
+			if s.State.State == client.UnitStateStopped {
+				delete(state, s.Component.ID)
+			}
+			c.state.UpdateComponentState(s)
 		}
-	}()
+	}
+}
+
+// Run runs the Coordinator. Must be called on the Coordinator's main goroutine.
+//
+// The RuntimeManager, ConfigManager and VarsManager that is passed into NewCoordinator are also ran and lifecycle controlled by the Run.
+//
+// In the case that either of the above managers fail, they will all be restarted unless the context was explicitly cancelled or timed out.
+func (c *Coordinator) Run(ctx context.Context) error {
+	// log all changes in the state of the runtime and update the coordinator state
+	// TODO: nothing cancels this listener goroutine when Run returns.
+	go c.watchRuntimeComponents(ctx)
 
 	for {
 		c.state.UpdateState(state.WithState(agentclient.Starting, "Waiting for initial configuration and composable variables"))
@@ -429,6 +443,7 @@ func (c *Coordinator) Run(ctx context.Context) error {
 
 // DiagnosticHooks returns diagnostic hooks that can be connected to the control server to provide diagnostic
 // information about the state of the Elastic Agent.
+// Called by external goroutines.
 func (c *Coordinator) DiagnosticHooks() diagnostics.Hooks {
 	return diagnostics.Hooks{
 		{
@@ -608,7 +623,8 @@ func (c *Coordinator) DiagnosticHooks() diagnostics.Hooks {
 	}
 }
 
-// runner performs the actual work of running all the managers
+// runner performs the actual work of running all the managers.
+// Called on the main Coordinator goroutine, from Coordinator.Run.
 //
 // if one of the managers fails the others are also stopped and then the whole runner returns
 func (c *Coordinator) runner(ctx context.Context) error {
@@ -707,6 +723,7 @@ func (c *Coordinator) runner(ctx context.Context) error {
 	}
 }
 
+// Always called on the main Coordinator goroutine.
 func (c *Coordinator) processConfig(ctx context.Context, cfg *config.Config) (err error) {
 	span, ctx := apm.StartSpan(ctx, "config", "app.internal")
 	defer func() {
@@ -775,6 +792,8 @@ func (c *Coordinator) processConfig(ctx context.Context, cfg *config.Config) (er
 	return nil
 }
 
+// processVars updates the transpiler vars in the Coordinator.
+// Called on the main Coordinator goroutine.
 func (c *Coordinator) processVars(ctx context.Context, vars []*transpiler.Vars) (err error) {
 	span, ctx := apm.StartSpan(ctx, "vars", "app.internal")
 	defer func() {
@@ -790,6 +809,7 @@ func (c *Coordinator) processVars(ctx context.Context, vars []*transpiler.Vars) 
 	return nil
 }
 
+// Called on the main Coordinator goroutine.
 func (c *Coordinator) processLogLevel(ctx context.Context, ll logp.Level) (err error) {
 	span, ctx := apm.StartSpan(ctx, "log_level", "app.internal")
 	defer func() {
@@ -806,6 +826,7 @@ func (c *Coordinator) processLogLevel(ctx context.Context, ll logp.Level) (err e
 	return nil
 }
 
+// Always called on the main Coordinator goroutine.
 func (c *Coordinator) process(ctx context.Context) (err error) {
 	span, ctx := apm.StartSpan(ctx, "process", "app.internal")
 	defer func() {
@@ -828,6 +849,8 @@ func (c *Coordinator) process(ctx context.Context) (err error) {
 	return nil
 }
 
+// Called from both the main Coordinator goroutine and from external
+// goroutines via diagnostics hooks.
 func (c *Coordinator) compute() (map[string]interface{}, []component.Component, error) {
 	ast := c.ast.Clone()
 	inputs, ok := transpiler.Lookup(ast, "inputs")
@@ -872,6 +895,11 @@ func (c *Coordinator) compute() (map[string]interface{}, []component.Component, 
 	return cfg, comps, nil
 }
 
+// handleCoordinatorDone is called when the Coordinator's context is
+// finished. It waits for the runtime, config, and vars managers to finish,
+// and collects their return values into an error if any of them returned
+// for a reason other than context.Canceled.
+// Called on the main Coordinator goroutine.
 func (c *Coordinator) handleCoordinatorDone(ctx context.Context, varsErrCh, runtimeErrCh, configErrCh chan error) error {
 	var runtimeErr error
 	var configErr error
@@ -879,7 +907,6 @@ func (c *Coordinator) handleCoordinatorDone(ctx context.Context, varsErrCh, runt
 	// in case other components are locked up, let us time out
 	timeoutWait := time.NewTimer(CoordinatorShutdownTimeout)
 	defer timeoutWait.Stop()
-	doneWait := false
 	var returnedRuntime, returnedConfig, returnedVars bool
 	/*
 		Wait for all subcomponents to gently shut down.
@@ -890,45 +917,29 @@ func (c *Coordinator) handleCoordinatorDone(ctx context.Context, varsErrCh, runt
 		If there's no errors from the channels, pass on the underlying context error
 	*/
 
-	for {
-		if doneWait { // we have a timeout, or all channels have returned
-			break
-		}
+waitLoop:
+	for !returnedRuntime || !returnedConfig || !returnedVars {
 		select {
+		case runtimeErr = <-runtimeErrCh:
+			returnedRuntime = true
+		case configErr = <-configErrCh:
+			returnedConfig = true
+		case varsErr = <-varsErrCh:
+			returnedVars = true
 		case <-timeoutWait.C:
 			var timeouts []string
-			if runtimeErr == nil {
+			if !returnedRuntime {
 				timeouts = []string{"no response from runtime component"}
 			}
-			if configErr == nil {
+			if !returnedConfig {
 				timeouts = append(timeouts, "no response from configWatcher component")
 			}
-			if varsErr == nil {
+			if !returnedVars {
 				timeouts = append(timeouts, "no response from varsWatcher component")
 			}
 			c.logger.Debugf("timeout while waiting for other components to shut down: %v", timeouts)
-			doneWait = true
-		case err, ok := <-runtimeErrCh:
-			if ok {
-				runtimeErr = err
-			}
-			returnedRuntime = true
-		case err, ok := <-configErrCh:
-			if ok {
-				configErr = err
-			}
-			returnedConfig = true
-		case err, ok := <-varsErrCh:
-			if ok {
-				varsErr = err
-			}
-			returnedVars = true
+			break waitLoop
 		}
-		if returnedRuntime && returnedConfig && returnedVars {
-			c.logger.Debugf("all error channels have returned in handleCoordinatorDone")
-			doneWait = true
-		}
-
 	}
 	// try not to lose any errors
 	var combinedErr error

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -270,6 +270,7 @@ func run(override cfgOverrider, testingMode bool, fleetInitTimeout time.Duration
 
 	appDone := make(chan bool)
 	appErr := make(chan error)
+	// Spawn the main Coordinator goroutine
 	go func() {
 		err := coord.Run(ctx)
 		close(appDone)

--- a/pkg/component/runtime/manager.go
+++ b/pkg/component/runtime/manager.go
@@ -615,7 +615,7 @@ func (m *Manager) CheckinV2(server proto.ElasticAgent_CheckinV2Server) error {
 }
 
 // Actions is the actions stream used to broker actions between Elastic Agent and components.
-func (m *Manager) Actdsfions(server proto.ElasticAgent_ActionsServer) error {
+func (m *Manager) Actions(server proto.ElasticAgent_ActionsServer) error {
 	initRespChan := make(chan *proto.ActionResponse)
 	go func() {
 		// go func will not be leaked, because when the main function
@@ -864,6 +864,7 @@ func (m *Manager) getCertificate(chi *tls.ClientHelloInfo) (*tls.Certificate, er
 	return nil, errors.New("no supported TLS certificate")
 }
 
+// Called from GRPC listeners
 func (m *Manager) getRuntimeFromToken(token string) *componentRuntimeState {
 	m.currentMx.RLock()
 	defer m.currentMx.RUnlock()

--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -91,7 +91,7 @@ func TestManager_SimpleComponentErr(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -186,7 +186,7 @@ func TestManager_FakeInput_StartStop(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -313,7 +313,7 @@ func TestManager_FakeInput_Features(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -502,7 +502,7 @@ func TestManager_FakeInput_BadUnitToGood(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -668,7 +668,7 @@ func TestManager_FakeInput_GoodUnitToBad(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -824,7 +824,7 @@ func TestManager_FakeInput_NoDeadlock(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -958,7 +958,7 @@ func TestManager_FakeInput_Configure(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -1078,7 +1078,7 @@ func TestManager_FakeInput_RemoveUnit(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -1231,7 +1231,7 @@ func TestManager_FakeInput_ActionState(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -1355,7 +1355,7 @@ func TestManager_FakeInput_Restarts(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -1490,7 +1490,7 @@ func TestManager_FakeInput_Restarts_ConfigKill(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -1632,7 +1632,7 @@ func TestManager_FakeInput_KeepsRestarting(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -1774,7 +1774,7 @@ func TestManager_FakeInput_RestartsOnMissedCheckins(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -1889,7 +1889,7 @@ func TestManager_FakeInput_InvalidAction(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -2014,7 +2014,7 @@ func TestManager_FakeInput_MultiComponent(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -2227,7 +2227,7 @@ func TestManager_FakeInput_LogLevel(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -2371,7 +2371,7 @@ func TestManager_FakeShipper(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -2672,7 +2672,7 @@ func TestManager_FakeInput_OutputChange(t *testing.T) {
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer waitCancel()
-	if err := m.WaitForReady(waitCtx); err != nil {
+	if err := m.waitForReady(waitCtx); err != nil {
 		require.NoError(t, err)
 	}
 

--- a/pkg/component/runtime/runtime.go
+++ b/pkg/component/runtime/runtime.go
@@ -132,15 +132,13 @@ func newComponentRuntimeState(m *Manager, logger *logger.Logger, monitor Monitor
 	})
 
 	// start the go-routine that watches for updates from the component
-	runner.Start(context.Background(), func(ctx context.Context) error {
+	go func() {
 		for {
 			select {
-			case <-ctx.Done():
-				runtimeRunner.Stop()
 			case <-runtimeRunner.Done():
 				// Exit from the watcher loop only when the runner is done
 				// This is the same behaviour as before this change, just refactored and cleaned up
-				return nil
+				return
 			case s := <-runtime.Watch():
 				state.latestMx.Lock()
 				state.latestState = s
@@ -160,7 +158,7 @@ func newComponentRuntimeState(m *Manager, logger *logger.Logger, monitor Monitor
 				}
 			}
 		}
-	})
+	}()
 
 	return state, nil
 }


### PR DESCRIPTION
This is just a cleanup and makes no behavior changes.

- Comment functions related to `Coordinator` and `CoordinatorState` to note what goroutine(s) they're called from
- Break a large anonymous goroutine in the Coordinator out into its own helper function, `watchRuntimeComponents`
- Make the test helper `runtime.(*Manager).WaitForReady` private
- Tidy up `Coordinator.handleCoordinatorDone`, fix an if statement that previously worked by accident so it's more clear that it does the right thing
- Fix some tests that were exercising behavior that was only used by the tests.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~
