### PR TITLE
Add new install checker that stops the watcher when Elastic Agent is uninstalled

### DIFF
--- a/internal/pkg/agent/application/upgrade/crash_checker.go
+++ b/internal/pkg/agent/application/upgrade/crash_checker.go
@@ -75,6 +75,7 @@ func (ch *CrashChecker) Run(ctx context.Context) {
 			pid, err := ch.sc.PID(ctx)
 			if err != nil {
 				ch.log.Error(err)
+				continue
 			}
 
 			ch.q.Push(pid)

--- a/internal/pkg/agent/application/upgrade/install_checker.go
+++ b/internal/pkg/agent/application/upgrade/install_checker.go
@@ -1,0 +1,62 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+)
+
+var (
+	// ErrAgentUninstall error for when the Elastic Agent has been uninstalled
+	ErrAgentUninstall = errors.New("Elastic Agent was uninstalled")
+)
+
+// InstallChecker checks for removal of the Elastic Agent.
+type InstallChecker struct {
+	notifyChan    chan error
+	log           *logger.Logger
+	checkInterval time.Duration
+}
+
+// NewInstallChecker creates a new install checker.
+func NewInstallChecker(ch chan error, log *logger.Logger, checkInterval time.Duration) (*InstallChecker, error) {
+	c := &InstallChecker{
+		notifyChan:    ch,
+		log:           log,
+		checkInterval: checkInterval,
+	}
+	return c, nil
+}
+
+// Run runs the checking loop.
+func (ch *InstallChecker) Run(ctx context.Context) {
+	ch.log.Debug("Install checker started")
+	for {
+		t := time.NewTimer(ch.checkInterval)
+
+		select {
+		case <-ctx.Done():
+			t.Stop()
+			return
+		case <-t.C:
+			status, reason := install.Status(paths.Top())
+			if status == install.Installed {
+				ch.log.Debug("retrieve service status: installed")
+				continue
+			}
+			ch.notifyChan <- fmt.Errorf("%w: %s", ErrAgentUninstall, reason)
+			t.Stop()
+			return
+		}
+	}
+}

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -100,8 +100,13 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 
 	errorCheckInterval := cfg.Settings.Upgrade.Watcher.ErrorCheck.Interval
 	crashCheckInterval := cfg.Settings.Upgrade.Watcher.CrashCheck.Interval
+	installCheckInterval := cfg.Settings.Upgrade.Watcher.InstallCheck.Interval
 	ctx := context.Background()
-	if err := watch(ctx, tilGrace, errorCheckInterval, crashCheckInterval, log); err != nil {
+	if err := watch(ctx, tilGrace, errorCheckInterval, crashCheckInterval, installCheckInterval, log); err != nil {
+		if errors.Is(err, upgrade.ErrAgentUninstall) {
+			log.Error("Exiting early due to: %v", err)
+			return err
+		}
 		log.Error("Error detected proceeding to rollback: %v", err)
 		err = upgrade.Rollback(ctx, log, marker.PrevHash, marker.Hash)
 		if err != nil {
@@ -125,9 +130,10 @@ func isWindows() bool {
 	return runtime.GOOS == "windows"
 }
 
-func watch(ctx context.Context, tilGrace time.Duration, errorCheckInterval, crashCheckInterval time.Duration, log *logger.Logger) error {
+func watch(ctx context.Context, tilGrace time.Duration, errorCheckInterval, crashCheckInterval, installCheckInterval time.Duration, log *logger.Logger) error {
 	errChan := make(chan error)
 	crashChan := make(chan error)
+	installChan := make(chan error)
 
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -136,6 +142,7 @@ func watch(ctx context.Context, tilGrace time.Duration, errorCheckInterval, cras
 		cancel()
 		close(errChan)
 		close(crashChan)
+		close(installChan)
 	}()
 
 	errorChecker, err := upgrade.NewErrorChecker(errChan, log, errorCheckInterval)
@@ -148,8 +155,14 @@ func watch(ctx context.Context, tilGrace time.Duration, errorCheckInterval, cras
 		return err
 	}
 
+	installChecker, err := upgrade.NewInstallChecker(installChan, log, installCheckInterval)
+	if err != nil {
+		return err
+	}
+
 	go errorChecker.Run(ctx)
 	go crashChecker.Run(ctx)
+	go installChecker.Run(ctx)
 
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
@@ -176,6 +189,10 @@ WATCHLOOP:
 		// Agent keeps crashing unexpectedly
 		case err := <-crashChan:
 			log.Error("Agent crash detected", err)
+			return err
+		// Agent removed
+		case err := <-installChan:
+			log.Warn("Agent uninstall detected")
 			return err
 		}
 	}

--- a/internal/pkg/agent/configuration/upgrade.go
+++ b/internal/pkg/agent/configuration/upgrade.go
@@ -15,6 +15,9 @@ const (
 
 	// interval between checks for new (upgraded) Agent crashing.
 	defaultCrashCheckInterval = 10 * time.Second
+
+	// interval between checks for Agent uninstall.
+	defaultInstallCheckInterval = 10 * time.Second
 )
 
 // UpgradeConfig is the configuration related to Agent upgrades.
@@ -23,9 +26,10 @@ type UpgradeConfig struct {
 }
 
 type UpgradeWatcherConfig struct {
-	GracePeriod time.Duration             `yaml:"grace_period" config:"grace_period" json:"grace_period"`
-	ErrorCheck  UpgradeWatcherCheckConfig `yaml:"error_check" config:"error_check" json:"error_check"`
-	CrashCheck  UpgradeWatcherCheckConfig `yaml:"crash_check" config:"crash_check" json:"crash_check"`
+	GracePeriod  time.Duration             `yaml:"grace_period" config:"grace_period" json:"grace_period"`
+	ErrorCheck   UpgradeWatcherCheckConfig `yaml:"error_check" config:"error_check" json:"error_check"`
+	CrashCheck   UpgradeWatcherCheckConfig `yaml:"crash_check" config:"crash_check" json:"crash_check"`
+	InstallCheck UpgradeWatcherCheckConfig `yaml:"install_check" config:"install_check" json:"install_check"`
 }
 type UpgradeWatcherCheckConfig struct {
 	Interval time.Duration `yaml:"interval" config:"interval" json:"interval"`
@@ -40,6 +44,9 @@ func DefaultUpgradeConfig() *UpgradeConfig {
 			},
 			CrashCheck: UpgradeWatcherCheckConfig{
 				Interval: defaultCrashCheckInterval,
+			},
+			InstallCheck: UpgradeWatcherCheckConfig{
+				Interval: defaultInstallCheckInterval,
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds a new `InstallChecker` that watches that the Elastic Agent remains installed why the watcher is running. In the case that the Elastic Agent gets uninstalled the watcher will stop.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

If an Elastic Agent is upgraded and then uninstalled during the grace period the watcher will remain running. This change ensures that it stops.

Without this change it is not possible to uninstall the Elastic Agent on Windows after an upgrade has been performed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [x] I have added an integration test or an E2E test

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #3039 (not closing, yet!)
