### PR TITLE
Adding generic_logs template for hints autodiscovery

### DIFF
--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/generic_logs.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/generic_logs.yml
@@ -1,0 +1,23 @@
+inputs:
+  - name: filestream-generic
+    id: hints-container-logs-${kubernetes.hints.container_id}
+    type: filestream
+    use_output: default
+    streams:
+      - condition: ${kubernetes.hints.generic_logs.container_logs.enabled} == true
+        data_stream:
+          dataset: kubernetes.container_logs
+          type: logs
+        exclude_files: [ ]
+        exclude_lines: [ ]
+        parsers:
+          - container:
+              format: auto
+              stream: ${kubernetes.hints.generic_logs.container_logs.stream|'all'}
+        paths:
+          - /var/log/containers/*${kubernetes.hints.container_id}.log
+        prospector:
+          scanner:
+            symlinks: true
+        tags: [ ]
+    data_stream.namespace: default


### PR DESCRIPTION
- Enhancement

## What does this PR do?

This PR adds the generic_logs template that needs to be used in an Elastic Agent Standalone scenario in order to support by default the container log processing.

This PR is the continuation of https://github.com/elastic/elastic-agent/pull/2386#issue-1635190424 in order to add the missing template needed to support the default behaviour of collection of logs

## Why is it important?

It is important in order to allow log collection for k8s pods for the hints aytodiscovery scenario
Relevant documentation PR is added here: https://github.com/elastic/ingest-docs/pull/304/files

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test


## How to test this PR locally

1. Install a local kubernetes cluster with kind
2. Create your stack `elastic-package stack up -d -vvv --version=8.8.1`
3. Download and install the elastic-agent-standalone manifest with the changes described in the documentation PR

Enabling hints in the kubernetes standalone manifest: 
```yaml
providers.kubernetes:
  node: ${NODE_NAME}
  scope: node
  hints:
    enabled: true
    default_container_logs: false 
```

Example to manually mount the needed generic_logs template under the inputs.d folder of Elastic Agent
```yaml
volumeMounts:
- name: external-inputs
  mountPath: /etc/elastic-agent/inputs.d/generic_logs.yml
...
volumes:
- name: external-inputs
  hostPath:
    path: /var/log/test/generic_logs.yml
```

4. Install agent manifest
5. Install nginx manifest
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: nginx
  name: nginx
  namespace: default
spec:
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
      annotations:
        co.elastic.hints/package: "generic_logs.container_logs"
        co.elastic.hints/stream: "stderr"
    spec:
      containers:
      - image: nginx
        name: nginx
```

5. Inspect the rendered configuration inside Elastic Agent
```bash
/usr/share/elastic-agent# /elastic-agent inspect -v --variables --variables-wait 2s
```

6. Exec to nginx code and produce stdout and stderror outputs:
```bash
kubectl exec -ti nginx-654557c679-rzrtt -- bash
root@nginx-654557c679-rzrtt:/# echo "stdout message" >> /proc/1/fd/1
root@nginx-654557c679-rzrtt:/# echo "stderror message" >> /proc/1/fd/2
```
7. Login to kibana and observe the stderror stream 
![Screenshot 2023-07-03 at 5 07 54 PM](https://github.com/elastic/elastic-agent/assets/1685415/ba40d083-ab1c-43dc-9bbd-aa8bd979b907)

