### PR TITLE
[Component spec files] Add units to duration values

### DIFF
--- a/changelog/fragments/1686770028-spec-timeout-units.yaml
+++ b/changelog/fragments/1686770028-spec-timeout-units.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Explicitly specify timeout units as seconds in Endpoint spec file
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/2870
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/2863

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -2098,17 +2098,6 @@ func gatherDurationFieldPaths(s interface{}, pathSoFar string) []string {
 	rt := reflect.TypeOf(s)
 	rv := reflect.ValueOf(s)
 
-	if rt.Kind() == reflect.Ptr {
-		if rv.IsNil() {
-			return gatheredPaths
-		}
-
-		// Recurse on the dereferenced pointer value.
-		morePaths := gatherDurationFieldPaths(rv.Elem().Interface(), pathSoFar)
-		gatheredPaths = append(gatheredPaths, morePaths...)
-		return gatheredPaths
-	}
-
 	switch rt.Kind() {
 	case reflect.Int64:
 		// If this is a time.Duration value, we gather its path.
@@ -2139,6 +2128,17 @@ func gatherDurationFieldPaths(s interface{}, pathSoFar string) []string {
 			morePaths := gatherDurationFieldPaths(rv.Field(i).Interface(), yamlFieldPath)
 			gatheredPaths = append(gatheredPaths, morePaths...)
 		}
+		return gatheredPaths
+
+	case reflect.Ptr:
+		if rv.IsNil() {
+			// Nil pointer, nothing more to do
+			return gatheredPaths
+		}
+
+		// Recurse on the dereferenced pointer value.
+		morePaths := gatherDurationFieldPaths(rv.Elem().Interface(), pathSoFar)
+		gatheredPaths = append(gatheredPaths, morePaths...)
 		return gatheredPaths
 	}
 

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -1930,8 +1930,8 @@ func TestSpecDurationsAreValid(t *testing.T) {
 
 	// Recursively reflect on component.Spec struct to find time.Duration fields
 	// and gather their paths.
-	for path, spec := range specFiles {
-		path, err = filepath.Abs(path)
+	for specFilePath, spec := range specFiles {
+		specFilePath, err = filepath.Abs(specFilePath)
 		require.NoError(t, err)
 
 		// Gather all duration fields' YAML paths so we an check if the
@@ -1940,7 +1940,7 @@ func TestSpecDurationsAreValid(t *testing.T) {
 
 		// Parse each spec file's YAML into a ucfg.Config object for
 		// easy access to field values via their paths.
-		data, err := os.ReadFile(path)
+		data, err := os.ReadFile(specFilePath)
 		require.NoError(t, err)
 
 		var v map[string]interface{}
@@ -1963,7 +1963,7 @@ func TestSpecDurationsAreValid(t *testing.T) {
 			// Ensure that value can be parsed as a time.Duration. This parsing will
 			// fail if there is no unit suffix explicity specified.
 			_, err = time.ParseDuration(value)
-			assert.NoErrorf(t, err, "in spec file [%s], field [%s] has invalid value [%s]: %s", path, durationFieldPath, value, err)
+			assert.NoErrorf(t, err, "in spec file [%s], field [%s] has invalid value [%s]: %s", specFilePath, durationFieldPath, value, err)
 		}
 	}
 }

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -2107,8 +2107,8 @@ func gatherDurationFieldPaths(s interface{}, pathSoFar string) []string {
 		}
 
 	case reflect.Slice:
+		// Recurse on slice elements
 		for i := 0; i < rv.Len(); i++ {
-			// Recurse on slice elements
 			morePaths := gatherDurationFieldPaths(rv.Index(i).Interface(), pathSoFar+"."+strconv.Itoa(i))
 			gatheredPaths = append(gatheredPaths, morePaths...)
 		}

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -1961,7 +1961,7 @@ func TestSpecDurationsAreValid(t *testing.T) {
 			require.NoError(t, err)
 
 			// Ensure that value can be parsed as a time.Duration. This parsing will
-			// fail if there is no unit suffix explicity specified.
+			// fail if there is no unit suffix explicitly specified.
 			_, err = time.ParseDuration(value)
 			assert.NoErrorf(t, err, "in spec file [%s], field [%s] has invalid value [%s]: %s", specFilePath, durationFieldPath, value, err)
 		}

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -1953,19 +1953,22 @@ func TestSpecDurationsAreValid(t *testing.T) {
 
 		// Check that every duration field in the spec file has
 		// valid syntax.
-		const durationPattern = `\d+[a-zA-Z]+$`
+		durationPattern, err := regexp.Compile(`\d+[a-zA-Z]+$`)
+		require.NoError(t, err)
+
 		for _, durationFieldPath := range durationFieldPaths {
 			exists, err := cfg.Has(durationFieldPath, -1, ucfg.PathSep("."))
 			if !exists {
 				continue
 			}
+			require.NoError(t, err)
 
 			value, err := cfg.String(durationFieldPath, -1, ucfg.PathSep("."))
+			require.NoError(t, err)
 
 			// Ensure that value is an integer (duration value)
 			// followed by a string suffix (duration units).
-			matched, err := regexp.MatchString(durationPattern, value)
-			require.NoError(t, err)
+			matched := durationPattern.MatchString(value)
 			require.Truef(t, matched, "in spec file [%s], field [%s] has value [%s] which does not match expected pattern [%s]", path, durationFieldPath, value, durationPattern)
 
 			// Ensure that value can be parsed as a time.Duration.

--- a/specs/endpoint-security.spec.yml
+++ b/specs/endpoint-security.spec.yml
@@ -26,7 +26,7 @@ inputs:
             - "verify"
             - "--log"
             - "stderr"
-          timeout: 30
+          timeout: 30s
         install:
           args:
             - "install"
@@ -35,13 +35,13 @@ inputs:
             - "--upgrade"
             - "--resources"
             - "endpoint-security-resources.zip"
-          timeout: 600
+          timeout: 600s
         uninstall:
           args:
             - "uninstall"
             - "--log"
             - "stderr"
-          timeout: 600
+          timeout: 600s
   - name: endpoint
     description: "Endpoint Security"
     platforms:


### PR DESCRIPTION
## What does this PR do?

This PR updates the Endpoint spec file to explicitly specify units for `inputs[].service.operations.*.timeout` values.

## Why is it important?

The `inputs[].service.operations.*.timeout` values are unmarshalled from YAML as [`time.Duration`](https://github.com/elastic/elastic-agent/blob/0c32b31933ba7898d1b753d1dda291372554869b/pkg/component/spec.go#L156).  By default, when no time unit is explicitly specified in these values, [`ms` is assumed](https://go.dev/play/p/U18P6hUQoKQ).  So, for example, `600` (no explicit time unit) will be parsed as `600ms` = `0.6s`.

Looking at https://github.com/elastic/beats/issues/19700, the intention with the timeout values in the Endpoint spec file was for their units to be in seconds.  

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] ~I have added an integration test or an E2E test~




## How to test this PR locally

Run the `TestSpecDurationsAreValid` defined in this PR.  It should pass.

However, if you remove the unit from a duration field in one of the spec files, the test should fail like so:
```
in spec file [/Users/shaunak/development/github/elastic-agent/specs/auditbeat.spec.yml], field [inputs.0.command.restart_monitoring_period] has value [5] which does not match expected pattern [\d+[a-zA-Z]+$]
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #2863

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
