### PR TITLE
[Hints Support] Add default host

### DIFF
--- a/changelog/fragments/1696935756-add-default-host.yaml
+++ b/changelog/fragments/1696935756-add-default-host.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Hints Autodiscovery for Elastic Agent - Add default host for each container in a pod
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/3575
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/1453

--- a/internal/pkg/composable/providers/kubernetes/hints.go
+++ b/internal/pkg/composable/providers/kubernetes/hints.go
@@ -26,6 +26,9 @@ const (
 	username    = "username"
 	password    = "password"
 	stream      = "stream" // this is the container stream: stdout/stderr
+
+	hints      = "hints"
+	processors = "processors"
 )
 
 type hintsBuilder struct {
@@ -250,83 +253,66 @@ func GenerateHintsMapping(hints mapstr.M, kubeMeta mapstr.M, logger *logp.Logger
 	return hintsMapping
 }
 
-// Generates the hints and processor mappings from provided pod annotation map
+// GetHintsMapping Generates the hints and processor mappings from provided pod annotation map
 func GetHintsMapping(k8sMapping map[string]interface{}, logger *logp.Logger, prefix string, cID string) hintsData {
 	hintData := hintsData{
 		composableMapping: mapstr.M{},
 		processors:        []mapstr.M{},
 	}
-	var hints mapstr.M
-	var containerProcessors []mapstr.M
 
-	if ann, ok := k8sMapping["annotations"]; ok {
-		annotations, _ := ann.(mapstr.M)
+	ann, ok := k8sMapping["annotations"]
+	if !ok {
+		return hintData
+	}
+	annotations, _ := ann.(mapstr.M)
 
-		if containerEntries, err := annotations.GetValue(prefix + ".hints"); err == nil {
-			entries, ok := containerEntries.(mapstr.M)
-			if ok && len(entries) > 0 {
-				for key := range entries {
-					parts := strings.Split(key, "/")
+	cName := ""
+	cHost := ""
+	// Get the name of the container from the metadata. We need it to extract the hints that affect it directly.
+	// E.g. co.elastic.hints.<container-name>/host: "..."
+	if con, ok := k8sMapping["container"]; ok {
+		containers, _ := con.(mapstr.M)
+		if name, err := containers.GetValue("name"); err == nil {
+			cName = name.(string)
+		}
+		if cPort, err := containers.GetValue("port"); err == nil {
+			// This is the default for the host value of a specific container.
+			cHost = "${kubernetes.pod.ip}:" + cPort.(string)
+		}
+	}
 
-					if len(parts) > 1 {
-						if con, ok := k8sMapping["container"]; ok {
-							containers, ok := con.(mapstr.M)
-							if ok {
-								if cname, err := containers.GetValue("name"); err == nil {
-									if parts[0] == cname {
-										// If there are hints like co.elastic.hints.<container_name>/ then add the values after the / to the corresponding container
-										// Eg Annotation "co.elastic.hints.nginx/stream: stderr" will create a hints entry for container nginx
-										hints, containerProcessors = GenerateHintsForContainer(annotations, parts[0], prefix)
-									}
-								}
-							}
-						}
-					}
-				}
+	hintsExtracted := utils.GenerateHints(annotations, cName, prefix)
+	if len(hintsExtracted) == 0 {
+		return hintData
+	}
+
+	// Check if host exists. Otherwise, add default entry for it.
+	if cHost != "" {
+		if hintsValues, ok := hintsExtracted[hints].(mapstr.M); ok {
+			if _, ok := hintsValues[host]; !ok {
+				hintsValues[host] = cHost
 			}
 		} else {
-			// If there are top level hints like co.elastic.hints/ then just add the values after the /
-			// Eg. Annotation "co.elastic.hints/stream: stderr" will will create a hints entries for all containers in the pod
-			hints = utils.GenerateHints(annotations, "", prefix)
-		}
-		logger.Debugf("Extracted hints are :%v", hints)
-
-		if len(hints) > 0 {
-			hintData = GenerateHintsResult(hints, k8sMapping, annotations, logger, prefix, cID)
-
-			// Only if there are processors defined in a specific container we append them to the processors of the top level
-			if len(containerProcessors) > 0 {
-				hintData.processors = append(hintData.processors, containerProcessors...)
+			hintsExtracted[hints] = mapstr.M{
+				host: cHost,
 			}
-			logger.Debugf("Generated Processors mapping :%v", hintData.processors)
 		}
 	}
 
-	return hintData
-}
+	logger.Debugf("Extracted hints are :%v", hintsExtracted)
 
-// Generates hints and processors list for specific containers
-func GenerateHintsForContainer(annotations mapstr.M, parts, prefix string) (mapstr.M, []mapstr.M) {
-	hints := utils.GenerateHints(annotations, parts, prefix)
-	// Processors for specific container
-	// We need to make an extra check if we have processors added only to the specific containers
-	containerProcessors := utils.GetConfigs(annotations, prefix, "hints."+parts+"/processors")
-
-	return hints, containerProcessors
-}
-
-// Generates the final hintData (hints and processors) struct that will be emitted in pods.
-func GenerateHintsResult(hints mapstr.M, k8sMapping map[string]interface{}, annotations mapstr.M, logger *logp.Logger, prefix, cID string) hintsData {
-	hintData := hintsData{
-		composableMapping: mapstr.M{},
-		processors:        []mapstr.M{},
-	}
-
-	hintData.composableMapping = GenerateHintsMapping(hints, k8sMapping, logger, cID)
+	hintData.composableMapping = GenerateHintsMapping(hintsExtracted, k8sMapping, logger, cID)
 	logger.Debugf("Generated hints mappings :%v", hintData.composableMapping)
 
-	// Eg  co.elastic.hints/processors.decode_json_fields.fields: "message" will add a processor in all containers of pod
-	hintData.processors = utils.GetConfigs(annotations, prefix, processorhints)
+	hintData.processors = utils.GetConfigs(annotations, prefix, hints+"/"+processors)
+	// We need to check the processors for the specific container, if they exist.
+	if cName != "" {
+		containerProcessors := utils.GetConfigs(annotations, prefix, hints+"."+cName+"/"+processors)
+		if len(containerProcessors) > 0 {
+			hintData.processors = append(hintData.processors, containerProcessors...)
+		}
+	}
+	logger.Debugf("Generated Processors mapping :%v", hintData.processors)
 
 	return hintData
 }

--- a/internal/pkg/composable/providers/kubernetes/hints.go
+++ b/internal/pkg/composable/providers/kubernetes/hints.go
@@ -275,11 +275,15 @@ func GetHintsMapping(k8sMapping map[string]interface{}, logger *logp.Logger, pre
 	if con, ok := k8sMapping["container"]; ok {
 		if containers, ok := con.(mapstr.M); ok {
 			if name, err := containers.GetValue("name"); err == nil {
-				cName = name.(string)
+				if nameString, ok := name.(string); ok {
+					cName = nameString
+				}
 			}
 			if cPort, err := containers.GetValue("port"); err == nil {
 				// This is the default for the host value of a specific container.
-				cHost = "${kubernetes.pod.ip}:" + cPort.(string)
+				if portString, ok := cPort.(string); ok {
+					cHost = "${kubernetes.pod.ip}:" + portString
+				}
 			}
 		}
 	}

--- a/internal/pkg/composable/providers/kubernetes/hints.go
+++ b/internal/pkg/composable/providers/kubernetes/hints.go
@@ -259,6 +259,8 @@ func GetHintsMapping(k8sMapping map[string]interface{}, logger *logp.Logger, pre
 		composableMapping: mapstr.M{},
 		processors:        []mapstr.M{},
 	}
+	cName := ""
+	cHost := ""
 
 	ann, ok := k8sMapping["annotations"]
 	if !ok {
@@ -266,8 +268,6 @@ func GetHintsMapping(k8sMapping map[string]interface{}, logger *logp.Logger, pre
 	}
 	annotations, _ := ann.(mapstr.M)
 
-	cName := ""
-	cHost := ""
 	// Get the name of the container from the metadata. We need it to extract the hints that affect it directly.
 	// E.g. co.elastic.hints.<container-name>/host: "..."
 	if con, ok := k8sMapping["container"]; ok {

--- a/internal/pkg/composable/providers/kubernetes/hints.go
+++ b/internal/pkg/composable/providers/kubernetes/hints.go
@@ -16,9 +16,10 @@ import (
 )
 
 const (
+	hints = "hints"
+
 	integration = "package"
 	datastreams = "data_streams"
-
 	host        = "host"
 	period      = "period"
 	timeout     = "timeout"
@@ -26,9 +27,7 @@ const (
 	username    = "username"
 	password    = "password"
 	stream      = "stream" // this is the container stream: stdout/stderr
-
-	hints      = "hints"
-	processors = "processors"
+	processors  = "processors"
 )
 
 type hintsBuilder struct {

--- a/internal/pkg/composable/providers/kubernetes/pod.go
+++ b/internal/pkg/composable/providers/kubernetes/pod.go
@@ -24,10 +24,6 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/composable"
 )
 
-const (
-	processorhints = "hints/processors"
-)
-
 type pod struct {
 	watcher           kubernetes.Watcher
 	nodeWatcher       kubernetes.Watcher


### PR DESCRIPTION
## What does this PR do?

Given a pod with containers, it adds `co.elastic.hints.<container-name>/host: '${kubernetes.pod.ip}:<container-port>'` to the annotations for each container.


## Why is it important?

The user no longer needs to specify the host for the hints, which until now was a mandatory step.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test


## How to test this PR locally

1. Clone this branch.
2. Follow the steps in the [README](https://github.com/elastic/elastic-agent/blob/main/README.md#testing-elastic-agent-on-kubernetes) file to create the EA and add it to Kubernetes.
3. Deploy a pod with at least one container and the required annotation `co.elastic.hints/package` and check if the results can be seen in ES.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/1453
- Relates to https://github.com/elastic/elastic-agent/issues/3063


## Results

**Context**: We have a nginx container with two pods: one in port 80, `nginx-1`, and another in port 81, `nginx-2`.

<details>
<summary>The manifest file for that would be something like this.</summary>

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: nginx
  annotations:
    co.elastic.hints/package: nginx
spec:
  volumes:
    - name: config
      configMap:
        name: nginx-conf
  containers:
    - name: nginx-1
      image: nginx
      ports:
        - containerPort: 80
    - name: nginx-2
      image: nginx
      ports:
        - containerPort: 81
      volumeMounts:
        - name: config
          mountPath: /etc/nginx/conf.d

```

</details>

#### Situation 1: Two pods and no annotation for host

If we have annotations only for the package:

```yaml
  annotations:
    co.elastic.hints/package: nginx
```

Then the defaults for the `host` will be used.

Inspecting the output of the inspect command (`elastic-agent inspect -v --variables --variables-wait 2s`) results in this:

```yaml
...
- data_stream.namespace: default
  id: <...>.nginx-1 <--------------------------- Our container nginx-1
  name: nginx/metrics-nginx
  ...
  streams:
    - data_stream:
        dataset: nginx.stubstatus
        type: metrics
      hosts:
        - 10.244.0.6:80 <---------------------------- Host of nginx-1
...
- data_stream.namespace: default
  id: <...>.nginx-2  <--------------------------- Our container nginx-2
  name: nginx/metrics-nginx
  ...
  streams:
    - data_stream:
        dataset: nginx.stubstatus
        type: metrics
      hosts:
        - 10.244.0.6:81 <---------------------------- Host of nginx-2
...
```

Checking the unique count of the containers has this output:
![Screenshot from 2023-10-09 17-28-36](https://github.com/elastic/elastic-agent/assets/113898685/da0e6fe3-a638-4b16-8f01-f0bbabbae5fb)


#### Situation 2: Two pods and only one host annotation for one pod

The annotations would be like this:

```yaml
  annotations:
    co.elastic.hints/package: nginx
    co.elastic.hints.nginx-1/host: '${kubernetes.pod.ip}:80'
```

The result is the same as situation 1, as the host for `nginx-2` will be the default (`'${kubernetes.pod.ip}:` + `port`).

#### Situation 3: Two pods and one top level annotation

The annotations would be like this:

```yaml
  annotations:
    co.elastic.hints/package: nginx
    co.elastic.hints/host: '${kubernetes.pod.ip}:82'
```

In this case, we are using a port that is not even possible (there is no nginx pod with port 82), to make sure the host works.

The output is the exact same as situation 1. The following happened in our code:

1. Checked the mappings for each container.
2. There was no default host defined for any of the containers.
3. Then add the default host for each container. 





