### PR TITLE
deployment/kubernetes: add elements for Universal Profiling

### DIFF
--- a/changelog/fragments/1686845318-deployment-kubernetes-add-elements-for-Universal-Profiling.yaml
+++ b/changelog/fragments/1686845318-deployment-kubernetes-add-elements-for-Universal-Profiling.yaml
@@ -11,7 +11,7 @@
 kind: enhancement
 
 # Change summary; a 80ish characters long description of the change.
-summary: deployment/kubernetes: add elements for Universal Profiling
+summary: deployment/kubernetes - add elements for Universal Profiling
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.

--- a/changelog/fragments/1686845318-deployment-kubernetes:-add-elements-for-Universal-Profiling.yaml
+++ b/changelog/fragments/1686845318-deployment-kubernetes:-add-elements-for-Universal-Profiling.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: deployment/kubernetes: add elements for Universal Profiling
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: Universal Profiling
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -62,12 +62,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: KUBERNETES_NODE_NAME
-              # Special environment indicator for Universal Profiling.
-              # If you are not using this integration, then this can be removed.
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
+            # Special environment indicator for Universal Profiling.
+            # If you are using the Universal Profiling integration, please uncomment these lines before applying.
+            #- name: KUBERNETES_NODE_NAME
+            #  valueFrom:
+            #    fieldRef:
+            #      fieldPath: spec.nodeName
           securityContext:
             runAsUser: 0
             # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
@@ -80,7 +80,7 @@ spec:
             ########################################################################################
             # The following capabilities are needed for Universal Profiling.
             # More fine graded capabilities are only available for newer Linux kernels.
-            # If you are using this integration, please uncomment these lines before applying.
+            # If you are using the Universal Profiling integration, please uncomment these lines before applying.
             #procMount: "Unmasked"
             #privileged: true
             #capabilities:
@@ -118,8 +118,9 @@ spec:
               mountPath: /sys/kernel/debug
             - name: elastic-agent-state
               mountPath: /usr/share/elastic-agent/state
-            - name: universal-profiling-cache
-              mountPath: /var/cache/Elastic
+            # If you are using the Universal Profiling integration, please uncomment these lines before applying.
+            #- name: universal-profiling-cache
+            #  mountPath: /var/cache/Elastic
       volumes:
         - name: proc
           hostPath:
@@ -161,12 +162,11 @@ spec:
             path: /var/lib/elastic-agent-managed/kube-system/state
             type: DirectoryOrCreate
         # Mount required for Universal Profiling.
-        # If you are not using this integration, then these volumes and the corresponding
-        # mounts can be removed.
-        - name: universal-profiling-cache
-          hostPath:
-            path: /var/cache/Elastic
-            type: DirectoryOrCreate
+        # If you are using the Universal Profiling integration, please uncomment these lines before applying.
+        #- name: universal-profiling-cache
+        #  hostPath:
+        #    path: /var/cache/Elastic
+        #    type: DirectoryOrCreate
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -62,6 +62,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              # Special environment indicator for Universal Profiling.
+              # If you are not using this integration, then this can be removed.
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           securityContext:
             runAsUser: 0
             # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
@@ -71,6 +77,15 @@ spec:
             #    - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
             #    - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
             #    - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for Containers' to modify 'rlimit_memlock'
+            ########################################################################################
+            # The following capabilities are needed for Universal Profiling.
+            # More fine graded capabilities are only available for newer Linux kernels.
+            # If you are using this integration, please uncomment these lines before applying.
+            #procMount: "Unmasked"
+            #privileged: true
+            #capabilities:
+            #  add:
+            #    - SYS_ADMIN
           resources:
             limits:
               memory: 700Mi
@@ -103,6 +118,8 @@ spec:
               mountPath: /sys/kernel/debug
             - name: elastic-agent-state
               mountPath: /usr/share/elastic-agent/state
+            - name: universal-profiling-cache
+              mountPath: /var/cache/Elastic
       volumes:
         - name: proc
           hostPath:
