### PR TITLE
Integration Test Framework: Fix SSH connection log message

### DIFF
--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -239,7 +239,12 @@ func (r *Runner) runMachines(ctx context.Context, sshAuth ssh.AuthMethod, repoAr
 
 // runMachine runs the batch on the machine.
 func (r *Runner) runMachine(ctx context.Context, sshAuth ssh.AuthMethod, logger Logger, repoArchive string, batch LayoutBatch, machine OGCMachine) (OSRunnerResult, error) {
-	logger.Logf("Starting SSH; connect with `ssh -i ./ogc-cache/id_rsa %s@%s`", machine.PublicIP, machine.Layout.Username)
+	sshPrivateKeyPath, err := filepath.Abs(filepath.Join(".ogc-cache", "id_rsa"))
+	if err != nil {
+		return OSRunnerResult{}, fmt.Errorf("failed to determine OGC SSH private key path: %w", err)
+	}
+
+	logger.Logf("Starting SSH; connect with `ssh -i %s %s@%s`", sshPrivateKeyPath, machine.Layout.Username, machine.PublicIP)
 	connectCtx, connectCancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer connectCancel()
 	client, err := sshConnect(connectCtx, machine.PublicIP, machine.Layout.Username, sshAuth)


### PR DESCRIPTION
## What does this PR do?

This PR fixes the log message about SSH'ing into the hosts used by the integration test framework for running tests. Specifically, this PR:
* makes the path to the SSH private key (used in the log message) portable across OSes,
* makes the path to the SSH private key absolute so it doesn't matter where the SSH command is executed from, and
* fixes the order of the username and hostname

## Why is it important?

So the SSH command emitted in the log message works.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~

## How to test this PR locally

Run any integration test and notice the messages about SSH'ing into the hosts used by the integration test framework.  Copy the SSH command mentioned in the log message, paste it into a new window, and try to execute it.

### Before this PR

```
$ mage integration:single TestFQDN
...
>>> Bring up instances through ogc
>>> (linux/amd64/ubuntu/22.04[7slm]) Starting SSH; connect with `ssh -i ./ogc-cache/id_rsa 34.72.227.174@ubuntu`
>>> (linux/arm64/ubuntu/22.04[7slm]) Starting SSH; connect with `ssh -i ./ogc-cache/id_rsa 34.68.6.202@ubuntu`
...
```

### After this PR

```
$ mage integration:single TestFQDN
...
>>> Bring up instances through ogc
>>> (linux/arm64/ubuntu/22.04[4v64]) Starting SSH; connect with `ssh -i /Users/shaunak/development/github/elastic-agent/.ogc-cache/id_rsa ubuntu@35.225.150.128`
>>> (linux/amd64/ubuntu/22.04[4v63]) Starting SSH; connect with `ssh -i /Users/shaunak/development/github/elastic-agent/.ogc-cache/id_rsa ubuntu@34.135.159.242`
...
```
