### PR TITLE
Make `mage integration clean` remove ogc cache

### DIFF
--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -57,3 +57,7 @@ the `mage package` command OR set the `AGENT_VERSION` environment variable to a 
 that includes the `-SNAPSHOT` suffix when running `mage integration:test` or
 `mage integration:local`.
 
+### OGC-related errors
+If you encounter any errors mentioning `ogc`, try running `mage integration:clean` and then
+re-running whatever `mage integration:*` target you were trying to run originally when you
+encountered the error.

--- a/magefile.go
+++ b/magefile.go
@@ -1266,6 +1266,10 @@ func majorMinor() string {
 // cleans up the integration testing leftovers
 func (Integration) Clean() error {
 	_ = os.RemoveAll(".agent-testing")
+
+	// Clean out .ogc-cache always
+	defer os.RemoveAll(".ogc-cache")
+
 	_, err := os.Stat(".ogc-cache")
 	if err == nil {
 		// .ogc-cache exists; need to run `Clean` from the runner
@@ -1278,7 +1282,7 @@ func (Integration) Clean() error {
 			return err
 		}
 	}
-	_ = os.RemoveAll(".ogc-cache")
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR always cleans the OGC cache folder when `mage integration:clean` is run.  The PR also adds a tip in the documentaion to run `mage integration:clean` if OGC-related errors are encountered when running other `mage integration:*` targets.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To help test authors try and get past any OGC-related errors due to stale contents in the OGC cache.

## Related issues
- Fixes #2794