### PR TITLE
[CI] macos arm tests trigger by comment

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,72 +4,73 @@ env:
   VAULT_PATH: "kv/ci-shared/observability-ingest/cloud/gcp"
   DOCKER_REGISTRY: "docker.elastic.co"
 steps:
-  - label: "Unit tests - Ubuntu 22.04"
-    key: "unit-tests-2204"
-    command: ".buildkite/scripts/steps/unit-tests.sh"
-    artifact_paths:
-      - "build/TEST-**"
-      - "build/diagnostics/*"
-      - "coverage.out"
-    agents:
-      provider: "gcp"
-      image: "family/core-ubuntu-2204"
-    retry:
-      manual:
-        allowed: true
+  # - label: "Unit tests - Ubuntu 22.04"
+  #   key: "unit-tests-2204"
+  #   command: ".buildkite/scripts/steps/unit-tests.sh"
+  #   artifact_paths:
+  #     - "build/TEST-**"
+  #     - "build/diagnostics/*"
+  #     - "coverage.out"
+  #   agents:
+  #     provider: "gcp"
+  #     image: "family/core-ubuntu-2204"
+  #   retry:
+  #     manual:
+  #       allowed: true
 
-  - label: "Unit tests - Ubuntu 22.04 ARM64"
-    key: "unit-tests-2204-arm64"
-    command: ".buildkite/scripts/steps/unit-tests.sh"
-    artifact_paths:
-      - "build/TEST-**"
-      - "build/diagnostics/*"
-      - "coverage.out"
-    agents:
-      provider: "aws"
-      imagePrefix: "core-ubuntu-2204-aarch64"
-      diskSizeGb: 200
-      instanceType: "m6g.4xlarge"
-    retry:
-      manual:
-        allowed: true
+  # - label: "Unit tests - Ubuntu 22.04 ARM64"
+  #   key: "unit-tests-2204-arm64"
+  #   command: ".buildkite/scripts/steps/unit-tests.sh"
+  #   artifact_paths:
+  #     - "build/TEST-**"
+  #     - "build/diagnostics/*"
+  #     - "coverage.out"
+  #   agents:
+  #     provider: "aws"
+  #     imagePrefix: "core-ubuntu-2204-aarch64"
+  #     diskSizeGb: 200
+  #     instanceType: "m6g.4xlarge"
+  #   retry:
+  #     manual:
+  #       allowed: true
 
-  - label: "Unit tests - Windows 2022"
-    key: "unit-tests-win2022"
-    command: ".\\.buildkite\\scripts\\steps\\unit-tests.ps1"
-    artifact_paths:
-      - "build/TEST-**"
-      - "build/diagnostics/*"
-      - "coverage.out"
-    agents:
-      provider: "gcp"
-      image: "family/core-windows-2022"
-      machine_type: "n2-standard-8"
-      disk_size: 200
-      disk_type: "pd-ssd"
-    retry:
-      manual:
-        allowed: true
+  # - label: "Unit tests - Windows 2022"
+  #   key: "unit-tests-win2022"
+  #   command: ".\\.buildkite\\scripts\\steps\\unit-tests.ps1"
+  #   artifact_paths:
+  #     - "build/TEST-**"
+  #     - "build/diagnostics/*"
+  #     - "coverage.out"
+  #   agents:
+  #     provider: "gcp"
+  #     image: "family/core-windows-2022"
+  #     machine_type: "n2-standard-8"
+  #     disk_size: 200
+  #     disk_type: "pd-ssd"
+  #   retry:
+  #     manual:
+  #       allowed: true
 
