### PR TITLE
[Do NOT Merge] Investigating why Agent keeps randomly disappearing during integration tests in CI

### DIFF
--- a/pkg/testing/fixture_install.go
+++ b/pkg/testing/fixture_install.go
@@ -85,6 +85,7 @@ func (i InstallOpts) toCmdArgs() []string {
 //   - the combined output of stdout and stderr
 //   - an error if any.
 func (f *Fixture) Install(ctx context.Context, installOpts *InstallOpts, opts ...process.CmdOption) ([]byte, error) {
+	f.t.Logf("[test %s] Inside fixture install function", f.t.Name())
 	installArgs := []string{"install"}
 	if installOpts != nil {
 		installArgs = append(installArgs, installOpts.toCmdArgs()...)
@@ -108,6 +109,7 @@ func (f *Fixture) Install(ctx context.Context, installOpts *InstallOpts, opts ..
 	f.setClient(c)
 
 	f.t.Cleanup(func() {
+		f.t.Logf("[test %s] Inside fixture cleanup function", f.t.Name())
 		if !f.installed {
 			// not installed; no need to clean up or collect diagnostics
 			return


### PR DESCRIPTION
## What does this PR do?

This PR adds logging, etc. to try and investigate why Agent is disappearing sometimes during integration tests running in Buildkite, with errors like the following:

While trying to run `elastic-agent status`
```
  fixture.go:365: >> running agent with: [/opt/Elastic/Agent/elastic-agent status --output yaml]
    upgrade_test.go:978: error getting the agent state: fork/exec /opt/Elastic/Agent/elastic-agent: no such file or directory
```

While trying to run `elastic-agent diagnostics` during test cleanup:

```
    fixture_install.go:126: collecting diagnostics; test failed
    fixture.go:365: >> running agent with: [/opt/Elastic/Agent/elastic-agent diagnostics -f /home/ubuntu/agent/build/diagnostics/TestStandaloneUpgradeFailsStatus-diagnostics-2023-09-07T05:38:45Z.zip]
    fixture_install.go:230: failed to collect diagnostics to /home/ubuntu/agent/build/diagnostics/TestStandaloneUpgradeFailsStatus-diagnostics-2023-09-07T05:38:45Z.zip (fork/exec /opt/Elastic/Agent/elastic-agent: no such file or directory): 
    fixture.go:365: >> running agent with: [/opt/Elastic/Agent/elastic-agent uninstall --force]
```

## Why is it important?

To remove flakiness from tests by ensuring that Agent doesn't randomly disappear while tests are running.

