### PR TITLE
[crossbuild] Fix path separators

### DIFF
--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -271,6 +271,13 @@ func (b GolangCrossBuilder) Build() error {
 		return errors.Wrap(err, "failed to determine mage-linux-"+builderArch+" relative path")
 	}
 
+	// If we're running this mage target on Windows, the path separator used in
+	// buildCmd will be `\`. But the buildCmd is executed inside a Linux Docker
+	// container. So we replace all `\` path separators with `/`.
+	if GOOS == "windows" {
+		buildCmd = strings.ReplaceAll(buildCmd, "\\", "/")
+	}
+
 	dockerRun := sh.RunCmd("docker", "run")
 	image, err := b.ImageSelector(b.Platform)
 	if err != nil {

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -273,10 +273,8 @@ func (b GolangCrossBuilder) Build() error {
 
 	// If we're running this mage target on Windows, the path separator used in
 	// buildCmd will be `\`. But the buildCmd is executed inside a Linux Docker
-	// container. So we replace all `\` path separators with `/`.
-	if GOOS == "windows" {
-		buildCmd = strings.ReplaceAll(buildCmd, "\\", "/")
-	}
+	// container. So we ensure that all path separators are `/`.
+	buildCmd = filepath.ToSlash(buildCmd)
 
 	dockerRun := sh.RunCmd("docker", "run")
 	image, err := b.ImageSelector(b.Platform)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR fixes the path separators in the `crossBuild` target, so if this target is invoked on a Windows host, it creates the correct build command to be run inside a Linux-based Docker container.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

So we can build Elastic Agent on Windows hosts.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without this PR, e.g. from `main`, we get the following error while building an Elastic Agent package on a Windows host:

```
$ EXTERNAL=true SNAPSHOT=true DEV=true PLATFORMS=windows/amd64 mage package 
...
sh: 1: buildmage-linux-amd64: not found
...
```