### PR TITLE
[Upgrade Details] Use `details.DownloadRate` type from elastic-agent-libs

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1165,12 +1165,12 @@ SOFTWARE
 
 
 --------------------------------------------------------------------------------
-Dependency : github.com/ycombinator/elastic-agent-libs
-Version: v0.0.0-20231120180527-82a87b8ca926
+Dependency : github.com/elastic/elastic-agent-libs
+Version: v0.7.2
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/ycombinator/elastic-agent-libs@v0.0.0-20231120180527-82a87b8ca926/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-libs@v0.7.2/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1165,12 +1165,12 @@ SOFTWARE
 
 
 --------------------------------------------------------------------------------
-Dependency : github.com/elastic/elastic-agent-libs
-Version: v0.7.0
+Dependency : github.com/ycombinator/elastic-agent-libs
+Version: v0.0.0-20231120175530-2423154723d5
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-libs@v0.7.0/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/ycombinator/elastic-agent-libs@v0.0.0-20231120175530-2423154723d5/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1166,11 +1166,11 @@ SOFTWARE
 
 --------------------------------------------------------------------------------
 Dependency : github.com/ycombinator/elastic-agent-libs
-Version: v0.0.0-20231120175530-2423154723d5
+Version: v0.0.0-20231120180527-82a87b8ca926
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/ycombinator/elastic-agent-libs@v0.0.0-20231120175530-2423154723d5/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/ycombinator/elastic-agent-libs@v0.0.0-20231120180527-82a87b8ca926/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/go.mod
+++ b/go.mod
@@ -182,7 +182,7 @@ replace (
 )
 
 // FIXME: remove once https://github.com/elastic/elastic-agent-libs/pull/166 is merged and new version is released
-replace github.com/elastic/elastic-agent-libs => github.com/ycombinator/elastic-agent-libs v0.0.0-20231120175530-2423154723d5
+replace github.com/elastic/elastic-agent-libs => github.com/ycombinator/elastic-agent-libs v0.0.0-20231120180527-82a87b8ca926
 
 // Exclude this version because the version has an invalid checksum.
 exclude github.com/docker/distribution v2.8.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/elastic/e2e-testing v1.1.0
 	github.com/elastic/elastic-agent-autodiscover v0.6.5
 	github.com/elastic/elastic-agent-client/v7 v7.5.0
+	// FIXME: bump up once https://github.com/elastic/elastic-agent-libs/pull/166 is merged and new version is released
 	github.com/elastic/elastic-agent-libs v0.7.0
 	github.com/elastic/elastic-agent-system-metrics v0.8.0
 	github.com/elastic/elastic-transport-go/v8 v8.3.0
@@ -179,6 +180,9 @@ replace (
 	github.com/fsnotify/fsnotify => github.com/adriansr/fsnotify v1.4.8-0.20211018144411-a81f2b630e7c
 	github.com/tonistiigi/fifo => github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c
 )
