### PR TITLE
Preserve prerelease and metadata in GetPrevMinor.

### DIFF
--- a/pkg/version/version_parser.go
+++ b/pkg/version/version_parser.go
@@ -113,8 +113,9 @@ func (psv ParsedSemVer) GetPreviousMinor() (*ParsedSemVer, error) {
 
 	if minor > 0 {
 		// We have at least one previous minor version in the current
-		// major version series
-		return NewParsedSemVer(major, minor-1, 0, "", ""), nil
+		// major version series. Set the patch to zero to guarnatee the
+		// version exists, the number of patch releases varies.
+		return NewParsedSemVer(major, minor-1, 0, psv.Prerelease(), psv.BuildMetadata()), nil
 	}
 
 	// We are at the first minor of the current major version series. To
@@ -122,7 +123,7 @@ func (psv ParsedSemVer) GetPreviousMinor() (*ParsedSemVer, error) {
 	// the release versions from the past major series'.
 	switch major {
 	case 8:
-		return NewParsedSemVer(7, 17, 10, "", ""), nil
+		return NewParsedSemVer(7, 17, 10, psv.Prerelease(), psv.BuildMetadata()), nil
 	}
 
 	return nil, fmt.Errorf("unable to determine previous minor version for [%s]", psv.String())

--- a/pkg/version/version_parser_test.go
+++ b/pkg/version/version_parser_test.go
@@ -360,3 +360,54 @@ func TestLess(t *testing.T) {
 		})
 	}
 }
+
+func TestPreviousMinor(t *testing.T) {
+	testcases := []struct {
+		name             string
+		version          string
+		prevMinorVersion string
+	}{
+		{
+			name:             "basic release version",
+			version:          "8.7.0",
+			prevMinorVersion: "8.6.0",
+		},
+		{
+			name:             "snapshot release version",
+			version:          "8.9.3-SNAPSHOT",
+			prevMinorVersion: "8.8.0-SNAPSHOT",
+		},
+		{
+			name:             "emergency release version",
+			version:          "8.9.0-er1",
+			prevMinorVersion: "8.8.0-er1",
+		},
+		{
+			name:             "previous major version",
+			version:          "8.0.0",
+			prevMinorVersion: "7.17.10",
+		},
+		{
+			name:             "previous major snapshot",
+			version:          "8.0.0-SNAPSHOT",
+			prevMinorVersion: "7.17.10-SNAPSHOT",
+		},
+		{
+			name:             "snapshot version with metadata",
+			version:          "8.9.1-SNAPSHOT+aaaaaa",
+			prevMinorVersion: "8.8.0-SNAPSHOT+aaaaaa",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := ParseVersion(tc.version)
+			require.NoError(t, err)
+			require.NotNil(t, parsed)
+
+			prev, err := parsed.GetPreviousMinor()
+			require.NoError(t, err)
+			require.Equal(t, tc.prevMinorVersion, prev.String())
+		})
+	}
+}


### PR DESCRIPTION
The GetPrevMinor function would discard build metadata, in particular it will drop the SNAPSHOT prerelease signifier which can cause us to upgrade to non-existent or incorrect versions.

Found when attempting to get main to run against the previous stack release: https://github.com/elastic/elastic-agent/pull/3276