### PR TITLE
Improve Upgrade-related logging

### DIFF
--- a/changelog/fragments/1694190260-improve-upgrade-logging.yaml
+++ b/changelog/fragments/1694190260-improve-upgrade-logging.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Improve logging during Agent upgrades
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/3382
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/upgrade/cleanup.go
+++ b/internal/pkg/agent/application/upgrade/cleanup.go
@@ -19,7 +19,7 @@ import (
 // cleanNonMatchingVersionsFromDownloads will remove files that do not have the passed version number from the downloads directory.
 func cleanNonMatchingVersionsFromDownloads(log *logger.Logger, version string) error {
 	downloadsPath := paths.Downloads()
-	log.Debugw("Cleaning up non-matching downloaded versions", "version", version, "downloads.path", downloadsPath)
+	log.Infow("Cleaning up non-matching downloaded versions", "version", version, "downloads.path", downloadsPath)
 
 	files, err := os.ReadDir(downloadsPath)
 	if os.IsNotExist(err) {

--- a/internal/pkg/agent/application/upgrade/crash_checker.go
+++ b/internal/pkg/agent/application/upgrade/crash_checker.go
@@ -7,7 +7,6 @@ package upgrade
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -64,7 +63,6 @@ func (ch *CrashChecker) Run(ctx context.Context) {
 
 	ch.log.Info("Crash checker started")
 	for {
-		ch.log.Infof("watcher having PID: %d", os.Getpid())
 		t := time.NewTimer(ch.checkInterval)
 
 		select {

--- a/internal/pkg/agent/application/upgrade/crash_checker.go
+++ b/internal/pkg/agent/application/upgrade/crash_checker.go
@@ -53,7 +53,7 @@ func NewCrashChecker(ctx context.Context, ch chan error, log *logger.Logger, che
 		return nil, err
 	}
 
-	log.Debugf("running checks using '%s' controller", c.sc.Name())
+	log.Infof("running checks using '%s' controller", c.sc.Name())
 
 	return c, nil
 }
@@ -62,9 +62,9 @@ func NewCrashChecker(ctx context.Context, ch chan error, log *logger.Logger, che
 func (ch *CrashChecker) Run(ctx context.Context) {
 	defer ch.sc.Close()
 
-	ch.log.Debug("Crash checker started")
+	ch.log.Info("Crash checker started")
 	for {
-		ch.log.Debugf("watcher having PID: %d", os.Getpid())
+		ch.log.Infof("watcher having PID: %d", os.Getpid())
 		t := time.NewTimer(ch.checkInterval)
 
 		select {
@@ -77,7 +77,7 @@ func (ch *CrashChecker) Run(ctx context.Context) {
 				ch.log.Error(err)
 			}
 
-			ch.log.Debugf("retrieved service PID [%d]", pid)
+			ch.log.Infof("retrieved service PID [%d]", pid)
 			ch.q.Push(pid)
 
 			// We decide if the Agent process has crashed in either of

--- a/internal/pkg/agent/application/upgrade/error_checker.go
+++ b/internal/pkg/agent/application/upgrade/error_checker.go
@@ -49,7 +49,7 @@ func NewErrorChecker(ch chan error, log *logger.Logger, checkInterval time.Durat
 
 // Run runs the checking loop.
 func (ch *ErrorChecker) Run(ctx context.Context) {
-	ch.log.Debug("Error checker started")
+	ch.log.Info("Error checker started")
 	for {
 		t := time.NewTimer(ch.checkInterval)
 		select {

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -55,7 +55,7 @@ func Rollback(ctx context.Context, log *logger.Logger, prevHash string, currentH
 
 // Cleanup removes all artifacts and files related to a specified version.
 func Cleanup(log *logger.Logger, currentHash string, removeMarker bool, keepLogs bool) error {
-	log.Debugw("Cleaning up upgrade", "hash", currentHash, "remove_marker", removeMarker)
+	log.Infow("Cleaning up upgrade", "hash", currentHash, "remove_marker", removeMarker)
 	<-time.After(afterRestartDelay)
 
 	// remove upgrade marker
@@ -78,7 +78,7 @@ func Cleanup(log *logger.Logger, currentHash string, removeMarker bool, keepLogs
 
 	// remove symlink to avoid upgrade failures, ignore error
 	prevSymlink := prevSymlinkPath()
-	log.Debugw("Removing previous symlink path", "file.path", prevSymlinkPath())
+	log.Infow("Removing previous symlink path", "file.path", prevSymlinkPath())
 	_ = os.Remove(prevSymlink)
 
 	dirPrefix := fmt.Sprintf("%s-", agentName)
@@ -93,7 +93,7 @@ func Cleanup(log *logger.Logger, currentHash string, removeMarker bool, keepLogs
 		}
 
 		hashedDir := filepath.Join(paths.Data(), dir)
-		log.Debugw("Removing hashed data directory", "file.path", hashedDir)
+		log.Infow("Removing hashed data directory", "file.path", hashedDir)
 		var ignoredDirs []string
 		if keepLogs {
 			ignoredDirs = append(ignoredDirs, "logs")
@@ -110,19 +110,19 @@ func Cleanup(log *logger.Logger, currentHash string, removeMarker bool, keepLogs
 // agent during upgrade period.
 func InvokeWatcher(log *logger.Logger) error {
 	if !IsUpgradeable() {
-		log.Debug("agent is not upgradable, not starting watcher")
+		log.Info("agent is not upgradable, not starting watcher")
 		return nil
 	}
 
 	cmd := invokeCmd()
 	defer func() {
 		if cmd.Process != nil {
-			log.Debugf("releasing watcher %v", cmd.Process.Pid)
+			log.Infof("releasing watcher %v", cmd.Process.Pid)
 			_ = cmd.Process.Release()
 		}
 	}()
 
-	log.Debugw("Starting upgrade watcher", "path", cmd.Path, "args", cmd.Args, "env", cmd.Env, "dir", cmd.Dir)
+	log.Infow("Starting upgrade watcher", "path", cmd.Path, "args", cmd.Args, "env", cmd.Env, "dir", cmd.Dir)
 	return cmd.Start()
 }
 

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -123,7 +123,15 @@ func InvokeWatcher(log *logger.Logger) error {
 	}()
 
 	log.Infow("Starting upgrade watcher", "path", cmd.Path, "args", cmd.Args, "env", cmd.Env, "dir", cmd.Dir)
-	return cmd.Start()
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start Upgrade Watcher: %w", err)
+	}
+
+	upgradeWatcherPID := cmd.Process.Pid
+	agentPID := os.Getpid()
+	log.Infow("Upgrade Watcher invoked", "agent.upgrade.watcher.process.pid", upgradeWatcherPID, "agent.process.pid", agentPID)
+
+	return nil
 }
 
 func restartAgent(ctx context.Context, log *logger.Logger) error {

--- a/internal/pkg/agent/application/upgrade/step_download.go
+++ b/internal/pkg/agent/application/upgrade/step_download.go
@@ -54,7 +54,7 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 		}
 	}
 
-	u.log.Debugw("Downloading upgrade artifact", "version", version,
+	u.log.Infow("Downloading upgrade artifact", "version", version,
 		"source_uri", settings.SourceURI, "drop_path", settings.DropPath,
 		"target_path", settings.TargetDirectory, "install_path", settings.InstallPath)
 
@@ -162,7 +162,7 @@ func (u *Upgrader) downloadWithRetries(
 
 	opFn := func() error {
 		attempt++
-		u.log.Debugf("download attempt %d", attempt)
+		u.log.Infof("download attempt %d", attempt)
 
 		downloader, err := downloaderCtor(version, u.log, settings)
 		if err != nil {

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -139,7 +139,7 @@ func UpdateActiveCommit(log *logger.Logger, hash string) error {
 // CleanMarker removes a marker from disk.
 func CleanMarker(log *logger.Logger) error {
 	markerFile := markerFilePath()
-	log.Debugw("Removing marker file", "file.path", markerFile)
+	log.Infow("Removing marker file", "file.path", markerFile)
 	if err := os.Remove(markerFile); !os.IsNotExist(err) {
 		return err
 	}

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -84,10 +84,12 @@ func unzip(log *logger.Logger, archivePath string) (string, error) {
 		path := filepath.Join(paths.Data(), strings.TrimPrefix(fileName, "data/"))
 
 		if f.FileInfo().IsDir() {
-			log.Debugw("Unpacking directory", "archive", "zip", "file.path", path)
+			// TODO: decide if this should be left as log.Debugw, in case log.Infow is too verbose
+			log.Infow("Unpacking directory", "archive", "zip", "file.path", path)
 			_ = os.MkdirAll(path, f.Mode())
 		} else {
-			log.Debugw("Unpacking file", "archive", "zip", "file.path", path)
+			// TODO: decide if this should be left as log.Debugw, in case log.Infow is too verbose
+			log.Infow("Unpacking file", "archive", "zip", "file.path", path)
 			_ = os.MkdirAll(filepath.Dir(path), f.Mode())
 			f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
 			if err != nil {
@@ -188,7 +190,8 @@ func untar(log *logger.Logger, version string, archivePath string) (string, erro
 		mode := fi.Mode()
 		switch {
 		case mode.IsRegular():
-			log.Debugw("Unpacking file", "archive", "tar", "file.path", abs)
+			// TODO: decide if this should be left as log.Debugw, in case log.Infow is too verbose
+			log.Infow("Unpacking file", "archive", "tar", "file.path", abs)
 			// just to be sure, it should already be created by Dir type
 			if err := os.MkdirAll(filepath.Dir(abs), 0755); err != nil {
 				return "", errors.New(err, "TarInstaller: creating directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
@@ -208,7 +211,8 @@ func untar(log *logger.Logger, version string, archivePath string) (string, erro
 				return "", fmt.Errorf("TarInstaller: error writing to %s: %w", abs, err)
 			}
 		case mode.IsDir():
-			log.Debugw("Unpacking directory", "archive", "tar", "file.path", abs)
+			// TODO: decide if this should be left as log.Debugw, in case log.Infow is too verbose
+			log.Infow("Unpacking directory", "archive", "tar", "file.path", abs)
 			if err := os.MkdirAll(abs, 0755); err != nil {
 				return "", errors.New(err, "TarInstaller: creating directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
 			}

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -84,12 +84,10 @@ func unzip(log *logger.Logger, archivePath string) (string, error) {
 		path := filepath.Join(paths.Data(), strings.TrimPrefix(fileName, "data/"))
 
 		if f.FileInfo().IsDir() {
-			// TODO: decide if this should be left as log.Debugw, in case log.Infow is too verbose
-			log.Infow("Unpacking directory", "archive", "zip", "file.path", path)
+			log.Debugw("Unpacking directory", "archive", "zip", "file.path", path)
 			_ = os.MkdirAll(path, f.Mode())
 		} else {
-			// TODO: decide if this should be left as log.Debugw, in case log.Infow is too verbose
-			log.Infow("Unpacking file", "archive", "zip", "file.path", path)
+			log.Debugw("Unpacking file", "archive", "zip", "file.path", path)
 			_ = os.MkdirAll(filepath.Dir(path), f.Mode())
 			f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
 			if err != nil {
@@ -190,8 +188,7 @@ func untar(log *logger.Logger, version string, archivePath string) (string, erro
 		mode := fi.Mode()
 		switch {
 		case mode.IsRegular():
-			// TODO: decide if this should be left as log.Debugw, in case log.Infow is too verbose
-			log.Infow("Unpacking file", "archive", "tar", "file.path", abs)
+			log.Debugw("Unpacking file", "archive", "tar", "file.path", abs)
 			// just to be sure, it should already be created by Dir type
 			if err := os.MkdirAll(filepath.Dir(abs), 0755); err != nil {
 				return "", errors.New(err, "TarInstaller: creating directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
@@ -211,8 +208,7 @@ func untar(log *logger.Logger, version string, archivePath string) (string, erro
 				return "", fmt.Errorf("TarInstaller: error writing to %s: %w", abs, err)
 			}
 		case mode.IsDir():
-			// TODO: decide if this should be left as log.Debugw, in case log.Infow is too verbose
-			log.Infow("Unpacking directory", "archive", "tar", "file.path", abs)
+			log.Debugw("Unpacking directory", "archive", "tar", "file.path", abs)
 			if err := os.MkdirAll(abs, 0755); err != nil {
 				return "", errors.New(err, "TarInstaller: creating directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
 			}

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -11,9 +11,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/otiai10/copy"
 	"go.elastic.co/apm"
+
+	"github.com/elastic/elastic-agent/internal/pkg/config"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/elastic/elastic-agent/internal/pkg/config"
-
 	"github.com/otiai10/copy"
 	"go.elastic.co/apm"
 
@@ -172,7 +171,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	cb := shutdownCallback(u.log, paths.Home(), release.Version(), version, release.TrimCommit(newHash))
 
 	// Clean everything from the downloads dir
-	u.log.Debugw("Removing downloads directory", "file.path", paths.Downloads())
+	u.log.Infow("Removing downloads directory", "file.path", paths.Downloads())
 	err = os.RemoveAll(paths.Downloads())
 	if err != nil {
 		u.log.Errorw("Unable to clean downloads after update", "error.message", err, "file.path", paths.Downloads())
@@ -231,11 +230,12 @@ func copyActionStore(log *logger.Logger, newHash string) error {
 	// copies legacy action_store.yml, state.yml and state.enc encrypted file if exists
 	storePaths := []string{paths.AgentActionStoreFile(), paths.AgentStateStoreYmlFile(), paths.AgentStateStoreFile()}
 	newHome := filepath.Join(filepath.Dir(paths.Home()), fmt.Sprintf("%s-%s", agentName, newHash))
-	log.Debugw("Copying action store", "new_home_path", newHome)
+	log.Infow("Copying action store", "new_home_path", newHome)
 
 	for _, currentActionStorePath := range storePaths {
 		newActionStorePath := filepath.Join(newHome, filepath.Base(currentActionStorePath))
-		log.Debugw("Copying action store path", "from", currentActionStorePath, "to", newActionStorePath)
+		// TODO: decide if this should be left as log.Debugw, in case log.Infow is too verbose
+		log.Infow("Copying action store path", "from", currentActionStorePath, "to", newActionStorePath)
 		currentActionStore, err := os.ReadFile(currentActionStorePath)
 		if os.IsNotExist(err) {
 			// nothing to copy
@@ -266,7 +266,7 @@ func copyRunDirectory(log *logger.Logger, newHash string) error {
 	err := copyDir(log, oldRunPath, newRunPath, true)
 	if os.IsNotExist(err) {
 		// nothing to copy, operation ok
-		log.Debugw("Run directory not present", "old_run_path", oldRunPath)
+		log.Infow("Run directory not present", "old_run_path", oldRunPath)
 		return nil
 	}
 	if err != nil {

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -234,7 +234,6 @@ func copyActionStore(log *logger.Logger, newHash string) error {
 
 	for _, currentActionStorePath := range storePaths {
 		newActionStorePath := filepath.Join(newHome, filepath.Base(currentActionStorePath))
-		// TODO: decide if this should be left as log.Debugw, in case log.Infow is too verbose
 		log.Infow("Copying action store path", "from", currentActionStorePath, "to", newActionStorePath)
 		currentActionStore, err := os.ReadFile(currentActionStorePath)
 		if os.IsNotExist(err) {

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -151,7 +151,7 @@ func run(override cfgOverrider, testingMode bool, fleetInitTimeout time.Duration
 		"source": agentName,
 	})
 
-	l.Infow("Elastic Agent started. PID = %d. Agent version = %s", os.Getpid(), version.GetAgentPackageVersion())
+	l.Infow("Elastic Agent started", "process.pid", os.Getpid(), "agent.version", version.GetAgentPackageVersion())
 
 	cfg, err = tryDelayEnroll(ctx, l, cfg, override)
 	if err != nil {

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -151,6 +151,8 @@ func run(override cfgOverrider, testingMode bool, fleetInitTimeout time.Duration
 		"source": agentName,
 	})
 
+	l.Infow("Elastic Agent started. PID = %d. Agent version = %s", os.Getpid(), version.GetAgentPackageVersion())
+
 	cfg, err = tryDelayEnroll(ctx, l, cfg, override)
 	if err != nil {
 		err = errors.New(err, "failed to perform delayed enrollment")

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -69,14 +69,14 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 	}
 	if marker == nil {
 		// no marker found we're not in upgrade process
-		log.Debugf("update marker not present at '%s'", paths.Data())
+		log.Infof("update marker not present at '%s'", paths.Data())
 		return nil
 	}
 
 	locker := filelock.NewAppLocker(paths.Top(), watcherLockFile)
 	if err := locker.TryLock(); err != nil {
 		if errors.Is(err, filelock.ErrAppAlreadyRunning) {
-			log.Debugf("exiting, lock already exists")
+			log.Info("exiting, lock already exists")
 			return nil
 		}
 
@@ -89,7 +89,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 
 	isWithinGrace, tilGrace := gracePeriod(marker, cfg.Settings.Upgrade.Watcher.GracePeriod)
 	if !isWithinGrace {
-		log.Debugf("not within grace [updatedOn %v] %v", marker.UpdatedOn.String(), time.Since(marker.UpdatedOn).String())
+		log.Infof("not within grace [updatedOn %v] %v", marker.UpdatedOn.String(), time.Since(marker.UpdatedOn).String())
 		// if it is started outside of upgrade loop
 		// if we're not within grace and marker is still there it might mean
 		// that cleanup was not performed ok, cleanup everything except current version

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/elastic/elastic-agent/version"
+
 	"github.com/elastic/elastic-agent/internal/pkg/config"
 
 	"github.com/spf13/cobra"
@@ -62,6 +64,7 @@ func newWatchCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command 
 }
 
 func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
+	log.Infow("Upgrade Watcher started. PID = %d. Agent version = %s", os.Getpid(), version.GetAgentPackageVersion())
 	marker, err := upgrade.LoadMarker()
 	if err != nil {
 		log.Error("failed to load marker", err)

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -64,7 +64,7 @@ func newWatchCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command 
 }
 
 func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
-	log.Infow("Upgrade Watcher started. PID = %d. Agent version = %s", os.Getpid(), version.GetAgentPackageVersion())
+	log.Infow("Upgrade Watcher started", "process.pid", os.Getpid(), "agent.version", version.GetAgentPackageVersion())
 	marker, err := upgrade.LoadMarker()
 	if err != nil {
 		log.Error("failed to load marker", err)


### PR DESCRIPTION
## What does this PR do?

This PR makes several improvements to logs emitted by the Agent upgrade process:
* Changes all DEBUG level messages to INFO level in the upgrade process, whether that's the steps that happen in the Agent or in the Upgrade Watcher.
   * The only exception to this is log messages where files/directories from the Agent artifact are being unpacked, as logging those at `INFO` level is unhelpefully verbose.
* Logs the Agent's version (including hash) and PID as early as possible after start up.
* Logs the Upgrade Watcher's version (including hash) and PID as early as possible after start up.
* Logs the Upgrade Watcher's PID when that process is spawned from the "main" Agent process.

## Why is it important?

To increase visibility into the Agent upgrade process, so we can tell from logs exactly where and how upgrades might have failed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] ~I have added an integration test or an E2E test~


## How to test this PR locally

Since this PR makes changes to the upgrade code in the coordinator's execution path, which is executed by the pre-upgrade Agent binary, as well as upgrade watcher code, which is executed by the post-upgrade Agent binary, two separate tests are necessary.

### Testing the changes in the upgrade code in the coordinator's execution path

1. Build Elastic Agent package from this PR's branch.
   ```
   EXTERNAL=true SNAPSHOT=true DEV=true PLATFORMS=linux/arm64 PACKAGES=tar.gz mage package
   ```
2. Install it.
3. Start checking the Agent logs for upgrade-related logs.
   ```
   hash=$(sudo elastic-agent version --binary-only --yaml | grep commit | cut -w -f3 | cut -c1-6)
   sudo tail -F /Library/Elastic/Agent/data/elastic-agent-$hash/logs/elastic-agent-$(date +%Y%m%d).ndjson | grep -i upgrade
   ```
3. In a separate window, trigger an upgrade to another version of Agent.
   ```
   sudo elastic-agent upgrade 8.9.2
   ```
5. Verify that we have more upgrade-related logs in the Agent logs than before this PR.

### Testing the changes in the upgrade watcher code

1. Install an older version of Agent, but one that's >= 8.10.0, since that's the version where the pre-upgrade Agent spawns the Upgrade Watcher using the post-upgrade Agent binary.
1. In a separate window, build Elastic Agent package from this PR's branch.
   ```
   EXTERNAL=true SNAPSHOT=true DEV=true PLATFORMS=linux/arm64 PACKAGES=tar.gz mage package
   ```
2. Trigger an upgrade to the built Agent.
   ```
   sudo elastic-agent upgrade 8.11.0-SNAPSHOT --source-uri=file://$(pwd)/build/distributions --skip-verify
   ```
2. Check the Upgrade Watcher logs for upgrade-related logs.
   ```
   hash=$(sudo elastic-agent version --binary-only --yaml | grep commit | cut -w -f3 | cut -c1-6)
   sudo tail -n +1 -F /Library/Elastic/Agent/data/elastic-agent-$hash/logs/elastic-agent-watcher-$(date +%Y%m%d).ndjson | grep -i upgrade
   ```
6. Verify that we have more upgrade-related logs in the Upgrade Watcher logs than before this PR.

## Related issues
- Relates https://github.com/elastic/elastic-agent/issues/2264#issuecomment-1692542941
