### PR TITLE
Agent hash workaround for upgrade to snapshot integration test

### DIFF
--- a/pkg/testing/fetcher_artifact.go
+++ b/pkg/testing/fetcher_artifact.go
@@ -97,7 +97,7 @@ func (r *artifactResult) Name() string {
 
 // Fetch performs the actual fetch into the provided directory.
 func (r *artifactResult) Fetch(ctx context.Context, l Logger, dir string) error {
-	err := downloadPackage(ctx, l, r.doer, r.src, filepath.Join(dir, r.path))
+	err := DownloadPackage(ctx, l, r.doer, r.src, filepath.Join(dir, r.path))
 	if err != nil {
 		return fmt.Errorf("failed to download %s: %w", r.src, err)
 	}
@@ -165,7 +165,7 @@ func findURI(ctx context.Context, doer httpDoer, version string) (string, error)
 	return "", fmt.Errorf("uri not detected")
 }
 
-func downloadPackage(ctx context.Context, l Logger, doer httpDoer, downloadPath string, packageFile string) error {
+func DownloadPackage(ctx context.Context, l Logger, doer httpDoer, downloadPath string, packageFile string) error {
 	l.Logf("Downloading artifact from %s", downloadPath)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", downloadPath, nil)

--- a/pkg/testing/tools/artifacts_api.go
+++ b/pkg/testing/tools/artifacts_api.go
@@ -43,11 +43,14 @@ type VersionBuilds struct {
 }
 
 type Package struct {
-	URL        string `json:"url"`
-	ShaURL     string `json:"sha_url"`
-	AscURL     string `json:"asc_url"`
-	Type       string `json:"type"`
-	Attributes struct {
+	URL          string   `json:"url"`
+	ShaURL       string   `json:"sha_url"`
+	AscURL       string   `json:"asc_url"`
+	Type         string   `json:"type"`
+	Architecture string   `json:"architecture"`
+	Os           []string `json:"os"`
+	Classifier   string   `json:"classifier"`
+	Attributes   struct {
 		ArtifactNoKpi string `json:"artifactNoKpi"`
 		Internal      string `json:"internal"`
 		ArtifactID    string `json:"artifact_id"`

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -9,8 +9,11 @@ package integration
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -275,11 +278,20 @@ func (s *StandaloneUpgradeTestSuite) TestUpgradeStandaloneElasticAgentToSnapshot
 	buildDetails, err := aac.GetBuildDetails(ctx, latestSnapshotVersion.VersionWithPrerelease(), upgradeVersionString)
 	s.Require().NoErrorf(err, "error accessing build details for version %q and buildID %q", latestSnapshotVersion.Original(), upgradeVersionString)
 	s.Require().NotNil(buildDetails)
-	agentBuildDetails, ok := buildDetails.Build.Projects["elastic-agent"]
+	agentProject, ok := buildDetails.Build.Projects["elastic-agent"]
 	s.Require().Truef(ok, "elastic agent project not found in version %q build %q", latestSnapshotVersion.Original(), upgradeVersionString)
-	s.T().Logf("agent build details: %+v", agentBuildDetails)
-	s.T().Logf("expected agent commit hash: %q", agentBuildDetails.CommitHash)
-	expectedAgentHashAfterUpgrade := agentBuildDetails.CommitHash
+	s.T().Logf("agent build details: %+v", agentProject)
+	s.T().Logf("expected agent commit hash: %q", agentProject.CommitHash)
+	expectedAgentHashAfterUpgrade := agentProject.CommitHash
+
+	// Workaround until issue with Artifact API build commit hash are resolved
+	actualAgentHashAfterUpgrade := extractCommitHashFromArtifact(s.T(), ctx, latestSnapshotVersion, agentProject)
+	s.Require().NotEmpty(actualAgentHashAfterUpgrade)
+
+	s.T().Logf("Artifact API hash: %q Actual package hash: %q", expectedAgentHashAfterUpgrade, actualAgentHashAfterUpgrade)
+
+	// override the expected hash with the one extracted from the actual artifact
+	expectedAgentHashAfterUpgrade = actualAgentHashAfterUpgrade
 
 	buildFragments := strings.Split(upgradeVersionString, "-")
 	s.Require().Lenf(buildFragments, 2, "version %q returned by artifact api is not in format <version>-<buildID>", upgradeVersionString)
@@ -309,7 +321,7 @@ func (s *StandaloneUpgradeTestSuite) TestUpgradeStandaloneElasticAgentToSnapshot
 		}
 		s.T().Logf("current agent state: %+v", state)
 		return state.Info.Commit == expectedAgentHashAfterUpgrade && state.State == cproto.State_HEALTHY
-	}, 10*time.Minute, 1*time.Second, "agent never upgraded to expected version")
+	}, 5*time.Minute, 1*time.Second, "agent never upgraded to expected version")
 
 	updateMarkerFile := filepath.Join(paths.DefaultBasePath, "Elastic", "Agent", "data", ".update-marker")
 
@@ -326,6 +338,37 @@ func (s *StandaloneUpgradeTestSuite) TestUpgradeStandaloneElasticAgentToSnapshot
 	// version, err := c.Version(ctx)
 	// s.Require().NoError(err, "error checking version after upgrade")
 	// s.Require().Equal(expectedAgentHashAfterUpgrade, version.Commit, "agent commit hash changed after upgrade")
+}
+
+func extractCommitHashFromArtifact(t *testing.T, ctx context.Context, artifactVersion *version.ParsedSemVer, agentProject tools.Project) string {
+	tmpDownloadDir := t.TempDir()
+
+	operatingSystem := runtime.GOOS
+	architecture := runtime.GOARCH
+	suffix, err := atesting.GetPackageSuffix(operatingSystem, architecture)
+	require.NoErrorf(t, err, "error determining suffix for OS %q and arch %q", operatingSystem, architecture)
+	prefix := fmt.Sprintf("elastic-agent-%s", artifactVersion.VersionWithPrerelease())
+	pkgName := fmt.Sprintf("%s-%s", prefix, suffix)
+	require.Containsf(t, agentProject.Packages, pkgName, "Artifact API response does not contain pkg %s", pkgName)
+	artifactFilePath := filepath.Join(tmpDownloadDir, pkgName)
+	err = atesting.DownloadPackage(ctx, t, http.DefaultClient, agentProject.Packages[pkgName].URL, artifactFilePath)
+	require.NoError(t, err, "error downloading package")
+	err = atesting.ExtractArtifact(t, artifactFilePath, tmpDownloadDir)
+	require.NoError(t, err, "error extracting artifact")
+	extractedDir := ""
+	entries, err := os.ReadDir(tmpDownloadDir)
+	require.NoError(t, err, "unable to read temp directory")
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), "elastic-agent-") {
+			extractedDir = e.Name()
+			break
+		}
+	}
+	hashFilePath := filepath.Join(tmpDownloadDir, extractedDir, ".build_hash.txt")
+	t.Logf("Accessing hash file %q", hashFilePath)
+	hashBytes, err := os.ReadFile(hashFilePath)
+	require.NoError(t, err, "error reading build hash")
+	return strings.TrimSpace(string(hashBytes))
 }
 
 func TestStandaloneUpgradeRetryDownload(t *testing.T) {

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -277,7 +277,8 @@ func (s *StandaloneUpgradeTestSuite) TestUpgradeStandaloneElasticAgentToSnapshot
 	s.Require().NotNil(buildDetails)
 	agentBuildDetails, ok := buildDetails.Build.Projects["elastic-agent"]
 	s.Require().Truef(ok, "elastic agent project not found in version %q build %q", latestSnapshotVersion.Original(), upgradeVersionString)
-
+	s.T().Logf("agent build details: %+v", agentBuildDetails)
+	s.T().Logf("expected agent commit hash: %q", agentBuildDetails.CommitHash)
 	expectedAgentHashAfterUpgrade := agentBuildDetails.CommitHash
 
 	buildFragments := strings.Split(upgradeVersionString, "-")

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -355,16 +355,12 @@ func extractCommitHashFromArtifact(t *testing.T, ctx context.Context, artifactVe
 	require.NoError(t, err, "error downloading package")
 	err = atesting.ExtractArtifact(t, artifactFilePath, tmpDownloadDir)
 	require.NoError(t, err, "error extracting artifact")
-	extractedDir := ""
-	entries, err := os.ReadDir(tmpDownloadDir)
-	require.NoError(t, err, "unable to read temp directory")
-	for _, e := range entries {
-		if e.IsDir() && strings.HasPrefix(e.Name(), "elastic-agent-") {
-			extractedDir = e.Name()
-			break
-		}
-	}
-	hashFilePath := filepath.Join(tmpDownloadDir, extractedDir, ".build_hash.txt")
+
+	matches, err := filepath.Glob(filepath.Join(tmpDownloadDir, "elastic-agent-*", ".build_hash.txt"))
+	require.NoError(t, err)
+	require.NotEmpty(t, matches)
+
+	hashFilePath := matches[0]
 	t.Logf("Accessing hash file %q", hashFilePath)
 	hashBytes, err := os.ReadFile(hashFilePath)
 	require.NoError(t, err, "error reading build hash")


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR  introduces a way to read the hash of the agent version we are upgrading to from the `.build_hash.txt` of the actual artifact instead of relying on the hash provided by artifact API. This is temporary until the hash from artifact API becomes reliable again.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
We want to avoid random failures of integration test `TestStandaloneUpgrade` due to artifact API reporting an incorrect hash
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally
Apply the attached patch file which forces the upgrade to a specific snapshot build that has mismatched hash in artifact api and test with and without the changes in this PR while running a single integration test
` AGENT_VERSION="8.9.0-SNAPSHOT" mage integration:single TestStandaloneUpgrade`

[test_hash_workaround.patch.txt](https://github.com/elastic/elastic-agent/files/11834695/test_hash_workaround.patch.txt)

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
