### PR TITLE
Enable tamper protection feature flag by default for Agent 8.11.0

### DIFF
--- a/changelog/fragments/1695780865-Enable-tamper-protection-feature-flag-by-default-for-Agent-8.11.0.yaml
+++ b/changelog/fragments/1695780865-Enable-tamper-protection-feature-flag-by-default-for-Agent-8.11.0.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Enable tamper protection feature flag by default for Agent 8.11.0
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/3478
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -19,7 +19,7 @@ import (
 // The following was agreed upon for upcoming releases
 // 8.10  - default is disabled
 // 8.11+ - default is enabled
-const defaultTamperProtection = false
+const defaultTamperProtection = true
 
 var (
 	current = Flags{
@@ -182,6 +182,8 @@ func Parse(policy any) (*Flags, error) {
 	// Tamper protection flag is optional, fallback on default value if missing
 	if parsedFlags.Agent.Features.TamperProtection != nil {
 		flags.setTamperProtection(parsedFlags.Agent.Features.TamperProtection.Enabled)
+	} else {
+		flags.setTamperProtection(defaultTamperProtection)
 	}
 
 	if err := flags.setSource(parsedFlags); err != nil {


### PR DESCRIPTION
## What does this PR do?

Enables tamper protection feature flag by default for Agent 8.11.0. 
In the 8.10.0 the default tamper protection feature flag disabled by default.

ATTN!!!: It is important to use the Agent with corresponding Endpoint build for 8.11.0 that has the feature flags default set to the same value for the feature to work correctly.
(omitting the link to Endpoint PR here since the Endpoint repository is private)

The combination of agent feature flag value in the policy
```
"agent": {
    "features": {
        "tamper_protection": {
        "enabled": false
     }
},
```
and the agent protection flag
```
agent:
  ....
  protection:
    enabled: true
````
define if the tamper protection is enabled or not.


Here are the tables that help to understand how this change of the tamper protection feature flag value affects 8.11 settings.
The difference is in **bold**

### 8.10.x

agent feature flag   |   agent protection flag  |   tamper protection enabled
-------------------|------------------------|-------------------
missing                    |    false                            |   false
missing                    |    true                            |   **false**
false                         |     false                           |   false
false                         |     true                           |   false
true                         |     false                           |   false
true                         |     true                           |   true

### 8.11.x

agent feature flag   |   agent protection flag  |   tamper protection enabled
-------------------|------------------------|-------------------
missing                    |    false                            |   false
missing                    |    true                            |   **true**
false                         |     false                           |   false
false                         |     true                           |   false
true                         |     false                           |   false
true                         |     true                           |   true


This shows that it's important to use the corresponding builds of Agent and Endpoint with the same defaults. 
This was discussed and agreed upon when the feature flag was initially introduced in 8.10.

For example if the builds are mismatched:
1. If we run the older build of Agent before this change with the newer build of Endpoint with this change. The older build of Agent would assume that the tamper protection is disabled when the feature flag is missing when the agent protection flag is set to true. While the newer version of Endpoint would assume that the feature is enabled and will enable the tamper protection.
2. If we run the newer build of Agent after this change and the older build of Endpoint without this change. The newer build of Agent would assume that the tamper protection is enabled when the feature flag is missing when the agent protection flag is set to true. While the older version of Endpoint would assume that the feature is disabled.


## Why is it important?

This is a part of planned tamper protection feature rollout step for 8.11.0 release.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

