### PR TITLE
fix the GCP credentials variable name

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -92,7 +92,7 @@ google_cloud_auth() {
 
     gcloud auth activate-service-account --key-file ${keyFile} 2> /dev/null
 
-    export GOOGLE_APPLICATIONS_CREDENTIALS=${secretFileLocation}
+    export GOOGLE_APPLICATION_CREDENTIALS=${secretFileLocation}
 }
 
 retry() {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fix the GCP credentials variable name according to the doc: https://cloud.google.com/docs/authentication/application-default-credentials#GAC

## Why is it important?

The credentials aren't working properly in some cases, for example, when the pipeline has multiple GCP credentials. 

## Checklist

It was tested in the other elastic repo.
