### PR TITLE
Increase test delay to avoid flakiness on Windows

### DIFF
--- a/internal/pkg/agent/install/progress_test.go
+++ b/internal/pkg/agent/install/progress_test.go
@@ -51,7 +51,7 @@ func TestProgress(t *testing.T) {
 		rs := pt.Start()
 
 		s := rs.StepStart("step 1 starting")
-		time.Sleep(15 * time.Millisecond) // to simulate work being done
+		time.Sleep(100 * time.Millisecond) // to simulate work being done
 		s.Failed()
 
 		rs.Failed()


### PR DESCRIPTION
## What does this PR do?

Increase test delay to avoid flakiness on Windows

## Why is it important?

`TestProgress/single_step_delayed_failure` was flaky on Windows.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
~~- [ ] I have added an integration test or an E2E test~~

~~## Author's Checklist~~
~~## How to test this PR locally~~
~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?

