### PR TITLE
Remove the agent version override in tests.

### DIFF
--- a/.buildkite/scripts/steps/integration_tests.sh
+++ b/.buildkite/scripts/steps/integration_tests.sh
@@ -5,8 +5,8 @@ source .buildkite/scripts/common.sh
 
 # Override the agent package version using a string with format <major>.<minor>.<patch>
 # NOTE: use only after version bump when the new version is not yet available, for example:
-# OVERRIDE_AGENT_PACKAGE_VERSION="8.10.3"
-OVERRIDE_AGENT_PACKAGE_VERSION="8.10.2"
+# OVERRIDE_AGENT_PACKAGE_VERSION="8.10.3" otherwise OVERRIDE_AGENT_PACKAGE_VERSION="".
+OVERRIDE_AGENT_PACKAGE_VERSION=""
 
 if [[ -n "$OVERRIDE_AGENT_PACKAGE_VERSION" ]]; then
   OVERRIDE_TEST_AGENT_VERSION=${OVERRIDE_AGENT_PACKAGE_VERSION}"-SNAPSHOT"

--- a/internal/pkg/agent/application/upgrade/artifact/download/snapshot/downloader.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/snapshot/downloader.go
@@ -88,6 +88,11 @@ func snapshotConfig(config *artifact.Config, versionOverride *agtversion.ParsedS
 }
 
 func snapshotURI(versionOverride *agtversion.ParsedSemVer, config *artifact.Config) (string, error) {
+	// Respect a non-default source URI even if the version is a snapshot.
+	if config.SourceURI != artifact.DefaultSourceURI {
+		return "", fmt.Errorf("skip snapshot download due to non-default sourceURI %s", config.SourceURI)
+	}
+
 	// snapshot downloader is used also by the 'localremote' impl in case of agent currently running off a snapshot build:
 	// the 'localremote' downloader does not pass a specific version, implying that we should update to the latest snapshot
 	// build of the same <major>.<minor>.<patch>-SNAPSHOT version

--- a/internal/pkg/agent/application/upgrade/artifact/download/snapshot/downloader.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/snapshot/downloader.go
@@ -90,7 +90,7 @@ func snapshotConfig(config *artifact.Config, versionOverride *agtversion.ParsedS
 func snapshotURI(versionOverride *agtversion.ParsedSemVer, config *artifact.Config) (string, error) {
 	// Respect a non-default source URI even if the version is a snapshot.
 	if config.SourceURI != artifact.DefaultSourceURI {
-		return "", fmt.Errorf("skip snapshot download due to non-default sourceURI %s", config.SourceURI)
+		return config.SourceURI, nil
 	}
 
 	// snapshot downloader is used also by the 'localremote' impl in case of agent currently running off a snapshot build:

--- a/internal/pkg/agent/application/upgrade/artifact/download/snapshot/downloader_test.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/snapshot/downloader_test.go
@@ -1,0 +1,27 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package snapshot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact"
+	"github.com/elastic/elastic-agent/pkg/version"
+)
+
+func TestNonDefaultSourceURI(t *testing.T) {
+	version, err := version.ParseVersion("8.12.0-SNAPSHOT")
+	require.NoError(t, err)
+
+	config := artifact.Config{
+		SourceURI: "localhost:1234",
+	}
+	sourceURI, err := snapshotURI(version, &config)
+	require.NoError(t, err)
+	require.Equal(t, config.SourceURI, sourceURI)
+
+}

--- a/pkg/testing/tools/artifacts_api.go
+++ b/pkg/testing/tools/artifacts_api.go
@@ -34,21 +34,20 @@ var (
 	ErrBadHTTPStatusCode = errors.New("bad http status code")
 )
 
+type Manifests struct {
+	LastUpdateTime         string `json:"last-update-time"`
+	SecondsSinceLastUpdate int    `json:"seconds-since-last-update"`
+}
+
 type VersionList struct {
-	Versions  []string `json:"versions"`
-	Aliases   []string `json:"aliases"`
-	Manifests struct {
-		LastUpdateTime         string `json:"last-update-time"`
-		SecondsSinceLastUpdate int    `json:"seconds-since-last-update"`
-	} `json:"manifests"`
+	Versions  []string  `json:"versions"`
+	Aliases   []string  `json:"aliases"`
+	Manifests Manifests `json:"manifests"`
 }
 
 type VersionBuilds struct {
-	Builds    []string `json:"builds"`
-	Manifests struct {
-		LastUpdateTime         string `json:"last-update-time"`
-		SecondsSinceLastUpdate int    `json:"seconds-since-last-update"`
-	} `json:"manifests"`
+	Builds    []string  `json:"builds"`
+	Manifests Manifests `json:"manifests"`
 }
 
 type Package struct {
@@ -99,18 +98,12 @@ type Build struct {
 
 type BuildDetails struct {
 	Build     Build
-	Manifests struct {
-		LastUpdateTime         string `json:"last-update-time"`
-		SecondsSinceLastUpdate int    `json:"seconds-since-last-update"`
-	} `json:"manifests"`
+	Manifests Manifests `json:"manifests"`
 }
 
 type SearchPackageResult struct {
 	Packages  map[string]Package `json:"packages"`
-	Manifests struct {
-		LastUpdateTime         string `json:"last-update-time"`
-		SecondsSinceLastUpdate int    `json:"seconds-since-last-update"`
-	} `json:"manifests"`
+	Manifests Manifests          `json:"manifests"`
 }
 
 type httpDoer interface {

--- a/testing/integration/upgrade_rollback_test.go
+++ b/testing/integration/upgrade_rollback_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
+	"github.com/elastic/elastic-agent/pkg/version"
 	"github.com/elastic/elastic-agent/testing/upgradetest"
 )
 
@@ -56,6 +57,11 @@ func TestStandaloneUpgradeRollback(t *testing.T) {
 
 	t.Logf("Testing Elastic Agent upgrade from %s to %s...", define.Version(), upgradeToVersion)
 
+	// We need to use the core version in the condition below because -SNAPSHOT is
+	// stripped from the ${agent.version.version} evaluation below.
+	parsedUpgradeToVersion, err := version.ParseVersion(upgradeToVersion)
+	require.NoError(t, err)
+
 	// Configure Agent with fast watcher configuration and also an invalid
 	// input when the Agent version matches the upgraded Agent version. This way
 	// the pre-upgrade version of the Agent runs healthy, but the post-upgrade
@@ -71,7 +77,7 @@ inputs:
   - condition: '${agent.version.version} == "%s"'
     type: invalid
     id: invalid-input
-`, upgradeToVersion)
+`, parsedUpgradeToVersion.CoreVersion())
 		return startFixture.Configure(ctx, []byte(invalidInputPolicy))
 	}
 

--- a/testing/upgradetest/versions.go
+++ b/testing/upgradetest/versions.go
@@ -89,19 +89,19 @@ func getUpgradableVersions(ctx context.Context, vList *tools.VersionList, upgrad
 			continue
 		}
 
-		isCurrentOrPrevMinor := (parsedUpgradeToVersion.Major() == parsedVersion.Major()) &&
-			(parsedUpgradeToVersion.Minor()-parsedVersion.Minor()) <= 1
+		isPrevMinor := (parsedUpgradeToVersion.Major() == parsedVersion.Major()) &&
+			(parsedUpgradeToVersion.Minor()-parsedVersion.Minor()) == 1
 
 		if parsedVersion.IsSnapshot() {
-			// Skip snapshot builds if the most recent version is released or this isn't the current
-			// or previous possibly unreleased minor version.
-			if !mostRecentIsUnreleased || !isCurrentOrPrevMinor {
+			// Allow returning the snapshot build of the previous minor if the current version is unreleased.
+			// In this situation the previous minor branch may also be unreleased immediately after feature freeze.
+			if !mostRecentIsUnreleased || !isPrevMinor {
 				continue
 			}
 		} else {
-			// Skip non-snapshot builds if the most recent is unrelesed and this version is the current or
-			// previous minor since they are not released yet.
-			if mostRecentIsUnreleased && isCurrentOrPrevMinor {
+			// Skip the non-snapshot build of the previous minor since it might only be available at
+			// staging.elastic.co which is not a default binary download location.
+			if mostRecentIsUnreleased && isPrevMinor {
 				continue
 			}
 		}

--- a/testing/upgradetest/versions.go
+++ b/testing/upgradetest/versions.go
@@ -42,6 +42,12 @@ func GetUpgradableVersions(ctx context.Context, upgradeToVersion string, current
 		return nil, errors.New("retrieved versions list from Artifact API is empty")
 	}
 
+	return getUpgradableVersions(ctx, vList, upgradeToVersion, currentMajorVersions, previousMajorVersions)
+}
+
+// Internal version of GetUpgradableVersions() with the artifacts API dependency removed for testing.
+func getUpgradableVersions(ctx context.Context, vList *tools.VersionList, upgradeToVersion string, currentMajorVersions int, previousMajorVersions int) ([]*version.ParsedSemVer, error) {
+	fmt.Println(vList)
 	parsedUpgradeToVersion, err := version.ParseVersion(upgradeToVersion)
 	if err != nil {
 		return nil, fmt.Errorf("upgradeToVersion %q is not a valid version string: %w", upgradeToVersion, err)

--- a/testing/upgradetest/versions.go
+++ b/testing/upgradetest/versions.go
@@ -93,7 +93,7 @@ func getUpgradableVersions(ctx context.Context, vList *tools.VersionList, upgrad
 			(parsedUpgradeToVersion.Minor()-parsedVersion.Minor()) <= 1
 
 		if parsedVersion.IsSnapshot() {
-			// Skip snapshot builds if the most recent version isn't unreleased and this isn't the current
+			// Skip snapshot builds if the most recent version is released or this isn't the current
 			// or previous possibly unreleased minor version.
 			if !mostRecentIsUnreleased || !isCurrentOrPrevMinor {
 				continue

--- a/testing/upgradetest/versions_test.go
+++ b/testing/upgradetest/versions_test.go
@@ -1,0 +1,85 @@
+package upgradetest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elastic/elastic-agent/pkg/testing/tools"
+	"github.com/elastic/elastic-agent/pkg/version"
+	"github.com/stretchr/testify/require"
+)
+
+// Response from https://artifacts-api.elastic.co/v1/versions shortly after the 8.11 feature freeze.
+var versionListAfter8_11FeatureFreeze = tools.VersionList{
+	Versions: []string{
+		"7.17.10",
+		"7.17.11",
+		"7.17.12",
+		"7.17.13",
+		"7.17.14-SNAPSHOT",
+		"7.17.14",
+		"8.7.1",
+		"8.8.0",
+		"8.8.1",
+		"8.8.2",
+		"8.9.0",
+		"8.9.1",
+		"8.9.2",
+		"8.10.0-SNAPSHOT",
+		"8.10.0",
+		"8.10.1-SNAPSHOT",
+		"8.10.1",
+		"8.10.2-SNAPSHOT",
+		"8.10.2",
+		"8.10.3-SNAPSHOT",
+		"8.10.3",
+		"8.11.0-SNAPSHOT",
+		"8.11.0",
+		"8.12.0-SNAPSHOT",
+	},
+	Aliases: []string{
+		"7.17-SNAPSHOT",
+		"7.17",
+		"8.7",
+		"8.8",
+		"8.9",
+		"8.10-SNAPSHOT",
+		"8.10",
+		"8.11-SNAPSHOT",
+		"8.11",
+		"8.12-SNAPSHOT",
+	},
+	Manifests: tools.Manifests{
+		LastUpdateTime:         "Tue, 10 Oct 2023 19:20:17 UTC",
+		SecondsSinceLastUpdate: 278,
+	},
+}
+
+// Tests that versiontest.PreviousMinor behaves correctly during the feature freeze period
+// where the both main and the previous minor release branch versions are unreleased.
+// Regression test for the problem described in https://github.com/elastic/elastic-agent/pull/3563#issuecomment-1756007790.
+func TestGetUpgradableVersionsAfterFeatureFreeze(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start from 8.12.0 assuming the 8.11.0 feature freeze has just happened.
+	// The 8.11.0 release is upgradable because the first 8.11.0 build candidate exists,
+	// but it is only available from staging.elastic.co which is not a binary download
+	// source that is supported by default.
+	currentVersion := "8.12.0"
+
+	// Since the 8.11.0 BC at staging.elastic.co isn't available to the agent by default,
+	// getUpgradableVersions should return 8.11.0-SNAPSHOT as the previous minor so an
+	// upgrade can proceed.
+	expectedPrevVersion := "8.11.0-SNAPSHOT"
+	expectedPrevParsed, err := version.ParseVersion(expectedPrevVersion)
+	require.NoError(t, err)
+
+	// Duplicate the logic from PreviousMinor where only the first version returned is inspected.
+	versions, err := getUpgradableVersions(ctx, &versionListAfter8_11FeatureFreeze, currentVersion, 1, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, versions)
+
+	prevMinor := versions[0]
+	require.Equal(t, expectedPrevParsed, prevMinor)
+}

--- a/testing/upgradetest/versions_test.go
+++ b/testing/upgradetest/versions_test.go
@@ -73,15 +73,14 @@ func TestGetUpgradableVersionsAfterFeatureFreeze(t *testing.T) {
 	currentVersion := "8.12.0"
 
 	// Since the 8.11.0 BC at staging.elastic.co isn't available to the agent by default,
-	// getUpgradableVersions should return 8.12.0-SNAPSHOT as the previous minor so an
-	// upgrade can proceed. It should also allow upgrading to 8.11.0-SNAPSHOT instead of
-	// 8.11.0.
+	// getUpgradableVersions should return 8.11.0-SNAPSHOT as the previous minor so an
+	// upgrade can proceed.
 	expectedUpgradableVersions := []string{
-		"8.12.0-SNAPSHOT", "8.11.0-SNAPSHOT", "8.10.3", "8.10.2", "7.17.14", "7.17.13",
+		"8.11.0-SNAPSHOT", "8.10.3", "8.10.2", "7.17.14", "7.17.13",
 	}
 
 	// Get several of the previous versions to ensure snapshot selection works correctly.
-	versions, err := getUpgradableVersions(ctx, &versionListAfter8_11FeatureFreeze, currentVersion, 4, 2)
+	versions, err := getUpgradableVersions(ctx, &versionListAfter8_11FeatureFreeze, currentVersion, 3, 2)
 	require.NoError(t, err)
 	require.NotEmpty(t, versions)
 

--- a/testing/upgradetest/versions_test.go
+++ b/testing/upgradetest/versions_test.go
@@ -1,11 +1,16 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package upgradetest
 
 import (
 	"context"
 	"testing"
 
-	"github.com/elastic/elastic-agent/pkg/testing/tools"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/pkg/testing/tools"
 )
 
 // Response from https://artifacts-api.elastic.co/v1/versions shortly after the 8.11 feature freeze.


### PR DESCRIPTION
We now have working 8.12.0, 8.11.0, and 8.10.3 snapshots.