-  - label: "Unit tests - Windows 2016"
-    key: "unit-tests-win2016"
-    command: ".\\.buildkite\\scripts\\steps\\unit-tests.ps1"
-    artifact_paths:
-      - "build/TEST-**"
-      - "build/diagnostics/*"
-      - "coverage.out"
-    agents:
-      provider: "gcp"
-      image: "family/core-windows-2016"
-      machine_type: "n2-standard-8"
-      disk_size: 200
-      disk_type: "pd-ssd"
-    retry:
-      manual:
-        allowed: true
+  # - label: "Unit tests - Windows 2016"
+  #   key: "unit-tests-win2016"
+  #   command: ".\\.buildkite\\scripts\\steps\\unit-tests.ps1"
+  #   artifact_paths:
+  #     - "build/TEST-**"
+  #     - "build/diagnostics/*"
+  #     - "coverage.out"
+  #   agents:
+  #     provider: "gcp"
+  #     image: "family/core-windows-2016"
+  #     machine_type: "n2-standard-8"
+  #     disk_size: 200
+  #     disk_type: "pd-ssd"
+  #   retry:
+  #     manual:
+  #       allowed: true
 
   - label: "Unit tests - MacOS 13 ARM"
     key: "unit-tests-macos-13-arm"
+    if: build.env("GITHUB_PR_COMMENT_VAR_TEST_TARGET") == "macosarm"
     command: ".buildkite/scripts/steps/unit-tests.sh"
     artifact_paths:
       - "build/TEST-**"
@@ -82,45 +83,45 @@ steps:
       manual:
         allowed: true
 
-  - label: "Unit tests - MacOS 13"
-    key: "unit-tests-macos-13"
-    command: ".buildkite/scripts/steps/unit-tests.sh"
-    artifact_paths:
-      - "build/TEST-**"
-      - "build/diagnostics/*"
-      - "coverage.out"
-    agents:
-      provider: orka
-      imagePrefix: generic-13-ventura-x64
-    retry:
-      manual:
-        allowed: true
+  # - label: "Unit tests - MacOS 13"
+  #   key: "unit-tests-macos-13"
+  #   command: ".buildkite/scripts/steps/unit-tests.sh"
+  #   artifact_paths:
+  #     - "build/TEST-**"
+  #     - "build/diagnostics/*"
+  #     - "coverage.out"
+  #   agents:
+  #     provider: orka
+  #     imagePrefix: generic-13-ventura-x64
+  #   retry:
+  #     manual:
+  #       allowed: true
 
-  - label: "Merge coverage reports"
-    key: "merge-coverage"
-    env:
-      BUILDKITE_REPO: ""
-    command: "
-      .buildkite/scripts/steps/merge.sh
-      unit-tests-2204
-      unit-tests-2204-arm64
-      unit-tests-win2016
-      unit-tests-win2022
-      unit-tests-macos-13
-      unit-tests-macos-13-arm
-      "
-    artifact_paths:
-      - "build/TEST-**"
-    agents:
-      image: "golang:1.20.10"
-    depends_on:
-      - unit-tests-2204
-      - unit-tests-2204-arm64
-      - unit-tests-win2022
-      - unit-tests-win2016
-      - unit-tests-macos-13
-      - unit-tests-macos-13-arm
-    allow_dependency_failure: true
+  # - label: "Merge coverage reports"
+  #   key: "merge-coverage"
+  #   env:
+  #     BUILDKITE_REPO: ""
+  #   command: "
+  #     .buildkite/scripts/steps/merge.sh
+  #     unit-tests-2204
+  #     unit-tests-2204-arm64
+  #     unit-tests-win2016
+  #     unit-tests-win2022
+  #     unit-tests-macos-13
+  #     unit-tests-macos-13-arm
+  #     "
+  #   artifact_paths:
+  #     - "build/TEST-**"
+  #   agents:
+  #     image: "golang:1.20.10"
+  #   depends_on:
+  #     - unit-tests-2204
+  #     - unit-tests-2204-arm64
+  #     - unit-tests-win2022
+  #     - unit-tests-win2016
+  #     - unit-tests-macos-13
+  #     - unit-tests-macos-13-arm
+  #   allow_dependency_failure: true
 
   - group: "K8s tests"
     key: "k8s-tests"
@@ -147,49 +148,49 @@ steps:
           manual:
             allowed: true
 
