### PR TITLE
Elastic Defend install path runtime prevention

### DIFF
--- a/changelog/fragments/1689883203-Elastic-Defend-runtime-prevention.yaml
+++ b/changelog/fragments/1689883203-Elastic-Defend-runtime-prevention.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Elastic Defend runtime prevention, if agent is installed in non-default location
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/paths/common.go
+++ b/internal/pkg/agent/application/paths/common.go
@@ -22,7 +22,7 @@ const (
 	// AgentLockFileName is the name of the overall Elastic Agent file lock.
 	AgentLockFileName = "agent.lock"
 	tempSubdir        = "tmp"
-	tempSubdirPerms   = 0770
+	tempSubdirPerms   = 0o770
 
 	darwin = "darwin"
 )
@@ -253,4 +253,9 @@ func binaryDir(baseDir string) string {
 // BinaryPath returns the application binary path that is concatenation of the directory and the agentName
 func BinaryPath(baseDir, agentName string) string {
 	return filepath.Join(binaryDir(baseDir), agentName)
+}
+
+// InstallPath returns the top level directory Agent will be installed into.
+func InstallPath(basePath string) string {
+	return filepath.Join(basePath, "Elastic", "Agent")
 }

--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -73,7 +73,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		return fmt.Errorf("unable to perform install command, not executed with %s permissions", utils.PermissionUser)
 	}
 
-	topPath := installPath(basePath)
+	topPath := paths.InstallPath(basePath)
 
 	status, reason := install.Status(topPath)
 	force, _ := cmd.Flags().GetBool("force")
@@ -237,8 +237,4 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 
 	fmt.Fprint(streams.Out, "Elastic Agent has been successfully installed.\n")
 	return nil
-}
-
-func installPath(basePath string) string {
-	return filepath.Join(basePath, "Elastic", "Agent")
 }

--- a/internal/pkg/agent/cmd/install_test.go
+++ b/internal/pkg/agent/cmd/install_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
 )
 
@@ -23,7 +24,7 @@ func TestInstallPath(t *testing.T) {
 
 	for name, basePath := range tests {
 		t.Run(name, func(t *testing.T) {
-			p := installPath(basePath)
+			p := paths.InstallPath(basePath)
 			require.Equal(t, basePath+"/Elastic/Agent", p)
 		})
 	}

--- a/internal/pkg/agent/cmd/install_windows_test.go
+++ b/internal/pkg/agent/cmd/install_windows_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
 )
 
