### PR TITLE
Skip flaky retry upgrade test.

### DIFF
--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -367,6 +367,8 @@ func TestStandaloneUpgradeRetryDownload(t *testing.T) {
 		}, // modifying /etc/hosts
 	})
 
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/3155")
+
 	upgradeFromVersion, err := version.ParseVersion(define.Version())
 	require.NoError(t, err)
 


### PR DESCRIPTION
This will fix the build on main and avoid wasting time while we investigate the root cause.

See https://github.com/elastic/elastic-agent/issues/3155

This test fails often enough for me that we just need to disable it while we investigate.