-  - label: ":sonarqube: Continuous Code Inspection"
-    env:
-      VAULT_SONAR_TOKEN_PATH: "kv/ci-shared/platform-ingest/elastic/elastic-agent/sonar-analyze-token"
-    agents:
-      image: "docker.elastic.co/cloud-ci/sonarqube/buildkite-scanner:latest"
-    command:
-      - "buildkite-agent artifact download --step merge-coverage build/TEST-go-unit.cov ."
-      - "/scan-source-code.sh"
-    depends_on:
-      - "merge-coverage"
-    retry:
-      manual:
-        allowed: true
+  # - label: ":sonarqube: Continuous Code Inspection"
+  #   env:
+  #     VAULT_SONAR_TOKEN_PATH: "kv/ci-shared/platform-ingest/elastic/elastic-agent/sonar-analyze-token"
+  #   agents:
+  #     image: "docker.elastic.co/cloud-ci/sonarqube/buildkite-scanner:latest"
+  #   command:
+  #     - "buildkite-agent artifact download --step merge-coverage build/TEST-go-unit.cov ."
+  #     - "/scan-source-code.sh"
+  #   depends_on:
+  #     - "merge-coverage"
+  #   retry:
+  #     manual:
+  #       allowed: true
 
-  - label: "Serverless integration test"
-    key: "serverless-integration-tests"
-    env:
-      TEST_INTEG_AUTH_ESS_REGION: us-east-1
-    command: ".buildkite/scripts/steps/integration_tests.sh serverless integration:single TestLogIngestionFleetManaged" #right now, run a single test in serverless mode as a sort of smoke test, instead of re-running the entire suite
-    artifact_paths:
-      - "build/TEST-**"
-      - "build/diagnostics/*"
-    agents:
-      provider: "gcp"
-      machineType: "n1-standard-8"
+  # - label: "Serverless integration test"
+  #   key: "serverless-integration-tests"
+  #   env:
+  #     TEST_INTEG_AUTH_ESS_REGION: us-east-1
+  #   command: ".buildkite/scripts/steps/integration_tests.sh serverless integration:single TestLogIngestionFleetManaged" #right now, run a single test in serverless mode as a sort of smoke test, instead of re-running the entire suite
+  #   artifact_paths:
+  #     - "build/TEST-**"
+  #     - "build/diagnostics/*"
+  #   agents:
+  #     provider: "gcp"
+  #     machineType: "n1-standard-8"
 
-  - label: "Integration tests"
-    key: "integration-tests"
-    env:
-      TEST_INTEG_AUTH_ESS_REGION: us-east-1
-    command: ".buildkite/scripts/steps/integration_tests.sh stateful"
-    artifact_paths:
-      - "build/TEST-**"
-      - "build/diagnostics/*"
-    agents:
-      provider: "gcp"
-      machineType: "n1-standard-8"
+  # - label: "Integration tests"
+  #   key: "integration-tests"
+  #   env:
+  #     TEST_INTEG_AUTH_ESS_REGION: us-east-1
+  #   command: ".buildkite/scripts/steps/integration_tests.sh stateful"
+  #   artifact_paths:
+  #     - "build/TEST-**"
+  #     - "build/diagnostics/*"
+  #   agents:
+  #     provider: "gcp"
+  #     machineType: "n1-standard-8"
 
-  - wait: ~
-    continue_on_failure: true
-  - label: "Processing test results"
-    agents:
-      provider: "gcp"
-    plugins:
-      - junit-annotate#v2.4.1:
-          artifacts: build/TEST-go-integration*.xml
+  # - wait: ~
+  #   continue_on_failure: true
+  # - label: "Processing test results"
+  #   agents:
+  #     provider: "gcp"
+  #   plugins:
+  #     - junit-annotate#v2.4.1:
+  #         artifacts: build/TEST-go-integration*.xml

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -9,7 +9,7 @@
             "set_commit_status": true,
             "build_on_commit": true,
             "build_on_comment": true,
-            "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",
+            "trigger_comment_regex": "buildkite test (?<test_target>[a-z]+)",
             "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",
             "skip_ci_labels": [  ],
             "skip_target_branches": [ ],


### PR DESCRIPTION
## What does this PR do?

Makes MacOS 13 ARM tests run only on demand by a comment `buildkite test macosarm`

## Why is it important?
We lack MacOS ARM machines and testing on ARM for each pull request exhausts the cluster
