### PR TITLE
Add cnative team as codeowner for k8s provider

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 
 /deploy/kubernetes @elastic/obs-cloudnative-monitoring
 /dev-tools/kubernetes @elastic/obs-cloudnative-monitoring
+/internal/pkg/composable/providers/kubernetes @elastic/obs-cloudnative-monitoring


### PR DESCRIPTION
## What does this PR do?

Add cloud-native group as codeowner for the k8s provider.
Related to https://github.com/elastic/elastic-agent/pull/3107#issuecomment-1686568690.