### PR TITLE
[CI] run MacOS 13 ARM unit tests only on main branch

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -71,9 +71,11 @@ steps:
           manual:
             allowed: true
 
+      # Runs inly on the main branch
       - label: "Unit tests - MacOS 13 ARM"
         key: "unit-tests-macos-13-arm"
         command: ".buildkite/scripts/steps/unit-tests.sh"
+        branches: main
         artifact_paths:
           - "build/TEST-**"
           - "build/diagnostics/*"
@@ -146,7 +148,6 @@ steps:
       unit-tests-win2016
       unit-tests-win2022
       unit-tests-macos-13
-      unit-tests-macos-13-arm
       unit-tests-win10
       unit-tests-win11
       "


### PR DESCRIPTION
## What does this PR do?
Makes MacOS 13 ARM unit tests to be executed only on push to the `main` branch

## Why is it important?

The Orka cluster on ARM MacOS VMs is being exhausted by pull requests. As it was discussed before we can run it only on `main` because there's no ARM-specific code for darwin. 