### PR TITLE
Allow SNAPSHOT=true for mage integration:*

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -1468,7 +1468,13 @@ func createTestRunner(matrix bool, singleTest string, batches ...define.Batch) (
 			return nil, err
 		}
 		if agentStackVersion == "" {
+			// always use snapshot for stack version
 			agentStackVersion = fmt.Sprintf("%s-SNAPSHOT", agentVersion)
+		}
+		if hasSnapshotEnv() {
+			// in the case that SNAPSHOT=true is set in the environment the
+			// default version of the agent is used, but as a snapshot build
+			agentVersion = fmt.Sprintf("%s-SNAPSHOT", agentVersion)
 		}
 	}
 	if agentStackVersion == "" {
@@ -1833,4 +1839,13 @@ func writeFile(name string, data []byte, perm os.FileMode) error {
 		return fmt.Errorf("failed to write file %s: %w", name, err)
 	}
 	return nil
+}
+
+func hasSnapshotEnv() bool {
+	snapshot := os.Getenv(snapshotEnv)
+	if snapshot == "" {
+		return false
+	}
+	b, _ := strconv.ParseBool(snapshot)
+	return b
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Add's support for parsing `SNAPSHOT=true` from the environment when running all `mage integration:*` targets.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This allows use just `SNAPSHOT=true` and it will use the Elastic Agent version from the repository with `-SNAPSHOT` appended. Removes the requirement of defining the whole `AGENT_VERSION` environment variable.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #2792 
