### PR TITLE
[Developer Documentation] Add details of Upgrade Watcher interactions with Agent and upgrade marker file

### DIFF
--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -38,19 +38,26 @@ sequenceDiagram
        A->>A: Extract new Agent artifact
        A->>A: Replace current Agent artifact with new one
        A->>UM: Create
+       A->>A: Update active commit file
        A->>UW: Start
        A->>A: Rexec to start new Agent artifact
        A->>FS: Ack successful upgrade
-       UW->>UM: Remove
        FS->>ES: Write successful ack in `.fleet-actions-results`
        FS->>ES: Update Agent doc in `.fleet-agents`<br />set `upgrade_status` = null<br />`upgraded_at` = <now><br />`upgrade_started_at` = null
        UI->>UI: Show Agent status as "healthy"
-   end
-   opt Rollback
-       UW->>A: Start
-       A->>FS: Ack failed upgrade
-       FS->>ES: Update Agent doc in `.fleet-agents`<br />set `upgrade_status` = null<br />`upgraded_at = <now>
-       UI->>UI: Show Agent status as "healthy"
-       UW->>UM: Remove
-   end
+       UW->>UW: Start watching new Agent
+       alt New Agent is OK
+         UW->>UM: Remove
+         UW->>UW: Cleanup old Agent files
+       else Rollback
+         UW->>UW: Replace current Agent artifact with old one
+         UW->>UW: Update active commit file
+         UW->>A: Rexec to start old Agent artifact
+         A->>FS: Ack failed upgrade
+         FS->>ES: Update Agent doc in `.fleet-agents`<br />set `upgrade_status` = null<br />`upgraded_at = <now>
+         UI->>UI: Show Agent status as "healthy"
+         UW->>UM: Remove
+         UW->>UW: Cleanup new Agent files
+       end
+    end
 ```

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -36,7 +36,7 @@ sequenceDiagram
        end
        A->>A: Download new Agent artifact
        A->>A: Extract new Agent artifact
-       A->>A: Replace current Agent artifact with new one
+       A->>A: Change symlink from current Agent binary to new one
        A->>UM: Create
        A->>A: Update active commit file
        A->>UW: Start
@@ -50,7 +50,7 @@ sequenceDiagram
          UW->>UM: Remove
          UW->>UW: Cleanup old Agent files
        else Rollback
-         UW->>UW: Replace current Agent artifact with old one
+         UW->>UW: Change symlink from current Agent binary to new one
          UW->>UW: Update active commit file
          UW->>A: Rexec to start old Agent artifact
          A->>FS: Ack failed upgrade


### PR DESCRIPTION
## What does this PR do?

This PR enhances the sequence diagram in https://github.com/elastic/elastic-agent/blob/main/docs/upgrades.md to include more details about the interplay between the Upgrade Watcher, the upgrade marker file, and the Agents (old or new).

## Why is it important?

To understand exactly the steps taken by the Upgrade Watcher during an ongoing upgrade, either to decide that the new (post-upgrade) Agent is running OK or that it needs to be rolled back to the old (pre-upgrade) Agent.
