### PR TITLE
Un-skip and fix flaky `TestStandaloneUpgradeFailsStatus` 

### DIFF
--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -933,8 +933,6 @@ func TestStandaloneUpgradeFailsStatus(t *testing.T) {
 		Sudo:    true, // requires Agent installation
 	})
 
-	t.Skip("Affected by https://github.com/elastic/elastic-agent/issues/3371, watcher left running at end of test")
-
 	upgradeFromVersion, err := version.ParseVersion(define.Version())
 	require.NoError(t, err)
 


### PR DESCRIPTION
## What does this PR do?

This PR un-skips the `TestStandaloneUpgradeFailsStatus` integration test, making any fixes as necessary for the test to pass consistently.

## Why is it important?

To have more test coverage.
