### PR TITLE
Support Hints per container input

### DIFF
--- a/changelog/fragments/1694692246-hintspercontainer.yaml
+++ b/changelog/fragments/1694692246-hintspercontainer.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Hints Autodiscovery for Elastic Agent - Define configuration through annotations for specific containers inside a pod
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/composable/providers/kubernetes/hints.go
+++ b/internal/pkg/composable/providers/kubernetes/hints.go
@@ -316,7 +316,7 @@ func GenerateHintsForContainer(annotations mapstr.M, parts string, prefix string
 }
 
 // Generates the final hintData (hints and processors) struct that will be emitted in pods.
-func GenerateHintsResult(hints mapstr.M, k8sMapping map[string]interface{}, annotations mapstr.M, logger *logp.Logger, prefix string, cID string) hintsData {
+func GenerateHintsResult(hints mapstr.M, k8sMapping map[string]interface{}, annotations mapstr.M, logger *logp.Logger, prefix, cID string) hintsData {
 	hintData := hintsData{
 		composableMapping: mapstr.M{},
 		processors:        []mapstr.M{},

--- a/internal/pkg/composable/providers/kubernetes/hints.go
+++ b/internal/pkg/composable/providers/kubernetes/hints.go
@@ -263,43 +263,43 @@ func GetHintsMapping(k8sMapping map[string]interface{}, logger *logp.Logger, pre
 		annotations, _ := ann.(mapstr.M)
 
 		if containerEntries, err := annotations.GetValue(prefix + ".hints"); err == nil {
-			if entries, ok := containerEntries.(mapstr.M); ok {
-				if len(entries) > 0 {
-					for key := range entries {
-						parts := strings.Split(key, "/")
-						if con, ok := k8sMapping["container"]; ok {
-							containers, _ := con.(mapstr.M)
-							if cname, err := containers.GetValue("name"); err == nil {
-								if parts[0] == cname {
-									// If there are hints like co.elastic.hints.<container_name>/ then add add the values after the / to the corresponding container
-									hints = utils.GenerateHints(annotations, parts[0], prefix)
-									//Processors for specific container
-									//We need to make an extra check if we have processors added only to the specific conatiners
-									containerProcessors = utils.GetConfigs(annotations, prefix, "hints."+parts[0]+"/processors")
+			entries, _ := containerEntries.(mapstr.M)
+			if len(entries) > 0 {
+				for key := range entries {
+					parts := strings.Split(key, "/")
+					if con, ok := k8sMapping["container"]; ok {
+						containers, _ := con.(mapstr.M)
+						if cname, err := containers.GetValue("name"); err == nil {
+							if parts[0] == cname {
+								// If there are hints like co.elastic.hints.<container_name>/ then add add the values after the / to the corresponding container
+								hints = utils.GenerateHints(annotations, parts[0], prefix)
+								//Processors for specific container
+								//We need to make an extra check if we have processors added only to the specific conatiners
+								containerProcessors = utils.GetConfigs(annotations, prefix, "hints."+parts[0]+"/processors")
 
-								} else {
-									// If there are top level hints like co.elastic.hints/ then just add the values after the /
-									hints = utils.GenerateHints(annotations, "", prefix)
-								}
-								if len(hints) > 0 {
-									logger.Debugf("Extracted hints are :%v", hints)
-									hintData.composableMapping = GenerateHintsMapping(hints, k8sMapping, logger, cID)
-									logger.Debugf("Generated hints mappings are :%v", hintData.composableMapping)
+							} else {
+								// If there are top level hints like co.elastic.hints/ then just add the values after the /
+								hints = utils.GenerateHints(annotations, "", prefix)
+							}
+							if len(hints) > 0 {
+								logger.Debugf("Extracted hints are :%v", hints)
+								hintData.composableMapping = GenerateHintsMapping(hints, k8sMapping, logger, cID)
+								logger.Debugf("Generated hints mappings are :%v", hintData.composableMapping)
 
-									hintData.processors = utils.GetConfigs(annotations, prefix, processorhints)
-									//Only if there are processors defined in a specific container we append the to the processors of the pod
-									if len(containerProcessors) > 0 {
-										for _, value := range containerProcessors {
-											hintData.processors = append(hintData.processors, value)
-										}
+								hintData.processors = utils.GetConfigs(annotations, prefix, processorhints)
+								//Only if there are processors defined in a specific container we append the to the processors of the pod
+								if len(containerProcessors) > 0 {
+									for _, value := range containerProcessors {
+										hintData.processors = append(hintData.processors, value)
 									}
-									logger.Debugf("Generated Processors are :%v", hintData.processors)
 								}
+								logger.Debugf("Generated Processors are :%v", hintData.processors)
 							}
 						}
 					}
 				}
 			}
+
 		}
 
 	}

--- a/internal/pkg/composable/providers/kubernetes/hints.go
+++ b/internal/pkg/composable/providers/kubernetes/hints.go
@@ -256,8 +256,8 @@ func GetHintsMapping(k8sMapping map[string]interface{}, logger *logp.Logger, pre
 		composableMapping: mapstr.M{},
 		processors:        []mapstr.M{},
 	}
-	hints := mapstr.M{}
-	containerProcessors := []mapstr.M{}
+	var hints mapstr.M
+	var containerProcessors []mapstr.M
 
 	if ann, ok := k8sMapping["annotations"]; ok {
 		annotations, _ := ann.(mapstr.M)
@@ -274,7 +274,7 @@ func GetHintsMapping(k8sMapping map[string]interface{}, logger *logp.Logger, pre
 								// If there are hints like co.elastic.hints.<container_name>/ then add add the values after the / to the corresponding container
 								hints = utils.GenerateHints(annotations, parts[0], prefix)
 								//Processors for specific container
-								//We need to make an extra check if we have processors added only to the specific conatiners
+								//We need to make an extra check if we have processors added only to the specific containers
 								containerProcessors = utils.GetConfigs(annotations, prefix, "hints."+parts[0]+"/processors")
 
 							} else {
@@ -289,9 +289,7 @@ func GetHintsMapping(k8sMapping map[string]interface{}, logger *logp.Logger, pre
 								hintData.processors = utils.GetConfigs(annotations, prefix, processorhints)
 								//Only if there are processors defined in a specific container we append the to the processors of the pod
 								if len(containerProcessors) > 0 {
-									for _, value := range containerProcessors {
-										hintData.processors = append(hintData.processors, value)
-									}
+									hintData.processors = append(hintData.processors, containerProcessors...)
 								}
 								logger.Debugf("Generated Processors are :%v", hintData.processors)
 							}

--- a/internal/pkg/composable/providers/kubernetes/hints.go
+++ b/internal/pkg/composable/providers/kubernetes/hints.go
@@ -273,8 +273,8 @@ func GetHintsMapping(k8sMapping map[string]interface{}, logger *logp.Logger, pre
 							if parts[0] == cname {
 								// If there are hints like co.elastic.hints.<container_name>/ then add add the values after the / to the corresponding container
 								hints = utils.GenerateHints(annotations, parts[0], prefix)
-								//Processors for specific container
-								//We need to make an extra check if we have processors added only to the specific containers
+								// Processors for specific container
+								// We need to make an extra check if we have processors added only to the specific containers
 								containerProcessors = utils.GetConfigs(annotations, prefix, "hints."+parts[0]+"/processors")
 
 							} else {
@@ -287,7 +287,7 @@ func GetHintsMapping(k8sMapping map[string]interface{}, logger *logp.Logger, pre
 								logger.Debugf("Generated hints mappings are :%v", hintData.composableMapping)
 
 								hintData.processors = utils.GetConfigs(annotations, prefix, processorhints)
-								//Only if there are processors defined in a specific container we append the to the processors of the pod
+								// Only if there are processors defined in a specific container we append them to the processors of the pod
 								if len(containerProcessors) > 0 {
 									hintData.processors = append(hintData.processors, containerProcessors...)
 								}

--- a/internal/pkg/composable/providers/kubernetes/hints.go
+++ b/internal/pkg/composable/providers/kubernetes/hints.go
@@ -315,7 +315,7 @@ func GenerateHintsForContainer(annotations mapstr.M, parts string, prefix string
 	return hints, containerProcessors
 }
 
-// Generates the final hintData (hints and processors) struct that will be emmitted in pods.
+// Generates the final hintData (hints and processors) struct that will be emitted in pods.
 func GenerateHintsResult(hints mapstr.M, k8sMapping map[string]interface{}, annotations mapstr.M, logger *logp.Logger, prefix string, cID string) hintsData {
 	hintData := hintsData{
 		composableMapping: mapstr.M{},

--- a/internal/pkg/composable/providers/kubernetes/hints.go
+++ b/internal/pkg/composable/providers/kubernetes/hints.go
@@ -271,7 +271,7 @@ func GetHintsMapping(k8sMapping map[string]interface{}, logger *logp.Logger, pre
 						containers, _ := con.(mapstr.M)
 						if cname, err := containers.GetValue("name"); err == nil {
 							if parts[0] == cname {
-								// If there are hints like co.elastic.hints.<container_name>/ then add add the values after the / to the corresponding container
+								// If there are hints like co.elastic.hints.<container_name>/ then add the values after the / to the corresponding container
 								hints = utils.GenerateHints(annotations, parts[0], prefix)
 								// Processors for specific container
 								// We need to make an extra check if we have processors added only to the specific containers

--- a/internal/pkg/composable/providers/kubernetes/hints.go
+++ b/internal/pkg/composable/providers/kubernetes/hints.go
@@ -306,7 +306,7 @@ func GetHintsMapping(k8sMapping map[string]interface{}, logger *logp.Logger, pre
 }
 
 // Generates hints and processors list for specific containers
-func GenerateHintsForContainer(annotations mapstr.M, parts string, prefix string) (mapstr.M, []mapstr.M) {
+func GenerateHintsForContainer(annotations mapstr.M, parts, prefix string) (mapstr.M, []mapstr.M) {
 	hints := utils.GenerateHints(annotations, parts, prefix)
 	// Processors for specific container
 	// We need to make an extra check if we have processors added only to the specific containers

--- a/internal/pkg/composable/providers/kubernetes/hints.go
+++ b/internal/pkg/composable/providers/kubernetes/hints.go
@@ -263,38 +263,45 @@ func GetHintsMapping(k8sMapping map[string]interface{}, logger *logp.Logger, pre
 		annotations, _ := ann.(mapstr.M)
 
 		if containerEntries, err := annotations.GetValue(prefix + ".hints"); err == nil {
-			entries, _ := containerEntries.(mapstr.M)
-			if len(entries) > 0 {
+			entries, ok := containerEntries.(mapstr.M)
+			if ok && len(entries) > 0 {
 				for key := range entries {
 					parts := strings.Split(key, "/")
-					if con, ok := k8sMapping["container"]; ok {
-						containers, _ := con.(mapstr.M)
-						if cname, err := containers.GetValue("name"); err == nil {
-							if parts[0] == cname {
-								// If there are hints like co.elastic.hints.<container_name>/ then add the values after the / to the corresponding container
-								hints = utils.GenerateHints(annotations, parts[0], prefix)
-								// Processors for specific container
-								// We need to make an extra check if we have processors added only to the specific containers
-								containerProcessors = utils.GetConfigs(annotations, prefix, "hints."+parts[0]+"/processors")
 
-							} else {
-								// If there are top level hints like co.elastic.hints/ then just add the values after the /
-								hints = utils.GenerateHints(annotations, "", prefix)
-							}
-							if len(hints) > 0 {
-								logger.Debugf("Extracted hints are :%v", hints)
-								hintData.composableMapping = GenerateHintsMapping(hints, k8sMapping, logger, cID)
-								logger.Debugf("Generated hints mappings are :%v", hintData.composableMapping)
+					if len(parts) > 0 {
+						if con, ok := k8sMapping["container"]; ok {
+							containers, ok := con.(mapstr.M)
+							if ok {
+								if cname, err := containers.GetValue("name"); err == nil {
+									if parts[0] == cname {
+										// If there are hints like co.elastic.hints.<container_name>/ then add the values after the / to the corresponding container
+										hints = utils.GenerateHints(annotations, parts[0], prefix)
+										// Processors for specific container
+										// We need to make an extra check if we have processors added only to the specific containers
+										containerProcessors = utils.GetConfigs(annotations, prefix, "hints."+parts[0]+"/processors")
 
-								hintData.processors = utils.GetConfigs(annotations, prefix, processorhints)
-								// Only if there are processors defined in a specific container we append them to the processors of the pod
-								if len(containerProcessors) > 0 {
-									hintData.processors = append(hintData.processors, containerProcessors...)
+									} else {
+										// If there are top level hints like co.elastic.hints/ then just add the values after the /
+										hints = utils.GenerateHints(annotations, "", prefix)
+									}
+									if len(hints) > 0 {
+										logger.Debugf("Extracted hints are :%v", hints)
+										hintData.composableMapping = GenerateHintsMapping(hints, k8sMapping, logger, cID)
+										logger.Debugf("Generated hints mappings are :%v", hintData.composableMapping)
+
+										hintData.processors = utils.GetConfigs(annotations, prefix, processorhints)
+										// Only if there are processors defined in a specific container we append them to the processors of the pod
+										if len(containerProcessors) > 0 {
+											hintData.processors = append(hintData.processors, containerProcessors...)
+										}
+										logger.Debugf("Generated Processors are :%v", hintData.processors)
+									}
 								}
-								logger.Debugf("Generated Processors are :%v", hintData.processors)
 							}
+
 						}
 					}
+
 				}
 			}
 

--- a/internal/pkg/composable/providers/kubernetes/hints_test.go
+++ b/internal/pkg/composable/providers/kubernetes/hints_test.go
@@ -479,44 +479,44 @@ func TestGenerateHintsMappingWithProcessors(t *testing.T) {
 // mappings.container.name = nginx defines the container we want to emmit the new configuration. Annotations for other containers like co.elastic.hints.webapp should be excluded
 func TestGenerateHintsMappingWithProcessorsForContainer(t *testing.T) {
 	logger := getLogger()
-	pod := &kubernetes.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testpod",
-			UID:       types.UID(uid),
-			Namespace: "testns",
-			Labels: map[string]string{
-				"foo":        "bar",
-				"with-dash":  "dash-value",
-				"with/slash": "some/path",
-			},
-			Annotations: map[string]string{
-				"app":                      "production",
-				"co.elastic.hints/package": "apache",
-				"co.elastic.hints/processors.decode_json_fields.fields":         "message",
-				"co.elastic.hints/processors.decode_json_fields.add_error_key":  "true",
-				"co.elastic.hints/processors.decode_json_fields.overwrite_keys": "true",
-				"co.elastic.hints/processors.decode_json_fields.target":         "team",
-				"co.elastic.hints.nginx/stream":                                 "stderr",
-				"co.elastic.hints.nginx/processors.add_fields.fields.name":      "myproject",
-				"co.elastic.hints.webapp/processors.add_fields.fields.name":     "myproject2",
-			},
-		},
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: "v1",
-		},
-		Spec: kubernetes.PodSpec{
-			NodeName: "testnode",
-		},
-		Status: kubernetes.PodStatus{PodIP: "127.0.0.5"},
-	}
+	// pod := &kubernetes.Pod{
+	// 	ObjectMeta: metav1.ObjectMeta{
+	// 		Name:      "testpod",
+	// 		UID:       types.UID(uid),
+	// 		Namespace: "testns",
+	// 		Labels: map[string]string{
+	// 			"foo":        "bar",
+	// 			"with-dash":  "dash-value",
+	// 			"with/slash": "some/path",
+	// 		},
+	// 		Annotations: map[string]string{
+	// 			"app":                      "production",
+	// 			"co.elastic.hints/package": "apache",
+	// 			"co.elastic.hints/processors.decode_json_fields.fields":         "message",
+	// 			"co.elastic.hints/processors.decode_json_fields.add_error_key":  "true",
+	// 			"co.elastic.hints/processors.decode_json_fields.overwrite_keys": "true",
+	// 			"co.elastic.hints/processors.decode_json_fields.target":         "team",
+	// 			"co.elastic.hints.nginx/stream":                                 "stderr",
+	// 			"co.elastic.hints.nginx/processors.add_fields.fields.name":      "myproject",
+	// 			"co.elastic.hints.webapp/processors.add_fields.fields.name":     "myproject2",
+	// 		},
+	// 	},
+	// 	TypeMeta: metav1.TypeMeta{
+	// 		Kind:       "Pod",
+	// 		APIVersion: "v1",
+	// 	},
+	// 	Spec: kubernetes.PodSpec{
+	// 		NodeName: "testnode",
+	// 	},
+	// 	Status: kubernetes.PodStatus{PodIP: "127.0.0.5"},
+	// }
 
 	mapping := map[string]interface{}{
-		"namespace": pod.GetNamespace(),
+		"namespace": "testns",
 		"pod": mapstr.M{
-			"uid":  string(pod.GetUID()),
-			"name": pod.GetName(),
-			"ip":   pod.Status.PodIP,
+			"uid":  string(types.UID(uid)),
+			"name": "testpod",
+			"ip":   "127.0.0.5",
 		},
 		"namespace_annotations": mapstr.M{
 			"nsa": "nsb",

--- a/internal/pkg/composable/providers/kubernetes/hints_test.go
+++ b/internal/pkg/composable/providers/kubernetes/hints_test.go
@@ -433,11 +433,10 @@ func TestGenerateHintsMappingWithProcessors(t *testing.T) {
 						},
 					},
 				},
-			},
-		},
+			}},
 	}
 
-	expected_hints := mapstr.M{
+	expectedhints := mapstr.M{
 		"container_id": "asdfghjkl",
 		"apache": mapstr.M{
 			"container_logs": mapstr.M{
@@ -447,7 +446,7 @@ func TestGenerateHintsMappingWithProcessors(t *testing.T) {
 		},
 	}
 
-	expected_procesors := []mapstr.M{
+	expectedprocesors := []mapstr.M{
 		0: {
 			"rename": mapstr.M{
 				"fail_on_error": "false",
@@ -467,9 +466,128 @@ func TestGenerateHintsMappingWithProcessors(t *testing.T) {
 
 	hintData := GetHintsMapping(mapping, logger, "co.elastic", "asdfghjkl")
 
-	assert.Equal(t, expected_hints, hintData.composableMapping)
+	assert.Equal(t, expectedhints, hintData.composableMapping)
 	//assert.Equal(t, expected_procesors, hintData.processors). We replace this assertion with assert.Contains in order to avoid flakiness in tests because map keys are not sorted
-	assert.Contains(t, expected_procesors, hintData.processors[0])
-	assert.Contains(t, expected_procesors, hintData.processors[1])
+	if len(hintData.processors) > 0 {
+		assert.Contains(t, expectedprocesors, hintData.processors[0])
+		assert.Contains(t, expectedprocesors, hintData.processors[1])
+	}
+}
 
+// This test evaluates the hints Generation when you define specific container nginx
+// Following will need to include all annotations after top level "co.elastic.hints/" plus those that defined for nginx with prefix "co.elastic.hints.nginx"
+// mappings.container.name = nginx defines the container we want to emmit the new configuration. Annotations for other containers like co.elastic.hints.webapp should be excluded
+func TestGenerateHintsMappingWithProcessorsForContainer(t *testing.T) {
+	logger := getLogger()
+	pod := &kubernetes.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testpod",
+			UID:       types.UID(uid),
+			Namespace: "testns",
+			Labels: map[string]string{
+				"foo":        "bar",
+				"with-dash":  "dash-value",
+				"with/slash": "some/path",
+			},
+			Annotations: map[string]string{
+				"app":                      "production",
+				"co.elastic.hints/package": "apache",
+				"co.elastic.hints/processors.decode_json_fields.fields":         "message",
+				"co.elastic.hints/processors.decode_json_fields.add_error_key":  "true",
+				"co.elastic.hints/processors.decode_json_fields.overwrite_keys": "true",
+				"co.elastic.hints/processors.decode_json_fields.target":         "team",
+				"co.elastic.hints.nginx/stream":                                 "stderr",
+				"co.elastic.hints.nginx/processors.add_fields.fields.name":      "myproject",
+				"co.elastic.hints.webapp/processors.add_fields.fields.name":     "myproject2",
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		Spec: kubernetes.PodSpec{
+			NodeName: "testnode",
+		},
+		Status: kubernetes.PodStatus{PodIP: "127.0.0.5"},
+	}
+
+	mapping := map[string]interface{}{
+		"namespace": pod.GetNamespace(),
+		"pod": mapstr.M{
+			"uid":  string(pod.GetUID()),
+			"name": pod.GetName(),
+			"ip":   pod.Status.PodIP,
+		},
+		"namespace_annotations": mapstr.M{
+			"nsa": "nsb",
+		},
+		"labels": mapstr.M{
+			"foo":        "bar",
+			"with-dash":  "dash-value",
+			"with/slash": "some/path",
+		},
+		"container": mapstr.M{
+			"name": "nginx",
+			"id":   "8863418215f5d6b1919db9b3b710615878f88b0773e2b098e714c8d696c3261f",
+		},
+		"annotations": mapstr.M{
+			"app": "production",
+			"co": mapstr.M{
+				"elastic": mapstr.M{
+					"hints/package": "apache",
+					"hints/processors": mapstr.M{
+						"decode_json_fields": mapstr.M{
+							"fields":         "message",
+							"add_error_key":  "true",
+							"overwrite_keys": "true",
+							"target":         "team",
+						}},
+					"hints": mapstr.M{
+						"nginx/processors": mapstr.M{
+							"add_fields": mapstr.M{
+								"name": "myproject",
+							},
+						},
+						"nginx/stream": "stderr",
+					},
+				},
+			},
+		},
+	}
+
+	expectedhints := mapstr.M{
+		"container_id": "asdfghjkl",
+		"apache": mapstr.M{
+			"container_logs": mapstr.M{
+				"enabled": true,
+			},
+			"stream":  "stderr",
+			"enabled": true,
+		},
+	}
+
+	expectedprocesors := []mapstr.M{
+		0: {
+			"decode_json_fields": mapstr.M{
+				"fields":         "message",
+				"add_error_key":  "true",
+				"overwrite_keys": "true",
+				"target":         "team",
+			},
+		},
+		1: {
+			"add_fields": mapstr.M{
+				"name": "myproject",
+			},
+		},
+	}
+
+	hintData := GetHintsMapping(mapping, logger, "co.elastic", "asdfghjkl")
+
+	assert.Equal(t, expectedhints, hintData.composableMapping)
+	//assert.Equal(t, expected_procesors, hintData.processors). We replace this assertion with assert.Contains in order to avoid flakiness in tests because map keys are not sorted
+	if len(hintData.processors) > 0 {
+		assert.Contains(t, expectedprocesors, hintData.processors[0])
+		assert.Contains(t, expectedprocesors, hintData.processors[1])
+	}
 }


### PR DESCRIPTION
Enhancement

## What does this PR do?

This PR is introrduces the functionality described in https://github.com/elastic/elastic-agent/issues/3161!
In more details users provide the container name in the hint and this functionality is applied only to a specific container of the pod. When a pod has multiple containers, the settings are shared unless you put the container name in the hint. 

For eg. `co.elastic.hints.nginx/stream: stderr` is an annotation (aka. hints) that will be applied to a container wtih name nginx

## Why is it important?

It introduces a missing functionality that exists in Hints autodiscovry for beats as described in the [Multiple Containers Section](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html#_multiple_containers)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## How to test this PR locally

1. Follow the same steps as desceibed in "How to test this PR locally" of https://github.com/elastic/elastic-agent/pull/3107 
2. Apply the nginx.yaml manifest that creates a pod with 2 containers
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: nginx
  name: nginx
  namespace: default
spec:
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
      annotations:
        co.elastic.hints/package: "container_logs"
        co.elastic.hints/processors.decode_json_fields.fields: "message"
        co.elastic.hints/processors.decode_json_fields.add_error_key: 'true'
        co.elastic.hints/processors.decode_json_fields.overwrite_keys: 'true'
        co.elastic.hints/processors.decode_json_fields.target: "team"
        co.elastic.hints.nginx/stream: stderr
        co.elastic.hints.nginx/processors.add_fields.fields.name: "myproject"
    spec:
      containers:
      - image: nginx
        name: nginx
      - image: training/webapp
        name: webapp
      
```
3. Exec into Elastic Agent 
```bash
kubectl exec -ti -n kube-system elastic-agent-t95bj -- bash

/share/elastic-agent# elastic-agent inspect -v --variables --variables-wait 2s
```


## Related issues

- Relates  https://github.com/elastic/elastic-agent/issues/3161


## Logs
Output file generated with inspect command
[agent.txt](https://github.com/elastic/elastic-agent/files/12608256/agent.txt)

```yaml
id: hints-filestream-container-logs-a3263d2b196abc0695f1ba1767cce0d0d40cef186cce132d3b39dcfb84ec74a0-kubernetes-9b52738c-3366-4f86-8fb3-bfefddd65ef0.nginx
[output .truncated..]
- decode_json_fields:    < ----- added from co.elastic.hints/processors.decode_json_fields.* 
      add_error_key: "true"
      fields: message
      overwrite_keys: "true"
      target: team

#<----- Added only to this container from co.elastic.hints.nginx/processors.add_fields.fields.name: "myproject"
  - add_fields:   
      fields:
        name: myproject
  streams:
  - data_stream:
      dataset: kubernetes.container_logs
      type: logs
    parsers:
    - container:
        format: auto
        stream: stderr. <-- From co.elastic.hints.nginx/stream: stderr

....

id: hints-filestream-container-logs-c28563d37f000e2b7a31f014ba403a0bc16a94dafc63169bc0f98143fc96832c-kubernetes-9b52738c-3366-4f86-8fb3-bfefddd65ef0.webapp
- decode_json_fields: < ----- added from co.elastic.hints/processors.decode_json_fields.* of 
      add_error_key: "true"
      fields: message
      overwrite_keys: "true"
      target: team
  streams:
  - data_stream:
      dataset: kubernetes.container_logs
      type: logs
    parsers:
    - container:
        format: auto
        stream: all. <---- This did not chane to stderr
##<----- Did not affected from   co.elastic.hints.nginx/processors.add_fields.fields.name: "myproject"
```





