### PR TITLE
`elastic-agent install`: Only uninstall when Agent is installed

### DIFF
--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -40,7 +40,7 @@ would like the Agent to operate.
 		},
 	}
 
-	cmd.Flags().BoolP("force", "f", false, "Force overwrite the current and do not prompt for confirmation")
+	cmd.Flags().BoolP("force", "f", false, "Force overwrite the current installation and do not prompt for confirmation")
 	cmd.Flags().BoolP("non-interactive", "n", false, "Install Elastic Agent in non-interactive mode which will not prompt on missing parameters but fails instead.")
 	cmd.Flags().String(flagInstallBasePath, paths.DefaultBasePath, "The path where the Elastic Agent will be installed. It must be an absolute path.")
 	addEnrollFlags(cmd)

--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -83,7 +83,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 
 	nonInteractive, _ := cmd.Flags().GetBool("non-interactive")
 	if nonInteractive {
-		fmt.Fprintf(streams.Out, "Installing in non-interactive mode.")
+		fmt.Fprintln(streams.Out, "Installing in non-interactive mode.")
 	}
 
 	if status == install.PackageInstall {

--- a/internal/pkg/agent/install/install.go
+++ b/internal/pkg/agent/install/install.go
@@ -58,7 +58,7 @@ func Install(cfgFile, topPath string, pt ProgressTrackerStep) error {
 	}
 
 	// copy source into install path
-	s = pt.StepStart("Copying files")
+	s := pt.StepStart("Copying files")
 	err = copy.Copy(dir, topPath, copy.Options{
 		OnSymlink: func(_ string) copy.SymlinkAction {
 			return copy.Shallow

--- a/internal/pkg/agent/install/install.go
+++ b/internal/pkg/agent/install/install.go
@@ -46,8 +46,11 @@ func Install(cfgFile, topPath string, pt ProgressTrackerStep) error {
 =======
 	// We only uninstall currently-installed Agent if --force
 	// is present.
+=======
+	// We only uninstall Agent if it is currently installed.
+>>>>>>> df1d9888d (Don't pass force)
 	status, _ := Status(topPath)
-	if status == Installed && force {
+	if status == Installed {
 		// Uninstall current installation
 		//
 		// There is no uninstall token for "install" command.

--- a/internal/pkg/agent/install/install.go
+++ b/internal/pkg/agent/install/install.go
@@ -28,27 +28,7 @@ func Install(cfgFile, topPath string, pt ProgressTrackerStep) error {
 		return errors.New(err, "failed to discover the source directory for installation", errors.TypeFilesystem)
 	}
 
-	// Uninstall current installation
-	//
-	// There is no uninstall token for "install" command.
-	// Uninstall will fail on protected agent.
-	// The protected Agent will need to be uninstalled first before it can be installed.
-	s := pt.StepStart("Uninstalling current Elastic Agent")
-	err = Uninstall(cfgFile, topPath, "", s)
-	if err != nil {
-		s.Failed()
-		return errors.New(
-			err,
-			fmt.Sprintf("failed to uninstall Agent at (%s)", filepath.Dir(topPath)),
-			errors.M("directory", filepath.Dir(topPath)))
-	}
-	s.Succeeded()
-=======
-	// We only uninstall currently-installed Agent if --force
-	// is present.
-=======
 	// We only uninstall Agent if it is currently installed.
->>>>>>> df1d9888d (Don't pass force)
 	status, _ := Status(topPath)
 	if status == Installed {
 		// Uninstall current installation
@@ -56,18 +36,17 @@ func Install(cfgFile, topPath string, pt ProgressTrackerStep) error {
 		// There is no uninstall token for "install" command.
 		// Uninstall will fail on protected agent.
 		// The protected Agent will need to be uninstalled first before it can be installed.
-		pt.StepStart("Uninstalling current Elastic Agent")
-		err = Uninstall(cfgFile, topPath, "")
+		s := pt.StepStart("Uninstalling current Elastic Agent")
+		err = Uninstall(cfgFile, topPath, "", s)
 		if err != nil {
-			pt.StepFailed()
+			s.Failed()
 			return errors.New(
 				err,
 				fmt.Sprintf("failed to uninstall Agent at (%s)", filepath.Dir(topPath)),
 				errors.M("directory", filepath.Dir(topPath)))
 		}
-		pt.StepSucceeded()
+		s.Succeeded()
 	}
->>>>>>> 369e7d8ba (Only uninstall if --force is present)
 
 	// ensure parent directory exists
 	err = os.MkdirAll(filepath.Dir(topPath), 0755)

--- a/internal/pkg/agent/install/install.go
+++ b/internal/pkg/agent/install/install.go
@@ -43,6 +43,28 @@ func Install(cfgFile, topPath string, pt ProgressTrackerStep) error {
 			errors.M("directory", filepath.Dir(topPath)))
 	}
 	s.Succeeded()
+=======
+	// We only uninstall currently-installed Agent if --force
+	// is present.
+	status, _ := Status(topPath)
+	if status == Installed && force {
+		// Uninstall current installation
+		//
+		// There is no uninstall token for "install" command.
+		// Uninstall will fail on protected agent.
+		// The protected Agent will need to be uninstalled first before it can be installed.
+		pt.StepStart("Uninstalling current Elastic Agent")
+		err = Uninstall(cfgFile, topPath, "")
+		if err != nil {
+			pt.StepFailed()
+			return errors.New(
+				err,
+				fmt.Sprintf("failed to uninstall Agent at (%s)", filepath.Dir(topPath)),
+				errors.M("directory", filepath.Dir(topPath)))
+		}
+		pt.StepSucceeded()
+	}
+>>>>>>> 369e7d8ba (Only uninstall if --force is present)
 
 	// ensure parent directory exists
 	err = os.MkdirAll(filepath.Dir(topPath), 0755)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR improves the `elastic-agent install` experience by only trying to uninstall the existing Elastic Agent installation if Elastic Agent is currently installed.

## Why is it important?

So the progress messages shown to the user during `elastic-agent install` are not misleading by suggesting that the existing Elastic Agent installation is being uninstalled, even when there is no Elastic Agent currently installed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~

## How to test this PR locally

1. Start with a host where Elastic Agent is NOT currently installed.
2. Build Elastic Agent from this PR and install it.
   ```
    sudo ./elastic-agent install
   ```
3. Verify that the progress messages shown do NOT include a message about Elastic Agent being uninstalled.
4. Verify that the installation succeeds.
   ```
    sudo elastic-agent status
   ```
5. Try to install Elastic Agent again.
   ```
    sudo ./elastic-agent install
   ```
6. Verify that installation fails with a message about Elastic Agent already being installed.
7. Try to install Elastic Agent again, this time with the `--force` flag.
   ```
    sudo ./elastic-agent install --force
   ```
8. Verify that the progress messages shown include a message about Elastic Agent being uninstalled.
9. Verify that the installation succeeds.
   ```
    sudo elastic-agent status
   ```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Resolves #3414

