### PR TITLE
Add ability to filter runner by TEST_PLATFORM

### DIFF
--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -49,6 +49,24 @@ pass `[testName]` to `go test` as `--run=[testName]`.
 
 - `mage integration:matrix` to run all tests on the complete matrix of supported operating systems and architectures of the Elastic Agent.
 
+#### Selecting specific platform
+
+By default, the runner will deploy to every combination of operating system and architecture that the tests define
+as supporting. When working on tests and debugging an issue it's better to limit the operating system and architecture
+to a specific one. This can be done inside a test but requires the test code to be modified. An easier way is available
+using the `TEST_PLATFORMS="linux/amd64"` environment variable. This variable can take multiple definitions with a space
+between, and it can be very specific or not very specific.
+
+- `TEST_PLATFORMS="linux" mage integration:test` to execute tests only on Linux using both AMD64 and ARM64.
+- `TEST_PLATFORMS="linux/amd64" mage integration:test` to execute tests only on Linux AMD64.
+- `TEST_PLATFORMS="linux/arm64/ubuntu mage integration:test` to execute tests only on Ubuntu ARM64.
+- `TEST_PLATFORMS="linux/amd64/ubuntu/20.04 mage integration:test` to execute tests only on Ubuntu 20.04 ARM64.
+- `TEST_PLATFORMS="windows/amd64/2022 mage integration:test` to execute tests only on Windows Server 2022.
+- `TEST_PLATFORMS="linux/amd64 windows/amd64/2022 mage integration:test` to execute tests on Linux AMD64 and Windows Server 2022.
+
+> **_NOTE:_**  This only filters down the tests based on the platform. It will not execute a tests on a platform unless
+> the test defines as supporting it.
+
 #### Passing additional go test flags
 
 When running the tests we can pass additional go test flag using the env variable `GOTEST_FLAGS`.

--- a/magefile.go
+++ b/magefile.go
@@ -1721,6 +1721,7 @@ func createTestRunner(matrix bool, singleTest string, goTestFlags string, batche
 		GOVersion:         goVersion,
 		RepoDir:           ".",
 		DiagnosticsDir:    diagDir,
+		Platforms:         testPlatforms(),
 		Matrix:            matrix,
 		SingleTest:        singleTest,
 		VerboseMode:       mg.Verbose(),
@@ -1775,6 +1776,20 @@ func timestampEnabled() bool {
 	}
 	b, _ := strconv.ParseBool(timestamp)
 	return b
+}
+
+func testPlatforms() []string {
+	platformsStr := os.Getenv("TEST_PLATFORMS")
+	if platformsStr == "" {
+		return nil
+	}
+	var platforms []string
+	for _, p := range strings.Split(platformsStr, " ") {
+		if p != "" {
+			platforms = append(platforms, p)
+		}
+	}
+	return platforms
 }
 
 // Pre-requisite: user must have the gcloud CLI installed

--- a/pkg/testing/runner/config.go
+++ b/pkg/testing/runner/config.go
@@ -6,6 +6,10 @@ package runner
 
 import (
 	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/elastic/elastic-agent/pkg/testing/define"
 )
 
 // Config provides the configuration for running the runner.
