### PR TITLE
[Buildkite][Integration tests] Change ESS region to `aws-eu-central-1`

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -10,7 +10,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-agent" && "$BUILDKITE_STEP_KEY" == 
 
   # Perform cleanup of integration tests resources
   echo "--- Cleaning up integration test resources"
-  TEST_INTEG_AUTH_ESS_REGION=aws-eu-central-1 SNAPSHOT=true mage integration:clean
+  TEST_INTEG_AUTH_ESS_REGION=us-east-1 SNAPSHOT=true mage integration:clean
 fi
 
 if [ -n "$GOOGLE_APPLICATION_CREDENTIALS" ]; then

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -10,7 +10,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-agent" && "$BUILDKITE_STEP_KEY" == 
 
   # Perform cleanup of integration tests resources
   echo "--- Cleaning up integration test resources"
-  TEST_INTEG_AUTH_ESS_REGION=azure-eastus2 SNAPSHOT=true mage integration:clean
+  TEST_INTEG_AUTH_ESS_REGION=aws-eu-central-1 SNAPSHOT=true mage integration:clean
 fi
 
 if [ -n "$GOOGLE_APPLICATION_CREDENTIALS" ]; then

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -138,6 +138,8 @@ steps:
 
   - label: "Serverless integration test"
     key: "serverless-integration-tests"
+    env:
+      TEST_INTEG_AUTH_ESS_REGION: aws-eu-central-1
     command: ".buildkite/scripts/steps/integration_tests.sh serverless integration:single TestMonitoringLogsShipped" #right now, run a single test in serverless mode as a sort of smoke test, instead of re-running the entire suite
     artifact_paths:
       - "build/TEST-**"
@@ -148,6 +150,8 @@ steps:
 
   - label: "Integration tests"
     key: "integration-tests"
+    env:
+      TEST_INTEG_AUTH_ESS_REGION: aws-eu-central-1
     command: ".buildkite/scripts/steps/integration_tests.sh stateful"
     artifact_paths:
       - "build/TEST-**"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -139,7 +139,7 @@ steps:
   - label: "Serverless integration test"
     key: "serverless-integration-tests"
     env:
-      TEST_INTEG_AUTH_ESS_REGION: aws-eu-central-1
+      TEST_INTEG_AUTH_ESS_REGION: us-east-1
     command: ".buildkite/scripts/steps/integration_tests.sh serverless integration:single TestMonitoringLogsShipped" #right now, run a single test in serverless mode as a sort of smoke test, instead of re-running the entire suite
     artifact_paths:
       - "build/TEST-**"
@@ -151,7 +151,7 @@ steps:
   - label: "Integration tests"
     key: "integration-tests"
     env:
-      TEST_INTEG_AUTH_ESS_REGION: aws-eu-central-1
+      TEST_INTEG_AUTH_ESS_REGION: us-east-1
     command: ".buildkite/scripts/steps/integration_tests.sh stateful"
     artifact_paths:
       - "build/TEST-**"

--- a/magefile.go
+++ b/magefile.go
@@ -1755,7 +1755,9 @@ func createTestRunner(matrix bool, singleTest string, goTestFlags string, batche
 		datacenter = "us-central1-a"
 	}
 
-	// Valid values are gcp-us-central1 (default), azure-eastus2
+	// Valid values are gcp-us-central1 (default), azure-eastus2,
+	// aws-eu-central-1, us-east-1 (which is an AWS region but the
+	// "aws" CSP prefix is not used by ESS for some reason!)
 	essRegion := os.Getenv("TEST_INTEG_AUTH_ESS_REGION")
 	if essRegion == "" {
 		essRegion = "gcp-us-central1"

--- a/pkg/testing/ess/deployment.go
+++ b/pkg/testing/ess/deployment.go
@@ -321,12 +321,19 @@ var createDeploymentRequestTemplate string
 var cloudProviderSpecificValues []byte
 
 func generateCreateDeploymentRequestBody(req CreateDeploymentRequest) ([]byte, error) {
-	regionParts := strings.Split(req.Region, "-")
-	if len(regionParts) < 2 {
-		return nil, fmt.Errorf("unable to parse CSP out of region [%s]", req.Region)
-	}
+	var csp string
+	// Special case: AWS us-east-1 region is just called
+	// us-east-1 (instead of aws-us-east-1)!
+	if req.Region == "us-east-1" {
+		csp = "aws"
+	} else {
+		regionParts := strings.Split(req.Region, "-")
+		if len(regionParts) < 2 {
+			return nil, fmt.Errorf("unable to parse CSP out of region [%s]", req.Region)
+		}
 
-	csp := regionParts[0]
+		csp = regionParts[0]
+	}
 	templateContext, err := createDeploymentTemplateContext(csp, req)
 	if err != nil {
 		return nil, fmt.Errorf("creating request template context: %w", err)


### PR DESCRIPTION
## What does this PR do?

This PR changes the ESS region used by integration tests, when run in Buildkite, to `aws-eu-central-1`. 

## Why is it important?

This is the only region that's working at the moment.  In other regions, we're experiencing a Kibana failure, which is not only causing integration tests to fail because the deployment cannot come up but it's also leaving these broken deployments orphaned which costs money!
