### PR TITLE
Allow upgrades in quick succession without interference from Upgrade Watcher

### DIFF
--- a/changelog/fragments/1694187216-Uninstall-finds-and-kills-any-running-watcher-process.yaml
+++ b/changelog/fragments/1694187216-Uninstall-finds-and-kills-any-running-watcher-process.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Uninstall finds and kills any running watcher process
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/3384
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/3371

--- a/changelog/fragments/1694455516-bugfix-allow-successive-upgrades.yaml
+++ b/changelog/fragments/1694455516-bugfix-allow-successive-upgrades.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Reliably perform an Agent upgrade even if a previous upgrade is in progress.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/3399
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/2706

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/reexec"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/transpiler"
 	"github.com/elastic/elastic-agent/internal/pkg/capabilities"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
@@ -441,6 +442,12 @@ func (c *Coordinator) Upgrade(ctx context.Context, version string, sourceURI str
 	}
 	if err != nil {
 		return err
+	}
+
+	// Kill any running Upgrade Watcher process so it doesn't interfere with
+	// this upgrade.
+	if err := install.KillWatcher(); err != nil {
+		return fmt.Errorf("unable to kill running Upgrade Watcher: %w", err)
 	}
 
 	// override the overall state to upgrading until the re-execution is complete

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -446,6 +446,7 @@ func (c *Coordinator) Upgrade(ctx context.Context, version string, sourceURI str
 
 	// Kill any running Upgrade Watcher process so it doesn't interfere with
 	// this upgrade.
+	c.logger.Infof("Killing any running Upgrade Watcher process before starting upgrade to %s", version)
 	if err := install.KillWatcher(); err != nil {
 		return fmt.Errorf("unable to kill running Upgrade Watcher: %w", err)
 	}

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -52,7 +52,7 @@ func Uninstall(cfgFile, topPath, uninstallToken string) error {
 	}
 
 	// kill any running watcher
-	if err := killWatcher(); err != nil {
+	if err := KillWatcher(); err != nil {
 		return fmt.Errorf("failed trying to kill any running watcher: %w", err)
 	}
 
@@ -299,8 +299,8 @@ func applyDynamics(ctx context.Context, log *logger.Logger, cfg *config.Config) 
 	return config.NewConfigFrom(finalConfig)
 }
 
-// killWatcher finds and kills any running Elastic Agent watcher.
-func killWatcher() error {
+// KillWatcher finds and kills any running Elastic Agent watcher.
+func KillWatcher() error {
 	procStats := process.Stats{
 		// filtering with '.*elastic-agent' or '^.*elastic-agent$' doesn't
 		// seem to work as expected, filtering is done in the for loop below

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -6,6 +6,7 @@ package install
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,9 +16,11 @@ import (
 
 	"github.com/kardianos/service"
 
+	"github.com/elastic/elastic-agent-system-metrics/metric/system/process"
+
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
-	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	aerrors "github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/transpiler"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/vars"
 	"github.com/elastic/elastic-agent/internal/pkg/capabilities"
@@ -41,11 +44,16 @@ func Uninstall(cfgFile, topPath, uninstallToken string) error {
 	if status == service.StatusRunning {
 		err := svc.Stop()
 		if err != nil {
-			return errors.New(
+			return aerrors.New(
 				err,
 				fmt.Sprintf("failed to stop service (%s)", paths.ServiceName),
-				errors.M("service", paths.ServiceName))
+				aerrors.M("service", paths.ServiceName))
 		}
+	}
+
+	// kill any running watcher
+	if err := killWatcher(); err != nil {
+		return fmt.Errorf("failed trying to kill any running watcher: %w", err)
 	}
 
 	// Uninstall components first
@@ -54,10 +62,10 @@ func Uninstall(cfgFile, topPath, uninstallToken string) error {
 		// If the components uninstall failed start the service again
 		if status == service.StatusRunning {
 			if startErr := svc.Start(); startErr != nil {
-				return errors.New(
+				return aerrors.New(
 					err,
 					fmt.Sprintf("failed to restart service (%s), after failed components uninstall: %v", paths.ServiceName, startErr),
-					errors.M("service", paths.ServiceName))
+					aerrors.M("service", paths.ServiceName))
 			}
 		}
 		return err
@@ -70,20 +78,20 @@ func Uninstall(cfgFile, topPath, uninstallToken string) error {
 	if paths.ShellWrapperPath != "" {
 		err = os.Remove(paths.ShellWrapperPath)
 		if !os.IsNotExist(err) && err != nil {
-			return errors.New(
+			return aerrors.New(
 				err,
 				fmt.Sprintf("failed to remove shell wrapper (%s)", paths.ShellWrapperPath),
-				errors.M("destination", paths.ShellWrapperPath))
+				aerrors.M("destination", paths.ShellWrapperPath))
 		}
 	}
 
 	// remove existing directory
 	err = RemovePath(topPath)
 	if err != nil {
-		return errors.New(
+		return aerrors.New(
 			err,
 			fmt.Sprintf("failed to remove installation directory (%s)", paths.Top()),
-			errors.M("directory", paths.Top()))
+			aerrors.M("directory", paths.Top()))
 	}
 
 	return nil
@@ -238,7 +246,7 @@ func uninstallServiceComponent(ctx context.Context, log *logp.Logger, comp compo
 func serviceComponentsFromConfig(specs component.RuntimeSpecs, cfg *config.Config) ([]component.Component, error) {
 	mm, err := cfg.ToMapStr()
 	if err != nil {
-		return nil, errors.New("failed to create a map from config", err)
+		return nil, aerrors.New("failed to create a map from config", err)
 	}
 	allComps, err := specs.ToComponents(mm, nil, logp.InfoLevel, nil)
 	if err != nil {
@@ -279,7 +287,7 @@ func applyDynamics(ctx context.Context, log *logger.Logger, cfg *config.Config) 
 		}
 		err = transpiler.Insert(ast, renderedInputs, "inputs")
 		if err != nil {
-			return nil, errors.New("inserting rendered inputs failed", err)
+			return nil, aerrors.New("inserting rendered inputs failed", err)
 		}
 	}
 
@@ -289,4 +297,41 @@ func applyDynamics(ctx context.Context, log *logger.Logger, cfg *config.Config) 
 	}
 
 	return config.NewConfigFrom(finalConfig)
+}
+
+// killWatcher finds and kills any running Elastic Agent watcher.
+func killWatcher() error {
+	procStats := process.Stats{
+		Procs:        []string{"elastic-agent"},
+		CacheCmdLine: true,
+	}
+	err := procStats.Init()
+	if err != nil {
+		return fmt.Errorf("failed to initialize process.Stats: %w", err)
+	}
+	pidMap, _, err := procStats.FetchPids()
+	if err != nil {
+		return fmt.Errorf("failed to fetch elastic-agent pids: %w", err)
+	}
+	var errs error
+	for pid, state := range pidMap {
+		if len(state.Args) < 2 {
+			// must have at least 2 args "elastic-agent watcher"
+			continue
+		}
+		if state.Args[0] == "elastic-agent" && state.Args[1] == "watcher" {
+			// it is a watcher
+			proc, err := os.FindProcess(pid)
+			if err != nil {
+				errs = errors.Join(errs, fmt.Errorf("failed to load watcher process with pid %d: %w", pid, err))
+				continue
+			}
+			err = proc.Kill()
+			if err != nil {
+				errs = errors.Join(errs, fmt.Errorf("failed to kill watcher process with pid %d: %w", pid, err))
+				continue
+			}
+		}
+	}
+	return errs
 }

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -328,7 +328,7 @@ func killWatcher() error {
 				continue
 			}
 			err = proc.Kill()
-			if err != nil {
+			if err != nil && !errors.Is(err, os.ErrProcessDone) {
 				errs = errors.Join(errs, fmt.Errorf("failed to kill watcher process with pid %d: %w", pid, err))
 				continue
 			}

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -302,7 +302,7 @@ func applyDynamics(ctx context.Context, log *logger.Logger, cfg *config.Config) 
 // killWatcher finds and kills any running Elastic Agent watcher.
 func killWatcher() error {
 	procStats := process.Stats{
-		Procs:        []string{"elastic-agent"},
+		Procs:        []string{".*elastic-agent"},
 		CacheCmdLine: true,
 	}
 	err := procStats.Init()
@@ -319,8 +319,8 @@ func killWatcher() error {
 			// must have at least 2 args "elastic-agent watcher"
 			continue
 		}
-		if state.Args[0] == "elastic-agent" && state.Args[1] == "watcher" {
-			// it is a watcher
+		if filepath.Base(state.Args[0]) == "elastic-agent" && state.Args[1] == "watch" {
+			// it is the watch subprocess
 			proc, err := os.FindProcess(pid)
 			if err != nil {
 				errs = errors.Join(errs, fmt.Errorf("failed to load watcher process with pid %d: %w", pid, err))

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -312,15 +312,15 @@ func killWatcher() error {
 	}
 	pidMap, _, err := procStats.FetchPids()
 	if err != nil {
-		return fmt.Errorf("failed to fetch elastic-agent pids: %w", err)
+		return fmt.Errorf("failed to fetch pids: %w", err)
 	}
 	var errs error
 	for pid, state := range pidMap {
 		if len(state.Args) < 2 {
-			// must have at least 2 args "elastic-agent watch"
+			// must have at least 2 args "elastic-agent[.exe] watch"
 			continue
 		}
-		if filepath.Base(state.Args[0]) == "elastic-agent" && state.Args[1] == "watch" {
+		if filepath.Base(state.Args[0]) == paths.BinaryName && state.Args[1] == "watch" {
 			// it is the watch subprocess
 			proc, err := os.FindProcess(pid)
 			if err != nil {

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -302,8 +302,9 @@ func applyDynamics(ctx context.Context, log *logger.Logger, cfg *config.Config) 
 // killWatcher finds and kills any running Elastic Agent watcher.
 func killWatcher() error {
 	procStats := process.Stats{
-		Procs:        []string{".*elastic-agent"},
-		CacheCmdLine: true,
+		// filtering with '.*elastic-agent' or '^.*elastic-agent$' doesn't
+		// seem to work as expected, filtering is done in the for loop below
+		Procs: []string{".*"},
 	}
 	err := procStats.Init()
 	if err != nil {
@@ -316,7 +317,7 @@ func killWatcher() error {
 	var errs error
 	for pid, state := range pidMap {
 		if len(state.Args) < 2 {
-			// must have at least 2 args "elastic-agent watcher"
+			// must have at least 2 args "elastic-agent watch"
 			continue
 		}
 		if filepath.Base(state.Args[0]) == "elastic-agent" && state.Args[1] == "watch" {


### PR DESCRIPTION
_This PR is currently based on https://github.com/elastic/elastic-agent/pull/3384. Once https://github.com/elastic/elastic-agent/pull/3384 is merged, I will rebase this PR on `main` and put it into review._

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR kills any Upgrade Watcher process before starting a new upgrade.

## Why is it important?

If the Upgrade Watcher from a previous upgrade is still running, by killing it before starting a new upgrade, we prevent the Upgrade Watcher from interfering with the new upgrade and potentially rolling it back.  This, in turn, enables users to request multiple upgrades in quick succession.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## How to test this PR locally

To this this PR we will be performing two upgrades in quick succession: from an already-released version of Agent, say `8.9.0`, to an Agent built from this PR's branch (`8.11.0`), and back to some other already-released version of Agent, say `8.9.2`. 

1. Download and install Elastic Agent `8.9.0`.
2. Checkout this PR's branch and build Elastic Agent `8.11.0` from it.
   ```
   SNAPSHOT=true EXTERNAL=true DEV=true PLATFORMS=darwin/arm64 PACKAGES=tar.gz mage package
   ```
3. Initiate an upgrade from Elastic Agent from `8.9.0` -> `8.11.0`.
   ```
   sudo elastic-agent upgrade 8.11.0 --source-uri=file://$(pwd)/build/distributions --skip-verify
   ```
4. Verify that the installed Elastic Agent is at version `8.11.0`.
   ```
   sudo elastic-agent version
   ```
5. Capture the hash of the installed Elastic Agent version; we will need this later when inspecting logs.
   ```
   hash=$(sudo elastic-agent version --binary-only --yaml | grep commit | cut -w -f3 | cut -c1-6)
   ```
6. Verify that the Upgrade Watcher process is running and note it's PID.
   ```
   pgrep -f 'elastic-agent watch'
   ```
7. While the Upgrade Watcher is still running, initiate the second upgrade from `8.11.0` -> `8.9.2`.
   ```
   sudo elastic-agent upgrade 8.9.2
   ```
8. Verify that the installed Elastic Agent is at version `8.9.2`.
   ```
   sudo elastic-agent version
   ```
9. Verify that the logs for `8.11.0` Agent mention that the Upgrade Watcher is being killed before starting a new upgrade.
   ```
   sudo grep 'Killing any.*8.9.2' "/Library/Elastic/Agent/data/elastic-agent-$hash/logs/elastic-agent-$(date +%Y%m%d).ndjson"
   ```
10. Verify that one Upgrade Watcher process is running and note it's PID. It should be different from the PID noted in step 5.
    ```
    pgrep -f 'elastic-agent watch'
    ```
11. Wait 10 minutes for the Upgrade Watcher process to finish running.
12. Verify that the installed Elastic Agent is still at version `8.9.2`.
    ```
    sudo elastic-agent version
    ```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #2706 
