### PR TITLE
prevent data race in testing artifact fetcher

### DIFF
--- a/pkg/testing/fetcher_artifact.go
+++ b/pkg/testing/fetcher_artifact.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -256,7 +257,7 @@ func DownloadPackage(ctx context.Context, l Logger, doer httpDoer, downloadPath 
 type writeProgress struct {
 	logger    Logger
 	total     uint64
-	completed uint64
+	completed atomic.Uint64
 }
 
 func newWriteProgress(ctx context.Context, l Logger, total uint64) *writeProgress {
@@ -270,7 +271,7 @@ func newWriteProgress(ctx context.Context, l Logger, total uint64) *writeProgres
 
 func (wp *writeProgress) Write(p []byte) (int, error) {
 	n := len(p)
-	wp.completed += uint64(n)
+	wp.completed.Add(uint64(n))
 	return n, nil
 }
 
@@ -282,7 +283,7 @@ func (wp *writeProgress) printProgress(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			wp.logger.Logf("Downloading artifact progress %.2f%%", float64(wp.completed)/float64(wp.total)*100.0)
+			wp.logger.Logf("Downloading artifact progress %.2f%%", float64(wp.completed.Load())/float64(wp.total)*100.0)
 		}
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Switch from `uint64` to an `atomic.Uint64` to prevent data race in testing artifact fetcher

## Why is it important?

In CI we can see the data race:

```
==================
WARNING: DATA RACE
Read at 0x00c0002dbc18 by goroutine 11:
  github.com/elastic/elastic-agent/pkg/testing.(*writeProgress).printProgress()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/src/github.com/elastic/elastic-agent/pkg/testing/fetcher_artifact.go:285 +0x158
  github.com/elastic/elastic-agent/pkg/testing.newWriteProgress.func1()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/src/github.com/elastic/elastic-agent/pkg/testing/fetcher_artifact.go:267 +0x4c

Previous write at 0x00c0002dbc18 by goroutine 9:
  github.com/elastic/elastic-agent/pkg/testing.(*writeProgress).Write()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/src/github.com/elastic/elastic-agent/pkg/testing/fetcher_artifact.go:273 +0x50
  io.(*teeReader).Read()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/.gvm/versions/go1.20.10.linux.arm64/src/io/io.go:615 +0xac
  io.copyBuffer()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/.gvm/versions/go1.20.10.linux.arm64/src/io/io.go:427 +0x1ec
  io.Copy()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/.gvm/versions/go1.20.10.linux.arm64/src/io/io.go:386 +0x74
  os.genericReadFrom()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/.gvm/versions/go1.20.10.linux.arm64/src/os/file.go:161 +0x2c
  os.(*File).ReadFrom()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/.gvm/versions/go1.20.10.linux.arm64/src/os/file.go:155 +0x2b0
  io.copyBuffer()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/.gvm/versions/go1.20.10.linux.arm64/src/io/io.go:413 +0x154
  io.Copy()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/.gvm/versions/go1.20.10.linux.arm64/src/io/io.go:386 +0x398
  github.com/elastic/elastic-agent/pkg/testing.DownloadPackage()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/src/github.com/elastic/elastic-agent/pkg/testing/fetcher_artifact.go:243 +0x320
  github.com/elastic/elastic-agent/pkg/testing.(*artifactResult).Fetch()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/src/github.com/elastic/elastic-agent/pkg/testing/fetcher_artifact.go:110 +0x284
  github.com/elastic/elastic-agent/pkg/testing.TestArtifactFetcher_SnapshotOnly()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/src/github.com/elastic/elastic-agent/pkg/testing/fetcher_artifact_test.go:95 +0xa10
  testing.tRunner()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/.gvm/versions/go1.20.10.linux.arm64/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/.gvm/versions/go1.20.10.linux.arm64/src/testing/testing.go:1629 +0x40

Goroutine 11 (running) created at:
  github.com/elastic/elastic-agent/pkg/testing.newWriteProgress()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/src/github.com/elastic/elastic-agent/pkg/testing/fetcher_artifact.go:267 +0x168
  github.com/elastic/elastic-agent/pkg/testing.DownloadPackage()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/src/github.com/elastic/elastic-agent/pkg/testing/fetcher_artifact.go:237 +0x268
  github.com/elastic/elastic-agent/pkg/testing.(*artifactResult).Fetch()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/src/github.com/elastic/elastic-agent/pkg/testing/fetcher_artifact.go:110 +0x284
  github.com/elastic/elastic-agent/pkg/testing.TestArtifactFetcher_SnapshotOnly()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/src/github.com/elastic/elastic-agent/pkg/testing/fetcher_artifact_test.go:95 +0xa10
  testing.tRunner()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/.gvm/versions/go1.20.10.linux.arm64/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/.gvm/versions/go1.20.10.linux.arm64/src/testing/testing.go:1629 +0x40

Goroutine 9 (running) created at:
  testing.(*T).Run()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/.gvm/versions/go1.20.10.linux.arm64/src/testing/testing.go:1629 +0x5b4
  testing.runTests.func1()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/.gvm/versions/go1.20.10.linux.arm64/src/testing/testing.go:2036 +0x80
  testing.tRunner()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/.gvm/versions/go1.20.10.linux.arm64/src/testing/testing.go:1576 +0x180
  testing.runTests()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/.gvm/versions/go1.20.10.linux.arm64/src/testing/testing.go:2034 +0x6a8
  testing.(*M).Run()
      /var/lib/jenkins/workspace/tic-agent_elastic-agent-mbp_8.11/.gvm/versions/go1.20.10.linux.arm64/src/testing/testing.go:1906 +0x8e0
  main.main()
      _testmain.go:59 +0x2b8
==================
```

## Checklist


- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Author's Checklist


## How to test this PR locally

```
go test -v -race ./pkg/testing -run TestArtifactFetcher_SnapshotOnly -count 10000
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
