### PR TITLE
Revert "[8.8](backport #2817) Fix timer reset patterns in the Agent"

### DIFF
--- a/internal/pkg/agent/application/managed_mode.go
+++ b/internal/pkg/agent/application/managed_mode.go
@@ -233,10 +233,6 @@ func runDispatcher(ctx context.Context, actionDispatcher dispatcher.Dispatcher, 
 			t.Reset(flushInterval)
 		case actions := <-fleetGateway.Actions():
 			actionDispatcher.Dispatch(ctx, actionAcker, actions...)
-			// Reset the timer safely, see https://pkg.go.dev/time#Timer.Reset
-			if !t.Stop() {
-				<-t.C
-			}
 			t.Reset(flushInterval)
 		}
 	}

--- a/internal/pkg/composable/controller.go
+++ b/internal/pkg/composable/controller.go
@@ -185,10 +185,6 @@ func (c *controller) Run(ctx context.Context) error {
 				cleanupFn()
 				return ctx.Err()
 			case <-notify:
-				// Reset the timer safely, see https://pkg.go.dev/time#Timer.Reset
-				if !t.Stop() {
-					<-t.C
-				}
 				t.Reset(100 * time.Millisecond)
 				c.logger.Debugf("Variable state changed for composable inputs; debounce started")
 				drainChan(notify)

--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -895,10 +895,6 @@ func TestManager_FakeInput_NoDeadlock(t *testing.T) {
 				return
 			case <-updatedCh:
 				// update did occur
-				// Reset the timer safely, see https://pkg.go.dev/time#Timer.Reset
-				if !t.Stop() {
-					<-t.C
-				}
 				t.Reset(15 * time.Second)
 			case <-t.C:
 				// timeout hit waiting for another update to work

--- a/pkg/component/runtime/service.go
+++ b/pkg/component/runtime/service.go
@@ -114,10 +114,7 @@ func (s *ServiceRuntime) Run(ctx context.Context, comm Communicator) (err error)
 				// Initial state on start
 				lastCheckin = time.Time{}
 				missedCheckins = 0
-				// Stop timer safely, see https://pkg.go.dev/time#Timer.Stop
-				if !checkinTimer.Stop() {
-					<-checkinTimer.C
-				}
+				checkinTimer.Stop()
 				cisStop()
 
 				// Start connection info
@@ -141,10 +138,7 @@ func (s *ServiceRuntime) Run(ctx context.Context, comm Communicator) (err error)
 			case actionStop, actionTeardown:
 				// Stop check-in timer
 				s.log.Debugf("stop check-in timer for %s service", s.name())
-				// Stop timer safely, see https://pkg.go.dev/time#Timer.Stop
-				if !checkinTimer.Stop() {
-					<-checkinTimer.C
-				}
+				checkinTimer.Stop()
 
 				// Stop connection info
 				s.log.Debugf("stop connection info for %s service", s.name())


### PR DESCRIPTION
Following @aleksmaus discovery, I'm reverting elastic/elastic-agent#2818 to unblock the service runtime.