### PR TITLE
Daily BK job deleting stale GCE instances

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -54,8 +54,8 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-agent" && "$BUILDKITE_STEP_KEY" == 
   export TEST_INTEG_AUTH_GCP_SERVICE_TOKEN_FILE=$(realpath ./gcp.json)
 
   # ESS credentials
-  export API_KEY_TOKEN_SECRET=$(vault kv get -field api_key ${CI_AGENT_QA_OBS_PATH})
-  echo ${API_KEY_TOKEN_SECRET} > ./apiKey
+  export API_KEY_TOKEN=$(vault kv get -field api_key ${CI_AGENT_QA_OBS_PATH})
+  echo ${API_KEY_TOKEN} > ./apiKey
   export TEST_INTEG_AUTH_ESS_APIKEY_FILE=$(realpath ./apiKey)
 fi
 

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -54,8 +54,8 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-agent" && "$BUILDKITE_STEP_KEY" == 
   export TEST_INTEG_AUTH_GCP_SERVICE_TOKEN_FILE=$(realpath ./gcp.json)
 
   # ESS credentials
-  export API_KEY_TOKEN=$(vault kv get -field api_key ${CI_AGENT_QA_OBS_PATH})
-  echo ${API_KEY_TOKEN} > ./apiKey
+  export API_KEY_TOKEN_SECRET=$(vault kv get -field api_key ${CI_AGENT_QA_OBS_PATH})
+  echo ${API_KEY_TOKEN_SECRET} > ./apiKey
   export TEST_INTEG_AUTH_ESS_APIKEY_FILE=$(realpath ./apiKey)
 fi
 

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -14,7 +14,7 @@ if [ -n "$TEST_INTEG_AUTH_GCP_SERVICE_TOKEN_FILE" ]; then
   fi
 fi
 
-sh .buildkite/hooks/unset-secrets.sh
+source .buildkite/scripts/unset-secrets.sh
 
 if command -v docker &>/dev/null; then
   DOCKER_REGISTRY="docker.elastic.co"

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -14,7 +14,7 @@ if [ -n "$TEST_INTEG_AUTH_GCP_SERVICE_TOKEN_FILE" ]; then
   fi
 fi
 
-unset GOOGLE_APPLICATION_GCP_SECRET API_KEY_TOKEN
+sh .buildkite/hooks/unset-secrets.sh
 
 if command -v docker &>/dev/null; then
   DOCKER_REGISTRY="docker.elastic.co"

--- a/.buildkite/misc/gce-cleanup.yml
+++ b/.buildkite/misc/gce-cleanup.yml
@@ -2,7 +2,7 @@
 version: "1.0"
 
 accounts:
-  - name: "elastic-platform-ingest"
+  - name: "${ACCOUNT_PROJECT}"
     driver: "gce"
     options:
       key: "${ACCOUNT_KEY}"

--- a/.buildkite/misc/gce-cleanup.yml
+++ b/.buildkite/misc/gce-cleanup.yml
@@ -1,0 +1,36 @@
+---
+version: "1.0"
+
+accounts:
+  - name: "elastic-platform-ingest"
+    driver: "gce"
+    options:
+      key: "${ACCOUNT_KEY}"
+      secret: "${ACCOUNT_SECRET}"
+      project: "${ACCOUNT_PROJECT}"
+
+scanners:
+  - account_name: "${ACCOUNT_PROJECT}"
+    resources:
+      - type: "node"
+        regions:
+          - "us-central1"
+        filters:
+          - type: "<"
+            pointer: "/extra/creationTimestamp"
+            param: "${CREATION_DATE}"
+            converters:
+              param: "date"
+              value: "date"
+          - type: "="
+            pointer: "/extra/labels/project"
+            param: "elastic-agent"
+          - type: "regex"
+            pointer: "/name"
+            param: "^ogc(.*)"
+          - type: "!="
+            pointer: "/state"
+            param: "unknown"
+          - type: "!="
+            pointer: "/state"
+            param: "terminated"

