### PR TITLE
Improve uninstall on Windows to remove directory even when uninstall is being executed from same directory

### DIFF
--- a/changelog/fragments/1688657261-Don't-trigger-IOC-alert-on-Windows-uninstall.yaml
+++ b/changelog/fragments/1688657261-Don't-trigger-IOC-alert-on-Windows-uninstall.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Don't trigger IOC alert on Windows uninstall
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: uninstall
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/3014
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/2970

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -78,13 +77,8 @@ func Uninstall(cfgFile, topPath, uninstallToken string) error {
 	}
 
 	// remove existing directory
-	err = os.RemoveAll(topPath)
+	err = RemovePath(topPath)
 	if err != nil {
-		if runtime.GOOS == "windows" { //nolint:goconst // it is more readable this way
-			// possible to fail on Windows, because elastic-agent.exe is running from
-			// this directory.
-			return nil
-		}
 		return errors.New(
 			err,
 			fmt.Sprintf("failed to remove installation directory (%s)", paths.Top()),
@@ -95,14 +89,33 @@ func Uninstall(cfgFile, topPath, uninstallToken string) error {
 }
 
 // RemovePath helps with removal path where there is a probability
-// of running into self which might prevent removal.
-// Removal will be initiated 2 seconds after a call.
+// of running into an executable running that might prevent removal
+// on Windows.
 func RemovePath(path string) error {
+	var previousPath string
 	cleanupErr := os.RemoveAll(path)
-	if cleanupErr != nil && isBlockingOnSelf(cleanupErr) {
-		delayedRemoval(path)
+	for cleanupErr != nil && isBlockingOnExe(cleanupErr) {
+		// remove the blocking exe
+		hardPath, hardErr := removeBlockingExe(cleanupErr)
+		if hardErr != nil {
+			// failed to remove the blocking exe (cannot continue)
+			return hardErr
+		}
+		// this if statement is being defensive and ensuring that an
+		// infinite loop to remove the same path does not occur
+		if hardPath != "" {
+			if previousPath == hardPath {
+				// no reason the previous path should be the same
+				// removeBlockingExe did not work correctly
+				//
+				// cleanupErr will contain the real error
+				return cleanupErr
+			}
+			previousPath = hardPath
+		}
+		// try to remove the original path now again
+		cleanupErr = os.RemoveAll(path)
 	}
-
 	return cleanupErr
 }
 
@@ -144,27 +157,6 @@ func containsString(str string, a []string, caseSensitive bool) bool {
 	}
 
 	return false
-}
-
-func isBlockingOnSelf(err error) bool {
-	// cannot remove self, this is expected on windows
-	// fails with  remove {path}}\elastic-agent.exe: Access is denied
-	return runtime.GOOS == "windows" &&
-		err != nil &&
-		strings.Contains(err.Error(), "elastic-agent.exe") &&
-		strings.Contains(err.Error(), "Access is denied")
-}
-
-func delayedRemoval(path string) {
-	// The installation path will still exists because we are executing from that
-	// directory. So cmd.exe is spawned that sleeps for 2 seconds (using ping, recommend way from
-	// from Windows) then rmdir is performed.
-	//nolint:gosec // it's not tainted
-	rmdir := exec.Command(
-		filepath.Join(os.Getenv("windir"), "system32", "cmd.exe"),
-		"/C", "ping", "-n", "2", "127.0.0.1", "&&", "rmdir", "/s", "/q", path)
-	_ = rmdir.Start()
-
 }
 
 func uninstallComponents(ctx context.Context, cfgFile string, uninstallToken string) error {

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -92,6 +92,10 @@ func Uninstall(cfgFile, topPath, uninstallToken string) error {
 // RemovePath helps with removal path where there is a probability
 // of running into an executable running that might prevent removal
 // on Windows.
+//
+// On Windows it is possible that a removal can spuriously error due
+// to an ERROR_SHARING_VIOLATION. RemovePath will retry up to 2
+// seconds if it keeps getting that error.
 func RemovePath(path string) error {
 	const arbitraryTimeout = 2 * time.Second
 	var start time.Time

--- a/internal/pkg/agent/install/uninstall_unix.go
+++ b/internal/pkg/agent/install/uninstall_unix.go
@@ -10,6 +10,10 @@ func isBlockingOnExe(_ error) bool {
 	return false
 }
 
-func removeBlockingExe(_ error) (string, error) {
-	return "", nil
+func removeBlockingExe(_ error) error {
+	return nil
+}
+
+func isRetryableError(_ error) bool {
+	return false
 }

--- a/internal/pkg/agent/install/uninstall_unix.go
+++ b/internal/pkg/agent/install/uninstall_unix.go
@@ -1,0 +1,15 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !windows
+
+package install
+
+func isBlockingOnExe(_ error) bool {
+	return false
+}
+
+func removeBlockingExe(_ error) (string, error) {
+	return "", nil
+}

--- a/internal/pkg/agent/install/uninstall_windows.go
+++ b/internal/pkg/agent/install/uninstall_windows.go
@@ -1,0 +1,150 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build windows
+
+package install
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func isBlockingOnExe(err error) bool {
+	if err == nil {
+		return false
+	}
+	path := getPathFromError(err)
+	return path != ""
+}
+
+func removeBlockingExe(blockingErr error) (string, error) {
+	path := getPathFromError(blockingErr)
+	if path == "" {
+		return "", nil
+	}
+
+	// open handle for delete only
+	h, err := openDeleteHandle(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to open handle for %q: %w", path, err)
+	}
+
+	// rename handle
+	err = renameHandle(h)
+	_ = windows.CloseHandle(h)
+	if err != nil {
+		return "", fmt.Errorf("failed to rename handle for %q: %w", path, err)
+	}
+
+	// re-open handle
+	h, err = openDeleteHandle(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to open handle after rename for %q: %w", path, err)
+	}
+
+	// dispose of the handle
+	err = disposeHandle(h)
+	_ = windows.CloseHandle(h)
+	if err != nil {
+		return "", fmt.Errorf("failed to dispose handle for %q: %w", path, err)
+	}
+	return path, nil
+}
+
+func getPathFromError(blockingErr error) string {
+	var perr *fs.PathError
+	if errors.As(blockingErr, &perr) {
+		var errno syscall.Errno
+		if errors.As(perr.Err, &errno) {
+			if errno == syscall.ERROR_ACCESS_DENIED {
+				return perr.Path
+			}
+		}
+	}
+	return ""
+}
+
+func openDeleteHandle(path string) (windows.Handle, error) {
+	wPath, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+	handle, err := windows.CreateFile(
+		wPath,
+		windows.DELETE,
+		0,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return handle, nil
+}
+
+func renameHandle(hHandle windows.Handle) error {
+	wRename, err := windows.UTF16FromString(":agentrm")
+	if err != nil {
+		return err
+	}
+
+	var rename fileRenameInfo
+	lpwStream := &wRename[0]
+	rename.FileNameLength = uint32(unsafe.Sizeof(lpwStream))
+
+	_, _, _ = windows.NewLazyDLL("kernel32.dll").NewProc("RtlCopyMemory").Call(
+		uintptr(unsafe.Pointer(&rename.FileName[0])),
+		uintptr(unsafe.Pointer(lpwStream)),
+		unsafe.Sizeof(lpwStream),
+	)
+
+	err = windows.SetFileInformationByHandle(
+		hHandle,
+		windows.FileRenameInfo,
+		(*byte)(unsafe.Pointer(&rename)),
+		uint32(unsafe.Sizeof(rename)+unsafe.Sizeof(lpwStream)),
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func disposeHandle(hHandle windows.Handle) error {
+	var deleteFile fileDispositionInfo
+	deleteFile.DeleteFile = true
+
+	err := windows.SetFileInformationByHandle(
+		hHandle,
+		windows.FileDispositionInfo,
+		(*byte)(unsafe.Pointer(&deleteFile)),
+		uint32(unsafe.Sizeof(deleteFile)),
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type fileRenameInfo struct {
+	Union struct {
+		ReplaceIfExists bool
+		Flags           uint32
+	}
+	RootDirectory  windows.Handle
+	FileNameLength uint32
+	FileName       [1]uint16
+}
+
+type fileDispositionInfo struct {
+	DeleteFile bool
+}

--- a/internal/pkg/agent/install/uninstall_windows_test.go
+++ b/internal/pkg/agent/install/uninstall_windows_test.go
@@ -1,0 +1,55 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build windows
+
+package install
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const simpleBlockForever = `
+package main
+
+import (
+    "math"
+    "time"
+)
+
+func main() {
+    <-time.After(time.Duration(math.MaxInt64))
+}
+`
+
+func TestRemovePath(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "subdir")
+	err := os.Mkdir(dir, 0644)
+	require.NoError(t, err)
+
+	src := filepath.Join(dir, "main.go")
+	err = os.WriteFile(src, []byte(simpleBlockForever), 0644)
+	require.NoError(t, err)
+
+	binary := filepath.Join(dir, "main.exe")
+	cmd := exec.Command("go", "build", "-o", binary, src)
+	_, err = cmd.CombinedOutput()
+	require.NoError(t, err)
+
+	cmd = exec.Command(binary)
+	err = cmd.Start()
+	require.NoError(t, err)
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	err = RemovePath(dir)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Previously the Elastic Agent would spawn a `cmd.exe` that would wait 2 seconds and then delete the `C:\Program Files\Elastic\Agent` directory. This triggers a Cloud IOC alert as that is something that nefarious applications do.

This provides a better way of uninstalling of Elastic Agent on Windows, by using the Windows API to allow removal of a directory even if there is an executable running inside of it.

This is the same as #3014 that was reverted, except it has retry logic added that keeps trying to remove the directory in the case that `ERROR_SHARING_VIOLATION` occurs. There is no way to delete a file that has that error, but some times Windows reports that error. This takes the same path that golang uses internally to remove a directory. See: https://github.com/golang/go/blob/master/src/testing/testing.go#L1257

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Two reasons this is important. Uninstall no longer has a 2 second delay for it to be fully removed, something that caused a problem with integration testing on Windows, and a Cloud IOC alert will no longer trigger when Elastic Agent is uninstalled.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test (enabled with Windows runner in other PR)

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
PS> .\elastic-agent install -f
PS> "C:\Program Files\Elastic\Agent\elastic-agent.exe" uninstall -f
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #2970 

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

```
PS C:\Program Files\Elastic> .\Agent\elastic-agent.exe uninstall
Elastic Agent will be uninstalled from your system at C:\Program Files\Elastic\Agent. Do you want to continue? [Y/n]:y
Elastic Agent has been uninstalled.
```
