### PR TITLE
Test against 8.10 on main with the 8.11 agent by editing the package version

### DIFF
--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -21,8 +21,6 @@ import (
 	"time"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
-	"github.com/elastic/elastic-agent/pkg/version"
-	agentVersion "github.com/elastic/elastic-agent/version"
 
 	"github.com/otiai10/copy"
 	"gopkg.in/yaml.v2"
@@ -32,6 +30,8 @@ import (
 	"github.com/elastic/elastic-agent/pkg/control/v2/client"
 	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
 	"github.com/elastic/elastic-agent/pkg/core/process"
+	"github.com/elastic/elastic-agent/pkg/version"
+	agentVersion "github.com/elastic/elastic-agent/version"
 )
 
 // Fixture handles the setup and management of the Elastic Agent.
@@ -179,7 +179,71 @@ func (f *Fixture) Prepare(ctx context.Context, components ...UsableComponent) er
 	if err != nil {
 		return err
 	}
+
 	f.workDir = finalDir
+
+	err = decreasePackageVersionDuringFeatureFreeze(f, f.workDir)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// After feature freeze the agent has the version of the next minor but there is a few
+// days of lag until the snapshot is produced to test against. To get around this the
+// tests continue to provision the previous minor and the agent package version is replaced
+// to report the previous minor version as well. As of the time of writing fleet server
+// will consider versions greater than its own to be unsupported. This allows the newer
+// agent to enroll.
+//
+// This function is meant to be temporary. Fleet server should be modified to allow the next
+// minor version to connect to get around this in a more sustainable way.
+func decreasePackageVersionDuringFeatureFreeze(f *Fixture, workDir string) error {
+	installFS := os.DirFS(workDir)
+	var matches []string
+	err := fs.WalkDir(installFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("my fs.WalkDir reveiced and error and aborted: %w",
+				err)
+		}
+
+		if d.Name() == agentVersion.PackageVersionFileName {
+			matches = append(matches, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	f.t.Logf("package version files found: %v\n", matches)
+
+	for _, m := range matches {
+		versionFile := filepath.Join(f.WorkDir(), m)
+
+		pv, err := version.ParseVersion(f.version)
+		if err != nil {
+			return fmt.Errorf("could not parse fixture version: %w", err)
+		}
+
+		if pv.Major() == 8 && pv.Minor() == 11 {
+			prev, err := pv.GetPreviousMinor()
+			if err != nil {
+				return fmt.Errorf("8.11 cannot be used right now, "+
+					"failed getting previous minor: %w", err)
+			}
+
+			err = os.WriteFile(versionFile, []byte(prev.String()), 0666)
+			if err != nil {
+				return fmt.Errorf("could not write package-version file %q: %w",
+					versionFile, err)
+			}
+
+			f.t.Logf("Updated package version file from %s to %s", pv.String(), prev.String())
+		}
+	}
+
 	return nil
 }
 
@@ -919,50 +983,4 @@ type AgentInspectOutput struct {
 	Signed struct {
 		Data string `yaml:"data"`
 	} `yaml:"signed"`
-}
-
-func decreasePackageVersionFor8_11(f *Fixture) error {
-	installFS := os.DirFS(f.WorkDir())
-	var matches []string
-
-	fmt.Printf("decreasePackageVersionFor8_11: installFS: %q\n", installFS)
-	err := fs.WalkDir(installFS, ".", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return fmt.Errorf("my fs.WalkDir reveiced and error and aborted: %w",
-				err)
-		}
-
-		if d.Name() == agentVersion.PackageVersionFileName {
-			matches = append(matches, path)
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("package version files found: %v\n", matches)
-
-	for _, m := range matches {
-		versionFile := filepath.Join(f.WorkDir(), m)
-		fmt.Printf("removing package version file %q\n", versionFile)
-
-		pv, err := version.ParseVersion(f.version)
-		if err != nil {
-			return fmt.Errorf("could not parse fixture version: %w", err)
-		}
-		if pv.Major() == 8 && pv.Minor() > 11 {
-			prev, err := pv.GetPreviousMinor()
-			if err != nil {
-				return fmt.Errorf("8.11 cannot be used right now, "+
-					"failed getting previous minor: %w", err)
-			}
-
-			err = os.WriteFile(versionFile, []byte(prev.String()), 0666)
-			return fmt.Errorf("could not write package-version file %q: %w",
-				versionFile, err)
-		}
-	}
-
-	return nil
 }

--- a/pkg/testing/fixture_install.go
+++ b/pkg/testing/fixture_install.go
@@ -147,7 +147,7 @@ func (f *Fixture) Install(ctx context.Context, installOpts *InstallOpts, opts ..
 		}
 	})
 
-	return out, decreasePackageVersionFor8_11(f)
+	return out, nil
 }
 
 type UninstallOpts struct {

--- a/pkg/testing/fixture_install.go
+++ b/pkg/testing/fixture_install.go
@@ -147,7 +147,7 @@ func (f *Fixture) Install(ctx context.Context, installOpts *InstallOpts, opts ..
 		}
 	})
 
