### PR TITLE
Diagnostics creates the necessary folder for -f argument

### DIFF
--- a/changelog/fragments/1693544911-Diagnostics-command-creates-necessary-folders-for--f-flag.yaml
+++ b/changelog/fragments/1693544911-Diagnostics-command-creates-necessary-folders-for--f-flag.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug
+
+# Change summary; a 80ish characters long description of the change.
+summary: Diagnostics command creates necessary folders for -f flag
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: diagnostics command
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/cmd/diagnostics_test.go
+++ b/internal/pkg/agent/cmd/diagnostics_test.go
@@ -1,0 +1,51 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_createFile(t *testing.T) {
+	dir := t.TempDir()
+	existingFile := "existingfile.zip"
+	f, err := os.Create(path.Join(dir, "existingFile"))
+	require.NoErrorf(t, err, "could not create file %q", path.Join(dir, "existingFile"))
+	err = f.Close()
+	require.NoError(t, err, "could not close file")
+
+	testCases := []struct {
+		name     string
+		filePath string
+	}{
+		{
+			name:     "ExistingFile",
+			filePath: path.Join(dir, existingFile),
+		},
+		{
+			name:     "NewFile",
+			filePath: path.Join(dir, "newfile.zip"),
+		},
+		{
+			name:     "NonexistentFolders",
+			filePath: path.Join(dir, "nonexistent", "folders", "file.zip"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			file, err := createFile(tc.filePath)
+			require.NoError(t, err, "failed creating diagnostics file %q",
+				tc.filePath)
+			defer func() {
+				file.Close()
+			}()
+		})
+	}
+}

--- a/internal/pkg/agent/cmd/logs_test.go
+++ b/internal/pkg/agent/cmd/logs_test.go
@@ -38,10 +38,10 @@ func TestGetLogFilenames(t *testing.T) {
 	t.Run("returns the correct sorted filelist", func(t *testing.T) {
 		dir := t.TempDir()
 
-		createFile(t, dir, file2)
-		createFile(t, dir, file)
-		createFile(t, dir, file1)
-		createFile(t, dir, file3)
+		createFileEmpty(t, dir, file2)
+		createFileEmpty(t, dir, file)
+		createFileEmpty(t, dir, file1)
+		createFileEmpty(t, dir, file3)
 
 		names, err := getLogFilenames(dir)
 		require.NoError(t, err)
@@ -62,14 +62,14 @@ func TestGetLogFilenames(t *testing.T) {
 		prevDayFile2 := "elastic-agent-20230529-2.ndjson"
 		prevDayFile3 := "elastic-agent-20230529-3.ndjson"
 
-		createFile(t, dir, file2)
-		createFile(t, dir, file)
-		createFile(t, dir, prevDayFile1)
-		createFile(t, dir, file1)
-		createFile(t, dir, prevDayFile)
-		createFile(t, dir, prevDayFile2)
-		createFile(t, dir, file3)
-		createFile(t, dir, prevDayFile3)
+		createFileEmpty(t, dir, file2)
+		createFileEmpty(t, dir, file)
+		createFileEmpty(t, dir, prevDayFile1)
+		createFileEmpty(t, dir, file1)
+		createFileEmpty(t, dir, prevDayFile)
+		createFileEmpty(t, dir, prevDayFile2)
+		createFileEmpty(t, dir, file3)
+		createFileEmpty(t, dir, prevDayFile3)
 
 		names, err := getLogFilenames(dir)
 		require.NoError(t, err)
@@ -99,7 +99,7 @@ func TestGetLogFilenames(t *testing.T) {
 
 	t.Run("does not return non-log entries", func(t *testing.T) {
 		dir := t.TempDir()
-		createFile(t, dir, "excluded")
+		createFileEmpty(t, dir, "excluded")
 
 		names, err := getLogFilenames(dir)
 		require.NoError(t, err)
@@ -109,7 +109,7 @@ func TestGetLogFilenames(t *testing.T) {
 
 	t.Run("returns a list of one", func(t *testing.T) {
 		dir := t.TempDir()
-		createFile(t, dir, file1)
+		createFileEmpty(t, dir, file1)
 
 		names, err := getLogFilenames(dir)
 		require.NoError(t, err)
@@ -539,7 +539,7 @@ func generateLines(prefix string, start, end int) string {
 	return b.String()
 }
 
-func createFile(t *testing.T, dir, name string) {
+func createFileEmpty(t *testing.T, dir, name string) {
 	createFileContent(t, dir, name, nil)
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fixes how the diagnostics command handles the custom path to save the diagnostics. Right now if the custom file path to save the diagnostics on contains folders that do not exist, the diagnostics fail to create the file, consequently failing to save the diagnostics.

## Why is it important?

It not clear on the diagnostics help the path to the file must exist, it'd be much easier for our users if the diagnostics is capable of creating the necessary folders.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

Run the diagnostics command with the `-f` flag, passing a path where at least one folder does not exist. It will fail on main and succeed with this change.
E.g.:
```
sudo elastic-agent diagnostics -f /tmp/nonexisting/path/diag.zip
Error: open /tmp/nonexisting/path/diag.zip: no such file or directory
```

## Related issues


- Closes #3339

## Logs

```
sudo elastic-agent diagnostics -f /tmp/nonexisting/path/diag.zip
Error: open /tmp/nonexisting/path/diag.zip: no such file or directory
```


## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
