### PR TITLE
[Integration Testing Framework] Randomize test order

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -1416,7 +1416,10 @@ func (Integration) TestOnRemote(ctx context.Context) error {
 			JUnitReportFile: fileName + ".xml",
 			Packages:        []string{packageName},
 			Tags:            []string{"integration"},
-			ExtraFlags:      []string{"-test.run", strings.Join(packageTests, "|")},
+			ExtraFlags: []string{
+				"-test.run", strings.Join(packageTests, "|"),
+				"-test.shuffle", "on",
+			},
 			Env: map[string]string{
 				"AGENT_VERSION":      version,
 				"TEST_DEFINE_PREFIX": testPrefix,


### PR DESCRIPTION
## What does this PR do?

This PR randomizes the order in which a batch of tests from the same package are run.

## Why is it important?

It will help ensure that we (test authors) don't inadvertently introduce dependencies between tests.
