### PR TITLE
`TestFQDN`: Increase timeout for data check to 2 minutes

### DIFF
--- a/testing/integration/fqdn_test.go
+++ b/testing/integration/fqdn_test.go
@@ -224,7 +224,7 @@ func verifyHostNameInIndices(t *testing.T, indices, hostname string, esClient *e
 			hit := body.Hits.Hits[0]
 			return hostname == hit.Source.Host.Name
 		},
-		1*time.Minute,
+		2*time.Minute,
 		5*time.Second,
 	)
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR increases the timeout of the check that looks for the expected hostname in `logs-*` and `metrics-*` indices from 1 minute to 2 minutes.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This test seems to _occasionally_ fail in CI ([example](https://buildkite.com/elastic/elastic-agent/builds/1482#01892a42-99f5-4d7d-9d50-ce150671e842)), however it doesn't seem to fail when run locally, even with a dozen+ attempts.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~
