### PR TITLE
Add filestream stream IDs to k8s manifests.

### DIFF
--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -340,7 +340,8 @@ data:
         data_stream:
           namespace: default
         streams:
-          - data_stream:
+          - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
+            data_stream:
               dataset: kubernetes.container_logs
               type: logs
             prospector.scanner.symlinks: true
@@ -360,7 +361,8 @@ data:
         type: filestream
         use_output: default
         streams:
-          - condition: ${kubernetes.hints.generic_logs.container_logs.enabled} == true
+          - id: hints-container-logs-${kubernetes.hints.container_id}
+            condition: ${kubernetes.hints.generic_logs.container_logs.enabled} == true
             data_stream:
               dataset: kubernetes.hints.container_logs
               type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
@@ -340,7 +340,8 @@ data:
         data_stream:
           namespace: default
         streams:
-          - data_stream:
+          - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
+            data_stream:
               dataset: kubernetes.container_logs
               type: logs
             prospector.scanner.symlinks: true
@@ -360,7 +361,8 @@ data:
         type: filestream
         use_output: default
         streams:
-          - condition: ${kubernetes.hints.generic_logs.container_logs.enabled} == true
+          - id: hints-container-logs-${kubernetes.hints.container_id}
+            condition: ${kubernetes.hints.generic_logs.container_logs.enabled} == true
             data_stream:
               dataset: kubernetes.hints.container_logs
               type: logs


### PR DESCRIPTION
Each filestream data stream also needs a unique ID, in addition to the input ID. The input ID is used by the agent itself, the stream level ID is what is used in the Filebeat registry.

- Closes https://github.com/elastic/elastic-agent/issues/2701