### PR TITLE
Un-hide `--base-path` install flag

### DIFF
--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -45,12 +45,6 @@ would like the Agent to operate.
 	cmd.Flags().String(flagInstallBasePath, paths.DefaultBasePath, "The path where the Elastic Agent will be installed. It must be an absolute path.")
 	addEnrollFlags(cmd)
 
-	// We are not supporting a custom base path, supplied via the `--base-path` CLI
-	// flag, just yet because we don't have Endpoint support for it yet. So we mark
-	// this flag as hidden.
-	// See also: https://github.com/elastic/elastic-agent/pull/2592
-	_ = cmd.Flags().MarkHidden(flagInstallBasePath)
-
 	return cmd
 }
 

--- a/testing/integration/install_test.go
+++ b/testing/integration/install_test.go
@@ -88,15 +88,6 @@ func TestInstallWithBasePath(t *testing.T) {
 	err = fixture.Prepare(context.Background())
 	require.NoError(t, err)
 
-	// The `--base-path` flag is defined for the `elastic-agent install` CLI sub-command BUT
-	// it is hidden (see https://github.com/elastic/elastic-agent/pull/2592).  So we validate
-	// here that the usage text for the `install` sub-command does NOT mention the `--base-path`
-	// flag in it.
-	const basePathFlag = "--base-path"
-	output, err := fixture.Exec(context.Background(), []string{"help", "install"})
-	require.NoError(t, err)
-	require.NotContains(t, string(output), basePathFlag)
-
 	// Set up random temporary directory to serve as base path for Elastic Agent
 	// installation.
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## What does this PR do?

This PR un-hides the `--base-path` flag defined on the `elastic-agent install` sub-command.

## Why is it important?

To allow users to install Elastic Agent in custom locations.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~ See https://github.com/elastic/ingest-docs/pull/532
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~ Already covered by https://github.com/elastic/elastic-agent/pull/2500 
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~ Already covered by https://github.com/elastic/elastic-agent/pull/2500 
- [ ] ~I have added an integration test or an E2E test~ Already covered by https://github.com/elastic/elastic-agent/pull/2578

