### PR TITLE
Add a version parameter to define.NewFixture

### DIFF
--- a/pkg/testing/define/define.go
+++ b/pkg/testing/define/define.go
@@ -63,8 +63,9 @@ func Version() string {
 	return ver
 }
 
-// NewFixture returns a new Elastic Agent testing fixture.
-func NewFixture(t *testing.T, opts ...atesting.FixtureOpt) (*atesting.Fixture, error) {
+// NewFixture returns a new Elastic Agent testing fixture with a LocalFetcher and
+// the agent logging to the test logger.
+func NewFixture(t *testing.T, version string, opts ...atesting.FixtureOpt) (*atesting.Fixture, error) {
 	buildsDir := os.Getenv("AGENT_BUILD_DIR")
 	if buildsDir == "" {
 		projectDir, err := findProjectRoot()
@@ -73,9 +74,10 @@ func NewFixture(t *testing.T, opts ...atesting.FixtureOpt) (*atesting.Fixture, e
 		}
 		buildsDir = filepath.Join(projectDir, "build", "distributions")
 	}
+
 	f := atesting.LocalFetcher(buildsDir)
 	opts = append(opts, atesting.WithFetcher(f), atesting.WithLogOutput())
-	return atesting.NewFixture(t, Version(), opts...)
+	return atesting.NewFixture(t, version, opts...)
 }
 
 // findProjectRoot finds the root directory of the project, by finding the go.mod file.

--- a/testing/integration/diagnostics_test.go
+++ b/testing/integration/diagnostics_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/elastic/elastic-agent/pkg/control/v2/client"
 	"github.com/elastic/elastic-agent/pkg/core/process"
-	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	integrationtest "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 )
@@ -68,7 +67,7 @@ type DiagnosticsIntegrationTestSuite struct {
 }
 
 func (s *DiagnosticsIntegrationTestSuite) SetupSuite() {
-	f, err := define.NewFixture(s.T())
+	f, err := define.NewFixture(s.T(), define.Version())
 	s.Require().NoError(err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -106,27 +105,27 @@ func (s *DiagnosticsIntegrationTestSuite) TestDiagnosticsFromHealthyAgent() {
 
 	err := s.f.Run(ctx, integrationtest.State{
 		Configure:  simpleConfig2,
-		AgentState: atesting.NewClientState(client.Healthy),
-		Components: map[string]atesting.ComponentState{
+		AgentState: integrationtest.NewClientState(client.Healthy),
+		Components: map[string]integrationtest.ComponentState{
 			"fake-default": {
-				State: atesting.NewClientState(client.Healthy),
-				Units: map[atesting.ComponentUnitKey]atesting.ComponentUnitState{
-					atesting.ComponentUnitKey{UnitType: client.UnitTypeOutput, UnitID: "fake-default"}: {
-						State: atesting.NewClientState(client.Healthy),
+				State: integrationtest.NewClientState(client.Healthy),
+				Units: map[integrationtest.ComponentUnitKey]integrationtest.ComponentUnitState{
+					integrationtest.ComponentUnitKey{UnitType: client.UnitTypeOutput, UnitID: "fake-default"}: {
+						State: integrationtest.NewClientState(client.Healthy),
 					},
-					atesting.ComponentUnitKey{UnitType: client.UnitTypeInput, UnitID: "fake-default-fake"}: {
-						State: atesting.NewClientState(client.Healthy),
+					integrationtest.ComponentUnitKey{UnitType: client.UnitTypeInput, UnitID: "fake-default-fake"}: {
+						State: integrationtest.NewClientState(client.Healthy),
 					},
 				},
 			},
 			"fake-shipper-default": {
-				State: atesting.NewClientState(client.Healthy),
-				Units: map[atesting.ComponentUnitKey]atesting.ComponentUnitState{
-					atesting.ComponentUnitKey{UnitType: client.UnitTypeOutput, UnitID: "fake-shipper-default"}: {
-						State: atesting.NewClientState(client.Healthy),
+				State: integrationtest.NewClientState(client.Healthy),
+				Units: map[integrationtest.ComponentUnitKey]integrationtest.ComponentUnitState{
+					integrationtest.ComponentUnitKey{UnitType: client.UnitTypeOutput, UnitID: "fake-shipper-default"}: {
+						State: integrationtest.NewClientState(client.Healthy),
 					},
-					atesting.ComponentUnitKey{UnitType: client.UnitTypeInput, UnitID: "fake-default"}: {
-						State: atesting.NewClientState(client.Healthy),
+					integrationtest.ComponentUnitKey{UnitType: client.UnitTypeInput, UnitID: "fake-default"}: {
+						State: integrationtest.NewClientState(client.Healthy),
 					},
 				},
 			},

--- a/testing/integration/enroll_test.go
+++ b/testing/integration/enroll_test.go
@@ -42,7 +42,7 @@ type EnrollRunner struct {
 
 func (runner *EnrollRunner) SetupSuite() {
 	runner.T().Logf("In SetupSuite")
-	agentFixture, err := define.NewFixture(runner.T())
+	agentFixture, err := define.NewFixture(runner.T(), define.Version())
 	runner.agentFixture = agentFixture
 	require.NoError(runner.T(), err)
 }
@@ -77,7 +77,7 @@ func (runner *EnrollRunner) TestEnroll() {
 	runner.T().Logf("created policy: %s", policy.ID)
 
 	runner.T().Cleanup(func() {
-		//After: unenroll
+		// After: unenroll
 		err = tools.UnEnrollAgent(runner.requirementsInfo.KibanaClient)
 		require.NoError(runner.T(), err)
 	})

--- a/testing/integration/fake_test.go
+++ b/testing/integration/fake_test.go
@@ -105,7 +105,7 @@ type FakeComponentIntegrationTestSuite struct {
 }
 
 func (s *FakeComponentIntegrationTestSuite) SetupSuite() {
-	f, err := define.NewFixture(s.T())
+	f, err := define.NewFixture(s.T(), define.Version())
 	s.Require().NoError(err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/testing/integration/fqdn_test.go
+++ b/testing/integration/fqdn_test.go
@@ -55,7 +55,7 @@ type FQDN struct {
 
 // Before suite
 func (s *FQDN) SetupSuite() {
-	agentFixture, err := define.NewFixture(s.T())
+	agentFixture, err := define.NewFixture(s.T(), define.Version())
 	require.NoError(s.T(), err)
 	s.agentFixture = agentFixture
 

--- a/testing/integration/install_test.go
+++ b/testing/integration/install_test.go
@@ -34,7 +34,7 @@ func TestInstallWithoutBasePath(t *testing.T) {
 	})
 
 	// Get path to Elastic Agent executable
-	fixture, err := define.NewFixture(t)
+	fixture, err := define.NewFixture(t, define.Version())
 	require.NoError(t, err)
 
 	// Prepare the Elastic Agent so the binary is extracted and ready to use.
@@ -77,7 +77,7 @@ func TestInstallWithBasePath(t *testing.T) {
 	})
 
 	// Get path to Elastic Agent executable
-	fixture, err := define.NewFixture(t)
+	fixture, err := define.NewFixture(t, define.Version())
 	require.NoError(t, err)
 
 	// Prepare the Elastic Agent so the binary is extracted and ready to use.

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -154,7 +154,7 @@ func (s *FleetManagedUpgradeTestSuite) TestUpgradeFleetManagedElasticAgent() {
 
 	// Upgrade Watcher check disabled until
 	// https://github.com/elastic/elastic-agent/issues/2977 is resolved.
-	//checkUpgradeWatcherRan(s.T(), s.agentFixture)
+	// checkUpgradeWatcherRan(s.T(), s.agentFixture)
 
 	s.T().Log("Getting Agent version...")
 	newVersion, err := tools.GetAgentVersion(kibClient)
@@ -198,9 +198,7 @@ type StandaloneUpgradeTestSuite struct {
 // Before suite
 func (s *StandaloneUpgradeTestSuite) SetupSuite() {
 
-	agentFixture, err := define.NewFixture(
-		s.T(),
-	)
+	agentFixture, err := define.NewFixture(s.T(), define.Version())
 
 	require.NoError(s.T(), err)
 
@@ -448,9 +446,7 @@ func newStandaloneUpgradeRetryDownloadTestSuite(info *define.Info, toVersion *ve
 
 // Before suite
 func (s *StandaloneUpgradeRetryDownloadTestSuite) SetupSuite() {
-	agentFixture, err := define.NewFixture(
-		s.T(),
-	)
+	agentFixture, err := define.NewFixture(s.T(), define.Version())
 	s.Require().NoError(err)
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Adds a version parameter to `define.NewFixture` which will be passed to `github.com/elastic/elastic-agent/pkg/testing.NewFixture` instead of the current local version.

## Why is it important?

`define.NewFixture` is a wrapper/sugar syntax for `github.com/elastic/elastic-agent/pkg/testing.NewFixture` but as it does not takes in the version, its usage is rather limited. Besides having two similar methods with such a difference is confusing.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~


## How to test this PR locally

Just run the integration tests, they should work as they did before.

## Related issues

- Relates #2482 

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
