### PR TITLE
Pass go test flags to integration tests

### DIFF
--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -232,11 +232,10 @@ func GoTest(ctx context.Context, params GoTestArgs) error {
 		)
 	}
 
+	testArgs = append(testArgs, params.ExtraFlags...)
 	if params.RunExpr != "" {
 		testArgs = append(testArgs, "-run", params.RunExpr)
 	}
-
-	testArgs = append(testArgs, params.ExtraFlags...)
 	testArgs = append(testArgs, params.Packages...)
 
 	args := append(gotestsumArgs, append([]string{"--"}, testArgs...)...)

--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -68,6 +68,7 @@ We want to run only the test named "TestStandaloneUpgrade"
 ##### Run a tests matching a partial expression
 We want to run any test with "Upgrade" in the name
 `GOTEST_FLAGS="-test.run Upgrade" mage integration:test`
+
 ##### Run a single test and signal that we want the short version
 We pass a `-test.short` flag along with the name match
 `GOTEST_FLAGS="-test.run ^TestStandaloneUpgrade$ -test.short" mage integration:test`

--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -49,6 +49,41 @@ pass `[testName]` to `go test` as `--run=[testName]`.
 
 - `mage integration:matrix` to run all tests on the complete matrix of supported operating systems and architectures of the Elastic Agent.
 
+#### Passing additional go test flags
+
+When running the tests we can pass additional go test flag using the env variable `GOTEST_FLAGS`.
+
+These flags are passed also when calculating batches for remote execution of integration tests.
+This allows for selecting a subset of test in a convenient way (see examples below)
+
+This feature is intended mostly for integration tests debugging/development without the need for
+new mage targets corresponding to a new set of test flags.
+
+A few examples:
+
+##### Run a single test with an exact match
+We want to run only the test named "TestStandaloneUpgrade"
+`GOTEST_FLAGS="-test.run ^TestStandaloneUpgrade$" mage integration:test`
+
+##### Run a tests matching a partial expression
+We want to run any test with "Upgrade" in the name
+`GOTEST_FLAGS="-test.run Upgrade" mage integration:test`
+##### Run a single test and signal that we want the short version
+We pass a `-test.short` flag along with the name match
+`GOTEST_FLAGS="-test.run ^TestStandaloneUpgrade$ -test.short" mage integration:test`
+
+##### Run a single test multiple times
+We pass a `-test.count` flag along with the name match
+`GOTEST_FLAGS="-test.run ^TestStandaloneUpgrade$ -test.count 10" mage integration:test`
+
+##### Run specific tests
+We pass a `-test.run` flag along with the names of the tests we want to run in OR
+`GOTEST_FLAGS="-test.run ^(TestStandaloneUpgrade|TestFleetManagedUpgrade)$" mage integration:test`
+
+##### Limitations
+Due to the way the parameters are passed to `devtools.GoTest` the value of the environment variable
+is split on space, so not all combination of flags and their values may be correctly split.
+
 ## Writing tests
 
 Write integration and E2E tests by adding them to the `testing/integration`

