### PR TITLE
Fix integration tests by waiting for the watcher to finish during upgrade tests

### DIFF
--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -366,7 +366,7 @@ func getUpgradableVersions(ctx context.Context, t *testing.T, upgradeToVersion s
 	t.Helper()
 
 	const currentMajorVersions = 2
-	const previousMajorVersions = 0
+	const previousMajorVersions = 1
 
 	aac := tools.NewArtifactAPIClient()
 	vList, err := aac.GetVersions(ctx)

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -45,6 +45,7 @@ import (
 	agtversion "github.com/elastic/elastic-agent/version"
 )
 
+const watcherWaitDuration = time.Minute + 30*time.Second
 const fastWatcherCfg = `
 agent.upgrade.watcher:
   grace_period: 1m
@@ -99,7 +100,7 @@ func TestFleetManagedUpgrade(t *testing.T) {
 
 			t.Cleanup(func() {
 				// Make sure the watcher is done at the end of the test.
-				time.Sleep(time.Minute + time.Second)
+				time.Sleep(watcherWaitDuration)
 			})
 
 			testUpgradeFleetManagedElasticAgent(t, ctx, info, agentFixture, parsedVersion, define.Version())
@@ -217,7 +218,7 @@ func TestStandaloneUpgrade(t *testing.T) {
 
 			t.Cleanup(func() {
 				// Make sure the watcher is done at the end of the test.
-				time.Sleep(time.Minute + time.Second)
+				time.Sleep(watcherWaitDuration)
 			})
 
 			parsedUpgradeVersion, err := version.ParseVersion(define.Version())
@@ -265,7 +266,7 @@ func TestStandaloneDowngradeWithGPGFallback(t *testing.T) {
 
 	t.Cleanup(func() {
 		// Make sure the watcher is done at the end of the test.
-		time.Sleep(time.Minute + time.Second)
+		time.Sleep(watcherWaitDuration)
 	})
 
 	_, defaultPGP := release.PGP()
@@ -305,7 +306,7 @@ func TestStandaloneDowngradeToPreviousSnapshotBuild(t *testing.T) {
 
 	t.Cleanup(func() {
 		// Make sure the watcher is done at the end of the test.
-		time.Sleep(time.Minute + time.Second)
+		time.Sleep(watcherWaitDuration)
 	})
 
 	// retrieve all the versions of agent from the artifact API
@@ -680,7 +681,7 @@ func TestStandaloneUpgradeRetryDownload(t *testing.T) {
 
 	t.Cleanup(func() {
 		// Make sure the watcher is done at the end of the test.
-		time.Sleep(time.Minute + time.Second)
+		time.Sleep(watcherWaitDuration)
 	})
 
 	t.Log("Install the built Agent")
@@ -844,7 +845,7 @@ func TestUpgradeBrokenPackageVersion(t *testing.T) {
 
 	t.Cleanup(func() {
 		// Make sure the watcher is done at the end of the test.
-		time.Sleep(time.Minute + time.Second)
+		time.Sleep(watcherWaitDuration)
 	})
 
 	output, err := tools.InstallStandaloneAgent(f)

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -45,7 +45,7 @@ import (
 	agtversion "github.com/elastic/elastic-agent/version"
 )
 
-const watcherWaitDuration = time.Minute + 30*time.Second
+const watcherWaitDuration = 10 * time.Minute
 const fastWatcherCfg = `
 agent.upgrade.watcher:
   grace_period: 1m

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -96,6 +96,12 @@ func TestFleetManagedUpgrade(t *testing.T) {
 
 			err = agentFixture.Configure(ctx, []byte(fastWatcherCfg))
 			require.NoError(t, err, "error configuring agent fixture")
+
+			t.Cleanup(func() {
+				// Make sure the watcher is done at the end of the test.
+				time.Sleep(time.Minute + time.Second)
+			})
+
 			testUpgradeFleetManagedElasticAgent(t, ctx, info, agentFixture, parsedVersion, define.Version())
 		})
 	}
