### PR TITLE
Use artifacts-snapshot instead of e2e-testing dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -154,6 +154,7 @@ require (
 )
 
 require (
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/hashicorp/go-version v1.2.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/onsi/gomega v1.27.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,8 @@ github.com/cavaliercoder/badio v0.0.0-20160213150051-ce5280129e9e h1:YYUjy5BRwO5
 github.com/cavaliercoder/badio v0.0.0-20160213150051-ce5280129e9e/go.mod h1:V284PjgVwSk4ETmz84rpu9ehpGg7swlIH8npP9k2bGw=
 github.com/cavaliercoder/go-rpm v0.0.0-20190131055624-7a9c54e3d83e h1:Gbx+iVCXG/1m5WSnidDGuHgN+vbIwl+6fR092ANU+Y8=
 github.com/cavaliercoder/go-rpm v0.0.0-20190131055624-7a9c54e3d83e/go.mod h1:AZIh1CCnMrcVm6afFf96PBvE2MRpWFco91z8ObJtgDY=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.2 h1:6Yo7N8UP2K6LWZnW94DLVSSrbobcWdVzAYOisuDPIFo=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=

--- a/pkg/testing/tools/artifacts_snapshot.go
+++ b/pkg/testing/tools/artifacts_snapshot.go
@@ -1,0 +1,204 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/google/uuid"
+	"golang.org/x/exp/maps"
+)
+
+const (
+	defaultAPIURL         = "https://artifacts-snapshot.elastic.co"
+	beatsManifestEndpoint = "beats/latest/%s.json"
+)
+
+type ArtifactSnapshotClient struct {
+	url        string
+	httpClient *http.Client
+}
+
+type ArtifactsManifestResponse struct {
+	BuildID     string `json:"build_id"`     // example value: "8.8.3-b1d8691a"
+	Version     string `json:"version"`      // example value: "8.8.3-SNAPSHOT"
+	ManifestURL string `json:"manifest_url"` // example value: https://artifacts-snapshot.elastic.co/beats/8.8.3-b1d8691a/manifest-8.8.3-SNAPSHOT.json
+	SummaryURL  string `json:"summary_url"`  // example value: https://artifacts-snapshot.elastic.co/beats/8.8.3-b1d8691a/summary-8.8.3-SNAPSHOT.html
+}
+
+type Projects struct {
+	Projects map[string]ProjectData `json:"projects"`
+}
+
+type ProjectData struct {
+	Branch     string                 `json:"branch"`
+	CommitHash string                 `json:"commit_hash"`
+	CommitURL  string                 `json:"commit_url"`
+	Packages   map[string]PackageData `json:"packages"`
+}
+
+type PackageData struct {
+	Url          string            `json:"url"`
+	ShaUrl       string            `json:"sha_url"`
+	Type         string            `json:"type"`
+	Architecture string            `json:"architecture"`
+	OS           []string          `json:"os"`
+	Attributes   map[string]string `json:"attributes"`
+}
+
+type PackageRequest struct {
+	// heartbeat-8.10.0-SNAPSHOT-linux-x86_64.tar.gz
+	Name       string
+	TargetPath string
+}
+
+func NewArtifactSnapshotClient() *ArtifactSnapshotClient {
+	return &ArtifactSnapshotClient{
+		url:        defaultAPIURL,
+		httpClient: new(http.Client),
+	}
+}
+
+func (c *ArtifactSnapshotClient) DownloadPackages(ctx context.Context, packageRequests []PackageRequest, version string) error {
+	manResponse, err := c.getManifestResponse(ctx, version)
+	if err != nil {
+		return fmt.Errorf("getting manifest response: %w", err)
+	}
+	manifestPackages, err := c.getManifestPackages(ctx, manResponse.ManifestURL)
+	if err != nil {
+		return fmt.Errorf("getting manifest packages: %w", err)
+	}
+	for _, pkg := range packageRequests {
+		pkgData, ok := manifestPackages[pkg.Name]
+		if !ok {
+			return fmt.Errorf("package %s not found in manifest", pkg)
+		}
+		err := c.downloadPackage(ctx, pkgData, pkg.TargetPath)
+		if err != nil {
+			return fmt.Errorf("downloading package: %w", err)
+		}
+	}
+	return nil
+}
+
+func (c *ArtifactSnapshotClient) getManifestResponse(ctx context.Context, version string) (*ArtifactsManifestResponse, error) {
+	endpoint := fmt.Sprintf(beatsManifestEndpoint, version)
+	url := fmt.Sprintf("%s/%s", c.url, endpoint)
+	response, err := c.createAndPerformRequest(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("creating and performing request: %w", err)
+	}
+	manResponse, err := checkResponseAndUnmarshal[ArtifactsManifestResponse](response)
+	if err != nil {
+		return nil, fmt.Errorf("checking response and unmarshalling: %w", err)
+	}
+	return manResponse, nil
+}
+
+func (c *ArtifactSnapshotClient) getManifestPackages(ctx context.Context, manifestURL string) (map[string]PackageData, error) {
+	response, err := c.createAndPerformRequest(ctx, manifestURL)
+	if err != nil {
+		return nil, fmt.Errorf("creating and performing request: %w", err)
+	}
+	manResponse, err := checkResponseAndUnmarshal[Projects](response)
+	if err != nil {
+		return nil, fmt.Errorf("checking response and unmarshalling: %w", err)
+	}
+	allPackages := make(map[string]PackageData)
+	for _, v := range maps.Values(manResponse.Projects) {
+		for k, pack := range v.Packages {
+			allPackages[k] = pack
+		}
+	}
+	return allPackages, nil
+}
+
+func (c *ArtifactSnapshotClient) downloadPackage(ctx context.Context, pkg PackageData, destinationDir string) error {
+
+	return nil
+}
+
+func downloadFile(url string, path string) error {
+	var filePath string
+	if path == "" {
+		tempParentDir := filepath.Join(os.TempDir(), uuid.NewString())
+		filePath = filepath.Join(tempParentDir, uuid.NewString())
+		path = filePath
+	} else {
+		filePath = filepath.Join(path, uuid.NewString())
+	}
+
+	tempFile, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("creating file: %w", err)
+	}
+	defer tempFile.Close()
+	exp := getExponentialBackOff(3)
+
+	retryCount := 1
+	var fileReader io.ReadCloser
+	download := func() error {
+		resp, err := http.Get(url)
+		if err != nil {
+			retryCount++
+			return fmt.Errorf("getting url %s: %w", url, err)
+		}
+		fileReader = resp.Body
+
+		return nil
+	}
+
+	err = backoff.Retry(download, exp)
+	if err != nil {
+		return err
+	}
+	defer fileReader.Close()
+
+	_, err = io.Copy(tempFile, fileReader)
+	if err != nil {
+		return fmt.Errorf("copying file: %w", err)
+	}
+
+	_ = os.Chmod(tempFile.Name(), 0666)
+
+	return nil
+}
+
+func getExponentialBackOff(elapsedTime time.Duration) *backoff.ExponentialBackOff {
+	var (
+		initialInterval     = 10 * time.Second
+		randomizationFactor = 0.5
+		multiplier          = 2.0
+		maxInterval         = 30 * time.Second
+		maxElapsedTime      = elapsedTime
+	)
+
+	exp := backoff.NewExponentialBackOff()
+	exp.InitialInterval = initialInterval
+	exp.RandomizationFactor = randomizationFactor
+	exp.Multiplier = multiplier
+	exp.MaxInterval = maxInterval
+	exp.MaxElapsedTime = maxElapsedTime
+
+	return exp
+}
+
+func (aac *ArtifactSnapshotClient) createAndPerformRequest(ctx context.Context, URL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, URL, nil)
+	if err != nil {
+		err = fmt.Errorf("composing request: %w", err)
+		return nil, err
+	}
+
+	resp, err := aac.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing http request %v: %w", req, err)
+	}
+
+	return resp, nil
+}

