### PR TITLE
Fix mage unitTest to actually run tests

### DIFF
--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -29,6 +29,7 @@ import (
 // how "go test" is invoked. "go test" is always invoked with -v for verbose.
 type GoTestArgs struct {
 	TestName            string            // Test name used in logging.
+	RunExpr             string            // Expression to pass to the -run argument of go test.
 	Race                bool              // Enable race detector.
 	Tags                []string          // Build tags to enable.
 	ExtraFlags          []string          // Extra flags to pass to 'go test'.
@@ -233,8 +234,8 @@ func GoTest(ctx context.Context, params GoTestArgs) error {
 		)
 	}
 
-	if params.TestName != "" {
-		testArgs = append(testArgs, "-run", params.TestName)
+	if params.RunExpr != "" {
+		testArgs = append(testArgs, "-run", params.RunExpr)
 	}
 
 	testArgs = append(testArgs, params.ExtraFlags...)

--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -28,7 +28,7 @@ import (
 // GoTestArgs are the arguments used for the "go*Test" targets and they define
 // how "go test" is invoked. "go test" is always invoked with -v for verbose.
 type GoTestArgs struct {
-	TestName            string            // Test name used in logging.
+	LogName             string            // Test name used in logging.
 	RunExpr             string            // Expression to pass to the -run argument of go test.
 	Race                bool              // Enable race detector.
 	Tags                []string          // Build tags to enable.
@@ -50,7 +50,7 @@ type TestBinaryArgs struct {
 func makeGoTestArgs(name string) GoTestArgs {
 	fileName := fmt.Sprintf("build/TEST-go-%s", strings.Replace(strings.ToLower(name), " ", "_", -1))
 	params := GoTestArgs{
-		TestName:        name,
+		LogName:         name,
 		Race:            RaceDetector,
 		Packages:        []string{"./..."},
 		OutputFile:      fileName + ".out",
@@ -67,7 +67,7 @@ func makeGoTestArgsForModule(name, module string) GoTestArgs {
 	fileName := fmt.Sprintf("build/TEST-go-%s-%s", strings.Replace(strings.ToLower(name), " ", "_", -1),
 		strings.Replace(strings.ToLower(module), " ", "_", -1))
 	params := GoTestArgs{
-		TestName:        fmt.Sprintf("%s-%s", name, module),
+		LogName:         fmt.Sprintf("%s-%s", name, module),
 		Race:            RaceDetector,
 		Packages:        []string{fmt.Sprintf("./module/%s/...", module)},
 		OutputFile:      fileName + ".out",
@@ -183,7 +183,7 @@ func InstallGoTestTools() {
 func GoTest(ctx context.Context, params GoTestArgs) error {
 	mg.Deps(InstallGoTestTools)
 
-	fmt.Println(">> go test:", params.TestName, "Testing")
+	fmt.Println(">> go test:", params.LogName, "Testing")
 
 	// We use gotestsum to drive the tests and produce a junit report.
 	// The tool runs `go test -json` in order to produce a structured log which makes it easier
@@ -337,11 +337,11 @@ func GoTest(ctx context.Context, params GoTestArgs) error {
 
 	// Return an error indicating that testing failed.
 	if goTestErr != nil {
-		fmt.Println(">> go test:", params.TestName, "Test Failed")
+		fmt.Println(">> go test:", params.LogName, "Test Failed")
 		return errors.Wrap(goTestErr, "go test returned a non-zero value")
 	}
 
-	fmt.Println(">> go test:", params.TestName, "Test Passed")
+	fmt.Println(">> go test:", params.LogName, "Test Passed")
 	return nil
 }
 

--- a/dev-tools/mage/gotest_test.go
+++ b/dev-tools/mage/gotest_test.go
@@ -197,41 +197,41 @@ var wantTestAssertOutput = `(?sm:
         	Error Trace:	.*gotest_test.go:\d+.*
         	Error:      	Should be true.*
         	Test:       	TestGoTest_Helper_AssertOutput/assert_fails.*
-    --- FAIL: TestGoTest_Helper_AssertOutput/assert_fails .*
+
 === FAIL: dev-tools/mage TestGoTest_Helper_AssertOutput/assert_with_message .*
     .*gotest_test.go:\d+:.*
         	Error Trace:	.*gotest_test.go:\d+.*
         	Error:      	Should be true.*
         	Test:       	TestGoTest_Helper_AssertOutput/assert_with_message.*
         	Messages:   	My message.*
-    --- FAIL: TestGoTest_Helper_AssertOutput/assert_with_message .*
+
 === FAIL: dev-tools/mage TestGoTest_Helper_AssertOutput/assert_with_messagef .*
     .*gotest_test.go:\d+:.*
         	Error Trace:	.*gotest_test.go:\d+.*
         	Error:      	Should be true.*
         	Test:       	TestGoTest_Helper_AssertOutput/assert_with_messagef.*
         	Messages:   	My message with arguments: 42.*
-    --- FAIL: TestGoTest_Helper_AssertOutput/assert_with_messagef .*
+
 === FAIL: dev-tools/mage TestGoTest_Helper_AssertOutput/require_fails .*
     .*gotest_test.go:\d+:.*
         	Error Trace:	.*gotest_test.go:\d+.*
         	Error:      	Should be true.*
         	Test:       	TestGoTest_Helper_AssertOutput/require_fails.*
-    --- FAIL: TestGoTest_Helper_AssertOutput/require_fails .*
+
 === FAIL: dev-tools/mage TestGoTest_Helper_AssertOutput/require_with_message .*
     .*gotest_test.go:\d+:.*
         	Error Trace:	.*gotest_test.go:\d+.*
         	Error:      	Should be true.*
         	Test:       	TestGoTest_Helper_AssertOutput/require_with_message.*
         	Messages:   	My message.*
-    --- FAIL: TestGoTest_Helper_AssertOutput/require_with_message .*
+
 === FAIL: dev-tools/mage TestGoTest_Helper_AssertOutput/require_with_messagef .*
     .*gotest_test.go:\d+:.*
         	Error Trace:	.*gotest_test.go:\d+.*
         	Error:      	Should be true.*
         	Test:       	TestGoTest_Helper_AssertOutput/require_with_messagef.*
         	Messages:   	My message with arguments: 42.*
-    --- FAIL: TestGoTest_Helper_AssertOutput/require_with_messagef .*
+
 === FAIL: dev-tools/mage TestGoTest_Helper_AssertOutput/equals_map .*
     .*gotest_test.go:\d+:.*
         	Error Trace:	.*gotest_test.go:\d+.*
@@ -293,17 +293,17 @@ var wantTestLogOutput = `(?sm:
     gotest_test.go:\d+: printf style log message: 42.*
     gotest_test.go:\d+: Log should fail.*
     gotest_test.go:\d+: Log should fail with printf style log: 23.*
-    --- FAIL: TestGoTest_Helper_LogOutput/on_error.*
+
 === FAIL: dev-tools/mage TestGoTest_Helper_LogOutput/on_fatal.*
     gotest_test.go:\d+: Log message should be printed.*
     gotest_test.go:\d+: printf style log message: 42.*
     gotest_test.go:\d+: Log should fail.*
-    --- FAIL: TestGoTest_Helper_LogOutput/on_fatal.*
+
 === FAIL: dev-tools/mage TestGoTest_Helper_LogOutput/on_fatalf.*
     gotest_test.go:\d+: Log message should be printed.*
     gotest_test.go:\d+: printf style log message: 42.*
     gotest_test.go:\d+: Log should fail with printf style log: 42.*
-    --- FAIL: TestGoTest_Helper_LogOutput/on_fatalf.*
+
 === FAIL: dev-tools/mage TestGoTest_Helper_LogOutput/with_newlines.*
     gotest_test.go:\d+: Log.*
         message.*
@@ -323,8 +323,9 @@ var wantTestLogOutput = `(?sm:
         style.*
         log:.*
         42.*
-    --- FAIL: TestGoTest_Helper_LogOutput/with_newlines.*
+
 === FAIL: dev-tools/mage TestGoTest_Helper_LogOutput.*
+
 DONE 5 tests, 5 failures in.*
 )`
 

--- a/dev-tools/mage/gotest_test.go
+++ b/dev-tools/mage/gotest_test.go
@@ -44,7 +44,7 @@ func TestGoTest_CaptureOutput(t *testing.T) {
 	errNonZero := "go test returned a non-zero value"
 	makeArgs := func(test string) GoTestArgs {
 		return GoTestArgs{
-			TestName:   "asserts",
+			LogName:    "asserts",
 			Packages:   []string{"."},
 			Env:        map[string]string{envGoTestHelper: "1"},
 			ExtraFlags: []string{"-test.run", test},

--- a/magefile.go
+++ b/magefile.go
@@ -1426,7 +1426,7 @@ func (Integration) TestOnRemote(ctx context.Context) error {
 		testName := fmt.Sprintf("remote-%s", testPrefix)
 		fileName := fmt.Sprintf("build/TEST-go-%s", testName)
 		params := mage.GoTestArgs{
-			TestName:        testName,
+			LogName:         testName,
 			OutputFile:      fileName + ".out",
 			JUnitReportFile: fileName + ".xml",
 			Packages:        []string{packageName},

--- a/magefile.go
+++ b/magefile.go
@@ -1336,9 +1336,9 @@ func (Integration) Local(ctx context.Context, testName string) error {
 	params.Tags = append(params.Tags, "local")
 	params.Packages = []string{"github.com/elastic/elastic-agent/testing/integration"}
 	if testName == "all" {
-		params.TestName = ""
+		params.RunExpr = ""
 	} else {
-		params.TestName = testName
+		params.RunExpr = testName
 	}
 	return devtools.GoTest(ctx, params)
 }


### PR DESCRIPTION
Follow up from https://github.com/elastic/elastic-agent/pull/3052

A previous PR re-used the `TestName` parameter as the argument to the `-run` arg of `go test`. The problem is that the original code intended this to only be use for logging purposes, see the comment in:

https://github.com/elastic/elastic-agent/blob/d20b1085a3c8ba92ff3f7401e363b34f21d97f3e/dev-tools/mage/gotest.go#L31

The `mage unitTest` target used by sonarcloud and CI is implemented by:

https://github.com/elastic/elastic-agent/blob/d20b1085a3c8ba92ff3f7401e363b34f21d97f3e/magefile.go#L330-L335

The default Go test args unconditionally set the test name to `Unit`:
https://github.com/elastic/elastic-agent/blob/d20b1085a3c8ba92ff3f7401e363b34f21d97f3e/dev-tools/mage/gotest.go#L90

The `makeGoTestArgs` function called here takes the input as the name of the test for use in logging and sets `TestName`:
https://github.com/elastic/elastic-agent/blob/d20b1085a3c8ba92ff3f7401e363b34f21d97f3e/dev-tools/mage/gotest.go#L49

The net effect is that `mage unitTest` is now equivalent to `go test -run Unit ./...` which causes us to skip every unit test. We have no test coverage because we aren't running any unit tests.

The tests in the PRs "pass" in the sense that they aren't running. `mage unitTest` now takes 7s to complete and logs it isn't running any tests, while `go test ./...` to run all tests takes almost 3 minutes on my machine and is obviously running tests.

I have fixed this by adding a separate `RunExpr` variable to do what the original change intended and also renamed `TestName` to run `LogName` to more clearly indicate its purpose.