### PR TITLE
Clean up Agent Coordinator and manager shutdown logic

### DIFF
--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -1218,7 +1218,7 @@ func (c *Coordinator) filterByCapabilities(comps []component.Component) []compon
 
 // collectManagerErrors listens on the shutdown channels for the
 // runtime, config, and vars managers, and waits for up to
-// CoordinationShutdownTimeout for them to report their final status.
+// the specified timeout for them to report their final status.
 // It returns any resulting errors as a multierror, or nil if no errors
 // were reported.
 // Called on the main Coordinator goroutine.

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -157,8 +158,9 @@ type VarsManager interface {
 // passing it into the components runtime manager.
 type ComponentsModifier func(comps []component.Component, cfg map[string]interface{}) ([]component.Component, error)
 
-// CoordinatorShutdownTimeout is how long the coordinator will wait during shutdown to receive a "clean" shutdown from other components
-var CoordinatorShutdownTimeout = time.Second * 5
+// managerShutdownTimeout is how long the coordinator will wait during shutdown
+// to receive termination states from its managers.
+const managerShutdownTimeout = time.Second * 5
 
 type configReloader interface {
 	Reload(*config.Config) error
@@ -615,45 +617,45 @@ func (c *Coordinator) watchRuntimeComponents(ctx context.Context) {
 //
 // The RuntimeManager, ConfigManager and VarsManager that is passed into NewCoordinator are also ran and lifecycle controlled by the Run.
 //
-// In the case that either of the above managers fail, they will all be restarted unless the context was explicitly cancelled or timed out.
+// If any of the three managers fail, the Coordinator will shut down and
+// Run will return an error.
 func (c *Coordinator) Run(ctx context.Context) error {
 	// log all changes in the state of the runtime and update the coordinator state
 	watchCtx, watchCanceller := context.WithCancel(ctx)
 	defer watchCanceller()
+	go c.watchRuntimeComponents(watchCtx)
+
 	// Close the state broadcaster on finish, but leave it running in the
 	// background until all subscribers have read the final values or their
 	// context ends, so test listeners and such can collect Coordinator's
 	// shutdown state.
 	defer close(c.stateBroadcaster.InputChan)
 
-	go c.watchRuntimeComponents(watchCtx)
+	// The usual state refresh happens in the main run loop in Coordinator.runner,
+	// so before/after the runner call we need to trigger state change broadcasts
+	// manually with refreshState.
+	c.setCoordinatorState(agentclient.Starting, "Waiting for initial configuration and composable variables")
+	c.refreshState()
 
-	for {
-		c.setCoordinatorState(agentclient.Starting, "Waiting for initial configuration and composable variables")
-		// The usual state refresh happens in the main run loop in Coordinator.runner,
-		// so before/after the runner call we need to trigger state change broadcasts
-		// manually.
-		c.refreshState()
-		err := c.runner(ctx)
+	err := c.runner(ctx)
+
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		c.setCoordinatorState(agentclient.Stopped, "Requested to be stopped")
+		c.setFleetState(agentclient.Stopped, "Requested to be stopped")
+	} else {
+		// runner should always return a non-nil error, but if it doesn't,
+		// report it.
+		message := "Coordinator terminated with unknown error (runner returned nil)"
 		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				c.setCoordinatorState(agentclient.Stopped, "Requested to be stopped")
-				c.setFleetState(agentclient.Stopped, "Requested to be stopped")
-				c.refreshState()
-				// do not restart
-				return err
-			}
-			if errors.Is(err, ErrFatalCoordinator) {
-				c.setCoordinatorState(agentclient.Failed, "Fatal coordinator error")
-				c.setFleetState(agentclient.Stopped, "Fatal coordinator error")
-				c.refreshState()
-				return err
-			}
+			message = fmt.Sprintf("Fatal coordinator error: %v", err.Error())
 		}
-		c.setCoordinatorState(agentclient.Failed, fmt.Sprintf("Coordinator failed and will be restarted: %s", err))
-		c.refreshState()
-		c.logger.Errorf("coordinator failed and will be restarted: %s", err)
+		c.setCoordinatorState(agentclient.Failed, message)
+		c.setFleetState(agentclient.Stopped, message)
 	}
+	// Broadcast the final state in case anyone is still listening
+	c.refreshState()
+
+	return err
 }
 
 // DiagnosticHooks returns diagnostic hooks that can be connected to the control server to provide diagnostic
@@ -877,7 +879,15 @@ func (c *Coordinator) runner(ctx context.Context) error {
 	for ctx.Err() == nil {
 		c.runLoopIteration(ctx)
 	}
-	return c.handleCoordinatorDone(ctx, varsErrCh, runtimeErrCh, configErrCh)
+
+	// If we got fatal errors from any of the managers, return them.
+	// Otherwise, just return the context's closing error.
+	err := collectManagerErrors(managerShutdownTimeout, varsErrCh, runtimeErrCh, configErrCh)
+	if err != nil {
+		c.logger.Debugf("Manager errors on Coordinator shutdown: %v", err.Error())
+		return err
+	}
+	return ctx.Err()
 }
 
 // runLoopIteration runs one iteration of the Coorinator's internal run
@@ -1207,27 +1217,34 @@ func (c *Coordinator) filterByCapabilities(comps []component.Component) []compon
 	return result
 }
 
