### PR TITLE
[Cloud Security] Support GCP CSPM integration

### DIFF
--- a/specs/cloudbeat.spec.yml
+++ b/specs/cloudbeat.spec.yml
@@ -50,6 +50,11 @@ inputs:
     platforms: *platforms
     outputs: *outputs
     command: *command
+  - name: cloudbeat/cis_gcp
+    description: "CIS GCP monitoring"
+    platforms: *platforms
+    outputs: *outputs
+    command: *command
   - name: cloudbeat/vuln_mgmt_aws
     description: "AWS Vulnerabilities management"
     platforms: *platforms


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
As part of the CSPM for GCP epic, a new integration will trigger Cloudbeat to assess misconfiguration in the client's GCP account. This PR adds support for a new input type named `cloudbeat/cis_gcp`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test
## Related issues
- https://github.com/elastic/cloudbeat/issues/769
