### PR TITLE
[Upgrade Details] Track failed download attempts

### DIFF
--- a/internal/pkg/agent/application/upgrade/step_download.go
+++ b/internal/pkg/agent/application/upgrade/step_download.go
@@ -248,6 +248,12 @@ func (u *Upgrader) downloadWithRetries(
 	opFn := func() error {
 		attempt++
 		u.log.Infof("download attempt %d", attempt)
+
+		// Reset upgrade details state to UPG_DOWNLOADING in case this is
+		// a retry attempt and we were in UPG_FAILED after the previous
+		// attempt failed.
+		upgradeDetails.SetState(details.StateDownloading)
+
 		var err error
 		path, err = u.downloadOnce(cancelCtx, factory, version, settings, upgradeDetails)
 		if err != nil {

--- a/internal/pkg/agent/application/upgrade/step_download.go
+++ b/internal/pkg/agent/application/upgrade/step_download.go
@@ -251,7 +251,7 @@ func (u *Upgrader) downloadWithRetries(
 		var err error
 		path, err = u.downloadOnce(cancelCtx, factory, version, settings, upgradeDetails)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to download artifact: %w", err)
 		}
 		return nil
 	}

--- a/internal/pkg/agent/application/upgrade/step_download.go
+++ b/internal/pkg/agent/application/upgrade/step_download.go
@@ -257,6 +257,9 @@ func (u *Upgrader) downloadWithRetries(
 	}
 
 	opFailureNotificationFn := func(err error, retryAfter time.Duration) {
+		// Set upgrade details state to UPG_FAILED (with error details). The state
+		// will be reset to UPG_DOWNLOADING before we retry the download.
+		upgradeDetails.Fail(err)
 		u.log.Warnf("%s; retrying (will be retry %d) in %s.", err.Error(), attempt, retryAfter)
 	}
 


### PR DESCRIPTION
## What does this PR do?

This PR implements better tracking of failed artifact download attempts. Specifically:
- when an artifact download fails, we now set the upgrade details state to `UPG_FAILED` with relevant error details.
- when an artifact download is retried, we now reset the upgrade details state to `UPG_DOWNLOADING`.

## Why is it important?

To know that download attempts have failed and the reason for their failure.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~

## How to test this PR locally

1. Build Agent from this PR's branch.
2. Attempt an Agent download to a non-existent Agent version.  This will ensure that artifact downloads fail.
   ```
   sudo elastic-agent upgrade 99.99.999
   ```
4. In a new window, start monitoring Agent logs for download failure and retry messages.
   ```
   sudo elastic-agent logs -f | grep -i 'download'
   ```
6. Immediately after Agent attempts to download the new artifact for the very first time, check the logs and verify that the state in the details is `UPG_DOWNLOADING`.  The log message should look like this:
   ```
   {"log.level":"info","@timestamp":"2023-11-15T00:14:30.490Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":492},"message":"updated upgrade details","log":{"source":"elastic-agent"},"upgrade_details":{"target_version":"99.99.999","state":"UPG_DOWNLOADING","metadata":{"scheduled_at":"0001-01-01T00:00:00Z"}},"ecs.version":"1.6.0"}
   ```
7. When a download attempt fails — but before it is retried — check the logs again and verify that the state in the details is `UPG_FAILED` with an error message explaining the reason the download failed. The log message should look like this:
   ```
   {"log.level":"info","@timestamp":"2023-11-15T00:15:18.146Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":492},"message":"updated upgrade details","log":{"source":"elastic-agent"},"upgrade_details":{"target_version":"99.99.999","state":"UPG_FAILED","metadata":{"scheduled_at":"0001-01-01T00:00:00Z","failed_state":"UPG_DOWNLOADING","error_msg":"unable to download artifact: ..."}},"ecs.version":"1.6.0"}
   ```
9. When Agent retries the download, check the logs and verify that the state in the details is `UPG_DOWNLOADING` again.  The log message should look like this:
   ```
   {"log.level":"info","@timestamp":"2023-11-15T00:15:41.358Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":492},"message":"updated upgrade details","log":{"source":"elastic-agent"},"upgrade_details":{"target_version":"99.99.999","state":"UPG_DOWNLOADING","metadata":{"scheduled_at":"0001-01-01T00:00:00Z"}},"ecs.version":"1.6.0"}
   ```

## Related issues

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates to https://github.com/elastic/elastic-agent/issues/3119#issuecomment-1743638526
