### PR TITLE
Add missing error check when installing agent in endpoint-security tests

### DIFF
--- a/testing/integration/endpoint_security_test.go
+++ b/testing/integration/endpoint_security_test.go
@@ -77,6 +77,7 @@ func TestInstallAndCLIUninstallWithEndpointSecurity(t *testing.T) {
 		},
 	}
 	policyResp, err := tools.InstallAgentWithPolicy(t, fixture, info.KibanaClient, createPolicyReq)
+	require.NoError(t, err)
 
 	t.Log("Installing Elastic Defend")
 	installElasticDefendPackage(t, info, policyResp.ID)
@@ -133,6 +134,7 @@ func TestInstallAndUnenrollWithEndpointSecurity(t *testing.T) {
 		},
 	}
 	policyResp, err := tools.InstallAgentWithPolicy(t, fixture, info.KibanaClient, createPolicyReq)
+	require.NoError(t, err)
 
 	t.Log("Installing Elastic Defend")
 	installElasticDefendPackage(t, info, policyResp.ID)


### PR DESCRIPTION
Fixes panics that should have failed with an error. Noticed in [this](https://buildkiteartifacts.com/e0f3970e-3a75-4621-919f-e6c773e2bb12/0187faac-2a90-4642-bc78-c33cefa167ba/01898dc5-e977-4b80-91e6-9a97023c0280/01898dc6-b3c3-43b1-aa09-01ffe1a3f85d/build/TEST-report.html?response-content-type=text%2Fhtml&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQPCP3C7LTYT34675%2F20230725%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230725T175815Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEJX%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJHMEUCIQCIl6JaB3B63ZJ0YSUnMrVBeyoC2uxjOpgAOUbQpYgrcAIgI4Fkfl678hNbWnVllLbTa5lWKx%2B1HXidzSgg8755dA0q8QMILRAAGgwwMzIzNzk3MDUzMDMiDLK8bhIC6qKLl2CdYSrOA3ljltHg0quAJp6fqzy3ew8mP63o0GDFR1fsRvcmXs3wJpo4swnmqtDoujcJYdzMyYNbk5x1rs%2FbOQ18e3GjlKC6H9lqO26TAnvGRmRrOr2OGQ0qf6loJS2HYY23IzVOGh%2BGUU81deuUEMnQCFuEHrx50e44tNzVKc0%2BWda8xBcnD%2FwyxiDxc2bTAP3Kegz38bHnlknSVUV85IGK4Yyy%2FOZOTATe9vP6vsLBtQQXI4N1n759Uhegh8tAQuR%2BhyhSAGqEr92s8%2Buwi7A5k0IXT4fucQ3IzAb9wTecA6aujQj5agIpcAuxQfVIZ2Sw%2BFyG4xFuXH6ybsAW2Hm81K2EQapsxH%2BsIqqouyD2WAgrrRyKJVE74ORNWU8zNYvx%2FJE6co1E1ofdUw4gq3flm2Zlq%2Fl1VtlB86cxZHgJxDkU2Lr8dbxKeOQwGqLGHIUYHZW0Ofhmlwa5knsEFhab%2F8aX8l9xcjPMdkjA%2FSezijmdRo95B7rsepTA5Sinp9k8rIAQq7N7%2BfTNB0gvFVhxQojtQSDAZjpneJkKSz70MqSK1gh3dy7GcLJWcd9AtRU31WEyYjVuBRGgqSS96gAIbQI6xdJMzAL9wYazIwlOE0Q6yTCT%2BP6lBjqlAa%2FirxDOatcMXOvKQCHF1Y8pRA1iqdwb2WPFqLcVgRD2krUvYZeUeD2DT9rnjqiB3VSJXAGGLRkGWPJ1Vq8f0NW6VtvmVHjTlmsGQoIGtWEVmGsJpsKYYsjvcHwKosMiLzEK9r2VF%2Bm5f2lNap2vOExWzkuJEefec9TC4yo0819jQG9KnISKQdWWfn6e5Y3qhv858V0fx3eCxuSiCNXGud0oUW3U7g%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=c6cf074f17fa7943d192968fee2cec4daefcca763bd4e84998c27b7de048718e#github.com/elastic/elastic-agent/testing/integration(linux/arm64/ubuntu/22.04)(sudo).github.com/elastic/elastic-agent/testing/integration.TestInstallAndCLIUninstallWithEndpointSecurity) test run hiding the real error.

```
--- FAIL: TestInstallAndCLIUninstallWithEndpointSecurity (0.37s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xae37bc]

goroutine 84 [running]:
testing.tRunner.func1.2({0xc59640, 0x18d0b20})
	/usr/local/go/src/testing/testing.go:1526 +0x1c8
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1529 +0x364
panic({0xc59640, 0x18d0b20})
	/usr/local/go/src/runtime/panic.go:884 +0x1f4
github.com/elastic/elastic-agent/testing/integration.TestInstallAndCLIUninstallWithEndpointSecurity(0x400039e340)
	/home/ubuntu/agent/testing/integration/endpoint_security_test.go:82 +0x29c
testing.tRunner(0x400039e340, 0xe260e8)
	/usr/local/go/src/testing/testing.go:1576 +0x104
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1629 +0x370
```