### PR TITLE
[EA standalone] Add state_namespace data stream by default to the manifests

### DIFF
--- a/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-daemonset-configmap.yaml
@@ -35,7 +35,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.29.2
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -352,7 +352,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.29.2
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -380,7 +380,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.29.2
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -521,7 +521,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.29.2
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:

--- a/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-daemonset-configmap.yaml
@@ -133,6 +133,21 @@ data:
             # ssl.certificate_authorities:
             #   - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
           - data_stream:
+              dataset: kubernetes.state_namespace
+              type: metrics
+            metricsets:
+              - state_namespace
+            add_metadata: true
+            hosts:
+              - 'kube-state-metrics:8080'
+            period: 10s
+            # Openshift:
+            # if to access 'kube-state-metrics' are used third party tools, like kube-rbac-proxy or similar, that perform RBAC authorization
+            # and/or tls termination, then configuration below should be considered:
+            # bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            # ssl.certificate_authorities:
+            #   - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+          - data_stream:
               dataset: kubernetes.state_node
               type: metrics
             metricsets:

--- a/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-ksm-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-ksm-daemonset-configmap.yaml
@@ -36,7 +36,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.42.0
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -127,7 +127,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.42.0
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -152,7 +152,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.42.0
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -293,7 +293,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.42.0
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:

--- a/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-ksm-statefulset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-ksm-statefulset-configmap.yaml
@@ -183,4 +183,4 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.42.0
+            version: 1.52.0

--- a/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-ksm-statefulset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-ksm-statefulset-configmap.yaml
@@ -82,6 +82,16 @@ data:
             bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
           - data_stream:
               type: metrics
+              dataset: kubernetes.state_namespace
+            metricsets:
+              - state_namespace
+            add_metadata: true
+            hosts:
+              - 'localhost:8080'
+            period: 10s
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          - data_stream:
+              type: metrics
               dataset: kubernetes.state_node
             metricsets:
               - state_node

--- a/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/base/elastic-agent-standalone-ksm-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/base/elastic-agent-standalone-ksm-daemonset-configmap.yaml
@@ -36,7 +36,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.42.0
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -127,7 +127,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.42.0
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -152,7 +152,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.42.0
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -293,7 +293,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.42.0
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:

--- a/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/base/elastic-agent-standalone-ksm-statefulset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/base/elastic-agent-standalone-ksm-statefulset-configmap.yaml
@@ -183,4 +183,4 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.42.0
+            version: 1.52.0

--- a/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/base/elastic-agent-standalone-ksm-statefulset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/base/elastic-agent-standalone-ksm-statefulset-configmap.yaml
@@ -82,6 +82,16 @@ data:
             bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
           - data_stream:
               type: metrics
+              dataset: kubernetes.state_namespace
+            metricsets:
+              - state_namespace
+            add_metadata: true
+            hosts:
+              - 'localhost:8080'
+            period: 10s
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          - data_stream:
+              type: metrics
               dataset: kubernetes.state_node
             metricsets:
               - state_node

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -727,7 +727,7 @@ spec:
                   fieldPath: metadata.name
             - name: STATE_PATH
               value: "/etc/elastic-agent"
-            # The following ELASTIC_NETINFO:false variable will disable the netinfo.enabled option of add-host-metadata processor. This will remove fields host.ip and host.mac.
+            # The following ELASTIC_NETINFO:false variable will disable the netinfo.enabled option of add-host-metadata processor. This will remove fields host.ip and host.mac.  
             # For more info: https://www.elastic.co/guide/en/beats/metricbeat/current/add-host-metadata.html
             - name: ELASTIC_NETINFO
               value: "false"

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -35,7 +35,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.29.2
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -352,7 +352,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.29.2
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -380,7 +380,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.29.2
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -521,7 +521,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.29.2
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -133,6 +133,21 @@ data:
             # ssl.certificate_authorities:
             #   - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
           - data_stream:
