### PR TITLE
Downgrade _two_ minors in integration test

### DIFF
--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -381,7 +381,12 @@ func TestStandaloneUpgradeRetryDownload(t *testing.T) {
 	currentVersion, err := version.ParseVersion(define.Version())
 	require.NoError(t, err)
 
+	// We go back TWO minors because sometimes we are in a situation where
+	// the current version has been advanced to the next release (e.g. 8.10.0)
+	// but the version before that (e.g. 8.9.0) hasn't been released yet.
 	previousVersion, err := currentVersion.GetPreviousMinor()
+	require.NoError(t, err)
+	previousVersion, err = previousVersion.GetPreviousMinor()
 	require.NoError(t, err)
 
 	// For testing the upgrade we actually perform a downgrade


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR updates the `TestStandaloneUpgradeRetryDownload` integration test to downgrade from the current (locally-built) Agent version to _two_ minor versions ago (instead of just _one_ minor version ago).

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Every so often, we find ourselves in a situation where the current (local) [version](https://github.com/elastic/elastic-agent/blob/a3403e5ec52b80fccb05b5c165e4f6372702f9ee/version/version.go#L7) of Agent has been bumped up, e.g. `8.10.0` but the previous minor version, e.g. `8.9.0`, has not yet been released.  So, to be safe, the test should downgrade from the current (locally-built) version of Agent to two minor versions ago.

In case you're wondering why the test attempts a _downgrade_ instead of an upgrade, it's because it's a lot simpler to calculate past version numbers from the current version than it is to figure out what the latest released version might be so we can upgrade to it from an older version.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~
