### PR TITLE
[Integration Test Framework] Allow creation of deployments in ESS QA Azure region

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -1725,11 +1725,13 @@ func createTestRunner(matrix bool, singleTest string, goTestFlags string, batche
 	if datacenter == "" {
 		datacenter = "us-central1-a"
 	}
+
+	// Valid values are gcp-us-central1 (default), azure-eastus2
 	essRegion := os.Getenv("TEST_INTEG_AUTH_ESS_REGION")
 	if essRegion == "" {
-		//essRegion = "gcp-us-central1"
-		essRegion = "azure-eastus2"
+		essRegion = "gcp-us-central1"
 	}
+
 	instanceProvisionerMode := os.Getenv("INSTANCE_PROVISIONER")
 	if instanceProvisionerMode == "" {
 		instanceProvisionerMode = "ogc"

--- a/magefile.go
+++ b/magefile.go
@@ -1727,7 +1727,8 @@ func createTestRunner(matrix bool, singleTest string, goTestFlags string, batche
 	}
 	essRegion := os.Getenv("TEST_INTEG_AUTH_ESS_REGION")
 	if essRegion == "" {
-		essRegion = "gcp-us-central1"
+		//essRegion = "gcp-us-central1"
+		essRegion = "azure-eastus2"
 	}
 	instanceProvisionerMode := os.Getenv("INSTANCE_PROVISIONER")
 	if instanceProvisionerMode == "" {

--- a/pkg/testing/ess/deployment.go
+++ b/pkg/testing/ess/deployment.go
@@ -333,7 +333,6 @@ func deploymentTemplateFactory(req CreateDeploymentRequest) (*template.Template,
 	return tpl, nil
 }
 
-// TODO: make work for cloud other than GCP
 const createDeploymentRequestTemplateGCP = `
 {
   "resources": {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR updates the Integration Test Framework code to allow the creation of test stack deployments in the Azure region (`azure-eastus2`) instead of the GCP region (`gcp-us-central1`) in the ESS QA environment. 

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Deployments in the GCP QA region appear to be taking indefinitely long to create today.  Meanwhile, deployments in the Azure QA region are being created normally. When such incidents occur, the changes in this PR will allow us to quickly switch the QA ESS region where we want deployments to be created by setting the value of the `TEST_INTEG_AUTH_ESS_REGION` environment variable.
