### PR TITLE
Fixing compile errors + more consistent naming

### DIFF
--- a/pkg/testing/tools/cmd.go
+++ b/pkg/testing/tools/cmd.go
@@ -10,8 +10,8 @@ import (
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 )
 
-// InstallElasticAgent force install the Elastic Agent through agentFixture.
-func InstallElasticAgent(fleetUrl string, enrollmentToken string, agentFixture *atesting.Fixture) ([]byte, error) {
+// InstallAgent force install the Elastic Agent through agentFixture.
+func InstallAgent(fleetUrl string, enrollmentToken string, agentFixture *atesting.Fixture) ([]byte, error) {
 	installOpts := atesting.InstallOpts{
 		NonInteractive: true,
 		Force:          true,
@@ -23,8 +23,8 @@ func InstallElasticAgent(fleetUrl string, enrollmentToken string, agentFixture *
 	return agentFixture.Install(context.Background(), &installOpts)
 }
 
-// InstallStandaloneElasticAgent force install the Elastic Agent through agentFixture.
-func InstallStandaloneElasticAgent(agentFixture *atesting.Fixture) ([]byte, error) {
+// InstallStandaloneAgent force install the Elastic Agent through agentFixture.
+func InstallStandaloneAgent(agentFixture *atesting.Fixture) ([]byte, error) {
 	installOpts := atesting.InstallOpts{
 		NonInteractive: true,
 		Force:          true,

--- a/pkg/testing/tools/tools.go
+++ b/pkg/testing/tools/tools.go
@@ -74,7 +74,7 @@ func InstallAgentWithPolicy(t *testing.T, agentFixture *atesting.Fixture, kibCli
 	}
 
 	// Enroll agent
-	output, err := InstallElasticAgent(fleetServerURL, enrollmentToken.APIKey, agentFixture)
+	output, err := InstallAgent(fleetServerURL, enrollmentToken.APIKey, agentFixture)
 	if err != nil {
 		t.Log(string(output))
 		return nil, fmt.Errorf("unable to enroll Elastic Agent: %w", err)

--- a/testing/integration/fqdn_test.go
+++ b/testing/integration/fqdn_test.go
@@ -100,7 +100,7 @@ func (s *FQDN) TestFQDN() {
 			kibana.MonitoringEnabledMetrics,
 		},
 	}
-	policy, err := tools.EnrollAgentWithPolicy(s.T(), s.agentFixture, kibClient, createPolicyReq)
+	policy, err := tools.InstallAgentWithPolicy(s.T(), s.agentFixture, kibClient, createPolicyReq)
 	require.NoError(s.T(), err)
 
 	// Verify that agent name is short hostname

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -115,7 +115,7 @@ func (s *FleetManagedUpgradeTestSuite) TestUpgradeFleetManagedElasticAgent() {
 	require.NoError(s.T(), err)
 
 	s.T().Log("Enrolling Elastic Agent...")
-	output, err := tools.EnrollElasticAgent(fleetServerURL, enrollmentToken.APIKey, s.agentFixture)
+	output, err := tools.InstallElasticAgent(fleetServerURL, enrollmentToken.APIKey, s.agentFixture)
 	if err != nil {
 		s.T().Log(string(output))
 	}

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -115,7 +115,7 @@ func (s *FleetManagedUpgradeTestSuite) TestUpgradeFleetManagedElasticAgent() {
 	require.NoError(s.T(), err)
 
 	s.T().Log("Enrolling Elastic Agent...")
-	output, err := tools.InstallElasticAgent(fleetServerURL, enrollmentToken.APIKey, s.agentFixture)
+	output, err := tools.InstallAgent(fleetServerURL, enrollmentToken.APIKey, s.agentFixture)
 	if err != nil {
 		s.T().Log(string(output))
 	}
@@ -210,7 +210,7 @@ func (s *StandaloneUpgradeTestSuite) TestUpgradeStandaloneElasticAgentToSnapshot
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	output, err := tools.InstallStandaloneElasticAgent(s.agentFixture)
+	output, err := tools.InstallStandaloneAgent(s.agentFixture)
 	s.T().Logf("Agent installation output: %q", string(output))
 	require.NoError(s.T(), err)
 
@@ -398,7 +398,7 @@ func (s *StandaloneUpgradeRetryDownloadTestSuite) TestUpgradeStandaloneElasticAg
 	ctx := context.Background()
 
 	s.T().Log("Install the built Agent")
-	output, err := tools.InstallStandaloneElasticAgent(s.agentFixture)
+	output, err := tools.InstallStandaloneAgent(s.agentFixture)
 	s.T().Log(string(output))
 	s.Require().NoError(err)
 


### PR DESCRIPTION
## What does this PR do?

This PR follows up https://github.com/elastic/elastic-agent/pull/2833 by fixing a couple of [compile errors](https://github.com/elastic/elastic-agent/pull/2833#issuecomment-1584882967) introduced in that PR. 

It also renames a couple of utility functions provided by the testing framework to use `Agent` instead of `ElasticAgent`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So integration/E2E tests can be run once again and to have consistency (and brevity) in naming.