### PR TITLE
Add support for diagnostics logging collection on k8s

### DIFF
--- a/changelog/fragments/1687251084-Fixed-diagnostics-logging-collection-on-k8s.yaml
+++ b/changelog/fragments/1687251084-Fixed-diagnostics-logging-collection-on-k8s.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fixed diagnostics logging collection on k8s
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 2905
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 2899

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -273,6 +273,13 @@ func redactKey(k string) bool {
 }
 
 func zipLogs(zw *zip.Writer, ts time.Time) error {
+	currentDir := fmt.Sprintf("%s-%s", agentName, release.ShortCommit())
+	if !paths.IsVersionHome() {
+		// running in a container with custom top path set
+		// logs are directly under top path
+		return zipLogsWithPath(paths.Home(), currentDir, true, zw, ts)
+	}
+
 	dataDir, err := os.Open(paths.Data())
 	if err != nil {
 		return err
@@ -285,7 +292,6 @@ func zipLogs(zw *zip.Writer, ts time.Time) error {
 	}
 
 	dirPrefix := fmt.Sprintf("%s-", agentName)
-	currentDir := fmt.Sprintf("%s-%s", agentName, release.ShortCommit())
 	for _, dir := range subdirs {
 		if !strings.HasPrefix(dir, dirPrefix) {
 			continue
@@ -295,7 +301,6 @@ func zipLogs(zw *zip.Writer, ts time.Time) error {
 		if err := zipLogsWithPath(path, dir, collectServices, zw, ts); err != nil {
 			return err
 		}
-
 	}
 
 	return nil


### PR DESCRIPTION
## What does this PR do?

This PR adds a support for unversioned path in diagnostics.

## Why is it important?

This is important because when running in k8s containers we are using state path so logs are not within a versioned directories. This has a side effect that resulting logs directory in a diagnostics package is empty

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

Discussed with @pierrehilbert that integration tests targeting k8s diagnostics will be part of future work.
Tested on:
- darwin/linux bare metal
- docker as a regular container 
- k8s deployment with custom state path

Fixes: #2899
