### PR TITLE
Adjust timeouts to remove flakiness from test

### DIFF
--- a/pkg/component/runtime/service_command_test.go
+++ b/pkg/component/runtime/service_command_test.go
@@ -312,7 +312,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 
 		// Since the service command is retried indefinitely, we need a way to
 		// stop the test within a reasonable amount of time
-		retryCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		retryCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 
 		defaultRetryInitInterval := 50 * time.Millisecond

--- a/pkg/component/runtime/service_command_test.go
+++ b/pkg/component/runtime/service_command_test.go
@@ -356,7 +356,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 		// Since the service command is retried indefinitely, we need a way to
 		// stop the test within a reasonable amount of time. However, we should never
 		// hit this timeout as the command should succeed before the timeout is reached.
-		retryCtx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		retryCtx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
 		defer cancel()
 
 		defaultRetryInitInterval := 50 * time.Millisecond
@@ -378,7 +378,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 		}
 		require.Eventually(t, func() bool {
 			return obs.Filter(successMsgFilterFn).Len() == 1
-		}, 4*time.Second, 1*time.Second)
+		}, 5*time.Second, 1*time.Second)
 
 		require.NoError(t, retryCtx.Err())
 

--- a/pkg/component/runtime/service_command_test.go
+++ b/pkg/component/runtime/service_command_test.go
@@ -343,7 +343,7 @@ func TestExecuteServiceCommand(t *testing.T) {
 		cmdCtx := context.Background()
 		log, obs := logger.NewTesting(t.Name())
 
-		const succeedCmdAfter = 2 * time.Second
+		const succeedCmdAfter = 3 * time.Second
 		now := time.Now()
 		exeConfig := progConfig{
 			ErrMessage:   "foo bar",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR adjusts timeouts in the `TestExecuteServiceCommand` test so it's not flaky on Windows in CI.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

The test appears to be flaky on Windows in CI.  For example:

https://fleet-ci.elastic.co/blue/organizations/jenkins/elastic-agent%2Felastic-agent-mbp/detail/main/1133/pipeline

I thought I had resolved the flakiness in the [PR that introduced the test](https://github.com/elastic/elastic-agent/pull/2889#issuecomment-1613868864) but apparently not so.  So this PR is another attempt at adjusting the timeouts for this test so it passes consistently on Windows in CI.

FWIW, I ran the test (after the changes in this PR) a 100 times locally on my Mac and it passed every time:

```
$ go test ./pkg/component/runtime/... -test.run TestExecuteServiceCommand/succeed_after_retry -test.count 100
ok  	github.com/elastic/elastic-agent/pkg/component/runtime	309.211s
```

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
