### PR TITLE
Update CLI documentation for `--path.install`

### DIFF
--- a/internal/pkg/agent/application/paths/common.go
+++ b/internal/pkg/agent/application/paths/common.go
@@ -59,7 +59,7 @@ func init() {
 	fs.StringVar(&configPath, "path.config", configPath, "Config path is the directory Agent looks for its config file")
 	fs.StringVar(&configFilePath, "c", DefaultConfigName, "Configuration file, relative to path.config")
 	fs.StringVar(&logsPath, "path.logs", logsPath, "Logs path contains Agent log output")
-	fs.StringVar(&installPath, "path.install", installPath, "Install path contains binaries Agent extracts")
+	fs.StringVar(&installPath, "path.install", installPath, "DEPRECATED, setting this flag has no effect since v8.6.0")
 
 	// enable user to download update artifacts to alternative place
 	// TODO: remove path.downloads support on next major (this can be configured using `agent.download.targetDirectory`)


### PR DESCRIPTION
## What does this PR do?

`--path.install` has no effect since v8.6.0, removing it is a breaking change because it would prevent the Elastic-Agent from running if `--path.install` is passed.

Instead of removing it, this commit updates its documentation to inform it is deprecated and has no effect.

## Why is it important?

It updates our CLI documentation to correctly reflect the Elastic-Agent behaviour.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
~~- [ ] I have added an integration test or an E2E test~~

~~## Author's Checklist~~
## How to test this PR locally

1. Build this PR
2. Run `./elastic-agent -h`
3. Assert that the CLI documentation for `--path.install` is `DEPRECATED, setting this flag has no effect since v8.6.0`

## Related issues
 - Closes: https://github.com/elastic/elastic-agent/pull/3863
~~## Use cases~~
~~## Screenshots~~
## Logs

```
./elastic-agent -h
Usage:
  elastic-agent [subcommand] [flags]
  elastic-agent [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  component   Tools to work on components
  diagnostics Gather diagnostics information from the Elastic Agent and write it to a zip archive
  enroll      Enroll the Elastic Agent into Fleet
  help        Help about any command
  inspect     Show current configuration of the Elastic Agent
  install     Install Elastic Agent permanently on this system
  logs        Output Elastic Agent logs
  restart     Restart the currently running Elastic Agent daemon
  run         Start the Elastic Agent
  status      Show the current status of the running Elastic Agent daemon
  uninstall   Uninstall Elastic Agent from this system
  upgrade     Upgrade the currently installed Elastic Agent to the specified version
  version     Display the version of the elastic-agent.
  watch       Watch the Elastic Agent for failures and initiate rollback

Flags:
  -c, --c string                     Configuration file, relative to path.config (default "elastic-agent.yml")
  -d, --d string                     Enable certain debug selectors
  -e, --e                            Log to stderr and disable syslog/file output
      --environment environmentVar   set environment being ran in (default default)
  -h, --help                         help for elastic-agent
      --path.config string           Config path is the directory Agent looks for its config file (default "/home/tiago/devel/elastic-agent")
      --path.downloads string        Downloads path contains binaries Agent downloads (default "/home/tiago/devel/elastic-agent/data/elastic-agent-unknow/downloads")
      --path.home string             Agent root path (default "/home/tiago/devel/elastic-agent")
      --path.install string          DEPRECATED, setting this flag has no effect since v8.6.0
      --path.logs string             Logs path contains Agent log output (default "/home/tiago/devel/elastic-agent")
  -v, --v                            Log at INFO level

Use "elastic-agent [command] --help" for more information about a command.
```

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
