### PR TITLE
Fix typo in artifact verification error log

### DIFF
--- a/internal/pkg/agent/application/upgrade/artifact/download/http/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/verifier.go
@@ -167,7 +167,7 @@ func (v *Verifier) verifyAsc(a artifact.Artifact, version string, pgpSources ...
 			v.log.Infof("Verification with PGP[%d] successful", i)
 			return nil
 		}
-		v.log.Warnf("Verification with PGP[%d] succfailed: %v", i, err)
+		v.log.Warnf("Verification with PGP[%d] failed: %v", i, err)
 	}
 
 	v.log.Warnf("Verification failed")


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fixes a confusing typo about verification failures.

## Why is it important?

It should be clear when an artifact verification fails.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Related https://github.com/elastic/ingest-dev/issues/2264