### PR TITLE
Fix runner/provisioners to account for the provision r when comparing instances and stacks

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -1772,10 +1772,14 @@ func createTestRunner(matrix bool, singleTest string, goTestFlags string, batche
 	fmt.Printf(">>>> Using %s instance provisioner\n", instanceProvisionerMode)
 	stackProvisionerMode := os.Getenv("STACK_PROVISIONER")
 	if stackProvisionerMode == "" {
-		stackProvisionerMode = "stateful"
+		stackProvisionerMode = ess.ProvisionerStateful
 	}
-	if stackProvisionerMode != "stateful" && stackProvisionerMode != "serverless" {
-		return nil, fmt.Errorf("STACK_PROVISIONER environment variable must be one of 'serverless' or 'stateful', not %s", stackProvisionerMode)
+	if stackProvisionerMode != ess.ProvisionerStateful &&
+		stackProvisionerMode != ess.ProvisionerServerless {
+		return nil, fmt.Errorf("STACK_PROVISIONER environment variable must be one of %q or %q, not %s",
+			ess.ProvisionerStateful,
+			ess.ProvisionerServerless,
+			stackProvisionerMode)
 	}
 	fmt.Printf(">>>> Using %s stack provisioner\n", stackProvisionerMode)
 
@@ -1831,9 +1835,9 @@ func createTestRunner(matrix bool, singleTest string, goTestFlags string, batche
 	}
 
 	var instanceProvisioner runner.InstanceProvisioner
-	if instanceProvisionerMode == "multipass" {
+	if instanceProvisionerMode == multipass.Name {
 		instanceProvisioner = multipass.NewProvisioner()
-	} else if instanceProvisionerMode == "ogc" {
+	} else if instanceProvisionerMode == ogc.Name {
 		instanceProvisioner, err = ogc.NewProvisioner(ogcCfg)
 		if err != nil {
 			return nil, err
@@ -1848,12 +1852,13 @@ func createTestRunner(matrix bool, singleTest string, goTestFlags string, batche
 		Region:     essRegion,
 	}
 	var stackProvisioner runner.StackProvisioner
-	if stackProvisionerMode == "stateful" {
+	if stackProvisionerMode == ess.ProvisionerStateful {
 		stackProvisioner, err = ess.NewProvisioner(provisionCfg)
 		if err != nil {
 			return nil, err
 		}
-	} else if stackProvisionerMode == "serverless" {
+
+	} else if stackProvisionerMode == ess.ProvisionerServerless {
 		stackProvisioner, err = ess.NewServerlessProvisioner(provisionCfg)
 		if err != nil {
 			return nil, err

--- a/pkg/testing/ess/serverless_test.go
+++ b/pkg/testing/ess/serverless_test.go
@@ -25,7 +25,7 @@ func TestProvisionGetRegions(t *testing.T) {
 	require.True(t, found)
 
 	cfg := ProvisionerConfig{Region: "bad-region-ID", APIKey: key}
-	prov := &ServerlessProvision{
+	prov := &ServerlessProvisioner{
 		cfg: cfg,
 		log: &defaultLogger{wrapped: logp.L()},
 	}

--- a/pkg/testing/multipass/provisioner.go
+++ b/pkg/testing/multipass/provisioner.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	Ubuntu = "ubuntu"
+	Name   = "multipass"
 )
 
 type provisioner struct {
@@ -33,6 +34,10 @@ type provisioner struct {
 // NewProvisioner creates the multipass provisioner
 func NewProvisioner() runner.InstanceProvisioner {
 	return &provisioner{}
+}
+
+func (p *provisioner) Name() string {
+	return Name
 }
 
 func (p *provisioner) SetLogger(l runner.Logger) {
@@ -92,12 +97,13 @@ func (p *provisioner) Provision(ctx context.Context, cfg runner.Config, batches 
 			return nil, fmt.Errorf("instance %s is not marked as running", batch.ID)
 		}
 		results = append(results, runner.Instance{
-			ID:         batch.ID,
-			Name:       batch.ID,
-			IP:         mi.IPv4[0],
-			Username:   "ubuntu",
-			RemotePath: "/home/ubuntu/agent",
-			Internal:   nil,
+			ID:          batch.ID,
+			Provisioner: Name,
+			Name:        batch.ID,
+			IP:          mi.IPv4[0],
+			Username:    "ubuntu",
+			RemotePath:  "/home/ubuntu/agent",
+			Internal:    nil,
 		})
 	}
 	return results, nil

--- a/pkg/testing/ogc/provisioner.go
+++ b/pkg/testing/ogc/provisioner.go
@@ -24,6 +24,7 @@ import (
 const (
 	// LayoutIntegrationTag is the tag added to all layouts for the integration testing framework.
 	LayoutIntegrationTag = "agent-integration"
+	Name                 = "ogc"
 )
 
 type provisioner struct {
@@ -40,6 +41,10 @@ func NewProvisioner(cfg Config) (runner.InstanceProvisioner, error) {
 	return &provisioner{
 		cfg: cfg,
 	}, nil
+}
+
+func (p *provisioner) Name() string {
+	return Name
 }
 
 func (p *provisioner) SetLogger(l runner.Logger) {
@@ -83,8 +88,8 @@ func (p *provisioner) Provision(ctx context.Context, cfg runner.Config, batches 
 		return nil, err
 	}
 	if len(machines) == 0 {
-		// print the output so its clear what went wrong
-		// without this it's unclear where OGC went wrong it
+		// Print the output so its clear what went wrong.
+		// Without this it's unclear where OGC went wrong, it
 		// doesn't do a great job of reporting a clean error
 		fmt.Fprintf(os.Stdout, "%s\n", upOutput)
 		return nil, fmt.Errorf("ogc didn't create any machines")
@@ -99,14 +104,15 @@ func (p *provisioner) Provision(ctx context.Context, cfg runner.Config, batches 
 			// without this it's unclear where OGC went wrong it
 			// doesn't do a great job of reporting a clean error
 			fmt.Fprintf(os.Stdout, "%s\n", upOutput)
-			return nil, fmt.Errorf("failed to find machine for layout ID: %s", b.ID)
+			return nil, fmt.Errorf("failed to find machine for batch ID: %s", b.ID)
 		}
 		instances = append(instances, runner.Instance{
-			ID:         b.ID,
-			Name:       machine.InstanceName,
-			IP:         machine.PublicIP,
-			Username:   machine.Layout.Username,
-			RemotePath: machine.Layout.RemotePath,
+			ID:          b.ID,
+			Provisioner: Name,
+			Name:        machine.InstanceName,
+			IP:          machine.PublicIP,
+			Username:    machine.Layout.Username,
+			RemotePath:  machine.Layout.RemotePath,
 			Internal: map[string]interface{}{
 				"instance_id": machine.InstanceID,
 			},

--- a/pkg/testing/runner/provisioner.go
+++ b/pkg/testing/runner/provisioner.go
@@ -18,6 +18,9 @@ type Instance struct {
 	ID string `yaml:"id"`
 	// Name is the nice-name of the instance.
 	Name string `yaml:"name"`
+	// Provisioner is the instance provider for the instance.
+	// See INSTANCE_PROVISIONER environment variable for the supported Provisioner.
+	Provisioner string `yaml:"provisioner"`
 	// IP is the IP address of the instance.
 	IP string `yaml:"ip"`
 	// Username is the username used to SSH to the instance.
@@ -32,6 +35,9 @@ type Instance struct {
 
 // InstanceProvisioner performs the provisioning of instances.
 type InstanceProvisioner interface {
+	// Name returns the name of the instance provisioner.
+	Name() string
+
 	// SetLogger sets the logger for it to use.
 	SetLogger(l Logger)
 
@@ -53,6 +59,10 @@ type Stack struct {
 	//
 	// This must be the same ID used for requesting a stack.
 	ID string `yaml:"id"`
+
+	// Provisioner is the stack provisioner. See STACK_PROVISIONER environment
+	// variable for the supported provisioners.
+	Provisioner string `yaml:"provisioner"`
 
 	// Version is the version of the stack.
 	Version string `yaml:"version"`
@@ -89,6 +99,9 @@ type StackRequest struct {
 
 // StackProvisioner performs the provisioning of stacks.
 type StackProvisioner interface {
+	// Name returns the name of the stack provisioner.
+	Name() string
+
 	// SetLogger sets the logger for it to use.
 	SetLogger(l Logger)
 

--- a/pkg/testing/runner/runner_test.go
+++ b/pkg/testing/runner/runner_test.go
@@ -38,12 +38,13 @@ func TestNewRunner_Clean(t *testing.T) {
 	require.NoError(t, err)
 
 	i1 := Instance{
-		ID:         "id-1",
-		Name:       "name-1",
-		IP:         "127.0.0.1",
-		Username:   "ubuntu",
-		RemotePath: "/home/ubuntu/agent",
-		Internal:   map[string]interface{}{}, // ElementsMatch fails without this set
+		ID:          "id-1",
+		Name:        "name-1",
+		Provisioner: ip.Name(),
+		IP:          "127.0.0.1",
+		Username:    "ubuntu",
+		RemotePath:  "/home/ubuntu/agent",
+		Internal:    map[string]interface{}{}, // ElementsMatch fails without this set
 	}
 	err = r.addOrUpdateInstance(StateInstance{
 		Instance: i1,
@@ -51,12 +52,13 @@ func TestNewRunner_Clean(t *testing.T) {
 	})
 	require.NoError(t, err)
 	i2 := Instance{
-		ID:         "id-2",
-		Name:       "name-2",
-		IP:         "127.0.0.2",
-		Username:   "ubuntu",
-		RemotePath: "/home/ubuntu/agent",
-		Internal:   map[string]interface{}{}, // ElementsMatch fails without this set
+		ID:          "id-2",
+		Name:        "name-2",
+		Provisioner: ip.Name(),
+		IP:          "127.0.0.2",
+		Username:    "ubuntu",
+		RemotePath:  "/home/ubuntu/agent",
+		Internal:    map[string]interface{}{}, // ElementsMatch fails without this set
 	}
 	err = r.addOrUpdateInstance(StateInstance{
 		Instance: i2,
@@ -64,16 +66,18 @@ func TestNewRunner_Clean(t *testing.T) {
 	})
 	require.NoError(t, err)
 	s1 := Stack{
-		ID:       "id-1",
-		Version:  "8.10.0",
-		Internal: map[string]interface{}{}, // ElementsMatch fails without this set
+		ID:          "id-1",
+		Provisioner: sp.Name(),
+		Version:     "8.10.0",
+		Internal:    map[string]interface{}{}, // ElementsMatch fails without this set
 	}
 	err = r.addOrUpdateStack(s1)
 	require.NoError(t, err)
 	s2 := Stack{
-		ID:       "id-2",
-		Version:  "8.9.0",
-		Internal: map[string]interface{}{}, // ElementsMatch fails without this set
+		ID:          "id-2",
+		Provisioner: sp.Name(),
+		Version:     "8.9.0",
+		Internal:    map[string]interface{}{}, // ElementsMatch fails without this set
 	}
 	err = r.addOrUpdateStack(s2)
 	require.NoError(t, err)
@@ -93,6 +97,10 @@ func TestNewRunner_Clean(t *testing.T) {
 type fakeInstanceProvisioner struct {
 	batches   []OSBatch
 	instances []Instance
+}
+
+func (f *fakeInstanceProvisioner) Name() string {
+	return "fake"
 }
 
 func (f *fakeInstanceProvisioner) SetLogger(_ Logger) {
@@ -127,6 +135,10 @@ type fakeStackProvisioner struct {
 	mx            sync.Mutex
 	requests      []StackRequest
 	deletedStacks []Stack
+}
+
+func (f *fakeStackProvisioner) Name() string {
+	return "fake"
 }
 
 func (f *fakeStackProvisioner) SetLogger(_ Logger) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

It adds the provisioner name to Stack and Instance so the test framework can differentiate stack and instances from different providers

## Why is it important?

The runner was not taking into account the provisioner when checking is there was already an instance or stack to be reused

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Author's Checklist


## How to test this PR locally

see https://github.com/elastic/elastic-agent/issues/3756

## Related issues


- Closes https://github.com/elastic/elastic-agent/issues/3756
- Closes https://github.com/elastic/elastic-agent/issues/3770


## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