+              dataset: kubernetes.state_namespace
+              type: metrics
+            metricsets:
+              - state_namespace
+            add_metadata: true
+            hosts:
+              - 'kube-state-metrics:8080'
+            period: 10s
+            # Openshift:
+            # if to access 'kube-state-metrics' are used third party tools, like kube-rbac-proxy or similar, that perform RBAC authorization
+            # and/or tls termination, then configuration below should be considered:
+            # bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            # ssl.certificate_authorities:
+            #   - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+          - data_stream:
               dataset: kubernetes.state_node
               type: metrics
             metricsets:
@@ -712,7 +727,7 @@ spec:
                   fieldPath: metadata.name
             - name: STATE_PATH
               value: "/etc/elastic-agent"
-            # The following ELASTIC_NETINFO:false variable will disable the netinfo.enabled option of add-host-metadata processor. This will remove fields host.ip and host.mac.  
+            # The following ELASTIC_NETINFO:false variable will disable the netinfo.enabled option of add-host-metadata processor. This will remove fields host.ip and host.mac.
             # For more info: https://www.elastic.co/guide/en/beats/metricbeat/current/add-host-metadata.html
             - name: ELASTIC_NETINFO
               value: "false"

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
@@ -35,7 +35,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.29.2
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -352,7 +352,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.29.2
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -380,7 +380,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.29.2
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -521,7 +521,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.29.2
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
@@ -133,6 +133,21 @@ data:
             # ssl.certificate_authorities:
             #   - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
           - data_stream:
+              dataset: kubernetes.state_namespace
+              type: metrics
+            metricsets:
+              - state_namespace
+            add_metadata: true
+            hosts:
+              - 'kube-state-metrics:8080'
+            period: 10s
+            # Openshift:
+            # if to access 'kube-state-metrics' are used third party tools, like kube-rbac-proxy or similar, that perform RBAC authorization
+            # and/or tls termination, then configuration below should be considered:
+            # bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            # ssl.certificate_authorities:
+            #   - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+          - data_stream:
               dataset: kubernetes.state_node
               type: metrics
             metricsets:

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-ksm-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-ksm-daemonset-configmap.yaml
@@ -36,7 +36,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.42.0
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -127,7 +127,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.42.0
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -152,7 +152,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.42.0
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:
@@ -293,7 +293,7 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.42.0
+            version: 1.52.0
         data_stream:
           namespace: default
         streams:

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-ksm-statefulset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-ksm-statefulset-configmap.yaml
@@ -183,4 +183,4 @@ data:
         meta:
           package:
             name: kubernetes
-            version: 1.42.0
+            version: 1.52.0

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-ksm-statefulset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-ksm-statefulset-configmap.yaml
@@ -82,6 +82,16 @@ data:
             bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
           - data_stream:
               type: metrics
+              dataset: kubernetes.state_namespace
+            metricsets:
+              - state_namespace
+            add_metadata: true
+            hosts:
+              - 'localhost:8080'
+            period: 10s
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          - data_stream:
+              type: metrics
               dataset: kubernetes.state_node
             metricsets:
               - state_node


### PR DESCRIPTION
## What does this PR do?

Add the `state_namespace` data stream by default to the EA manifest files.

This data stream was introduced in version 8.11.0.

The package version was also updated to 1.52.0 as the data stream was [introduced there](https://github.com/elastic/integrations/blob/af38b975375ce4504b2589ea9df4aa45c77dc205/packages/kubernetes/changelog.yml#L12).


## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## How to test this PR locally

1. Clone this branch.
2. Deploy EA standalone in version 8.11.0.
3. Check `state_namespace` metrics are there.

## Related issues

Relates to https://github.com/elastic/elastic-agent/issues/3100.


## Screenshots


![image](https://github.com/elastic/elastic-agent/assets/113898685/0711c4c5-fce7-44e8-b6bd-7408d10c1b67)
