### PR TITLE
Integration tests: Pass along verbse statements in debian handler, tweak archiver

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -1537,8 +1537,9 @@ func createTestRunner(matrix bool, singleTest string, batches ...define.Batch) (
 			ServiceTokenPath: serviceTokenPath,
 			Datacenter:       datacenter,
 		},
-		Matrix:     matrix,
-		SingleTest: singleTest,
+		Matrix:      matrix,
+		SingleTest:  singleTest,
+		VerboseMode: mg.Verbose(),
 	}, batches...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create runner: %w", err)

--- a/pkg/testing/runner/archiver.go
+++ b/pkg/testing/runner/archiver.go
@@ -54,7 +54,6 @@ func createRepoZipArchive(ctx context.Context, dir string, dest string) error {
 	defer zw.Close()
 
 	s := bufio.NewScanner(&stdout)
-	var fileCount int
 	s.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		if i := strings.IndexRune(string(data), '\x00'); i >= 0 {
 			return i + 1, data[0:i], nil
@@ -97,14 +96,12 @@ func createRepoZipArchive(ctx context.Context, dir string, dest string) error {
 			if err != nil {
 				return fmt.Errorf("failed to copy zip entry %s: %w", line, err)
 			}
-			fileCount++
 			return nil
 		}(s.Text())
 		if err != nil {
 			return fmt.Errorf("error adding files: %w", err)
 		}
 	}
-	fmt.Printf(">> Added %d files to zip archive\n", fileCount)
 	return nil
 }
 

--- a/pkg/testing/runner/config.go
+++ b/pkg/testing/runner/config.go
@@ -27,6 +27,9 @@ type Config struct {
 
 	// SingleTest only has the runner run that specific test.
 	SingleTest string
+
+	// VerboseMode passed along a verbose mode flag to tests
+	VerboseMode bool
 }
 
 // Validate returns an error if the information is invalid.