-// handleCoordinatorDone is called when the Coordinator's context is
-// finished. It waits for the runtime, config, and vars managers to finish,
-// and collects their return values into an error if any of them returned
-// for a reason other than context.Canceled.
+// collectManagerErrors listens on the shutdown channels for the
+// runtime, config, and vars managers, and waits for up to
+// CoordinationShutdownTimeout for them to report their final status.
+// It returns any resulting errors as a multierror, or nil if no errors
+// were reported.
 // Called on the main Coordinator goroutine.
-func (c *Coordinator) handleCoordinatorDone(ctx context.Context, varsErrCh, runtimeErrCh, configErrCh chan error) error {
+func collectManagerErrors(timeout time.Duration, varsErrCh, runtimeErrCh, configErrCh chan error) error {
 	var runtimeErr error
 	var configErr error
 	var varsErr error
 	// in case other components are locked up, let us time out
-	timeoutWait := time.NewTimer(CoordinatorShutdownTimeout)
+	timeoutWait := time.NewTimer(timeout)
 	defer timeoutWait.Stop()
 	var returnedRuntime, returnedConfig, returnedVars bool
 	/*
-		Wait for all subcomponents to gently shut down.
+		Wait for all managers to gently shut down. All managers send
+		an error status on their termination channel after their Run method
+		returns.
 		Logic:
-		If all three subcomponent channels return an error, or close,
-		Assume shutdown is complete.
-		If there's a non-nil error, return it as an ErrFatalCoordinator,
-		If there's no errors from the channels, pass on the underlying context error
+		If all three manager channels return a value, or close, we're done.
+		If any errors are non-nil (and not just context.Canceled), collect and
+		return them with multierror.
+		Otherwise, return nil.
 	*/
+
+	// combinedErr will store any reported errors as well as timeout errors
+	// for unresponsive managers.
+	var combinedErr error
 
 waitLoop:
 	for !returnedRuntime || !returnedConfig || !returnedVars {
@@ -1241,37 +1258,29 @@ waitLoop:
 		case <-timeoutWait.C:
 			var timeouts []string
 			if !returnedRuntime {
-				timeouts = []string{"no response from runtime component"}
+				timeouts = []string{"no response from runtime manager"}
 			}
 			if !returnedConfig {
-				timeouts = append(timeouts, "no response from configWatcher component")
+				timeouts = append(timeouts, "no response from config manager")
 			}
 			if !returnedVars {
-				timeouts = append(timeouts, "no response from varsWatcher component")
+				timeouts = append(timeouts, "no response from vars manager")
 			}
-			c.logger.Debugf("timeout while waiting for other components to shut down: %v", timeouts)
+			timeoutStr := strings.Join(timeouts, ", ")
+			combinedErr = multierror.Append(combinedErr, fmt.Errorf("timeout while waiting for managers to shut down: %v", timeoutStr))
 			break waitLoop
 		}
 	}
-	// try not to lose any errors
-	var combinedErr error
 	if runtimeErr != nil && !errors.Is(runtimeErr, context.Canceled) {
-		c.logger.Debugf("runtime component shut down with error: %s", runtimeErr)
-		combinedErr = multierror.Append(combinedErr, fmt.Errorf("runtime Manager: %w", runtimeErr))
+		combinedErr = multierror.Append(combinedErr, fmt.Errorf("runtime manager: %w", runtimeErr))
 	}
 	if configErr != nil && !errors.Is(configErr, context.Canceled) {
-		c.logger.Debugf("config manager shut down with error: %s", configErr)
-		combinedErr = multierror.Append(combinedErr, fmt.Errorf("config Manager: %w", configErr))
+		combinedErr = multierror.Append(combinedErr, fmt.Errorf("config manager: %w", configErr))
 	}
 	if varsErr != nil && !errors.Is(varsErr, context.Canceled) {
-		c.logger.Debugf("varsWatcher shut down with error: %s", varsErr)
-		combinedErr = multierror.Append(combinedErr, fmt.Errorf("vars Watcher: %w", varsErr))
+		combinedErr = multierror.Append(combinedErr, fmt.Errorf("vars manager: %w", varsErr))
 	}
-	if combinedErr != nil {
-		return fmt.Errorf("%w: %s", ErrFatalCoordinator, combinedErr.Error()) //nolint:errorlint //errors.Is() won't work if we pass through the combined errors with %w
-	}
-	// if there's no component errors, continue to pass along the context error
-	return ctx.Err()
+	return combinedErr
 }
 
 type coordinatorComponentLog struct {

--- a/internal/pkg/agent/application/coordinator/coordinator_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_test.go
@@ -331,7 +331,7 @@ func TestCollectManagerErrorsTimeout(t *testing.T) {
 	}, handlerChan)
 }
 