@@ -131,8 +148,8 @@ spec:
           hostPath:
             path: /etc/machine-id
             type: File
-        # Needed for 'Defend for containers' integration (cloud-defend)
-        # If you are not using this integration, then these volumes and the corresponding
+        # Needed for 'Defend for containers' integration (cloud-defend) and Universal Profiling
+        # If you are not using one of these integrations, then these volumes and the corresponding
         # mounts can be removed.
         - name: sys-kernel-debug
           hostPath:
@@ -142,6 +159,13 @@ spec:
         - name: elastic-agent-state
           hostPath:
             path: /var/lib/elastic-agent-managed/kube-system/state
+            type: DirectoryOrCreate
+        # Mount required for Universal Profiling.
+        # If you are not using this integration, then these volumes and the corresponding
+        # mounts can be removed.
+        - name: universal-profiling-cache
+          hostPath:
+            path: /var/cache/Elastic
             type: DirectoryOrCreate
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -62,12 +62,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            # Special environment indicator for Universal Profiling.
-            # If you are using the Universal Profiling integration, please uncomment these lines before applying.
-            #- name: KUBERNETES_NODE_NAME
-            #  valueFrom:
-            #    fieldRef:
-            #      fieldPath: spec.nodeName
           securityContext:
             runAsUser: 0
             # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -62,6 +62,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              # Special environment indicator for Universal Profiling.
+              # If you are not using this integration, then this can be removed.
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           securityContext:
             runAsUser: 0
             # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
@@ -71,6 +77,15 @@ spec:
             #    - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
             #    - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
             #    - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for Containers' to modify 'rlimit_memlock'
+            ########################################################################################
+            # The following capabilities are needed for Universal Profiling.
+            # More fine graded capabilities are only available for newer Linux kernels.
+            # If you are using this integration, please uncomment these lines before applying.
+            #procMount: "Unmasked"
+            #privileged: true
+            #capabilities:
+            #  add:
+            #    - SYS_ADMIN
           resources:
             limits:
               memory: 700Mi
@@ -103,6 +118,8 @@ spec:
               mountPath: /sys/kernel/debug
             - name: elastic-agent-state
               mountPath: /usr/share/elastic-agent/state
+            - name: universal-profiling-cache
+              mountPath: /var/cache/Elastic
       volumes:
         - name: proc
           hostPath:
@@ -131,8 +148,8 @@ spec:
           hostPath:
             path: /etc/machine-id
             type: File
-        # Needed for 'Defend for containers' integration (cloud-defend)
-        # If you are not using this integration, then these volumes and the corresponding
+        # Needed for 'Defend for containers' integration (cloud-defend) and Universal Profiling
+        # If you are not using one of these integrations, then these volumes and the corresponding
         # mounts can be removed.
         - name: sys-kernel-debug
           hostPath:
@@ -142,4 +159,11 @@ spec:
         - name: elastic-agent-state
           hostPath:
             path: /var/lib/elastic-agent-managed/kube-system/state
+            type: DirectoryOrCreate
+        # Mount required for Universal Profiling.
+        # If you are not using this integration, then these volumes and the corresponding
+        # mounts can be removed.
+        - name: universal-profiling-cache
+          hostPath:
+            path: /var/cache/Elastic
             type: DirectoryOrCreate

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -62,12 +62,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            # Special environment indicator for Universal Profiling.
-            # If you are using the Universal Profiling integration, please uncomment these lines before applying.
-            #- name: KUBERNETES_NODE_NAME
-            #  valueFrom:
-            #    fieldRef:
-            #      fieldPath: spec.nodeName
           securityContext:
             runAsUser: 0
             # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -62,12 +62,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: KUBERNETES_NODE_NAME
-              # Special environment indicator for Universal Profiling.
-              # If you are not using this integration, then this can be removed.
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
+            # Special environment indicator for Universal Profiling.
+            # If you are using the Universal Profiling integration, please uncomment these lines before applying.
+            #- name: KUBERNETES_NODE_NAME
+            #  valueFrom:
+            #    fieldRef:
+            #      fieldPath: spec.nodeName
           securityContext:
             runAsUser: 0
             # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
