### PR TITLE
Improve error messages

### DIFF
--- a/internal/pkg/agent/application/filters/stream_checker.go
+++ b/internal/pkg/agent/application/filters/stream_checker.go
@@ -5,6 +5,7 @@
 package filters
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
@@ -66,7 +67,7 @@ func StreamChecker(log *logger.Logger, ast *transpiler.AST) error {
 		}
 
 		if !matchesNamespaceContraints(namespace) {
-			return ErrInvalidNamespace
+			return fmt.Errorf("%w. Namespace: %q ", ErrInvalidNamespace, namespace)
 		}
 
 		// get the type, longest type for now is metrics
@@ -96,7 +97,7 @@ func StreamChecker(log *logger.Logger, ast *transpiler.AST) error {
 		}
 
 		if !matchesTypeConstraints(datasetType) {
-			return ErrInvalidIndex
+			return fmt.Errorf("%w: Dataset type: %q", ErrInvalidIndex, datasetType)
 		}
 
 		streamsNode, ok := inputNode.Find("streams")
@@ -143,7 +144,7 @@ func StreamChecker(log *logger.Logger, ast *transpiler.AST) error {
 			}
 		}
 		if !matchesDatasetConstraints(datasetName) {
-			return ErrInvalidDataset
+			return fmt.Errorf("%w. Dataset name: %q", ErrInvalidDataset, datasetName)
 		}
 	}
 
@@ -152,10 +153,9 @@ func StreamChecker(log *logger.Logger, ast *transpiler.AST) error {
 
 // The only two requirement are that it has only characters allowed in an Elasticsearch index name
 // Index names must meet the following criteria:
-//
-//	Not longer than 100 bytes
-//	Lowercase only
-//	Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
+//   - Not longer than 100 bytes
+//   - Lowercase only
+//   - Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
 func matchesNamespaceContraints(namespace string) bool {
 	// length restriction is in bytes, not characters
 	if len(namespace) <= 0 || len(namespace) > 100 {
@@ -166,11 +166,10 @@ func matchesNamespaceContraints(namespace string) bool {
 }
 
 // matchesTypeConstraints fails for following rules. As type is first element of resulting index prefix restrictions need to be applied.
-//
-//	Not longer than 20 bytes
-//	Lowercase only
-//	Cannot start with -, _, +
-//	Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
+//   - Not longer than 20 bytes
+//   - Lowercase only
+//   - Cannot start with -, _, +
+//   - Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
 func matchesTypeConstraints(dsType string) bool {
 	// length restriction is in bytes, not characters
 	if len(dsType) <= 0 || len(dsType) > 20 {

--- a/internal/pkg/agent/application/filters/stream_checker_test.go
+++ b/internal/pkg/agent/application/filters/stream_checker_test.go
@@ -258,7 +258,8 @@ func TestStreamCheck(t *testing.T) {
 			assert.NoError(t, err)
 
 			result := StreamChecker(log, ast)
-			assert.Equal(t, tc.result, result)
+			t.Log("StreamChecker returned: ", result)
+			assert.ErrorIs(t, result, tc.result, "error is different from expected")
 		})
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Improve validation error messages by adding the value that did not
pass the validation.

## Why is it important?

It helps to fix issues when Elastic-Agent fails to apply policies sent by Fleet

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
~~- [ ] I have added an integration test or an E2E test~~

~~## Author's Checklist~~
## How to test this PR locally
Run a standalone Elastic-Agent with a very simple plolicy like this:
```yaml
outputs:
  default:
    type: elasticsearch
    hosts:
      - https://localhost:9200
    username: "elastic"
    password: "changeme"
    ssl.verification_mode: none
inputs:
  - id: test-fix-error-messages
    name: Test Fix Error messages
    type: filestream
    use_output: default
    data_stream:
      namespace: default
    streams:
      - id: fix-error-messages-stream
        data_stream:
          dataset: "invalid dataset . , \""
        paths:
          - /tmp/foo.log

agent.monitoring:
  enabled: false
  logs: false
  metrics: 
```

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~


## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
