### PR TITLE
Change BK machine type in integration pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,3 +12,4 @@ steps:
       - "build/diagnostics/*"
     agents:
       provider: "gcp"
+      machineType: "n1-standard-8"


### PR DESCRIPTION
## What does this PR do?

Change the machine type for the unit test integration pipeline. It was reported that the pipeline was failing with exit 255 which is indicative of OOM event.
