### PR TITLE
[Bug] Do not fail when remote PGPs are not available

### DIFF
--- a/changelog/fragments/1695035111-Resilient-handling-of-air-gapped-PGP-checks.yaml
+++ b/changelog/fragments/1695035111-Resilient-handling-of-air-gapped-PGP-checks.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Resilient handling of air gapped PGP checks
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: Elastic Agent should not fail when remote PGP is specified (or official Elastic fallback PGP used) and remote is not available
+
+# Affected component; a word indicating the component this changeset affects.
+component: elastic-agent
+
+# PR number; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 3427
+
+# Issue number; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 3368

--- a/internal/pkg/agent/application/upgrade/artifact/download/fs/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/fs/verifier.go
@@ -122,13 +122,14 @@ func (v *Verifier) verifyAsc(fullPath string, skipDefaultPgp bool, pgpSources ..
 			continue
 		}
 		raw, err := download.PgpBytesFromSource(check, v.client)
+		if errors.Is(err, download.ErrRemotePGPDownloadFailed) {
+			v.log.Warnf("Skipped remote PGP located at %q because it's unavailable: %v", strings.TrimPrefix(check, download.PgpSourceURIPrefix), err)
+			continue
+		}
 		if err != nil {
-			if errors.Is(err, download.ErrRemotePGPDownloadFailed) {
-				v.log.Warnf("Skipped remote PGP located at %q because it's unavailable: %v", strings.TrimPrefix(check, download.PgpSourceURIPrefix), err)
-				continue
-			}
 			return err
 		}
+
 		if len(raw) == 0 {
 			continue
 		}

