### PR TITLE
increase internal/pkg/agent/install.RemovePath arbitrary timeout

### DIFF
--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -97,8 +97,8 @@ func Uninstall(cfgFile, topPath, uninstallToken string) error {
 // to an ERROR_SHARING_VIOLATION. RemovePath will retry up to 2
 // seconds if it keeps getting that error.
 func RemovePath(path string) error {
-	const arbitraryTimeout = 2 * time.Second
-	var start time.Time
+	const arbitraryTimeout = 5 * time.Second
+	start := time.Now()
 	nextSleep := 1 * time.Millisecond
 	for {
 		err := os.RemoveAll(path)
@@ -115,9 +115,8 @@ func RemovePath(path string) error {
 		if !isRetryableError(err) {
 			return err
 		}
-		if start.IsZero() {
-			start = time.Now()
-		} else if d := time.Since(start) + nextSleep; d >= arbitraryTimeout {
+		
+		if d := time.Since(start) + nextSleep; d >= arbitraryTimeout {
 			return err
 		}
 	}

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -115,7 +115,7 @@ func RemovePath(path string) error {
 		if !isRetryableError(err) {
 			return err
 		}
-		
+
 		if d := time.Since(start) + nextSleep; d >= arbitraryTimeout {
 			return err
 		}

--- a/internal/pkg/agent/install/uninstall_windows_test.go
+++ b/internal/pkg/agent/install/uninstall_windows_test.go
@@ -29,6 +29,7 @@ func main() {
 `
 
 func TestRemovePath(t *testing.T) {
+	t.Skip("Flaky test, see https://github.com/elastic/elastic-agent/issues/3221")
 	dir := filepath.Join(t.TempDir(), "subdir")
 	err := os.Mkdir(dir, 0644)
 	require.NoError(t, err)

--- a/internal/pkg/agent/install/uninstall_windows_test.go
+++ b/internal/pkg/agent/install/uninstall_windows_test.go
@@ -29,7 +29,6 @@ func main() {
 `
 
 func TestRemovePath(t *testing.T) {
-	t.Skip("Flaky test, see https://github.com/elastic/elastic-agent/issues/3221")
 	dir := filepath.Join(t.TempDir(), "subdir")
 	err := os.Mkdir(dir, 0644)
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

increases internal/pkg/agent/install.RemovePath arbitraty timeout.

## Why is it important?

On non-CI machine 2s is enough, as it keeps failing on CI, let's increase it.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

run the test, it should be skipped

## Related issues

- Closes #3221 

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