@@ -23,7 +24,7 @@ func TestInstallPath(t *testing.T) {
 
 	for name, basePath := range tests {
 		t.Run(name, func(t *testing.T) {
-			p := installPath(basePath)
+			p := paths.InstallPath(basePath)
 			require.Equal(t, basePath+`\Elastic\Agent`, p)
 		})
 	}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -824,6 +824,9 @@ func varsForPlatform(platform PlatformDetail) (*transpiler.Vars, error) {
 		return nil, err
 	}
 	return transpiler.NewVars("", map[string]interface{}{
+		"install": map[string]interface{}{
+			"in_default": paths.ArePathsEqual(paths.Top(), paths.InstallPath(paths.DefaultBasePath)),
+		},
 		"runtime": map[string]interface{}{
 			"platform": platform.String(),
 			"os":       platform.OS,
@@ -831,9 +834,6 @@ func varsForPlatform(platform PlatformDetail) (*transpiler.Vars, error) {
 			"family":   platform.Family,
 			"major":    platform.Major,
 			"minor":    platform.Minor,
-			"install": map[string]interface{}{
-				"default": paths.ArePathsEqual(paths.Top(), paths.InstallPath(paths.DefaultBasePath)),
-			},
 		},
 		"user": map[string]interface{}{
 			"root": hasRoot,

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func TestToComponents(t *testing.T) {
-	var linuxAMD64Platform = PlatformDetail{
+	linuxAMD64Platform := PlatformDetail{
 		Platform: Platform{
 			OS:   Linux,
 			Arch: AMD64,
@@ -1711,7 +1711,8 @@ func TestToComponents(t *testing.T) {
 			headers: &testHeadersProvider{headers: map[string]string{
 				"header-one": "val-1",
 			}},
-		}, {
+		},
+		{
 			Name:     "Headers injection merge",
 			Platform: linuxAMD64Platform,
 			Policy: map[string]interface{}{
@@ -1892,7 +1893,8 @@ func TestToComponents(t *testing.T) {
 				for i, expected := range scenario.Result {
 					actual := result[i]
 					if expected.Err != nil {
-						assert.Equal(t, expected.Err, actual.Err)
+						assert.Contains(t, actual.Err.Error(), expected.Err.Error())
+						// assert.Equal(t, expected.Err, actual.Err)
 						assert.EqualValues(t, expected.Units, actual.Units)
 					} else {
 						assert.NoError(t, actual.Err, "Expected no error for component "+actual.ID)
@@ -1957,7 +1959,11 @@ func TestPreventionsAreValid(t *testing.T) {
 			"family":   "family",
 			"major":    "major",
 			"minor":    "minor",
+			"install": map[string]interface{}{
+				"default": true,
+			},
 		},
+
 		"user": map[string]interface{}{
 			"root": false,
 		},
@@ -2042,21 +2048,26 @@ func TestInjectingInputPolicyID(t *testing.T) {
 	}{
 		{"NilEverything", nil, nil, nil},
 		{"NilInput", fleetPolicy, nil, nil},
-		{"NilPolicy", nil,
+		{
+			"NilPolicy", nil,
 			map[string]interface{}{},
 			map[string]interface{}{},
 		},
-		{"EmptyPolicy", map[string]interface{}{},
+		{
+			"EmptyPolicy",
+			map[string]interface{}{},
 			map[string]interface{}{},
 			map[string]interface{}{},
 		},
-		{"CreatePolicyRevision", fleetPolicy,
+		{
+			"CreatePolicyRevision", fleetPolicy,
 			map[string]interface{}{},
 			map[string]interface{}{
 				"policy": map[string]interface{}{"revision": testRevision},
 			},
 		},
-		{"NilPolicyObjectType", fleetPolicy,
+		{
+			"NilPolicyObjectType", fleetPolicy,
 			map[string]interface{}{
 				"policy": nil,
 			},
@@ -2064,7 +2075,8 @@ func TestInjectingInputPolicyID(t *testing.T) {
 				"policy": map[string]interface{}{"revision": testRevision},
 			},
 		},
-		{"InjectPolicyRevision", fleetPolicy,
+		{
+			"InjectPolicyRevision", fleetPolicy,
 			map[string]interface{}{
 				"policy": map[string]interface{}{"key": "value"},
 			},
@@ -2072,7 +2084,8 @@ func TestInjectingInputPolicyID(t *testing.T) {
 				"policy": map[string]interface{}{"key": "value", "revision": testRevision},
 			},
 		},
-		{"UnknownPolicyObjectType", fleetPolicy,
+		{
+			"UnknownPolicyObjectType", fleetPolicy,
 			map[string]interface{}{
 				"policy": map[string]int{"key": 10},
 			},

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -1894,7 +1894,6 @@ func TestToComponents(t *testing.T) {
 					actual := result[i]
 					if expected.Err != nil {
 						assert.Contains(t, actual.Err.Error(), expected.Err.Error())
-						// assert.Equal(t, expected.Err, actual.Err)
 						assert.EqualValues(t, expected.Units, actual.Units)
 					} else {
 						assert.NoError(t, actual.Err, "Expected no error for component "+actual.ID)
@@ -1952,6 +1951,9 @@ func TestPreventionsAreValid(t *testing.T) {
 	// you update `docs/component-specs.md` in the same PR to document
 	// the change.
 	vars, err := transpiler.NewVars("", map[string]interface{}{
+		"install": map[string]interface{}{
+			"in_default": true,
+		},
 		"runtime": map[string]interface{}{
 			"platform": "platform",
 			"os":       "os",
@@ -1959,11 +1961,7 @@ func TestPreventionsAreValid(t *testing.T) {
 			"family":   "family",
 			"major":    "major",
 			"minor":    "minor",
-			"install": map[string]interface{}{
-				"default": true,
-			},
 		},
-
 		"user": map[string]interface{}{
 			"root": false,
 		},

--- a/pkg/testing/tools/cmd.go
+++ b/pkg/testing/tools/cmd.go
@@ -11,15 +11,7 @@ import (
 )
 
 // InstallAgent force install the Elastic Agent through agentFixture.
-func InstallAgent(fleetUrl string, enrollmentToken string, agentFixture *atesting.Fixture) ([]byte, error) {
-	installOpts := atesting.InstallOpts{
-		NonInteractive: true,
-		Force:          true,
-		EnrollOpts: atesting.EnrollOpts{
-			URL:             fleetUrl,
-			EnrollmentToken: enrollmentToken,
-		},
-	}
+func InstallAgent(installOpts atesting.InstallOpts, agentFixture *atesting.Fixture) ([]byte, error) {
 	return agentFixture.Install(context.Background(), &installOpts)
 }
 

--- a/pkg/testing/tools/tools.go
+++ b/pkg/testing/tools/tools.go
@@ -52,7 +52,7 @@ func WaitForPolicyRevision(t *testing.T, client *kibana.Client, agentID string, 
 // InstallAgentWithPolicy creates the given policy, enrolls the given agent
 // fixture in Fleet using the default Fleet Server, waits for the agent to be
 // online, and returns the created policy.
-func InstallAgentWithPolicy(t *testing.T, agentFixture *atesting.Fixture, kibClient *kibana.Client, createPolicyReq kibana.AgentPolicy) (*kibana.PolicyResponse, error) {
+func InstallAgentWithPolicy(t *testing.T, installOpts atesting.InstallOpts, agentFixture *atesting.Fixture, kibClient *kibana.Client, createPolicyReq kibana.AgentPolicy) (*kibana.PolicyResponse, error) {
 	t.Helper()
 
 	policy, err := kibClient.CreatePolicy(createPolicyReq)
@@ -79,7 +79,11 @@ func InstallAgentWithPolicy(t *testing.T, agentFixture *atesting.Fixture, kibCli
 
 	// Enroll agent
 	t.Logf("Unpacking and installing Elastic Agent")
-	output, err := InstallAgent(fleetServerURL, enrollmentToken.APIKey, agentFixture)
+	installOpts.EnrollOpts = atesting.EnrollOpts{
+		URL:             fleetServerURL,
+		EnrollmentToken: enrollmentToken.APIKey,
+	}
+	output, err := InstallAgent(installOpts, agentFixture)
 	if err != nil {
 		t.Log(string(output))
 		return nil, fmt.Errorf("unable to enroll Elastic Agent: %w", err)

--- a/specs/endpoint-security.spec.yml
+++ b/specs/endpoint-security.spec.yml
@@ -59,6 +59,10 @@ inputs:
     proxied_actions:
       - UNENROLL
       - UPGRADE
+    runtime:
+      preventions:
+        - condition: ${runtime.install.default} == false
+          message: "Elastic Defend requires Elastic Agent be installed at the default installation path"
     service:
       cport: 6788
       log:
@@ -78,6 +82,8 @@ inputs:
       preventions:
         - condition: ${user.root} == false
           message: "Elastic Agent must be running as Administrator or SYSTEM"
+        - condition: ${runtime.install.default} == false
+          message: "Elastic Defend requires Elastic Agent be installed at the default installation path"
     service:
       cport: 6788
       log:

--- a/specs/endpoint-security.spec.yml
+++ b/specs/endpoint-security.spec.yml
@@ -19,7 +19,7 @@ inputs:
           message: "No support for RHEL7 on arm64"
         - condition: ${user.root} == false
           message: "Elastic Agent must be running as root"
-        - condition: ${runtime.install.default} == false
+        - condition: ${install.in_default} == false
           message: "Elastic Defend requires Elastic Agent be installed at the default installation path"
     service:
       cport: 6788
@@ -61,7 +61,7 @@ inputs:
       - UPGRADE
     runtime:
       preventions:
-        - condition: ${runtime.install.default} == false
+        - condition: ${install.in_default} == false
           message: "Elastic Defend requires Elastic Agent be installed at the default installation path"
     service:
       cport: 6788
@@ -82,7 +82,7 @@ inputs:
       preventions:
         - condition: ${user.root} == false
           message: "Elastic Agent must be running as Administrator or SYSTEM"
-        - condition: ${runtime.install.default} == false
+        - condition: ${install.in_default} == false
           message: "Elastic Defend requires Elastic Agent be installed at the default installation path"
     service:
       cport: 6788

--- a/specs/endpoint-security.spec.yml
+++ b/specs/endpoint-security.spec.yml
@@ -19,6 +19,8 @@ inputs:
           message: "No support for RHEL7 on arm64"
         - condition: ${user.root} == false
           message: "Elastic Agent must be running as root"
+        - condition: ${runtime.install.default} == false
+          message: "Elastic Defend requires Elastic Agent be installed at the default installation path"
     service:
       cport: 6788
       log:

--- a/testing/integration/endpoint_security_test.go
+++ b/testing/integration/endpoint_security_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,7 +24,10 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/elastic/elastic-agent-libs/kibana"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/pkg/control/v2/client"
+	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
+	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
 )
@@ -76,11 +80,16 @@ func TestInstallAndCLIUninstallWithEndpointSecurity(t *testing.T) {
 			kibana.MonitoringEnabledMetrics,
 		},
 	}
-	policyResp, err := tools.InstallAgentWithPolicy(t, fixture, info.KibanaClient, createPolicyReq)
+	installOpts := atesting.InstallOpts{
+		NonInteractive: true,
+		Force:          true,
+	}
+	policyResp, err := tools.InstallAgentWithPolicy(t, installOpts, fixture, info.KibanaClient, createPolicyReq)
 	require.NoError(t, err)
 
 	t.Log("Installing Elastic Defend")
-	installElasticDefendPackage(t, info, policyResp.ID)
+	pkgPolicyResp, err := installElasticDefendPackage(t, info, policyResp.ID)
+	require.NoErrorf(t, err, "Policy Response was: %v", pkgPolicyResp)
 
 	t.Log("Polling for endpoint-security to become Healthy")
 	ctx, cancel := context.WithTimeout(context.Background(), endpointHealthPollingTimeout)
@@ -114,7 +123,7 @@ func TestInstallAndUnenrollWithEndpointSecurity(t *testing.T) {
 		Isolate: false,
 		Sudo:    true, // requires Agent installation
 		OS: []define.OS{
-			define.OS{Type: define.Linux, Arch: define.AMD64},
+			{Type: define.Linux, Arch: define.AMD64},
 		},
 	})
 
@@ -217,12 +226,14 @@ func TestInstallAndUnenrollWithEndpointSecurity(t *testing.T) {
 }
 
 // Installs the Elastic Defend package to cause the agent to install the endpoint-security service.
-func installElasticDefendPackage(t *testing.T, info *define.Info, policyID string) {
+func installElasticDefendPackage(t *testing.T, info *define.Info, policyID string) (*tools.PackagePolicyResponse, error) {
 	t.Helper()
 
 	t.Log("Templating endpoint package policy request")
 	tmpl, err := template.New("pkgpolicy").Parse(endpointPackagePolicyTemplate)
-	require.NoError(t, err)
+	if err != nil {
+		return nil, fmt.Errorf("error creating new template: %w", err)
+	}
 
 	packagePolicyID := uuid.New().String()
 	var pkgPolicyBuf bytes.Buffer
@@ -232,21 +243,95 @@ func installElasticDefendPackage(t *testing.T, info *define.Info, policyID strin
 		PolicyID: policyID,
 		Version:  endpointPackageVersion,
 	})
-	require.NoError(t, err)
+	if err != nil {
+		return nil, fmt.Errorf("error executing template: %w", err)
+	}
 
 	// Make sure the templated value is actually valid JSON before making the API request.
 	// Using json.Unmarshal will give us the actual syntax error, calling json.Valid() would not.
 	packagePolicyReq := tools.PackagePolicyRequest{}
 	err = json.Unmarshal(pkgPolicyBuf.Bytes(), &packagePolicyReq)
-	require.NoErrorf(t, err, "Templated package policy is not valid JSON:\n%s", pkgPolicyBuf.String())
+	if err != nil {
+		return nil, fmt.Errorf("templated package policy is not valid JSON: %s, %w", pkgPolicyBuf.String(), err)
+	}
 
 	t.Log("POST /api/fleet/package_policies")
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	pkgResp, err := tools.InstallFleetPackage(ctx, info.KibanaClient, &packagePolicyReq)
-	require.NoError(t, err)
+	if err != nil {
+		return nil, fmt.Errorf("error installing fleet package: %w", err)
+	}
 	t.Logf("Endpoint package Policy Response:\n%+v", pkgResp)
+	return pkgResp, err
+}
+
+// Tests that install of Elastic Defend fails if Agent is installed in a base
+// path other than default
+func TestEndpointSecurityNonDefaultBasePath(t *testing.T) {
+	info := define.Require(t, define.Requirements{
+		Stack:   &define.Stack{},
+		Local:   false, // requires Agent installation
+		Isolate: false,
+		Sudo:    true, // requires Agent installation
+	})
+
+	// Get path to agent executable.
+	fixture, err := define.NewFixture(t, define.Version())
+	require.NoError(t, err)
+
+	t.Log("Enrolling the agent in Fleet")
+	policyUUID := uuid.New().String()
+	createPolicyReq := kibana.AgentPolicy{
+		Name:        "test-policy-" + policyUUID,
+		Namespace:   "default",
+		Description: "Test policy " + policyUUID,
+		MonitoringEnabled: []kibana.MonitoringEnabledOption{
+			kibana.MonitoringEnabledLogs,
+			kibana.MonitoringEnabledMetrics,
+		},
+	}
+	installOpts := atesting.InstallOpts{
+		NonInteractive: true,
+		Force:          true,
+		BasePath:       filepath.Join(paths.DefaultBasePath, "not_default"),
+	}
+	policyResp, err := tools.InstallAgentWithPolicy(t, installOpts, fixture, info.KibanaClient, createPolicyReq)
+
+	t.Log("Installing Elastic Defend")
+	pkgPolicyResp, err := installElasticDefendPackage(t, info, policyResp.ID)
+	require.NoErrorf(t, err, "Policy Response was: %v", pkgPolicyResp)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := fixture.Client()
+
+	require.Eventually(t, func() bool {
+		err := c.Connect(ctx)
+		if err != nil {
+			t.Logf("connecting client to agent: %v", err)
+			return false
+		}
+		defer c.Disconnect()
+		state, err := c.State(ctx)
+		if err != nil {
+			t.Logf("error getting the agent state: %v", err)
+			return false
+		}
+		t.Logf("agent state: %+v", state)
+		if state.State != cproto.State_DEGRADED {
+			return false
+		}
+		for _, c := range state.Components {
+			if strings.Contains(c.Message,
+				"Elastic Defend requires Elastic Agent be installed at the default installation path") {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Minute, 10*time.Second, "Agent never became DEGRADED with default install message")
 }
 
 func agentAndEndpointAreHealthy(t *testing.T, ctx context.Context, agentClient client.Client) bool {

--- a/testing/integration/endpoint_security_test.go
+++ b/testing/integration/endpoint_security_test.go
@@ -142,7 +142,11 @@ func TestInstallAndUnenrollWithEndpointSecurity(t *testing.T) {
 			kibana.MonitoringEnabledMetrics,
 		},
 	}
-	policyResp, err := tools.InstallAgentWithPolicy(t, fixture, info.KibanaClient, createPolicyReq)
+	installOpts := atesting.InstallOpts{
+		NonInteractive: true,
+		Force:          true,
+	}
+	policyResp, err := tools.InstallAgentWithPolicy(t, installOpts, fixture, info.KibanaClient, createPolicyReq)
 	require.NoError(t, err)
 
 	t.Log("Installing Elastic Defend")

--- a/testing/integration/endpoint_security_test.go
+++ b/testing/integration/endpoint_security_test.go
@@ -302,6 +302,7 @@ func TestEndpointSecurityNonDefaultBasePath(t *testing.T) {
 		BasePath:       filepath.Join(paths.DefaultBasePath, "not_default"),
 	}
 	policyResp, err := tools.InstallAgentWithPolicy(t, installOpts, fixture, info.KibanaClient, createPolicyReq)
+	require.NoErrorf(t, err, "Policy Response was: %v", policyResp)
 
 	t.Log("Installing Elastic Defend")
 	pkgPolicyResp, err := installElasticDefendPackage(t, info, policyResp.ID)

--- a/testing/integration/enroll_test.go
+++ b/testing/integration/enroll_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestEnrollAndLog(t *testing.T) {
+	t.Skip("Test is flaky; see https://github.com/elastic/elastic-agent/issues/3081")
 	info := define.Require(t, define.Requirements{
 		OS: []define.OS{
 			{Type: define.Linux},
@@ -32,9 +33,6 @@ func TestEnrollAndLog(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
-
-	t.Skip("Test is flaky; see https://github.com/elastic/elastic-agent/issues/3081")
-
 	t.Logf("got namespace: %s", info.Namespace)
 	suite.Run(t, &EnrollRunner{requirementsInfo: info})
 }

--- a/testing/integration/enroll_test.go
+++ b/testing/integration/enroll_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestEnrollAndLog(t *testing.T) {
-	t.Skip("Test is flaky; see https://github.com/elastic/elastic-agent/issues/3081")
-
 	info := define.Require(t, define.Requirements{
 		OS: []define.OS{
 			{Type: define.Linux},
@@ -35,6 +33,7 @@ func TestEnrollAndLog(t *testing.T) {
 		Sudo:  true,
 	})
 	t.Logf("got namespace: %s", info.Namespace)
+	t.Skip("Test is flaky; see https://github.com/elastic/elastic-agent/issues/3081")
 	suite.Run(t, &EnrollRunner{requirementsInfo: info})
 }
 

--- a/testing/integration/enroll_test.go
+++ b/testing/integration/enroll_test.go
@@ -25,6 +25,7 @@ import (
 
 func TestEnrollAndLog(t *testing.T) {
 	t.Skip("Test is flaky; see https://github.com/elastic/elastic-agent/issues/3081")
+
 	info := define.Require(t, define.Requirements{
 		OS: []define.OS{
 			{Type: define.Linux},

--- a/testing/integration/enroll_test.go
+++ b/testing/integration/enroll_test.go
@@ -78,12 +78,16 @@ func (runner *EnrollRunner) TestEnroll() {
 	}
 	// Stage 1: Install
 	// As part of the cleanup process, we'll uninstall the agent
-	policy, err := tools.InstallAgentWithPolicy(t, runner.agentFixture, kibClient, createPolicyReq)
+	installOpts := atesting.InstallOpts{
+		NonInteractive: true,
+		Force:          true,
+	}
+	policy, err := tools.InstallAgentWithPolicy(t, installOpts, runner.agentFixture, kibClient, createPolicyReq)
 	require.NoError(t, err)
 	t.Logf("created policy: %s", policy.ID)
 
 	t.Cleanup(func() {
-		//After: unenroll
+		// After: unenroll
 		t.Logf("Cleanup: unenrolling agent")
 		err = tools.UnEnrollAgent(info.KibanaClient)
 		require.NoError(t, err)

--- a/testing/integration/fqdn_test.go
+++ b/testing/integration/fqdn_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/kibana"
 
+	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
 
@@ -92,7 +93,11 @@ func TestFQDN(t *testing.T) {
 			},
 		},
 	}
-	policy, err := tools.InstallAgentWithPolicy(t, agentFixture, kibClient, createPolicyReq)
+	installOpts := atesting.InstallOpts{
+		NonInteractive: true,
+		Force:          true,
+	}
+	policy, err := tools.InstallAgentWithPolicy(t, installOpts, agentFixture, kibClient, createPolicyReq)
 	require.NoError(t, err)
 
 	t.Log("Verify that agent name is short hostname")
@@ -162,9 +167,9 @@ func TestFQDN(t *testing.T) {
 
 	// TODO: Re-enable assertion once https://github.com/elastic/elastic-agent/issues/3078 is
 	// investigated for root cause and resolved.
-	//t.Log("Verify that hostname in `logs-*` and `metrics-*` is short hostname again")
-	//verifyHostNameInIndices(t, "logs-*", shortName, info.ESClient)
-	//verifyHostNameInIndices(t, "metrics-*", shortName, info.ESClient)
+	// t.Log("Verify that hostname in `logs-*` and `metrics-*` is short hostname again")
+	// verifyHostNameInIndices(t, "logs-*", shortName, info.ESClient)
+	// verifyHostNameInIndices(t, "metrics-*", shortName, info.ESClient)
 }
 
 func verifyAgentName(t *testing.T, hostname string, kibClient *kibana.Client) *kibana.AgentExisting {
@@ -276,7 +281,7 @@ func setHostFQDN(ctx context.Context, etcHosts []byte, externalIP, fqdn string, 
 	line := fmt.Sprintf("%s\t%s %s\n", externalIP, fqdn, shortName)
 
 	etcHosts = append(etcHosts, []byte(line)...)
-	err := os.WriteFile(filename, etcHosts, 0644)
+	err := os.WriteFile(filename, etcHosts, 0o644)
 	if err != nil {
 		return err
 	}
@@ -293,7 +298,7 @@ func setHostFQDN(ctx context.Context, etcHosts []byte, externalIP, fqdn string, 
 
 func setEtcHosts(data []byte) error {
 	filename := string(filepath.Separator) + filepath.Join("etc", "hosts")
-	return os.WriteFile(filename, data, 0644)
+	return os.WriteFile(filename, data, 0o644)
 }
 
 func setHostname(ctx context.Context, hostname string, log func(args ...any)) error {

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -112,7 +112,15 @@ func TestFleetManagedUpgrade(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Enrolling Elastic Agent...")
-	output, err := tools.InstallAgent(fleetServerURL, enrollmentToken.APIKey, agentFixture)
+	installOpts := atesting.InstallOpts{
+		NonInteractive: true,
+		Force:          true,
+		EnrollOpts: atesting.EnrollOpts{
+			URL:             fleetServerURL,
+			EnrollmentToken: enrollmentToken.APIKey,
+		},
+	}
+	output, err := tools.InstallAgent(installOpts, agentFixture)
 	if err != nil {
 		t.Log(string(output))
 	}
@@ -430,7 +438,7 @@ func TestStandaloneUpgradeRetryDownload(t *testing.T) {
 	defer restoreEtcHosts()
 
 	t.Log("Start the Agent upgrade")
-	var toVersion = upgradeToVersion.String()
+	toVersion := upgradeToVersion.String()
 	var wg sync.WaitGroup
 	go func() {
 		wg.Add(1)
@@ -573,7 +581,7 @@ func TestUpgradeBrokenPackageVersion(t *testing.T) {
 
 	actualVersion := unmarshalVersionOutput(t, actualVersionBytes, "daemon")
 
-	//start the upgrade to the latest version
+	// start the upgrade to the latest version
 	require.NotEmpty(t, actualVersion, "broken agent package version should not be empty")
 
 	// upgrade to latest version whatever that will be
@@ -605,7 +613,6 @@ func TestUpgradeBrokenPackageVersion(t *testing.T) {
 			state.Info.Snapshot == parsedLatestVersion.IsSnapshot() &&
 			state.State == cproto.State_HEALTHY
 	}, 5*time.Minute, 10*time.Second, "agent never upgraded to expected version")
-
 }
 
 func removePackageVersionFiles(t *testing.T, f *atesting.Fixture) {

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -138,7 +138,7 @@ func TestFleetManagedUpgrade(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log(`Waiting for enrolled Agent status to be "online"...`)
-	require.Eventually(t, tools.WaitForAgentStatus(t, kibClient, "online"), 3*time.Minute, 15*time.Second, "Agent status is not online")
+	require.Eventually(t, tools.WaitForAgentStatus(t, kibClient, "online"), 10*time.Minute, 15*time.Second, "Agent status is not online")
 
 	// Upgrade Watcher check disabled until
 	// https://github.com/elastic/elastic-agent/issues/2977 is resolved.


### PR DESCRIPTION
## What does this PR do?

- adds runtime prevention that prevents Elastic Defend from running if Agent is not installed in the default location
- Shows all prevention messages
- Integration test that installs agent in a non default location and tries to add Elastic Defend to the policy

## Why is it important?

Elastic Defend require the default installation path.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## Author's Checklist

- [x] Check on Linux
- [x] Check on Windows

## How to test this PR locally

### Integration test

``` bash
mage integration:single  TestEndpointSecurityNonDefaultBasePath
```

### By Hand

1. Install stack
2. Create policy without Elastic Defend
3. Install Agent, use `--base-path=<not the default>` during install
4. Check Agent is healthy in Fleet and CLI
5. Add Elastic Defend to the policy
6. Check that Agent is Degraded with 1 or more components/units in a failed state
7. Check logs and `elastic-agent status` output to make sure "Elastic Defend requires Elastic Agent be installed at the default installation path" is listed

## Related issues

- Closes #2599

## Screenshots

### elastic-agent status output (shows 2 prevention reasons displayed)

``` bash
sudo elastic-agent status
┌─ fleet
│  └─ status: (HEALTHY) Connected
└─ elastic-agent
   ├─ status: (DEGRADED) 1 or more components/units in a failed state
   └─ endpoint-default
      ├─ status: (FAILED) No support for RHEL7 on arm64, Elastic Defend requires Elastic Agent be installed at the default installation path
      ├─ endpoint-default
      │  └─ status: (FAILED) No support for RHEL7 on arm64, Elastic Defend requires Elastic Agent be installed at the default installation path
      └─ endpoint-default-2e416b68-7aa7-4cac-817b-c6a7fb2c1357
         └─ status: (FAILED) No support for RHEL7 on arm64, Elastic Defend requires Elastic Agent be installed at the default installation path

```

### Fleet Screenshot
<img width="1288" alt="Screenshot 2023-07-20 at 14 36 25" src="https://github.com/elastic/elastic-agent/assets/57081003/2160b884-cb82-411f-a263-24d73cc3999e">

## Logs

### Logs Screenshot
<img width="1288" alt="Screenshot 2023-07-20 at 14 37 07" src="https://github.com/elastic/elastic-agent/assets/57081003/3b6b6920-6308-4c7c-aabf-79ce1ab57f1f">


