### PR TITLE
[BUG] Treat elastic-security container platforms as separate inputs

### DIFF
--- a/specs/endpoint-security.spec.yml
+++ b/specs/endpoint-security.spec.yml
@@ -5,13 +5,11 @@ inputs:
     platforms:
       - linux/amd64
       - linux/arm64
-      - container/amd64
-      - container/arm64
-    outputs:
+    outputs: &outputs
       - elasticsearch
       - logstash
       - kafka
-    proxied_actions:
+    proxied_actions: &proxied_actions
       - UNENROLL
       - UPGRADE
     runtime:
@@ -22,7 +20,7 @@ inputs:
           message: "Elastic Agent must be running as root"
         - condition: ${install.in_default} == false
           message: "Elastic Defend requires Elastic Agent be installed at the default installation path"
-    service:
+    service: &service
       cport: 6788
       log:
         path: "/opt/Elastic/Endpoint/state/log/endpoint-*.log"
@@ -57,9 +55,7 @@ inputs:
     outputs:
       - elasticsearch
       - logstash
-    proxied_actions:
-      - UNENROLL
-      - UPGRADE
+    proxied_actions: *proxied_actions
     runtime:
       preventions:
         - condition: ${install.in_default} == false
@@ -76,9 +72,7 @@ inputs:
     outputs:
       - elasticsearch
       - logstash
-    proxied_actions:
-      - UNENROLL
-      - UPGRADE
+    proxied_actions: *proxied_actions
     runtime:
       preventions:
         - condition: ${user.root} == false
@@ -90,3 +84,17 @@ inputs:
       log:
         path: "C:\\Program Files\\Elastic\\Endpoint\\state\\log\\endpoint-*.log"
       operations: *operations
+  - name: endpoint
+    description: "Endpoint Security"
+    platforms:
+      - container/amd64
+      - container/arm64
+    outputs: *outputs
+    proxied_actions: *proxied_actions
+    runtime:
+      preventions:
+        - condition: ${runtime.arch} == 'arm64' and ${runtime.family} == 'redhat' and ${runtime.major} == '7'
+          message: "No support for RHEL7 on arm64"
+        - condition: ${user.root} == false
+          message: "Elastic Agent must be running as root"
+    service: *service


### PR DESCRIPTION
## What does this PR do?

This PR  modifies the elastic security spec file by treating the container platforms as separate inputs without the restriction of requiring the default install location. 

## Why is it important?
This fixes an issue where the beta deployment of Endpoint in K8s would throw an error on deployment. 

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test