--- a/.buildkite/pipeline.elastic-agent-gce-cleanup.yml
+++ b/.buildkite/pipeline.elastic-agent-gce-cleanup.yml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+
+# Removes stale GCE instances having matching labels, name prefixes and older than 24 hours
+# See gce-cleanup.sh and .buildkite/misc/gce-cleanup.yml
+env:
+  VAULT_PATH: "kv/ci-shared/observability-ingest/cloud/gcp"
+  DOCKER_REGISTRY: "docker.elastic.co"
+steps:
+  - label: "GCE Cleanup"
+    key: "gce-cleanup"
+    command: ".buildkite/scripts/steps/gce-cleanup.sh"
+    agents:
+      provider: "gcp"

--- a/.buildkite/scripts/steps/gce-cleanup.sh
+++ b/.buildkite/scripts/steps/gce-cleanup.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 
-set -exuo pipefail
+set -euo pipefail
 
 export ACCOUNT_KEY_SECRET=$(vault kv get -field=client_email $VAULT_PATH)
 export ACCOUNT_SECRET=$(vault kv get -field=private_key $VAULT_PATH)
 export ACCOUNT_PROJECT_SECRET=$(vault kv get -field=project_id $VAULT_PATH)
 export CREATION_DATE=$(date -Is -d "24 hours ago")
 
-
+set +e
 docker run -v $(pwd)/.buildkite/misc/gce-cleanup.yml:/etc/cloud-reaper/config.yml \
   -e ACCOUNT_SECRET="$ACCOUNT_SECRET" \
   -e ACCOUNT_KEY="$ACCOUNT_KEY_SECRET" \
   -e ACCOUNT_PROJECT=$ACCOUNT_PROJECT_SECRET \
   -e CREATION_DATE=$CREATION_DATE \
   ${DOCKER_REGISTRY}/observability-ci/cloud-reaper:0.3.0 cloud-reaper --config /etc/cloud-reaper/config.yml destroy --confirm
+
+unset ACCOUNT_KEY_SECRET
+unset ACCOUNT_SECRET
+unset ACCOUNT_PROJECT_SECRET

--- a/.buildkite/scripts/steps/gce-cleanup.sh
+++ b/.buildkite/scripts/steps/gce-cleanup.sh
@@ -7,14 +7,9 @@ export ACCOUNT_SECRET=$(vault kv get -field=private_key $VAULT_PATH)
 export ACCOUNT_PROJECT_SECRET=$(vault kv get -field=project_id $VAULT_PATH)
 export CREATION_DATE=$(date -Is -d "24 hours ago")
 
-set +e
 docker run -v $(pwd)/.buildkite/misc/gce-cleanup.yml:/etc/cloud-reaper/config.yml \
   -e ACCOUNT_SECRET="$ACCOUNT_SECRET" \
   -e ACCOUNT_KEY="$ACCOUNT_KEY_SECRET" \
   -e ACCOUNT_PROJECT=$ACCOUNT_PROJECT_SECRET \
   -e CREATION_DATE=$CREATION_DATE \
   ${DOCKER_REGISTRY}/observability-ci/cloud-reaper:0.3.0 cloud-reaper --config /etc/cloud-reaper/config.yml destroy --confirm
-
-unset ACCOUNT_KEY_SECRET
-unset ACCOUNT_SECRET
-unset ACCOUNT_PROJECT_SECRET

--- a/.buildkite/scripts/steps/gce-cleanup.sh
+++ b/.buildkite/scripts/steps/gce-cleanup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+export ACCOUNT_KEY_SECRET=$(vault kv get -field=client_email $VAULT_PATH)
+export ACCOUNT_SECRET=$(vault kv get -field=private_key $VAULT_PATH)
+export ACCOUNT_PROJECT_SECRET=$(vault kv get -field=project_id $VAULT_PATH)
+export CREATION_DATE=$(date -Is -d "24 hours ago")
+
+
+docker run -v $(pwd)/.buildkite/misc/gce-cleanup.yml:/etc/cloud-reaper/config.yml \
+  -e ACCOUNT_SECRET="$ACCOUNT_SECRET" \
+  -e ACCOUNT_KEY="$ACCOUNT_KEY_SECRET" \
+  -e ACCOUNT_PROJECT=$ACCOUNT_PROJECT_SECRET \
+  -e CREATION_DATE=$CREATION_DATE \
+  ${DOCKER_REGISTRY}/observability-ci/cloud-reaper:0.3.0 cloud-reaper --config /etc/cloud-reaper/config.yml destroy --confirm