-func TestCoordinatorShutdownErrorOneResponse(t *testing.T) {
+func TestCollectManagerErrorsOneResponse(t *testing.T) {
 	handlerChan, _, _, config := setupManagerShutdownChannels(10 * time.Millisecond)
 
 	// Send an error for the config manager -- we should also get a
@@ -347,7 +347,7 @@ func TestCoordinatorShutdownErrorOneResponse(t *testing.T) {
 	}, handlerChan)
 }
 
-func TestCoordinatorShutdownErrorAllResponses(t *testing.T) {
+func TestCollectManagerErrorsAllResponses(t *testing.T) {
 	handlerChan, runtime, varWatcher, config := setupManagerShutdownChannels(5 * time.Second)
 	runtimeErrStr := "runtime error"
 	varsErrStr := "vars error"
@@ -383,7 +383,7 @@ func waitAndTestError(t *testing.T, check func(error) bool, handlerErr chan erro
 	for {
 		select {
 		case <-waitCtx.Done():
-			t.Fatalf("handleCoordinatorDone timed out while waiting for shutdown")
+			t.Fatalf("timed out while waiting for response from collectManagerErrors")
 		case gotErr := <-handlerErr:
 			if handlerErr != nil {
 				if check(gotErr) {

--- a/internal/pkg/agent/application/coordinator/coordinator_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_test.go
@@ -320,25 +320,35 @@ func TestCoordinator_StateSubscribe(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestCoordinatorShutdownTimeout(t *testing.T) {
-	CoordinatorShutdownTimeout = time.Millisecond
-	handlerChan, _, _, _ := setupAndWaitCoordinatorDone()
-	waitAndTestError(t, func(err error) bool { return errors.Is(err, context.Canceled) }, handlerChan)
+func TestCollectManagerErrorsTimeout(t *testing.T) {
+	handlerChan, _, _, _ := setupManagerShutdownChannels(time.Millisecond)
+	// Don't send anything to the shutdown channels, causing a timeout
+	// in collectManagerErrors
+	waitAndTestError(t, func(err error) bool {
+		return err != nil &&
+			strings.Contains(err.Error(), "1 error occurred") &&
+			strings.Contains(err.Error(), "timeout while waiting for managers")
+	}, handlerChan)
 }
 
 func TestCoordinatorShutdownErrorOneResponse(t *testing.T) {
-	CoordinatorShutdownTimeout = 10 * time.Millisecond
-	handlerChan, _, _, config := setupAndWaitCoordinatorDone()
+	handlerChan, _, _, config := setupManagerShutdownChannels(10 * time.Millisecond)
 
+	// Send an error for the config manager -- we should also get a
+	// timeout error since we don't send anything on the other two channels.
 	cfgErrStr := "config watcher error"
 	config <- errors.New(cfgErrStr)
 
-	waitAndTestError(t, func(err error) bool { return strings.Contains(err.Error(), cfgErrStr) }, handlerChan)
+	waitAndTestError(t, func(err error) bool {
+		return err != nil &&
+			strings.Contains(err.Error(), "2 errors occurred") &&
+			strings.Contains(err.Error(), cfgErrStr) &&
+			strings.Contains(err.Error(), "timeout while waiting for managers")
+	}, handlerChan)
 }
 
 func TestCoordinatorShutdownErrorAllResponses(t *testing.T) {
-	CoordinatorShutdownTimeout = 5 * time.Second
-	handlerChan, runtime, varWatcher, config := setupAndWaitCoordinatorDone()
+	handlerChan, runtime, varWatcher, config := setupManagerShutdownChannels(5 * time.Second)
 	runtimeErrStr := "runtime error"
 	varsErrStr := "vars error"
 	runtime <- errors.New(runtimeErrStr)
@@ -346,20 +356,24 @@ func TestCoordinatorShutdownErrorAllResponses(t *testing.T) {
 	config <- nil
 
 	waitAndTestError(t, func(err error) bool {
-		return strings.Contains(err.Error(), runtimeErrStr) &&
+		return err != nil &&
+			strings.Contains(err.Error(), "2 errors occurred") &&
+			strings.Contains(err.Error(), runtimeErrStr) &&
 			strings.Contains(err.Error(), varsErrStr)
 	}, handlerChan)
 }
 
-func TestCoordinatorShutdownAllResponsesNoErrors(t *testing.T) {
-	CoordinatorShutdownTimeout = 5 * time.Second
-	handlerChan, runtime, varWatcher, config := setupAndWaitCoordinatorDone()
+func TestCollectManagerErrorsAllResponsesNoErrors(t *testing.T) {
+	handlerChan, runtime, varWatcher, config := setupManagerShutdownChannels(5 * time.Second)
 	runtime <- nil
 	varWatcher <- nil
-	config <- nil
+	config <- context.Canceled
+
+	// All errors are nil or context.Canceled, so collectManagerErrors
+	// should also return nil.
 
 	waitAndTestError(t, func(err error) bool {
-		return errors.Is(err, context.Canceled)
+		return err == nil
 	}, handlerChan)
 }
 
@@ -383,20 +397,14 @@ func waitAndTestError(t *testing.T, check func(error) bool, handlerErr chan erro
 	}
 }
 
-func setupAndWaitCoordinatorDone() (chan error, chan error, chan error, chan error) {
+func setupManagerShutdownChannels(timeout time.Duration) (chan error, chan error, chan error, chan error) {
 	runtime := make(chan error)
 	varWatcher := make(chan error)
 	config := make(chan error)
 
-	testCord := Coordinator{logger: logp.L()}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	// emulate shutdown
-	cancel()
-
 	handlerChan := make(chan error)
 	go func() {
-		handlerErr := testCord.handleCoordinatorDone(ctx, varWatcher, runtime, config)
+		handlerErr := collectManagerErrors(timeout, varWatcher, runtime, config)
 		handlerChan <- handlerErr
 	}()
 


### PR DESCRIPTION
Clean up `Coordinator` shutdown handling and fix the no-op retry loop described in https://github.com/elastic/elastic-agent/issues/2789.

The previous retry logic in `(*Coordinator).Run` never took effect: the only possible error return was considered fatal, and so there was never an actual retry. This returned error (`ErrFatalCoordinator`) was a placeholder returned in part out of caution, since accidentally retrying a fatal error could deadlock the Agent.

Following discussion in https://github.com/elastic/elastic-agent/issues/2789, the new model is:
- All errors that cause a Manager's Run routine to terminate are considered fatal
- Managers should send non-fatal errors to the manager's existing error channel instead of returning

(This is already how managers work in practice.)

This PR:
- Removes the retry loop in `(*Coordinator).Run` and instead explicitly passes on error results returned by `runner`
- Removes the `ErrFatalCoordinator` placeholder error and instead reports any Manager failures directly
- Renames `(*Coordinator).handleCoordinatorDone` to a standalone function `collectManagerErrors` to better reflect its behavior, and makes its timeout a parameter so tests don't need to mess with a shared global variable
- Reports manager shutdown timeouts as explicit errors

This is cleanup only. There should be no functional change from this PR except that some shutdown errors give more precise messages.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/2789
