### PR TITLE
[Integration Test][`TestFQDN`] Disable flaky assertion

### DIFF
--- a/testing/integration/fqdn_test.go
+++ b/testing/integration/fqdn_test.go
@@ -159,9 +159,11 @@ func TestFQDN(t *testing.T) {
 	t.Log("Verify that agent name is short hostname again")
 	verifyAgentName(t, shortName, info.KibanaClient)
 
-	t.Log("Verify that hostname in `logs-*` and `metrics-*` is short hostname again")
-	verifyHostNameInIndices(t, "logs-*", shortName, info.ESClient)
-	verifyHostNameInIndices(t, "metrics-*", shortName, info.ESClient)
+	// TODO: Re-enable assertion once https://github.com/elastic/elastic-agent/issues/3078 is
+	// investigated for root cause and resolved.
+	//t.Log("Verify that hostname in `logs-*` and `metrics-*` is short hostname again")
+	//verifyHostNameInIndices(t, "logs-*", shortName, info.ESClient)
+	//verifyHostNameInIndices(t, "metrics-*", shortName, info.ESClient)
 }
 
 func verifyAgentName(t *testing.T, hostname string, kibClient *kibana.Client) *kibana.AgentExisting {


### PR DESCRIPTION
## What does this PR do?

This PR disables a flaky assertion in the `TestFQDN` integration test.

## Why is it important?

So Ci is not flaky.

## Related issues

Related to https://github.com/elastic/elastic-agent/issues/3078