### PR TITLE
modify runtime variable 'install.in_default' with rpm/deb

### DIFF
--- a/docs/component-specs.md
+++ b/docs/component-specs.md
@@ -91,6 +91,7 @@ The variables that can be accessed by a condition are:
 - `runtime.family`: OS family, e.g. `"debian"`, `"redhat"`, `"windows"`, `"darwin"`
 - `runtime.major`, `runtime.minor`: the operating system version. Note that these are strings not integers, so they must be converted in order to use numeric comparison. For example to check if the OS major version is at most 12, use `number(runtime.major) <= 12`.
 - `user.root`: true if Agent is being run with root / administrator permissions.
+- `install.in_default`: true if the Agent is installed in the default location or has been installed via deb or rpm.
 
 ### `command` (required for shipper)
 

--- a/internal/pkg/agent/install/install_windows.go
+++ b/internal/pkg/agent/install/install_windows.go
@@ -44,9 +44,3 @@ func postInstall(topPath string) error {
 
 	return nil
 }
-
-// checkPackageInstall is used for unix based systems to see if the Elastic-Agent was installed through a package manager.
-// returns false
-func checkPackageInstall() bool {
-	return false
-}

--- a/internal/pkg/agent/install/installed.go
+++ b/internal/pkg/agent/install/installed.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kardianos/service"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/install/pkgmgr"
 )
 
 // StatusType is the return status types.