@@ -80,7 +80,7 @@ spec:
             ########################################################################################
             # The following capabilities are needed for Universal Profiling.
             # More fine graded capabilities are only available for newer Linux kernels.
-            # If you are using this integration, please uncomment these lines before applying.
+            # If you are using the Universal Profiling integration, please uncomment these lines before applying.
             #procMount: "Unmasked"
             #privileged: true
             #capabilities:
@@ -118,8 +118,9 @@ spec:
               mountPath: /sys/kernel/debug
             - name: elastic-agent-state
               mountPath: /usr/share/elastic-agent/state
-            - name: universal-profiling-cache
-              mountPath: /var/cache/Elastic
+            # If you are using the Universal Profiling integration, please uncomment these lines before applying.
+            #- name: universal-profiling-cache
+            #  mountPath: /var/cache/Elastic
       volumes:
         - name: proc
           hostPath:
@@ -161,9 +162,8 @@ spec:
             path: /var/lib/elastic-agent-managed/kube-system/state
             type: DirectoryOrCreate
         # Mount required for Universal Profiling.
-        # If you are not using this integration, then these volumes and the corresponding
-        # mounts can be removed.
-        - name: universal-profiling-cache
-          hostPath:
-            path: /var/cache/Elastic
-            type: DirectoryOrCreate
+        # If you are using the Universal Profiling integration, please uncomment these lines before applying.
+        #- name: universal-profiling-cache
+        #  hostPath:
+        #    path: /var/cache/Elastic
+        #    type: DirectoryOrCreate

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -735,6 +735,12 @@ spec:
                   fieldPath: metadata.name
             - name: STATE_PATH
               value: "/etc/elastic-agent"
+            - name: KUBERNETES_NODE_NAME
+              # Special environment indicator for Universal Profiling.
+              # If you are not using this integration, then this can be removed.
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           securityContext:
             runAsUser: 0
             # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
@@ -744,6 +750,15 @@ spec:
             #    - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
             #    - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
             #    - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for Containers' to modify 'rlimit_memlock'
+            ########################################################################################
+            # The following capabilities are needed for Universal Profiling.
+            # More fine graded capabilities are only available for newer Linux kernels.
+            # If you are using this integration, please uncomment these lines before applying.
+            #procMount: "Unmasked"
+            #privileged: true
+            #capabilities:
+            #  add:
+            #    - SYS_ADMIN
           resources:
             limits:
               memory: 700Mi
@@ -780,6 +795,8 @@ spec:
               mountPath: /sys/kernel/debug
             - name: elastic-agent-state
               mountPath: /usr/share/elastic-agent/state
+            - name: universal-profiling-cache
+              mountPath: /var/cache/Elastic
       volumes:
         - name: datastreams
           configMap:
@@ -809,8 +826,8 @@ spec:
         - name: var-lib
           hostPath:
             path: /var/lib
-        # Needed for 'Defend for containers' integration (cloud-defend)
-        # If you are not using this integration, then these volumes and the corresponding
+        # Needed for 'Defend for containers' integration (cloud-defend) and Universal Profiling
+        # If you are not using one of these integrations, then these volumes and the corresponding
         # mounts can be removed.
         - name: sys-kernel-debug
           hostPath:
@@ -820,6 +837,13 @@ spec:
         - name: elastic-agent-state
           hostPath:
             path: /var/lib/elastic-agent-standalone/kube-system/state
+            type: DirectoryOrCreate
+        # Mount required for Universal Profiling.
+        # If you are not using this integration, then these volumes and the corresponding
+        # mounts can be removed.
+        - name: universal-profiling-cache
+          hostPath:
+            path: /var/cache/Elastic
             type: DirectoryOrCreate
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -735,12 +735,12 @@ spec:
                   fieldPath: metadata.name
             - name: STATE_PATH
               value: "/etc/elastic-agent"
