### PR TITLE
Enable running govulncheck in PRs

### DIFF
--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -103,6 +103,15 @@ targets:
       content: '{{ source "latestGoVersion" }}'
       file: .golangci.yml
       matchpattern: '\d+.\d+.\d+'
+  update-govulncheck:
+    name: "Update govulncheck.yml"
+    sourceid: latestGoVersion
+    scmid: githubConfig
+    kind: file
+    spec:
+      content: '{{ source "latestGoVersion" }}'
+      file: .github/workflows/govulncheck.yml
+      matchpattern: '\d+.\d+.\d+'
   update-version.asciidoc:
     name: "Update version.asciidoc"
     sourceid: latestGoVersion

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,17 @@
+name: govulncheck
+on:
+  pull_request:
+
+jobs:
+  govulncheck:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    name: vulncheck
+    runs-on: ${{  matrix.os }}
+    steps:
+      - id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+           go-version-input: 1.20.6
+           go-package: ./...


### PR DESCRIPTION
- Closes https://github.com/elastic/ingest-dev/issues/2258

Enable running govulncheck in PRs to pre-emptively detect security issues.