### PR TITLE
[Feature] Secondary fallback for package signature verification

### DIFF
--- a/internal/pkg/agent/application/application.go
+++ b/internal/pkg/agent/application/application.go
@@ -160,7 +160,7 @@ func New(
 				EndpointSignedComponentModifier(),
 			)
 
-			managed, err = newManagedConfigManager(ctx, log, agentInfo, cfg, store, runtime, fleetInitTimeout)
+			managed, err = newManagedConfigManager(ctx, log, agentInfo, cfg, store, runtime, fleetInitTimeout, upgrader)
 			if err != nil {
 				return nil, nil, nil, err
 			}

--- a/internal/pkg/agent/application/managed_mode.go
+++ b/internal/pkg/agent/application/managed_mode.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/actions"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/actions/handlers"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/dispatcher"
@@ -38,17 +39,18 @@ import (
 const dispatchFlushInterval = time.Minute * 5
 
 type managedConfigManager struct {
-	log              *logger.Logger
-	agentInfo        *info.AgentInfo
-	cfg              *configuration.Configuration
-	client           *remote.Client
-	store            storage.Store
-	stateStore       *store.StateStore
-	actionQueue      *queue.ActionQueue
-	dispatcher       *dispatcher.ActionDispatcher
-	runtime          *runtime.Manager
-	coord            *coordinator.Coordinator
-	fleetInitTimeout time.Duration
+	log                  *logger.Logger
+	agentInfo            *info.AgentInfo
+	cfg                  *configuration.Configuration
+	client               *remote.Client
+	store                storage.Store
+	stateStore           *store.StateStore
+	actionQueue          *queue.ActionQueue
+	dispatcher           *dispatcher.ActionDispatcher
+	runtime              *runtime.Manager
+	coord                *coordinator.Coordinator
+	fleetInitTimeout     time.Duration
+	initialClientSetters []actions.ClientSetter
 
 	ch    chan coordinator.ConfigChange
 	errCh chan error
@@ -62,6 +64,7 @@ func newManagedConfigManager(
 	storeSaver storage.Store,
 	runtime *runtime.Manager,
 	fleetInitTimeout time.Duration,
+	clientSetters ...actions.ClientSetter,
 ) (*managedConfigManager, error) {
 	client, err := fleetclient.NewAuthWithConfig(log, cfg.Fleet.AccessAPIKey, cfg.Fleet.Client)
 	if err != nil {
@@ -88,18 +91,19 @@ func newManagedConfigManager(
 	}
 
 	return &managedConfigManager{
-		log:              log,
-		agentInfo:        agentInfo,
-		cfg:              cfg,
-		client:           client,
-		store:            storeSaver,
-		stateStore:       stateStore,
-		actionQueue:      actionQueue,
-		dispatcher:       actionDispatcher,
-		runtime:          runtime,
-		fleetInitTimeout: fleetInitTimeout,
-		ch:               make(chan coordinator.ConfigChange),
-		errCh:            make(chan error),
+		log:                  log,
+		agentInfo:            agentInfo,
+		cfg:                  cfg,
+		client:               client,
+		store:                storeSaver,
+		stateStore:           stateStore,
+		actionQueue:          actionQueue,
+		dispatcher:           actionDispatcher,
+		runtime:              runtime,
+		fleetInitTimeout:     fleetInitTimeout,
+		ch:                   make(chan coordinator.ConfigChange),
+		errCh:                make(chan error),
+		initialClientSetters: clientSetters,
 	}, nil
 }
 
@@ -195,6 +199,9 @@ func (m *managedConfigManager) Run(ctx context.Context) error {
 	if m.cfg.Fleet.Server == nil {
 		policyChanger.AddSetter(gateway)
 		policyChanger.AddSetter(ack)
+		for _, cs := range m.initialClientSetters {
+			policyChanger.AddSetter(cs)
+		}
 	}
 
 	// Proxy errors from the gateway to our own channel.

--- a/internal/pkg/agent/application/upgrade/artifact/download/fs/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/fs/verifier.go
@@ -124,7 +124,7 @@ func (v *Verifier) verifyAsc(fullPath string, skipDefaultPgp bool, pgpSources ..
 		if len(check) == 0 {
 			continue
 		}
-		raw, err := download.PgpBytesFromSource(v.log, check, v.client)
+		raw, err := download.PgpBytesFromSource(v.log, check, &v.client)
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/verifier.go
@@ -125,7 +125,7 @@ func (v *Verifier) verifyAsc(a artifact.Artifact, version string, skipDefaultPgp
 		if len(check) == 0 {
 			continue
 		}
-		raw, err := download.PgpBytesFromSource(v.log, check, v.client)
+		raw, err := download.PgpBytesFromSource(v.log, check, &v.client)
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/agent/application/upgrade/artifact/download/verifier_test.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/verifier_test.go
@@ -1,0 +1,126 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package download
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPgpBytesFromSource(t *testing.T) {
+	testCases := []struct {
+		Name         string
+		Source       string
+		ClientDoErr  error
+		ClientBody   []byte
+		ClientStatus int
+
+		ExpectedPGP        []byte
+		ExpectedErr        error
+		ExpectedLogMessage string
+	}{
+		{
+			"successfull call",
+			PgpSourceURIPrefix + "https://location/path",
+			nil,
+			[]byte("pgp-body"),
+			200,
+			[]byte("pgp-body"),
+			nil,
+			"",
+		},
+		{
+			"unknown source call",
+			"https://location/path",
+			nil,
+			[]byte("pgp-body"),
+			200,
+			nil,
+			ErrUnknownPGPSource,
+			"",
+		},
+		{
+			"invalid location is filtered call",
+			PgpSourceURIPrefix + "http://location/path",
+			nil,
+			[]byte("pgp-body"),
+			200,
+			nil,
+			nil,
+			"Skipped remote PGP located ",
+		},
+		{
+			"do error is filtered",
+			PgpSourceURIPrefix + "https://location/path",
+			errors.New("error"),
+			[]byte("pgp-body"),
+			200,
+			nil,
+			nil,
+			"Skipped remote PGP located",
+		},
+		{
+			"invalid status code is filtered out",
+			PgpSourceURIPrefix + "https://location/path",
+			nil,
+			[]byte("pgp-body"),
+			500,
+			nil,
+			nil,
+			"Failed to fetch remote PGP",
+		},
+		{
+			"invalid status code is filtered out",
+			PgpSourceURIPrefix + "https://location/path",
+			nil,
+			[]byte("pgp-body"),
+			404,
+			nil,
+			nil,
+			"Failed to fetch remote PGP",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			log, obs := logger.NewTesting(tc.Name)
+			mockClient := &MockClient{
+				DoFunc: func(req *http.Request) (*http.Response, error) {
+					if tc.ClientDoErr != nil {
+						return nil, tc.ClientDoErr
+					}
+
+					return &http.Response{
+						StatusCode: tc.ClientStatus,
+						Body:       io.NopCloser(bytes.NewReader(tc.ClientBody)),
+					}, nil
+				},
+			}
+
+			resPgp, resErr := PgpBytesFromSource(log, tc.Source, mockClient)
+			require.Equal(t, tc.ExpectedErr, resErr)
+			require.Equal(t, tc.ExpectedPGP, resPgp)
+			if tc.ExpectedLogMessage != "" {
+				logs := obs.FilterMessageSnippet(tc.ExpectedLogMessage)
+				require.NotEqual(t, 0, logs.Len())
+			}
+
+		})
+	}
+}
+
+type MockClient struct {
+	DoFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *MockClient) Do(req *http.Request) (*http.Response, error) {
+	return m.DoFunc(req)
+}

--- a/internal/pkg/agent/application/upgrade/step_download.go
+++ b/internal/pkg/agent/application/upgrade/step_download.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -103,7 +104,11 @@ func (u *Upgrader) appendFallbackPGP(targetVersion string, pgpBytes []string) []
 			// best effort log failure
 			u.log.Warnf("failed to parse secondary fallback %q: %v", u.fleetServerURI, err)
 		} else {
-			secondaryFallback := download.PgpSourceURIPrefix + u.fleetServerURI + fmt.Sprintf(fleetUpgradeFallbackPGPFormat, tpv.Major(), tpv.Minor(), tpv.Patch())
+			secondaryPath := path.Join(
+				u.fleetServerURI,
+				fmt.Sprintf(fleetUpgradeFallbackPGPFormat, tpv.Major(), tpv.Minor(), tpv.Patch()),
+			)
+			secondaryFallback := download.PgpSourceURIPrefix + secondaryPath
 			pgpBytes = append(pgpBytes, secondaryFallback)
 		}
 	}

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/acker"
+	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
 	"github.com/elastic/elastic-agent/internal/pkg/release"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
@@ -45,10 +46,11 @@ var ErrSameVersion = errors.New("upgrade did not occur because its the same vers
 
 // Upgrader performs an upgrade
 type Upgrader struct {
-	log         *logger.Logger
-	settings    *artifact.Config
-	agentInfo   *info.AgentInfo
-	upgradeable bool
+	log            *logger.Logger
+	settings       *artifact.Config
+	agentInfo      *info.AgentInfo
+	upgradeable    bool
+	fleetServerURI string
 }
 
 // IsUpgradeable when agent is installed and running as a service or flag was provided.
@@ -66,6 +68,15 @@ func NewUpgrader(log *logger.Logger, settings *artifact.Config, agentInfo *info.
 		agentInfo:   agentInfo,
 		upgradeable: IsUpgradeable(),
 	}
+}
+
+// SetClient reloads URI based on up to date fleet client
+func (u *Upgrader) SetClient(c client.Sender) {
+	if c == nil {
+		u.fleetServerURI = ""
+	}
+
+	u.fleetServerURI = c.URI()
 }
 
 // Reload reloads the artifact configuration for the upgrader.


### PR DESCRIPTION
## What does this PR do?

This PR adds a capability to check for fleet server hosted PGP as the last resort in case elastic artifact API is unavailable.
Fleet server will host this PGP per version. any snapshot flags or other version qualifiers are ignored. 

## Why is it important?

Add ability to upgrade securiely in Air gapped environment where fleet server is only reachable URI.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

Fixes: #3264