+
+// FIXME: remove once https://github.com/elastic/elastic-agent-libs/pull/166 is merged and new version is released
+replace github.com/elastic/elastic-agent-libs => github.com/ycombinator/elastic-agent-libs v0.0.0-20231120175530-2423154723d5
 
 // Exclude this version because the version has an invalid checksum.
 exclude github.com/docker/distribution v2.8.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,7 @@ require (
 	github.com/elastic/e2e-testing v1.1.0
 	github.com/elastic/elastic-agent-autodiscover v0.6.5
 	github.com/elastic/elastic-agent-client/v7 v7.5.0
-	// FIXME: bump up once https://github.com/elastic/elastic-agent-libs/pull/166 is merged and new version is released
-	github.com/elastic/elastic-agent-libs v0.7.0
+	github.com/elastic/elastic-agent-libs v0.7.2
 	github.com/elastic/elastic-agent-system-metrics v0.8.0
 	github.com/elastic/elastic-transport-go/v8 v8.3.0
 	github.com/elastic/go-elasticsearch/v8 v8.10.1
@@ -180,9 +179,6 @@ replace (
 	github.com/fsnotify/fsnotify => github.com/adriansr/fsnotify v1.4.8-0.20211018144411-a81f2b630e7c
 	github.com/tonistiigi/fifo => github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c
 )
-
-// FIXME: remove once https://github.com/elastic/elastic-agent-libs/pull/166 is merged and new version is released
-replace github.com/elastic/elastic-agent-libs => github.com/ycombinator/elastic-agent-libs v0.0.0-20231120180527-82a87b8ca926
 
 // Exclude this version because the version has an invalid checksum.
 exclude github.com/docker/distribution v2.8.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1737,8 +1737,8 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMx
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/ycombinator/elastic-agent-libs v0.0.0-20231120175530-2423154723d5 h1:tyjcd30tHnApHEdFWD3cvDfG7PS2FI9bufbwUlBbVtg=
-github.com/ycombinator/elastic-agent-libs v0.0.0-20231120175530-2423154723d5/go.mod h1:pVBEElQJUO9mr4WStWNXuQGsJn54lcjAoYAHmsvBLBc=
+github.com/ycombinator/elastic-agent-libs v0.0.0-20231120180527-82a87b8ca926 h1:gLhw5YIjBFkZV/V5662hDSJX9KCDUew8JiSvyq6trkc=
+github.com/ycombinator/elastic-agent-libs v0.0.0-20231120180527-82a87b8ca926/go.mod h1:pVBEElQJUO9mr4WStWNXuQGsJn54lcjAoYAHmsvBLBc=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a h1:fZHgsYlfvtyqToslyjUt3VOPF4J7aK/3MPcK7xp3PDk=
 github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a/go.mod h1:ul22v+Nro/R083muKhosV54bj5niojjWZvU8xrevuH4=

--- a/go.sum
+++ b/go.sum
@@ -781,6 +781,8 @@ github.com/elastic/elastic-agent-autodiscover v0.6.5 h1:5DeMpuNc8c/tN6HN0A4A2uOF
 github.com/elastic/elastic-agent-autodiscover v0.6.5/go.mod h1:chulyCAyZb/njMHgzkhC/yWnt8v/Y6eCRUhmFVnsA5o=
 github.com/elastic/elastic-agent-client/v7 v7.5.0 h1:niI3WQ+01Lnp2r5LxK8SyNhrPJe13vBiOkqrDRK2oTA=
 github.com/elastic/elastic-agent-client/v7 v7.5.0/go.mod h1:DYoX95xjC4BW/p2avyu724Qr2+hoUIz9eCU9CVS1d+0=
+github.com/elastic/elastic-agent-libs v0.7.2 h1:yT0hF0UAxJCdQqhHh6SFpgYrcpB10oFzPj8IaytPS2o=
+github.com/elastic/elastic-agent-libs v0.7.2/go.mod h1:pVBEElQJUO9mr4WStWNXuQGsJn54lcjAoYAHmsvBLBc=
 github.com/elastic/elastic-agent-system-metrics v0.8.0 h1:EsWbtd83JvnaqnL57bKS1E6GhOdemTRbxdFDcenR8zQ=
 github.com/elastic/elastic-agent-system-metrics v0.8.0/go.mod h1:9C1UEfj0P687HAzZepHszN6zXA+2tN2Lx3Osvq1zby8=
 github.com/elastic/elastic-integration-corpus-generator-tool v0.5.0/go.mod h1:uf9N86y+UACGybdEhZLpwZ93XHWVhsYZAA4c2T2v6YM=
@@ -1737,8 +1739,6 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMx
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/ycombinator/elastic-agent-libs v0.0.0-20231120180527-82a87b8ca926 h1:gLhw5YIjBFkZV/V5662hDSJX9KCDUew8JiSvyq6trkc=
-github.com/ycombinator/elastic-agent-libs v0.0.0-20231120180527-82a87b8ca926/go.mod h1:pVBEElQJUO9mr4WStWNXuQGsJn54lcjAoYAHmsvBLBc=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a h1:fZHgsYlfvtyqToslyjUt3VOPF4J7aK/3MPcK7xp3PDk=
 github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a/go.mod h1:ul22v+Nro/R083muKhosV54bj5niojjWZvU8xrevuH4=

--- a/go.sum
+++ b/go.sum
@@ -781,8 +781,6 @@ github.com/elastic/elastic-agent-autodiscover v0.6.5 h1:5DeMpuNc8c/tN6HN0A4A2uOF
 github.com/elastic/elastic-agent-autodiscover v0.6.5/go.mod h1:chulyCAyZb/njMHgzkhC/yWnt8v/Y6eCRUhmFVnsA5o=
 github.com/elastic/elastic-agent-client/v7 v7.5.0 h1:niI3WQ+01Lnp2r5LxK8SyNhrPJe13vBiOkqrDRK2oTA=
 github.com/elastic/elastic-agent-client/v7 v7.5.0/go.mod h1:DYoX95xjC4BW/p2avyu724Qr2+hoUIz9eCU9CVS1d+0=
-github.com/elastic/elastic-agent-libs v0.7.0 h1:g/+Gzpn4ayXPFbfZsn5lGjbPR1TGqlVpshJVVUNJGlQ=
-github.com/elastic/elastic-agent-libs v0.7.0/go.mod h1:o+EySawBZGeYu49shJxerg2wRCimS1dhrD4As0MS700=
 github.com/elastic/elastic-agent-system-metrics v0.8.0 h1:EsWbtd83JvnaqnL57bKS1E6GhOdemTRbxdFDcenR8zQ=
 github.com/elastic/elastic-agent-system-metrics v0.8.0/go.mod h1:9C1UEfj0P687HAzZepHszN6zXA+2tN2Lx3Osvq1zby8=
 github.com/elastic/elastic-integration-corpus-generator-tool v0.5.0/go.mod h1:uf9N86y+UACGybdEhZLpwZ93XHWVhsYZAA4c2T2v6YM=
@@ -1739,6 +1737,8 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMx
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/ycombinator/elastic-agent-libs v0.0.0-20231120175530-2423154723d5 h1:tyjcd30tHnApHEdFWD3cvDfG7PS2FI9bufbwUlBbVtg=
+github.com/ycombinator/elastic-agent-libs v0.0.0-20231120175530-2423154723d5/go.mod h1:pVBEElQJUO9mr4WStWNXuQGsJn54lcjAoYAHmsvBLBc=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a h1:fZHgsYlfvtyqToslyjUt3VOPF4J7aK/3MPcK7xp3PDk=
 github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a/go.mod h1:ul22v+Nro/R083muKhosV54bj5niojjWZvU8xrevuH4=

--- a/internal/pkg/agent/application/upgrade/details/details.go
+++ b/internal/pkg/agent/application/upgrade/details/details.go
@@ -5,21 +5,11 @@
 package details
 
 import (
-	"encoding/json"
-	"fmt"
-	"math"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/elastic/elastic-agent-libs/upgrade/details"
-
-	"github.com/docker/go-units"
 )
-
-// downloadRate is a float64 that can be safely marshalled to JSON
-// when the value is Infinity. The rate is always in bytes/second units.
-type downloadRate float64
 
 // Observer is a function that will be called with upgrade details
 type Observer func(details *Details)
@@ -185,37 +175,4 @@ func equalTimePointers(t, otherT *time.Time) bool {
 	}
 
 	return t.Equal(*otherT)
-}
-
-func (dr *downloadRate) MarshalJSON() ([]byte, error) {
-	downloadRateBytesPerSecond := float64(*dr)
-	if math.IsInf(downloadRateBytesPerSecond, 0) {
-		return json.Marshal("+Inf bps")
-	}
-
-	return json.Marshal(
-		fmt.Sprintf("%sps", units.HumanSizeWithPrecision(downloadRateBytesPerSecond, 2)),
-	)
-}
-
-func (dr *downloadRate) UnmarshalJSON(data []byte) error {
-	var downloadRateStr string
-	err := json.Unmarshal(data, &downloadRateStr)
-	if err != nil {
-		return err
-	}
-
-	if downloadRateStr == "+Inf bps" {
-		*dr = downloadRate(math.Inf(1))
-		return nil
-	}
-
-	downloadRateStr = strings.TrimSuffix(downloadRateStr, "ps")
-	downloadRateBytesPerSecond, err := units.FromHumanSize(downloadRateStr)
-	if err != nil {
-		return err
-	}
-
-	*dr = downloadRate(downloadRateBytesPerSecond)
-	return nil
 }

