### PR TITLE
[Upgrade Watcher] Fix error messages

### DIFF
--- a/changelog/fragments/1689622778-upgrade-watcher-fix-error-message.yaml
+++ b/changelog/fragments/1689622778-upgrade-watcher-fix-error-message.yaml
@@ -11,7 +11,7 @@
 kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
-summary: Fix error message from Upgrade Watcher
+summary: Fix error messages from Upgrade Watcher
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.

--- a/changelog/fragments/1689622778-upgrade-watcher-fix-error-message.yaml
+++ b/changelog/fragments/1689622778-upgrade-watcher-fix-error-message.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix error message from Upgrade Watcher
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/3093
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -116,7 +116,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 	removeMarker := !isWindows()
 	err = upgrade.Cleanup(log, marker.Hash, removeMarker, false)
 	if err != nil {
-		log.Error("rollback failed", err)
+		log.Error("cleanup failed", err)
 	}
 	return err
 }

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -116,7 +116,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 	removeMarker := !isWindows()
 	err = upgrade.Cleanup(log, marker.Hash, removeMarker, false)
 	if err != nil {
-		log.Error("cleanup failed", err)
+		log.Error("cleanup after successful watch failed", err)
 	}
 	return err
 }

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -92,7 +92,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		// that cleanup was not performed ok, cleanup everything except current version
 		// hash is the same as hash of agent which initiated watcher.
 		if err := upgrade.Cleanup(log, release.ShortCommit(), true, false); err != nil {
-			log.Error("rollback failed", err)
+			log.Error("clean up of prior watcher run failed", err)
 		}
 		// exit nicely
 		return nil


### PR DESCRIPTION
## What does this PR do?

This PR fixes a couple of error messages in the Upgrade Watcher.

## Why is it important?

The error messages were misleading, which makes it confusing when troubleshooting.

