### PR TITLE
Remove noisy deprecation warnings from build actions

### DIFF
--- a/internal/pkg/agent/vault/vault_darwin.c
+++ b/internal/pkg/agent/vault/vault_darwin.c
@@ -59,8 +59,6 @@ OSStatus CreateAccessWithUid(uid_t uid, SecAccessRef * ret_access) {
     return SecAccessCreateFromOwnerAndACL(&owner, 1, &acls, ret_access);
 }
 
-#pragma clang diagnostic pop
-
 OSStatus OpenKeychain(SecKeychainRef keychain) {
     OSStatus status = SecKeychainSetPreferenceDomain(kSecPreferencesDomainSystem);
     if (status == noErr) {
@@ -205,6 +203,8 @@ OSStatus RemoveKeychainItem(SecKeychainRef keychain, const char *name, const cha
 
     return status;
 }
+
+#pragma clang diagnostic pop
 
 char* GetOSStatusMessage(OSStatus status) {
     CFStringRef s = SecCopyErrorMessageString(status, NULL);


### PR DESCRIPTION
As pointed out in https://github.com/elastic/elastic-agent/issues/2639, building and testing on mac produces a lot of noisy deprecation warnings. While the real solution is to migrate to a current API (followup issue: https://github.com/elastic/elastic-agent/issues/2961), this PR suppresses deprecation warnings for the specific file that is causing this issue. (These warnings were already suppressed within that file, but only for a specific function; this PR extends that to cover all relevant sections of the code.)

This PR doesn't change any behavior, it just suppresses build warnings within a specific C file.

Fixes https://github.com/elastic/elastic-agent/issues/2639

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~