--- a/.buildkite/scripts/unset-secrets.sh
+++ b/.buildkite/scripts/unset-secrets.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 # Unset all variables ending with _SECRET
 for var in $(printenv | sed 's;=.*;;' | sort); do
-  if [[ "$var" == *_SECRET ]]; then
+  if [[ "$var" == *_SECRET || "$var" == *_TOKEN]]; then
       unset "$var"
   fi
 done

--- a/.buildkite/scripts/unset-secrets.sh
+++ b/.buildkite/scripts/unset-secrets.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 set -euo pipefail
-# Unset all variables ending with _SECRET
+# Unset all variables ending with _SECRET or _TOKEN
 for var in $(printenv | sed 's;=.*;;' | sort); do
-  if [[ "$var" == *_SECRET || "$var" == *_TOKEN]]; then
+  if [[ "$var" == *_SECRET || "$var" == *_TOKEN ]]; then
       unset "$var"
   fi
 done

--- a/.buildkite/scripts/unset-secrets.sh
+++ b/.buildkite/scripts/unset-secrets.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+# Unset all variables ending with _SECRET
+for var in $(printenv | sed 's;=.*;;' | sort); do
+  if [[ "$var" == *_SECRET ]]; then
+      unset "$var"
+  fi
+done

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -156,7 +156,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
   name: buildkite-elastic-agent-gce-cleanup
-  description: Buildkite pipeline to clean up stale GCE instances
+  description: Clean up stale GCE instances
   links:
     - title: Pipeline
       url: https://buildkite.com/elastic/elastic-agent

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -48,14 +48,14 @@ spec:
         filter_condition: >-
           build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
       cancel_intermediate_builds: true
-      cancel_intermediate_builds_branch_filter: '!main'
+      cancel_intermediate_builds_branch_filter: "!main"
       skip_intermediate_builds: true
-      skip_intermediate_builds_branch_filter: '!main'
+      skip_intermediate_builds_branch_filter: "!main"
       env:
-        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
-        SLACK_NOTIFICATIONS_CHANNEL: '#ingest-notifications'
-        SLACK_NOTIFICATIONS_ALL_BRANCHES: 'false'
-        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: "true"
+        SLACK_NOTIFICATIONS_CHANNEL: "#ingest-notifications"
+        SLACK_NOTIFICATIONS_ALL_BRANCHES: "false"
+        SLACK_NOTIFICATIONS_ON_SUCCESS: "false"
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ
@@ -96,9 +96,9 @@ spec:
         filter_condition: >-
           build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
       cancel_intermediate_builds: true
-      cancel_intermediate_builds_branch_filter: '!main'
+      cancel_intermediate_builds_branch_filter: "!main"
       skip_intermediate_builds: true
-      skip_intermediate_builds_branch_filter: '!main'
+      skip_intermediate_builds_branch_filter: "!main"
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ
@@ -143,8 +143,51 @@ spec:
       schedules:
         Daily main:
           branch: main
-          cronline: '@daily'
+          cronline: "@daily"
           message: Builds daily `main` dra
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: BUILD_AND_READ
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-elastic-agent-gce-cleanup
+  description: Buildkite pipeline to clean up stale GCE instances
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elastic-agent
+
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: elastic-agent-gce-cleanup
+      description: Buildkite pipeline for packaging Elastic Agent core binary and publish it to DRA
+    spec:
+      pipeline_file: ".buildkite/pipeline.elastic-agent-gce-cleanup.yml"
+      provider_settings:
+        build_pull_request_forks: false
+        build_pull_requests: false # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
+        publish_commit_status: false # do not update status of commits for this pipeline
+        build_tags: false
+        build_branches: false
+        filter_enabled: true
+        filter_condition: >-
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
+      repository: elastic/elastic-agent
+      schedules:
+        Daily main:
+          branch: main
+          cronline: "@daily"
+          message: Daily GCE cleanup
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION

- Enhancement

## What does this PR do?

Daily buildkite job that cleans up stale GCE instances left after integration tests
Removes stale GCE instances having matching labels, name prefixes and older than 24 hours

## Why is it important?
Integration tests are being interrupted without a proper cleanup when we add new commits to pull requests.
It's a temporary solution. Normally we should make the CI system manage build agents. 
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

