### PR TITLE
skip downgrade test when only one snapshot version is available

### DIFF
--- a/pkg/testing/tools/artifacts_api.go
+++ b/pkg/testing/tools/artifacts_api.go
@@ -23,7 +23,7 @@ const (
 	artifactsAPIV1VersionsEndpoint      = "v1/versions/"
 	artifactsAPIV1VersionBuildsEndpoint = "v1/versions/%s/builds/"
 	artifactAPIV1BuildDetailsEndpoint   = "v1/versions/%s/builds/%s"
-	//artifactAPIV1SearchVersionPackage = "v1/search/%s/%s"
+	// artifactAPIV1SearchVersionPackage = "v1/search/%s/%s"
 )
 
 var (
@@ -275,9 +275,10 @@ func GetLatestSnapshotVersion(ctx context.Context, log logger, aac *ArtifactAPIC
 		return nil, ErrSnapshotVersionsEmpty
 	}
 
-	// normally the output of the versions returned by artifact API is already sorted in ascending order,
-	// if we want to sort in descending order we could use
-	sort.Sort(sort.Reverse(sortedParsedVersions))
+	// normally the output of the versions returned by artifact API is already
+	// sorted in ascending order.If we want to sort in descending order we can
+	// use sort.Reverse.
+	sort.Sort(sortedParsedVersions)
 
 	var latestSnapshotVersion *version.ParsedSemVer
 	// fetch the latest SNAPSHOT build

--- a/pkg/testing/tools/artifacts_api.go
+++ b/pkg/testing/tools/artifacts_api.go
@@ -276,9 +276,9 @@ func GetLatestSnapshotVersion(ctx context.Context, log logger, aac *ArtifactAPIC
 	}
 
 	// normally the output of the versions returned by artifact API is already
-	// sorted in ascending order.If we want to sort in descending order we can
-	// use sort.Reverse.
-	sort.Sort(sortedParsedVersions)
+	// sorted in ascending order.If we want to sort in descending order we need
+	// to pass a sort.Reverse to sort.Sort.
+	sort.Sort(sort.Reverse(sortedParsedVersions))
 
 	var latestSnapshotVersion *version.ParsedSemVer
 	// fetch the latest SNAPSHOT build

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -261,7 +261,7 @@ func TestStandaloneUpgradeWithGPGFallback(t *testing.T) {
 	testStandaloneUpgrade(ctx, t, agentFixture, parsedVersion, toVersion, "", false, false, true, customPGP)
 }
 
-func TestStandaloneUpgradeToSpecificSnapshotBuild(t *testing.T) {
+func TestStandaloneDowngradeToPreviousSnapshotBuild(t *testing.T) {
 	define.Require(t, define.Requirements{
 		Local: false, // requires Agent installation
 		Sudo:  true,  // requires Agent installation
@@ -293,12 +293,12 @@ func TestStandaloneUpgradeToSpecificSnapshotBuild(t *testing.T) {
 	builds, err := aac.GetBuildsForVersion(ctx, latestSnapshotVersion.VersionWithPrerelease())
 	require.NoError(t, err)
 
-	upgradeVersionString := builds.Builds[0]
-	if len(builds.Builds) > 2 {
-		// if ther is more than 1 build, take the penultimate build of the
-		// snapshot (the builds are ordered from most to least recent)
-		upgradeVersionString = builds.Builds[1]
+	if len(builds.Builds) < 2 {
+		t.Skip("there is only one SNAPSHOT version available, " +
+			"the test requires at least 2 so it can downgrade to the previous" +
+			"SNAPSHOT")
 	}
+	upgradeVersionString := builds.Builds[1]
 
 	t.Logf("Targeting build %q of version %q", upgradeVersionString, latestSnapshotVersion)
 

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -273,7 +273,6 @@ func TestStandaloneUpgradeToSpecificSnapshotBuild(t *testing.T) {
 		t.Skipf("Version %s is lower than min version %s", define.Version(), minVersion)
 	}
 
-	// prepare the agent fixture
 	agentFixture, err := define.NewFixture(t, define.Version())
 	require.NoError(t, err)
 
@@ -293,11 +292,13 @@ func TestStandaloneUpgradeToSpecificSnapshotBuild(t *testing.T) {
 	// get all the builds of the snapshot version (need to pass x.y.z-SNAPSHOT format)
 	builds, err := aac.GetBuildsForVersion(ctx, latestSnapshotVersion.VersionWithPrerelease())
 	require.NoError(t, err)
-	// TODO if we don't have at least 2 builds, select the next older snapshot build
-	require.Greater(t, len(builds.Builds), 1)
 
-	// take the penultimate build of the snapshot (the builds are ordered from most to least recent)
-	upgradeVersionString := builds.Builds[1]
+	upgradeVersionString := builds.Builds[0]
+	if len(builds.Builds) > 2 {
+		// if ther is more than 1 build, take the penultimate build of the
+		// snapshot (the builds are ordered from most to least recent)
+		upgradeVersionString = builds.Builds[1]
+	}
 
 	t.Logf("Targeting build %q of version %q", upgradeVersionString, latestSnapshotVersion)
 


### PR DESCRIPTION
Commit message:
>**Tile:** 
skip downgrade test when only one snapshot version is available (#3293)
**Message:**
TestStandaloneUpgradeToSpecificSnapshotBuild actually test a downgrade to a previous SNAPSHOT. This fix renames it to TestStandaloneDowngradeToPreviousSnapshotBuild. It also skips the test if there is only one SNAPSHOT available as, in that case, there is no 'previous' SNAPSHOT to downgrade to.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

It fixes TestStandaloneUpgradeToSpecificSnapshotBuild to work is there is only one snapshot build available.

## Why is it important?

When there is only one snapshot version for the current version the test fails.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~


## How to test this PR locally

```
INSTANCE_PROVISIONER="multipass" \
SNAPSHOT=true \
TEST_PLATFORMS="linux/amd64" \
mage integration:single TestStandaloneUpgradeToSpecificSnapshotBuild
```

## Related issues

- N/A

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
