### PR TITLE
[Upgrade Details] When state is set to something other than `StateFailed`, clear related metadata fields

### DIFF
--- a/internal/pkg/agent/application/upgrade/details/details.go
+++ b/internal/pkg/agent/application/upgrade/details/details.go
@@ -67,6 +67,15 @@ func (d *Details) SetState(s State) {
 	defer d.mu.Unlock()
 
 	d.State = s
+
+	// If State is something other than StateFailed, make sure to clear
+	// Metadata.FailedState and Metadata.ErrorMsg as those two fields
+	// should be set when State is set to StateFailed. See the Fail method.
+	if s != StateFailed {
+		d.Metadata.ErrorMsg = ""
+		d.Metadata.FailedState = ""
+	}
+
 	d.notifyObservers()
 }
 

--- a/internal/pkg/agent/application/upgrade/details/details_test.go
+++ b/internal/pkg/agent/application/upgrade/details/details_test.go
@@ -38,6 +38,12 @@ func TestDetailsFail(t *testing.T) {
 	require.Equal(t, StateFailed, det.State)
 	require.Equal(t, StateRequested, det.Metadata.FailedState)
 	require.Equal(t, err.Error(), det.Metadata.ErrorMsg)
+
+	// Check that resetting state to something other than StateFailed
+	// clears Metadata.FailedState and Metadata.ErrorMsg
+	det.SetState(StateDownloading)
+	require.Equal(t, State(""), det.Metadata.FailedState)
+	require.Equal(t, "", det.Metadata.ErrorMsg)
 }
 
 func TestDetailsObserver(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

This PR fixes the Upgrade Details struct such that setting its `State` field to anything other than `StateFailed` clears associated fields, `Metadata.FailedState` and `Metadata.ErrorMsg`.

## Why is it important?

The `Metadata.FailedState` and `Metadata.ErrorMsg` should only be set when `State` is set to `StateFailed`. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~
