### PR TITLE
Fix race detector errors in TestCoordinatorDiagnosticHooks

### DIFF
--- a/internal/pkg/agent/application/coordinator/diagnostics_test.go
+++ b/internal/pkg/agent/application/coordinator/diagnostics_test.go
@@ -24,6 +24,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	"github.com/elastic/elastic-agent-libs/atomic"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
@@ -248,13 +249,30 @@ func TestCoordinatorDiagnosticHooks(t *testing.T) {
 
 			initialConf := config.MustNewConfigFrom(configBytes)
 
+			// These flags are set in callbacks from the Coordinator goroutine
+			// when the mocked functions are invoked, so we can tell in the
+			// assertions below when it's safe to advance to the next stage of
+			// the test.
+			configCalled := atomic.NewBool(false)
+			ackCalled := atomic.NewBool(false)
+
 			initialConfChange := mocks.NewConfigChange(t)
-			initialConfChange.EXPECT().Config().Return(initialConf)
-			initialConfChange.EXPECT().Ack().Return(nil).Times(1)
+			initialConfChange.EXPECT().Config().RunAndReturn(func() *config.Config {
+				configCalled.Store(true)
+				return initialConf
+			})
+			initialConfChange.EXPECT().Ack().RunAndReturn(func() error {
+				ackCalled.Store(true)
+				return nil
+			}).Times(1)
 			mustWriteToChannelBeforeTimeout[coordinator.ConfigChange](t, initialConfChange, helper.configChangeChannel, 100*time.Millisecond)
 
-			assert.Eventually(t, func() bool { return sut.State().State == cproto.State_HEALTHY }, 1*time.Second, 50*time.Millisecond)
-			assert.Eventually(t, func() bool { return len(initialConfChange.Calls) > 1 /*both Config and Ack have been called)*/ }, 1*time.Second, 50*time.Millisecond)
+			assert.Eventually(t, func() bool {
+				return sut.State().State == cproto.State_HEALTHY
+			}, 1*time.Second, 50*time.Millisecond)
+			assert.Eventually(t, func() bool {
+				return configCalled.Load() && ackCalled.Load()
+			}, 1*time.Second, 50*time.Millisecond)
 			t.Logf("Agent state: %s", sut.State().State)
 
 			// Send runtime component state


### PR DESCRIPTION
`TestCoordinatorDiagnosticHooks` triggered the race detector because it accessed bare variables in its mocks from multiple goroutines. This fix makes the relevant conditions atomic and sets them from explicit callbacks instead. Followup from https://github.com/elastic/elastic-agent/pull/2790.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~
