### PR TITLE
Fix race detector errors in TestActionDispatcher

### DIFF
--- a/internal/pkg/agent/application/coordinator/diagnostics_test.go
+++ b/internal/pkg/agent/application/coordinator/diagnostics_test.go
@@ -249,8 +249,13 @@ func TestCoordinatorDiagnosticHooks(t *testing.T) {
 
 			initialConf := config.MustNewConfigFrom(configBytes)
 
+			// These flags are set in callbacks from the Coordinator goroutine
+			// when the mocked functions are invoked, so we can tell in the
+			// assertions below when it's safe to advance to the next stage of
+			// the test.
 			configCalled := atomic.NewBool(false)
 			ackCalled := atomic.NewBool(false)
+
 			initialConfChange := mocks.NewConfigChange(t)
 			initialConfChange.EXPECT().Config().RunAndReturn(func() *config.Config {
 				configCalled.Store(true)


### PR DESCRIPTION
Fix the race detector errors in `TestActionDispatcher` (see https://github.com/elastic/elastic-agent/pull/2790).

The initial error was related to checking bare mock variables in an `assert.Eventually`, which is a technical race condition but usually a mild one. I addressed it by instead notifying a channel from an explicitly added mock callback, which fixed the race detector error. However this then uncovered a more fundamental logical race in the test: the condition being waited on only verified one function invocation, but assumed that the others had also happened, when in fact this wasn't guaranteed, and the test became flaky on CI while passing locally.

This problem too could be "fixed" by synchronizing on those additional calls, but at that point the mock framework itself would be superfluous -- we would be explicitly waiting for a specific set of calls, then calling into mock helpers to verify that that same specific set of calls had happened. So I'm looking into `ActionDispatcher` itself to see if there's a better way to test this, or if the difficulty indicates real races in the component, and I'm leaving the PR in draft while I investigate.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~