### PR TITLE
Increase the time between RemovePath retries

### DIFF
--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -103,7 +103,7 @@ func RemovePath(path string) error {
 	}
 
 	const arbitraryTimeout = 7 * time.Second
-	const nextSleep = 100 * time.Millisecond
+	const nextSleep = 500 * time.Millisecond
 	t := time.NewTicker(nextSleep)
 	defer t.Stop()
 	start := time.Now()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Increase the time between RemovePath retries. It's yet another attempt to fix this issue by following the same [approach used by Go](https://github.com/golang/go/blob/master/src/testing/testing.go#L1257). 

## Why is it important?

`RemovePath` is still failing on windows test

## Checklist


- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

  ## Related issues

- Closes #3342 

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
