### PR TITLE
Fix typo for the word failed in the GPG verifiers.

### DIFF
--- a/internal/pkg/agent/application/upgrade/artifact/download/fs/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/fs/verifier.go
@@ -153,7 +153,7 @@ func (v *Verifier) verifyAsc(fullPath string, pgpSources ...string) error {
 			v.log.Infof("Verification with PGP[%d] successful", i)
 			return nil
 		}
-		v.log.Warnf("Verification with PGP[%d] succfailed: %v", i, err)
+		v.log.Warnf("Verification with PGP[%d] failed: %v", i, err)
 	}
 
 	v.log.Warnf("Verification failed")

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/verifier.go
@@ -167,7 +167,7 @@ func (v *Verifier) verifyAsc(a artifact.Artifact, version string, pgpSources ...
 			v.log.Infof("Verification with PGP[%d] successful", i)
 			return nil
 		}
-		v.log.Warnf("Verification with PGP[%d] succfailed: %v", i, err)
+		v.log.Warnf("Verification with PGP[%d] failed: %v", i, err)
 	}
 
 	v.log.Warnf("Verification failed")


### PR DESCRIPTION
Replace `succfailed` with `failed` so that if GPG verification fails the error is clear.