### PR TITLE
[Kubernetes secret provider] Add cache for the secrets

### DIFF
--- a/changelog/fragments/1701091034-add-cache-for-secrets.yaml
+++ b/changelog/fragments/1701091034-add-cache-for-secrets.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: add cache for secrets when using kubernetes secret provider
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/3822
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/3594

--- a/internal/pkg/composable/providers/kubernetessecrets/config.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/config.go
@@ -15,11 +15,11 @@ type Config struct {
 	KubeConfig        string                       `config:"kube_config"`
 	KubeClientOptions kubernetes.KubeClientOptions `config:"kube_client_options"`
 
-	TTLUpdate time.Duration `config:"ttl_update"`
-	TTLDelete time.Duration `config:"ttl_delete"`
+	RefreshInterval time.Duration `config:"refresh_interval"`
+	TTLDelete       time.Duration `config:"ttl_delete"`
 }
 
 func (c *Config) InitDefaults() {
-	c.TTLUpdate = 60 * time.Second
+	c.RefreshInterval = 60 * time.Second
 	c.TTLDelete = 1 * time.Hour
 }

--- a/internal/pkg/composable/providers/kubernetessecrets/config.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/config.go
@@ -15,5 +15,5 @@ type Config struct {
 }
 
 func (c *Config) InitDefaults() {
-	c.TTL = 10
+	c.TTL = 1
 }

--- a/internal/pkg/composable/providers/kubernetessecrets/config.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/config.go
@@ -10,4 +10,10 @@ import "github.com/elastic/elastic-agent-autodiscover/kubernetes"
 type Config struct {
 	KubeConfig        string                       `config:"kube_config"`
 	KubeClientOptions kubernetes.KubeClientOptions `config:"kube_client_options"`
+
+	TTL int `config:"ttl"`
+}
+
+func (c *Config) InitDefaults() {
+	c.TTL = 10
 }

--- a/internal/pkg/composable/providers/kubernetessecrets/config.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/config.go
@@ -11,9 +11,11 @@ type Config struct {
 	KubeConfig        string                       `config:"kube_config"`
 	KubeClientOptions kubernetes.KubeClientOptions `config:"kube_client_options"`
 
-	TTL int `config:"ttl"`
+	TTL string `config:"ttl"`
 }
 
+var defaultTTL = "60s"
+
 func (c *Config) InitDefaults() {
-	c.TTL = 1
+	c.TTL = defaultTTL
 }

--- a/internal/pkg/composable/providers/kubernetessecrets/config.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/config.go
@@ -17,9 +17,11 @@ type Config struct {
 
 	RefreshInterval time.Duration `config:"refresh_interval"`
 	TTLDelete       time.Duration `config:"ttl_delete"`
+	Timeout         time.Duration `config:"timeout"`
 }
 
 func (c *Config) InitDefaults() {
 	c.RefreshInterval = 60 * time.Second
 	c.TTLDelete = 1 * time.Hour
+	c.Timeout = 5 * time.Second
 }

--- a/internal/pkg/composable/providers/kubernetessecrets/config.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/config.go
@@ -4,18 +4,22 @@
 
 package kubernetessecrets
 
-import "github.com/elastic/elastic-agent-autodiscover/kubernetes"
+import (
+	"time"
+
+	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
+)
 
 // Config for kubernetes provider
 type Config struct {
 	KubeConfig        string                       `config:"kube_config"`
 	KubeClientOptions kubernetes.KubeClientOptions `config:"kube_client_options"`
 
-	TTL string `config:"ttl"`
+	TTLUpdate time.Duration `config:"ttl_update"`
+	TTLDelete time.Duration `config:"ttl_delete"`
 }
 
-var defaultTTL = "60s"
-
 func (c *Config) InitDefaults() {
-	c.TTL = defaultTTL
+	c.TTLUpdate = 60 * time.Second
+	c.TTLDelete = 1 * time.Hour
 }

