### PR TITLE
Enable timestamps in buildkite integration tests.

### DIFF
--- a/.buildkite/scripts/integration_tests.sh
+++ b/.buildkite/scripts/integration_tests.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 
 # Install Go TODO: mode to makefile
-if ! command -v go &>/dev/null; then  
+if ! command -v go &>/dev/null; then
   echo "Go is not installed. Installing Go..."
   export GO_VERSION=`cat .go-version`
   curl -O https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz
@@ -11,7 +11,7 @@ if ! command -v go &>/dev/null; then
   source ~/.bashrc
   mkdir $HOME/go
   mkdir $HOME/go/bin
-  export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin  
+  export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
   echo "Go has been installed."
 else
   echo "Go is already installed."
@@ -25,7 +25,7 @@ DEV=true EXTERNAL=true SNAPSHOT=true PLATFORMS=linux/amd64,linux/arm64 PACKAGES=
 
 # Run integration tests
 set +e
-SNAPSHOT=true mage integration:test
+TEST_INTEG_TIMESTAMP=true SNAPSHOT=true mage integration:test
 TESTS_EXIT_STATUS=$?
 set -e
 


### PR DESCRIPTION
Follow up from https://github.com/elastic/elastic-agent/pull/2998, enable integration test timestamps when they are run from buildkite.