### PR TITLE
Refactoring HTTP downloader progress reporter to accept multiple observers

### DIFF
--- a/internal/pkg/agent/application/upgrade/artifact/download/http/downloader.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/downloader.go
@@ -206,9 +206,9 @@ func (e *Downloader) downloadFile(ctx context.Context, artifactName, filename, f
 		}
 	}
 
-	plo := newLoggingProgressObserver(e.log, e.config.HTTPTransportSettings.Timeout)
+	lpObs := newLoggingProgressObserver(e.log, e.config.HTTPTransportSettings.Timeout)
 	reportCtx, reportCancel := context.WithCancel(ctx)
-	dp := newDownloadProgressReporter(sourceURI, e.config.HTTPTransportSettings.Timeout, fileSize, plo)
+	dp := newDownloadProgressReporter(sourceURI, e.config.HTTPTransportSettings.Timeout, fileSize, lpObs)
 	dp.Report(reportCtx)
 	_, err = io.Copy(destinationFile, io.TeeReader(resp.Body, dp))
 	if err != nil {

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/downloader.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/downloader.go
@@ -206,7 +206,7 @@ func (e *Downloader) downloadFile(ctx context.Context, artifactName, filename, f
 		}
 	}
 
-	plo := newLoggerProgressObserver(e.log, e.config.HTTPTransportSettings.Timeout)
+	plo := newLoggingProgressObserver(e.log, e.config.HTTPTransportSettings.Timeout)
 	reportCtx, reportCancel := context.WithCancel(ctx)
 	dp := newDownloadProgressReporter(sourceURI, e.config.HTTPTransportSettings.Timeout, fileSize, plo)
 	dp.Report(reportCtx)

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/downloader.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/downloader.go
@@ -17,14 +17,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/go-units"
-
-	"github.com/elastic/elastic-agent-libs/atomic"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact/download"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
 const (
@@ -46,13 +44,13 @@ const (
 
 // Downloader is a downloader able to fetch artifacts from elastic.co web page.
 type Downloader struct {
-	log    progressLogger
+	log    *logger.Logger
 	config *artifact.Config
 	client http.Client
 }
 
 // NewDownloader creates and configures Elastic Downloader
-func NewDownloader(log progressLogger, config *artifact.Config) (*Downloader, error) {
+func NewDownloader(log *logger.Logger, config *artifact.Config) (*Downloader, error) {
 	client, err := config.HTTPTransportSettings.Client(
 		httpcommon.WithAPMHTTPInstrumentation(),
 		httpcommon.WithKeepaliveSettings{Disable: false, IdleConnTimeout: 30 * time.Second},
@@ -66,7 +64,7 @@ func NewDownloader(log progressLogger, config *artifact.Config) (*Downloader, er
 }
 
 // NewDownloaderWithClient creates Elastic Downloader with specific client used
-func NewDownloaderWithClient(log progressLogger, config *artifact.Config, client http.Client) *Downloader {
+func NewDownloaderWithClient(log *logger.Logger, config *artifact.Config, client http.Client) *Downloader {
 	return &Downloader{
 		log:    log,
 		config: config,
@@ -208,8 +206,9 @@ func (e *Downloader) downloadFile(ctx context.Context, artifactName, filename, f
 		}
 	}
 
+	plo := newLoggerProgressObserver(e.log, e.config.HTTPTransportSettings.Timeout)
 	reportCtx, reportCancel := context.WithCancel(ctx)
-	dp := newDownloadProgressReporter(e.log, sourceURI, e.config.HTTPTransportSettings.Timeout, fileSize)
+	dp := newDownloadProgressReporter(sourceURI, e.config.HTTPTransportSettings.Timeout, fileSize, plo)
 	dp.Report(reportCtx)
 	_, err = io.Copy(destinationFile, io.TeeReader(resp.Body, dp))
 	if err != nil {
@@ -222,138 +221,4 @@ func (e *Downloader) downloadFile(ctx context.Context, artifactName, filename, f
 	dp.ReportComplete()
 
 	return fullPath, nil
-}
-
-type downloadProgressReporter struct {
-	log         progressLogger
-	sourceURI   string
-	interval    time.Duration
-	warnTimeout time.Duration
-	length      float64
-
-	downloaded atomic.Int
-	started    time.Time
-}
-
-func newDownloadProgressReporter(log progressLogger, sourceURI string, timeout time.Duration, length int) *downloadProgressReporter {
-	interval := time.Duration(float64(timeout) * downloadProgressIntervalPercentage)
-	if interval == 0 {
-		interval = downloadProgressMinInterval
-	}
-
-	return &downloadProgressReporter{
-		log:         log,
-		sourceURI:   sourceURI,
-		interval:    interval,
-		warnTimeout: time.Duration(float64(timeout) * warningProgressIntervalPercentage),
-		length:      float64(length),
-	}
-}
-
-func (dp *downloadProgressReporter) Write(b []byte) (int, error) {
-	n := len(b)
-	dp.downloaded.Add(n)
-	return n, nil
-}
-
-func (dp *downloadProgressReporter) Report(ctx context.Context) {
-	started := time.Now()
-	dp.started = started
-	sourceURI := dp.sourceURI
-	log := dp.log
-	length := dp.length
-	warnTimeout := dp.warnTimeout
-	interval := dp.interval
-
-	go func() {
-		t := time.NewTicker(interval)
-		defer t.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-t.C:
-				now := time.Now()
-				timePast := now.Sub(started)
-				downloaded := float64(dp.downloaded.Load())
-				bytesPerSecond := downloaded / float64(timePast/time.Second)
-
-				var msg string
-				var args []interface{}
-				if length > 0 {
-					// length of the download is known, so more detail can be provided
-					percentComplete := downloaded / length * 100.0
-					msg = "download progress from %s is %s/%s (%.2f%% complete) @ %sps"
-					args = []interface{}{
-						sourceURI, units.HumanSize(downloaded), units.HumanSize(length), percentComplete, units.HumanSize(bytesPerSecond),
-					}
-				} else {
-					// length unknown so provide the amount downloaded and the speed
-					msg = "download progress from %s has fetched %s @ %sps"
-					args = []interface{}{
-						sourceURI, units.HumanSize(downloaded), units.HumanSize(bytesPerSecond),
-					}
-				}
-
-				log.Infof(msg, args...)
-				if timePast >= warnTimeout {
-					// duplicate to warn when over the warnTimeout; this still has it logging to info that way if
-					// they are filtering the logs to info they still see the messages when over the warnTimeout, but
-					// when filtering only by warn they see these messages only
-					log.Warnf(msg, args...)
-				}
-			}
-		}
-	}()
-}
-
-func (dp *downloadProgressReporter) ReportComplete() {
-	now := time.Now()
-	timePast := now.Sub(dp.started)
-	downloaded := float64(dp.downloaded.Load())
-	bytesPerSecond := downloaded / float64(timePast/time.Second)
-	msg := "download from %s completed in %s @ %sps"
-	args := []interface{}{
-		dp.sourceURI, units.HumanDuration(timePast), units.HumanSize(bytesPerSecond),
-	}
-	dp.log.Infof(msg, args...)
-	if timePast >= dp.warnTimeout {
-		// see reason in `Report`
-		dp.log.Warnf(msg, args...)
-	}
-}
-
-func (dp *downloadProgressReporter) ReportFailed(err error) {
-	now := time.Now()
-	timePast := now.Sub(dp.started)
-	downloaded := float64(dp.downloaded.Load())
-	bytesPerSecond := downloaded / float64(timePast/time.Second)
-	var msg string
-	var args []interface{}
-	if dp.length > 0 {
-		// length of the download is known, so more detail can be provided
-		percentComplete := downloaded / dp.length * 100.0
-		msg = "download from %s failed at %s/%s (%.2f%% complete) @ %sps: %s"
-		args = []interface{}{
-			dp.sourceURI, units.HumanSize(downloaded), units.HumanSize(dp.length), percentComplete, units.HumanSize(bytesPerSecond), err,
-		}
-	} else {
-		// length unknown so provide the amount downloaded and the speed
-		msg = "download from %s failed at %s @ %sps: %s"
-		args = []interface{}{
-			dp.sourceURI, units.HumanSize(downloaded), units.HumanSize(bytesPerSecond), err,
-		}
-	}
-	dp.log.Infof(msg, args...)
-	if timePast >= dp.warnTimeout {
-		// see reason in `Report`
-		dp.log.Warnf(msg, args...)
-	}
-}
-
-// progressLogger is a logger that only needs to implement Infof and Warnf, as those are the only functions
-// that the downloadProgressReporter uses.
-type progressLogger interface {
-	Infof(format string, args ...interface{})
-	Warnf(format string, args ...interface{})
 }

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/downloader.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/downloader.go
@@ -206,9 +206,9 @@ func (e *Downloader) downloadFile(ctx context.Context, artifactName, filename, f
 		}
 	}
 
-	lpObs := newLoggingProgressObserver(e.log, e.config.HTTPTransportSettings.Timeout)
+	loggingObserver := newLoggingProgressObserver(e.log, e.config.HTTPTransportSettings.Timeout)
 	reportCtx, reportCancel := context.WithCancel(ctx)
-	dp := newDownloadProgressReporter(sourceURI, e.config.HTTPTransportSettings.Timeout, fileSize, lpObs)
+	dp := newDownloadProgressReporter(sourceURI, e.config.HTTPTransportSettings.Timeout, fileSize, loggingObserver)
 	dp.Report(reportCtx)
 	_, err = io.Copy(destinationFile, io.TeeReader(resp.Body, dp))
 	if err != nil {

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/downloader.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/downloader.go
@@ -207,17 +207,14 @@ func (e *Downloader) downloadFile(ctx context.Context, artifactName, filename, f
 	}
 
 	loggingObserver := newLoggingProgressObserver(e.log, e.config.HTTPTransportSettings.Timeout)
-	reportCtx, reportCancel := context.WithCancel(ctx)
 	dp := newDownloadProgressReporter(sourceURI, e.config.HTTPTransportSettings.Timeout, fileSize, loggingObserver)
-	dp.Report(reportCtx)
+	dp.Report()
 	_, err = io.Copy(destinationFile, io.TeeReader(resp.Body, dp))
 	if err != nil {
-		reportCancel()
 		dp.ReportFailed(err)
 		// return path, file already exists and needs to be cleaned up
 		return fullPath, errors.New(err, "copying fetched package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
 	}
-	reportCancel()
 	dp.ReportComplete()
 
 	return fullPath, nil

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/downloader.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/downloader.go
@@ -208,7 +208,7 @@ func (e *Downloader) downloadFile(ctx context.Context, artifactName, filename, f
 
 	loggingObserver := newLoggingProgressObserver(e.log, e.config.HTTPTransportSettings.Timeout)
 	dp := newDownloadProgressReporter(sourceURI, e.config.HTTPTransportSettings.Timeout, fileSize, loggingObserver)
-	dp.Report()
+	dp.Report(ctx)
 	_, err = io.Copy(destinationFile, io.TeeReader(resp.Body, dp))
 	if err != nil {
 		dp.ReportFailed(err)

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/downloader_test.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/downloader_test.go
@@ -132,6 +132,12 @@ func TestDownloadLogProgressWithLength(t *testing.T) {
 		`^download from ` + expectedURL + `(.sha512)? completed in \d+ \S+ @ \S+$`,
 	)
 
+	// Consider only progress logs
+	obs = obs.Filter(func(entry observer.LoggedEntry) bool {
+		return expectedProgressRegexp.MatchString(entry.Message) ||
+			expectedCompletedRegexp.MatchString(entry.Message)
+	})
+
 	// Two files are downloaded. Each file is being downloaded in 100 chunks with a delay of 10ms between chunks. The
 	// expected time to download is, therefore, 100 * 10ms = 1000ms. In reality, the actual download time will be a bit
 	// more than 1000ms because some time is spent downloading the chunk, in between inter-chunk delays.
@@ -199,6 +205,12 @@ func TestDownloadLogProgressWithoutLength(t *testing.T) {
 	expectedCompletedRegexp := regexp.MustCompile(
 		`^download from ` + expectedURL + `(.sha512)? completed in \d+ \S+ @ \S+$`,
 	)
+
+	// Consider only progress logs
+	obs = obs.Filter(func(entry observer.LoggedEntry) bool {
+		return expectedProgressRegexp.MatchString(entry.Message) ||
+			expectedCompletedRegexp.MatchString(entry.Message)
+	})
 
 	// Two files are downloaded. Each file is being downloaded in 100 chunks with a delay of 10ms between chunks. The
 	// expected time to download is, therefore, 100 * 10ms = 1000ms. In reality, the actual download time will be a bit

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/downloader_test.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/downloader_test.go
@@ -6,17 +6,22 @@ package http
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"regexp"
 	"strconv"
-	"sync"
 	"testing"
 	"time"
 
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
 
 	"github.com/docker/go-units"
 	"github.com/stretchr/testify/assert"
@@ -57,7 +62,7 @@ func TestDownloadBodyError(t *testing.T) {
 		Architecture:    "64",
 	}
 
-	log := newRecordLogger()
+	log, obs := logger.NewTesting("downloader")
 	testClient := NewDownloaderWithClient(log, config, *client)
 	artifactPath, err := testClient.Download(context.Background(), beatSpec, version)
 	os.Remove(artifactPath)
@@ -65,13 +70,15 @@ func TestDownloadBodyError(t *testing.T) {
 		t.Fatal("expected Download to return an error")
 	}
 
-	log.lock.RLock()
-	defer log.lock.RUnlock()
+	infoLogs := obs.FilterLevelExact(zapcore.InfoLevel).TakeAll()
+	warnLogs := obs.FilterLevelExact(zapcore.WarnLevel).TakeAll()
 
-	require.GreaterOrEqual(t, len(log.info), 1, "download error not logged at info level")
-	assert.True(t, containsMessage(log.info, "download from %s failed at %s @ %sps: %s"))
-	require.GreaterOrEqual(t, len(log.warn), 1, "download error not logged at warn level")
-	assert.True(t, containsMessage(log.warn, "download from %s failed at %s @ %sps: %s"))
+	expectedURL := fmt.Sprintf("%s/%s-%s-%s", srv.URL, "beats/filebeat/filebeat", version, "linux-x86_64.tar.gz")
+	expectedMsg := fmt.Sprintf("download from %s failed at 0B @ NaNBps: unexpected EOF", expectedURL)
+	require.GreaterOrEqual(t, len(infoLogs), 1, "download error not logged at info level")
+	assert.True(t, containsMessage(infoLogs, expectedMsg))
+	require.GreaterOrEqual(t, len(warnLogs), 1, "download error not logged at warn level")
+	assert.True(t, containsMessage(warnLogs, expectedMsg))
 }
 
 func TestDownloadLogProgressWithLength(t *testing.T) {
@@ -111,16 +118,19 @@ func TestDownloadLogProgressWithLength(t *testing.T) {
 		},
 	}
 
-	log := newRecordLogger()
+	log, obs := logger.NewTesting("downloader")
 	testClient := NewDownloaderWithClient(log, config, *client)
 	artifactPath, err := testClient.Download(context.Background(), beatSpec, version)
 	os.Remove(artifactPath)
 	require.NoError(t, err, "Download should not have errored")
 
-	log.lock.RLock()
-	defer log.lock.RUnlock()
-
-	expectedProgressMsg := "download progress from %s is %s/%s (%.2f%% complete) @ %sps"
+	expectedURL := fmt.Sprintf("%s/%s-%s-%s", srv.URL, "beats/filebeat/filebeat", version, "linux-x86_64.tar.gz")
+	expectedProgressRegexp := regexp.MustCompile(
+		`^download progress from ` + expectedURL + `(.sha512)? is \S+/\S+ \(\d+\.\d{2}% complete\) @ \S+$`,
+	)
+	expectedCompletedRegexp := regexp.MustCompile(
+		`^download from ` + expectedURL + `(.sha512)? completed in \d+ \S+ @ \S+$`,
+	)
 
 	// Two files are downloaded. Each file is being downloaded in 100 chunks with a delay of 10ms between chunks. The
 	// expected time to download is, therefore, 100 * 10ms = 1000ms. In reality, the actual download time will be a bit
@@ -129,7 +139,7 @@ func TestDownloadLogProgressWithLength(t *testing.T) {
 	// the actual total download time / 50ms, for each file. That works out to at least 1000ms / 50ms = 20 INFO log
 	// messages, for each file, about its download progress. Additionally, we should expect 1 INFO log message, for
 	// each file, about the download completing.
-	assertLogs(t, log.info, 20, expectedProgressMsg)
+	assertLogs(t, obs.FilterLevelExact(zapcore.InfoLevel).TakeAll(), 20, expectedProgressRegexp, expectedCompletedRegexp)
 
 	// By similar math as above, since the download of each file is expected to take 1000ms, and the progress logger
 	// starts issuing WARN messages once the download has taken more than 75% of the expected time,
@@ -137,7 +147,7 @@ func TestDownloadLogProgressWithLength(t *testing.T) {
 	// reporting happens every 50 seconds, we should see at least 250s / 50s = 5 WARN log messages, for each file,
 	// about its download progress. Additionally, we should expect 1 WARN message, for each file, about the download
 	// completing.
-	assertLogs(t, log.warn, 5, expectedProgressMsg)
+	assertLogs(t, obs.FilterLevelExact(zapcore.WarnLevel).TakeAll(), 5, expectedProgressRegexp, expectedCompletedRegexp)
 }
 
 func TestDownloadLogProgressWithoutLength(t *testing.T) {
@@ -176,16 +186,19 @@ func TestDownloadLogProgressWithoutLength(t *testing.T) {
 		},
 	}
 
-	log := newRecordLogger()
+	log, obs := logger.NewTesting("downloader")
 	testClient := NewDownloaderWithClient(log, config, *client)
 	artifactPath, err := testClient.Download(context.Background(), beatSpec, version)
 	os.Remove(artifactPath)
 	require.NoError(t, err, "Download should not have errored")
 
-	log.lock.RLock()
-	defer log.lock.RUnlock()
-
-	expectedProgressMsg := "download progress from %s has fetched %s @ %sps"
+	expectedURL := fmt.Sprintf("%s/%s-%s-%s", srv.URL, "beats/filebeat/filebeat", version, "linux-x86_64.tar.gz")
+	expectedProgressRegexp := regexp.MustCompile(
+		`^download progress from ` + expectedURL + `(.sha512)? has fetched \S+ @ \S+$`,
+	)
+	expectedCompletedRegexp := regexp.MustCompile(
+		`^download from ` + expectedURL + `(.sha512)? completed in \d+ \S+ @ \S+$`,
+	)
 
 	// Two files are downloaded. Each file is being downloaded in 100 chunks with a delay of 10ms between chunks. The
 	// expected time to download is, therefore, 100 * 10ms = 1000ms. In reality, the actual download time will be a bit
@@ -194,7 +207,7 @@ func TestDownloadLogProgressWithoutLength(t *testing.T) {
 	// the actual total download time / 50ms, for each file. That works out to at least 1000ms / 50ms = 20 INFO log
 	// messages, for each file, about its download progress. Additionally, we should expect 1 INFO log message, for
 	// each file, about the download completing.
-	assertLogs(t, log.info, 20, expectedProgressMsg)
+	assertLogs(t, obs.FilterLevelExact(zapcore.InfoLevel).TakeAll(), 20, expectedProgressRegexp, expectedCompletedRegexp)
 
 	// By similar math as above, since the download of each file is expected to take 1000ms, and the progress logger
 	// starts issuing WARN messages once the download has taken more than 75% of the expected time,
@@ -202,48 +215,19 @@ func TestDownloadLogProgressWithoutLength(t *testing.T) {
 	// reporting happens every 50 seconds, we should see at least 250s / 50s = 5 WARN log messages, for each file,
 	// about its download progress. Additionally, we should expect 1 WARN message, for each file, about the download
 	// completing.
-	assertLogs(t, log.warn, 5, expectedProgressMsg)
+	assertLogs(t, obs.FilterLevelExact(zapcore.WarnLevel).TakeAll(), 5, expectedProgressRegexp, expectedCompletedRegexp)
 }
 
-type logMessage struct {
-	record string
-	args   []interface{}
-}
-
-type recordLogger struct {
-	lock sync.RWMutex
-	info []logMessage
-	warn []logMessage
-}
-
-func newRecordLogger() *recordLogger {
-	return &recordLogger{
-		info: make([]logMessage, 0, 10),
-		warn: make([]logMessage, 0, 10),
-	}
-}
-
-func (f *recordLogger) Infof(record string, args ...interface{}) {
-	f.lock.Lock()
-	defer f.lock.Unlock()
-	f.info = append(f.info, logMessage{record, args})
-}
-
-func (f *recordLogger) Warnf(record string, args ...interface{}) {
-	f.lock.Lock()
-	defer f.lock.Unlock()
-	f.warn = append(f.warn, logMessage{record, args})
-}
-
-func containsMessage(logs []logMessage, msg string) bool {
+func containsMessage(logs []observer.LoggedEntry, msg string) bool {
 	for _, item := range logs {
-		if item.record == msg {
+		if item.Message == msg {
 			return true
 		}
 	}
 	return false
 }
-func assertLogs(t *testing.T, logs []logMessage, minExpectedProgressLogs int, expectedProgressMsg string) {
+
+func assertLogs(t *testing.T, logs []observer.LoggedEntry, minExpectedProgressLogs int, expectedProgressRegexp, expectedCompletedRegexp *regexp.Regexp) {
 	t.Helper()
 
 	// Verify that we've logged at least minExpectedProgressLogs (about download progress) + 1 log
@@ -253,21 +237,21 @@ func assertLogs(t *testing.T, logs []logMessage, minExpectedProgressLogs int, ex
 	// Verify that the first minExpectedProgressLogs messages are about the download progress (for the first file).
 	i := 0
 	for ; i < minExpectedProgressLogs; i++ {
-		assert.Equal(t, logs[i].record, expectedProgressMsg)
+		assert.Regexp(t, expectedProgressRegexp, logs[i].Message)
 	}
 
 	// Find the next message that's about the download being completed (for the first file).
 	found := false
 	for ; i < len(logs) && !found; i++ {
-		found = logs[i].record == "download from %s completed in %s @ %sps"
+		found = expectedCompletedRegexp.MatchString(logs[i].Message)
 	}
 	assert.True(t, found)
 
 	// Verify that the next minExpectedProgressLogs messages are about the download progress (for the second file).
 	for j := 0; j < minExpectedProgressLogs; j++ {
-		assert.Equal(t, logs[i+j].record, expectedProgressMsg)
+		assert.Regexp(t, expectedProgressRegexp, logs[i+j].Message)
 	}
 
 	// Verify that the last message is about the download being completed (for the second file).
-	assert.Equal(t, logs[len(logs)-1].record, "download from %s completed in %s @ %sps")
+	assert.Regexp(t, expectedCompletedRegexp, logs[len(logs)-1].Message)
 }

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/progress_observer.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/progress_observer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/progress_observer.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/progress_observer.go
@@ -1,0 +1,96 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package http
+
+import (
+	"time"
+
+	"github.com/docker/go-units"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+)
+
+type progressObserver interface {
+	// Report is called on a periodic basis with information about the download's progress so far.
+	Report(sourceURI string, timePast time.Duration, downloadedBytes, totalBytes, percentComplete, downloadRate float64)
+
+	// ReportComplete is called when the download completes successfully.
+	ReportComplete(sourceURI string, timePast time.Duration, downloadRate float64)
+
+	// ReportFailed is called if the download does not complete successfully.
+	ReportFailed(sourceURI string, timePast time.Duration, downloadedBytes, totalBytes, percentComplete, downloadRate float64, err error)
+}
+
+type loggerProgressObserver struct {
+	log         *logger.Logger
+	warnTimeout time.Duration
+}
+
+func newLoggerProgressObserver(log *logger.Logger, downloadTimeout time.Duration) *loggerProgressObserver {
+	return &loggerProgressObserver{
+		log:         log,
+		warnTimeout: time.Duration(float64(downloadTimeout) * warningProgressIntervalPercentage),
+	}
+}
+
+func (plo *loggerProgressObserver) Report(sourceURI string, timePast time.Duration, downloadedBytes, totalBytes, percentComplete, downloadRate float64) {
+	var msg string
+	var args []interface{}
+	if totalBytes > 0 {
+		// length of the download is known, so more detail can be provided
+		msg = "download progress from %s is %s/%s (%.2f%% complete) @ %sps"
+		args = []interface{}{
+			sourceURI, units.HumanSize(downloadedBytes), units.HumanSize(totalBytes), percentComplete, units.HumanSize(downloadRate),
+		}
+	} else {
+		// length unknown so provide the amount downloaded and the speed
+		msg = "download progress from %s has fetched %s @ %sps"
+		args = []interface{}{
+			sourceURI, units.HumanSize(downloadedBytes), units.HumanSize(downloadRate),
+		}
+	}
+
+	plo.log.Infof(msg, args...)
+	if timePast >= plo.warnTimeout {
+		// duplicate to warn when over the warnTimeout; this still has it logging to info that way if
+		// they are filtering the logs to info they still see the messages when over the warnTimeout, but
+		// when filtering only by warn they see these messages only
+		plo.log.Warnf(msg, args...)
+	}
+}
+
+func (plo *loggerProgressObserver) ReportComplete(sourceURI string, timePast time.Duration, downloadRate float64) {
+	msg := "download from %s completed in %s @ %sps"
+	args := []interface{}{
+		sourceURI, units.HumanDuration(timePast), units.HumanSize(downloadRate),
+	}
+	plo.log.Infof(msg, args...)
+	if timePast >= plo.warnTimeout {
+		// see reason in `Report`
+		plo.log.Warnf(msg, args...)
+	}
+}
+
+func (plo *loggerProgressObserver) ReportFailed(sourceURI string, timePast time.Duration, downloadedBytes, totalBytes, percentComplete, downloadRate float64, err error) {
+	var msg string
+	var args []interface{}
+	if totalBytes > 0 {
+		// length of the download is known, so more detail can be provided
+		msg = "download from %s failed at %s/%s (%.2f%% complete) @ %sps: %s"
+		args = []interface{}{
+			sourceURI, units.HumanSize(downloadedBytes), units.HumanSize(totalBytes), percentComplete, units.HumanSize(downloadRate), err,
+		}
+	} else {
+		// length unknown so provide the amount downloaded and the speed
+		msg = "download from %s failed at %s @ %sps: %s"
+		args = []interface{}{
+			sourceURI, units.HumanSize(downloadedBytes), units.HumanSize(downloadRate), err,
+		}
+	}
+	plo.log.Infof(msg, args...)
+	if timePast >= plo.warnTimeout {
+		// see reason in `Report`
+		plo.log.Warnf(msg, args...)
+	}
+}

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/progress_observer.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/progress_observer.go
@@ -15,26 +15,26 @@ type progressObserver interface {
 	// Report is called on a periodic basis with information about the download's progress so far.
 	Report(sourceURI string, timePast time.Duration, downloadedBytes, totalBytes, percentComplete, downloadRate float64)
 
-	// ReportComplete is called when the download completes successfully.
-	ReportComplete(sourceURI string, timePast time.Duration, downloadRate float64)
+	// ReportCompleted is called when the download completes successfully.
+	ReportCompleted(sourceURI string, timePast time.Duration, downloadRate float64)
 
 	// ReportFailed is called if the download does not complete successfully.
 	ReportFailed(sourceURI string, timePast time.Duration, downloadedBytes, totalBytes, percentComplete, downloadRate float64, err error)
 }
 
-type loggerProgressObserver struct {
+type loggingProgressObserver struct {
 	log         *logger.Logger
 	warnTimeout time.Duration
 }
 
-func newLoggerProgressObserver(log *logger.Logger, downloadTimeout time.Duration) *loggerProgressObserver {
-	return &loggerProgressObserver{
+func newLoggingProgressObserver(log *logger.Logger, downloadTimeout time.Duration) *loggingProgressObserver {
+	return &loggingProgressObserver{
 		log:         log,
 		warnTimeout: time.Duration(float64(downloadTimeout) * warningProgressIntervalPercentage),
 	}
 }
 
-func (plo *loggerProgressObserver) Report(sourceURI string, timePast time.Duration, downloadedBytes, totalBytes, percentComplete, downloadRate float64) {
+func (plo *loggingProgressObserver) Report(sourceURI string, timePast time.Duration, downloadedBytes, totalBytes, percentComplete, downloadRate float64) {
 	var msg string
 	var args []interface{}
 	if totalBytes > 0 {
@@ -60,7 +60,7 @@ func (plo *loggerProgressObserver) Report(sourceURI string, timePast time.Durati
 	}
 }
 
-func (plo *loggerProgressObserver) ReportComplete(sourceURI string, timePast time.Duration, downloadRate float64) {
+func (plo *loggingProgressObserver) ReportCompleted(sourceURI string, timePast time.Duration, downloadRate float64) {
 	msg := "download from %s completed in %s @ %sps"
 	args := []interface{}{
 		sourceURI, units.HumanDuration(timePast), units.HumanSize(downloadRate),
@@ -72,7 +72,7 @@ func (plo *loggerProgressObserver) ReportComplete(sourceURI string, timePast tim
 	}
 }
 
-func (plo *loggerProgressObserver) ReportFailed(sourceURI string, timePast time.Duration, downloadedBytes, totalBytes, percentComplete, downloadRate float64, err error) {
+func (plo *loggingProgressObserver) ReportFailed(sourceURI string, timePast time.Duration, downloadedBytes, totalBytes, percentComplete, downloadRate float64, err error) {
 	var msg string
 	var args []interface{}
 	if totalBytes > 0 {

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/progress_observer.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/progress_observer.go
@@ -35,7 +35,7 @@ func newLoggingProgressObserver(log *logger.Logger, downloadTimeout time.Duratio
 	}
 }
 
-func (plo *loggingProgressObserver) Report(sourceURI string, timePast time.Duration, downloadedBytes, totalBytes, percentComplete, downloadRate float64) {
+func (lpObs *loggingProgressObserver) Report(sourceURI string, timePast time.Duration, downloadedBytes, totalBytes, percentComplete, downloadRate float64) {
 	var msg string
 	var args []interface{}
 	if totalBytes > 0 {
@@ -52,28 +52,28 @@ func (plo *loggingProgressObserver) Report(sourceURI string, timePast time.Durat
 		}
 	}
 
-	plo.log.Infof(msg, args...)
-	if timePast >= plo.warnTimeout {
+	lpObs.log.Infof(msg, args...)
+	if timePast >= lpObs.warnTimeout {
 		// duplicate to warn when over the warnTimeout; this still has it logging to info that way if
 		// they are filtering the logs to info they still see the messages when over the warnTimeout, but
 		// when filtering only by warn they see these messages only
-		plo.log.Warnf(msg, args...)
+		lpObs.log.Warnf(msg, args...)
 	}
 }
 
-func (plo *loggingProgressObserver) ReportCompleted(sourceURI string, timePast time.Duration, downloadRate float64) {
+func (lpObs *loggingProgressObserver) ReportCompleted(sourceURI string, timePast time.Duration, downloadRate float64) {
 	msg := "download from %s completed in %s @ %sps"
 	args := []interface{}{
 		sourceURI, units.HumanDuration(timePast), units.HumanSize(downloadRate),
 	}
-	plo.log.Infof(msg, args...)
-	if timePast >= plo.warnTimeout {
+	lpObs.log.Infof(msg, args...)
+	if timePast >= lpObs.warnTimeout {
 		// see reason in `Report`
-		plo.log.Warnf(msg, args...)
+		lpObs.log.Warnf(msg, args...)
 	}
 }
 
-func (plo *loggingProgressObserver) ReportFailed(sourceURI string, timePast time.Duration, downloadedBytes, totalBytes, percentComplete, downloadRate float64, err error) {
+func (lpObs *loggingProgressObserver) ReportFailed(sourceURI string, timePast time.Duration, downloadedBytes, totalBytes, percentComplete, downloadRate float64, err error) {
 	var msg string
 	var args []interface{}
 	if totalBytes > 0 {
@@ -89,9 +89,9 @@ func (plo *loggingProgressObserver) ReportFailed(sourceURI string, timePast time
 			sourceURI, units.HumanSize(downloadedBytes), units.HumanSize(downloadRate), err,
 		}
 	}
-	plo.log.Infof(msg, args...)
-	if timePast >= plo.warnTimeout {
+	lpObs.log.Infof(msg, args...)
+	if timePast >= lpObs.warnTimeout {
 		// see reason in `Report`
-		plo.log.Warnf(msg, args...)
+		lpObs.log.Warnf(msg, args...)
 	}
 }

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/progress_reporter.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/progress_reporter.go
@@ -1,0 +1,103 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package http
+
+import (
+	"context"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/atomic"
+)
+
+type downloadProgressReporter struct {
+	sourceURI   string
+	interval    time.Duration
+	warnTimeout time.Duration
+	length      float64
+
+	downloaded atomic.Int
+	started    time.Time
+
+	progressObservers []progressObserver
+}
+
+func newDownloadProgressReporter(sourceURI string, timeout time.Duration, length int, progressObservers ...progressObserver) *downloadProgressReporter {
+	interval := time.Duration(float64(timeout) * downloadProgressIntervalPercentage)
+	if interval == 0 {
+		interval = downloadProgressMinInterval
+	}
+
+	return &downloadProgressReporter{
+		sourceURI:         sourceURI,
+		interval:          interval,
+		warnTimeout:       time.Duration(float64(timeout) * warningProgressIntervalPercentage),
+		length:            float64(length),
+		progressObservers: progressObservers,
+	}
+}
+
+func (dp *downloadProgressReporter) Write(b []byte) (int, error) {
+	n := len(b)
+	dp.downloaded.Add(n)
+	return n, nil
+}
+
+func (dp *downloadProgressReporter) Report(ctx context.Context) {
+	started := time.Now()
+	dp.started = started
+	sourceURI := dp.sourceURI
+	length := dp.length
+	interval := dp.interval
+
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				now := time.Now()
+				timePast := now.Sub(started)
+				downloaded := float64(dp.downloaded.Load())
+				bytesPerSecond := downloaded / float64(timePast/time.Second)
+				var percentComplete float64
+				if length > 0 {
+					percentComplete = downloaded / length * 100.0
+				}
+
+				for _, obs := range dp.progressObservers {
+					obs.Report(sourceURI, timePast, downloaded, length, percentComplete, bytesPerSecond)
+				}
+			}
+		}
+	}()
+}
+
+func (dp *downloadProgressReporter) ReportComplete() {
+	now := time.Now()
+	timePast := now.Sub(dp.started)
+	downloaded := float64(dp.downloaded.Load())
+	bytesPerSecond := downloaded / float64(timePast/time.Second)
+
+	for _, obs := range dp.progressObservers {
+		obs.ReportComplete(dp.sourceURI, timePast, bytesPerSecond)
+	}
+}
+
+func (dp *downloadProgressReporter) ReportFailed(err error) {
+	now := time.Now()
+	timePast := now.Sub(dp.started)
+	downloaded := float64(dp.downloaded.Load())
+	bytesPerSecond := downloaded / float64(timePast/time.Second)
+	var percentComplete float64
+	if dp.length > 0 {
+		percentComplete = downloaded / dp.length * 100.0
+	}
+
+	for _, obs := range dp.progressObservers {
+		obs.ReportFailed(dp.sourceURI, timePast, downloaded, dp.length, percentComplete, bytesPerSecond, err)
+	}
+}

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/progress_reporter.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/progress_reporter.go
@@ -44,6 +44,8 @@ func (dp *downloadProgressReporter) Write(b []byte) (int, error) {
 	return n, nil
 }
 
+// Report periodically reports download progress to registered observers. Callers MUST cancel
+// the context passed to this method to avoid resource leaks.
 func (dp *downloadProgressReporter) Report(ctx context.Context) {
 	started := time.Now()
 	dp.started = started

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/progress_reporter.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/progress_reporter.go
@@ -53,6 +53,11 @@ func (dp *downloadProgressReporter) Report(ctx context.Context) {
 	length := dp.length
 	interval := dp.interval
 
+	// If there are no observers to report progress to, there is nothing to do!
+	if len(dp.progressObservers) == 0 {
+		return
+	}
+
 	go func() {
 		t := time.NewTicker(interval)
 		defer t.Stop()

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/progress_reporter.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/progress_reporter.go
@@ -83,7 +83,7 @@ func (dp *downloadProgressReporter) ReportComplete() {
 	bytesPerSecond := downloaded / float64(timePast/time.Second)
 
 	for _, obs := range dp.progressObservers {
-		obs.ReportComplete(dp.sourceURI, timePast, bytesPerSecond)
+		obs.ReportCompleted(dp.sourceURI, timePast, bytesPerSecond)
 	}
 }
 

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/verifier.go
@@ -20,6 +20,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact/download"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
 const (
@@ -33,7 +34,7 @@ type Verifier struct {
 	client        http.Client
 	pgpBytes      []byte
 	allowEmptyPgp bool
-	log           progressLogger
+	log           *logger.Logger
 }
 
 func (v *Verifier) Name() string {
@@ -42,7 +43,7 @@ func (v *Verifier) Name() string {
 
 // NewVerifier create a verifier checking downloaded package on preconfigured
 // location against a key stored on elastic.co website.
-func NewVerifier(log progressLogger, config *artifact.Config, allowEmptyPgp bool, pgp []byte) (*Verifier, error) {
+func NewVerifier(log *logger.Logger, config *artifact.Config, allowEmptyPgp bool, pgp []byte) (*Verifier, error) {
 	if len(pgp) == 0 && !allowEmptyPgp {
 		return nil, errors.New("expecting PGP but retrieved none", errors.TypeSecurity)
 	}


### PR DESCRIPTION
## What does this PR do?

Prior to this PR, the HTTP downloader's `progressReporter` would report download progress in Agent logs. This functionality was implemented entirely within the `progressReporter` code.

This PR refactors the `progressReporter` code to accept multiple observers and introduces a new observer, `loggingProgressObserver`, that logs the observed progress in Agent logs, preserving the behavior prior to this PR. 

## Why is it important?

This PR is purely a refactoring PR; it does not change any functionality.  Functionally, the HTTP downloader's progress will continue to be reported in Agent logs. 

However, in https://github.com/elastic/elastic-agent/pull/3527, we will need the `progressReporter` to also report progress to another observer.  This PR makes it easy to accomplish that in a clean manner.  More context here: https://github.com/elastic/elastic-agent/pull/3527#discussion_r1347016802

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates to https://github.com/elastic/elastic-agent/pull/3527#discussion_r1347016802
