### PR TITLE
multipass: ensure instance does not exist

### DIFF
--- a/pkg/testing/multipass/provisioner.go
+++ b/pkg/testing/multipass/provisioner.go
@@ -7,6 +7,7 @@ package multipass
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -122,6 +123,12 @@ func (p *provisioner) Clean(ctx context.Context, _ runner.Config, instances []ru
 
 // launch creates an instance.
 func (p *provisioner) launch(ctx context.Context, cfg runner.Config, batch runner.OSBatch) error {
+	// check if instance already exists
+	err := p.ensureInstanceNotExist(ctx, batch)
+	if err != nil {
+		p.logger.Logf(
+			"could not check multipass instance %q does not exists, moving on anyway. Err: %v", err)
+	}
 	args := []string{
 		"launch",
 		"-c", "2",
@@ -145,9 +152,14 @@ func (p *provisioner) launch(ctx context.Context, cfg runner.Config, batch runne
 		return fmt.Errorf("failed to marshal cloud-init configuration: %w", err)
 	}
 
+	p.logger.Logf("Launching multipass instance %s", batch.ID)
 	var output bytes.Buffer
-	p.logger.Logf("Launching multipass image %s", batch.ID)
-	proc, err := process.Start("multipass", process.WithContext(ctx), process.WithArgs(args), process.WithCmdOptions(runner.AttachOut(&output), runner.AttachErr(&output)))
+	proc, err := process.Start("multipass",
+		process.WithContext(ctx),
+		process.WithArgs(args),
+		process.WithCmdOptions(
+			runner.AttachOut(&output),
+			runner.AttachErr(&output)))
 	if err != nil {
 		return fmt.Errorf("failed to run multipass launch: %w", err)
 	}
@@ -167,6 +179,56 @@ func (p *provisioner) launch(ctx context.Context, cfg runner.Config, batch runne
 		fmt.Fprintf(os.Stdout, "%s\n", output.Bytes())
 		return fmt.Errorf("failed to run multipass launch: exited with code: %d", ps.ExitCode())
 	}
+	return nil
+}
+
+func (p *provisioner) ensureInstanceNotExist(ctx context.Context, batch runner.OSBatch) error {
+	var output bytes.Buffer
+	proc, err := process.Start("multipass",
+		process.WithContext(ctx),
+		process.WithArgs([]string{"list", "--format", "json"}),
+		process.WithCmdOptions(
+			runner.AttachOut(&output),
+			runner.AttachErr(&output)))
+	if err != nil {
+		return fmt.Errorf("multipass list failed: %w", err)
+	}
+
+	<-proc.Wait()
+	list := struct {
+		List []struct {
+			Ipv4    []string `json:"ipv4"`
+			Name    string   `json:"name"`
+			Release string   `json:"release"`
+			State   string   `json:"state"`
+		} `json:"list"`
+	}{}
+	err = json.NewDecoder(&output).Decode(&list)
+	if err != nil {
+		return fmt.Errorf("could not decode mutipass list output: %w", err)
+	}
+
+	for _, i := range list.List {
+		if i.Name == batch.ID {
+			p.logger.Logf("multipass trying to delete instance %s", batch.ID)
+
+			output.Reset()
+			proc, err = process.Start("multipass",
+				process.WithContext(ctx),
+				process.WithArgs([]string{"delete", "--purge", batch.ID}),
+				process.WithCmdOptions(
+					runner.AttachOut(&output),
+					runner.AttachErr(&output)))
+			if err != nil {
+				return fmt.Errorf("multipass instance %q already exist, state %q. Could not delete it: %w",
+					batch.ID, i.State, err)
+			}
+			<-proc.Wait()
+
+			break
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

It deletes and purges the multipass instance if it already exists.

## Why is it important?

The multipass provisioner tries to launch a nre instance, if it already exists the test setup fails.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool]~~(https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

Run a integration test with the multipass provider twice, the multipass setup will succeeded in the second attempt.

## Related issues

- Relates #3403 

## Use cases

rerunning a test using the multipass provider


## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
