### PR TITLE
[Integration Test Framework] Disable timeout for test binary execution

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -1419,6 +1419,7 @@ func (Integration) TestOnRemote(ctx context.Context) error {
 			ExtraFlags: []string{
 				"-test.run", strings.Join(packageTests, "|"),
 				"-test.shuffle", "on",
+				"-test.timeout", "0",
 			},
 			Env: map[string]string{
 				"AGENT_VERSION":      version,

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -330,7 +330,7 @@ func (s *StandaloneUpgradeTestSuite) TestUpgradeStandaloneElasticAgentToSnapshot
 func TestStandaloneUpgradeRetryDownload(t *testing.T) {
 	info := define.Require(t, define.Requirements{
 		Local:   false, // requires Agent installation
-		Isolate: true,
+		Isolate: false,
 		Sudo:    true, // requires Agent installation and modifying /etc/hosts
 		OS: []define.OS{
 			{Type: define.Linux},


### PR DESCRIPTION
## What does this PR do?

This PR disables the timeout for executing the test binary used in integration/E2E tests.

## Why is it important?

Some integration/E2E tests can take a few minutes to run.  Moreover, the integration test runner will try to run such tests in a group (for all tests in the same package with `Isolate: false`).  As such, the total runtime of such a group of tests may exceed `go test`'s default timeout for the test binary, which is 10 minutes.
