### PR TITLE
Disable proxy tests while flakiness is addressed.

### DIFF
--- a/testing/integration/proxy_url_test.go
+++ b/testing/integration/proxy_url_test.go
@@ -94,6 +94,7 @@ func TestProxyURL_EnrollProxyAndNoProxyInThePolicy(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/3154")
 
 	p := SetupTest(t)
 	t.Cleanup(func() {
@@ -137,6 +138,7 @@ func TestProxyURL_EnrollProxyAndEmptyProxyInThePolicy(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/3154")
 
 	p := SetupTest(t)
 	t.Cleanup(func() {
@@ -181,6 +183,7 @@ func TestProxyURL_ProxyInThePolicyTakesPrecedence(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/3154")
 
 	p := SetupTest(t)
 	t.Cleanup(func() {
@@ -239,6 +242,7 @@ func TestProxyURL_NoEnrollProxyAndProxyInThePolicy(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/3154")
 
 	p := SetupTest(t)
 	t.Cleanup(func() {
@@ -301,6 +305,7 @@ func TestProxyURL_RemoveProxyFromThePolicy(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/3154")
 
 	p := SetupTest(t)
 	t.Cleanup(func() {


### PR DESCRIPTION
All of the proxy tests are currently flaky and fail regularly, see https://github.com/elastic/elastic-agent/issues/3154

Disabling them while we investigate a fix to unblock CI.