@@ -16,6 +20,11 @@ type Config struct {
 	GOVersion         string
 	RepoDir           string
 	DiagnosticsDir    string
+
+	// Platforms filters the tests to only run on the provided list
+	// of platforms even if the tests supports more than what is
+	// defined in this list.
+	Platforms []string
 
 	// Matrix enables matrix testing. This explodes each test to
 	// run on all supported platforms the runner supports.
@@ -54,5 +63,53 @@ func (c *Config) Validate() error {
 	if c.RepoDir == "" {
 		return errors.New("field RepoDir must be set")
 	}
+	_, err := c.GetPlatforms()
+	if err != nil {
+		return err
+	}
 	return nil
+}
+
+// GetPlatforms returns the defined platforms for the configuration.
+func (c *Config) GetPlatforms() ([]define.OS, error) {
+	var each []define.OS
+	for _, platform := range c.Platforms {
+		o, err := parsePlatform(platform)
+		if err != nil {
+			return nil, err
+		}
+		each = append(each, o)
+	}
+	return each, nil
+}
+
+func parsePlatform(platform string) (define.OS, error) {
+	separated := strings.Split(platform, "/")
+	var os define.OS
+	switch len(separated) {
+	case 0:
+		return define.OS{}, fmt.Errorf("failed to parse platform string %q: empty string", platform)
+	case 1:
+		os = define.OS{Type: separated[0]}
+	case 2:
+		os = define.OS{Type: separated[0], Arch: separated[1]}
+	case 3:
+		if separated[0] == define.Linux {
+			os = define.OS{Type: separated[0], Arch: separated[1], Distro: separated[2]}
+		} else {
+			os = define.OS{Type: separated[0], Arch: separated[1], Version: separated[2]}
+		}
+	case 4:
+		if separated[0] == define.Linux {
+			os = define.OS{Type: separated[0], Arch: separated[1], Distro: separated[2], Version: separated[3]}
+		} else {
+			return define.OS{}, fmt.Errorf("failed to parse platform string %q: more than 2 separators", platform)
+		}
+	default:
+		return define.OS{}, fmt.Errorf("failed to parse platform string %q: more than 3 separators", platform)
+	}
+	if err := os.Validate(); err != nil {
+		return define.OS{}, fmt.Errorf("failed to parse platform string %q: %w", platform, err)
+	}
+	return os, nil
 }

--- a/pkg/testing/runner/config_test.go
+++ b/pkg/testing/runner/config_test.go
@@ -1,0 +1,136 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+)
+
+func TestConfig_GetPlatforms(t *testing.T) {
+	scenarios := []struct {
+		Platforms []string
+		Results   []define.OS
+		Err       error
+	}{
+		{
+			Platforms: nil,
+		},
+		{
+			Platforms: []string{""},
+			Err:       errors.New(`failed to parse platform string "": type must be defined`),
+		},
+		{
+			Platforms: []string{"unknown"},
+			Err:       errors.New(`failed to parse platform string "unknown": type must be either darwin, linux, or windows`),
+		},
+		{
+			Platforms: []string{"linux/blah"},
+			Err:       errors.New(`failed to parse platform string "linux/blah": arch must be either amd64 or arm64`),
+		},
+		{
+			Platforms: []string{"linux/arm64/centos/12/toomany"},
+			Err:       errors.New(`failed to parse platform string "linux/arm64/centos/12/toomany": more than 3 separators`),
+		},
+		{
+			Platforms: []string{"windows/arm64"},
+			Err:       errors.New(`failed to parse platform string "windows/arm64": windows on arm64 not supported`),
+		},
+		{
+			Platforms: []string{"linux/arm64/centos", "windows/arm64/toomany/2022"},
+			Err:       errors.New(`failed to parse platform string "windows/arm64/toomany/2022": more than 2 separators`),
+		},
+		{
+			Platforms: []string{
+				"linux",
+				"linux/amd64",
+				"linux/arm64",
+				"linux/amd64/ubuntu",
+				"linux/arm64/ubuntu/22.04",
+				"darwin",
+				"darwin/amd64",
+				"darwin/arm64",
+				"darwin/amd64/ventura",
+				"windows",
+				"windows/amd64",
+				"windows/amd64/2022",
+			},
+			Results: []define.OS{
+				{
+					Type: define.Linux,
+				},
+				{
+					Type: define.Linux,
+					Arch: define.AMD64,
+				},
+				{
+					Type: define.Linux,
+					Arch: define.ARM64,
+				},
+				{
+					Type:   define.Linux,
+					Arch:   define.AMD64,
+					Distro: Ubuntu,
+				},
+				{
+					Type:    define.Linux,
+					Arch:    define.ARM64,
+					Distro:  Ubuntu,
+					Version: "22.04",
+				},
+				{
+					Type: define.Darwin,
+				},
+				{
+					Type: define.Darwin,
+					Arch: define.AMD64,
+				},
+				{
+					Type: define.Darwin,
+					Arch: define.ARM64,
+				},
+				{
+					Type:    define.Darwin,
+					Arch:    define.AMD64,
+					Version: "ventura",
+				},
+				{
+					Type: define.Windows,
+				},
+				{
+					Type: define.Windows,
+					Arch: define.AMD64,
+				},
+				{
+					Type:    define.Windows,
+					Arch:    define.AMD64,
+					Version: "2022",
+				},
+			},
+		},
+	}
+	for _, scenario := range scenarios {
+		var name string
+		if scenario.Platforms == nil {
+			name = "empty"
+		} else {
+			name = fmt.Sprintf("platforms:%s", strings.Join(scenario.Platforms, ","))
+		}
+		t.Run(name, func(t *testing.T) {
+			c := Config{
+				Platforms: scenario.Platforms,
+			}
+			actual, err := c.GetPlatforms()
+			if scenario.Err == nil {
+				require.NoError(t, err)
+				require.Equal(t, scenario.Results, actual)
+			} else {
+				require.EqualError(t, err, scenario.Err.Error())
+			}
+		})
+	}
+}

