### PR TITLE
Fix flakiness in host/TestContextProvider

### DIFF
--- a/internal/pkg/composable/controller.go
+++ b/internal/pkg/composable/controller.go
@@ -74,6 +74,8 @@ func New(log *logger.Logger, c *config.Config, managed bool) (Controller, error)
 			return nil, errors.New(err, fmt.Sprintf("failed to build provider '%s'", name), errors.TypeConfig, errors.M("provider", name))
 		}
 		contextProviders[name] = &contextProviderState{
+			// Safe for Context to be nil here because it will be filled in
+			// by (*controller).Run before the provider is started.
 			provider: provider,
 		}
 	}
@@ -110,7 +112,7 @@ func (c *controller) Run(ctx context.Context) error {
 	c.logger.Debugf("Starting controller for composable inputs")
 	defer c.logger.Debugf("Stopped controller for composable inputs")
 
-	notify := make(chan bool, 1) // sized so we can store 1 notification or proceed
+	stateChangedChan := make(chan bool, 1) // sized so we can store 1 notification or proceed
 	localCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -122,7 +124,7 @@ func (c *controller) Run(ctx context.Context) error {
 	// run all the enabled context providers
 	for name, state := range c.contextProviders {
 		state.Context = localCtx
-		state.signal = notify
+		state.signal = stateChangedChan
 		go func(name string, state *contextProviderState) {
 			defer wg.Done()
 			err := state.provider.Run(state)
@@ -139,7 +141,7 @@ func (c *controller) Run(ctx context.Context) error {
 	// run all the enabled dynamic providers
 	for name, state := range c.dynamicProviders {
 		state.Context = localCtx
-		state.signal = notify
+		state.signal = stateChangedChan
 		go func(name string, state *dynamicProviderState) {
 			defer wg.Done()
 			err := state.provider.Run(state)
@@ -167,7 +169,7 @@ func (c *controller) Run(ctx context.Context) error {
 				select {
 				case <-emptyChan.Done():
 					return
-				case <-notify:
+				case <-stateChangedChan:
 				}
 			}
 		}()
@@ -184,10 +186,10 @@ func (c *controller) Run(ctx context.Context) error {
 			case <-ctx.Done():
 				cleanupFn()
 				return ctx.Err()
-			case <-notify:
+			case <-stateChangedChan:
 				t.Reset(100 * time.Millisecond)
 				c.logger.Debugf("Variable state changed for composable inputs; debounce started")
-				drainChan(notify)
+				drainChan(stateChangedChan)
 				break DEBOUNCE
 			}
 		}
@@ -198,7 +200,7 @@ func (c *controller) Run(ctx context.Context) error {
 			cleanupFn()
 			return ctx.Err()
 		case <-t.C:
-			drainChan(notify)
+			drainChan(stateChangedChan)
 			// batching done, gather results
 		}
 
@@ -314,6 +316,10 @@ func (c *contextProviderState) Set(mapping map[string]interface{}) error {
 	}
 	c.mapping = mapping
 
+	// Notify the controller Run loop that a state has changed. The notification
+	// channel has buffer size 1 so this ensures that an update will always
+	// happen after this change, while coalescing multiple simultaneous changes
+	// into a single controller update.
 	select {
 	case c.signal <- true:
 	default:

--- a/internal/pkg/composable/testing/context.go
+++ b/internal/pkg/composable/testing/context.go
@@ -16,7 +16,9 @@ type ContextComm struct {
 	lock     sync.Mutex
 	previous map[string]interface{}
 	current  map[string]interface{}
-	onSet    func()
+	// Set calls onSet with the new value, so tests can
+	// verify data from the provider.
+	onSet func(map[string]interface{})
 }
 
 // NewContextComm creates a new ContextComm.
@@ -41,8 +43,9 @@ func (t *ContextComm) Set(mapping map[string]interface{}) error {
 	t.lock.Unlock()
 
 	if onSet != nil {
-		onSet()
+		onSet(mapping)
 	}
+
 	return nil
 }
 
@@ -61,7 +64,7 @@ func (t *ContextComm) Current() map[string]interface{} {
 }
 
 // CallOnSet sets the OnSet callback.
-func (t *ContextComm) CallOnSet(f func()) {
+func (t *ContextComm) CallOnSet(f func(map[string]interface{})) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	t.onSet = f


### PR DESCRIPTION
Despite [recent fixes](https://github.com/elastic/elastic-agent/pull/2787) of data races in `host/TextContextProvider` found by the go race detector, there were still underlying logical races in the test, causing it to be flaky. Specifically, the test expected that after notification of a change it could always request the current value to get the content of that change, when in fact (when CI is running slow enough) it was possible for the current value to change a second time while still handling the first notification.

This PR passes the changed value along with the notification callback, so the test can always observe the exact sequence. It also adds some comments and clarifies some code in `composable.controller`, since troubleshooting this problem involved working through some of that code.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~
