### PR TITLE
[Integration Test] New Agent after upgrade fails to start

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=elastic_elastic-agent_AYluowg0xMq8P7b4moiZ
 sonar.host.url=https://sonar.elastic.dev
 
 sonar.sources=.
-sonar.exclusions=**/*_test.go, .git/**, dev-tools/**, /magefile.go, changelog/**, _meta/**, deploy/**, docs/**, img/**, specs/**, pkg/testing/**, pkg/component/fake/**
+sonar.exclusions=**/*_test.go, .git/**, dev-tools/**, /magefile.go, changelog/**, _meta/**, deploy/**, docs/**, img/**, specs/**, pkg/testing/**, pkg/component/fake/**m **/mocks/*.go
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -1136,7 +1136,7 @@ func TestStandaloneUpgradeFailsRestart(t *testing.T) {
 
 	// Ensure new (post-upgrade) version is running and Agent is healthy
 	require.Eventually(t, func() bool {
-		return checkAgentHealthAndVersion(t, ctx, fromF, toVersion, false, "")
+		return checkAgentHealthAndVersion(t, ctx, fromF, toVersionParsed.CoreVersion(), toVersionParsed.IsSnapshot(), "")
 	}, 2*time.Minute, 10*time.Second, "Installed Agent never became healthy")
 
 	// A few seconds after the upgrade, deliberately restart upgraded Agent a
@@ -1151,13 +1151,11 @@ func TestStandaloneUpgradeFailsRestart(t *testing.T) {
 	}
 
 	// Ensure that the Upgrade Watcher has stopped running.
-	parsedFromVersion, err := version.ParseVersion(fromVersion)
-	require.NoError(t, err)
-	waitForUpgradeWatcherToComplete(t, fromF, parsedFromVersion, standaloneWatcherDuration)
+	waitForUpgradeWatcherToComplete(t, fromF, fromVersionParsed, standaloneWatcherDuration)
 
 	// Ensure that the original version of Agent is running again.
 	t.Log("Check Agent version to ensure rollback is successful")
 	require.Eventually(t, func() bool {
-		return checkAgentHealthAndVersion(t, ctx, fromF, fromVersion, false, "")
+		return checkAgentHealthAndVersion(t, ctx, fromF, fromVersionParsed.CoreVersion(), false, "")
 	}, 2*time.Minute, 10*time.Second, "Installed Agent never became healthy")
 }

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -1138,7 +1138,7 @@ func TestStandaloneUpgradeFailsRestart(t *testing.T) {
 	require.NoErrorf(t, err, "error triggering agent upgrade to version %q", toVersion.String())
 
 	// Ensure that the Upgrade Watcher has stopped running.
-	waitForUpgradeWatcherToComplete(t, agentFixture, upgradeFromVersion, standaloneWatcherDuration)
+	waitForUpgradeWatcherToComplete(t, f, fromVersion, standaloneWatcherDuration)
 
 	// Ensure that the original version of Agent is running again.
 	t.Log("Check Agent version to ensure rollback is successful")

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -1134,7 +1134,7 @@ func TestStandaloneUpgradeFailsRestart(t *testing.T) {
 	// Try upgrading to the fake Agent package.
 	t.Logf("Attempting upgrade to %s using Agent package at %s", toVersion.String(), packagePath)
 	ctx, _ = context.WithTimeout(ctx, 2*time.Minute)
-	_, err = c.Upgrade(ctx, toVersion.String(), "file://"+packagePath, true)
+	_, err = c.Upgrade(ctx, toVersion.String(), "file://"+packagePath, true, false)
 	require.NoErrorf(t, err, "error triggering agent upgrade to version %q", toVersion.String())
 
 	// Ensure that the Upgrade Watcher has stopped running.

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -1138,7 +1138,7 @@ func TestStandaloneUpgradeFailsRestart(t *testing.T) {
 	require.NoErrorf(t, err, "error triggering agent upgrade to version %q", toVersion.String())
 
 	// Ensure that the Upgrade Watcher has stopped running.
-	checkUpgradeWatcherRan(t, f)
+	waitForUpgradeWatcherToComplete(t, agentFixture, upgradeFromVersion, standaloneWatcherDuration)
 
 	// Ensure that the original version of Agent is running again.
 	t.Log("Check Agent version to ensure rollback is successful")

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -1060,3 +1060,19 @@ type CustomPGP struct {
 	PGPUri  string
 	PGPPath string
 }
+
+// TestStandaloneUpgradeFailsRestart tests the scenario where upgrading to a new version
+// of Agent fails due to the new Agent binary not starting up. It checks that the Agent is
+// rolled back to the previous version.
+func TestStandaloneUpgradeFailsRestart(t *testing.T) {
+	// Install the current version of Agent.
+
+	// Create a fake Agent package that contains a fake binary that will
+	// deliberately fail to start.
+
+	// Try upgrading to the fake Agent package.
+
+	// Ensure that the Upgrade Watcher has stopped running.
+
+	// Ensure that the original version of Agent is running again.
+}

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -1133,13 +1133,19 @@ func TestStandaloneUpgradeFailsRestart(t *testing.T) {
 
 	// Try upgrading to the fake Agent package.
 	t.Logf("Attempting upgrade to %s using Agent package at %s", toVersion.String(), packagePath)
-	time.Sleep(5 * time.Minute)
-	//ctx, _ = context.WithTimeout(ctx, 2*time.Minute)
-	//_, err = c.Upgrade(ctx, toVersion.String(), "file://"+packagePath, true)
-	//require.NoErrorf(t, err, "error triggering agent upgrade to version %q", toVersion.String())
+	ctx, _ = context.WithTimeout(ctx, 2*time.Minute)
+	_, err = c.Upgrade(ctx, toVersion.String(), "file://"+packagePath, true)
+	require.NoErrorf(t, err, "error triggering agent upgrade to version %q", toVersion.String())
 
 	// Ensure that the Upgrade Watcher has stopped running.
+	checkUpgradeWatcherRan(t, f)
+
 	// Ensure that the original version of Agent is running again.
+	t.Log("Check Agent version to ensure rollback is successful")
+	currentVersion, err := getVersion(t, ctx, f)
+	require.NoError(t, err)
+	require.Equal(t, fromVersion, currentVersion.Binary.Version)
+	require.Equal(t, fromVersion, currentVersion.Daemon.Version)
 }
 
 func createFakeBrokenAgentPackage(t *testing.T, version *version.ParsedSemVer) string {

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -1151,7 +1151,7 @@ func TestStandaloneUpgradeFailsRestart(t *testing.T) {
 	}
 
 	// Ensure that the Upgrade Watcher has stopped running.
-	waitForUpgradeWatcherToComplete(t, fromF, fromVersionParsed, standaloneWatcherDuration)
+	checkUpgradeWatcherRan(t, fromF, fromVersionParsed)
 
 	// Ensure that the original version of Agent is running again.
 	t.Log("Check Agent version to ensure rollback is successful")

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -1133,7 +1133,7 @@ func TestStandaloneUpgradeFailsRestart(t *testing.T) {
 
 	// Try upgrading to the fake Agent package.
 	t.Logf("Attempting upgrade to %s using Agent package at %s", toVersion.String(), packagePath)
-	ctx, _ = context.WithTimeout(ctx, 2*time.Minute)
+	ctx, _ = context.WithTimeout(ctx, 5*time.Minute)
 	_, err = c.Upgrade(ctx, toVersion.String(), "file://"+packagePath, true, false)
 	require.NoErrorf(t, err, "error triggering agent upgrade to version %q", toVersion.String())
 

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -1074,10 +1074,6 @@ func TestStandaloneUpgradeFailsRestart(t *testing.T) {
 		// It's not safe to run this test locally as it
 		// installs Elastic Agent.
 		Local: false,
-
-		OS: []define.OS{
-			{Type: define.Linux}, // Fake broken Agent package only works on Linux
-		},
 	})
 
 	toVersion := define.Version()


### PR DESCRIPTION
## What does this PR do?

Relates https://github.com/elastic/elastic-agent/issues/2176

This PR adds an integration test that ensures an Agent upgrade is rolled back because the new Agent (after upgrade) fails to start.

The test creates a fake Agent package containing a fake Agent binary that immediately exits with a non-zero status code.  The test installs the locally-built Agent and then attempts to upgrade to the fake Agent package. The upgrade is expected to fail due to the new (fake) Agent binary failing to start successfully, and therefore the upgrade should be rolled back to the previous Agent version.

## Why is it important?

To ensure the upgrade/rollback behavior is working as expected.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [x] I have added an integration test or an E2E test

## How to test this PR locally

1. Build Agent locally.
   ```
   DEV=true EXTERNAL=true SNAPSHOT=true PLATFORMS=linux/amd64,linux/arm64 PACKAGES=tar.gz mage package
   ```

2. Run the test in this PR.
   ```
   SNAPSHOT=true mage integration:single TestStandaloneUpgradeFailsRestart
   ```

## Related issues
- Related to https://github.com/elastic/elastic-agent/issues/2176