-            - name: KUBERNETES_NODE_NAME
-              # Special environment indicator for Universal Profiling.
-              # If you are not using this integration, then this can be removed.
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
+            # Special environment indicator for Universal Profiling.
+            # If you are using the Universal Profiling integration, please uncomment these lines before applying.
+            #- name: KUBERNETES_NODE_NAME
+            #  valueFrom:
+            #    fieldRef:
+            #      fieldPath: spec.nodeName
           securityContext:
             runAsUser: 0
             # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
@@ -753,7 +753,7 @@ spec:
             ########################################################################################
             # The following capabilities are needed for Universal Profiling.
             # More fine graded capabilities are only available for newer Linux kernels.
-            # If you are using this integration, please uncomment these lines before applying.
+            # If you are using the Universal Profiling integration, please uncomment these lines before applying.
             #procMount: "Unmasked"
             #privileged: true
             #capabilities:
@@ -795,8 +795,9 @@ spec:
               mountPath: /sys/kernel/debug
             - name: elastic-agent-state
               mountPath: /usr/share/elastic-agent/state
-            - name: universal-profiling-cache
-              mountPath: /var/cache/Elastic
+            # If you are using the Universal Profiling integration, please uncomment these lines before applying.
+            #- name: universal-profiling-cache
+            #  mountPath: /var/cache/Elastic
       volumes:
         - name: datastreams
           configMap:
@@ -839,12 +840,11 @@ spec:
             path: /var/lib/elastic-agent-standalone/kube-system/state
             type: DirectoryOrCreate
         # Mount required for Universal Profiling.
-        # If you are not using this integration, then these volumes and the corresponding
-        # mounts can be removed.
-        - name: universal-profiling-cache
-          hostPath:
-            path: /var/cache/Elastic
-            type: DirectoryOrCreate
+        # If you are using the Universal Profiling integration, please uncomment these lines before applying.
+        #- name: universal-profiling-cache
+        #  hostPath:
+        #    path: /var/cache/Elastic
+        #    type: DirectoryOrCreate
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -735,12 +735,6 @@ spec:
                   fieldPath: metadata.name
             - name: STATE_PATH
               value: "/etc/elastic-agent"
-            # Special environment indicator for Universal Profiling.
-            # If you are using the Universal Profiling integration, please uncomment these lines before applying.
-            #- name: KUBERNETES_NODE_NAME
-            #  valueFrom:
-            #    fieldRef:
-            #      fieldPath: spec.nodeName
           securityContext:
             runAsUser: 0
             # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
@@ -63,6 +63,12 @@ spec:
                   fieldPath: metadata.name
             - name: STATE_PATH
               value: "/etc/elastic-agent"
+            - name: KUBERNETES_NODE_NAME
+              # Special environment indicator for Universal Profiling.
+              # If you are not using this integration, then this can be removed.
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           securityContext:
             runAsUser: 0
             # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
@@ -72,6 +78,15 @@ spec:
             #    - BPF # (since Linux 5.8) allows loading of BPF programs, create most map types, load BTF, iterate programs and maps.
             #    - PERFMON # (since Linux 5.8) allows attaching of BPF programs used for performance metrics and observability operations.
             #    - SYS_RESOURCE # Allow use of special resources or raising of resource limits. Used by 'Defend for Containers' to modify 'rlimit_memlock'
+            ########################################################################################
+            # The following capabilities are needed for Universal Profiling.
+            # More fine graded capabilities are only available for newer Linux kernels.
+            # If you are using this integration, please uncomment these lines before applying.
+            #procMount: "Unmasked"
+            #privileged: true
+            #capabilities:
+            #  add:
+            #    - SYS_ADMIN
           resources:
             limits:
               memory: 700Mi
@@ -108,6 +123,8 @@ spec:
               mountPath: /sys/kernel/debug
             - name: elastic-agent-state
               mountPath: /usr/share/elastic-agent/state
+            - name: universal-profiling-cache
+              mountPath: /var/cache/Elastic
       volumes:
         - name: datastreams
           configMap:
