### PR TITLE
Disable exposing metrics server on all interfaces

### DIFF
--- a/internal/pkg/agent/application/monitoring/server.go
+++ b/internal/pkg/agent/application/monitoring/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
+	monitoringCfg "github.com/elastic/elastic-agent/internal/pkg/core/monitoring/config"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
@@ -36,6 +37,10 @@ func NewServer(
 	if err := createAgentMonitoringDrop(endpointConfig.Host); err != nil {
 		// log but ignore
 		log.Warnf("failed to create monitoring drop: %v", err)
+	}
+
+	if endpointConfig.Host == "" {
+		endpointConfig.Host = monitoringCfg.DefaultHost
 	}
 
 	cfg, err := config.NewConfigFrom(endpointConfig)

--- a/internal/pkg/agent/application/monitoring/server.go
+++ b/internal/pkg/agent/application/monitoring/server.go
@@ -39,7 +39,7 @@ func NewServer(
 		log.Warnf("failed to create monitoring drop: %v", err)
 	}
 
-	if endpointConfig.Host == "" {
+	if strings.TrimSpace(endpointConfig.Host) == "" {
 		endpointConfig.Host = monitoringCfg.DefaultHost
 	}
 

--- a/internal/pkg/core/monitoring/config/config.go
+++ b/internal/pkg/core/monitoring/config/config.go
@@ -4,10 +4,19 @@
 
 package config
 
-import "time"
+import (
+	"time"
 
-const defaultPort = 6791
-const defaultNamespace = "default"
+	c "github.com/elastic/elastic-agent-libs/config"
+)
+
+const (
+	defaultPort      = 6791
+	defaultNamespace = "default"
+
+	// DefaultHost is used when host is not defined or empty
+	DefaultHost = "localhost"
+)
 
 // MonitoringConfig describes a configuration of a monitoring
 type MonitoringConfig struct {
@@ -33,6 +42,39 @@ type MonitoringHTTPConfig struct {
 	Buffer  *BufferConfig `yaml:"buffer" config:"buffer"`
 }
 
+// Unpack reads a config object into the settings.
+func (c *MonitoringHTTPConfig) Unpack(cfg *c.C) error {
+	// do not use MonitoringHTTPConfig, it will end up in a loop
+	tmp := struct {
+		Enabled bool          `yaml:"enabled" config:"enabled"`
+		Host    string        `yaml:"host" config:"host"`
+		Port    int           `yaml:"port" config:"port" validate:"min=0,max=65535,nonzero"`
+		Buffer  *BufferConfig `yaml:"buffer" config:"buffer"`
+	}{
+		Enabled: c.Enabled,
+		Host:    c.Host,
+		Port:    c.Port,
+		Buffer:  c.Buffer,
+	}
+
+	if err := cfg.Unpack(&tmp); err != nil {
+		return err
+	}
+
+	if tmp.Host == "" {
+		tmp.Host = DefaultHost
+	}
+
+	*c = MonitoringHTTPConfig{
+		Enabled: tmp.Enabled,
+		Host:    tmp.Host,
+		Port:    tmp.Port,
+		Buffer:  tmp.Buffer,
+	}
+
+	return nil
+}
+
 // PprofConfig is a struct for the pprof enablement flag.
 // It is a nil struct by default to allow the agent to use the a value that the user has injected into fleet.yml as the source of truth that is passed to beats
 // TODO get this value from Kibana?
@@ -55,7 +97,7 @@ func DefaultConfig() *MonitoringConfig {
 		MonitorTraces:  false,
 		HTTP: &MonitoringHTTPConfig{
 			Enabled: false,
-			Host:    "localhost",
+			Host:    DefaultHost,
 			Port:    defaultPort,
 		},
 		Namespace:   defaultNamespace,

--- a/internal/pkg/core/monitoring/config/config.go
+++ b/internal/pkg/core/monitoring/config/config.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"strings"
 	"time"
 
 	c "github.com/elastic/elastic-agent-libs/config"
@@ -61,7 +62,7 @@ func (c *MonitoringHTTPConfig) Unpack(cfg *c.C) error {
 		return err
 	}
 
-	if tmp.Host == "" {
+	if strings.TrimSpace(tmp.Host) == "" {
 		tmp.Host = DefaultHost
 	}
 

--- a/internal/pkg/core/monitoring/config/config_test.go
+++ b/internal/pkg/core/monitoring/config/config_test.go
@@ -13,6 +13,51 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/config"
 )
 
+func TestHost(t *testing.T) {
+	testCases := []struct {
+		name         string
+		config       string
+		expectedHost string
+	}{
+		{"no host", `enabled: true
+logs: true
+metrics: true
+http:
+  enabled: true`, defaultHost},
+		{"empty host", `enabled: true
+logs: true
+metrics: true
+http:
+  enabled: true
+  host: ""`, defaultHost},
+		{"default", `enabled: true
+logs: true
+metrics: true
+http:
+  enabled: true
+  host: localhost`, defaultHost},
+		{"custom host", `enabled: true
+logs: true
+metrics: true
+http:
+  enabled: true
+  host: custom`, "custom"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := config.NewConfigFrom(tc.config)
+			require.NoError(t, err, "failed to create config")
+
+			cfg := DefaultConfig()
+			c.Unpack(&cfg)
+			require.NoError(t, err, "failed to unpack config")
+
+			require.Equal(t, tc.expectedHost, cfg.HTTP.Host)
+		})
+	}
+}
+
 func TestAPMConfig(t *testing.T) {
 	tcs := map[string]struct {
 		in  map[string]interface{}

--- a/internal/pkg/core/monitoring/config/config_test.go
+++ b/internal/pkg/core/monitoring/config/config_test.go
@@ -23,19 +23,19 @@ func TestHost(t *testing.T) {
 logs: true
 metrics: true
 http:
-  enabled: true`, defaultHost},
+  enabled: true`, DefaultHost},
 		{"empty host", `enabled: true
 logs: true
 metrics: true
 http:
   enabled: true
-  host: ""`, defaultHost},
+  host: ""`, DefaultHost},
 		{"default", `enabled: true
 logs: true
 metrics: true
 http:
   enabled: true
-  host: localhost`, defaultHost},
+  host: localhost`, DefaultHost},
 		{"custom host", `enabled: true
 logs: true
 metrics: true

--- a/internal/pkg/core/monitoring/config/config_test.go
+++ b/internal/pkg/core/monitoring/config/config_test.go
@@ -50,7 +50,7 @@ http:
 			require.NoError(t, err, "failed to create config")
 
 			cfg := DefaultConfig()
-			c.Unpack(&cfg)
+			err = c.Unpack(&cfg)
 			require.NoError(t, err, "failed to unpack config")
 
 			require.Equal(t, tc.expectedHost, cfg.HTTP.Host)

--- a/internal/pkg/core/monitoring/config/config_test.go
+++ b/internal/pkg/core/monitoring/config/config_test.go
@@ -30,6 +30,12 @@ metrics: true
 http:
   enabled: true
   host: ""`, DefaultHost},
+		{"whitespace host", `enabled: true
+logs: true
+metrics: true
+http:
+  enabled: true
+  host: "   "`, DefaultHost},
 		{"default", `enabled: true
 logs: true
 metrics: true


### PR DESCRIPTION
## What does this PR do?

This PR disables option to configure agent in a way that it will expose monitoring agent on all interfaces. 
Empty value for `agent.monitoring.http.host` is now disabled and is replaced by localhost

Agents upgraded from <8.5 do have empty host due to change in defaults in 8.5. These agents are exposing metrics endpoint on all interfaces not on purpose.

Guard is implemented at the time of configuration unpacking and at the time of server creation to minimize future misbehavior with possible code changes 


Fixes: https://github.com/elastic/elastic-agent/issues/2509