-	return out, nil
+	return out, decreasePackageVersionFor8_11(f)
 }
 
 type UninstallOpts struct {

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -283,7 +283,11 @@ func (r *Runner) Clean() error {
 }
 
 // runInstances runs the batch on each instance in parallel.
-func (r *Runner) runInstances(ctx context.Context, sshAuth ssh.AuthMethod, repoArchive string, instances []StateInstance) (map[string]OSRunnerResult, error) {
+func (r *Runner) runInstances(
+	ctx context.Context,
+	sshAuth ssh.AuthMethod,
+	repoArchive string,
+	instances []StateInstance) (map[string]OSRunnerResult, error) {
 	g, ctx := errgroup.WithContext(ctx)
 	results := make(map[string]OSRunnerResult)
 	var resultsMx sync.Mutex
@@ -315,7 +319,13 @@ func (r *Runner) runInstances(ctx context.Context, sshAuth ssh.AuthMethod, repoA
 }
 
 // runInstance runs the batch on the machine.
-func (r *Runner) runInstance(ctx context.Context, sshAuth ssh.AuthMethod, logger Logger, repoArchive string, batch OSBatch, instance StateInstance) (OSRunnerResult, error) {
+func (r *Runner) runInstance(
+	ctx context.Context,
+	sshAuth ssh.AuthMethod,
+	logger Logger,
+	repoArchive string,
+	batch OSBatch,
+	instance StateInstance) (OSRunnerResult, error) {
 	sshPrivateKeyPath, err := filepath.Abs(filepath.Join(r.cfg.StateDir, "id_rsa"))
 	if err != nil {
 		return OSRunnerResult{}, fmt.Errorf("failed to determine OGC SSH private key path: %w", err)
@@ -368,7 +378,9 @@ func (r *Runner) runInstance(ctx context.Context, sshAuth ssh.AuthMethod, logger
 		// wait for the stack to be ready before continuing
 		r.stacksReady.Wait()
 		if r.stacksErr != nil {
-			return OSRunnerResult{}, fmt.Errorf("%s unable to continue because stack never became ready: %w", instance.Name, r.stacksErr)
+			return OSRunnerResult{}, fmt.Errorf(
+				"%s unable to continue because stack never became ready: %w",
+				instance.Name, r.stacksErr)
 		}
 		stack, ok := r.getStackForBatchID(batch.ID)
 		if !ok {

--- a/pkg/version/version_parser.go
+++ b/pkg/version/version_parser.go
@@ -113,8 +113,9 @@ func (psv ParsedSemVer) GetPreviousMinor() (*ParsedSemVer, error) {
 
 	if minor > 0 {
 		// We have at least one previous minor version in the current
-		// major version series
-		return NewParsedSemVer(major, minor-1, 0, "", ""), nil
+		// major version series. Set the patch to zero to guarnatee the
+		// version exists, the number of patch releases varies.
+		return NewParsedSemVer(major, minor-1, 0, psv.Prerelease(), psv.BuildMetadata()), nil
 	}
 
 	// We are at the first minor of the current major version series. To
@@ -122,7 +123,7 @@ func (psv ParsedSemVer) GetPreviousMinor() (*ParsedSemVer, error) {
 	// the release versions from the past major series'.
 	switch major {
 	case 8:
-		return NewParsedSemVer(7, 17, 10, "", ""), nil
+		return NewParsedSemVer(7, 17, 10, psv.Prerelease(), psv.BuildMetadata()), nil
 	}
 
 	return nil, fmt.Errorf("unable to determine previous minor version for [%s]", psv.String())

--- a/pkg/version/version_parser_test.go
+++ b/pkg/version/version_parser_test.go
@@ -360,3 +360,54 @@ func TestLess(t *testing.T) {
 		})
 	}
 }
+
+func TestPreviousMinor(t *testing.T) {
+	testcases := []struct {
+		name             string
+		version          string
+		prevMinorVersion string
+	}{
+		{
+			name:             "basic release version",
+			version:          "8.7.0",
+			prevMinorVersion: "8.6.0",
+		},
+		{
+			name:             "snapshot release version",
+			version:          "8.9.3-SNAPSHOT",
+			prevMinorVersion: "8.8.0-SNAPSHOT",
+		},
+		{
+			name:             "emergency release version",
+			version:          "8.9.0-er1",
+			prevMinorVersion: "8.8.0-er1",
+		},
+		{
+			name:             "previous major version",
+			version:          "8.0.0",
+			prevMinorVersion: "7.17.10",
+		},
+		{
+			name:             "previous major snapshot",
+			version:          "8.0.0-SNAPSHOT",
+			prevMinorVersion: "7.17.10-SNAPSHOT",
+		},
+		{
+			name:             "snapshot version with metadata",
+			version:          "8.9.1-SNAPSHOT+aaaaaa",
+			prevMinorVersion: "8.8.0-SNAPSHOT+aaaaaa",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := ParseVersion(tc.version)
+			require.NoError(t, err)
+			require.NotNil(t, parsed)
+
+			prev, err := parsed.GetPreviousMinor()
+			require.NoError(t, err)
+			require.Equal(t, tc.prevMinorVersion, prev.String())
+		})
+	}
+}


### PR DESCRIPTION
The same as https://github.com/elastic/elastic-agent/pull/3276/files but with the package version file edit moved to happen in the right place.

Also fixes a bug in the GetPrevMinor() method of our version parser package. We need to keep this change.

I hope we get an 8.11 snapshot soon and we don't need this, but if we don't we'll merge it and then revert once the 8.11 snapshot is ready and work on less ugly solution for the next time this happens.