### PR TITLE
[Non-Root] Hide --unprivileged installation flag until supported

### DIFF
--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -48,7 +48,7 @@ would like the Agent to operate.
 	cmd.Flags().BoolP("non-interactive", "n", false, "Install Elastic Agent in non-interactive mode which will not prompt on missing parameters but fails instead.")
 	cmd.Flags().String(flagInstallBasePath, paths.DefaultBasePath, "The path where the Elastic Agent will be installed. It must be an absolute path.")
 	cmd.Flags().Bool(flagInstallUnprivileged, false, "Installed Elastic Agent will create an 'elastic-agent' user and run as that user. (experimental)")
-	cmd.Flags().MarkHidden(flagInstallUnprivileged) // Hidden until fully supported
+	_ = cmd.Flags().MarkHidden(flagInstallUnprivileged) // Hidden until fully supported
 	addEnrollFlags(cmd)
 
 	return cmd

--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -47,7 +47,8 @@ would like the Agent to operate.
 	cmd.Flags().BoolP("force", "f", false, "Force overwrite the current installation and do not prompt for confirmation")
 	cmd.Flags().BoolP("non-interactive", "n", false, "Install Elastic Agent in non-interactive mode which will not prompt on missing parameters but fails instead.")
 	cmd.Flags().String(flagInstallBasePath, paths.DefaultBasePath, "The path where the Elastic Agent will be installed. It must be an absolute path.")
-	cmd.Flags().Bool(flagInstallUnprivileged, false, "Installed Elastic Agent will create an 'elastic-agent' user and run as that user.")
+	cmd.Flags().Bool(flagInstallUnprivileged, false, "Installed Elastic Agent will create an 'elastic-agent' user and run as that user. (experimental)")
+	cmd.Flags().MarkHidden(flagInstallUnprivileged) // Hidden until fully supported
 	addEnrollFlags(cmd)
 
 	return cmd
@@ -76,6 +77,9 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 	unprivileged, _ := cmd.Flags().GetBool(flagInstallUnprivileged)
 	if unprivileged && runtime.GOOS != "linux" {
 		return fmt.Errorf("unable to perform install command, unprivileged is currently only supported on Linux")
+	}
+	if unprivileged {
+		fmt.Fprintln(streams.Out, "Unprivileged installation mode enabled; this is an experimental and currently unsupported feature.")
 	}
 
 	topPath := paths.InstallPath(basePath)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

HIde's the `--unprivileged` installation flag until it is fully supported. Includes a message during installation explaining that when used it is experimental and unsupported.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Make it clear that its not to be used until the feature is complete.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

