### PR TITLE
Increase the Windows OnFailureDelayDuration delay to 15s

### DIFF
--- a/changelog/fragments/1698259940-Increase-wait-period-between-service-restarts-on-failure-to-15s-on-Windows.yaml
+++ b/changelog/fragments/1698259940-Increase-wait-period-between-service-restarts-on-failure-to-15s-on-Windows.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Increase wait period between service restarts on failure to 15s on Windows.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: This is the same value used by endpoint-security.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1698259940-Increase-wait-period-between-service-restarts-on-failure-to-15s-on-Windows.yaml
+++ b/changelog/fragments/1698259940-Increase-wait-period-between-service-restarts-on-failure-to-15s-on-Windows.yaml
@@ -16,7 +16,7 @@ summary: Increase wait period between service restarts on failure to 15s on Wind
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
 # NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
-description: This is the same value used by endpoint-security.
+description: This is the same value used by other Elastic windows services like endpoint-security.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component: "elastic-agent"

--- a/internal/pkg/agent/install/svc.go
+++ b/internal/pkg/agent/install/svc.go
@@ -49,7 +49,7 @@ func newService(topPath string) (service.Service, error) {
 
 			// Windows setup restart on failure
 			"OnFailure":              "restart",
-			"OnFailureDelayDuration": "1s",
+			"OnFailureDelayDuration": "15s", // Matches the value used by endpoint-security.
 			"OnFailureResetPeriod":   10,
 		},
 	}


### PR DESCRIPTION
Increase the Windows `OnFailureDelayDuration` delay to 15s. This is the delay before the service is restarted when it exits unexpectedly. This is the same value used by endpoint-security by default.

Note that this change only applies to new agent installations. We would need to add code to migrate existing agent installations to the new value.

It was originally suggested that we increase this to 30s+ in https://github.com/elastic/elastic-agent/issues/3307#issuecomment-1696423487 but I am confident the root cause for that problem was addressed by https://github.com/elastic/elastic-agent-libs/pull/155.

Regardless I don't think our current default for this value was chosen for any particular reason and we can at least have agent behave consistently with endpoint. Speaking with @bjmcnic a 15s delay would also mitigate the original problem in all but the most extreme cases even if it were to still go unfixed.