--- a/internal/pkg/agent/application/upgrade/details/details.go
+++ b/internal/pkg/agent/application/upgrade/details/details.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/elastic/elastic-agent-libs/upgrade/details"
+
 	"github.com/docker/go-units"
 )
 
@@ -43,7 +45,7 @@ type Metadata struct {
 
 	// DownloadRate is the rate, in bytes per second, at which the download
 	// is progressing.
-	DownloadRate downloadRate `json:"download_rate,omitempty" yaml:"download_rate,omitempty"`
+	DownloadRate details.DownloadRate `json:"download_rate,omitempty" yaml:"download_rate,omitempty"`
 
 	// FailedState is the state an upgrade was in if/when it failed. Use the
 	// Fail() method of UpgradeDetails to correctly record details when
@@ -93,7 +95,7 @@ func (d *Details) SetDownloadProgress(percent, rateBytesPerSecond float64) {
 	defer d.mu.Unlock()
 
 	d.Metadata.DownloadPercent = percent
-	d.Metadata.DownloadRate = downloadRate(rateBytesPerSecond)
+	d.Metadata.DownloadRate = details.DownloadRate(rateBytesPerSecond)
 	d.notifyObservers()
 }
 

--- a/internal/pkg/agent/application/upgrade/details/details_test.go
+++ b/internal/pkg/agent/application/upgrade/details/details_test.go
@@ -80,7 +80,7 @@ func TestDetailsDownloadRateJSON(t *testing.T) {
 		var unmarshalledDetails Details
 		err = json.Unmarshal(data, &unmarshalledDetails)
 		require.NoError(t, err)
-		require.Equal(t, float64(1800), float64(unmarshalledDetails.Metadata.DownloadRate))
+		require.Equal(t, float64(1794), float64(unmarshalledDetails.Metadata.DownloadRate))
 		require.Equal(t, .8, unmarshalledDetails.Metadata.DownloadPercent)
 	})
 


### PR DESCRIPTION
## What does this PR do?

This is a refactoring PR. It moves the `details.DownloadRate` type from the `github.com/elastic/elastic-agent` module to the `github.com/elastic/elastic-agent-libs` module.

## Why is it important?

So packages within the `github.com/elastic/elastic-agent-libs` module can reuse the `details.DownloadRate` type; see https://github.com/elastic/elastic-agent-libs/pull/166.

## Related issues
* Closes https://github.com/elastic/elastic-agent/issues/3792