--- a/magefile.go
+++ b/magefile.go
@@ -1435,7 +1435,7 @@ func (Integration) TestOnRemote(ctx context.Context) error {
 		extraFlags := make([]string, 0, len(goTestFlags)+3)
 		extraFlags = append(extraFlags, goTestFlags...)
 		extraFlags = append(extraFlags, "-test.shuffle", "on",
-			"-test.timeout", "0", "-test.run", "^("+strings.Join(packageTests, "|")+")$")
+			"-test.timeout", "0", "-test.run", "'^("+strings.Join(packageTests, "|")+")$'")
 		params := mage.GoTestArgs{
 			LogName:         testName,
 			OutputFile:      fileName + ".out",

--- a/magefile.go
+++ b/magefile.go
@@ -1441,7 +1441,7 @@ func (Integration) TestOnRemote(ctx context.Context) error {
 			extraFlags = append(extraFlags, goTestFlags...)
 		}
 		extraFlags = append(extraFlags, "-test.shuffle", "on",
-			"-test.timeout", "0", "-test.run", strings.Join(packageTests, "|"))
+			"-test.timeout", "0", "-test.run", "^("+strings.Join(packageTests, "|")+")$")
 		params := mage.GoTestArgs{
 			LogName:         testName,
 			OutputFile:      fileName + ".out",

--- a/magefile.go
+++ b/magefile.go
@@ -1405,7 +1405,11 @@ func (Integration) TestOnRemote(ctx context.Context) error {
 		return errors.New("TEST_DEFINE_TESTS environment variable must be set")
 	}
 
-	goTestFlags := strings.SplitN(os.Getenv("GOTEST_FLAGS"), " ", -1)
+	var goTestFlags []string
+	rawTestFlags := os.Getenv("GOTEST_FLAGS")
+	if rawTestFlags != "" {
+		goTestFlags = strings.Split(rawTestFlags, " ")
+	}
 
 	tests := strings.Split(testsStr, ",")
 	testsByPackage := make(map[string][]string)
@@ -1433,9 +1437,11 @@ func (Integration) TestOnRemote(ctx context.Context) error {
 		testName := fmt.Sprintf("remote-%s", testPrefix)
 		fileName := fmt.Sprintf("build/TEST-go-%s", testName)
 		extraFlags := make([]string, 0, len(goTestFlags)+3)
-		extraFlags = append(extraFlags, goTestFlags...)
+		if len(goTestFlags) > 0 {
+			extraFlags = append(extraFlags, goTestFlags...)
+		}
 		extraFlags = append(extraFlags, "-test.shuffle", "on",
-			"-test.timeout", "0", "-test.run", "'^("+strings.Join(packageTests, "|")+")$'")
+			"-test.timeout", "0", "-test.run", strings.Join(packageTests, "|"))
 		params := mage.GoTestArgs{
 			LogName:         testName,
 			OutputFile:      fileName + ".out",

--- a/magefile.go
+++ b/magefile.go
@@ -1436,7 +1436,7 @@ func (Integration) TestOnRemote(ctx context.Context) error {
 		testPrefix := fmt.Sprintf("%s.%s", prefix, filepath.Base(packageName))
 		testName := fmt.Sprintf("remote-%s", testPrefix)
 		fileName := fmt.Sprintf("build/TEST-go-%s", testName)
-		extraFlags := make([]string, 0, len(goTestFlags)+3)
+		extraFlags := make([]string, 0, len(goTestFlags)+6)
 		if len(goTestFlags) > 0 {
 			extraFlags = append(extraFlags, goTestFlags...)
 		}

--- a/pkg/testing/define/batch.go
+++ b/pkg/testing/define/batch.go
@@ -83,11 +83,15 @@ func DetermineBatches(dir string, testFlags string, buildTags ...string) ([]Batc
 	if !filepath.IsAbs(dir) && !strings.HasPrefix(dir, "./") {
 		dir = "./" + dir
 	}
-	flags := strings.SplitN(testFlags, " ", -1)
+
 	// run 'go test' and collect the JSON output to be parsed
 	// #nosec G204 -- test function code, it will be okay
 	cmdArgs := []string{"test", "-v", "--tags", strings.Join(buildTags, ","), "-json"}
-	cmdArgs = append(cmdArgs, flags...)
+	if testFlags != "" {
+		flags := strings.Split(testFlags, " ")
+		cmdArgs = append(cmdArgs, flags...)
+	}
+
 	cmdArgs = append(cmdArgs, dir)
 	testCmd := exec.Command("go", cmdArgs...)
 	output, err := testCmd.Output()

--- a/pkg/testing/define/batch.go
+++ b/pkg/testing/define/batch.go
@@ -69,7 +69,7 @@ type BatchPackageTests struct {
 
 // DetermineBatches parses the package directory with the possible extra build
 // tags to determine the set of batches for the package.
-func DetermineBatches(dir string, buildTags ...string) ([]Batch, error) {
+func DetermineBatches(dir string, testFlags string, buildTags ...string) ([]Batch, error) {
 	const (
 		defineMatcher = "define skip; requirements: "
 	)
@@ -83,10 +83,12 @@ func DetermineBatches(dir string, buildTags ...string) ([]Batch, error) {
 	if !filepath.IsAbs(dir) && !strings.HasPrefix(dir, "./") {
 		dir = "./" + dir
 	}
-
+	flags := strings.SplitN(testFlags, " ", -1)
 	// run 'go test' and collect the JSON output to be parsed
 	// #nosec G204 -- test function code, it will be okay
-	cmdArgs := []string{"test", "-v", "--tags", strings.Join(buildTags, ","), "-json", dir}
+	cmdArgs := []string{"test", "-v", "--tags", strings.Join(buildTags, ","), "-json"}
+	cmdArgs = append(cmdArgs, flags...)
+	cmdArgs = append(cmdArgs, dir)
 	testCmd := exec.Command("go", cmdArgs...)
 	output, err := testCmd.Output()
 	if err != nil {
@@ -202,6 +204,13 @@ func appendTest(batches []Batch, tar testActionResult, req Requirements) []Batch
 func appendPackageTest(tests []BatchPackageTests, pkg string, name string) []BatchPackageTests {
 	for i, pt := range tests {
 		if pt.Name == pkg {
+			for _, testName := range pt.Tests {
+				if testName == name {
+					// we already selected this test for this package for this batch,
+					// we can return immediately
+					return tests
+				}
+			}
 			pt.Tests = append(pt.Tests, name)
 			tests[i] = pt
 			return tests

--- a/pkg/testing/define/batch_test.go
+++ b/pkg/testing/define/batch_test.go
@@ -276,7 +276,84 @@ func TestBatch(t *testing.T) {
 		},
 	}
 
-	actual, err := DetermineBatches("testdata", "batch_test")
+	actual, err := DetermineBatches("testdata", "", "batch_test")
 	require.NoError(t, err)
 	require.EqualValues(t, expected, actual)
+}
+
+var testLinuxLocalTests = []string{"TestLinuxLocal"}
+
+var testLinuxLocalBatch = []Batch{
+	{
+		OS: OS{
+			Type: "linux",
+			Arch: "amd64",
+		},
+		Tests: []BatchPackageTests{
+			{
+				Name:  "github.com/elastic/elastic-agent/pkg/testing/define/testdata",
+				Tests: testLinuxLocalTests,
+			},
+		},
+	},
+	{
+		OS: OS{
+			Type: "linux",
+			Arch: "arm64",
+		},
+		Tests: []BatchPackageTests{
+			{
+				Name:  "github.com/elastic/elastic-agent/pkg/testing/define/testdata",
+				Tests: testLinuxLocalTests,
+			},
+		},
+	},
+}
+
+func TestGoTestFlags(t *testing.T) {
+	testcases := []struct {
+		name     string
+		flags    string
+		expected []Batch
+	}{
+		{
+			name:     "Run single test",
+			flags:    "-run ^TestLinuxLocal$",
+			expected: testLinuxLocalBatch,
+		},
+		{
+			name:     "Run single test with short flag",
+			flags:    "-run ^TestLinuxLocal$ -short",
+			expected: testLinuxLocalBatch,
+		},
+		{
+			name:     "specify non-existing test",
+			flags:    "-run ^thisdoesnotexist$",
+			expected: nil,
+		},
+		{
+			name:     "specify multiple run flags - last one wins - no test",
+			flags:    "-run ^TestLinuxLocal$ -run ^thisdoesnotexist$",
+			expected: nil,
+		},
+		{
+			name:     "specify multiple run flags - last one wins - TestLinuxLocal",
+			flags:    "-run ^thisdoesnotexist$ -run ^TestLinuxLocal$",
+			expected: testLinuxLocalBatch,
+		},
+		{
+			name:     "count flag will not multiply the test entries in each batch",
+			flags:    "-run ^TestLinuxLocal$ -count 2",
+			expected: testLinuxLocalBatch,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := DetermineBatches("testdata", tc.flags, "batch_test")
+			require.NoError(t, err)
+			require.EqualValues(t, tc.expected, actual)
+		})
+	}
+
 }

--- a/pkg/testing/runner/config.go
+++ b/pkg/testing/runner/config.go
@@ -33,6 +33,9 @@ type Config struct {
 
 	// Timestamp enables timestamps on the console output.
 	Timestamp bool
+
+	// Testflags contains extra go test flags to be set when running tests
+	TestFlags string
 }
 
 // Validate returns an error if the information is invalid.

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -264,7 +264,7 @@ func (r *Runner) runMachine(ctx context.Context, sshAuth ssh.AuthMethod, logger 
 	}
 
 	// ensure that we have all the requirements for the stack if required
-	var env map[string]string
+	env := map[string]string{}
 	if batch.Batch.Stack != nil {
 		ch, err := r.getCloudForBatchID(batch.ID)
 		if err != nil {
@@ -276,17 +276,18 @@ func (r *Runner) runMachine(ctx context.Context, sshAuth ssh.AuthMethod, logger 
 			return OSRunnerResult{}, fmt.Errorf("cannot continue because stack never became ready")
 		}
 		logger.Logf("Will continue, stack is ready")
-		env = map[string]string{
-			"ELASTICSEARCH_HOST":     resp.ElasticsearchEndpoint,
-			"ELASTICSEARCH_USERNAME": resp.Username,
-			"ELASTICSEARCH_PASSWORD": resp.Password,
-			"KIBANA_HOST":            resp.KibanaEndpoint,
-			"KIBANA_USERNAME":        resp.Username,
-			"KIBANA_PASSWORD":        resp.Password,
-		}
-		logger.Logf("Created Stack with Kibana host %s, %s/%s", resp.KibanaEndpoint, resp.Username, resp.Password)
+		env["ELASTICSEARCH_HOST"] = resp.ElasticsearchEndpoint
+		env["ELASTICSEARCH_USERNAME"] = resp.Username
+		env["ELASTICSEARCH_PASSWORD"] = resp.Password
+		env["KIBANA_HOST"] = resp.KibanaEndpoint
+		env["KIBANA_USERNAME"] = resp.Username
+		env["KIBANA_PASSWORD"] = resp.Password
 
+		logger.Logf("Created Stack with Kibana host %s, %s/%s", resp.KibanaEndpoint, resp.Username, resp.Password)
 	}
+
+	// set the go test flags
+	env["GOTEST_FLAGS"] = r.cfg.TestFlags
 
 	// run the actual tests on the host
 	prefix := fmt.Sprintf("%s-%s-%s-%s", batch.LayoutOS.OS.Type, batch.LayoutOS.OS.Arch, batch.LayoutOS.OS.Distro, strings.Replace(batch.LayoutOS.OS.Version, ".", "", -1))


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

It allows to propagate go test flags to the actual go test command allowing for finer control over the test execution.
The `-test.short` is also important for allowing a quicker execution for PRs, for example while maintaining a full integration test run in other contexts.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Try to run integration tests (both locally and remotely) with some custom go test flags. There are some examples listed in the [dev-guide](https://github.com/elastic/elastic-agent/blob/b2a0f2dc837a524763b893a134d552e77b3d17ff/docs/test-framework-dev-guide.md#passing-additional-go-test-flags), for example:

We pass a `-test.run` flag along with the names of the tests we want to run in OR
```
GOTEST_FLAGS="-test.run ^(TestStandaloneUpgrade|TestFleetManagedUpgrade)$" mage integration:test
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #2955 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