--- a/internal/pkg/composable/providers/kubernetessecrets/config.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/config.go
@@ -17,11 +17,13 @@ type Config struct {
 
 	RefreshInterval time.Duration `config:"refresh_interval"`
 	TTLDelete       time.Duration `config:"ttl_delete"`
-	Timeout         time.Duration `config:"timeout"`
+	RequestTimeout  time.Duration `config:"request_timeout"`
+	DisableCache    bool          `config:"disable_cache"`
 }
 
 func (c *Config) InitDefaults() {
 	c.RefreshInterval = 60 * time.Second
 	c.TTLDelete = 1 * time.Hour
-	c.Timeout = 5 * time.Second
+	c.RequestTimeout = 5 * time.Second
+	c.DisableCache = false
 }

--- a/internal/pkg/composable/providers/kubernetessecrets/config.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/config.go
@@ -16,9 +16,9 @@ type Config struct {
 	KubeClientOptions kubernetes.KubeClientOptions `config:"kube_client_options"`
 
 	RefreshInterval time.Duration `config:"cache_refresh_interval"`
-	TTLDelete       time.Duration `config:"cache_ttl_delete"`
+	TTLDelete       time.Duration `config:"cache_ttl"`
 	RequestTimeout  time.Duration `config:"cache_request_timeout"`
-	DisableCache    bool          `config:"cache_disable_cache"`
+	DisableCache    bool          `config:"cache_disable"`
 }
 
 func (c *Config) InitDefaults() {

--- a/internal/pkg/composable/providers/kubernetessecrets/config.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/config.go
@@ -15,10 +15,10 @@ type Config struct {
 	KubeConfig        string                       `config:"kube_config"`
 	KubeClientOptions kubernetes.KubeClientOptions `config:"kube_client_options"`
 
-	RefreshInterval time.Duration `config:"refresh_interval"`
-	TTLDelete       time.Duration `config:"ttl_delete"`
-	RequestTimeout  time.Duration `config:"request_timeout"`
-	DisableCache    bool          `config:"disable_cache"`
+	RefreshInterval time.Duration `config:"cache_refresh_interval"`
+	TTLDelete       time.Duration `config:"cache_ttl_delete"`
+	RequestTimeout  time.Duration `config:"cache_request_timeout"`
+	DisableCache    bool          `config:"cache_disable_cache"`
 }
 
 func (c *Config) InitDefaults() {

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
@@ -140,12 +140,13 @@ func (p *contextProviderK8sSecrets) getFromCache(key string) (string, bool) {
 		}
 	}
 
+	var pass string
 	p.secretsCacheMx.Lock()
 	data, ok := p.secretsCache[key]
 	data.lastAccess = time.Now()
+	pass = data.value
 	p.secretsCacheMx.Unlock()
-
-	return data.value, ok
+	return pass, ok
 }
 
 func (p *contextProviderK8sSecrets) addToCache(key string) (secretsData, bool) {

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
@@ -125,7 +125,7 @@ func (p *contextProviderK8sSecrets) updateCache() {
 		} else {
 			// if the secret has not been accessed in over 1h, delete it
 			// to avoid keeping secrets in cache that are no longer in use
-			diff := time.Now().Sub(data.lastAccess).Hours()
+			diff := time.Since(data.lastAccess).Hours()
 			if diff > 1 {
 				delete(p.secretsCache, name)
 			} else {

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
@@ -102,7 +102,7 @@ func (p *contextProviderK8sSecrets) updateSecrets(ctx context.Context) {
 
 func (p *contextProviderK8sSecrets) updateCache() {
 	p.secretsCacheMx.Lock()
-	for name, _ := range p.secretsCache {
+	for name := range p.secretsCache {
 		newValue, ok := p.fetchSecret(name)
 
 		// remove the secret from the cache

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
@@ -6,6 +6,7 @@ package kubernetessecrets
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -108,7 +109,7 @@ func (p *contextProviderK8sSecrets) updateCache() {
 	// to place the secrets we want to keep
 	cacheTmp := make(map[string]*secretsData)
 
-	p.secretsCacheMx.RLock()
+	p.secretsCacheMx.Lock()
 	for name, data := range p.secretsCache {
 		diff := time.Since(data.lastAccess)
 		if diff < p.config.TTLDelete {
@@ -123,9 +124,6 @@ func (p *contextProviderK8sSecrets) updateCache() {
 
 		}
 	}
-	p.secretsCacheMx.RUnlock()
-
-	p.secretsCacheMx.Lock()
 	p.secretsCache = cacheTmp
 	p.secretsCacheMx.Unlock()
 }
@@ -148,6 +146,7 @@ func (p *contextProviderK8sSecrets) getFromCache(key string) (string, bool) {
 	p.secretsCacheMx.Lock()
 	data, ok := p.secretsCache[key]
 	data.lastAccess = time.Now()
+	fmt.Println(data.lastAccess)
 	pass = data.value
 	p.secretsCacheMx.Unlock()
 	return pass, ok

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
@@ -106,7 +106,7 @@ func (p *contextProviderK8sSecrets) updateSecrets(ctx context.Context) {
 func (p *contextProviderK8sSecrets) updateCache() {
 	p.secretsCacheMx.Lock()
 	// deleting entries does not free the memory, so we need to create a new map
-	// to place the ones the secrets we want to keep
+	// to place the secrets we want to keep
 	cacheTmp := make(map[string]*secretsData)
 	for name, data := range p.secretsCache {
 		diff := time.Since(data.lastAccess)
@@ -186,9 +186,9 @@ func (p *contextProviderK8sSecrets) fetchSecret(key string) (string, bool) {
 	secretName := tokens[2]
 	secretVar := tokens[3]
 
-	secretIntefrace := client.CoreV1().Secrets(ns)
+	secretInterface := client.CoreV1().Secrets(ns)
 	ctx := context.TODO()
-	secret, err := secretIntefrace.Get(ctx, secretName, metav1.GetOptions{})
+	secret, err := secretInterface.Get(ctx, secretName, metav1.GetOptions{})
 	if err != nil {
 		p.logger.Errorf("Could not retrieve secret from k8s API: %v", err)
 		return "", false

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
@@ -89,16 +89,16 @@ func getK8sClient(kubeconfig string, opt kubernetes.KubeClientOptions) (k8sclien
 	return kubernetes.GetKubernetesClient(kubeconfig, opt)
 }
 
-// Update the secrets in the cache every TTL minutes
+// Update the secrets in the cache every RefreshInterval
 func (p *contextProviderK8sSecrets) updateSecrets(ctx context.Context) {
-	timer := time.NewTimer(p.config.TTLUpdate)
+	timer := time.NewTimer(p.config.RefreshInterval)
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-timer.C:
 			p.updateCache()
-			timer.Reset(p.config.TTLUpdate)
+			timer.Reset(p.config.RefreshInterval)
 		}
 	}
 }

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
@@ -78,7 +78,7 @@ func (p *contextProviderK8sSecrets) Fetch(key string) (string, bool) {
 func (p *contextProviderK8sSecrets) Run(ctx context.Context, comm corecomp.ContextProviderComm) error {
 	client, err := getK8sClientFunc(p.config.KubeConfig, p.config.KubeClientOptions)
 	if err != nil {
-		p.logger.Debugf("Kubernetes_secrets provider skipped, unable to connect: %s", err)
+		p.logger.Debugf("kubernetes_secrets provider skipped, unable to connect: %s", err)
 		return nil
 	}
 	p.clientMx.Lock()

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
@@ -209,7 +209,6 @@ func (p *contextProviderK8sSecrets) validateKey(key string) bool {
 	return true
 }
 
-// This is only called by getFromCache function, which is already locking the cache.
 func (p *contextProviderK8sSecrets) addToCache(key string) (string, bool) {
 	valid := p.validateKey(key)
 	if !valid {

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
@@ -120,8 +120,7 @@ func (p *contextProviderK8sSecrets) updateSecrets(ctx context.Context) {
 func (p *contextProviderK8sSecrets) mergeWithCurrent(updatedMap map[string]*secretsData) map[string]*secretsData {
 	merged := make(map[string]*secretsData)
 	for name, data := range p.secretsCache {
-		lastAccess := data.lastAccess
-		diff := time.Since(lastAccess)
+		diff := time.Since(data.lastAccess)
 		if diff < p.config.TTLDelete {
 			merged[name] = data
 		}

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
@@ -237,6 +237,7 @@ func Test_K8sSecretsProvider_Check_TTL(t *testing.T) {
 	require.NoError(t, err)
 
 	// wait for ttl update
+	<-time.After(ttlUpdate)
 	assert.Eventuallyf(t, func() bool {
 		val, found = fp.Fetch("kubernetes_secrets.test_namespace.testing_secret.secret_value")
 		return found && val == newPass
@@ -244,6 +245,7 @@ func Test_K8sSecretsProvider_Check_TTL(t *testing.T) {
 
 	// After TTL delete, secret should no longer be found in cache since it was never
 	// fetched during that time
+	<-time.After(ttlDelete)
 	assert.Eventuallyf(t, func() bool {
 		fp.secretsCacheMx.Lock()
 		size := len(fp.secretsCache)

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
@@ -203,7 +203,7 @@ func Test_K8sSecretsProvider_Check_TTL(t *testing.T) {
 
 	// Secret cache should be empty at start
 	fp.secretsCacheMx.Lock()
-	assert.Equal(t, len(fp.secretsCache), 0)
+	assert.Equal(t, 0, len(fp.secretsCache))
 	fp.secretsCacheMx.Unlock()
 
 	// Secret should be in the cache after this call

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
@@ -238,7 +238,7 @@ func Test_K8sSecretsProvider_Check_TTL(t *testing.T) {
 
 	// wait for ttl update
 	<-time.After(ttlUpdate * 2)
-	val, found = fp.Fetch("kubernetes_secrets.test_namespace.testing_secret.secret_value")
+	val, found = fp.Fetch(key)
 	assert.True(t, found)
 	assert.Equal(t, newPass, val)
 

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
@@ -145,7 +145,7 @@ func Test_K8sSecretsProvider_Check_TTL(t *testing.T) {
 	ttlDelete, err := time.ParseDuration("1s")
 	require.NoError(t, err)
 
-	ttlUpdate, err := time.ParseDuration("100ms")
+	refreshInterval, err := time.ParseDuration("100ms")
 	require.NoError(t, err)
 
 	secret := &v1.Secret{
@@ -167,8 +167,8 @@ func Test_K8sSecretsProvider_Check_TTL(t *testing.T) {
 	logger := logp.NewLogger("test_k8s_secrets")
 
 	c := map[string]interface{}{
-		"ttl_update": ttlUpdate,
-		"ttl_delete": ttlDelete,
+		"refresh_interval": refreshInterval,
+		"ttl_delete":       ttlDelete,
 	}
 	cfg, err := config.NewConfigFrom(c)
 	require.NoError(t, err)
@@ -237,11 +237,11 @@ func Test_K8sSecretsProvider_Check_TTL(t *testing.T) {
 	require.NoError(t, err)
 
 	// wait for ttl update
-	<-time.After(ttlUpdate)
+	<-time.After(refreshInterval)
 	assert.Eventuallyf(t, func() bool {
 		val, found = fp.Fetch(key)
 		return found && val == newPass
-	}, ttlUpdate*3, ttlUpdate, "Failed to update the secret value after TTL update has passed.")
+	}, refreshInterval*3, refreshInterval, "Failed to update the secret value after TTL update has passed.")
 
 	// After TTL delete, secret should no longer be found in cache since it was never
 	// fetched during that time

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
@@ -112,9 +112,9 @@ func Test_K8sSecretsProvider_Fetch_Cache_Enabled(t *testing.T) {
 	logger := logp.NewLogger("test_k8s_secrets")
 
 	c := map[string]interface{}{
-		"refresh_interval": refreshInterval,
-		"ttl_delete":       ttlDelete,
-		"disable_cache":    false,
+		"cache_refresh_interval": refreshInterval,
+		"cache_ttl_delete":       ttlDelete,
+		"cache_disable_cache":    false,
 	}
 	cfg, err := config.NewConfigFrom(c)
 	require.NoError(t, err)
@@ -223,7 +223,7 @@ func Test_K8sSecretsProvider_Fetch_Cache_Disabled(t *testing.T) {
 	logger := logp.NewLogger("test_k8s_secrets")
 
 	c := map[string]interface{}{
-		"disable_cache": true,
+		"cache_disable_cache": true,
 	}
 	cfg, err := config.NewConfigFrom(c)
 	require.NoError(t, err)

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
@@ -113,8 +113,8 @@ func Test_K8sSecretsProvider_Fetch_Cache_Enabled(t *testing.T) {
 
 	c := map[string]interface{}{
 		"cache_refresh_interval": refreshInterval,
-		"cache_ttl_delete":       ttlDelete,
-		"cache_disable_cache":    false,
+		"cache_ttl":              ttlDelete,
+		"cache_disable":          false,
 	}
 	cfg, err := config.NewConfigFrom(c)
 	require.NoError(t, err)
@@ -223,7 +223,7 @@ func Test_K8sSecretsProvider_Fetch_Cache_Disabled(t *testing.T) {
 	logger := logp.NewLogger("test_k8s_secrets")
 
 	c := map[string]interface{}{
-		"cache_disable_cache": true,
+		"cache_disable": true,
 	}
 	cfg, err := config.NewConfigFrom(c)
 	require.NoError(t, err)


### PR DESCRIPTION
## What does this PR do?

Currently, we make a request to the API Server every time we need to get the value of a secret. This issue is better explained [here](https://github.com/elastic/elastic-agent/issues/3594). Discussion also present in the issue.

With this PR, we use a map to store the secrets like this:

1. Once the kubernetes secret provider starts running, we launch a go routine that will update the cache every TTL minutes. [TTL](https://github.com/constanca-m/elastic-agent/blob/dadc79b3d338bd2f4b37e3488c453d145450e436/internal/pkg/composable/providers/kubernetessecrets/config.go#L14) is a new option in the configuration of the provider. By default it is set to 10 minutes.
2. To update the cache, we range over every secret stored there, and make a new request to the API Server to obtain the current value.

The secrets are accessed from the outside through the function [Fetch](https://github.com/constanca-m/elastic-agent/blob/dadc79b3d338bd2f4b37e3488c453d145450e436/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go#L59). If we try to retrieve a secret that is not present in our map, then we make a request to the API Server to obtain its value and store it in the map. This function never causes an update on the secret values.

The only difference from this approach to the current one is that we know store the values of the secrets and secret values.

**Warning**:  Sometimes the secret values are not updated in time and we can be using incorrect ones until the update happens. This is also happening now.



## Why is it important?

To stop overwhelming the API Server with secret requests.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test


## How to test this PR locally

1. Clone this branch.
2. Follow [these steps](https://github.com/constanca-m/elastic-agent/blob/kubernetes-cache-secrets/README.md#testing-elastic-agent-on-kubernetes) from the README file.

## Related issues

- Relates to https://github.com/elastic/elastic-agent/issues/3594


## Screenshots

There should not be a change in behavior apart from a decrease in calls to the API Server. Everything else works as expected/before:

![image](https://github.com/elastic/elastic-agent/assets/113898685/526d9202-91d1-4875-89af-d0482e08b9aa)

