### PR TITLE
[Service Runtime] Add ability for service operations to be retried

### DIFF
--- a/changelog/fragments/1687301871-service-command-retries.yaml
+++ b/changelog/fragments/1687301871-service-command-retries.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Retry service commands indefinitely with exponential backoff
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/2889
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/docs/component-specs.md
+++ b/docs/component-specs.md
@@ -154,6 +154,8 @@ The path to this service's logs directory.
 - `args` (identical to `command.args`): the command-line arguments to pass for this operation
 - `env` (identical to `command.env`): the environment variables to set for this operation
 - `timeout`: the timeout duration for this operation.
+- `retry`: (optional) configuration for retrying the operation
+  - `init_interval`: interval before the first retry. The interval between subsequent retries will increase exponentially (with some random jitter).
 
 For example:
 

--- a/pkg/component/runtime/service.go
+++ b/pkg/component/runtime/service.go
@@ -29,7 +29,9 @@ var (
 	ErrInvalidServiceSpec = errors.New("invalid service spec")
 )
 
-type executeServiceCommandFunc func(ctx context.Context, log *logger.Logger, binaryPath string, spec *component.ServiceOperationsCommandSpec) error
+// executeServiceCommandFunc executes the given binary according to configuration in spec. If shouldRetry == true,
+// the command will be retried indefinitely; otherwise, it will not be retried.
+type executeServiceCommandFunc func(ctx context.Context, log *logger.Logger, binaryPath string, spec *component.ServiceOperationsCommandSpec, shouldRetry bool) error
 
 // serviceRuntime provides the command runtime for running a component as a service.
 type serviceRuntime struct {
@@ -433,7 +435,7 @@ func (s *serviceRuntime) check(ctx context.Context) error {
 		return ErrOperationSpecUndefined
 	}
 	s.log.Debugf("check if the %s is installed", s.comp.InputSpec.BinaryName)
-	return s.executeServiceCommandImpl(ctx, s.log, s.comp.InputSpec.BinaryPath, s.comp.InputSpec.Spec.Service.Operations.Check)
+	return s.executeServiceCommandImpl(ctx, s.log, s.comp.InputSpec.BinaryPath, s.comp.InputSpec.Spec.Service.Operations.Check, false)
 }
 
 // install executes the service install command
@@ -443,7 +445,7 @@ func (s *serviceRuntime) install(ctx context.Context) error {
 		return ErrOperationSpecUndefined
 	}
 	s.log.Debugf("install %s service", s.comp.InputSpec.BinaryName)
-	return s.executeServiceCommandImpl(ctx, s.log, s.comp.InputSpec.BinaryPath, s.comp.InputSpec.Spec.Service.Operations.Install)
+	return s.executeServiceCommandImpl(ctx, s.log, s.comp.InputSpec.BinaryPath, s.comp.InputSpec.Spec.Service.Operations.Install, true)
 }
 
 // uninstall executes the service uninstall command
@@ -462,5 +464,5 @@ func uninstallService(ctx context.Context, log *logger.Logger, comp component.Co
 		return ErrOperationSpecUndefined
 	}
 	log.Debugf("uninstall %s service", comp.InputSpec.BinaryName)
-	return executeServiceCommandImpl(ctx, log, comp.InputSpec.BinaryPath, comp.InputSpec.Spec.Service.Operations.Uninstall)
+	return executeServiceCommandImpl(ctx, log, comp.InputSpec.BinaryPath, comp.InputSpec.Spec.Service.Operations.Uninstall, true)
 }

--- a/pkg/component/runtime/service_command.go
+++ b/pkg/component/runtime/service_command.go
@@ -107,16 +107,17 @@ func executeServiceCommand(ctx context.Context, log *logger.Logger, binaryPath s
 		return executeCommand(ctx, log, binaryPath, spec.Args, envSpecToEnv(spec.Env), spec.Timeout)
 	}
 