@@ -209,6 +215,11 @@ func TestStandaloneUpgrade(t *testing.T) {
 			err = agentFixture.Configure(ctx, []byte(fastWatcherCfg))
 			require.NoError(t, err, "error configuring agent fixture")
 
+			t.Cleanup(func() {
+				// Make sure the watcher is done at the end of the test.
+				time.Sleep(time.Minute + time.Second)
+			})
+
 			parsedUpgradeVersion, err := version.ParseVersion(define.Version())
 			require.NoErrorf(t, err, "define.Version() %q cannot be parsed as agent version", define.Version())
 			skipVerify := version_8_7_0.Less(*parsedVersion)
@@ -252,6 +263,11 @@ func TestStandaloneDowngradeWithGPGFallback(t *testing.T) {
 	err = agentFixture.Configure(ctx, []byte(fastWatcherCfg))
 	require.NoError(t, err, "error configuring agent fixture")
 
+	t.Cleanup(func() {
+		// Make sure the watcher is done at the end of the test.
+		time.Sleep(time.Minute + time.Second)
+	})
+
 	_, defaultPGP := release.PGP()
 	firstSeven := string(defaultPGP[:7])
 	customPGP := strings.Replace(
@@ -286,6 +302,11 @@ func TestStandaloneDowngradeToPreviousSnapshotBuild(t *testing.T) {
 
 	err = agentFixture.Configure(ctx, []byte(fastWatcherCfg))
 	require.NoError(t, err, "error configuring agent fixture")
+
+	t.Cleanup(func() {
+		// Make sure the watcher is done at the end of the test.
+		time.Sleep(time.Minute + time.Second)
+	})
 
 	// retrieve all the versions of agent from the artifact API
 	aac := tools.NewArtifactAPIClient()
@@ -338,7 +359,6 @@ func TestStandaloneDowngradeToPreviousSnapshotBuild(t *testing.T) {
 	parsedFromVersion, err := version.ParseVersion(define.Version())
 	require.NoErrorf(t, err, "define.Version() %q cannot be parsed as agent version", define.Version())
 	testStandaloneUpgrade(ctx, t, agentFixture, parsedFromVersion, upgradeInputVersion, expectedAgentHashAfterUpgrade, false, true, false, "")
-
 }
 
 func getUpgradableVersions(ctx context.Context, t *testing.T, upgradeToVersion string) (upgradableVersions []*version.ParsedSemVer) {
@@ -658,6 +678,11 @@ func TestStandaloneUpgradeRetryDownload(t *testing.T) {
 	err = agentFixture.Configure(ctx, []byte(fastWatcherCfg))
 	require.NoError(t, err, "error configuring agent fixture")
 
+	t.Cleanup(func() {
+		// Make sure the watcher is done at the end of the test.
+		time.Sleep(time.Minute + time.Second)
+	})
+
 	t.Log("Install the built Agent")
 	output, err := tools.InstallStandaloneAgent(agentFixture)
 	t.Log(string(output))
@@ -813,6 +838,14 @@ func TestUpgradeBrokenPackageVersion(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	err = f.Configure(ctx, []byte(fastWatcherCfg))
+	require.NoError(t, err, "error configuring agent fixture")
+
+	t.Cleanup(func() {
+		// Make sure the watcher is done at the end of the test.
+		time.Sleep(time.Minute + time.Second)
+	})
 
 	output, err := tools.InstallStandaloneAgent(f)
 	t.Logf("Agent installation output: %q", string(output))

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -345,7 +345,7 @@ func getUpgradableVersions(ctx context.Context, t *testing.T, upgradeToVersion s
 	t.Helper()
 
 	const currentMajorVersions = 2
-	const previousMajorVersions = 1
+	const previousMajorVersions = 0
 
 	aac := tools.NewArtifactAPIClient()
 	vList, err := aac.GetVersions(ctx)


### PR DESCRIPTION
This is a work around while we implement a fix for https://github.com/elastic/elastic-agent/issues/3371.

If the watcher is still running at the end of a test, it will observe the normal uninstall+reinstall as a crash and roll back the agent at the start of the next generally causing chaos and failing tests.