--- a/pkg/testing/runner/config.go
+++ b/pkg/testing/runner/config.go
@@ -98,10 +98,10 @@ type GCEConfig struct {
 // Validate returns an error if the information is invalid.
 func (gce *GCEConfig) Validate() error {
 	if gce.ServiceTokenPath == "" {
-		return errors.New("ServiceTokenPath must be set")
+		return errors.New("ServiceTokenPath must be set") //nolint:stylecheck // references a specific field
 	}
 	if gce.Datacenter == "" {
-		return errors.New("Datacenter must be set")
+		return errors.New("Datacenter must be set") //nolint:stylecheck // references a specific field
 	}
 	return gce.ensureParsed()
 }

--- a/pkg/testing/runner/config.go
+++ b/pkg/testing/runner/config.go
@@ -79,10 +79,10 @@ type ESSConfig struct {
 // Validate returns an error if the information is invalid.
 func (ess *ESSConfig) Validate() error {
 	if ess.APIKey == "" {
-		return errors.New("APIKey must be set")
+		return errors.New("APIKey must be set") //nolint:stylecheck // references a specific field
 	}
 	if ess.Region == "" {
-		return errors.New("Region must be set")
+		return errors.New("Region must be set") //nolint:stylecheck // references a specific field
 	}
 	return nil
 }

--- a/pkg/testing/runner/config.go
+++ b/pkg/testing/runner/config.go
@@ -35,19 +35,19 @@ type Config struct {
 // Validate returns an error if the information is invalid.
 func (c *Config) Validate() error {
 	if c.AgentVersion == "" {
-		return errors.New("AgentVersion must be set")
+		return errors.New("field AgentVersion must be set")
 	}
 	if c.AgentStackVersion == "" {
-		return errors.New("AgentStackVersion must be set")
+		return errors.New("field AgentStackVersion must be set")
 	}
 	if c.BuildDir == "" {
-		return errors.New("BuildDir must be set")
+		return errors.New("field BuildDir must be set")
 	}
 	if c.GOVersion == "" {
-		return errors.New("GOVersion must be set")
+		return errors.New("field GOVersion must be set")
 	}
 	if c.RepoDir == "" {
-		return errors.New("RepoDir must be set")
+		return errors.New("field RepoDir must be set")
 	}
 	if c.ESS == nil {
 		// in the future we could adjust to work on different providers
@@ -56,7 +56,7 @@ func (c *Config) Validate() error {
 	}
 	err := c.ESS.Validate()
 	if err != nil {
-		return fmt.Errorf("ESS error: %w", err)
+		return fmt.Errorf("error validating ESS: %w", err)
 	}
 	if c.GCE == nil {
 		// in the future we could adjust to work on different providers
@@ -65,7 +65,7 @@ func (c *Config) Validate() error {
 	}
 	err = c.GCE.Validate()
 	if err != nil {
-		return fmt.Errorf("GCE error: %w", err)
+		return fmt.Errorf("error validating GCE: %w", err)
 	}
 	return err
 }
@@ -79,10 +79,10 @@ type ESSConfig struct {
 // Validate returns an error if the information is invalid.
 func (ess *ESSConfig) Validate() error {
 	if ess.APIKey == "" {
-		return errors.New("APIKey must be set") //nolint:stylecheck // references a specific field
+		return errors.New("field APIKey must be set")
 	}
 	if ess.Region == "" {
-		return errors.New("Region must be set") //nolint:stylecheck // references a specific field
+		return errors.New("field Region must be set")
 	}
 	return nil
 }
@@ -98,10 +98,10 @@ type GCEConfig struct {
 // Validate returns an error if the information is invalid.
 func (gce *GCEConfig) Validate() error {
 	if gce.ServiceTokenPath == "" {
-		return errors.New("ServiceTokenPath must be set") //nolint:stylecheck // references a specific field
+		return errors.New("field ServiceTokenPath must be set")
 	}
 	if gce.Datacenter == "" {
-		return errors.New("Datacenter must be set") //nolint:stylecheck // references a specific field
+		return errors.New("field Datacenter must be set")
 	}
 	return gce.ensureParsed()
 }

--- a/pkg/testing/runner/debian.go
+++ b/pkg/testing/runner/debian.go
@@ -147,7 +147,11 @@ func (DebianRunner) Run(ctx context.Context, c *ssh.Client, logger Logger, agent
 		vars := fmt.Sprintf(`GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" AGENT_VERSION="%s" TEST_DEFINE_PREFIX="%s" TEST_DEFINE_TESTS="%s"`, agentVersion, prefix, strings.Join(tests, ","))
 		vars = extendVars(vars, env)
 		logger.Logf("Starting tests")
-		script := fmt.Sprintf(`cd agent && %s ~/go/bin/mage integration:testOnRemote`, vars)
+		logArg := ""
+		if mg.Verbose() {
+			logArg = "-v"
+		}
+		script := fmt.Sprintf(`cd agent && %s ~/go/bin/mage %s integration:testOnRemote`, vars, logArg)
 		execTest := strings.NewReader(script)
 
 		session, err := c.NewSession()

--- a/pkg/testing/runner/debian.go
+++ b/pkg/testing/runner/debian.go
@@ -15,8 +15,6 @@ import (
 
 	"golang.org/x/crypto/ssh"
 
-	"github.com/magefile/mage/mg"
-
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 )
 
@@ -128,7 +126,7 @@ func (DebianRunner) Prepare(ctx context.Context, c *ssh.Client, logger Logger, a
 }
 
 // Run the test
-func (DebianRunner) Run(ctx context.Context, c *ssh.Client, logger Logger, agentVersion string, prefix string, batch define.Batch, env map[string]string) (OSRunnerResult, error) {
+func (DebianRunner) Run(ctx context.Context, verbose bool, c *ssh.Client, logger Logger, agentVersion string, prefix string, batch define.Batch, env map[string]string) (OSRunnerResult, error) {
 	var tests []string
 	for _, pkg := range batch.Tests {
 		for _, test := range pkg.Tests {
@@ -148,7 +146,7 @@ func (DebianRunner) Run(ctx context.Context, c *ssh.Client, logger Logger, agent
 		vars = extendVars(vars, env)
 		logger.Logf("Starting tests")
 		logArg := ""
-		if mg.Verbose() {
+		if verbose {
 			logArg = "-v"
 		}
 		script := fmt.Sprintf(`cd agent && %s ~/go/bin/mage %s integration:testOnRemote`, vars, logArg)
@@ -182,7 +180,7 @@ func (DebianRunner) Run(ctx context.Context, c *ssh.Client, logger Logger, agent
 		vars = extendVars(vars, env)
 		logger.Logf("Starting sudo tests")
 		logArg := ""
-		if mg.Verbose() {
+		if verbose {
 			logArg = "-v"
 		}
 		script := fmt.Sprintf(`cd agent && sudo %s ~/go/bin/mage %s integration:testOnRemote`, vars, logArg)

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -54,7 +54,7 @@ type OSRunner interface {
 	// Prepare prepares the runner to actual run on the host.
 	Prepare(ctx context.Context, c *ssh.Client, logger Logger, arch string, goVersion string, repoArchive string, buildPath string) error
 	// Run runs the actual tests and provides the result.
-	Run(ctx context.Context, c *ssh.Client, logger Logger, agentVersion string, prefix string, batch define.Batch, env map[string]string) (OSRunnerResult, error)
+	Run(ctx context.Context, verbose bool, c *ssh.Client, logger Logger, agentVersion string, prefix string, batch define.Batch, env map[string]string) (OSRunnerResult, error)
 }
 
 // Logger is a simple logging interface used by each runner type.
@@ -275,7 +275,7 @@ func (r *Runner) runMachine(ctx context.Context, sshAuth ssh.AuthMethod, logger 
 
 	// run the actual tests on the host
 	prefix := fmt.Sprintf("%s-%s-%s-%s", batch.LayoutOS.OS.Type, batch.LayoutOS.OS.Arch, batch.LayoutOS.OS.Distro, strings.Replace(batch.LayoutOS.OS.Version, ".", "", -1))
-	result, err := batch.LayoutOS.Runner.Run(ctx, client, logger, r.cfg.AgentVersion, prefix, batch.Batch, env)
+	result, err := batch.LayoutOS.Runner.Run(ctx, r.cfg.VerboseMode, client, logger, r.cfg.AgentVersion, prefix, batch.Batch, env)
 	if err != nil {
 		logger.Logf("Failed to execute tests on instance: %s", err)
 		return OSRunnerResult{}, fmt.Errorf("failed to execute tests on instance %s: %w", machine.InstanceName, err)


### PR DESCRIPTION
## What does this PR do?

Another set of small, minor fixes. There's a few things here:

- Change the behavior of archiver.go to make it more intuitive. Right now, it excludes any file outside of git, which excudes newly-created code files. This is a tad unintuitive, as yesterday I spent 40 minutes trying to figure out why none of the tests would build on a remote GCP instance. This still excludes files marked by `.gitignore` and others, so we're not trying to zip up random build artifacts, etc.
- Pass along verbose states to `testOnremote`

## Why is it important?

This improves logging and makes behavior more intuitive.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test
