### PR TITLE
Make upgrade watcher configurable

### DIFF
--- a/internal/pkg/agent/application/upgrade/crash_checker_test.go
+++ b/internal/pkg/agent/application/upgrade/crash_checker_test.go
@@ -133,7 +133,7 @@ func testableChecker(t *testing.T, pider *testPider) (*CrashChecker, chan error)
 	ch, err := NewCrashChecker(context.Background(), errChan, l)
 	require.NoError(t, err)
 
-	ch.checkPeriod = testCheckPeriod
+	ch.checkInterval = testCheckPeriod
 	ch.sc.Close()
 	ch.sc = pider
 

--- a/internal/pkg/agent/application/upgrade/crash_checker_test.go
+++ b/internal/pkg/agent/application/upgrade/crash_checker_test.go
@@ -130,10 +130,9 @@ func TestChecker(t *testing.T) {
 func testableChecker(t *testing.T, pider *testPider) (*CrashChecker, chan error) {
 	errChan := make(chan error, 1)
 	l, _ := logger.New("", false)
-	ch, err := NewCrashChecker(context.Background(), errChan, l)
+	ch, err := NewCrashChecker(context.Background(), errChan, l, testCheckPeriod)
 	require.NoError(t, err)
 
-	ch.checkInterval = testCheckPeriod
 	ch.sc.Close()
 	ch.sc = pider
 

--- a/internal/pkg/agent/application/upgrade/error_checker.go
+++ b/internal/pkg/agent/application/upgrade/error_checker.go
@@ -19,7 +19,6 @@ import (
 )
 
 const (
-	statusCheckPeriod        = 30 * time.Second
 	statusCheckMissesAllowed = 4 // enable 2 minute start
 )
 
@@ -32,15 +31,17 @@ type ErrorChecker struct {
 	notifyChan      chan error
 	log             *logger.Logger
 	agentClient     client.Client
+	checkInterval   time.Duration
 }
 
 // NewErrorChecker creates a new error checker.
-func NewErrorChecker(ch chan error, log *logger.Logger) (*ErrorChecker, error) {
+func NewErrorChecker(ch chan error, log *logger.Logger, checkInterval time.Duration) (*ErrorChecker, error) {
 	c := client.New()
 	ec := &ErrorChecker{
-		notifyChan:  ch,
-		agentClient: c,
-		log:         log,
+		notifyChan:    ch,
+		agentClient:   c,
+		log:           log,
+		checkInterval: checkInterval,
 	}
 
 	return ec, nil
@@ -50,7 +51,7 @@ func NewErrorChecker(ch chan error, log *logger.Logger) (*ErrorChecker, error) {
 func (ch *ErrorChecker) Run(ctx context.Context) {
 	ch.log.Debug("Error checker started")
 	for {
-		t := time.NewTimer(statusCheckPeriod)
+		t := time.NewTimer(ch.checkInterval)
 		select {
 		case <-ctx.Done():
 			t.Stop()

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -7,12 +7,13 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"os"
 	"os/signal"
 	"runtime"
 	"syscall"
 	"time"
+
+	"github.com/elastic/elastic-agent/internal/pkg/config"
 
 	"github.com/spf13/cobra"
 

--- a/internal/pkg/agent/configuration/settings.go
+++ b/internal/pkg/agent/configuration/settings.go
@@ -20,7 +20,8 @@ type SettingsConfig struct {
 	GRPC             *GRPCConfig                     `yaml:"grpc" config:"grpc" json:"grpc"`
 	MonitoringConfig *monitoringCfg.MonitoringConfig `yaml:"monitoring" config:"monitoring" json:"monitoring"`
 	LoggingConfig    *logger.Config                  `yaml:"logging,omitempty" config:"logging,omitempty" json:"logging,omitempty"`
-
+	Upgrade          *UpgradeConfig                  `yaml:"upgrade" config:"upgrade" json:"upgrade"
+`
 	// standalone config
 	Reload              *ReloadConfig `config:"reload" yaml:"reload" json:"reload"`
 	Path                string        `config:"path" yaml:"path" json:"path"`
@@ -35,6 +36,7 @@ func DefaultSettingsConfig() *SettingsConfig {
 		LoggingConfig:       logger.DefaultLoggingConfig(),
 		MonitoringConfig:    monitoringCfg.DefaultConfig(),
 		GRPC:                DefaultGRPCConfig(),
+		Upgrade:             DefaultUpgradeConfig(),
 		Reload:              DefaultReloadConfig(),
 		V1MonitoringEnabled: true,
 	}

--- a/internal/pkg/agent/configuration/settings.go
+++ b/internal/pkg/agent/configuration/settings.go
@@ -20,8 +20,8 @@ type SettingsConfig struct {
 	GRPC             *GRPCConfig                     `yaml:"grpc" config:"grpc" json:"grpc"`
 	MonitoringConfig *monitoringCfg.MonitoringConfig `yaml:"monitoring" config:"monitoring" json:"monitoring"`
 	LoggingConfig    *logger.Config                  `yaml:"logging,omitempty" config:"logging,omitempty" json:"logging,omitempty"`
-	Upgrade          *UpgradeConfig                  `yaml:"upgrade" config:"upgrade" json:"upgrade"
-`
+	Upgrade          *UpgradeConfig                  `yaml:"upgrade" config:"upgrade" json:"upgrade"`
+
 	// standalone config
 	Reload              *ReloadConfig `config:"reload" yaml:"reload" json:"reload"`
 	Path                string        `config:"path" yaml:"path" json:"path"`

--- a/internal/pkg/agent/configuration/upgrade.go
+++ b/internal/pkg/agent/configuration/upgrade.go
@@ -1,0 +1,23 @@
+package configuration
+
+import "time"
+
+// period during which we monitor for failures resulting in a rollback
+const defaultGracePeriodDuration = 10 * time.Minute
+
+// UpgradeConfig is the configuration related to Agent upgrades.
+type UpgradeConfig struct {
+	Watcher *UpgradeWatcherConfig `yaml:"watcher" config:"watcher" json:"watcher"`
+}
+
+type UpgradeWatcherConfig struct {
+	GracePeriod time.Duration `yaml:"grace_period" config:"grace_period" json:"grace_period"`
+}
+
+func DefaultUpgradeConfig() *UpgradeConfig {
+	return &UpgradeConfig{
+		Watcher: &UpgradeWatcherConfig{
+			GracePeriod: defaultGracePeriodDuration,
+		},
+	}
+}

--- a/internal/pkg/agent/configuration/upgrade.go
+++ b/internal/pkg/agent/configuration/upgrade.go
@@ -6,8 +6,16 @@ package configuration
 
 import "time"
 
-// period during which we monitor for failures resulting in a rollback
-const defaultGracePeriodDuration = 10 * time.Minute
+const (
+	// period during which we monitor for failures resulting in a rollback.
+	defaultGracePeriodDuration = 10 * time.Minute
+
+	// interval between checks for new (upgraded) Agent returning an error status.
+	defaultStatusCheckInterval = 30 * time.Second
+
+	// interval between checks for new (upgraded) Agent crashing.
+	defaultCrashCheckInterval = 10 * time.Second
+)
 
 // UpgradeConfig is the configuration related to Agent upgrades.
 type UpgradeConfig struct {
@@ -15,13 +23,24 @@ type UpgradeConfig struct {
 }
 
 type UpgradeWatcherConfig struct {
-	GracePeriod time.Duration `yaml:"grace_period" config:"grace_period" json:"grace_period"`
+	GracePeriod time.Duration             `yaml:"grace_period" config:"grace_period" json:"grace_period"`
+	ErrorCheck  UpgradeWatcherCheckConfig `yaml:"error_check" config:"error_check" json:"error_check"`
+	CrashCheck  UpgradeWatcherCheckConfig `yaml:"crash_check" config:"crash_check" json:"crash_check"`
+}
+type UpgradeWatcherCheckConfig struct {
+	Interval time.Duration `yaml:"interval" config:"interval" json:"interval"`
 }
 
 func DefaultUpgradeConfig() *UpgradeConfig {
 	return &UpgradeConfig{
 		Watcher: &UpgradeWatcherConfig{
 			GracePeriod: defaultGracePeriodDuration,
+			ErrorCheck: UpgradeWatcherCheckConfig{
+				Interval: defaultStatusCheckInterval,
+			},
+			CrashCheck: UpgradeWatcherCheckConfig{
+				Interval: defaultCrashCheckInterval,
+			},
 		},
 	}
 }

--- a/internal/pkg/agent/configuration/upgrade.go
+++ b/internal/pkg/agent/configuration/upgrade.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package configuration
 
 import "time"

--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -131,9 +131,10 @@ func (f *Fixture) Client() client.Client {
 
 // Prepare prepares the Elastic Agent for usage.
 //
-// This must be called before `Run` or `Install` can be called. `components` defines the components that you want to
-// be prepared for the Elastic Agent. See the definition on defining usable components on the `UsableComponent`
-// structure.
+// This must be called before `Configure`, `Run`, or `Install` can be called.
+// `components` defines the components that you want to be prepared for the
+// Elastic Agent. See the definition on defining usable components on the
+// `UsableComponent` structure.
 //
 // Note: If no `components` are defined then the Elastic Agent will keep all the components that are shipped with the
 // fetched build of the Elastic Agent.
@@ -167,6 +168,19 @@ func (f *Fixture) Prepare(ctx context.Context, components ...UsableComponent) er
 	}
 	f.workDir = finalDir
 	return nil
+}
+
+// Configure replaces the default Agent configuration file with the provided
+// configuration. This must be called after `Prepare` is called but before `Run`
+// or `Install` can be called.
+func (f *Fixture) Configure(ctx context.Context, yamlConfig []byte) error {
+	err := f.ensurePrepared(ctx)
+	if err != nil {
+		return err
+	}
+
+	cfgFilePath := filepath.Join(f.workDir, "elastic-agent.yml")
+	return os.WriteFile(cfgFilePath, yamlConfig, 0600)
 }
 
 func ExtractArtifact(l Logger, artifactFile, outputDir string) error {

--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -183,6 +183,12 @@ func (f *Fixture) Configure(ctx context.Context, yamlConfig []byte) error {
 	return os.WriteFile(cfgFilePath, yamlConfig, 0600)
 }
 
+// WorkDir returns the installed fixture's work dir AKA base dir AKA top dir. This
+// must be called after `Install` is called.
+func (f *Fixture) WorkDir() string {
+	return f.workDir
+}
+
 func ExtractArtifact(l Logger, artifactFile, outputDir string) error {
 	filename := filepath.Base(artifactFile)
 	_, ext, err := splitFileType(filename)

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -86,7 +86,18 @@ func (s *FleetManagedUpgradeTestSuite) SetupSuite() {
 		s.agentFromVersion,
 		atesting.WithFetcher(atesting.ArtifactFetcher()),
 	)
-	require.NoError(s.T(), err)
+	s.Require().NoError(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = agentFixture.Prepare(ctx)
+	s.Require().NoError(err, "error preparing agent fixture")
+
+	agentTestCfg := `agent.upgrade.watcher.grace_period: 30s`
+	err = agentFixture.Configure(ctx, []byte(agentTestCfg))
+	s.Require().NoError(err, "error configuring agent fixture")
+
 	s.agentFixture = agentFixture
 }
 
@@ -435,6 +446,11 @@ func (s *StandaloneUpgradeRetryDownloadTestSuite) SetupSuite() {
 
 	err = agentFixture.Prepare(ctx)
 	s.Require().NoError(err, "error preparing agent fixture")
+
+	agentTestCfg := `agent.upgrade.watcher.grace_period: 30s`
+	err = agentFixture.Configure(ctx, []byte(agentTestCfg))
+	s.Require().NoError(err, "error configuring agent fixture")
+
 	s.agentFixture = agentFixture
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR introduces a new `agent.upgrade` section in the Elastic Agent configuration file.  Initially, this section can be used to override the Upgrade Watcher's settings like so:

```yml
agent.upgrade:
  watcher:
    grace_period: 1m
    error_check:
      interval: 15s
    crash_check:
      interval: 15s
```

The default values of these settings are the same as they were before the changes in this PR.

This PR also introduces a new method on the `testing.Fixture` struct: 

```go
// Configure replaces the default Agent configuration file with the provided
// configuration. This must be called after `Prepare` is called but before `Run`
// or `Install` can be called.
func (f *Fixture) Configure(ctx context.Context, yamlConfig []byte) error {
```

This new method will allow tests to replace the default contents of the `elastic-agent.yml` file for the Agent fixture under test with the provided configuration (`yamlConfig`). 


<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To allow tests to configure the Agent as desired for testing purposes.  For example, upgrade tests may want to reduce the Upgrade Watcher's grace period from the default of 10 minutes to something much shorter, say 30 seconds, for tests to complete in a reasonable amount of time.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [x] I have added an integration test or an E2E test

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #2796
