### PR TITLE
[Upgrade Details] Inform the Upgrade Marker Watcher when an upgrade starts

### DIFF
--- a/internal/pkg/agent/application/upgrade/marker_watcher.go
+++ b/internal/pkg/agent/application/upgrade/marker_watcher.go
@@ -19,12 +19,15 @@ import (
 type MarkerWatcher interface {
 	Watch() <-chan UpdateMarker
 	Run(ctx context.Context) error
+	SetUpgradeStarted()
 }
 
 type MarkerFileWatcher struct {
 	markerFilePath string
 	logger         *logger.Logger
 	updateCh       chan UpdateMarker
+
+	upgradeStarted bool
 }
 
 func newMarkerFileWatcher(upgradeMarkerFilePath string, logger *logger.Logger) MarkerWatcher {
@@ -34,11 +37,16 @@ func newMarkerFileWatcher(upgradeMarkerFilePath string, logger *logger.Logger) M
 		markerFilePath: upgradeMarkerFilePath,
 		logger:         logger,
 		updateCh:       make(chan UpdateMarker),
+		upgradeStarted: false,
 	}
 }
 
 func (mfw *MarkerFileWatcher) Watch() <-chan UpdateMarker {
 	return mfw.updateCh
+}
+
+func (mfw *MarkerFileWatcher) SetUpgradeStarted() {
+	mfw.upgradeStarted = true
 }
 
 func (mfw *MarkerFileWatcher) Run(ctx context.Context) error {
@@ -115,12 +123,12 @@ func (mfw *MarkerFileWatcher) processMarker(currentVersion string, commit string
 	}
 
 	// If the marker exists but the version of Agent we're running right
-	// now is the same as the prevVersion recorded in the marker, it means
-	// the upgrade was rolled back. Ideally, this UPG_ROLLBACK state would've
+	// now is the same as the prevVersion recorded in the marker AND an upgrade
+	// has not started, it means the upgrade was rolled back. Ideally, this UPG_ROLLBACK state would've
 	// been recorded in the marker's upgrade details field but, in case it
 	// isn't for some reason, we fallback to explicitly setting that state as
 	// part of the upgrade details in the marker.
-	if marker.PrevVersion == currentVersion && marker.PrevHash == commit {
+	if marker.PrevVersion == currentVersion && marker.PrevHash == commit && !mfw.upgradeStarted {
 		if marker.Details == nil {
 			marker.Details = details.NewDetails("unknown", details.StateRollback, marker.GetActionID())
 		} else {

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -134,6 +134,8 @@ func (u *Upgrader) Upgradeable() bool {
 // Upgrade upgrades running agent, function returns shutdown callback that must be called by reexec.
 func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string, action *fleetapi.ActionUpgrade, det *details.Details, skipVerifyOverride bool, skipDefaultPgp bool, pgpBytes ...string) (_ reexec.ShutdownCallbackFn, err error) {
 	u.log.Infow("Upgrading agent", "version", version, "source_uri", sourceURI)
+	u.markerWatcher.SetUpgradeStarted()
+
 	span, ctx := apm.StartSpan(ctx, "upgrade", "app.internal")
 	defer span.End()
 

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -134,6 +134,14 @@ func (u *Upgrader) Upgradeable() bool {
 // Upgrade upgrades running agent, function returns shutdown callback that must be called by reexec.
 func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string, action *fleetapi.ActionUpgrade, det *details.Details, skipVerifyOverride bool, skipDefaultPgp bool, pgpBytes ...string) (_ reexec.ShutdownCallbackFn, err error) {
 	u.log.Infow("Upgrading agent", "version", version, "source_uri", sourceURI)
+
+	// Inform the Upgrade Marker Watcher that we've started upgrading. Note that this
+	// is only possible to do in-memory since, today, the  process that's initiating
+	// the upgrade is the same as the Agent process in which the Upgrade Marker Watcher is
+	// running. If/when, in the future, the process initiating the upgrade is separated
+	// from the Agent process in which the Upgrade Marker Watcher is running, such in-memory
+	// communication will need to be replaced with inter-process communication (e.g. via
+	// a file, e.g. the Upgrade Marker file or something else).
 	u.markerWatcher.SetUpgradeStarted()
 
 	span, ctx := apm.StartSpan(ctx, "upgrade", "app.internal")


### PR DESCRIPTION
## What does this PR do?

This PR allows the part of the upgrade process performed by the old (pre-upgrade) Agent to inform the Upgrade Marker Watcher when an upgrade starts.

## Why is it important?

The Upgrade Marker Watcher's job is to watch for changes to the Upgrade Marker file and process said changes.  As part of this processing, it implements fallback logic to determine if the upgrade has been rolled back.  For this, it checks whether the running Agent's version is the same as the `prev_version` noted in the Upgrade Marker. 

However, this version check alone is not sufficient to say that the Agent has rolled back, as the check will also succeed in the period right after the old (pre-upgrade) Agent creates the Upgrade Marker but before it re-execs and starts up the new (post-upgrade) Agent.  If the old (pre-upgrade) Agent can communicate to the Upgrade Marker Watcher when it starts an upgrade, the Upgrade Marker Watcher can then know that it's not being rolled back even though the versions are the same.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates to https://github.com/elastic/elastic-agent/pull/3827#discussion_r1408553007

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
