### PR TITLE
Remove 8.9 schedule for DRA artifacts

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -141,10 +141,6 @@ spec:
           build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
       repository: elastic/elastic-agent
       schedules:
-        Daily 8_9:
-          branch: '8.9'
-          cronline: '@daily'
-          message: Builds daily `8.9` dra
         Daily main:
           branch: main
           cronline: '@daily'


### PR DESCRIPTION
Since buildkite pipelines were not backported to 8.9, the scheduled DRA job for 8.9 branch is continuously failing. This removes it.