### PR TITLE
Disable flaky test `TestRemovePath`

### DIFF
--- a/internal/pkg/agent/install/uninstall_windows_test.go
+++ b/internal/pkg/agent/install/uninstall_windows_test.go
@@ -29,6 +29,7 @@ func main() {
 `
 
 func TestRemovePath(t *testing.T) {
+	t.Skip("Flaky test https://github.com/elastic/elastic-agent/issues/3069")
 	dir := filepath.Join(t.TempDir(), "subdir")
 	err := os.Mkdir(dir, 0644)
 	require.NoError(t, err)


### PR DESCRIPTION
Skips `TestRemovePath` which is causing CI failures, see https://github.com/elastic/elastic-agent/issues/3069