### PR TITLE
Fix mapping the upgrading state to degraded.

### DIFF
--- a/changelog/fragments/1691694963-Stop-translating-the-Upgrading-agent-state-to-Degraded.yaml
+++ b/changelog/fragments/1691694963-Stop-translating-the-Upgrading-agent-state-to-Degraded.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Stop translating the Upgrading agent state to Degraded
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/3227
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -389,16 +389,20 @@ func agentStateToString(state agentclient.State) string {
 		return fleetStateStarting
 	case agentclient.Configuring:
 		return fleetStateOnline
-	case agentclient.Stopping:
-		return fleetStateOnline
-	case agentclient.Stopped:
-		return fleetStateOnline
 	case agentclient.Upgrading:
 		return fleetStateOnline
 	case agentclient.Rollback:
 		return fleetStateDegraded
 	case agentclient.Degraded:
 		return fleetStateDegraded
+	// Report Stopping and Stopped as online since Fleet doesn't understand these states yet.
+	// Usually Stopping and Stopped mean the agent is going to stop checking in at which point Fleet
+	// will update the state to offline. Use the online state here since there isn't anything better
+	// at the moment, and the agent will end up in the expected offline state eventually.
+	case agentclient.Stopping:
+		return fleetStateOnline
+	case agentclient.Stopped:
+		return fleetStateOnline
 	}
 	// Unknown states map to degraded.
 	return fleetStateDegraded

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -387,6 +387,19 @@ func agentStateToString(state agentclient.State) string {
 		return fleetStateError
 	case agentclient.Starting:
 		return fleetStateStarting
+	case agentclient.Configuring:
+		return fleetStateOnline
+	case agentclient.Stopping:
+		return fleetStateOnline
+	case agentclient.Stopped:
+		return fleetStateOnline
+	case agentclient.Upgrading:
+		return fleetStateOnline
+	case agentclient.Rollback:
+		return fleetStateDegraded
+	case agentclient.Degraded:
+		return fleetStateDegraded
 	}
+	// Unknown states map to degraded.
 	return fleetStateDegraded
 }

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -465,7 +465,7 @@ func TestAgentStateToString(t *testing.T) {
 		// everything else maps to degraded
 		{
 			agentState:         agentclient.Configuring,
-			expectedFleetState: fleetStateDegraded,
+			expectedFleetState: fleetStateOnline,
 		},
 		{
 			agentState:         agentclient.Degraded,
@@ -473,18 +473,23 @@ func TestAgentStateToString(t *testing.T) {
 		},
 		{
 			agentState:         agentclient.Stopping,
-			expectedFleetState: fleetStateDegraded,
+			expectedFleetState: fleetStateOnline,
 		},
 		{
 			agentState:         agentclient.Stopped,
-			expectedFleetState: fleetStateDegraded,
+			expectedFleetState: fleetStateOnline,
 		},
 		{
 			agentState:         agentclient.Upgrading,
-			expectedFleetState: fleetStateDegraded,
+			expectedFleetState: fleetStateOnline,
 		},
 		{
 			agentState:         agentclient.Rollback,
+			expectedFleetState: fleetStateDegraded,
+		},
+		{
+			// Unknown states should map to degraded.
+			agentState:         agentclient.Rollback + 1,
 			expectedFleetState: fleetStateDegraded,
 		},
 	}


### PR DESCRIPTION
Degraded is interpreted by users as the agent being in an error state. We should not report degraded for situations where the agent is working as expected.

Long term we should probably just send these states directly to Fleet rather than translating them into a less fine grained set of states.

- Closes https://github.com/elastic/elastic-agent/issues/2273
