### PR TITLE
Add colors for log messages based on their level

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2845,6 +2845,36 @@ Contents of probable licence file $GOMODCACHE/github.com/elastic/go-ucfg@v0.8.6/
 
 
 --------------------------------------------------------------------------------
+Dependency : github.com/fatih/color
+Version: v1.15.0
+Licence type (autodetected): MIT
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/fatih/color@v1.15.0/LICENSE.md:
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Fatih Arslan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+--------------------------------------------------------------------------------
 Dependency : github.com/gofrs/flock
 Version: v0.8.1
 Licence type (autodetected): BSD-3-Clause
@@ -10070,36 +10100,6 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
---------------------------------------------------------------------------------
-Dependency : github.com/fatih/color
-Version: v1.15.0
-Licence type (autodetected): MIT
---------------------------------------------------------------------------------
-
-Contents of probable licence file $GOMODCACHE/github.com/fatih/color@v1.15.0/LICENSE.md:
-
-The MIT License (MIT)
-
-Copyright (c) 2013 Fatih Arslan
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 --------------------------------------------------------------------------------

--- a/changelog/fragments/1693813219-log-command-colors.yaml
+++ b/changelog/fragments/1693813219-log-command-colors.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add colors for log messages based on their level
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: CLI
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/elastic/go-licenser v0.4.1
 	github.com/elastic/go-sysinfo v1.11.0
 	github.com/elastic/go-ucfg v0.8.6
