### PR TITLE
Log an error when a store exists but we can't load it

### DIFF
--- a/internal/pkg/agent/storage/store/action_store.go
+++ b/internal/pkg/agent/storage/store/action_store.go
@@ -33,7 +33,7 @@ func newActionStore(log *logger.Logger, store storeLoad) (*actionStore, error) {
 	// and return an empty store.
 	reader, err := store.Load()
 	if err != nil {
-		log.Errorf("failed to load action store, resetting its contents: %v", err.Error())
+		log.Errorf("failed to load action store, returning empty contents: %v", err.Error())
 		return &actionStore{log: log, store: store}, nil
 	}
 	defer reader.Close()

--- a/internal/pkg/agent/storage/store/action_store.go
+++ b/internal/pkg/agent/storage/store/action_store.go
@@ -29,10 +29,11 @@ type actionStore struct {
 
 // newActionStore creates a new action store.
 func newActionStore(log *logger.Logger, store storeLoad) (*actionStore, error) {
-	// If the store exists we will read it, if any errors is returned we assume we do not have anything
-	// persisted and we return an empty store.
+	// If the store exists we will read it, if an error is returned we log it
+	// and return an empty store.
 	reader, err := store.Load()
 	if err != nil {
+		log.Errorf("failed to load action store, resetting its contents: %v", err.Error())
 		return &actionStore{log: log, store: store}, nil
 	}
 	defer reader.Close()

--- a/internal/pkg/agent/storage/store/state_store.go
+++ b/internal/pkg/agent/storage/store/state_store.go
@@ -91,8 +91,8 @@ func NewStateStoreActionAcker(acker acker.Acker, store *StateStore) *StateStoreA
 
 // NewStateStore creates a new state store.
 func NewStateStore(log *logger.Logger, store storeLoad) (*StateStore, error) {
-	// If the store exists we will read it, if any errors is returned we log an
-	// error and return an empty store.
+	// If the store exists we will read it, if an error is returned we log it
+	// and return an empty store.
 	reader, err := store.Load()
 	if err != nil {
 		log.Errorf("failed to load state store, returning empty contents: %v", err.Error())

--- a/internal/pkg/agent/storage/store/state_store.go
+++ b/internal/pkg/agent/storage/store/state_store.go
@@ -91,11 +91,11 @@ func NewStateStoreActionAcker(acker acker.Acker, store *StateStore) *StateStoreA
 
 // NewStateStore creates a new state store.
 func NewStateStore(log *logger.Logger, store storeLoad) (*StateStore, error) {
-	// If the store exists we will read it, if any errors is returned we assume we do not have anything
-	// persisted and we return an empty store.
+	// If the store exists we will read it, if any errors is returned we log an
+	// error and return an empty store.
 	reader, err := store.Load()
 	if err != nil {
-		//nolint:nilerr // wad
+		log.Errorf("failed to load state store, returning empty contents: %v", err.Error())
 		return &StateStore{log: log, store: store}, nil
 	}
 	defer reader.Close()


### PR DESCRIPTION
When opening a state store or action store, if the store already exists but there's an error loading it, log the error instead of silently returning an empty store (but then return an empty store anyway, because there's nothing else we can do).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~
