### PR TITLE
Skip flaky `TestEnrollAndLog` E2E test

### DIFF
--- a/testing/integration/enroll_test.go
+++ b/testing/integration/enroll_test.go
@@ -32,6 +32,9 @@ func TestEnrollAndLog(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
+
+	t.Skip("Test is flaky; see https://github.com/elastic/elastic-agent/issues/3081")
+
 	t.Logf("got namespace: %s", info.Namespace)
 	suite.Run(t, &EnrollRunner{requirementsInfo: info})
 }


### PR DESCRIPTION
## What does this PR do?

This PR skips the flaky `TestEnrollAndLog` E2E test.

## Why is it important?

To avoid flaky tests.

## Related issues
-  Related to https://github.com/elastic/elastic-agent/issues/3081
