### PR TITLE
Small improvements on integration tests

### DIFF
--- a/pkg/testing/tools/testcontext/testcontext.go
+++ b/pkg/testing/tools/testcontext/testcontext.go
@@ -1,0 +1,24 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package testcontext
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// WithDeadline returns a context with a deadline. The deadline is the earliest
+// of either the provided 'deadline' or t.Deadline().
+func WithDeadline(
+	t *testing.T,
+	parent context.Context,
+	deadline time.Time) (context.Context, context.CancelFunc) {
+	if d, ok := t.Deadline(); ok {
+		deadline = d
+	}
+	ctx, cancel := context.WithDeadline(parent, deadline)
+	return ctx, cancel
+}

--- a/testing/integration/install_test.go
+++ b/testing/integration/install_test.go
@@ -53,8 +53,8 @@ func TestInstallWithoutBasePath(t *testing.T) {
 	}
 
 	topPath := filepath.Join(defaultBasePath, "Elastic", "Agent")
-	_, err = os.Stat(topPath)
-	require.True(t, os.IsNotExist(err))
+	err = os.RemoveAll(topPath)
+	require.NoError(t, err, "failed to remove %q. The test requires this path not to exist.")
 
 	// Run `elastic-agent install`.  We use `--force` to prevent interactive
 	// execution.

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -470,7 +470,8 @@ func testStandaloneUpgrade(
 	}
 
 	upgradeTriggerOutput, err := f.Exec(ctx, upgradeCmdArgs)
-	require.NoErrorf(t, err, "error triggering agent upgrade to version %q, output:\n%s%", parsedUpgradeVersion, upgradeTriggerOutput)
+	require.NoErrorf(t, err, "error triggering agent upgrade to version %q, output:\n%s",
+		parsedUpgradeVersion, upgradeTriggerOutput)
 
 	require.Eventuallyf(t, func() bool {
 		return checkAgentHealthAndVersion(t, ctx, f, parsedUpgradeVersion.CoreVersion(), parsedUpgradeVersion.IsSnapshot(), expectedAgentHashAfterUpgrade)


### PR DESCRIPTION
 - remove missing verb on printf-like call
 - remove folder as it might be left over from another test

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fixes a possible cause of flakiness on tests and the missing verb on a printf-like call.

## Why is it important?

To avoid test flakiness

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~


## Related issues

- N/A

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
