### PR TITLE
Isolate standalone upgrade retry test

### DIFF
--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -330,7 +330,7 @@ func (s *StandaloneUpgradeTestSuite) TestUpgradeStandaloneElasticAgentToSnapshot
 func TestStandaloneUpgradeRetryDownload(t *testing.T) {
 	info := define.Require(t, define.Requirements{
 		Local:   false, // requires Agent installation
-		Isolate: false,
+		Isolate: true,
 		Sudo:    true, // requires Agent installation and modifying /etc/hosts
 		OS: []define.OS{
 			{Type: define.Linux},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR isolates the `TestStandaloneUpgradeRetryDownload` E2E test.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

This test is consistently failing when run along with other E2E/integration tests.  However, it passes when the test is run just by itself.  While we investigate what's going on, we can run this test in an isolated fashion, thus allowing all tests to be run and enabled for PR builds in CI.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
