### PR TITLE
Fix broken reference to common.sh

### DIFF
--- a/.buildkite/scripts/steps/build-agent-core.sh
+++ b/.buildkite/scripts/steps/build-agent-core.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-source ../scripts/common.sh
+source .buildkite/scripts/common.sh
 BEAT_VERSION=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+(\-[a-zA-Z]+[0-9]+)?' "${WORKSPACE}/version/version.go")
 export BEAT_VERSION
 


### PR DESCRIPTION
Fix a broken reference to `common.sh` in `build-agent-core.sh`