### PR TITLE
invalidate fetcher cache if hash files are different

### DIFF
--- a/pkg/testing/fetcher.go
+++ b/pkg/testing/fetcher.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,8 +52,12 @@ func GetPackageSuffix(operatingSystem string, architecture string) (string, erro
 type FetcherResult interface {
 	// Name is the name of the fetched result.
 	Name() string
+
 	// Fetch performs the actual fetch into the provided directory.
 	Fetch(ctx context.Context, l Logger, dir string) error
+
+	// FetchHash fetches the hash file for the artefact.
+	FetchHash(ctx context.Context, l Logger, dir string) error
 }
 
 // Fetcher provides a path for fetching the Elastic Agent compressed archive
@@ -85,16 +90,57 @@ type fetcherCache struct {
 func (c *fetcherCache) fetch(ctx context.Context, l Logger, res FetcherResult) (string, error) {
 	name := res.Name()
 	src := filepath.Join(c.dir, name)
-	_, err := os.Stat(src)
-	if err == nil || os.IsExist(err) {
-		l.Logf("Using existing artifact %s", name)
-		return src, nil
+
+	if c.isSameArtefact(ctx, src, res, l) {
+		_, err := os.Stat(src)
+		if err == nil || os.IsExist(err) {
+			l.Logf("Using existing artifact %s", name)
+			return src, nil
+		}
 	}
-	err = res.Fetch(ctx, l, c.dir)
+
+	err := res.Fetch(ctx, l, c.dir)
 	if err != nil {
 		return "", err
 	}
 	return src, nil
+}
+
+func (c *fetcherCache) isSameArtefact(ctx context.Context, path string, res FetcherResult, l Logger) bool {
+	// Only SNAPSHOT versions have the same name and might be different.
+	if strings.Contains(path, "SNAPSHOT") {
+		return true
+	}
+
+	hashPath := path + hashExt
+	_, err := os.Stat(hashPath)
+	if err != nil && !errors.Is(err, fs.ErrExist) {
+		return false
+	}
+
+	cachedHash, err := os.ReadFile(hashPath)
+	if err != nil {
+		l.Logf("fetcher cache could not open cached hash file to ensure the cached artefact"+
+			"is valid: %v. Not using cache", err)
+		return false
+	}
+
+	err = res.FetchHash(ctx, l, c.dir)
+	if err != nil {
+		l.Logf("fetcher cache could fetch hash file to ensure the cached artefact"+
+			"is valid: %v. Not using cache", err)
+		return false
+	}
+
+	// the res.FetchHash above overrides the hash file.
+	newHash, err := os.ReadFile(hashPath)
+	if err != nil {
+		l.Logf("fetcher cache could not open hash file to ensure the cached artefact"+
+			"is valid: %v. Not using cache", err)
+		return false
+	}
+
+	return string(newHash) == string(cachedHash)
 }
 
 func splitFileType(name string) (string, string, error) {

--- a/pkg/testing/fetcher_artifact.go
+++ b/pkg/testing/fetcher_artifact.go
@@ -99,11 +99,21 @@ func (r *artifactResult) Name() string {
 func (r *artifactResult) Fetch(ctx context.Context, l Logger, dir string) error {
 	err := DownloadPackage(ctx, l, r.doer, r.src, filepath.Join(dir, r.path))
 	if err != nil {
-		return fmt.Errorf("failed to download %s: %w", r.src, err)
+		return fmt.Errorf("failed to fetch package %s: %w", r.src, err)
 	}
 
 	// fetch package hash
-	err = DownloadPackage(ctx, l, r.doer, r.src+hashExt, filepath.Join(dir, r.path+hashExt))
+	err = r.FetchHash(ctx, l, dir)
+	if err != nil {
+		return fmt.Errorf("failed to fetch hash file %s: %w", r.src, err)
+	}
+
+	return nil
+}
+
+// FetchHash fetches the hash file for the artefact.
+func (r *artifactResult) FetchHash(ctx context.Context, l Logger, dir string) error {
+	err := DownloadPackage(ctx, l, r.doer, r.src+hashExt, filepath.Join(dir, r.path+hashExt))
 	if err != nil {
 		return fmt.Errorf("failed to download %s: %w", r.src, err)
 	}

--- a/pkg/testing/fetcher_local.go
+++ b/pkg/testing/fetcher_local.go
@@ -88,7 +88,7 @@ func (r *localFetcherResult) Name() string {
 }
 
 // Fetch performs the actual fetch into the provided directory.
-func (r *localFetcherResult) Fetch(_ context.Context, _ Logger, dir string) error {
+func (r *localFetcherResult) Fetch(ctx context.Context, l Logger, dir string) error {
 	fullPath := filepath.Join(r.src, r.path)
 	path := filepath.Join(dir, r.path)
 
@@ -97,10 +97,17 @@ func (r *localFetcherResult) Fetch(_ context.Context, _ Logger, dir string) erro
 		return fmt.Errorf("error copying file: %w", err)
 	}
 
-	// fetch artifact hash
-	err = copyFile(fullPath+hashExt, path+hashExt)
+	return r.FetchHash(ctx, l, dir)
+}
+
+// FetchHash fetches the hash file for the artefact.
+func (r *localFetcherResult) FetchHash(_ context.Context, _ Logger, dir string) error {
+	fullPath := filepath.Join(r.src, r.path)
+	path := filepath.Join(dir, r.path)
+
+	err := copyFile(fullPath+hashExt, path+hashExt)
 	if err != nil {
-		return fmt.Errorf("error copying file: %w", err)
+		return fmt.Errorf("error copying hash file: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
SNAPSHOT builds, either local or from the artifacts API, are expected to be different even though their names are the same. 

Therefore this change makes the fetcher cache to fetch the hash file and compare with the cached hash file only for SNAPSHOT versions. Non-SNAPSHOT versions are considered to be stable.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This change makes the fetcher cache to fetch the hash file and compare with the cached hash file only for SNAPSHOT versions. Non-SNAPSHOT versions are considered to be stable.

## Why is it important?

SNAPSHOT builds, either local or from the artifacts API, are expected to be different even though their names are the same. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~


## Related issues

- N/A



## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
