### PR TITLE
Fix TestRemovePath being flagged as a possible virus

### DIFF
--- a/internal/pkg/agent/install/testblocking/main.go
+++ b/internal/pkg/agent/install/testblocking/main.go
@@ -1,0 +1,15 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"math"
+	"time"
+)
+
+// Simple program that blocks forever to ensure exes running from a directory on Windows can be removed during uninstall.
+func main() {
+	<-time.After(time.Duration(math.MaxInt64))
+}

--- a/internal/pkg/agent/install/uninstall_windows_test.go
+++ b/internal/pkg/agent/install/uninstall_windows_test.go
@@ -7,7 +7,6 @@
 package install
 
 import (
-	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -15,41 +14,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const simpleBlockForever = `
-package main
-
-import (
-    "math"
-    "time"
-)
-
-func main() {
-    <-time.After(time.Duration(math.MaxInt64))
-}
-`
-
 func TestRemovePath(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "subdir")
-	err := os.Mkdir(dir, 0644)
-	require.NoError(t, err)
+	const binaryName = "testblocking"
+	binaryPath, err := filepath.Abs(filepath.Join(binaryName, binaryName+".exe"))
+	require.NoErrorf(t, err, "failed abs %s", binaryPath)
 
-	src := filepath.Join(dir, "main.go")
-	err = os.WriteFile(src, []byte(simpleBlockForever), 0644)
-	require.NoError(t, err)
-
-	binary := filepath.Join(dir, "main.exe")
-	cmd := exec.Command("go", "build", "-o", binary, src)
-	_, err = cmd.CombinedOutput()
-	require.NoError(t, err)
-
-	cmd = exec.Command(binary)
+	cmd := exec.Command(binaryPath)
 	err = cmd.Start()
 	require.NoError(t, err)
 	defer func() {
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
 	}()
-
-	err = RemovePath(dir)
-	require.NoError(t, err)
 }

--- a/internal/pkg/agent/install/uninstall_windows_test.go
+++ b/internal/pkg/agent/install/uninstall_windows_test.go
@@ -22,9 +22,10 @@ func TestRemovePath(t *testing.T) {
 		binaryName = pkgName + ".exe"
 	)
 
-	// Create a temporary directory that we can safely remove.
-	destDir := filepath.Join(t.TempDir(), "subdir")
-	err := os.Mkdir(destDir, 0644)
+	// Create a temporary directory that we can safely remove. The directory is created as a new
+	// sub-directory. This avoids having Microsoft Defender quarantine the file if it is exec'd from
+	// the default temporary directory.
+	destDir, err := os.MkdirTemp(pkgName, t.Name())
 	require.NoError(t, err)
 
 	// Copy the test executable to the new temporary directory.

--- a/magefile.go
+++ b/magefile.go
@@ -256,16 +256,19 @@ func (Build) Clean() {
 // TestBinaries build the required binaries for the test suite.
 func (Build) TestBinaries() error {
 	wd, _ := os.Getwd()
-	p := filepath.Join(wd, "pkg", "component", "fake")
-	for _, name := range []string{"component", "shipper"} {
-		binary := name
+	testBinaryPkgs := []string{
+		filepath.Join(wd, "pkg", "component", "fake", "component"),
+		filepath.Join(wd, "pkg", "component", "fake", "shipper"),
+		filepath.Join(wd, "internal", "pkg", "agent", "install", "testblocking"),
+	}
+	for _, pkg := range testBinaryPkgs {
+		binary := filepath.Base(pkg)
 		if runtime.GOOS == "windows" {
 			binary += ".exe"
 		}
 
-		fakeDir := filepath.Join(p, name)
-		outputName := filepath.Join(fakeDir, binary)
-		err := RunGo("build", "-o", outputName, filepath.Join(fakeDir))
+		outputName := filepath.Join(pkg, binary)
+		err := RunGo("build", "-o", outputName, filepath.Join(pkg))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
My suspicion is this test gets flagged as malware because it writes code to disk and then compiles it by executing `go build` itself. This does seem like something malware could do, so I changed this to use the same build strategy the fake component uses. The `mage build:testBinary` target must be used to build the binaries before the test can run, which is a dependency of `mage unitTest`.