### PR TITLE
improve reporting of errors during uninstall

### DIFF
--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -192,7 +192,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 
 		defer func() {
 			if err != nil {
-				_ = install.Uninstall(cfgFile, topPath, "")
+				_ = install.Uninstall(cfgFile, topPath, "", force)
 			}
 		}()
 
@@ -235,7 +235,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 			pt.StepFailed()
 			if status != install.PackageInstall {
 				var exitErr *exec.ExitError
-				_ = install.Uninstall(cfgFile, topPath, "")
+				_ = install.Uninstall(cfgFile, topPath, "", force)
 				if err != nil && errors.As(err, &exitErr) {
 					return fmt.Errorf("enroll command failed with exit code: %d", exitErr.ExitCode())
 				}

--- a/internal/pkg/agent/cmd/uninstall.go
+++ b/internal/pkg/agent/cmd/uninstall.go
@@ -80,7 +80,7 @@ func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		}
 	}
 
-	err = install.Uninstall(paths.ConfigFile(), paths.Top(), uninstallToken)
+	err = install.Uninstall(paths.ConfigFile(), paths.Top(), uninstallToken, force)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/agent/install/install.go
+++ b/internal/pkg/agent/install/install.go
@@ -35,7 +35,7 @@ func Install(cfgFile, topPath string, pt *ProgressTracker) error {
 	// Uninstall will fail on protected agent.
 	// The protected Agent will need to be uninstalled first before it can be installed.
 	pt.StepStart("Uninstalling current Elastic Agent")
-	err = Uninstall(cfgFile, topPath, "")
+	err = Uninstall(cfgFile, topPath, "", true)
 	if err != nil && !errors.Is(err, service.ErrNotInstalled) {
 		pt.StepFailed()
 		return errors.New(

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -36,7 +36,14 @@ func Uninstall(cfgFile, topPath, uninstallToken string) error {
 	if err != nil {
 		return err
 	}
-	status, _ := svc.Status()
+
+	status, err := svc.Status()
+	if err != nil {
+		return errors.New(
+			err,
+			fmt.Sprintf("failed to get status for service (%s)", paths.ServiceName),
+			errors.M("service", paths.ServiceName))
+	}
 
 	if status == service.StatusRunning {
 		err := svc.Stop()
@@ -60,11 +67,19 @@ func Uninstall(cfgFile, topPath, uninstallToken string) error {
 					errors.M("service", paths.ServiceName))
 			}
 		}
-		return err
+		return errors.New(
+			err,
+			fmt.Sprintf("failed to uninstall components for service (%s)", paths.ServiceName),
+			errors.M("service", paths.ServiceName))
 	}
 
-	// Uninstall service only after components were uninstalled successfully
-	_ = svc.Uninstall()
+	err = svc.Uninstall()
+	if err != nil {
+		return errors.New(
+			err,
+			fmt.Sprintf("failed to uninstall service (%s)", paths.ServiceName),
+			errors.M("service", paths.ServiceName))
+	}
 
 	// remove, if present on platform
 	if paths.ShellWrapperPath != "" {


### PR DESCRIPTION
## What does this PR do?

Report errors during uninstall process, rather than ignoring and continuing.

## Why is it important?

Current code will ignore and not log errors that occur during uninstall.  This makes it very hard to debug.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
~~- [ ] I have added an integration test or an E2E test~~ current uninstall tests should be sufficient

## How to test this PR locally

1. install elastic-agent
2. run `elastic-agent uninstall`

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/3372

