### PR TITLE
Add generated protobuf code files to sonar exclusions list

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,10 @@ sonar.projectKey=elastic_elastic-agent_AYluowg0xMq8P7b4moiZ
 sonar.host.url=https://sonar.elastic.dev
 
 sonar.sources=.
-sonar.exclusions=**/*_test.go, .git/**, dev-tools/**, /magefile.go, changelog/**, _meta/**, deploy/**, docs/**, img/**, specs/**, pkg/testing/**, pkg/component/fake/**, testing/**, **/mocks/*.go
+sonar.exclusions=.git/**, dev-tools/**, /magefile.go, changelog/**, \
+  _meta/**, deploy/**, docs/**, img/**, specs/**, \
+  */*_test.go, pkg/testing/**, pkg/component/fake/**, testing/**, **/mocks/*.go, \
+  pkg/control/v1/proto/*.pb.go, pkg/control/v2/cproto/*.pb.go
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 


### PR DESCRIPTION
## What does this PR do?

This PR configures Sonar to exclude the code files generated by from code coverage analysis.

## Why is it important?

Generated code does not come with corresponding generated tests — that would be silly! As such, if Sonar sees _only_ changes to generated code, it will flag it as a decrease in code coverage which, while technically correct, is practically useless.