+	github.com/fatih/color v1.15.0
 	github.com/gofrs/flock v0.8.1
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/google/go-cmp v0.5.9
@@ -88,7 +89,6 @@ require (
 	github.com/elastic/gosigar v0.14.2 // indirect
 	github.com/emicklei/go-restful/v3 v3.10.1 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
-	github.com/fatih/color v1.15.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/internal/pkg/agent/cmd/logs.go
+++ b/internal/pkg/agent/cmd/logs.go
@@ -15,10 +15,13 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
@@ -33,45 +36,84 @@ const (
 )
 
 var (
-	logFilePattern = regexp.MustCompile(`elastic-agent-(\d+)(-\d+)?\.ndjson$`)
+	logFilePattern  = regexp.MustCompile(`elastic-agent-(\d+)(-\d+)?\.ndjson$`)
+	errLineFiltered = errors.New("this line was filtered out")
 )
 
 // filter for each log line, returns `true` if we print the line
 type filterFunc func([]byte) bool
+
+// modifier for each log line, returns a modified message.
+// If a modification is anything other than replacing characters
+// the new value must be allocated (byte slice).
+type modifierFunc func([]byte) []byte
 
 // logEntry represents a part of the elastic agent log entry
 type logEntry struct {
 	Component struct {
 		ID string `json:"id"`
 	} `json:"component"`
+	LogLevel string `json:"log.level"`
 }
 
-// createComponentFilter creates a new log line filter that
+// createComponentFilter creates a new log entry filter that
 // lets print only the log lines that contain the given component ID.
 func createComponentFilter(id string) filterFunc {
-	return func(line []byte) bool {
-		var entry logEntry
-		err := json.Unmarshal(line, &entry)
+	return func(entry []byte) bool {
+		var e logEntry
+		err := json.Unmarshal(entry, &e)
 		if err != nil {
 			return false
 		}
-		return entry.Component.ID == id
+		return e.Component.ID == id
+	}
+}
+
+func addColorModifier(entry []byte) []byte {
+	var e logEntry
+	err := json.Unmarshal(entry, &e)
+	if err != nil {
+		return entry
+	}
+	switch strings.ToLower(e.LogLevel) {
+
+	case logp.InfoLevel.String():
+		return []byte(color.CyanString(string(entry)))
+	case logp.WarnLevel.String():
+		return []byte(color.YellowString(string(entry)))
+	case logp.ErrorLevel.String():
+		return []byte(color.RedString(string(entry)))
+	case logp.CriticalLevel.String():
+		return []byte(color.HiRedString(string(entry)))
+	default:
+		return entry
 	}
 }
 
 // stackWriter collects written byte slices and then pops them in
 // the reversed (LIFO) order.
+// Supports filtering and modification of each written byte slice.
 type stackWriter struct {
-	lines [][]byte
+	lines    [][]byte
+	filter   filterFunc
+	modifier modifierFunc
 }
 
 // Write implements `io.Writer`
 func (s *stackWriter) Write(line []byte) (int, error) {
+	if s.filter != nil && !s.filter(line) {
+		return 0, errLineFiltered
+	}
 	// we must allocate and copy to preserve the state,
 	// `line` is normally a slice on the reading buffer which
 	// gets overwritten
 	l := make([]byte, len(line))
 	copy(l, line)
+
+	if s.modifier != nil {
+		l = s.modifier(l)
+	}
+
 	s.lines = append(s.lines, l)
 	return len(l), nil
 }
@@ -83,13 +125,17 @@ func (s stackWriter) PopAll(w io.Writer) error {
 		if err != nil {
 			return fmt.Errorf("failed to print the log line to the writer: %w", err)
 		}
+		_, err = w.Write([]byte{'\n'})
+		if err != nil {
+			return fmt.Errorf("failed to print the log line to the writer: %w", err)
+		}
 	}
 
 	return nil
 }
 
-// newFilteringWriter create a writer proxy that filters out log lines according to the given `filter`
-func newFilteringWriter(ctx context.Context, w io.Writer, filter filterFunc) io.Writer {
+// newWrappedWriter create a writer proxy that filters out log lines according to the given `filter`
+func newWrappedWriter(ctx context.Context, w io.Writer, filter filterFunc, modifier modifierFunc) io.Writer {
 	pr, pw := io.Pipe()
 	scanner := bufio.NewScanner(pr)
 	go func() {
@@ -99,8 +145,11 @@ func newFilteringWriter(ctx context.Context, w io.Writer, filter filterFunc) io.
 				return
 			default:
 				line := scanner.Bytes()
-				if !filter(line) {
+				if filter != nil && !filter(line) {
 					continue
+				}
+				if modifier != nil {
+					line = modifier(line)
 				}
 				_, _ = w.Write(line)
 				_, _ = w.Write([]byte{'\n'})
@@ -125,7 +174,9 @@ func newLogsCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
 	}
 
 	cmd.Flags().BoolP("follow", "f", false, "Do not stop when end of file is reached, but rather to wait for additional data to be appended to the log file.")
+	cmd.Flags().BoolP("no-color", "", false, "Do not apply colors to different log levels.")
 	cmd.Flags().IntP("number", "n", 10, "Maximum number of lines at the end of logs to output.")
+
 	cmd.Flags().StringP("component", "C", "", "Filter logs and output only logs for the given component ID.")
 
 	return cmd
@@ -135,18 +186,26 @@ func logsCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 	component, _ := cmd.Flags().GetString("component")
 	lines, _ := cmd.Flags().GetInt("number")
 	follow, _ := cmd.Flags().GetBool("follow")
+	noColor, _ := cmd.Flags().GetBool("no-color")
 
-	var filter filterFunc
+	var (
+		filter   filterFunc
+		modifier modifierFunc
+	)
 
 	if component != "" {
 		filter = createComponentFilter(component)
+	}
+
+	if !noColor {
+		modifier = addColorModifier
 	}
 
 	logsDir := filepath.Join(paths.Home(), logger.DefaultLogDirectory)
 	// uncomment for debugging
 	// fmt.Fprintf(streams.Err, "logs dir: %q", logsDir)
 
-	err := printLogs(cmd.Context(), streams.Out, logsDir, lines, follow, filter)
+	err := printLogs(cmd.Context(), streams.Out, logsDir, lines, follow, filter, modifier)
 	if err != nil {
 		return fmt.Errorf("failed to get logs: %w", err)
 	}
@@ -157,7 +216,7 @@ func logsCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 // printLogs prints the last `lines` number of log lines from the log files in `dir`
 // applying the `filter` and printing all the log lines to `w`.
 // if `follow` is true it will keep printing all the log updates afterwards.
-func printLogs(ctx context.Context, w io.Writer, dir string, lines int, follow bool, filter filterFunc) error {
+func printLogs(ctx context.Context, w io.Writer, dir string, lines int, follow bool, filter filterFunc, modifier modifierFunc) error {
 	files, err := getLogFilenames(dir)
 	if err != nil {
 		return fmt.Errorf("failed to fetch log filenames: %w", err)
@@ -166,7 +225,10 @@ func printLogs(ctx context.Context, w io.Writer, dir string, lines int, follow b
 		return nil
 	}
 
-	stackWriter := &stackWriter{}
+	stackWriter := &stackWriter{
+		filter:   filter,
+		modifier: modifier,
+	}
 
 	var (
 		fileIndex = len(files) - 1
@@ -188,7 +250,7 @@ func printLogs(ctx context.Context, w io.Writer, dir string, lines int, follow b
 	for {
 		filename := files[fileIndex]
 		// try to read the requested amount of lines from the end of the file
-		justPrinted, err := printLogFile(filename, lines-printed, stackWriter, buf, filter)
+		justPrinted, err := printLogFile(filename, lines-printed, stackWriter, buf)
 		if err != nil {
 			return fmt.Errorf("failed to print log file %q: %w", filename, err)
 		}
@@ -213,8 +275,9 @@ func printLogs(ctx context.Context, w io.Writer, dir string, lines int, follow b
 
 	if follow {
 		output := w
-		if filter != nil {
-			output = newFilteringWriter(ctx, w, filter)
+
+		if filter != nil || modifier != nil {
+			output = newWrappedWriter(ctx, w, filter, modifier)
 		}
 		err = watchLogsDir(ctx, dir, fileToFollow, followOffset, output)
 		if err != nil {
@@ -228,7 +291,7 @@ func printLogs(ctx context.Context, w io.Writer, dir string, lines int, follow b
 // printLogFile reads the target file defined by the absolute path `filename` backwards in chunks
 // defined by the size of the given `buf`  until it finds enough lines defined by `maxLines`
 // or the whole file is read. Prints all found lines to `w` in LIFO order.
-func printLogFile(filename string, maxLines int, w io.Writer, buf []byte, filter filterFunc) (linesWritten int, err error) {
+func printLogFile(filename string, maxLines int, w *stackWriter, buf []byte) (linesWritten int, err error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return 0, fmt.Errorf("failed to open log file %q for reading: %w", filename, err)
@@ -244,11 +307,14 @@ func printLogFile(filename string, maxLines int, w io.Writer, buf []byte, filter
 
 	var leftOverBuf []byte
 
-	// reading chunks starting with the end of the file and try to find
+	// reading chunks in reverse starting with the end of the file and try to find
 	// lines up to the requested amount, once found - stop
 	for {
 		offset -= bufferSize
 		if offset < 0 {
+			// shorten the buffer so we don't read anything extra during the
+			// last iteration of `ReadAt`
+			buf = buf[0 : bufferSize+offset]
 			// this chunk is smaller than the buffer
 			offset = 0
 		}
@@ -260,56 +326,65 @@ func printLogFile(filename string, maxLines int, w io.Writer, buf []byte, filter
 
 		chunk := buf[:bytesRead]
 
-		// the current chunk must contains leftovers (incomplete line) from the previous chunk
+		// the current chunk must contain leftovers (incomplete entry) from the previous chunk
 		if len(leftOverBuf) != 0 {
-			chunk = append(chunk, leftOverBuf...)
+			newChunk := make([]byte, len(chunk)+len(leftOverBuf))
+			copy(newChunk[:len(chunk)], chunk)
+			copy(newChunk[len(chunk):], leftOverBuf)
+			chunk = newChunk
 			leftOverBuf = nil
 		}
 
-		// the first line ends at the end for the current chunk
-		lineEnd := len(chunk)
+		// the first entry ends at the end for the current chunk
+		entryEnd := len(chunk)
 		for i := len(chunk) - 1; i >= 0; i-- {
 			if chunk[i] != '\n' {
 				continue
 			}
 
-			line := chunk[i+1 : lineEnd]
+			// the log entry excluding the new line character
+			entry := chunk[i+1 : entryEnd]
+			// the next entry will end where this entry starts
+			entryEnd = i
 
-			// if it's a trailing new line
-			if len(line) == 0 {
+			// if it's a trailing new line, the entry is empty
+			if len(entry) == 0 {
 				continue
 			}
 
-			// the next line will end where this line starts
-			lineEnd = i + 1
-
-			if filter != nil && !filter(line) {
+			_, err := w.Write(entry)
+			if errors.Is(err, errLineFiltered) {
 				continue
 			}
-
-			_, err := w.Write(line)
 			if err != nil {
 				return linesWritten, fmt.Errorf("failed to print log line: %w", err)
 			}
-
 			linesWritten++
 			if linesWritten == maxLines {
 				return linesWritten, nil
 			}
 		}
 
-		if lineEnd != 0 {
-			leftOverBuf = make([]byte, lineEnd)
-			copy(leftOverBuf, chunk[:lineEnd])
+		// if the last new line character was found somewhere in the middle of the chunk
+		// we keep the rest which will join the next chunk
+		if entryEnd != 0 {
+			leftOverBuf = make([]byte, entryEnd)
+			copy(leftOverBuf, chunk[:entryEnd])
 		}
 
+		// if there is nothing left to read from the file
 		if offset == 0 {
 			break
 		}
 	}
 
-	if len(leftOverBuf) != 0 && (filter == nil || filter(leftOverBuf)) {
+	// the very last part of the chunk without a new line character becomes
+	// the final line
+	if len(leftOverBuf) > 0 {
 		_, err := w.Write(leftOverBuf)
+		if errors.Is(err, errLineFiltered) {
+			return linesWritten, nil
+		}
 		if err != nil {
 			err = fmt.Errorf("failed to print log line: %w", err)
 			return linesWritten, err

--- a/internal/pkg/agent/cmd/logs_test.go
+++ b/internal/pkg/agent/cmd/logs_test.go
@@ -34,6 +34,18 @@ type testFile struct {
 	content string
 }
 
+// just wraps the whole line in exclamation marks
+func exclamationModifier(msg []byte) []byte {
+	if len(msg) == 0 {
+		return msg
+	}
+	newMsg := make([]byte, len(msg)+2)
+	newMsg[0] = '!'
+	copy(newMsg[1:len(newMsg)-1], msg)
+	newMsg[len(newMsg)-1] = '!'
+	return newMsg
+}
+
 func TestGetLogFilenames(t *testing.T) {
 	t.Run("returns the correct sorted filelist", func(t *testing.T) {
 		dir := t.TempDir()
@@ -239,7 +251,7 @@ func TestPrintLogs(t *testing.T) {
 				createFileContent(t, dir, f.name, bytes.NewBuffer([]byte(f.content)))
 			}
 			result := bytes.NewBuffer(nil)
-			err := printLogs(context.Background(), result, dir, tc.lines, false, nil)
+			err := printLogs(context.Background(), result, dir, tc.lines, false, nil, nil)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.expected, result.String())
@@ -255,7 +267,7 @@ func TestPrintLogs(t *testing.T) {
 		logResult := newChanWriter()
 		errChan := make(chan error)
 		go func() {
-			errChan <- printLogs(ctx, logResult, dir, 5, true, nil)
+			errChan <- printLogs(ctx, logResult, dir, 5, true, nil, nil)
 		}()
 
 		var expected string
@@ -300,7 +312,7 @@ func TestPrintLogs(t *testing.T) {
 		})
 	})
 
-	t.Run("returns tail and then follows the logs with filter", func(t *testing.T) {
+	t.Run("returns tail and then follows the logs with filter and modifier", func(t *testing.T) {
 		dir := t.TempDir()
 		content := []byte(`{"component":{"id":"match"}, "message":"test1"}
 {"component":{"id":"non-match"}, "message":"test2"}
@@ -316,15 +328,15 @@ func TestPrintLogs(t *testing.T) {
 		logResult := newChanWriter()
 		errChan := make(chan error)
 		go func() {
-			errChan <- printLogs(ctx, logResult, dir, 3, true, createComponentFilter("match"))
+			errChan <- printLogs(ctx, logResult, dir, 3, true, createComponentFilter("match"), exclamationModifier)
 		}()
 
 		var expected string
 
 		t.Run("tails filtering the file", func(t *testing.T) {
-			expected = `{"component":{"id":"match"}, "message":"test3"}
-{"component":{"id":"match"}, "message":"test4"}
-{"component":{"id":"match"}, "message":"test6"}
+			expected = `!{"component":{"id":"match"}, "message":"test3"}!
+!{"component":{"id":"match"}, "message":"test4"}!
+!{"component":{"id":"match"}, "message":"test6"}!
 `
 			logResult.waitUntilMatch(t, expected, time.Second)
 		})
@@ -347,10 +359,10 @@ func TestPrintLogs(t *testing.T) {
 
 			time.Sleep(watchInterval)
 
-			expected += `{"component":{"id":"match"}, "message":"test7"}
-{"component":{"id":"match"}, "message":"test9"}
-{"component":{"id":"match"}, "message":"test10"}
-{"component":{"id":"match"}, "message":"test12"}
+			expected += `!{"component":{"id":"match"}, "message":"test7"}!
+!{"component":{"id":"match"}, "message":"test9"}!
+!{"component":{"id":"match"}, "message":"test10"}!
+!{"component":{"id":"match"}, "message":"test12"}!
 `
 
 			logResult.waitUntilMatch(t, expected, 2*watchInterval)
@@ -366,8 +378,8 @@ func TestPrintLogs(t *testing.T) {
 
 			time.Sleep(watchInterval)
 
-			expected += `{"component":{"id":"match"}, "message":"test13"}
-{"component":{"id":"match"}, "message":"test15"}
+			expected += `!{"component":{"id":"match"}, "message":"test13"}!
+!{"component":{"id":"match"}, "message":"test15"}!
 `
 
 			logResult.waitUntilMatch(t, expected, 2*watchInterval)
@@ -439,7 +451,7 @@ func TestPrintLogFile(t *testing.T) {
 
 			buf := make([]byte, testBufferSize)
 
-			printed, err := printLogFile(filepath.Join(dir, filename), tc.lines, sw, buf, nil)
+			printed, err := printLogFile(filepath.Join(dir, filename), tc.lines, sw, buf)
 			require.NoError(t, err)
 
 			result := bytes.NewBuffer(nil)
@@ -465,15 +477,20 @@ func TestPrintLogFile(t *testing.T) {
 
 		createFileContent(t, dir, "test.ndjson", bytes.NewBuffer(entries))
 
-		result := bytes.NewBuffer(nil)
+		sw := &stackWriter{
+			filter: createComponentFilter(matchingID),
+		}
 		testBuffer := make([]byte, 16) // so the buffer is not aligned
-		_, err := printLogFile(filepath.Join(dir, "test.ndjson"), 2, result, testBuffer, createComponentFilter(matchingID))
+		_, err := printLogFile(filepath.Join(dir, "test.ndjson"), 2, sw, testBuffer)
 		require.NoError(t, err)
 
 		var expected []byte
 		expected = append(expected, matchingEntry...)
 		expected = append(expected, matchingEntry...)
-		require.Equal(t, string(expected), result.String())
+		w := bytes.NewBuffer(nil)
+		err = sw.PopAll(w)
+		require.NoError(t, err)
+		require.Equal(t, string(expected), w.String())
 	})
 
 	t.Run("filters out all entries", func(t *testing.T) {
@@ -486,14 +503,74 @@ func TestPrintLogFile(t *testing.T) {
 
 		createFileContent(t, dir, "test.ndjson", bytes.NewBuffer(entries))
 
-		result := bytes.NewBuffer(nil)
+		sw := &stackWriter{
+			filter: createComponentFilter(matchingID),
+		}
+
 		testBuffer := make([]byte, 16) // so the buffer is not aligned
-		_, err := printLogFile(filepath.Join(dir, "test.ndjson"), 2, result, testBuffer, createComponentFilter(matchingID))
+		_, err := printLogFile(filepath.Join(dir, "test.ndjson"), 2, sw, testBuffer)
 		require.NoError(t, err)
 
-		var expected []byte
-		require.Equal(t, string(expected), result.String())
+		w := bytes.NewBuffer(nil)
+		err = sw.PopAll(w)
+		require.NoError(t, err)
+
+		require.Equal(t, "", w.String())
 	})
+
+	t.Run("modifies entries with the given modifier", func(t *testing.T) {
+		dir := t.TempDir()
+		entries := []byte("first\nsecond\n")
+
+		createFileContent(t, dir, "test.ndjson", bytes.NewBuffer(entries))
+
+		sw := &stackWriter{
+			modifier: exclamationModifier,
+		}
+		testBuffer := make([]byte, 4) // so the buffer is not aligned
+		_, err := printLogFile(filepath.Join(dir, "test.ndjson"), 2, sw, testBuffer)
+		require.NoError(t, err)
+
+		expected := []byte("!first!\n!second!\n")
+		w := bytes.NewBuffer(nil)
+		err = sw.PopAll(w)
+		require.NoError(t, err)
+		require.Equal(t, string(expected), w.String())
+	})
+}
+
+func TestColorModifier(t *testing.T) {
+	t.Skip() // remove if you want to see examples of the messages on your terminal
+	cases := []struct {
+		name string
+		msg  []byte
+	}{
+		{
+			name: "debug",
+			msg:  []byte(`{"level": "debug", "message": "this is an example"}`),
+		},
+		{
+			name: "info",
+			msg:  []byte(`{"level": "info", "message": "this is an example"}`),
+		},
+		{
+			name: "warning",
+			msg:  []byte(`{"level": "warning", "message": "this is an example"}`),
+		},
+		{
+			name: "error",
+			msg:  []byte(`{"level": "error", "message": "this is an example"}`),
+		},
+		{
+			name: "critical",
+			msg:  []byte(`{"level": "critical", "message": "this is an example"}`),
+		},
+	}
+
+	for _, tc := range cases {
+		//nolint:forbidigo // for testing purposes
+		fmt.Println(string(addColorModifier(tc.msg)))
+	}
 }
 
 func TestCreateComponentFilter(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

`elastic-agent logs` command now has colors. To disable colors use the `--no-colors` flag.

Also, fixed a few bugs in printing logs related to buffering.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Easier to follow the logs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
~~- [ ] I have added an integration test or an E2E test~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Run the stack snapshot using:

```sh
elastic-package stack up --version=8.11.0-SNAPSHOT -v
```

Build the agent:

```sh
DEV=true SNAPSHOT=true PLATFORMS=darwin/arm64 mage package
```

Enroll the built agent into the stack's Fleet:

Note: you need to put your platform in the environment variable.

```sh
cd build/distributions
tar xvfz elastic-agent-8.11.0-SNAPSHOT-*.tar.gz
cd elastic-agent-8.11.0-SNAPSHOT-*
sudo ./elastic-agent install -i --url=https://localhost:8220 --enrollment-token=<HERE GOES YOUR TOKEN>
```

Note the `-i` flag for insecure TLS.

Run the logs command and observe the colored output:

```sh
sudo elastic-agent logs -f
```

Run with the `--no-colors` flag and see no color:

```
sudo elastic-agent logs -f --no-color
```


https://github.com/elastic/elastic-agent/assets/887952/bf517a8d-1619-4aa1-bd9e-1146b9890528


