### PR TITLE
Update endpoint package version on tests

### DIFF
--- a/testing/integration/endpoint_security_test.go
+++ b/testing/integration/endpoint_security_test.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	// TODO: Setup a GitHub Action to update this for each release of https://github.com/elastic/endpoint-package
-	endpointPackageVersion       = "8.9.0"
+	endpointPackageVersion       = "8.11.0"
 	endpointHealthPollingTimeout = 2 * time.Minute
 )
 

--- a/testing/integration/upgrade_fleet_test.go
+++ b/testing/integration/upgrade_fleet_test.go
@@ -142,7 +142,7 @@ func testUpgradeFleetManagedElasticAgent(ctx context.Context, t *testing.T, info
 
 	// wait for the watcher to show up
 	t.Logf("Waiting for upgrade watcher to start...")
-	err = upgradetest.WaitForWatcher(ctx, 2*time.Minute, 10*time.Second)
+	err = upgradetest.WaitForWatcher(ctx, 5*time.Minute, 10*time.Second)
 	require.NoError(t, err)
 	t.Logf("Upgrade watcher started")
 


### PR DESCRIPTION
## What does this PR do?

Update the endpoint package version for integration tests, some tests were failing because the old version was not found.

## Why is it important?

Fixes: https://github.com/elastic/elastic-agent/issues/3524, at least until newer versions are released.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
~~- [ ] I have added an integration test or an E2E test~~

~~## Author's Checklist~~
## How to test this PR locally
Run the integration tests: `mage integration:test`

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?

