### PR TITLE
Run mage check in CI.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ notice:
 ## check-ci: Run all the checks under the ci, this doesn't include the linter which is run via a github action.
 .PHONY: check-ci
 check-ci:
-	@mage check
+	@mage -v check
 	@$(MAKE) notice
 	@$(MAKE) -C deploy/kubernetes generate-k8s
 	@$(MAKE) check-no-changes

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ notice:
 .PHONY: check-ci
 check-ci:
 	@mage update
+	@mage check
 	@$(MAKE) notice
 	@$(MAKE) -C deploy/kubernetes generate-k8s
 	@$(MAKE) check-no-changes

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ notice:
 ## check-ci: Run all the checks under the ci, this doesn't include the linter which is run via a github action.
 .PHONY: check-ci
 check-ci:
-	@mage update
 	@mage check
 	@$(MAKE) notice
 	@$(MAKE) -C deploy/kubernetes generate-k8s

--- a/magefile.go
+++ b/magefile.go
@@ -273,7 +273,7 @@ func (Build) TestBinaries() error {
 
 // All run all the code checks.
 func (Check) All() {
-	mg.SerialDeps(Check.License, Integration.Check, Check.GoLint)
+	mg.SerialDeps(Check.License, Integration.Check)
 }
 
 // GoLint run the code through the linter.

--- a/pkg/testing/tools/artifacts_api.go
+++ b/pkg/testing/tools/artifacts_api.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package tools
 
 import (

--- a/pkg/testing/tools/artifacts_api_test.go
+++ b/pkg/testing/tools/artifacts_api_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package tools
 
 import (

--- a/testing/fleetservertest/checkin.go
+++ b/testing/fleetservertest/checkin.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package fleetservertest
 
 const (

--- a/testing/fleetservertest/fleetserver.go
+++ b/testing/fleetservertest/fleetserver.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package fleetservertest
 
 import (

--- a/testing/fleetservertest/fleetserver_test.go
+++ b/testing/fleetservertest/fleetserver_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package fleetservertest
 
 import (

--- a/testing/fleetservertest/handlers.go
+++ b/testing/fleetservertest/handlers.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package fleetservertest
 
 import (

--- a/testing/fleetservertest/models.go
+++ b/testing/fleetservertest/models.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package fleetservertest
 
 // =============================================================================

--- a/testing/fleetservertest/server.go
+++ b/testing/fleetservertest/server.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package fleetservertest
 
 import (


### PR DESCRIPTION
Apparently we were not running the `mage check` command in CI. This ensures we have the appropriate license headers in all files, among other things.