--- a/pkg/testing/runner/config_test.go
+++ b/pkg/testing/runner/config_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package runner
 
 import (

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -143,6 +143,10 @@ func NewRunner(cfg Config, ip InstanceProvisioner, sp StackProvisioner, batches 
 	if err != nil {
 		return nil, err
 	}
+	platforms, err := cfg.GetPlatforms()
+	if err != nil {
+		return nil, err
+	}
 
 	logger := &runnerLogger{
 		writer:    os.Stdout,
@@ -153,7 +157,7 @@ func NewRunner(cfg Config, ip InstanceProvisioner, sp StackProvisioner, batches 
 
 	var osBatches []OSBatch
 	for _, b := range batches {
-		lbs, err := createBatches(b, cfg.Matrix)
+		lbs, err := createBatches(b, platforms, cfg.Matrix)
 		if err != nil {
 			return nil, err
 		}
@@ -819,9 +823,9 @@ func findBatchByID(id string, batches []OSBatch) (OSBatch, bool) {
 	return OSBatch{}, false
 }
 
-func createBatches(batch define.Batch, matrix bool) ([]OSBatch, error) {
+func createBatches(batch define.Batch, platforms []define.OS, matrix bool) ([]OSBatch, error) {
 	var batches []OSBatch
-	specifics, err := getSupported(batch.OS)
+	specifics, err := getSupported(batch.OS, platforms)
 	if errors.Is(err, ErrOSNotSupported) {
 		var s SupportedOS
 		s.OS.Type = batch.OS.Type

--- a/pkg/testing/runner/supported_test.go
+++ b/pkg/testing/runner/supported_test.go
@@ -1,0 +1,88 @@
+package runner
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+)
+
+func TestGetSupported(t *testing.T) {
+	scenarios := []struct {
+		Name      string
+		OS        define.OS
+		Platforms []define.OS
+		Results   []SupportedOS
+		Err       error
+	}{
+		{
+			Name: "not supported",
+			OS: define.OS{
+				Type: define.Darwin,
+				Arch: define.AMD64,
+			},
+			Err: errors.New("os/arch not currently supported: darwin/amd64"),
+		},
+		{
+			Name: "ubuntu/not specific",
+			OS: define.OS{
+				Type: define.Linux,
+				Arch: define.AMD64,
+			},
+			Results: []SupportedOS{
+				UbuntuAMD64_2204,
+				UbuntuAMD64_2004,
+			},
+		},
+		{
+			Name: "ubuntu/specific",
+			OS: define.OS{
+				Type:    define.Linux,
+				Arch:    define.AMD64,
+				Distro:  Ubuntu,
+				Version: "20.04",
+			},
+			Results: []SupportedOS{
+				UbuntuAMD64_2004,
+			},
+		},
+		{
+			Name: "ubuntu/platform filter",
+			OS: define.OS{
+				Type: define.Linux,
+				Arch: define.AMD64,
+			},
+			Platforms: []define.OS{
+				{
+					Type:    define.Linux,
+					Arch:    define.AMD64,
+					Distro:  Ubuntu,
+					Version: "20.04",
+				},
+				// should not have an effect
+				{
+					Type:    define.Linux,
+					Arch:    define.ARM64,
+					Distro:  Ubuntu,
+					Version: "20.04",
+				},
+			},
+			Results: []SupportedOS{
+				UbuntuAMD64_2004,
+			},
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			actual, err := getSupported(scenario.OS, scenario.Platforms)
+			if scenario.Err == nil {
+				require.NoError(t, err)
+				require.Equal(t, scenario.Results, actual)
+			} else {
+				require.EqualError(t, err, scenario.Err.Error())
+			}
+		})
+	}
+}

--- a/pkg/testing/runner/supported_test.go
+++ b/pkg/testing/runner/supported_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package runner
 
 import (


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds a new environment variable that will adjust the integration test runner to only run tests on the platforms defined in the `TEST_PLATFORM` variable. This is done in a way that allows the runner to use the platforms selected to adjust non-specific tests. Meaning if a test is not specific to the Ubuntu version and the caller has `TEST_PLATFORM=linux/amd64/ubuntu/20.04` it will use Ubuntu 20.04 instead of the default 22.04.

Note: I tried to make it use the `PLATFORM` variable so it could share the same variable as packaging. This does not work because the dev-tools/ parses that environment variable in a `init()` function.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

When debugging integration tests is nice to be able to select only a specific instance to run it on without having to modify the test. Before it required the test adjust the `define.Require` definition, now it can be done at execution time.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

Logs below show it switching to using Ubuntu 20.04 instead of the default 22.04.

```
$  TEST_PLATFORMS="linux/amd64/ubuntu/20.04" SNAPSHOT="true" mage integration:single TestStandaloneUpgradeRetryDownload
>>> Creating zip archive of repo to send to remote hosts
>>> Reusing stack 8.10.0-SNAPSHOT (8100-SNAPSHOT)
>>> Pulling latest ogc image
>>> Import layouts into ogc
>>> Bring up instances through ogc
>>> (linux-amd64-ubuntu-2004) Starting SSH; connect with `ssh -i /Users/blake/Go/src/github.com/elastic/elastic-agent/.integration-cache/id_rsa ubuntu@34.69.35.102`
>>> (linux-amd64-ubuntu-2004) Connected over SSH
>>> (linux-amd64-ubuntu-2004) Preparing instance
>>> (linux-amd64-ubuntu-2004) Running apt-get update
>>> (linux-amd64-ubuntu-2004) Install build-essential and unzip
>>> (linux-amd64-ubuntu-2004) Install golang 1.20.6 (amd64)
>>> (linux-amd64-ubuntu-2004) Copying repo
>>> (linux-amd64-ubuntu-2004) Running make mage and prepareOnRemote
>>> (linux-amd64-ubuntu-2004) Copying agent build elastic-agent-8.10.0-SNAPSHOT-linux-x86_64.tar.gz
>>> (linux-amd64-ubuntu-2004) Using Stack with Kibana host https://c6181b2954664dd6a0bcea006371e240.us-central1.gcp.qa.cld.elstc.co:9243, elastic/XRE775cZNMuIl0W0f40UQzUE
>>> (linux-amd64-ubuntu-2004) Running sudo tests...
>>> (linux-amd64-ubuntu-2004) Test output (sudo) (stderr): go: downloading github.com/rs/zerolog v1.27.0
>>> (linux-amd64-ubuntu-2004) Test output (sudo) (stdout): >> go test: remote-linux-amd64-ubuntu-2004-sudo.integration Testing
>>> (linux-amd64-ubuntu-2004) Test output (sudo) (stdout): exec: gotestsum --no-color -f standard-quiet --junitfile build/TEST-go-remote-linux-amd64-ubuntu-2004-sudo.integration.xml --jsonfile build/TEST-go-remote-linux-amd64-ubuntu-2004-sudo.integration.out.json -- -tags integration -test.shuffle on -test.timeout 0 -test.run ^(TestStandaloneUpgradeRetryDownload)$ github.com/elastic/elastic-agent/testing/integration
>>> (linux-amd64-ubuntu-2004) Test output (sudo) (stderr): go: downloading github.com/spf13/cobra v1.3.0
>>> (linux-amd64-ubuntu-2004) Test output (sudo) (stderr): go: downloading github.com/gorilla/mux v1.8.0
>>> (linux-amd64-ubuntu-2004) Test output (sudo) (stderr): go: downloading github.com/google/go-cmp v0.5.9
>>> (linux-amd64-ubuntu-2004) Test output (sudo) (stderr): go: downloading github.com/spf13/pflag v1.0.5
>>> (linux-amd64-ubuntu-2004) Test output (sudo) (stdout): -test.shuffle 1691085468881635913
>>> (linux-amd64-ubuntu-2004) Test output (sudo) (stdout): ok   github.com/elastic/elastic-agent/testing/integration    0.017s
>>> (linux-amd64-ubuntu-2004) Test output (sudo) (stdout): === Skipped
>>> (linux-amd64-ubuntu-2004) Test output (sudo) (stdout): === SKIP: testing/integration TestStandaloneUpgradeRetryDownload (0.00s)
>>> (linux-amd64-ubuntu-2004) Test output (sudo) (stdout): upgrade_test.go:588: Flaky test: https://github.com/elastic/elastic-agent/issues/3155
>>> (linux-amd64-ubuntu-2004) Test output (sudo) (stdout): DONE 1 tests, 1 skipped in 58.913s
>>> (linux-amd64-ubuntu-2004) Test output (sudo) (stdout): >> go test: remote-linux-amd64-ubuntu-2004-sudo.integration Test Passed
>>> Testing completed (1 successful)
>>> Console output written here: build/TEST-go-integration.out
>>> Console JSON output written here: build/TEST-go-integration.out.json
>>> JUnit XML written here: build/TEST-go-integration.xml
>>> Diagnostic output (if present) here: build/diagnostics
```
