### PR TITLE
[Upgrade Watcher] Add logging to rollback restart step

### DIFF
--- a/changelog/fragments/1692141038-upgrade-watcher-logging.yaml
+++ b/changelog/fragments/1692141038-upgrade-watcher-logging.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Adds more logging to the rollback process
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/3245
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -148,20 +148,20 @@ func restartAgent(ctx context.Context, log *logger.Logger) error {
 
 	for i := maxRestartCount; i >= 1; i-- {
 		backExp.Wait()
-
 		attempt := maxRestartCount - i + 1
-		log.Infof("Restarting Agent; attempt %d of %d", attempt, maxRestartCount)
+		log.Infof("Restarting Agent via control protocol; attempt %d of %d", attempt, maxRestartCount)
 
 		err := restartFn(ctx)
 		if err == nil {
-			log.Warnf("Failed to restart agent: %s", err.Error())
 			break
 		}
 
 		if i == 1 {
-			log.Error("Failed to restart agent after final attempt")
+			log.Error("Failed to restart agent via control protocol after final attempt")
 			return err
 		}
+
+		log.Warnf("Failed to restart agent via control protocol: %s; will try again in %v", err.Error(), backExp.NextWait())
 	}
 
 	close(signal)

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -146,17 +146,16 @@ func restartAgent(ctx context.Context, log *logger.Logger) error {
 	signal := make(chan struct{})
 	backExp := backoff.NewExpBackoff(signal, restartBackoffInit, restartBackoffMax)
 
-	for i := maxRestartCount; i >= 1; i-- {
+	for restartAttempt := 1; restartAttempt <= maxRestartCount; restartAttempt++ {
 		backExp.Wait()
-		attempt := maxRestartCount - i + 1
-		log.Infof("Restarting Agent via control protocol; attempt %d of %d", attempt, maxRestartCount)
+		log.Infof("Restarting Agent via control protocol; attempt %d of %d", restartAttempt, maxRestartCount)
 
 		err := restartFn(ctx)
 		if err == nil {
 			break
 		}
 
-		if i == 1 {
+		if restartAttempt == maxRestartCount {
 			log.Error("Failed to restart agent via control protocol after final attempt")
 			return err
 		}

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -63,6 +63,10 @@ func newRunCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
 		Short: "Start the Elastic Agent",
 		Long:  "This command starts the Elastic Agent.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// FIXME: remove this — testing only!
+			time.Sleep(10 * time.Second)
+			return errors.New("deliberately crashing agent very early")
+
 			// done very early so the encrypted store is never used
 			disableEncryptedStore, _ := cmd.Flags().GetBool("disable-encrypted-store")
 			if disableEncryptedStore {

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -152,6 +152,9 @@ func run(override cfgOverrider, testingMode bool, fleetInitTimeout time.Duration
 		"source": agentName,
 	})
 
+	// Make sure to flush any buffered logs before we're done.
+	defer l.Sync()
+
 	cfg, err = tryDelayEnroll(ctx, l, cfg, override)
 	if err != nil {
 		err = errors.New(err, "failed to perform delayed enrollment")

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -63,10 +63,6 @@ func newRunCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
 		Short: "Start the Elastic Agent",
 		Long:  "This command starts the Elastic Agent.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			// FIXME: remove this — testing only!
-			time.Sleep(10 * time.Second)
-			return errors.New("deliberately crashing agent very early")
-
 			// done very early so the encrypted store is never used
 			disableEncryptedStore, _ := cmd.Flags().GetBool("disable-encrypted-store")
 			if disableEncryptedStore {

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -148,12 +148,12 @@ func run(override cfgOverrider, testingMode bool, fleetInitTimeout time.Duration
 		return err
 	}
 
+	// Make sure to flush any buffered logs before we're done.
+	defer baseLogger.Sync() //nolint:errcheck // flushing buffered logs is best effort.
+
 	l := baseLogger.With("log", map[string]interface{}{
 		"source": agentName,
 	})
-
-	// Make sure to flush any buffered logs before we're done.
-	defer l.Sync() //nolint:errcheck // flushing buffered logs is best effort.
 
 	cfg, err = tryDelayEnroll(ctx, l, cfg, override)
 	if err != nil {

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -153,7 +153,7 @@ func run(override cfgOverrider, testingMode bool, fleetInitTimeout time.Duration
 	})
 
 	// Make sure to flush any buffered logs before we're done.
-	defer l.Sync()
+	defer l.Sync() //nolint:errcheck // flushing buffered logs is best effort.
 
 	cfg, err = tryDelayEnroll(ctx, l, cfg, override)
 	if err != nil {

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -48,7 +48,7 @@ func newWatchCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command 
 			}
 
 			// Make sure to flush any buffered logs before we're done.
-			defer log.Sync()
+			defer log.Sync() //nolint:errcheck // flushing buffered logs is best effort.
 
 			if err := watchCmd(log, cfg); err != nil {
 				log.Errorw("Watch command failed", "error.message", err)

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -47,6 +47,9 @@ func newWatchCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command 
 				os.Exit(3)
 			}
 
+			// Make sure to flush any buffered logs before we're done.
+			defer log.Sync()
+
 			if err := watchCmd(log, cfg); err != nil {
 				log.Errorw("Watch command failed", "error.message", err)
 				fmt.Fprintf(streams.Err, "Watch command failed: %v\n%s\n", err, troubleshootMessage())

--- a/version/version.go
+++ b/version/version.go
@@ -4,6 +4,5 @@
 
 package version
 
-// FIXME: remove this — testing only!
-const defaultBeatVersion = "8.12.0"
+const defaultBeatVersion = "8.11.0"
 const Agent = defaultBeatVersion

--- a/version/version.go
+++ b/version/version.go
@@ -4,5 +4,6 @@
 
 package version
 
-const defaultBeatVersion = "8.11.0"
+// FIXME: remove this — testing only!
+const defaultBeatVersion = "8.12.0"
 const Agent = defaultBeatVersion


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR adds logging to the restart step of the Agent upgrade rollback process.

## Why is it important?

To better understand the progress of the upgrade rollback process.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] ~I have added an integration test or an E2E test~

## How to test this PR locally

1. Build an install Agent from `main` (currently at version `8.11.0`).
   ```
   EXTERNAL=true SNAPSHOT=true  DEV=true PLATFORMS=linux/arm64 PACKAGES=tar.gz mage package
   ```
3. Build Agent package from this PR (currently at version `8.12.0`).  Make sure NOT to use `SNAPSHOT=true` or `EXTERNAL=true`.
   ```
   DEV=true PLATFORMS=linux/arm64 PACKAGES=tar.gz mage package
   ```
4. Upgrade the installed `8.11.0` Agent to the `8.12.0` Agent built with this PR.
   ```
   sudo elastic-agent upgrade 8.12.0 --source-uri file://$(pwd)/build/distributions/ --skip-verify
   ```
6. Tail the Upgrade Watcher logs and ensure that the log messages in this PR show up.
   ```
   tail -F /opt/Elastic/Agent/data/elastic-agent-b8da42/logs/elastic-agent-watcher-$(date +%Y%m%d).ndjson
   ```
