### PR TITLE
Enhance local fetcher to accept versions with SNAPSHOT suffix

### DIFF
--- a/pkg/testing/fetcher_local_test.go
+++ b/pkg/testing/fetcher_local_test.go
@@ -7,7 +7,7 @@ package testing
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -21,52 +21,61 @@ func TestLocalFetcher_Name(t *testing.T) {
 	require.Equal(t, "local", f.Name())
 }
 
-func TestLocalFetcher_IgnoresSnapshot(t *testing.T) {
-	td := t.TempDir()
+func TestLocalFetcher(t *testing.T) {
+	// t.Skip()
+	baseVersion := "8.7.0"
+	snapshotContent := []byte("snapshot contents")
+	noSnapshotContent := []byte("not snapshot contents")
 
+	testdata := t.TempDir()
 	suffix, err := GetPackageSuffix(runtime.GOOS, runtime.GOARCH)
 	require.NoError(t, err)
 
-	snapshotPath := fmt.Sprintf("elastic-agent-8.7.0-SNAPSHOT-%s", suffix)
-	notSnapshotPath := fmt.Sprintf("elastic-agent-8.7.0-%s", suffix)
-	require.NoError(t, ioutil.WriteFile(filepath.Join(td, snapshotPath), []byte("snapshot contents"), 0644))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(td, notSnapshotPath), []byte("not snapshot contents"), 0644))
+	snapshotPath := fmt.Sprintf("elastic-agent-%s-SNAPSHOT-%s", baseVersion, suffix)
+	notSnapshotPath := fmt.Sprintf("elastic-agent-%s-%s", baseVersion, suffix)
+	require.NoError(t, os.WriteFile(filepath.Join(testdata, snapshotPath), snapshotContent, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(testdata, notSnapshotPath), noSnapshotContent, 0644))
 
-	f := LocalFetcher(td)
+	tcs := []struct {
+		name    string
+		version string
+		opts    []localFetcherOpt
+		want    []byte
+	}{
+		{
+			name:    "IgnoreSnapshot",
+			version: baseVersion,
+			want:    noSnapshotContent,
+		}, {
+			name:    "SnapshotOnly",
+			version: baseVersion,
+			opts:    []localFetcherOpt{WithLocalSnapshotOnly()},
+			want:    snapshotContent,
+		}, {
+			name:    "version with snapshot",
+			version: baseVersion + "-SNAPSHOT",
+			want:    snapshotContent,
+		}, {
+			name:    "version with snapshot and SnapshotOnly",
+			version: baseVersion + "-SNAPSHOT",
+			opts:    []localFetcherOpt{WithLocalSnapshotOnly()},
+			want:    snapshotContent,
+		},
+	}
 
-	tmp := t.TempDir()
-	res, err := f.Fetch(context.Background(), runtime.GOOS, runtime.GOARCH, "8.7.0")
-	require.NoError(t, err)
+	for _, tc := range tcs {
+		tmp := t.TempDir()
 
-	err = res.Fetch(context.Background(), t, tmp)
-	require.NoError(t, err)
-	content, err := ioutil.ReadFile(filepath.Join(tmp, res.Name()))
-	require.NoError(t, err)
+		f := LocalFetcher(testdata, tc.opts...)
+		got, err := f.Fetch(
+			context.Background(), runtime.GOOS, runtime.GOARCH, tc.version)
+		require.NoError(t, err)
 
-	assert.Equal(t, []byte("not snapshot contents"), content)
-}
+		err = got.Fetch(context.Background(), t, tmp)
+		require.NoError(t, err)
+		content, err := os.ReadFile(filepath.Join(tmp, got.Name()))
+		require.NoError(t, err)
 
-func TestLocalFetcher_SnapshotFirst(t *testing.T) {
-	td := t.TempDir()
-
-	suffix, err := GetPackageSuffix(runtime.GOOS, runtime.GOARCH)
-	require.NoError(t, err)
-
-	snapshotPath := fmt.Sprintf("elastic-agent-8.7.0-SNAPSHOT-%s", suffix)
-	notSnapshotPath := fmt.Sprintf("elastic-agent-8.7.0-%s", suffix)
-	require.NoError(t, ioutil.WriteFile(filepath.Join(td, snapshotPath), []byte("snapshot contents"), 0644))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(td, notSnapshotPath), []byte("not snapshot contents"), 0644))
-
-	f := LocalFetcher(td, WithLocalSnapshotOnly())
-
-	tmp := t.TempDir()
-	res, err := f.Fetch(context.Background(), runtime.GOOS, runtime.GOARCH, "8.7.0")
-	require.NoError(t, err)
-
-	err = res.Fetch(context.Background(), t, tmp)
-	require.NoError(t, err)
-	content, err := ioutil.ReadFile(filepath.Join(tmp, res.Name()))
-	require.NoError(t, err)
-
-	assert.Equal(t, []byte("snapshot contents"), content)
+		assert.Equal(t, string(tc.want), string(content))
+	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Enhance local fetcher to accept versions with SNAPSHOT suffix and avoid potentially having it trying to fetch a `-SNAPSHOT-SNAPSHOT` version.

It also changes the tests to a table test

## Why is it important?

Enhance local fetcher to accept versions with SNAPSHOT suffix and avoid potentially having it trying to fetch a `-SNAPSHOT-SNAPSHOT` version

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

 - Run all the integration tests, they should keep passing
 - create an integration test using the local fetcher and passing the version with `-SNAPSHOT`

## Related issues

- Relates #https://github.com/elastic/elastic-agent/issues/2482

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
