### PR TITLE
Don't create a stack on a single run that doesn't require a stack

### DIFF
--- a/pkg/testing/define/batch_test.go
+++ b/pkg/testing/define/batch_test.go
@@ -143,7 +143,8 @@ func TestBatch(t *testing.T) {
 							Name: "TestSpecificCombinationTwo",
 						},
 						{
-							Name: "TestSpecificCombinationWithCloud",
+							Name:  "TestSpecificCombinationWithCloud",
+							Stack: true,
 						},
 					},
 				},

--- a/pkg/testing/define/batch_test.go
+++ b/pkg/testing/define/batch_test.go
@@ -16,54 +16,78 @@ func TestBatch(t *testing.T) {
 	darwinLocalTests := []BatchPackageTests{
 		{
 			Name: pkgName,
-			Tests: []string{
-				"TestAnyLocal",
-				"TestDarwinLocal",
+			Tests: []BatchPackageTest{
+				{
+					Name: "TestAnyLocal",
+				},
+				{
+					Name: "TestDarwinLocal",
+				},
 			},
 		},
 	}
 	darwinSudoTests := []BatchPackageTests{
 		{
 			Name: pkgName,
-			Tests: []string{
-				"TestAnySudo",
-				"TestDarwinSudo",
+			Tests: []BatchPackageTest{
+				{
+					Name: "TestAnySudo",
+				},
+				{
+					Name: "TestDarwinSudo",
+				},
 			},
 		},
 	}
 	linuxLocalTests := []BatchPackageTests{
 		{
 			Name: pkgName,
-			Tests: []string{
-				"TestAnyLocal",
-				"TestLinuxLocal",
+			Tests: []BatchPackageTest{
+				{
+					Name: "TestAnyLocal",
+				},
+				{
+					Name: "TestLinuxLocal",
+				},
 			},
 		},
 	}
 	linuxSudoTests := []BatchPackageTests{
 		{
 			Name: pkgName,
-			Tests: []string{
-				"TestAnySudo",
-				"TestLinuxSudo",
+			Tests: []BatchPackageTest{
+				{
+					Name: "TestAnySudo",
+				},
+				{
+					Name: "TestLinuxSudo",
+				},
 			},
 		},
 	}
 	windowsLocalTests := []BatchPackageTests{
 		{
 			Name: pkgName,
-			Tests: []string{
-				"TestAnyLocal",
-				"TestWindowsLocal",
+			Tests: []BatchPackageTest{
+				{
+					Name: "TestAnyLocal",
+				},
+				{
+					Name: "TestWindowsLocal",
+				},
 			},
 		},
 	}
 	windowsSudoTests := []BatchPackageTests{
 		{
 			Name: pkgName,
-			Tests: []string{
-				"TestAnySudo",
-				"TestWindowsSudo",
+			Tests: []BatchPackageTest{
+				{
+					Name: "TestAnySudo",
+				},
+				{
+					Name: "TestWindowsSudo",
+				},
 			},
 		},
 	}
@@ -105,12 +129,22 @@ func TestBatch(t *testing.T) {
 			Tests: []BatchPackageTests{
 				{
 					Name: pkgName,
-					Tests: []string{
-						"TestAnyLocal",
-						"TestLinuxLocal",
-						"TestSpecificCombinationOne",
-						"TestSpecificCombinationTwo",
-						"TestSpecificCombinationWithCloud",
+					Tests: []BatchPackageTest{
+						{
+							Name: "TestAnyLocal",
+						},
+						{
+							Name: "TestLinuxLocal",
+						},
+						{
+							Name: "TestSpecificCombinationOne",
+						},
+						{
+							Name: "TestSpecificCombinationTwo",
+						},
+						{
+							Name: "TestSpecificCombinationWithCloud",
+						},
 					},
 				},
 			},
@@ -133,8 +167,10 @@ func TestBatch(t *testing.T) {
 			Tests: []BatchPackageTests{
 				{
 					Name: pkgName,
-					Tests: []string{
-						"TestAnyIsolate",
+					Tests: []BatchPackageTest{
+						{
+							Name: "TestAnyIsolate",
+						},
 					},
 				},
 			},
@@ -148,8 +184,10 @@ func TestBatch(t *testing.T) {
 			Tests: []BatchPackageTests{
 				{
 					Name: pkgName,
-					Tests: []string{
-						"TestAnyIsolate",
+					Tests: []BatchPackageTest{
+						{
+							Name: "TestAnyIsolate",
+						},
 					},
 				},
 			},
@@ -163,8 +201,10 @@ func TestBatch(t *testing.T) {
 			Tests: []BatchPackageTests{
 				{
 					Name: pkgName,
-					Tests: []string{
-						"TestAnyIsolate",
+					Tests: []BatchPackageTest{
+						{
+							Name: "TestAnyIsolate",
+						},
 					},
 				},
 			},
@@ -178,8 +218,10 @@ func TestBatch(t *testing.T) {
 			Tests: []BatchPackageTests{
 				{
 					Name: pkgName,
-					Tests: []string{
-						"TestAnyIsolate",
+					Tests: []BatchPackageTest{
+						{
+							Name: "TestAnyIsolate",
+						},
 					},
 				},
 			},
@@ -193,8 +235,10 @@ func TestBatch(t *testing.T) {
 			Tests: []BatchPackageTests{
 				{
 					Name: pkgName,
-					Tests: []string{
-						"TestAnyIsolate",
+					Tests: []BatchPackageTest{
+						{
+							Name: "TestAnyIsolate",
+						},
 					},
 				},
 			},
@@ -208,8 +252,10 @@ func TestBatch(t *testing.T) {
 			Tests: []BatchPackageTests{
 				{
 					Name: pkgName,
-					Tests: []string{
-						"TestDarwinIsolate",
+					Tests: []BatchPackageTest{
+						{
+							Name: "TestDarwinIsolate",
+						},
 					},
 				},
 			},
@@ -223,8 +269,10 @@ func TestBatch(t *testing.T) {
 			Tests: []BatchPackageTests{
 				{
 					Name: pkgName,
-					Tests: []string{
-						"TestDarwinIsolate",
+					Tests: []BatchPackageTest{
+						{
+							Name: "TestDarwinIsolate",
+						},
 					},
 				},
 			},
@@ -238,8 +286,10 @@ func TestBatch(t *testing.T) {
 			Tests: []BatchPackageTests{
 				{
 					Name: pkgName,
-					Tests: []string{
-						"TestLinuxIsolate",
+					Tests: []BatchPackageTest{
+						{
+							Name: "TestLinuxIsolate",
+						},
 					},
 				},
 			},
@@ -253,8 +303,10 @@ func TestBatch(t *testing.T) {
 			Tests: []BatchPackageTests{
 				{
 					Name: pkgName,
-					Tests: []string{
-						"TestLinuxIsolate",
+					Tests: []BatchPackageTest{
+						{
+							Name: "TestLinuxIsolate",
+						},
 					},
 				},
 			},
@@ -268,8 +320,10 @@ func TestBatch(t *testing.T) {
 			Tests: []BatchPackageTests{
 				{
 					Name: pkgName,
-					Tests: []string{
-						"TestWindowsIsolate",
+					Tests: []BatchPackageTest{
+						{
+							Name: "TestWindowsIsolate",
+						},
 					},
 				},
 			},
@@ -281,7 +335,11 @@ func TestBatch(t *testing.T) {
 	require.EqualValues(t, expected, actual)
 }
 
-var testLinuxLocalTests = []string{"TestLinuxLocal"}
+var testLinuxLocalTests = []BatchPackageTest{
+	{
+		Name: "TestLinuxLocal",
+	},
+}
 
 var testLinuxLocalBatch = []Batch{
 	{

--- a/pkg/testing/ogc/provisioner.go
+++ b/pkg/testing/ogc/provisioner.go
@@ -294,7 +294,7 @@ func osBatchToOGC(cacheDir string, batch runner.OSBatch) Layout {
 		} else if len(batch.Batch.Tests) > 0 {
 			test = batch.Batch.Tests[0]
 		}
-		tags = append(tags, fmt.Sprintf("%s-%s", path.Base(test.Name), strings.ToLower(test.Tests[0])))
+		tags = append(tags, fmt.Sprintf("%s-%s", path.Base(test.Name), strings.ToLower(test.Tests[0].Name)))
 	}
 	los, _ := findOSLayout(batch.OS.OS)
 	return Layout{

--- a/pkg/testing/runner/debian.go
+++ b/pkg/testing/runner/debian.go
@@ -185,13 +185,13 @@ func (DebianRunner) Run(ctx context.Context, verbose bool, sshClient *ssh.Client
 	var tests []string
 	for _, pkg := range batch.Tests {
 		for _, test := range pkg.Tests {
-			tests = append(tests, fmt.Sprintf("%s:%s", pkg.Name, test))
+			tests = append(tests, fmt.Sprintf("%s:%s", pkg.Name, test.Name))
 		}
 	}
 	var sudoTests []string
 	for _, pkg := range batch.SudoTests {
 		for _, test := range pkg.Tests {
-			sudoTests = append(sudoTests, fmt.Sprintf("%s:%s", pkg.Name, test))
+			sudoTests = append(sudoTests, fmt.Sprintf("%s:%s", pkg.Name, test.Name))
 		}
 	}
 

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -887,30 +887,38 @@ func filterSingleTest(batches []OSBatch, singleTest string) ([]OSBatch, error) {
 func filterSingleTestBatch(batch OSBatch, testName string) (OSBatch, bool) {
 	for _, pt := range batch.Batch.Tests {
 		for _, t := range pt.Tests {
-			if t == testName {
+			if t.Name == testName {
 				// filter batch to only run one test
 				batch.Batch.Tests = []define.BatchPackageTests{
 					{
 						Name:  pt.Name,
-						Tests: []string{testName},
+						Tests: []define.BatchPackageTest{t},
 					},
 				}
 				batch.Batch.SudoTests = nil
+				// remove stack requirement when the test doesn't need a stack
+				if !t.Stack {
+					batch.Batch.Stack = nil
+				}
 				return batch, true
 			}
 		}
 	}
 	for _, pt := range batch.Batch.SudoTests {
 		for _, t := range pt.Tests {
-			if t == testName {
+			if t.Name == testName {
 				// filter batch to only run one test
 				batch.Batch.SudoTests = []define.BatchPackageTests{
 					{
 						Name:  pt.Name,
-						Tests: []string{testName},
+						Tests: []define.BatchPackageTest{t},
 					},
 				}
 				batch.Batch.Tests = nil
+				// remove stack requirement when the test doesn't need a stack
+				if !t.Stack {
+					batch.Batch.Stack = nil
+				}
 				return batch, true
 			}
 		}
@@ -941,11 +949,11 @@ func createBatchID(batch OSBatch) string {
 	if batch.Batch.Isolate {
 		if len(batch.Batch.Tests) > 0 {
 			// only ever has one test in an isolated batch
-			id += "-" + batch.Batch.Tests[0].Tests[0]
+			id += "-" + batch.Batch.Tests[0].Tests[0].Name
 		}
 		if len(batch.Batch.SudoTests) > 0 {
 			// only ever has one test in an isolated batch
-			id += "-" + batch.Batch.SudoTests[0].Tests[0]
+			id += "-" + batch.Batch.SudoTests[0].Tests[0].Name
 		}
 	}
 	return strings.ToLower(id)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

When running `mage integration:single TestFakeComponent` the integration testing runner would create a stack even though the test did not require a stack. 

This is because the `pkg/testing/define` merged batches of tests that didn't require a stack and those that didn't as they can be ran in the same batch. This is fine until then only a single test is selected out of that batch and the test doesn't need a stack.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Makes it faster to run the integration tests for a single test in the case that it doesn't need a stack.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run `mage integration:single TestFakeComponent` and notice that a stack is no longer provisioned.
