### PR TITLE
Fix timer reset patterns in the Agent

### DIFF
--- a/internal/pkg/agent/application/managed_mode.go
+++ b/internal/pkg/agent/application/managed_mode.go
@@ -233,6 +233,10 @@ func runDispatcher(ctx context.Context, actionDispatcher dispatcher.Dispatcher, 
 			t.Reset(flushInterval)
 		case actions := <-fleetGateway.Actions():
 			actionDispatcher.Dispatch(ctx, actionAcker, actions...)
+			// Reset the timer safely, see https://pkg.go.dev/time#Timer.Reset
+			if !t.Stop() {
+				<-t.C
+			}
 			t.Reset(flushInterval)
 		}
 	}

--- a/internal/pkg/composable/controller.go
+++ b/internal/pkg/composable/controller.go
@@ -187,6 +187,10 @@ func (c *controller) Run(ctx context.Context) error {
 				cleanupFn()
 				return ctx.Err()
 			case <-stateChangedChan:
+				// Reset the timer safely, see https://pkg.go.dev/time#Timer.Reset
+				if !t.Stop() {
+					<-t.C
+				}
 				t.Reset(100 * time.Millisecond)
 				c.logger.Debugf("Variable state changed for composable inputs; debounce started")
 				drainChan(stateChangedChan)

--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -896,6 +896,10 @@ func TestManager_FakeInput_NoDeadlock(t *testing.T) {
 				return
 			case <-updatedCh:
 				// update did occur
+				// Reset the timer safely, see https://pkg.go.dev/time#Timer.Reset
+				if !t.Stop() {
+					<-t.C
+				}
 				t.Reset(15 * time.Second)
 			case <-t.C:
 				// timeout hit waiting for another update to work

--- a/pkg/component/runtime/service.go
+++ b/pkg/component/runtime/service.go
@@ -114,7 +114,10 @@ func (s *ServiceRuntime) Run(ctx context.Context, comm Communicator) (err error)
 				// Initial state on start
 				lastCheckin = time.Time{}
 				missedCheckins = 0
-				checkinTimer.Stop()
+				// Stop timer safely, see https://pkg.go.dev/time#Timer.Stop
+				if !checkinTimer.Stop() {
+					<-checkinTimer.C
+				}
 				cisStop()
 
 				// Start connection info
@@ -138,7 +141,10 @@ func (s *ServiceRuntime) Run(ctx context.Context, comm Communicator) (err error)
 			case actionStop, actionTeardown:
 				// Stop check-in timer
 				s.log.Debugf("stop check-in timer for %s service", s.name())
-				checkinTimer.Stop()
+				// Stop timer safely, see https://pkg.go.dev/time#Timer.Stop
+				if !checkinTimer.Stop() {
+					<-checkinTimer.C
+				}
 
 				// Stop connection info
 				s.log.Debugf("stop connection info for %s service", s.name())


### PR DESCRIPTION
A few places in the Agent code use `Timer.Reset` when the timer isn't known to have expired. The [go docs](https://pkg.go.dev/time#Timer.Reset) say:

    If a program has already received a value from t.C, the timer is known to have expired
    and the channel drained, so t.Reset can be used directly. If a program has not yet received
    a value from t.C, however, the timer must be stopped and—if Stop reports that the timer
    expired before being stopped—the channel explicitly drained:

```go
if !t.Stop() {
  <-t.C
}
t.Reset(d)
```

This is usually a minor error but it causes races in the timer handling and in rare cases can even cause a panic. (Callers who habitually reset to a consistent interval like this might prefer `time.Ticker` which requires less boilerplate to reset safely.)

This PR fixes all the calls to `Timer.Reset` that showed up in static analysis.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~
