### PR TITLE
Fix mage and go buildkit script exit codes

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -58,7 +58,9 @@ mage() {
     fi
     pushd "$WORKSPACE"
     command "mage" "$@"
+    ACTUAL_EXIT_CODE=$?
     popd
+    return $ACTUAL_EXIT_CODE
 }
 
 # Wrapper function for executing go
@@ -78,7 +80,9 @@ go(){
     fi
     pushd "$WORKSPACE"
     command go "$@"
+    ACTUAL_EXIT_CODE=$?
     popd
+    return $ACTUAL_EXIT_CODE
 }
 
 google_cloud_auth() {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes the buildkit job to fail when `mage` or `go` functions actual fail.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without this change CI integration failures will not mark the tests as failed.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #3148