@@ -137,8 +154,8 @@ spec:
         - name: var-lib
           hostPath:
             path: /var/lib
-        # Needed for 'Defend for containers' integration (cloud-defend)
-        # If you are not using this integration, then these volumes and the corresponding
+        # Needed for 'Defend for containers' integration (cloud-defend) and Universal Profiling
+        # If you are not using one of these integrations, then these volumes and the corresponding
         # mounts can be removed.
         - name: sys-kernel-debug
           hostPath:
@@ -148,4 +165,11 @@ spec:
         - name: elastic-agent-state
           hostPath:
             path: /var/lib/elastic-agent-standalone/kube-system/state
+            type: DirectoryOrCreate
+        # Mount required for Universal Profiling.
+        # If you are not using this integration, then these volumes and the corresponding
+        # mounts can be removed.
+        - name: universal-profiling-cache
+          hostPath:
+            path: /var/cache/Elastic
             type: DirectoryOrCreate

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
@@ -63,12 +63,6 @@ spec:
                   fieldPath: metadata.name
             - name: STATE_PATH
               value: "/etc/elastic-agent"
-            # Special environment indicator for Universal Profiling.
-            # If you are using the Universal Profiling integration, please uncomment these lines before applying.
-            #- name: KUBERNETES_NODE_NAME
-            #  valueFrom:
-            #    fieldRef:
-            #      fieldPath: spec.nodeName
           securityContext:
             runAsUser: 0
             # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
@@ -63,12 +63,12 @@ spec:
                   fieldPath: metadata.name
             - name: STATE_PATH
               value: "/etc/elastic-agent"
-            - name: KUBERNETES_NODE_NAME
-              # Special environment indicator for Universal Profiling.
-              # If you are not using this integration, then this can be removed.
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
+            # Special environment indicator for Universal Profiling.
+            # If you are using the Universal Profiling integration, please uncomment these lines before applying.
+            #- name: KUBERNETES_NODE_NAME
+            #  valueFrom:
+            #    fieldRef:
+            #      fieldPath: spec.nodeName
           securityContext:
             runAsUser: 0
             # The following capabilities are needed for 'Defend for containers' integration (cloud-defend)
@@ -81,7 +81,7 @@ spec:
             ########################################################################################
             # The following capabilities are needed for Universal Profiling.
             # More fine graded capabilities are only available for newer Linux kernels.
-            # If you are using this integration, please uncomment these lines before applying.
+            # If you are using the Universal Profiling integration, please uncomment these lines before applying.
             #procMount: "Unmasked"
             #privileged: true
             #capabilities:
@@ -123,8 +123,9 @@ spec:
               mountPath: /sys/kernel/debug
             - name: elastic-agent-state
               mountPath: /usr/share/elastic-agent/state
-            - name: universal-profiling-cache
-              mountPath: /var/cache/Elastic
+            # If you are using the Universal Profiling integration, please uncomment these lines before applying.
+            #- name: universal-profiling-cache
+            #  mountPath: /var/cache/Elastic
       volumes:
         - name: datastreams
           configMap:
@@ -167,9 +168,8 @@ spec:
             path: /var/lib/elastic-agent-standalone/kube-system/state
             type: DirectoryOrCreate
         # Mount required for Universal Profiling.
-        # If you are not using this integration, then these volumes and the corresponding
-        # mounts can be removed.
-        - name: universal-profiling-cache
-          hostPath:
-            path: /var/cache/Elastic
-            type: DirectoryOrCreate
+        # If you are using the Universal Profiling integration, please uncomment these lines before applying.
+        #- name: universal-profiling-cache
+        #  hostPath:
+        #    path: /var/cache/Elastic
+        #    type: DirectoryOrCreate


### PR DESCRIPTION
## What does this PR do?

Adding additional elements to the manifest so the Universal Profiling integration can be used.

## Why is it important?

Without these additional elements the Universal Profiling integration will not work.

## Checklist


- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

