### PR TITLE
Fix when fixture.Install logs  'ignoring AGENT_KEEP_INSTALLED...'

### DIFF
--- a/pkg/testing/fixture_install.go
+++ b/pkg/testing/fixture_install.go
@@ -129,12 +129,14 @@ func (f *Fixture) Install(ctx context.Context, installOpts *InstallOpts, opts ..
 
 		// environment variable AGENT_KEEP_INSTALLED=true will skip the uninstall
 		// useful to debug the issue with the Elastic Agent
-		if keepInstalled() && f.t.Failed() {
-			f.t.Logf("skipping uninstall; AGENT_KEEP_INSTALLED=true")
+		if f.t.Failed() && keepInstalled() {
+			f.t.Logf("skipping uninstall; test failed and AGENT_KEEP_INSTALLED=true")
 			return
-		} else {
+		}
+
+		if keepInstalled() {
 			f.t.Logf("ignoring AGENT_KEEP_INSTALLED=true as test succeeded, " +
-				"keeping the agent installed will jeperdise other tests")
+				"keeping the agent installed will jeopardise other tests")
 		}
 
 		out, err := f.Uninstall(ctx, &UninstallOpts{Force: true, UninstallToken: f.uninstallToken})


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Avoid the Fixture.Install method logging _ignoring AGENT_KEEP_INSTALLED=true as test succeeded, keeping the agent installed will jeperdise other tests_ when AGENT_KEEP_INSTALLED isn't set. It also fixes the typo.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
