### PR TITLE
Document monitoring.use_output in reference configs.

### DIFF
--- a/_meta/config/common.p2.yml.tmpl
+++ b/_meta/config/common.p2.yml.tmpl
@@ -62,6 +62,8 @@ inputs:
 #   # exposes /debug/pprof/ endpoints
 #   # recommended that these endpoints are only enabled if the monitoring endpoint is set to localhost
 #   pprof.enabled: false
+#   # The name of the output to use for monitoring data.
+#   use_output: monitoring
 #   # exposes agent metrics using http, by default sockets and named pipes are used
 #   http:
 #       # enables http endpoint

--- a/_meta/config/common.reference.p2.yml.tmpl
+++ b/_meta/config/common.reference.p2.yml.tmpl
@@ -131,6 +131,8 @@ inputs:
 #   # exposes /debug/pprof/ endpoints
 #   # recommended that these endpoints are only enabled if the monitoring endpoint is set to localhost
 #   pprof.enabled: false
+#   # The name of the output to use for monitoring data.
+#   use_output: monitoring
 #   # exposes agent metrics using http, by default sockets and named pipes are used
 #   http:
 #       # enables http endpoint

--- a/elastic-agent.reference.yml
+++ b/elastic-agent.reference.yml
@@ -137,6 +137,8 @@ inputs:
 #   # exposes /debug/pprof/ endpoints
 #   # recommended that these endpoints are only enabled if the monitoring endpoint is set to localhost
 #   pprof.enabled: false
+#   # The name of the output to use for monitoring data.
+#   use_output: monitoring
 #   # exposes agent metrics using http, by default sockets and named pipes are used
 #   http:
 #       # enables http endpoint

--- a/elastic-agent.yml
+++ b/elastic-agent.yml
@@ -68,6 +68,8 @@ inputs:
 #   # exposes /debug/pprof/ endpoints
 #   # recommended that these endpoints are only enabled if the monitoring endpoint is set to localhost
 #   pprof.enabled: false
+#   # The name of the output to use for monitoring data.
+#   use_output: monitoring
 #   # exposes agent metrics using http, by default sockets and named pipes are used
 #   http:
 #       # enables http endpoint


### PR DESCRIPTION
The `use_output` key was missing from the reference configurations, but was present in our documentation. https://www.elastic.co/guide/en/fleet/current/elastic-agent-monitoring-configuration.html