--- a/internal/pkg/agent/application/upgrade/artifact/download/fs/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/fs/verifier.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact"
@@ -122,6 +123,10 @@ func (v *Verifier) verifyAsc(fullPath string, skipDefaultPgp bool, pgpSources ..
 		}
 		raw, err := download.PgpBytesFromSource(check, v.client)
 		if err != nil {
+			if errors.Is(err, download.ErrRemotePGPDownloadFailed) {
+				v.log.Warnf("Skipped remote PGP located at %q because it's unavailable: %v", strings.TrimPrefix(check, download.PgpSourceURIPrefix), err)
+				continue
+			}
 			return err
 		}
 		if len(raw) == 0 {

--- a/internal/pkg/agent/application/upgrade/artifact/download/fs/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/fs/verifier.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact"
@@ -125,11 +124,7 @@ func (v *Verifier) verifyAsc(fullPath string, skipDefaultPgp bool, pgpSources ..
 		if len(check) == 0 {
 			continue
 		}
-		raw, err := download.PgpBytesFromSource(check, v.client)
-		if errors.Is(err, download.ErrRemotePGPDownloadFailed) {
-			v.log.Warnf("Skipped remote PGP located at %q because it's unavailable: %v", strings.TrimPrefix(check, download.PgpSourceURIPrefix), err)
-			continue
-		}
+		raw, err := download.PgpBytesFromSource(v.log, check, v.client)
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/agent/application/upgrade/artifact/download/fs/verifier_test.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/fs/verifier_test.go
@@ -173,7 +173,7 @@ func prepareFetchVerifyTests(dropPath, targetDir, targetFilePath, hashTargetFile
 }
 
 func TestVerify(t *testing.T) {
-	log, _ := logger.New("", false)
+	log, obs := logger.NewTesting("TestVerify")
 	targetDir, err := ioutil.TempDir(os.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
@@ -213,6 +213,10 @@ func TestVerify(t *testing.T) {
 
 	err = testVerifier.Verify(beatSpec, version, false)
 	require.NoError(t, err)
+
+	// log message informing remote PGP was skipped
+	logs := obs.FilterMessageSnippet("Skipped remote PGP located at")
+	require.Equal(t, 0, logs.Len())
 
 	os.Remove(artifact)
 	os.Remove(artifact + ".sha512")

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/verifier.go
@@ -125,11 +125,7 @@ func (v *Verifier) verifyAsc(a artifact.Artifact, version string, skipDefaultPgp
 		if len(check) == 0 {
 			continue
 		}
-		raw, err := download.PgpBytesFromSource(check, v.client)
-		if errors.Is(err, download.ErrRemotePGPDownloadFailed) {
-			v.log.Warnf("Skipped remote PGP located at %q because it's unavailable: %v", strings.TrimPrefix(check, download.PgpSourceURIPrefix), err)
-			continue
-		}
+		raw, err := download.PgpBytesFromSource(v.log, check, v.client)
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/verifier.go
@@ -123,6 +123,10 @@ func (v *Verifier) verifyAsc(a artifact.Artifact, version string, skipDefaultPgp
 		}
 		raw, err := download.PgpBytesFromSource(check, v.client)
 		if err != nil {
+			if errors.Is(err, download.ErrRemotePGPDownloadFailed) {
+				v.log.Warnf("Skipped remote PGP located at %q because it's unavailable: %v", strings.TrimPrefix(check, download.PgpSourceURIPrefix), err)
+				continue
+			}
 			return err
 		}
 		if len(raw) == 0 {

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/verifier.go
@@ -122,13 +122,14 @@ func (v *Verifier) verifyAsc(a artifact.Artifact, version string, skipDefaultPgp
 			continue
 		}
 		raw, err := download.PgpBytesFromSource(check, v.client)
+		if errors.Is(err, download.ErrRemotePGPDownloadFailed) {
+			v.log.Warnf("Skipped remote PGP located at %q because it's unavailable: %v", strings.TrimPrefix(check, download.PgpSourceURIPrefix), err)
+			continue
+		}
 		if err != nil {
-			if errors.Is(err, download.ErrRemotePGPDownloadFailed) {
-				v.log.Warnf("Skipped remote PGP located at %q because it's unavailable: %v", strings.TrimPrefix(check, download.PgpSourceURIPrefix), err)
-				continue
-			}
 			return err
 		}
+
 		if len(raw) == 0 {
 			continue
 		}

--- a/internal/pkg/agent/application/upgrade/artifact/download/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/verifier.go
@@ -20,11 +20,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact"
 	"github.com/hashicorp/go-multierror"
 
 	"golang.org/x/crypto/openpgp" //nolint:staticcheck // crypto/openpgp is only receiving security updates.
 
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 )
 

--- a/internal/pkg/agent/application/upgrade/artifact/download/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/verifier.go
@@ -38,7 +38,7 @@ var (
 	ErrInvalidLocation         = errors.New("Remote PGP location is invalid")
 )
 
-// warnLogger is a logger that only needs to implement Infof and Warnf, as those are the only functions
+// warnLogger is a logger that only needs to implement Warnf, as that is the only functions
 // that the downloadProgressReporter uses.
 type warnLogger interface {
 	Warnf(format string, args ...interface{})

--- a/internal/pkg/agent/application/upgrade/artifact/download/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/verifier.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact"
+	"github.com/hashicorp/go-multierror"
 
 	"golang.org/x/crypto/openpgp" //nolint:staticcheck // crypto/openpgp is only receiving security updates.
 
@@ -30,6 +31,10 @@ import (
 const (
 	PgpSourceRawPrefix = "pgp_raw:"
 	PgpSourceURIPrefix = "pgp_uri:"
+)
+
+var (
+	ErrRemotePGPDownloadFailed = errors.New("Remote PGP download failed")
 )
 
 // ChecksumMismatchError indicates the expected checksum for a file does not
@@ -206,7 +211,7 @@ func fetchPgpFromURI(uri string, client http.Client) ([]byte, error) {
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, multierror.Append(err, ErrRemotePGPDownloadFailed)
 	}
 	defer resp.Body.Close()
 

--- a/internal/pkg/agent/install/uninstall_windows_test.go
+++ b/internal/pkg/agent/install/uninstall_windows_test.go
@@ -22,6 +22,8 @@ func TestRemovePath(t *testing.T) {
 		binaryName = pkgName + ".exe"
 	)
 
+	t.Skip("https://github.com/elastic/elastic-agent/issues/3221")
+
 	// Create a temporary directory that we can safely remove. The directory is created as a new
 	// sub-directory. This avoids having Microsoft Defender quarantine the file if it is exec'd from
 	// the default temporary directory.

--- a/testing/integration/upgrade_test.go
+++ b/testing/integration/upgrade_test.go
@@ -328,7 +328,7 @@ func TestStandaloneUpgradeWithGPGFallbackOneRemoteFailing(t *testing.T) {
 
 	customPGP := CustomPGP{
 		PGP:    newPgp,
-		PGPUri: "http://127.0.0.1:3456/non/existing/path",
+		PGPUri: "https://127.0.0.1:3456/non/existing/path",
 	}
 
 	testStandaloneUpgrade(ctx, t, agentFixture, fromVersion, toVersion, "", false, false, true, customPGP)


### PR DESCRIPTION
This PR adds filtering capabilities for incorrect location or download failure when trying to fetch PGP keys before verification. 
When this error is encountered warning is logged and key not considered. This will not prevent from verifying in air gapped environments where default elastic artifact api is not available

Fixes #3368 