### PR TITLE
Add support for timestamps on runner

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -1529,6 +1529,7 @@ func createTestRunner(matrix bool, singleTest string, batches ...define.Batch) (
 	if essRegion == "" {
 		essRegion = "gcp-us-central1"
 	}
+	timestamp := timestampEnabled()
 	r, err := runner.NewRunner(runner.Config{
 		AgentVersion:      agentVersion,
 		AgentStackVersion: agentStackVersion,
@@ -1546,6 +1547,7 @@ func createTestRunner(matrix bool, singleTest string, batches ...define.Batch) (
 		Matrix:      matrix,
 		SingleTest:  singleTest,
 		VerboseMode: mg.Verbose(),
+		Timestamp:   timestamp,
 	}, batches...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create runner: %w", err)
@@ -1563,6 +1565,15 @@ func shouldBuildAgent() bool {
 		return false
 	}
 	return ret
+}
+
+func timestampEnabled() bool {
+	timestamp := os.Getenv("TEST_INTEG_TIMESTAMP")
+	if timestamp == "" {
+		return false
+	}
+	b, _ := strconv.ParseBool(timestamp)
+	return b
 }
 
 // Pre-requisite: user must have the gcloud CLI installed

--- a/pkg/testing/runner/config.go
+++ b/pkg/testing/runner/config.go
@@ -30,6 +30,9 @@ type Config struct {
 
 	// VerboseMode passed along a verbose mode flag to tests
 	VerboseMode bool
+
+	// Timestamp enables timestamps on the console output.
+	Timestamp bool
 }
 
 // Validate returns an error if the information is invalid.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds the `TEST_INTEG_TIMESTAMP=true` option to support outputting the timestamp to the console when running `mage integration:*` targets.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Allows the ability to see how long it takes for different stages.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

`TEST_INTEG_TIMESTAMP=true mage integration:test`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #2835 

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

```
[Jul  5 08:57:49.348] >>> Bring down instances through ogc
[Jul  5 08:57:58.472] >>> Pulling latest ogc image
[Jul  5 08:57:58.472] >>> Creating zip archive of repo to send to remote hosts
[Jul  5 08:57:58.472] >>> Create SSH keys to use for SSH
[Jul  5 08:58:00.991] >>> Creating ESS cloud 8.10.0-SNAPSHOT (at-blake-rouse-agent-testing-8100-SNAPSHOT)
[Jul  5 08:58:08.195] >>> Import layouts into ogc
```
