### PR TITLE
[Upgrade Details] Implement tracking of `UPG_SCHEDULED` state

### DIFF
--- a/internal/pkg/agent/application/dispatcher/dispatcher.go
+++ b/internal/pkg/agent/application/dispatcher/dispatcher.go
@@ -294,8 +294,8 @@ func reportNextScheduledUpgrade(input []fleetapi.Action, detailsSetter details.O
 		}
 
 		start, err := uAction.StartTime()
-		if errors.Is(err, fleetapi.ErrNoStartTime) {
-			log.Warnf("scheduled upgrade action [id = %s] has no start time!", uAction.ID())
+		if err != nil {
+			log.Errorf("failed to get start time for scheduled upgrade action [id = %s]", uAction.ID())
 			continue
 		}
 

--- a/internal/pkg/agent/application/dispatcher/dispatcher.go
+++ b/internal/pkg/agent/application/dispatcher/dispatcher.go
@@ -294,7 +294,7 @@ func reportNextScheduledUpgrade(input []fleetapi.Action, detailsSetter details.O
 		}
 
 		start, err := uAction.StartTime()
-		if err == fleetapi.ErrNoStartTime {
+		if errors.Is(err, fleetapi.ErrNoStartTime) {
 			log.Warnf("scheduled upgrade action [id = %s] has no start time!", uAction.ID())
 			continue
 		}

--- a/internal/pkg/agent/application/dispatcher/dispatcher_test.go
+++ b/internal/pkg/agent/application/dispatcher/dispatcher_test.go
@@ -560,8 +560,7 @@ func TestReportNextScheduledUpgrade(t *testing.T) {
 
 			reportNextScheduledUpgrade(test.actions, detailsSetter, log)
 
-			//require.True(t, test.expectedDetails.Equals(actualDetails))
-			require.Equal(t, test.expectedDetails, actualDetails) // FIXME replace with above assertion once https://github.com/elastic/elastic-agent/pull/3694 is merged
+			require.True(t, test.expectedDetails.Equals(actualDetails))
 			if test.expectedWarningLogMsg != "" {
 				logs := obs.TakeAll()
 				require.Len(t, logs, 1)

--- a/internal/pkg/agent/application/managed_mode.go
+++ b/internal/pkg/agent/application/managed_mode.go
@@ -163,7 +163,7 @@ func (m *managedConfigManager) Run(ctx context.Context) error {
 		// persisted action on disk we should be able to ask Fleet to get the latest configuration.
 		// But at the moment this is not possible because the policy change was acked.
 		m.log.Info("restoring current policy from disk")
-		m.dispatcher.Dispatch(ctx, actionAcker, actions...)
+		m.dispatcher.Dispatch(ctx, m.coord, actionAcker, actions...)
 		stateRestored = true
 	}
 

--- a/internal/pkg/agent/application/managed_mode_test.go
+++ b/internal/pkg/agent/application/managed_mode_test.go
@@ -98,7 +98,7 @@ func Test_runDispatcher(t *testing.T) {
 		},
 		mockDispatcher: func() *mockDispatcher {
 			dispatcher := &mockDispatcher{}
-			dispatcher.On("Dispatch", mock.Anything, mock.Anything, mock.Anything).Once()
+			dispatcher.On("Dispatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once()
 			return dispatcher
 		},
 		interval: time.Second,
@@ -111,8 +111,8 @@ func Test_runDispatcher(t *testing.T) {
 		},
 		mockDispatcher: func() *mockDispatcher {
 			dispatcher := &mockDispatcher{}
-			dispatcher.On("Dispatch", mock.Anything, mock.Anything, mock.Anything).Once()
-			dispatcher.On("Dispatch", mock.Anything, mock.Anything, mock.Anything).Maybe() // allow a second call in case there are timing issues in the CI pipeline
+			dispatcher.On("Dispatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once()
+			dispatcher.On("Dispatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe() // allow a second call in case there are timing issues in the CI pipeline
 			return dispatcher
 		},
 		interval: time.Millisecond * 60,

--- a/internal/pkg/agent/application/upgrade/details/details.go
+++ b/internal/pkg/agent/application/upgrade/details/details.go
@@ -127,6 +127,24 @@ func (d *Details) RegisterObserver(observer Observer) {
 	d.notifyObserver(observer)
 }
 
+// Equals compares the non-lock fields of two Details structs.
+func (d *Details) Equals(otherD *Details) bool {
+	// If both addresses are equal or both are nil
+	if d == otherD {
+		return true
+	}
+
+	// If only one is nil but the other is not
+	if d == nil || otherD == nil {
+		return false
+	}
+
+	return d.State == otherD.State &&
+		d.TargetVersion == otherD.TargetVersion &&
+		d.ActionID == otherD.ActionID &&
+		d.Metadata.Equals(otherD.Metadata)
+}
+
 func (d *Details) notifyObservers() {
 	for _, observer := range d.observers {
 		d.notifyObserver(observer)
@@ -145,6 +163,14 @@ func (d *Details) notifyObserver(observer Observer) {
 		}
 		observer(&dCopy)
 	}
+}
+
+func (m Metadata) Equals(otherM Metadata) bool {
+	return m.ScheduledAt.Equal(otherM.ScheduledAt) &&
+		m.FailedState == otherM.FailedState &&
+		m.ErrorMsg == otherM.ErrorMsg &&
+		m.DownloadPercent == otherM.DownloadPercent &&
+		m.DownloadRate == otherM.DownloadRate
 }
 
 func (dr *downloadRate) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR enhances Elastic Agent to track the `UPG_SCHEDULED` state.  It tracks this state for the first (next) scheduled upgrade.

## Why is it important?

Users can know if an upgrade has been scheduled and when it has been scheduled for.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates to https://github.com/elastic/elastic-agent/issues/3119#issuecomment-1743638526