-	return executeServiceCommandWithRetries(
+	executeServiceCommandWithRetries(
 		ctx, log, binaryPath, spec,
 		context.Background(), 20*time.Second, 15*time.Minute,
 	)
+	return nil
 }
 
 func executeServiceCommandWithRetries(
 	cmdCtx context.Context, log *logger.Logger, binaryPath string, spec *component.ServiceOperationsCommandSpec,
 	retryCtx context.Context, defaultRetrySleepInitDuration time.Duration, retrySleepMaxDuration time.Duration,
-) error {
+) {
 	// If no initial sleep duration is specified, use default value
 	retrySleepInitDuration := spec.RetrySleepInitDuration
 	if retrySleepInitDuration == 0 {
@@ -128,7 +129,6 @@ func executeServiceCommandWithRetries(
 		binaryPath, spec.Args, envSpecToEnv(spec.Env), spec.Timeout,
 		retryCtx, retrySleepInitDuration, retrySleepMaxDuration,
 	)
-	return nil
 }
 
 type cmdRetryInfo struct {

--- a/pkg/component/runtime/service_command.go
+++ b/pkg/component/runtime/service_command.go
@@ -163,7 +163,7 @@ func executeServiceCommandWithRetries(
 	go func() {
 		retryAttempt := 0
 
-		// nolint: errcheck // No point checking the error inside the goroutine.
+		//nolint: errcheck // No point checking the error inside the goroutine.
 		backoff.RetryNotify(
 			func() error {
 				return executeCommand(cmdCtx, log, binaryPath, spec.Args, envSpecToEnv(spec.Env), spec.Timeout)

--- a/pkg/component/runtime/service_command.go
+++ b/pkg/component/runtime/service_command.go
@@ -116,18 +116,18 @@ func executeServiceCommand(ctx context.Context, log *logger.Logger, binaryPath s
 
 func executeServiceCommandWithRetries(
 	cmdCtx context.Context, log *logger.Logger, binaryPath string, spec *component.ServiceOperationsCommandSpec,
-	retryCtx context.Context, defaultRetrySleepInitDuration time.Duration, retrySleepMaxDuration time.Duration,
+	retryCtx context.Context, defaultRetryInitInterval time.Duration, retryMaxInterval time.Duration,
 ) {
-	// If no initial sleep duration is specified, use default value
-	retrySleepInitDuration := spec.RetrySleepInitDuration
-	if retrySleepInitDuration == 0 {
-		retrySleepInitDuration = defaultRetrySleepInitDuration
+	// If no initial retry interval is specified, use default value
+	retryInitInterval := spec.Retry.InitInterval
+	if retryInitInterval == 0 {
+		retryInitInterval = defaultRetryInitInterval
 	}
 
 	serviceCmdRetrier.Start(
 		cmdCtx, log,
 		binaryPath, spec.Args, envSpecToEnv(spec.Env), spec.Timeout,
-		retryCtx, retrySleepInitDuration, retrySleepMaxDuration,
+		retryCtx, retryInitInterval, retryMaxInterval,
 	)
 }
 

--- a/pkg/component/runtime/service_command.go
+++ b/pkg/component/runtime/service_command.go
@@ -93,6 +93,13 @@ func executeCommand(ctx context.Context, log *logger.Logger, binaryPath string, 
 }
 
 func executeServiceCommand(ctx context.Context, log *logger.Logger, binaryPath string, spec *component.ServiceOperationsCommandSpec) error {
+	// TODO: due to infinite retries, we may still be trying to (re)execute
+	// a service command when a new call to executeServiceCommand is made. So,
+	// before we call executeServiceCommandWithRetries (again), we need to:
+	// - cancel the previous retryCtx (if one exists),
+	// - cancel the previous cmdCtx (if one exists),
+	// - ensure that the previous command actually stopped running
+
 	return executeServiceCommandWithRetries(
 		ctx, log, binaryPath, spec,
 		context.Background(), 20*time.Second, 15*time.Minute,

--- a/pkg/component/runtime/service_command.go
+++ b/pkg/component/runtime/service_command.go
@@ -57,24 +57,22 @@ func executeCommand(ctx context.Context, log *logger.Logger, binaryPath string, 
 	// channel for the last error message from the stderr output
 	errch := make(chan string, 1)
 	ctxStderr := contextio.NewReader(ctx, proc.Stderr)
-	if ctxStderr != nil {
-		go func() {
-			var errText string
-			scanner := bufio.NewScanner(ctxStderr)
-			for scanner.Scan() {
-				line := scanner.Text()
-				if len(line) > 0 {
-					txt := strings.TrimSpace(line)
-					if len(txt) > 0 {
-						errText = txt
-						// Log error output line
-						log.Error(errText)
-					}
+	go func() {
+		var errText string
+		scanner := bufio.NewScanner(ctxStderr)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if len(line) > 0 {
+				txt := strings.TrimSpace(line)
+				if len(txt) > 0 {
+					errText = txt
+					// Log error output line
+					log.Error(errText)
 				}
 			}
-			errch <- errText
-		}()
-	}
+		}
+		errch <- errText
+	}()
 
 	procState := <-proc.Wait()
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {

--- a/pkg/component/runtime/service_command.go
+++ b/pkg/component/runtime/service_command.go
@@ -162,6 +162,8 @@ func executeServiceCommandWithRetries(
 	// goroutine.
 	go func() {
 		retryAttempt := 0
+
+		// nolint: errcheck // No point checking the error inside the goroutine.
 		backoff.RetryNotify(
 			func() error {
 				return executeCommand(cmdCtx, log, binaryPath, spec.Args, envSpecToEnv(spec.Env), spec.Timeout)

--- a/pkg/component/runtime/service_command.go
+++ b/pkg/component/runtime/service_command.go
@@ -198,8 +198,8 @@ func (cr *cmdRetrier) Start(
 }
 
 func (cr *cmdRetrier) Stop(cmdKey uint64, log *logger.Logger) {
-	cr.mu.RLock()
-	defer cr.mu.RUnlock()
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
 	info, exists := cr.cmds[cmdKey]
 	if !exists {
 		log.Debugf("no retries for command key [%d] are pending; nothing to do", cmdKey)

--- a/pkg/component/runtime/service_command.go
+++ b/pkg/component/runtime/service_command.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -22,6 +23,34 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 	"github.com/elastic/elastic-agent/pkg/core/process"
 )
+
+type cancelFns struct {
+	fns map[string]context.CancelFunc
+	mu  sync.RWMutex
+}
+
+func (c *cancelFns) Add(name string, canceFunc context.CancelFunc) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.fns == nil {
+		c.fns = map[string]context.CancelFunc{}
+	}
+
+	c.fns[name] = canceFunc
+}
+
+func (c *cancelFns) Cancel(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if cancelFunc, exists := c.fns[name]; exists {
+		cancelFunc()
+		delete(c.fns, name)
+	}
+}
+
+var retryCancelFns = cancelFns{}
 
 func executeCommand(ctx context.Context, log *logger.Logger, binaryPath string, args []string, env []string, timeout time.Duration) error {
 	log = log.With("context", "command output")
@@ -93,9 +122,16 @@ func executeCommand(ctx context.Context, log *logger.Logger, binaryPath string, 
 }
 
 func executeServiceCommand(ctx context.Context, log *logger.Logger, binaryPath string, spec *component.ServiceOperationsCommandSpec) error {
+	// If there is a previous incarnation of the command executing (due to infinite
+	// retries), make sure to cancel it first before starting a new one here.
+	retryCancelFns.Cancel(binaryPath)
+
+	retryCtx, retryCancel := context.WithCancel(context.Background())
+	retryCancelFns.Add(binaryPath, retryCancel)
+
 	return executeServiceCommandWithRetries(
 		ctx, log, binaryPath, spec,
-		context.Background(), 20*time.Second, 15*time.Minute,
+		retryCtx, 20*time.Second, 15*time.Minute,
 	)
 }
 
@@ -121,22 +157,32 @@ func executeServiceCommandWithRetries(
 
 	backoffCtx := backoff.WithContext(expBackoff, retryCtx)
 
-	retryAttempt := 0
-	return backoff.RetryNotify(
-		func() error {
-			return executeCommand(cmdCtx, log, binaryPath, spec.Args, envSpecToEnv(spec.Env), spec.Timeout)
-		},
-		backoffCtx,
-		func(err error, retryAfter time.Duration) {
-			retryAttempt++
-			log.Warnf(
-				"service command execution failed with error [%s], retrying (will be retry [%d]) after [%s]",
-				err.Error(),
-				retryAttempt,
-				retryAfter,
-			)
-		},
-	)
+	// Since we will be executing the command with infinite retries, we don't
+	// want to block.  So we execute the command with retries in its own
+	// goroutine.
+	go func() {
+		retryAttempt := 0
+		backoff.RetryNotify(
+			func() error {
+				return executeCommand(cmdCtx, log, binaryPath, spec.Args, envSpecToEnv(spec.Env), spec.Timeout)
+			},
+			backoffCtx,
+			func(err error, retryAfter time.Duration) {
+				retryAttempt++
+				log.Warnf(
+					"service command execution failed with error [%s], retrying (will be retry [%d]) after [%s]",
+					err.Error(),
+					retryAttempt,
+					retryAfter,
+				)
+			},
+		)
+
+		// Command executed successfully.
+		retryCancelFns.Cancel(binaryPath)
+	}()
+
+	return nil
 }
 
 func envSpecToEnv(envSpecs []component.CommandEnvSpec) []string {

--- a/pkg/component/runtime/service_command_test.go
+++ b/pkg/component/runtime/service_command_test.go
@@ -286,12 +286,12 @@ func TestExecuteServiceCommand(t *testing.T) {
 		retryCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 
-		defaultRetrySleepInitDuration := 50 * time.Millisecond
-		retrySleepMaxDuration := 200 * time.Millisecond
+		defaultRetryInitInterval := 50 * time.Millisecond
+		retryMaxInterval := 200 * time.Millisecond
 
 		executeServiceCommandWithRetries(
 			cmdCtx, log, exePath, &component.ServiceOperationsCommandSpec{},
-			retryCtx, defaultRetrySleepInitDuration, retrySleepMaxDuration,
+			retryCtx, defaultRetryInitInterval, retryMaxInterval,
 		)
 
 		<-retryCtx.Done()
@@ -315,8 +315,8 @@ func TestExecuteServiceCommand(t *testing.T) {
 		retryCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
-		defaultRetrySleepInitDuration := 50 * time.Millisecond
-		retrySleepMaxDuration := 1 * time.Second
+		defaultRetryInitInterval := 50 * time.Millisecond
+		retryMaxInterval := 1 * time.Second
 
 		spec := &component.ServiceOperationsCommandSpec{
 			// We deliberately set RetrySleepInitDuration to just shorter
@@ -325,11 +325,13 @@ func TestExecuteServiceCommand(t *testing.T) {
 			// - one message about the next (first) retry
 			// - one more execution of the command, as a result of the first retry
 			// - one message about the next (second) retry
-			RetrySleepInitDuration: 700 * time.Millisecond,
+			Retry: component.RetryConfig{
+				InitInterval: 700 * time.Millisecond,
+			},
 		}
 		executeServiceCommandWithRetries(
 			cmdCtx, log, exePath, spec,
-			retryCtx, defaultRetrySleepInitDuration, retrySleepMaxDuration,
+			retryCtx, defaultRetryInitInterval, retryMaxInterval,
 		)
 
 		<-retryCtx.Done()
@@ -357,15 +359,17 @@ func TestExecuteServiceCommand(t *testing.T) {
 		retryCtx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 		defer cancel()
 
-		defaultRetrySleepInitDuration := 50 * time.Millisecond
-		retrySleepMaxDuration := 1 * time.Second
+		defaultRetryInitInterval := 50 * time.Millisecond
+		retryMaxInterval := 1 * time.Second
 
 		spec := &component.ServiceOperationsCommandSpec{
-			RetrySleepInitDuration: 200 * time.Millisecond,
+			Retry: component.RetryConfig{
+				InitInterval: 200 * time.Millisecond,
+			},
 		}
 		executeServiceCommandWithRetries(
 			cmdCtx, log, exePath, spec,
-			retryCtx, defaultRetrySleepInitDuration, retrySleepMaxDuration,
+			retryCtx, defaultRetryInitInterval, retryMaxInterval,
 		)
 
 		// Give the command time to succeed.
@@ -396,8 +400,8 @@ func TestExecuteServiceCommand(t *testing.T) {
 		exePath, err := prepareTestProg(context.Background(), log, t.TempDir(), exeConfig)
 		require.NoError(t, err)
 
-		defaultRetrySleepInitDuration := 50 * time.Millisecond
-		retrySleepMaxDuration := 200 * time.Millisecond
+		defaultRetryInitInterval := 50 * time.Millisecond
+		retryMaxInterval := 200 * time.Millisecond
 
 		// First call
 		cmd1Ctx := context.Background()
@@ -405,7 +409,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 
 		executeServiceCommandWithRetries(
 			cmd1Ctx, log, exePath, &component.ServiceOperationsCommandSpec{},
-			retry1Ctx, defaultRetrySleepInitDuration, retrySleepMaxDuration,
+			retry1Ctx, defaultRetryInitInterval, retryMaxInterval,
 		)
 
 		debugLogs := obs.FilterLevelExact(zapcore.DebugLevel).TakeAll()
@@ -428,7 +432,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 
 		executeServiceCommandWithRetries(
 			cmd2Ctx, log, exePath, &component.ServiceOperationsCommandSpec{},
-			retry2Ctx, defaultRetrySleepInitDuration, retrySleepMaxDuration,
+			retry2Ctx, defaultRetryInitInterval, retryMaxInterval,
 		)
 
 		debugLogs = obs.FilterLevelExact(zapcore.DebugLevel).TakeAll()

--- a/pkg/component/runtime/service_command_test.go
+++ b/pkg/component/runtime/service_command_test.go
@@ -302,7 +302,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 		exeConfig := progConfig{
 			ErrMessage:   "foo bar",
 			ExitCode:     111,
-			SucceedAfter: now.Add(1 * time.Second).UnixMilli(),
+			SucceedAfter: now.Add(2 * time.Second).UnixMilli(),
 		}
 		exePath, err := prepareTestProg(cmdCtx, log, t.TempDir(), exeConfig)
 		require.NoError(t, err)
@@ -310,7 +310,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 		// Since the service command is retried indefinitely, we need a way to
 		// stop the test within a reasonable amount of time. However, we should never
 		// hit this timeout as the command should succeed before the timeout is reached.
-		retryCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		retryCtx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 		defer cancel()
 
 		defaultRetrySleepInitDuration := 50 * time.Millisecond

--- a/pkg/component/runtime/service_command_test.go
+++ b/pkg/component/runtime/service_command_test.go
@@ -213,7 +213,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 		require.Equal(t, fmt.Sprintf("spec is nil, nothing to execute, binaryPath: %s", exePath), warnLogs.TakeAll()[0].Message)
 	})
 
-	// Execution succeeded
+	// Execution succeeds on first attempt
 	t.Run("successful_execution", func(t *testing.T) {
 		ctx := context.Background()
 		log, observer := logger.NewTesting(t.Name())
@@ -226,7 +226,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 		require.Equal(t, 0, observer.Len())
 	})
 
-	// Execution failed - no retry configuration in spec
+	// Execution fails indefinitely and there is no retry configuration in spec
 	t.Run("failed_execution_no_retry_config", func(t *testing.T) {
 		cmdCtx := context.Background()
 		log, observer := logger.NewTesting(t.Name())
@@ -256,7 +256,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 		checkRetryLogs(t, observer, exeConfig)
 	})
 
-	// Execution failed - with retry configuration in spec
+	// Execution fails indefinitely but there is retry configuration in spec
 	t.Run("failed_execution_with_retry_config", func(t *testing.T) {
 		cmdCtx := context.Background()
 		log, observer := logger.NewTesting(t.Name())
@@ -295,7 +295,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 		checkRetryLogs(t, observer, exeConfig)
 	})
 
-	// Execution succeeded after a few retries
+	// Execution fails initially but then succeeds after a few retries
 	t.Run("succeed_after_retry", func(t *testing.T) {
 		cmdCtx := context.Background()
 		log, observer := logger.NewTesting(t.Name())

--- a/pkg/component/runtime/service_command_test.go
+++ b/pkg/component/runtime/service_command_test.go
@@ -59,7 +59,7 @@ func main() {
 const testModFile = `
 module prog
 
-go 1.18
+go 1.19
 `
 
 func renderTestProg(cfg progConfig) string {

--- a/pkg/component/runtime/service_command_test.go
+++ b/pkg/component/runtime/service_command_test.go
@@ -240,7 +240,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 
 		// Since the service command is retried indefinitely, we need a way to
 		// stop the test within a reasonable amount of time
-		retryCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		retryCtx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 		defer cancel()
 
 		defaultRetrySleepInitDuration := 50 * time.Millisecond

--- a/pkg/component/runtime/service_command_test.go
+++ b/pkg/component/runtime/service_command_test.go
@@ -300,11 +300,12 @@ func TestExecuteServiceCommand(t *testing.T) {
 		cmdCtx := context.Background()
 		log, observer := logger.NewTesting(t.Name())
 
+		const succeedCmdAfter = 2 * time.Second
 		now := time.Now()
 		exeConfig := progConfig{
 			ErrMessage:   "foo bar",
 			ExitCode:     111,
-			SucceedAfter: now.Add(2 * time.Second).UnixMilli(),
+			SucceedAfter: now.Add(succeedCmdAfter).UnixMilli(),
 		}
 		exePath, err := prepareTestProg(cmdCtx, log, t.TempDir(), exeConfig)
 		require.NoError(t, err)
@@ -328,7 +329,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		// Give the command time to succeed.
-		time.Sleep(2 * time.Second)
+		time.Sleep(succeedCmdAfter)
 
 		require.NoError(t, retryCtx.Err())
 		checkRetryLogs(t, observer, exeConfig)

--- a/pkg/component/runtime/service_command_test.go
+++ b/pkg/component/runtime/service_command_test.go
@@ -289,11 +289,10 @@ func TestExecuteServiceCommand(t *testing.T) {
 		defaultRetrySleepInitDuration := 50 * time.Millisecond
 		retrySleepMaxDuration := 200 * time.Millisecond
 
-		err = executeServiceCommandWithRetries(
+		executeServiceCommandWithRetries(
 			cmdCtx, log, exePath, &component.ServiceOperationsCommandSpec{},
 			retryCtx, defaultRetrySleepInitDuration, retrySleepMaxDuration,
 		)
-		require.NoError(t, err)
 
 		<-retryCtx.Done()
 		checkRetryLogs(t, obs, exeConfig)
@@ -328,11 +327,10 @@ func TestExecuteServiceCommand(t *testing.T) {
 			// - one message about the next (second) retry
 			RetrySleepInitDuration: 700 * time.Millisecond,
 		}
-		err = executeServiceCommandWithRetries(
+		executeServiceCommandWithRetries(
 			cmdCtx, log, exePath, spec,
 			retryCtx, defaultRetrySleepInitDuration, retrySleepMaxDuration,
 		)
-		require.NoError(t, err)
 
 		<-retryCtx.Done()
 		checkRetryLogs(t, obs, exeConfig)
@@ -365,11 +363,10 @@ func TestExecuteServiceCommand(t *testing.T) {
 		spec := &component.ServiceOperationsCommandSpec{
 			RetrySleepInitDuration: 200 * time.Millisecond,
 		}
-		err = executeServiceCommandWithRetries(
+		executeServiceCommandWithRetries(
 			cmdCtx, log, exePath, spec,
 			retryCtx, defaultRetrySleepInitDuration, retrySleepMaxDuration,
 		)
-		require.NoError(t, err)
 
 		// Give the command time to succeed.
 		successMsgFilterFn := func(l observer.LoggedEntry) bool {
@@ -406,11 +403,10 @@ func TestExecuteServiceCommand(t *testing.T) {
 		cmd1Ctx := context.Background()
 		retry1Ctx := context.Background()
 
-		err = executeServiceCommandWithRetries(
+		executeServiceCommandWithRetries(
 			cmd1Ctx, log, exePath, &component.ServiceOperationsCommandSpec{},
 			retry1Ctx, defaultRetrySleepInitDuration, retrySleepMaxDuration,
 		)
-		require.NoError(t, err)
 
 		debugLogs := obs.FilterLevelExact(zapcore.DebugLevel).TakeAll()
 		require.Len(t, debugLogs, 1)
@@ -430,11 +426,10 @@ func TestExecuteServiceCommand(t *testing.T) {
 		retry2Ctx, cancel2 := context.WithTimeout(context.Background(), 4*time.Second)
 		defer cancel2()
 
-		err = executeServiceCommandWithRetries(
+		executeServiceCommandWithRetries(
 			cmd2Ctx, log, exePath, &component.ServiceOperationsCommandSpec{},
 			retry2Ctx, defaultRetrySleepInitDuration, retrySleepMaxDuration,
 		)
-		require.NoError(t, err)
 
 		debugLogs = obs.FilterLevelExact(zapcore.DebugLevel).TakeAll()
 		require.Len(t, debugLogs, 2)

--- a/pkg/component/runtime/service_command_test.go
+++ b/pkg/component/runtime/service_command_test.go
@@ -305,7 +305,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 		cmdCtx := context.Background()
 		log, obs := logger.NewTesting(t.Name())
 
-		const succeedCmdAfter = 1 * time.Second
+		const succeedCmdAfter = 2 * time.Second
 		now := time.Now()
 		exeConfig := progConfig{
 			ErrMessage:   "foo bar",

--- a/pkg/component/runtime/service_command_test.go
+++ b/pkg/component/runtime/service_command_test.go
@@ -416,7 +416,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 		require.Len(t, debugLogs, 1)
 		require.Equal(t,
 			fmt.Sprintf(
-				"no retries for command key [%d] are pending; nothing to do",
+				"no retries for command key [%s] are pending; nothing to do",
 				serviceCmdRetrier.cmdKey(exePath, nil, nil),
 			),
 			debugLogs[0].Message,
@@ -439,7 +439,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 		require.Len(t, debugLogs, 2)
 		require.Equal(t,
 			fmt.Sprintf(
-				"retries and command process for command key [%d] stopped",
+				"retries and command process for command key [%s] stopped",
 				serviceCmdRetrier.cmdKey(exePath, nil, nil),
 			),
 			debugLogs[1].Message,

--- a/pkg/component/runtime/service_command_test.go
+++ b/pkg/component/runtime/service_command_test.go
@@ -353,10 +353,12 @@ func TestExecuteServiceCommand(t *testing.T) {
 func checkRetryLogs(t *testing.T, obs *observer.ObservedLogs, exeConfig progConfig) {
 	t.Helper()
 
+	// We expect there to be at least 2 log entries as this would indicate that
+	// at least one round of retries was attempted.
 	logs := obs.TakeAll()
 	require.GreaterOrEqual(t, len(logs), 2)
+
 	for i, l := range logs {
-		t.Logf("[%s] %s", l.Level, l.Message)
 		if i%2 == 0 {
 			require.Equal(t, zapcore.ErrorLevel, l.Level)
 			require.Equal(t, exeConfig.ErrMessage, l.Message)

--- a/pkg/component/runtime/service_command_test.go
+++ b/pkg/component/runtime/service_command_test.go
@@ -240,7 +240,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 
 		// Since the service command is retried indefinitely, we need a way to
 		// stop the test within a reasonable amount of time
-		retryCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		retryCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 
 		defaultRetrySleepInitDuration := 50 * time.Millisecond

--- a/pkg/component/runtime/service_command_test.go
+++ b/pkg/component/runtime/service_command_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go.uber.org/zap/zaptest/observer"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +16,8 @@ import (
 	"testing"
 	"text/template"
 	"time"
+
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/pkg/component/spec.go
+++ b/pkg/component/spec.go
@@ -154,6 +154,5 @@ type ServiceOperationsCommandSpec struct {
 	Args                   []string         `config:"args,omitempty" yaml:"args,omitempty"`
 	Env                    []CommandEnvSpec `config:"env,omitempty" yaml:"env,omitempty"`
 	Timeout                time.Duration    `config:"timeout,omitempty" yaml:"timeout,omitempty"`
-	RetryMaxCount          uint64           `config:"retry_max_count,omitempty" yaml:"retry_max_count,omitempty"`
 	RetrySleepInitDuration time.Duration    `config:"retry_sleep_init_duration,omitempty" yaml:"retry_sleep_init_duration,omitempty"`
 }

--- a/pkg/component/spec.go
+++ b/pkg/component/spec.go
@@ -151,8 +151,12 @@ type ServiceOperationsSpec struct {
 
 // ServiceOperationsCommandSpec is the specification for execution of binaries to perform the check, install, and uninstall.
 type ServiceOperationsCommandSpec struct {
-	Args                   []string         `config:"args,omitempty" yaml:"args,omitempty"`
-	Env                    []CommandEnvSpec `config:"env,omitempty" yaml:"env,omitempty"`
-	Timeout                time.Duration    `config:"timeout,omitempty" yaml:"timeout,omitempty"`
-	RetrySleepInitDuration time.Duration    `config:"retry_sleep_init_duration,omitempty" yaml:"retry_sleep_init_duration,omitempty"`
+	Args    []string         `config:"args,omitempty" yaml:"args,omitempty"`
+	Env     []CommandEnvSpec `config:"env,omitempty" yaml:"env,omitempty"`
+	Timeout time.Duration    `config:"timeout,omitempty" yaml:"timeout,omitempty"`
+	Retry   RetryConfig
+}
+
+type RetryConfig struct {
+	InitInterval time.Duration `config:"init_interval,omitempty" yaml:"init_interval,omitempty"`
 }

--- a/pkg/component/spec.go
+++ b/pkg/component/spec.go
@@ -151,7 +151,9 @@ type ServiceOperationsSpec struct {
 
 // ServiceOperationsCommandSpec is the specification for execution of binaries to perform the check, install, and uninstall.
 type ServiceOperationsCommandSpec struct {
-	Args    []string         `config:"args,omitempty" yaml:"args,omitempty"`
-	Env     []CommandEnvSpec `config:"env,omitempty" yaml:"env,omitempty"`
-	Timeout time.Duration    `config:"timeout,omitempty" yaml:"timeout,omitempty"`
+	Args                   []string         `config:"args,omitempty" yaml:"args,omitempty"`
+	Env                    []CommandEnvSpec `config:"env,omitempty" yaml:"env,omitempty"`
+	Timeout                time.Duration    `config:"timeout,omitempty" yaml:"timeout,omitempty"`
+	RetryMaxCount          uint64           `config:"retry_max_count,omitempty" yaml:"retry_max_count,omitempty"`
+	RetrySleepInitDuration time.Duration    `config:"retry_sleep_init_duration,omitempty" yaml:"retry_sleep_init_duration,omitempty"`
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR adds the ability for service operations to be retried.  Service components can optionally specify retries for their operations in their spec files like so:

```yml
version: 2
inputs:
  - name: endpoint
    service:
      operations:
        install:
          retry:
            init_interval: 60s
```

With the above spec definition, the `install` operation of the `endpoint` service will be retried indefinitely, with the duration between retries will start at 60 seconds and grow exponentially (with some random jitter). 

If `retry_sleep_init_duration` is omitted, it will default to **20 seconds**.

The duration between retries will grow exponentially (with some random jitter) but will be capped at approximately **15 minutes**.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

In cases where a service operation may be flaky due to transient issues, it makes sense to retry the operation  indefinitely, giving it an opportunity to succeed.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
