### PR TITLE
[Release] Update version to 8.9.1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -4,4 +4,4 @@
 
 package version
 
-const defaultBeatVersion = "8.9.0"
+const defaultBeatVersion = "8.9.1"


### PR DESCRIPTION
Updates references to the new release 8.9.1.

Merge after the release 8.9.0.