### PR TITLE
Runtime + Coordinator cleanups

### DIFF
--- a/pkg/component/runtime/command.go
+++ b/pkg/component/runtime/command.go
@@ -53,8 +53,8 @@ type procState struct {
 	state *os.ProcessState
 }
 
-// CommandRuntime provides the command runtime for running a component as a subprocess.
-type CommandRuntime struct {
+// commandRuntime provides the command runtime for running a component as a subprocess.
+type commandRuntime struct {
 	logStd *logWriter
 	logErr *logWriter
 
@@ -75,9 +75,9 @@ type CommandRuntime struct {
 	restartBucket  *rate.Limiter
 }
 
-// NewCommandRuntime creates a new command runtime for the provided component.
-func NewCommandRuntime(comp component.Component, log *logger.Logger, monitor MonitoringManager) (ComponentRuntime, error) {
-	c := &CommandRuntime{
+// newCommandRuntime creates a new command runtime for the provided component.
+func newCommandRuntime(comp component.Component, log *logger.Logger, monitor MonitoringManager) (*commandRuntime, error) {
+	c := &commandRuntime{
 		current:     comp,
 		monitor:     monitor,
 		ch:          make(chan ComponentState),
@@ -106,7 +106,7 @@ func NewCommandRuntime(comp component.Component, log *logger.Logger, monitor Mon
 // Called by Manager inside a goroutine. Run does not return until the passed in context is done. Run is always
 // called before any of the other methods in the interface and once the context is done none of those methods should
 // ever be called again.
-func (c *CommandRuntime) Run(ctx context.Context, comm Communicator) error {
+func (c *commandRuntime) Run(ctx context.Context, comm Communicator) error {
 	cmdSpec := c.getCommandSpec()
 	checkinPeriod := cmdSpec.Timeouts.Checkin
 	restartPeriod := cmdSpec.Timeouts.Restart
@@ -223,14 +223,14 @@ func (c *CommandRuntime) Run(ctx context.Context, comm Communicator) error {
 // Watch returns the channel that sends component state.
 //
 // Channel should send a new state anytime a state for a unit or the whole component changes.
-func (c *CommandRuntime) Watch() <-chan ComponentState {
+func (c *commandRuntime) Watch() <-chan ComponentState {
 	return c.ch
 }
 
 // Start starts the component.
 //
 // Non-blocking and never returns an error.
-func (c *CommandRuntime) Start() error {
+func (c *commandRuntime) Start() error {
 	// clear channel so it's the latest action
 	select {
 	case <-c.actionCh:
@@ -243,7 +243,7 @@ func (c *CommandRuntime) Start() error {
 // Update updates the currComp runtime with a new-revision for the component definition.
 //
 // Non-blocking and never returns an error.
-func (c *CommandRuntime) Update(comp component.Component) error {
+func (c *commandRuntime) Update(comp component.Component) error {
 	// clear channel so it's the latest component
 	select {
 	case <-c.compCh:
@@ -256,7 +256,7 @@ func (c *CommandRuntime) Update(comp component.Component) error {
 // Stop stops the component.
 //
 // Non-blocking and never returns an error.
-func (c *CommandRuntime) Stop() error {
+func (c *commandRuntime) Stop() error {
 	// clear channel so it's the latest action
 	select {
 	case <-c.actionCh:
@@ -269,7 +269,7 @@ func (c *CommandRuntime) Stop() error {
 // Teardown tears down the component.
 //
 // Non-blocking and never returns an error.
-func (c *CommandRuntime) Teardown() error {
+func (c *commandRuntime) Teardown() error {
 	// clear channel so it's the latest action
 	select {
 	case <-c.actionCh:
@@ -280,14 +280,14 @@ func (c *CommandRuntime) Teardown() error {
 }
 
 // forceCompState force updates the state for the entire component, forcing that state on all units.
-func (c *CommandRuntime) forceCompState(state client.UnitState, msg string) {
+func (c *commandRuntime) forceCompState(state client.UnitState, msg string) {
 	if c.state.forceState(state, msg) {
 		c.sendObserved()
 	}
 }
 
 // compState updates just the component state not all the units.
-func (c *CommandRuntime) compState(state client.UnitState) {
+func (c *commandRuntime) compState(state client.UnitState) {
 	msg := stateUnknownMessage
 	if state == client.UnitStateHealthy {
 		msg = fmt.Sprintf("Healthy: communicating with pid '%d'", c.proc.PID)
@@ -303,11 +303,11 @@ func (c *CommandRuntime) compState(state client.UnitState) {
 	}
 }
 
-func (c *CommandRuntime) sendObserved() {
+func (c *commandRuntime) sendObserved() {
 	c.ch <- c.state.Copy()
 }
 
-func (c *CommandRuntime) start(comm Communicator) error {
+func (c *commandRuntime) start(comm Communicator) error {
 	if c.proc != nil {
 		// already running
 		return nil
@@ -361,7 +361,7 @@ func (c *CommandRuntime) start(comm Communicator) error {
 	return nil
 }
 
-func (c *CommandRuntime) stop(ctx context.Context) error {
+func (c *commandRuntime) stop(ctx context.Context) error {
 	if c.proc == nil {
 		// already stopped, ensure that state of the component is also stopped
 		if c.state.State != client.UnitStateStopped {
@@ -391,7 +391,7 @@ func (c *CommandRuntime) stop(ctx context.Context) error {
 	return c.proc.Stop()
 }
 
-func (c *CommandRuntime) startWatcher(info *process.Info, comm Communicator) {
+func (c *commandRuntime) startWatcher(info *process.Info, comm Communicator) {
 	go func() {
 		err := comm.WriteConnInfo(info.Stdin)
 		if err != nil {
@@ -411,7 +411,7 @@ func (c *CommandRuntime) startWatcher(info *process.Info, comm Communicator) {
 	}()
 }
 
-func (c *CommandRuntime) handleProc(state *os.ProcessState) bool {
+func (c *commandRuntime) handleProc(state *os.ProcessState) bool {
 	switch c.actionState {
 	case actionStart:
 		if c.restartBucket != nil && c.restartBucket.Allow() {
@@ -435,11 +435,11 @@ func (c *CommandRuntime) handleProc(state *os.ProcessState) bool {
 	return false
 }
 
-func (c *CommandRuntime) workDirPath() string {
+func (c *commandRuntime) workDirPath() string {
 	return filepath.Join(paths.Run(), c.current.ID)
 }
 
-func (c *CommandRuntime) workDir(uid int, gid int) (string, error) {
+func (c *commandRuntime) workDir(uid int, gid int) (string, error) {
 	path := c.workDirPath()
 	err := os.MkdirAll(path, runDirMod)
 	if err != nil {
@@ -459,7 +459,7 @@ func (c *CommandRuntime) workDir(uid int, gid int) (string, error) {
 	return path, nil
 }
 
-func (c *CommandRuntime) getSpecType() string {
+func (c *commandRuntime) getSpecType() string {
 	if c.current.InputSpec != nil {
 		return c.current.InputSpec.InputType
 	}
@@ -469,7 +469,7 @@ func (c *CommandRuntime) getSpecType() string {
 	return ""
 }
 
-func (c *CommandRuntime) getSpecBinaryName() string {
+func (c *commandRuntime) getSpecBinaryName() string {
 	if c.current.InputSpec != nil {
 		return c.current.InputSpec.BinaryName
 	}
@@ -479,7 +479,7 @@ func (c *CommandRuntime) getSpecBinaryName() string {
 	return ""
 }
 
-func (c *CommandRuntime) getSpecBinaryPath() string {
+func (c *commandRuntime) getSpecBinaryPath() string {
 	if c.current.InputSpec != nil {
 		return c.current.InputSpec.BinaryPath
 	}
@@ -489,7 +489,7 @@ func (c *CommandRuntime) getSpecBinaryPath() string {
 	return ""
 }
 
-func (c *CommandRuntime) getCommandSpec() *component.CommandSpec {
+func (c *commandRuntime) getCommandSpec() *component.CommandSpec {
 	if c.current.InputSpec != nil {
 		return c.current.InputSpec.Spec.Command
 	}
@@ -499,7 +499,7 @@ func (c *CommandRuntime) getCommandSpec() *component.CommandSpec {
 	return nil
 }
 
-func (c *CommandRuntime) syncLogLevels() {
+func (c *commandRuntime) syncLogLevels() {
 	ll, unitLevels := getLogLevels(c.current)
 	c.logStd.SetLevels(ll, unitLevels)
 	ll, unitLevels = getLogLevels(c.current) // don't want to share mapping of units (so new map is generated)

--- a/pkg/component/runtime/failed.go
+++ b/pkg/component/runtime/failed.go
@@ -13,19 +13,19 @@ import (
 	"github.com/elastic/elastic-agent/pkg/component"
 )
 
-// FailedRuntime is used for a component that has an error from the component loader.
-type FailedRuntime struct {
+// failedRuntime is used for a component that has an error from the component loader.
+type failedRuntime struct {
 	ch      chan ComponentState
 	current component.Component
 	done    chan bool
 }
 
-// NewFailedRuntime creates a runtime for a component that has an error from the component loader.
-func NewFailedRuntime(comp component.Component) (ComponentRuntime, error) {
+// newFailedRuntime creates a runtime for a component that has an error from the component loader.
+func newFailedRuntime(comp component.Component) (*failedRuntime, error) {
 	if comp.Err == nil {
 		return nil, errors.New("must be a component that has a defined error")
 	}
-	return &FailedRuntime{
+	return &failedRuntime{
 		ch:      make(chan ComponentState),
 		current: comp,
 		done:    make(chan bool),
@@ -33,7 +33,7 @@ func NewFailedRuntime(comp component.Component) (ComponentRuntime, error) {
 }
 
 // Run runs the runtime for a component that got an error from the component loader.
-func (c *FailedRuntime) Run(ctx context.Context, _ Communicator) error {
+func (c *failedRuntime) Run(ctx context.Context, _ Communicator) error {
 	// state is hard coded to failed
 	c.ch <- createState(c.current, false)
 	select {
@@ -48,17 +48,17 @@ func (c *FailedRuntime) Run(ctx context.Context, _ Communicator) error {
 }
 
 // Watch returns the watch channel.
-func (c *FailedRuntime) Watch() <-chan ComponentState {
+func (c *failedRuntime) Watch() <-chan ComponentState {
 	return c.ch
 }
 
 // Start does nothing.
-func (c *FailedRuntime) Start() error {
+func (c *failedRuntime) Start() error {
 	return nil
 }
 
 // Update updates the component state.
-func (c *FailedRuntime) Update(comp component.Component) error {
+func (c *failedRuntime) Update(comp component.Component) error {
 	if comp.Err == nil {
 		return errors.New("cannot update to a component without a defined error")
 	}
@@ -67,7 +67,7 @@ func (c *FailedRuntime) Update(comp component.Component) error {
 }
 
 // Stop marks it stopped.
-func (c *FailedRuntime) Stop() error {
+func (c *failedRuntime) Stop() error {
 	go func() {
 		close(c.done)
 	}()
@@ -75,7 +75,7 @@ func (c *FailedRuntime) Stop() error {
 }
 
 // Teardown marks it stopped.
-func (c *FailedRuntime) Teardown() error {
+func (c *failedRuntime) Teardown() error {
 	return c.Stop()
 }
 

--- a/pkg/component/runtime/manager.go
+++ b/pkg/component/runtime/manager.go
@@ -322,7 +322,7 @@ func (m *Manager) State() []ComponentComponentState {
 		crs.latestMx.RLock()
 		var legacyPID string
 		if crs.runtime != nil {
-			if commandRuntime, ok := crs.runtime.(*CommandRuntime); ok {
+			if commandRuntime, ok := crs.runtime.(*commandRuntime); ok {
 				if commandRuntime != nil {
 					procInfo := commandRuntime.proc
 					if procInfo != nil {

--- a/pkg/component/runtime/runtime.go
+++ b/pkg/component/runtime/runtime.go
@@ -17,8 +17,8 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
-// ComponentRuntime manages runtime lifecycle operations for a component and stores its state.
-type ComponentRuntime interface {
+// componentRuntime manages runtime lifecycle operations for a component and stores its state.
+type componentRuntime interface {
 	// Run starts the runtime for the component.
 	//
 	// Called by Manager inside a goroutine. Run does not return until the passed in context is done. Run is always
@@ -53,27 +53,27 @@ type ComponentRuntime interface {
 	Teardown() error
 }
 
-// NewComponentRuntime creates the proper runtime based on the input specification for the component.
-func NewComponentRuntime(
+// newComponentRuntime creates the proper runtime based on the input specification for the component.
+func newComponentRuntime(
 	comp component.Component,
 	logger *logger.Logger,
 	monitor MonitoringManager,
-) (ComponentRuntime, error) {
+) (componentRuntime, error) {
 	if comp.Err != nil {
-		return NewFailedRuntime(comp)
+		return newFailedRuntime(comp)
 	}
 	if comp.InputSpec != nil {
 		if comp.InputSpec.Spec.Command != nil {
-			return NewCommandRuntime(comp, logger, monitor)
+			return newCommandRuntime(comp, logger, monitor)
 		}
 		if comp.InputSpec.Spec.Service != nil {
-			return NewServiceRuntime(comp, logger)
+			return newServiceRuntime(comp, logger)
 		}
 		return nil, errors.New("unknown component runtime")
 	}
 	if comp.ShipperSpec != nil {
 		if comp.ShipperSpec.Spec.Command != nil {
-			return NewCommandRuntime(comp, logger, monitor)
+			return newCommandRuntime(comp, logger, monitor)
 		}
 		return nil, errors.New("components for shippers can only support command runtime")
 	}
@@ -88,7 +88,7 @@ type componentRuntimeState struct {
 	id         string
 	currCompMx sync.RWMutex
 	currComp   component.Component
-	runtime    ComponentRuntime
+	runtime    componentRuntime
 
 	shuttingDown atomic.Bool
 
@@ -104,7 +104,7 @@ func newComponentRuntimeState(m *Manager, logger *logger.Logger, monitor Monitor
 	if err != nil {
 		return nil, err
 	}
-	runtime, err := NewComponentRuntime(comp, logger, monitor)
+	runtime, err := newComponentRuntime(comp, logger, monitor)
 	if err != nil {
 		return nil, err
 	}
@@ -124,45 +124,44 @@ func newComponentRuntimeState(m *Manager, logger *logger.Logger, monitor Monitor
 		actions: make(map[string]func(response *proto.ActionResponse)),
 	}
 
+	// Start the goroutine that spawns and monitors the component runtime.
+	go state.runLoop()
+
+	return state, nil
+}
+
+func (s *componentRuntimeState) runLoop() {
 	// start the go-routine that operates the runtime for the component
 	runtimeRunner := runner.Start(context.Background(), func(ctx context.Context) error {
-		defer comm.destroy()
-		_ = runtime.Run(ctx, comm)
+		defer s.comm.destroy()
+		_ = s.runtime.Run(ctx, s.comm)
 		return nil
 	})
 
-	// start the go-routine that watches for updates from the component
-	runner.Start(context.Background(), func(ctx context.Context) error {
-		for {
-			select {
-			case <-ctx.Done():
+	for {
+		select {
+		case <-runtimeRunner.Done():
+			// Exit from the watcher loop only when the runner is done
+			return
+		case componentState := <-s.runtime.Watch():
+			s.latestMx.Lock()
+			s.latestState = componentState
+			s.latestMx.Unlock()
+			if s.manager.stateChanged(s, componentState) {
 				runtimeRunner.Stop()
-			case <-runtimeRunner.Done():
-				// Exit from the watcher loop only when the runner is done
-				// This is the same behaviour as before this change, just refactored and cleaned up
-				return nil
-			case s := <-runtime.Watch():
-				state.latestMx.Lock()
-				state.latestState = s
-				state.latestMx.Unlock()
-				if state.manager.stateChanged(state, s) {
-					runtimeRunner.Stop()
-				}
-			case ar := <-comm.actionsResponse:
-				state.actionsMx.Lock()
-				callback, ok := state.actions[ar.Id]
-				if ok {
-					delete(state.actions, ar.Id)
-				}
-				state.actionsMx.Unlock()
-				if ok {
-					callback(ar)
-				}
+			}
+		case ar := <-s.comm.actionsResponse:
+			s.actionsMx.Lock()
+			callback, ok := s.actions[ar.Id]
+			if ok {
+				delete(s.actions, ar.Id)
+			}
+			s.actionsMx.Unlock()
+			if ok {
+				callback(ar)
 			}
 		}
-	})
-
-	return state, nil
+	}
 }
 
 func (s *componentRuntimeState) getCurrent() component.Component {

--- a/pkg/component/runtime/service.go
+++ b/pkg/component/runtime/service.go
@@ -31,8 +31,8 @@ var (
 
 type executeServiceCommandFunc func(ctx context.Context, log *logger.Logger, binaryPath string, spec *component.ServiceOperationsCommandSpec) error
 
-// ServiceRuntime provides the command runtime for running a component as a service.
-type ServiceRuntime struct {
+// serviceRuntime provides the command runtime for running a component as a service.
+type serviceRuntime struct {
 	comp component.Component
 	log  *logger.Logger
 
@@ -46,8 +46,8 @@ type ServiceRuntime struct {
 	executeServiceCommandImpl executeServiceCommandFunc
 }
 
-// NewServiceRuntime creates a new command runtime for the provided component.
-func NewServiceRuntime(comp component.Component, logger *logger.Logger) (ComponentRuntime, error) {
+// newServiceRuntime creates a new command runtime for the provided component.
+func newServiceRuntime(comp component.Component, logger *logger.Logger) (*serviceRuntime, error) {
 	if comp.ShipperSpec != nil {
 		return nil, errors.New("service runtime not supported for a shipper specification")
 	}
@@ -60,7 +60,7 @@ func NewServiceRuntime(comp component.Component, logger *logger.Logger) (Compone
 
 	state := newComponentState(&comp)
 
-	s := &ServiceRuntime{
+	s := &serviceRuntime{
 		comp:                      comp,
 		log:                       logger.Named("service_runtime"),
 		ch:                        make(chan ComponentState),
@@ -81,7 +81,7 @@ func NewServiceRuntime(comp component.Component, logger *logger.Logger) (Compone
 // Called by Manager inside a goroutine. Run does not return until the passed in context is done. Run is always
 // called before any of the other methods in the interface and once the context is done none of those methods should
 // ever be called again.
-func (s *ServiceRuntime) Run(ctx context.Context, comm Communicator) (err error) {
+func (s *serviceRuntime) Run(ctx context.Context, comm Communicator) (err error) {
 	checkinTimer := time.NewTimer(s.checkinPeriod())
 	defer checkinTimer.Stop()
 
@@ -161,7 +161,7 @@ func (s *ServiceRuntime) Run(ctx context.Context, comm Communicator) (err error)
 	}
 }
 
-func (s *ServiceRuntime) start(ctx context.Context) (err error) {
+func (s *serviceRuntime) start(ctx context.Context) (err error) {
 	name := s.name()
 
 	// Set state to starting
@@ -184,7 +184,7 @@ func (s *ServiceRuntime) start(ctx context.Context) (err error) {
 	return nil
 }
 
-func (s *ServiceRuntime) stop(ctx context.Context, comm Communicator, lastCheckin time.Time, teardown bool) {
+func (s *serviceRuntime) stop(ctx context.Context, comm Communicator, lastCheckin time.Time, teardown bool) {
 	name := s.name()
 
 	s.log.Debugf("stopping %s service runtime", name)
@@ -224,7 +224,7 @@ func (s *ServiceRuntime) stop(ctx context.Context, comm Communicator, lastChecki
 }
 
 // awaitCheckin awaits checkin with timeout.
-func (s *ServiceRuntime) awaitCheckin(ctx context.Context, comm Communicator, timeout time.Duration) bool {
+func (s *serviceRuntime) awaitCheckin(ctx context.Context, comm Communicator, timeout time.Duration) bool {
 	name := s.name()
 	t := time.NewTimer(timeout)
 	defer t.Stop()
@@ -245,7 +245,7 @@ func (s *ServiceRuntime) awaitCheckin(ctx context.Context, comm Communicator, ti
 	}
 }
 
-func (s *ServiceRuntime) processNewComp(newComp component.Component, comm Communicator) {
+func (s *serviceRuntime) processNewComp(newComp component.Component, comm Communicator) {
 	s.log.Debugf("observed component update for %s service", s.name())
 	sendExpected := s.state.syncExpected(&newComp)
 	changed := s.state.syncUnits(&newComp)
@@ -257,7 +257,7 @@ func (s *ServiceRuntime) processNewComp(newComp component.Component, comm Commun
 	}
 }
 
-func (s *ServiceRuntime) processCheckin(checkin *proto.CheckinObserved, comm Communicator, lastCheckin *time.Time) {
+func (s *serviceRuntime) processCheckin(checkin *proto.CheckinObserved, comm Communicator, lastCheckin *time.Time) {
 	name := s.name()
 
 	s.log.Debugf("observed check-in for %s service: %v", name, checkin)
@@ -298,13 +298,13 @@ func (s *ServiceRuntime) processCheckin(checkin *proto.CheckinObserved, comm Com
 }
 
 // isRunning returns true is the service is running
-func (s *ServiceRuntime) isRunning() bool {
+func (s *serviceRuntime) isRunning() bool {
 	return s.state.State != client.UnitStateStopping &&
 		s.state.State != client.UnitStateStopped
 }
 
 // checkStatus checks check-ins state, called on timer
-func (s *ServiceRuntime) checkStatus(checkinPeriod time.Duration, lastCheckin *time.Time, missedCheckins *int) {
+func (s *serviceRuntime) checkStatus(checkinPeriod time.Duration, lastCheckin *time.Time, missedCheckins *int) {
 	if s.isRunning() {
 		now := time.Now().UTC()
 		if lastCheckin.IsZero() {
@@ -328,7 +328,7 @@ func (s *ServiceRuntime) checkStatus(checkinPeriod time.Duration, lastCheckin *t
 	}
 }
 
-func (s *ServiceRuntime) checkinPeriod() time.Duration {
+func (s *serviceRuntime) checkinPeriod() time.Duration {
 	checkinPeriod := s.comp.InputSpec.Spec.Service.Timeouts.Checkin
 	if checkinPeriod == 0 {
 		checkinPeriod = defaultCheckServiceStatusInterval
@@ -339,14 +339,14 @@ func (s *ServiceRuntime) checkinPeriod() time.Duration {
 // Watch returns a channel to watch for component state changes.
 //
 // A new state is sent anytime the state for a unit or the whole component changes.
-func (s *ServiceRuntime) Watch() <-chan ComponentState {
+func (s *serviceRuntime) Watch() <-chan ComponentState {
 	return s.ch
 }
 
 // Start starts the service.
 //
 // Non-blocking and never returns an error.
-func (s *ServiceRuntime) Start() error {
+func (s *serviceRuntime) Start() error {
 	// clear channel so it's the latest action
 	select {
 	case <-s.actionCh:
@@ -359,7 +359,7 @@ func (s *ServiceRuntime) Start() error {
 // Update updates the currComp runtime with a new-revision for the component definition.
 //
 // Non-blocking and never returns an error.
-func (s *ServiceRuntime) Update(comp component.Component) error {
+func (s *serviceRuntime) Update(comp component.Component) error {
 	// clear channel so it's the latest component
 	select {
 	case <-s.compCh:
@@ -372,7 +372,7 @@ func (s *ServiceRuntime) Update(comp component.Component) error {
 // Stop stops the service.
 //
 // Non-blocking and never returns an error.
-func (s *ServiceRuntime) Stop() error {
+func (s *serviceRuntime) Stop() error {
 	// clear channel so it's the latest action
 	select {
 	case <-s.actionCh:
@@ -385,7 +385,7 @@ func (s *ServiceRuntime) Stop() error {
 // Teardown stop and uninstall the service.
 //
 // Non-blocking and never returns an error.
-func (s *ServiceRuntime) Teardown() error {
+func (s *serviceRuntime) Teardown() error {
 	// clear channel so it's the latest action
 	select {
 	case <-s.actionCh:
@@ -395,17 +395,17 @@ func (s *ServiceRuntime) Teardown() error {
 	return nil
 }
 
-func (s *ServiceRuntime) forceCompState(state client.UnitState, msg string) {
+func (s *serviceRuntime) forceCompState(state client.UnitState, msg string) {
 	if s.state.forceState(state, msg) {
 		s.sendObserved()
 	}
 }
 
-func (s *ServiceRuntime) sendObserved() {
+func (s *serviceRuntime) sendObserved() {
 	s.ch <- s.state.Copy()
 }
 
-func (s *ServiceRuntime) compState(state client.UnitState, missedCheckins int) {
+func (s *serviceRuntime) compState(state client.UnitState, missedCheckins int) {
 	name := s.name()
 	msg := stateUnknownMessage
 	if state == client.UnitStateHealthy {
@@ -422,12 +422,12 @@ func (s *ServiceRuntime) compState(state client.UnitState, missedCheckins int) {
 	}
 }
 
-func (s *ServiceRuntime) name() string {
+func (s *serviceRuntime) name() string {
 	return s.comp.InputSpec.Spec.Name
 }
 
 // check executes the service check command
-func (s *ServiceRuntime) check(ctx context.Context) error {
+func (s *serviceRuntime) check(ctx context.Context) error {
 	if s.comp.InputSpec.Spec.Service.Operations.Check == nil {
 		s.log.Errorf("missing check spec for %s service", s.comp.InputSpec.BinaryName)
 		return ErrOperationSpecUndefined
@@ -437,7 +437,7 @@ func (s *ServiceRuntime) check(ctx context.Context) error {
 }
 
 // install executes the service install command
-func (s *ServiceRuntime) install(ctx context.Context) error {
+func (s *serviceRuntime) install(ctx context.Context) error {
 	if s.comp.InputSpec.Spec.Service.Operations.Install == nil {
 		s.log.Errorf("missing install spec for %s service", s.comp.InputSpec.BinaryName)
 		return ErrOperationSpecUndefined
@@ -447,7 +447,7 @@ func (s *ServiceRuntime) install(ctx context.Context) error {
 }
 
 // uninstall executes the service uninstall command
-func (s *ServiceRuntime) uninstall(ctx context.Context) error {
+func (s *serviceRuntime) uninstall(ctx context.Context) error {
 	return uninstallService(ctx, s.log, s.comp, s.executeServiceCommandImpl)
 }
 


### PR DESCRIPTION
This is code cleanup only, it does not change any behavior.

A few cleanups around the runtime and coordinator:
- ~~Break `(*Coordinator).compute()` into two pieces, `(*Coordinator).recomputeConfig` and `(*Coordinator).recomputeComponents`~~
  * This one ended up breaking the diagnostics tests, because the Coordinator's component generation continues to modify the generated config, and the diagnostics expect the final modified version -- thus the config can't be fully generated without also regenerating the components. This is potentially undesirable behavior, but outside the scope of this PR, so I moved these back into a single function for now.
- Move the main monitoring loop for `componentRuntimeState` from an anonymous goroutine in the initialization into an explicit named helper function, `(*componentRuntimeState).runLoop`.
- Make `ComponentRuntime` and its various concrete implementations internal-only (these are only used from the `runtime` package and this lets us be more flexible about cleanups and refactors -- if a dependency arises in the future we can reconsider what interfaces we want to expose).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~
