### PR TITLE
Improve the coordinator logging correctness

### DIFF
--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -1238,6 +1238,9 @@ type coordinatorUnitLog struct {
 }
 
 func logBasedOnState(l *logger.Logger, state client.UnitState, msg string, args ...interface{}) {
+	// Skipping one more stack frame in order to have correct file line set in the logger output while using this wrapper function
+	l = logger.AddCallerSkip(l, 1)
+
 	switch state {
 	case client.UnitStateStarting:
 		l.With(args...).Info(msg)

--- a/pkg/core/logger/logger.go
+++ b/pkg/core/logger/logger.go
@@ -71,6 +71,13 @@ func NewWithoutConfig(name string) *Logger {
 	return logp.NewLogger(name)
 }
 
+// AddCallerSkip returns new logger with incremented stack frames to skip.
+// This is needed in order to correctly report the log file lines when the logging statement
+// is wrapped in some convenience wrapping function for example.
+func AddCallerSkip(l *Logger, skip int) *Logger {
+	return l.WithOptions(zap.AddCallerSkip(skip))
+}
+
 func new(name string, cfg *Config, logInternal bool) (*Logger, error) {
 	commonCfg, err := ToCommonConfig(cfg)
 	if err != nil {


### PR DESCRIPTION
## What does this PR do?

Improves the coordinator logging correctness.

Before this change the logger reported lines for each use of the ```logBasedOnState``` wrapper function as the lines within that function, where one would expect the line where the logging was called.

```
{"log.level":"info","@timestamp":"2023-08-22T21:34:18.707-0400","log.origin":{"file.name":"coordinator/coordinator.go","file.line":1249},"message":"Unit state changed system/metrics-default-system/metrics-system-58826646-b1bc-45c9-a0dc-1d5e1ccb2414 (STARTING->HEALTHY): Healthy","log":{"source":"elastic-agent"},"component":{"id":"system/metrics-default","state":"HEALTHY"},"unit":{"id":"system/metrics-default-system/metrics-system-58826646-b1bc-45c9-a0dc-1d5e1ccb2414","type":"input","state":"HEALTHY","old_state":"STARTING"},"ecs.version":"1.6.0"}  
```

After the change the logging picks up the correct file line where logging statement was called

```
{"log.level":"info","@timestamp":"2023-08-22T21:24:32.570-0400","log.origin":{"file.name":"coordinator/coordinator.go","file.line":558},"message":"Unit state changed system/metrics-default-system/metrics-system-58826646-b1bc-45c9-a0dc-1d5e1ccb2414 (STARTING->HEALTHY): Healthy","log":{"source":"elastic-agent"},"component":{"id":"system/metrics-default","state":"HEALTHY"},"unit":{"id":"system/metrics-default-system/metrics-system-58826646-b1bc-45c9-a0dc-1d5e1ccb2414","type":"input","state":"HEALTHY","old_state":"STARTING"},"ecs.version":"1.6.0"}  
```

Exposed ```AddCallerSkip``` API in the ```pkg/core/logger/logger.go``` in order keep the ```zap``` details encapsulated.

## Why is it important?

Improve coordinator logging correctness

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