--- a/pkg/testing/tools/artifacts_snapshot_test.go
+++ b/pkg/testing/tools/artifacts_snapshot_test.go
@@ -1,0 +1,33 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArtifactsSnapshotManifest(t *testing.T) {
+
+	snapshotClient := NewArtifactSnapshotClient()
+	resp, err := snapshotClient.getManifestResponse(context.Background(), "8.10.0-SNAPSHOT")
+	assert.NoError(t, err)
+
+	t.Logf("resp: %+v\n", resp)
+
+}
+
+func TestArtifactsSnapshotProjects(t *testing.T) {
+	ctx := context.Background()
+	snapshotClient := NewArtifactSnapshotClient()
+	resp, err := snapshotClient.getManifestResponse(ctx, "8.10.0-SNAPSHOT")
+	assert.NoError(t, err)
+	packageMap, err := snapshotClient.getManifestPackages(ctx, resp.ManifestURL)
+	assert.NoError(t, err)
+	t.Logf("packageMap: %+v\n", packageMap)
+	t.Log("------------------")
+	t.Log(packageMap["auditbeat-8.10.0-SNAPSHOT-aarch64.rpm"])
+	t.Log("------------------")
+	t.Log(packageMap["auditbeat-8.10.0-SNAPSHOT-aarch64.rpm"].Url)
+
+}


### PR DESCRIPTION
- Enhancement

## What does this PR do?
Use artifacts-snapshot instead of the dependency from e2e-testing
## Why is it important?
Artifacts-api has some delay before we can get a new version of a recently published artifact. Artifacts-snapshot can be used to immediate artefacts retrievial especially when we bump the current version.

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

`DEV=true EXTERNAL=true SNAPSHOT=true PLATFORMS=linux/amd64,linux/arm64 PACKAGES=tar.gz mage package`
## Related issues