### PR TITLE
Limit batchID length.

### DIFF
--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -7,6 +7,7 @@ package runner
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
 	"errors"
 	"fmt"
 	"io"
@@ -15,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"gopkg.in/yaml.v2"
 
@@ -1019,6 +1021,15 @@ func createBatchID(batch OSBatch) string {
 			id += "-" + batch.Batch.SudoTests[0].Tests[0].Name
 		}
 	}
+
+	// The batchID needs to be at most 63 characters long otherwise
+	// OGC will fail to instantiate the VM.
+	if len(id) > 63 {
+		hash := fmt.Sprintf("%X", md5.Sum([]byte(id)))
+		hashLen := utf8.RuneCountInString(hash)
+		id = id[:63-hashLen-1] + "-" + hash
+	}
+
 	return strings.ToLower(id)
 }
 

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -1024,10 +1024,11 @@ func createBatchID(batch OSBatch) string {
 
 	// The batchID needs to be at most 63 characters long otherwise
 	// OGC will fail to instantiate the VM.
-	if len(id) > 63 {
-		hash := fmt.Sprintf("%X", md5.Sum([]byte(id)))
+	maxIDLen := 63
+	if len(id) > maxIDLen {
+		hash := fmt.Sprintf("%x", md5.Sum([]byte(id)))
 		hashLen := utf8.RuneCountInString(hash)
-		id = id[:63-hashLen-1] + "-" + hash
+		id = id[:maxIDLen-hashLen-1] + "-" + hash
 	}
 
 	return strings.ToLower(id)


### PR DESCRIPTION

## What does this PR do?

If the BatchID is longer than 63 characters, OGC will fail to instantiate a GCP VM, this commit fixes this by using a MD5 hash of the whole ID and ensuring the final ID is at most 63 characters long.


## Why is it important?

It fixes the integration tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
~~- [ ] I have added an integration test or an E2E test~~

~~## Author's Checklist~~

## How to test this PR locally

Run the integration tests, they should not fail.

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~

## Logs

OGC error logged before the fix:
```
libcloud.common.google.InvalidRequestError: {'message': "Invalid value for field 'firewall': 'linux-amd64-ubuntu-2204-testinstallandunenrollwithendpointsecurity'. Must be a match of regex '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?|[1-9][0-9]{0,19}'", 'domain': 'global', 'reason': 'invalid'}
```

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
