### PR TITLE
add exception for unit keyword

### DIFF
--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -233,7 +233,7 @@ func GoTest(ctx context.Context, params GoTestArgs) error {
 		)
 	}
 
-	if params.TestName != "" {
+	if params.TestName != "" && params.TestName != "Unit" {
 		testArgs = append(testArgs, "-run", params.TestName)
 	}
 


### PR DESCRIPTION
Fixing sonarcloud coverage issue with `-run Unit` option