### PR TITLE
Fix flakiness on enrollment integration test and rename it

### DIFF
--- a/pkg/testing/tools/check/check.go
+++ b/pkg/testing/tools/check/check.go
@@ -1,0 +1,41 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package check
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
+	integrationtest "github.com/elastic/elastic-agent/pkg/testing"
+)
+
+// ConnectedToFleet checks if the agent defined in the fixture is connected to
+// Fleet Server. It uses assert.Eventually and if it fails the last error will
+// be printed. It returns if the agent is connected to Fleet Server or not.
+func ConnectedToFleet(t *testing.T, fixture *integrationtest.Fixture) bool {
+	t.Helper()
+
+	var err error
+	var agentStatus integrationtest.AgentStatusOutput
+	assertFn := func() bool {
+		agentStatus, err = fixture.ExecStatus(context.Background())
+		return agentStatus.FleetState == int(cproto.State_HEALTHY)
+	}
+
+	connected := assert.Eventually(t, assertFn, 5*time.Minute, 5*time.Second,
+		"want fleet state %s, got %s. agent status: %v",
+		cproto.State_HEALTHY, cproto.State(agentStatus.FleetState), agentStatus)
+
+	if !connected && err != nil {
+		t.Logf("agent isn't connected to fleet-server: last error from agent status command: %v",
+			err)
+	}
+
+	return connected
+}

--- a/testing/integration/proxy_url_test.go
+++ b/testing/integration/proxy_url_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
 	integrationtest "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/check"
 	"github.com/elastic/elastic-agent/testing/fleetservertest"
 	"github.com/elastic/elastic-agent/testing/proxytest"
 	"github.com/elastic/elastic-agent/version"
@@ -130,7 +130,7 @@ func TestProxyURL_EnrollProxyAndNoProxyInThePolicy(t *testing.T) {
 		require.NoError(t, err, "failed to install agent")
 	}
 
-	p.assertConnectedFleet(t)
+	check.ConnectedToFleet(t, p.fixture)
 }
 
 func TestProxyURL_EnrollProxyAndEmptyProxyInThePolicy(t *testing.T) {
@@ -175,7 +175,7 @@ func TestProxyURL_EnrollProxyAndEmptyProxyInThePolicy(t *testing.T) {
 		require.NoError(t, err, "failed to install agent")
 	}
 
-	p.assertConnectedFleet(t)
+	check.ConnectedToFleet(t, p.fixture)
 }
 
 func TestProxyURL_ProxyInThePolicyTakesPrecedence(t *testing.T) {
@@ -220,7 +220,7 @@ func TestProxyURL_ProxyInThePolicyTakesPrecedence(t *testing.T) {
 		require.NoError(t, err, "failed to install agent")
 	}
 
-	p.assertConnectedFleet(t)
+	check.ConnectedToFleet(t, p.fixture)
 
 	// ensure the agent is communicating through the proxy set in the policy
 	want := fleetservertest.NewPathCheckin(p.policyData.AgentID)
@@ -282,7 +282,7 @@ func TestProxyURL_NoEnrollProxyAndProxyInThePolicy(t *testing.T) {
 		require.NoError(t, err, "failed to install agent")
 	}
 
-	p.assertConnectedFleet(t)
+	check.ConnectedToFleet(t, p.fixture)
 
 	// ensure the agent is communicating through the new proxy
 	if !assert.Eventually(t, func() bool {
@@ -343,7 +343,7 @@ func TestProxyURL_RemoveProxyFromThePolicy(t *testing.T) {
 	}
 
 	// assert the agent is actually connected to fleet.
-	p.assertConnectedFleet(t)
+	check.ConnectedToFleet(t, p.fixture)
 
 	// ensure the agent is communicating through the proxy set in the policy
 	if !assert.Eventually(t, func() bool {
@@ -389,24 +389,7 @@ func TestProxyURL_RemoveProxyFromThePolicy(t *testing.T) {
 	assert.Equal(t, inspect.Fleet.ProxyURL, want)
 
 	// assert, again, the agent is actually connected to fleet.
-	p.assertConnectedFleet(t)
-}
-
-func (p *ProxyURL) assertConnectedFleet(t *testing.T) {
-	t.Helper()
-
-	var err error
-	var agentStatus integrationtest.AgentStatusOutput
-	if !assert.Eventually(t, func() bool {
-		agentStatus, err = p.fixture.ExecStatus(context.Background())
-		return agentStatus.FleetState == int(cproto.State_HEALTHY)
-	}, 5*time.Minute, 5*time.Second,
-		"want fleet state %s, got %s. agent status: %v",
-		cproto.State_HEALTHY, cproto.State(agentStatus.FleetState), agentStatus) {
-		if err != nil {
-			t.Logf("[assertConnectedFleet] last error from agent status command: %v", err)
-		}
-	}
+	check.ConnectedToFleet(t, p.fixture)
 }
 
 func (p *ProxyURL) setupFleet(t *testing.T, fleetHost string) {


### PR DESCRIPTION
## What does this PR do?

Fix flakiness on enrollment integration test and rename it so it better reflects what is tested by it.

I continually run the test for 20h and it did not fail.

## Why is it important?

The test was flaky and the name was misleading. It could lead one to believe the test was just the enrollement, when it actually tests the enrollment and the monitoring is shipping logs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

Run it continuously, it should not fail.

```sh
AGENT_VERSION=8.10.0-SNAPSHOT AGENT_KEEP_INSTALLED=true TEST_RUN_UNTIL_FAILURE=true mage integration:single TestMonitoringLogsShipped
```

I run it for 20h, no issues.

## Related issues

- Closes #3081 

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
