### PR TITLE
Fix race detector errors in TestPrintLogs

### DIFF
--- a/internal/pkg/agent/cmd/logs_test.go
+++ b/internal/pkg/agent/cmd/logs_test.go
@@ -303,13 +303,12 @@ func TestPrintLogs(t *testing.T) {
 	t.Run("returns tail and then follows the logs with filter", func(t *testing.T) {
 		dir := t.TempDir()
 		content := []byte(`{"component":{"id":"match"}, "message":"test1"}
-
-	   {"component":{"id":"non-match"}, "message":"test2"}
-	   {"component":{"id":"match"}, "message":"test3"}
-	   {"component":{"id":"match"}, "message":"test4"}
-	   {"component":{"id":"non-match"}, "message":"test5"}
-	   {"component":{"id":"match"}, "message":"test6"}
-	   `)
+{"component":{"id":"non-match"}, "message":"test2"}
+{"component":{"id":"match"}, "message":"test3"}
+{"component":{"id":"match"}, "message":"test4"}
+{"component":{"id":"non-match"}, "message":"test5"}
+{"component":{"id":"match"}, "message":"test6"}
+`)
 
 		createFileContent(t, dir, file1, bytes.NewBuffer(content))
 		ctx, cancel := context.WithCancel(context.Background())
@@ -324,10 +323,9 @@ func TestPrintLogs(t *testing.T) {
 
 		t.Run("tails filtering the file", func(t *testing.T) {
 			expected = `{"component":{"id":"match"}, "message":"test3"}
-
-	   {"component":{"id":"match"}, "message":"test4"}
-	   {"component":{"id":"match"}, "message":"test6"}
-	   `
+{"component":{"id":"match"}, "message":"test4"}
+{"component":{"id":"match"}, "message":"test6"}
+`
 			logResult.waitUntilMatch(t, expected, time.Second)
 		})
 
@@ -336,13 +334,12 @@ func TestPrintLogs(t *testing.T) {
 			require.NoError(t, err)
 
 			content := `{"component":{"id":"match"}, "message":"test7"}
-
-	   {"component":{"id":"non-match"}, "message":"test8"}
-	   {"component":{"id":"match"}, "message":"test9"}
-	   {"component":{"id":"match"}, "message":"test10"}
-	   {"component":{"id":"non-match"}, "message":"test11"}
-	   {"component":{"id":"match"}, "message":"test12"}
-	   `
+{"component":{"id":"non-match"}, "message":"test8"}
+{"component":{"id":"match"}, "message":"test9"}
+{"component":{"id":"match"}, "message":"test10"}
+{"component":{"id":"non-match"}, "message":"test11"}
+{"component":{"id":"match"}, "message":"test12"}
+`
 
 			_, err = f.WriteString(content)
 			require.NoError(t, err)
@@ -351,30 +348,27 @@ func TestPrintLogs(t *testing.T) {
 			time.Sleep(watchInterval)
 
 			expected += `{"component":{"id":"match"}, "message":"test7"}
-
-	   {"component":{"id":"match"}, "message":"test9"}
-	   {"component":{"id":"match"}, "message":"test10"}
-	   {"component":{"id":"match"}, "message":"test12"}
-	   `
+{"component":{"id":"match"}, "message":"test9"}
+{"component":{"id":"match"}, "message":"test10"}
+{"component":{"id":"match"}, "message":"test12"}
+`
 
 			logResult.waitUntilMatch(t, expected, 2*watchInterval)
 		})
 
 		t.Run("detects a new file and switches to it with filter", func(t *testing.T) {
 			content := `{"component":{"id":"match"}, "message":"test13"}
-
-	   {"component":{"id":"non-match"}, "message":"test14"}
-	   {"component":{"id":"match"}, "message":"test15"}
-	   `
+{"component":{"id":"non-match"}, "message":"test14"}
+{"component":{"id":"match"}, "message":"test15"}
+`
 
 			createFileContent(t, dir, file2, bytes.NewBuffer([]byte(content)))
 
 			time.Sleep(watchInterval)
 
 			expected += `{"component":{"id":"match"}, "message":"test13"}
-
-	   {"component":{"id":"match"}, "message":"test15"}
-	   `
+{"component":{"id":"match"}, "message":"test15"}
+`
 
 			logResult.waitUntilMatch(t, expected, 2*watchInterval)
 		})

--- a/internal/pkg/agent/cmd/logs_test.go
+++ b/internal/pkg/agent/cmd/logs_test.go
@@ -585,6 +585,7 @@ func (cw *chanWriter) waitUntilMatch(
 	expected string,
 	timeout time.Duration,
 ) {
+	t.Helper()
 	timeoutChan := time.After(timeout)
 	for string(cw.result) != expected {
 		select {


### PR DESCRIPTION
Fix race detector errors in `TestPrintLogs` by adding a helper implementation of `io.Writer` that synchronizes writes through a channel instead of sharing a writable buffer between goroutines.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~

## How to test this PR locally

Running `go test -race` on this test previously produced several race detector errors. With this PR there are none. The other logic of the test is unchanged.

## Related issues

- Followup from https://github.com/elastic/elastic-agent/pull/2790