@@ -31,7 +32,7 @@ const (
 func Status(topPath string) (StatusType, string) {
 	expected := filepath.Join(topPath, paths.BinaryName)
 	status, reason := checkService(topPath)
-	if checkPackageInstall() {
+	if pkgmgr.InstalledViaExternalPkgMgr() {
 		if status == Installed {
 			return PackageInstall, "service running"
 		}

--- a/internal/pkg/agent/install/pkgmgr/pkgmgr_unix.go
+++ b/internal/pkg/agent/install/pkgmgr/pkgmgr_unix.go
@@ -1,0 +1,61 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !windows
+
+package pkgmgr
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+)
+
+// InstalledViaExternalPkgMgr returns true if Agent was installed with
+// rpm or dep package managers
+func InstalledViaExternalPkgMgr() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+
+	binaryName := paths.BinaryName
+
+	// NOTE searching for english words might not be a great idea as far as portability goes.
+	// list all installed packages then search for paths.BinaryName?
+	// dpkg is strange as the remove and purge processes leads to the package bing isted after a remove, but not after a purge
+
+	// check debian based systems (or systems that use dpkg)
+	// If the package has been installed, the status starts with "install"
+	// If the package has been removed (but not pruged) status starts with "deinstall"
+	// If purged or never installed, rc is 1
+	if _, err := exec.Command("which", "dpkg-query").Output(); err == nil {
+		out, err := exec.Command("dpkg-query", "-W", "-f", "${Status}", binaryName).Output()
+		if err != nil {
+			return false
+		}
+		if strings.HasPrefix(string(out), "deinstall") {
+			return false
+		}
+		return true
+	}
+
+	// check rhel and sles based systems (or systems that use rpm)
+	// if package has been installed the query will returns the list of associated files.
+	// otherwise if uninstalled, or has never been installled status ends with "not installed"
+	if _, err := exec.Command("which", "rpm").Output(); err == nil {
+		out, err := exec.Command("rpm", "-q", binaryName, "--state").Output()
+		if err != nil {
+			return false
+		}
+		if strings.HasSuffix(string(out), "not installed") {
+			return false
+		}
+		return true
+
+	}
+
+	return false
+}

--- a/internal/pkg/agent/install/pkgmgr/pkgmgr_unix.go
+++ b/internal/pkg/agent/install/pkgmgr/pkgmgr_unix.go
@@ -25,11 +25,11 @@ func InstalledViaExternalPkgMgr() bool {
 
 	// NOTE searching for english words might not be a great idea as far as portability goes.
 	// list all installed packages then search for paths.BinaryName?
-	// dpkg is strange as the remove and purge processes leads to the package bing isted after a remove, but not after a purge
+	// dpkg is strange as the remove and purge processes leads to the package bing listed after a remove, but not after a purge
 
 	// check debian based systems (or systems that use dpkg)
 	// If the package has been installed, the status starts with "install"
-	// If the package has been removed (but not pruged) status starts with "deinstall"
+	// If the package has been removed (but not purged) status starts with "deinstall"
 	// If purged or never installed, rc is 1
 	if _, err := exec.Command("which", "dpkg-query").Output(); err == nil {
 		out, err := exec.Command("dpkg-query", "-W", "-f", "${Status}", binaryName).Output()
@@ -44,7 +44,7 @@ func InstalledViaExternalPkgMgr() bool {
 
 	// check rhel and sles based systems (or systems that use rpm)
 	// if package has been installed the query will returns the list of associated files.
-	// otherwise if uninstalled, or has never been installled status ends with "not installed"
+	// otherwise if uninstalled, or has never been installed status ends with "not installed"
 	if _, err := exec.Command("which", "rpm").Output(); err == nil {
 		out, err := exec.Command("rpm", "-q", binaryName, "--state").Output()
 		if err != nil {

--- a/internal/pkg/agent/install/pkgmgr/pkgmgr_windows.go
+++ b/internal/pkg/agent/install/pkgmgr/pkgmgr_windows.go
@@ -2,12 +2,11 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build !windows
+//go:build windows
 
-package install
+package pkgmgr
 
-// postInstall performs post installation for unix-based systems.
-func postInstall(topPath string) error {
-	// do nothing
-	return nil
+// InstalledViaExternalPkgMgr returns false under windows
+func InstalledViaExternalPkgMgr() bool {
+	return false
 }

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -14,6 +14,7 @@ import (
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/install/pkgmgr"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/transpiler"
 	"github.com/elastic/elastic-agent/internal/pkg/eql"
 	"github.com/elastic/elastic-agent/pkg/features"
@@ -844,7 +845,7 @@ func varsForPlatform(platform PlatformDetail) (*transpiler.Vars, error) {
 	}
 	return transpiler.NewVars("", map[string]interface{}{
 		"install": map[string]interface{}{
-			"in_default": paths.ArePathsEqual(paths.Top(), paths.InstallPath(paths.DefaultBasePath)),
+			"in_default": paths.ArePathsEqual(paths.Top(), paths.InstallPath(paths.DefaultBasePath)) || pkgmgr.InstalledViaExternalPkgMgr(),
 		},
 		"runtime": map[string]interface{}{
 			"platform": platform.String(),


### PR DESCRIPTION
## What does this PR do?

changes how the `install.in_default` runtime protection variable is calculated on systems where elastic-agent is installed via deb or rpm package.  Previously this would have returned false be cause the install path is not the same as the `tar.gz` install.  However, endpoint knows how to operate when elastic-agent is installed as a deb or rpm, so now it will return true.

## Why is it important?

This is required because the runtime prevention was blocking the install of endpoint on systems installed via deb/rpm.

example:

```
sudo elastic-agent status
┌─ fleet
│  └─ status: (HEALTHY) Connected
└─ elastic-agent
   ├─ status: (DEGRADED) 1 or more components/units in a failed state
   └─ endpoint-default
      ├─ status: (FAILED) Elastic Defend requires Elastic Agent be installed at the default installation path
      ├─ endpoint-default
      │  └─ status: (FAILED) Elastic Defend requires Elastic Agent be installed at the default installation path
      └─ endpoint-default-3575ea0b-e4a5-4b6d-b95e-a1ec04cb1683
         └─ status: (FAILED) Elastic Defend requires Elastic Agent be installed at the default installation path
```		 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] I have added an integration test or an E2E test

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally


1. Debian or RPM system
2. Stack version 8.10.0
3. default version of elastic-agent 8.10.0
4. build custom version of elastic-agent off this PR, but change version to 8.10.0
5. create a policy with system and endpoint integrations
6. install default elastic-agent, should get error message above
7. uninstall elastic-agent
8. install custom elastic-agent, no error, agent should be healthy and endpoint sending data

## Related issues

- Closes #3280

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
