### PR TITLE
Added verification fallback to https://artifacts.elastic.co/GPG-KEY-elastic-agent

### DIFF
--- a/internal/pkg/agent/application/upgrade/step_download_test.go
+++ b/internal/pkg/agent/application/upgrade/step_download_test.go
@@ -30,6 +30,28 @@ func (md *mockDownloader) Download(ctx context.Context, agentArtifact artifact.A
 	return md.downloadPath, md.downloadErr
 }
 
+func TestFallbackIsAppended(t *testing.T) {
+	testCases := []struct {
+		name        string
+		passedBytes []string
+		expectedLen int
+	}{
+		{"nil input", nil, 1},
+		{"empty input", []string{}, 1},
+		{"valid input", []string{"pgp-bytes"}, 2},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := appendFallbackPGP(tc.passedBytes)
+			// check default fallback is passed and is very last
+			require.NotNil(t, res)
+			require.Equal(t, tc.expectedLen, len(res))
+			require.Equal(t, download.PgpSourceURIPrefix+defaultUpgradeFallbackPGP, res[len(res)-1])
+		})
+	}
+}
+
 func TestDownloadWithRetries(t *testing.T) {
 	expectedDownloadPath := "https://artifacts.elastic.co/downloads/beats/elastic-agent"
 	testLogger, obs := logger.NewTesting("TestDownloadWithRetries")


### PR DESCRIPTION
## What does this PR do?

This PRs adds a fallback to a downloader. When downloadArtifact is called, it appends a fallback key into a passed keys collection.
This key is used as a last resort for signature verification of downloaded packages and is useful when embedded key is no longer used. 
This option is used regardless of mode in which ugprade was triggered let it be standalone CLI trigger or managed action. 
 
## Why is it important?

Option to support older agents when keys are rotated.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## How to test this

- temper embedded key
- build agent locally
- install built agent (managed)
- try to upgrade 
- should pass (first verification with embedded key fails, fallback should be fine)
