### PR TITLE
Add missing contexts (and therefore timeouts) to integration test code

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -1887,7 +1887,9 @@ func createTestRunner(matrix bool, singleTest string, goTestFlags string, batche
 		}
 
 	} else if stackProvisionerMode == ess.ProvisionerServerless {
-		stackProvisioner, err = ess.NewServerlessProvisioner(provisionCfg)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		stackProvisioner, err = ess.NewServerlessProvisioner(ctx, provisionCfg)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/testing/ess/serverless.go
+++ b/pkg/testing/ess/serverless.go
@@ -139,9 +139,9 @@ func (srv *ServerlessClient) DeploymentIsReady(ctx context.Context) (bool, error
 }
 
 // DeleteDeployment deletes the deployment
-func (srv *ServerlessClient) DeleteDeployment() error {
+func (srv *ServerlessClient) DeleteDeployment(ctx context.Context) error {
 	endpoint := fmt.Sprintf("%s/api/v1/serverless/projects/%s/%s", serverlessURL, srv.proj.Type, srv.proj.ID)
-	req, err := http.NewRequestWithContext(context.Background(), "DELETE", endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
 	if err != nil {
 		return fmt.Errorf("error creating HTTP request: %w", err)
 	}

--- a/pkg/testing/ess/serverless_provisioner.go
+++ b/pkg/testing/ess/serverless_provisioner.go
@@ -178,7 +178,7 @@ func (prov *ServerlessProvisioner) Delete(ctx context.Context, stack runner.Stac
 	client.proj.Credentials.Password = stack.Password
 
 	prov.log.Logf("Destroying serverless stack %s [stack_id: %s, deployment_id: %s]", stack.Version, stack.ID, deploymentID)
-	err = client.DeleteDeployment()
+	err = client.DeleteDeployment(ctx)
 	if err != nil {
 		return fmt.Errorf("error removing serverless stack %s [stack_id: %s, deployment_id: %s]: %w", stack.Version, stack.ID, deploymentID, err)
 	}

--- a/pkg/testing/ess/serverless_provisioner.go
+++ b/pkg/testing/ess/serverless_provisioner.go
@@ -47,12 +47,12 @@ type ServerlessRegions struct {
 }
 
 // NewServerlessProvisioner creates a new StackProvisioner instance for serverless
-func NewServerlessProvisioner(cfg ProvisionerConfig) (runner.StackProvisioner, error) {
+func NewServerlessProvisioner(ctx context.Context, cfg ProvisionerConfig) (runner.StackProvisioner, error) {
 	prov := &ServerlessProvisioner{
 		cfg: cfg,
 		log: &defaultLogger{wrapped: logp.L()},
 	}
-	err := prov.CheckCloudRegion()
+	err := prov.CheckCloudRegion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error checking region setting: %w", err)
 	}
@@ -188,10 +188,10 @@ func (prov *ServerlessProvisioner) Delete(ctx context.Context, stack runner.Stac
 // CheckCloudRegion checks to see if the provided region is valid for the serverless
 // if we have an invalid region, overwrite with a valid one.
 // The "normal" and serverless ESS APIs have different regions, hence why we need this.
-func (prov *ServerlessProvisioner) CheckCloudRegion() error {
+func (prov *ServerlessProvisioner) CheckCloudRegion(ctx context.Context) error {
 	urlPath := fmt.Sprintf("%s/api/v1/serverless/regions", serverlessURL)
 
-	httpHandler, err := http.NewRequestWithContext(context.Background(), "GET", urlPath, nil)
+	httpHandler, err := http.NewRequestWithContext(ctx, "GET", urlPath, nil)
 	if err != nil {
 		return fmt.Errorf("error creating new httpRequest: %w", err)
 	}

--- a/pkg/testing/ess/serverless_test.go
+++ b/pkg/testing/ess/serverless_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestProvisionGetRegions(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*240)
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	defer cancel()
 
 	_ = logp.DevelopmentSetup()
@@ -39,7 +39,7 @@ func TestProvisionGetRegions(t *testing.T) {
 }
 
 func TestStackProvisioner(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	_ = logp.DevelopmentSetup()
@@ -82,7 +82,7 @@ func TestStartServerless(t *testing.T) {
 		key,
 		&defaultLogger{wrapped: logp.L()})
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*240)
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	defer cancel()
 
 	req := ServerlessRequest{Name: "ingest-e2e-test", RegionID: "aws-eu-west-1"}

--- a/pkg/testing/ess/serverless_test.go
+++ b/pkg/testing/ess/serverless_test.go
@@ -95,6 +95,6 @@ func TestStartServerless(t *testing.T) {
 	t.Logf("got endpoints: %#v", clientHandle.proj.Endpoints)
 	t.Logf("got auth: %#v", clientHandle.proj.Credentials)
 
-	err = clientHandle.DeleteDeployment()
+	err = clientHandle.DeleteDeployment(ctx)
 	require.NoError(t, err)
 }

--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -480,7 +480,7 @@ func (f *Fixture) Run(ctx context.Context, states ...State) error {
 			}
 		case state := <-stateCh:
 			if smInstance != nil {
-				cfg, cont, err := smInstance.next(state)
+				cfg, cont, err := smInstance.next(ctx, state)
 				if err != nil {
 					killProc()
 					return fmt.Errorf("state management failed with unexpected error: %w", err)

--- a/pkg/testing/machine.go
+++ b/pkg/testing/machine.go
@@ -286,7 +286,9 @@ func stateComponentsReached(components map[string]ComponentState, agentComponent
 		return false
 	}
 	found := make(map[string]bool)
-	for _, agentComp := range agentComponents {
+	for i := range agentComponents {
+		// Index the array to avoid aliasing a temporary loop value when taking the address below.
+		agentComp := agentComponents[i]
 		state, ok := components[agentComp.ID]
 		if !ok {
 			if strict {
@@ -301,7 +303,7 @@ func stateComponentsReached(components map[string]ComponentState, agentComponent
 			return false
 		}
 	}
-	for compID, _ := range components {
+	for compID := range components {
 		_, ok := found[compID]
 		if !ok {
 			// was not found
@@ -337,7 +339,9 @@ func stateComponentUnitsReached(units map[ComponentUnitKey]ComponentUnitState, c
 		return false
 	}
 	found := make(map[ComponentUnitKey]bool)
-	for _, compUnit := range compUnits {
+	for i := range compUnits {
+		// Index the array to avoid aliasing a temporary loop value when taking the address below.
+		compUnit := compUnits[i]
 		key := ComponentUnitKey{UnitType: compUnit.UnitType, UnitID: compUnit.UnitID}
 		state, ok := units[key]
 		if !ok {
@@ -353,7 +357,7 @@ func stateComponentUnitsReached(units map[ComponentUnitKey]ComponentUnitState, c
 			return false
 		}
 	}
-	for key, _ := range units {
+	for key := range units {
 		_, ok := found[key]
 		if !ok {
 			// was not found

--- a/pkg/testing/tools/check/check.go
+++ b/pkg/testing/tools/check/check.go
@@ -45,12 +45,13 @@ func ConnectedToFleet(t *testing.T, fixture *integrationtest.Fixture, timeout ti
 // FleetAgentStatus returns a niladic function that returns true if the agent
 // has reached expectedStatus; false otherwise. The returned function is intended
 // for use with assert.Eventually or require.Eventually.
-func FleetAgentStatus(t *testing.T,
+func FleetAgentStatus(ctx context.Context,
+	t *testing.T,
 	client *kibana.Client,
 	policyID,
 	expectedStatus string) func() bool {
 	return func() bool {
-		currentStatus, err := fleettools.GetAgentStatus(client, policyID)
+		currentStatus, err := fleettools.GetAgentStatus(ctx, client, policyID)
 		if err != nil {
 			t.Errorf("unable to determine agent status: %s", err.Error())
 			return false

--- a/pkg/testing/tools/check/check.go
+++ b/pkg/testing/tools/check/check.go
@@ -20,13 +20,13 @@ import (
 // ConnectedToFleet checks if the agent defined in the fixture is connected to
 // Fleet Server. It uses assert.Eventually and if it fails the last error will
 // be printed. It returns if the agent is connected to Fleet Server or not.
-func ConnectedToFleet(t *testing.T, fixture *integrationtest.Fixture, timeout time.Duration) bool {
+func ConnectedToFleet(ctx context.Context, t *testing.T, fixture *integrationtest.Fixture, timeout time.Duration) bool {
 	t.Helper()
 
 	var err error
 	var agentStatus integrationtest.AgentStatusOutput
 	assertFn := func() bool {
-		agentStatus, err = fixture.ExecStatus(context.Background())
+		agentStatus, err = fixture.ExecStatus(ctx)
 		return agentStatus.FleetState == int(cproto.State_HEALTHY)
 	}
 

--- a/pkg/testing/tools/estools/elasticsearch.go
+++ b/pkg/testing/tools/estools/elasticsearch.go
@@ -143,8 +143,8 @@ type Lifecycle struct {
 }
 
 // GetAllindicies returns a list of indicies on the target ES instance
-func GetAllindicies(client elastictransport.Interface) ([]Index, error) {
-	return GetIndicesWithContext(context.Background(), client, []string{})
+func GetAllindicies(ctx context.Context, client elastictransport.Interface) ([]Index, error) {
+	return GetIndicesWithContext(ctx, client, []string{})
 }
 
 // GetIndicesWithContext returns a list of indicies on the target ES instance with the provided context
@@ -202,8 +202,8 @@ func CreateAPIKey(ctx context.Context, client elastictransport.Interface, req AP
 }
 
 // FindMatchingLogLines returns any logs with message fields that match the given line
-func FindMatchingLogLines(client elastictransport.Interface, namespace, line string) (Documents, error) {
-	return FindMatchingLogLinesWithContext(context.Background(), client, namespace, line)
+func FindMatchingLogLines(ctx context.Context, client elastictransport.Interface, namespace, line string) (Documents, error) {
+	return FindMatchingLogLinesWithContext(ctx, client, namespace, line)
 }
 
 // GetLatestDocumentMatchingQuery returns the last document that matches the given query.
@@ -368,8 +368,8 @@ func FindMatchingLogLinesWithContext(ctx context.Context, client elastictranspor
 
 // CheckForErrorsInLogs checks to see if any error-level lines exist
 // excludeStrings can be used to remove any particular error strings from logs
-func CheckForErrorsInLogs(client elastictransport.Interface, namespace string, excludeStrings []string) (Documents, error) {
-	return CheckForErrorsInLogsWithContext(context.Background(), client, namespace, excludeStrings)
+func CheckForErrorsInLogs(ctx context.Context, client elastictransport.Interface, namespace string, excludeStrings []string) (Documents, error) {
+	return CheckForErrorsInLogsWithContext(ctx, client, namespace, excludeStrings)
 }
 
 // CheckForErrorsInLogsWithContext checks to see if any error-level lines exist
@@ -438,12 +438,12 @@ func CheckForErrorsInLogsWithContext(ctx context.Context, client elastictranspor
 }
 
 // GetLogsForDataset returns any logs associated with the datastream
-func GetLogsForDataset(client elastictransport.Interface, index string) (Documents, error) {
-	return GetLogsForDatasetWithContext(context.Background(), client, index)
+func GetLogsForDataset(ctx context.Context, client elastictransport.Interface, index string) (Documents, error) {
+	return GetLogsForDatasetWithContext(ctx, client, index)
 }
 
 // GetLogsForAgentID returns any logs associated with the agent ID
-func GetLogsForAgentID(client elastictransport.Interface, id string) (Documents, error) {
+func GetLogsForAgentID(ctx context.Context, client elastictransport.Interface, id string) (Documents, error) {
 	indexQuery := map[string]interface{}{
 		"query": map[string]interface{}{
 			"match": map[string]interface{}{
@@ -465,7 +465,7 @@ func GetLogsForAgentID(client elastictransport.Interface, id string) (Documents,
 		es.Search.WithBody(&buf),
 		es.Search.WithTrackTotalHits(true),
 		es.Search.WithPretty(),
-		es.Search.WithContext(context.Background()),
+		es.Search.WithContext(ctx),
 		es.Search.WithQuery(fmt.Sprintf(`elastic_agent.id:%s`, id)),
 		// magic number, we try to get all entries it helps debugging test failures
 		es.Search.WithSize(300),

--- a/pkg/testing/tools/fleettools/fleet.go
+++ b/pkg/testing/tools/fleettools/fleet.go
@@ -15,8 +15,8 @@ import (
 )
 
 // GetAgentByPolicyIDAndHostnameFromList get an agent by the local_metadata.host.name property, reading from the agents list
-func GetAgentByPolicyIDAndHostnameFromList(client *kibana.Client, policyID, hostname string) (*kibana.AgentExisting, error) {
-	listAgentsResp, err := client.ListAgents(context.Background(), kibana.ListAgentsRequest{})
+func GetAgentByPolicyIDAndHostnameFromList(ctx context.Context, client *kibana.Client, policyID, hostname string) (*kibana.AgentExisting, error) {
+	listAgentsResp, err := client.ListAgents(ctx, kibana.ListAgentsRequest{})
 	if err != nil {
 		return nil, err
 	}
@@ -44,21 +44,21 @@ func GetAgentByPolicyIDAndHostnameFromList(client *kibana.Client, policyID, host
 	return hostnameAgents[0], nil
 }
 
-func GetAgentIDByHostname(client *kibana.Client, policyID, hostname string) (string, error) {
-	agent, err := GetAgentByPolicyIDAndHostnameFromList(client, policyID, hostname)
+func GetAgentIDByHostname(ctx context.Context, client *kibana.Client, policyID, hostname string) (string, error) {
+	agent, err := GetAgentByPolicyIDAndHostnameFromList(ctx, client, policyID, hostname)
 	if err != nil {
 		return "", err
 	}
 	return agent.Agent.ID, nil
 }
 
-func GetAgentStatus(client *kibana.Client, policyID string) (string, error) {
+func GetAgentStatus(ctx context.Context, client *kibana.Client, policyID string) (string, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return "", err
 	}
 
-	agent, err := GetAgentByPolicyIDAndHostnameFromList(client, policyID, hostname)
+	agent, err := GetAgentByPolicyIDAndHostnameFromList(ctx, client, policyID, hostname)
 	if err != nil {
 		return "", err
 	}
@@ -66,13 +66,13 @@ func GetAgentStatus(client *kibana.Client, policyID string) (string, error) {
 	return agent.Status, nil
 }
 
-func GetAgentVersion(client *kibana.Client, policyID string) (string, error) {
+func GetAgentVersion(ctx context.Context, client *kibana.Client, policyID string) (string, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return "", err
 	}
 
-	agent, err := GetAgentByPolicyIDAndHostnameFromList(client, policyID, hostname)
+	agent, err := GetAgentByPolicyIDAndHostnameFromList(ctx, client, policyID, hostname)
 	if err != nil {
 		return "", err
 	}
@@ -80,12 +80,12 @@ func GetAgentVersion(client *kibana.Client, policyID string) (string, error) {
 	return agent.Agent.Version, err
 }
 
-func UnEnrollAgent(client *kibana.Client, policyID string) error {
+func UnEnrollAgent(ctx context.Context, client *kibana.Client, policyID string) error {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return err
 	}
-	agentID, err := GetAgentIDByHostname(client, policyID, hostname)
+	agentID, err := GetAgentIDByHostname(ctx, client, policyID, hostname)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func UnEnrollAgent(client *kibana.Client, policyID string) error {
 		ID:     agentID,
 		Revoke: true,
 	}
-	_, err = client.UnEnrollAgent(context.Background(), unEnrollAgentReq)
+	_, err = client.UnEnrollAgent(ctx, unEnrollAgentReq)
 	if err != nil {
 		return fmt.Errorf("unable to unenroll agent with ID [%s]: %w", agentID, err)
 	}
@@ -102,13 +102,13 @@ func UnEnrollAgent(client *kibana.Client, policyID string) error {
 	return nil
 }
 
-func UpgradeAgent(client *kibana.Client, policyID, version string, force bool) error {
+func UpgradeAgent(ctx context.Context, client *kibana.Client, policyID, version string, force bool) error {
 	// TODO: fix me: this does not work if FQDN is enabled
 	hostname, err := os.Hostname()
 	if err != nil {
 		return err
 	}
-	agentID, err := GetAgentIDByHostname(client, policyID, hostname)
+	agentID, err := GetAgentIDByHostname(ctx, client, policyID, hostname)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func UpgradeAgent(client *kibana.Client, policyID, version string, force bool) e
 		Version: version,
 		Force:   force,
 	}
-	_, err = client.UpgradeAgent(context.Background(), upgradeAgentReq)
+	_, err = client.UpgradeAgent(ctx, upgradeAgentReq)
 	if err != nil {
 		return fmt.Errorf("unable to upgrade agent with ID [%s]: %w", agentID, err)
 	}
@@ -126,9 +126,9 @@ func UpgradeAgent(client *kibana.Client, policyID, version string, force bool) e
 	return nil
 }
 
-func DefaultURL(client *kibana.Client) (string, error) {
+func DefaultURL(ctx context.Context, client *kibana.Client) (string, error) {
 	req := kibana.ListFleetServerHostsRequest{}
-	resp, err := client.ListFleetServerHosts(context.Background(), req)
+	resp, err := client.ListFleetServerHosts(ctx, req)
 	if err != nil {
 		return "", fmt.Errorf("unable to list fleet server hosts: %w", err)
 	}

--- a/pkg/testing/tools/tools.go
+++ b/pkg/testing/tools/tools.go
@@ -22,10 +22,10 @@ import (
 // given agent's policy revision has reached the given policy revision; false
 // otherwise. The returned function is intended
 // for use with assert.Eventually or require.Eventually.
-func IsPolicyRevision(t *testing.T, client *kibana.Client, agentID string, policyRevision int) func() bool {
+func IsPolicyRevision(ctx context.Context, t *testing.T, client *kibana.Client, agentID string, policyRevision int) func() bool {
 	return func() bool {
 		getAgentReq := kibana.GetAgentRequest{ID: agentID}
-		updatedPolicyAgent, err := client.GetAgent(context.Background(), getAgentReq)
+		updatedPolicyAgent, err := client.GetAgent(ctx, getAgentReq)
 		if err != nil {
 			t.Logf("failed to get agent document to check policy revision: %v", err)
 			return false
@@ -136,10 +136,10 @@ func InstallAgentForPolicy(ctx context.Context, t *testing.T,
 }
 
 // InstallStandaloneAgent force install the Elastic Agent through agentFixture.
-func InstallStandaloneAgent(agentFixture *atesting.Fixture) ([]byte, error) {
+func InstallStandaloneAgent(ctx context.Context, agentFixture *atesting.Fixture) ([]byte, error) {
 	installOpts := atesting.InstallOpts{
 		NonInteractive: true,
 		Force:          true,
 	}
-	return agentFixture.Install(context.Background(), &installOpts)
+	return agentFixture.Install(ctx, &installOpts)
 }

--- a/pkg/testing/tools/tools.go
+++ b/pkg/testing/tools/tools.go
@@ -99,7 +99,7 @@ func InstallAgentForPolicy(ctx context.Context, t *testing.T,
 	}
 
 	// Get default Fleet Server URL
-	fleetServerURL, err := fleettools.DefaultURL(kibClient)
+	fleetServerURL, err := fleettools.DefaultURL(ctx, kibClient)
 	if err != nil {
 		return fmt.Errorf("unable to get default Fleet Server URL: %w", err)
 	}
@@ -126,7 +126,7 @@ func InstallAgentForPolicy(ctx context.Context, t *testing.T,
 	// Wait for Agent to be healthy
 	require.Eventually(
 		t,
-		check.FleetAgentStatus(t, kibClient, policyID, "online"),
+		check.FleetAgentStatus(ctx, t, kibClient, policyID, "online"),
 		timeout,
 		10*time.Second,
 		"Elastic Agent status is not online",

--- a/testing/integration/diagnostics_test.go
+++ b/testing/integration/diagnostics_test.go
@@ -109,7 +109,7 @@ func TestDiagnosticsOptionalValues(t *testing.T) {
 		Configure:  simpleConfig2,
 		AgentState: integrationtest.NewClientState(client.Healthy),
 		Components: componentSetup,
-		After:      testDiagnosticsFactory(ctx, t, diagpprof, diagCompPprof, fixture, []string{"diagnostics", "-p"}),
+		After:      testDiagnosticsFactory(t, diagpprof, diagCompPprof, fixture, []string{"diagnostics", "-p"}),
 	})
 
 }
@@ -132,13 +132,13 @@ func TestDiagnosticsCommand(t *testing.T) {
 		Configure:  simpleConfig2,
 		AgentState: integrationtest.NewClientState(client.Healthy),
 		Components: componentSetup,
-		After:      testDiagnosticsFactory(ctx, t, diagnosticsFiles, compDiagnosticsFiles, f, []string{"diagnostics", "collect"}),
+		After:      testDiagnosticsFactory(t, diagnosticsFiles, compDiagnosticsFiles, f, []string{"diagnostics", "collect"}),
 	})
 	assert.NoError(t, err)
 }
 
-func testDiagnosticsFactory(ctx context.Context, t *testing.T, diagFiles []string, diagCompFiles []string, fix *integrationtest.Fixture, cmd []string) func() error {
-	return func() error {
+func testDiagnosticsFactory(t *testing.T, diagFiles []string, diagCompFiles []string, fix *integrationtest.Fixture, cmd []string) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
 		diagnosticCommandWD := t.TempDir()
 		diagnosticCmdOutput, err := fix.Exec(ctx, cmd, process.WithWorkDir(diagnosticCommandWD))
 

--- a/testing/integration/endpoint_security_test.go
+++ b/testing/integration/endpoint_security_test.go
@@ -192,7 +192,7 @@ func testInstallAndCLIUninstallWithEndpointSecurity(t *testing.T, info *define.I
 
 	t.Cleanup(func() {
 		t.Log("Un-enrolling Elastic Agent...")
-		assert.NoError(t, fleettools.UnEnrollAgent(info.KibanaClient, policy.ID))
+		assert.NoError(t, fleettools.UnEnrollAgent(ctx, info.KibanaClient, policy.ID))
 	})
 
 	t.Log("Installing Elastic Defend")
@@ -273,7 +273,7 @@ func testInstallAndUnenrollWithEndpointSecurity(t *testing.T, info *define.Info,
 	hostname, err := os.Hostname()
 	require.NoError(t, err)
 
-	agentID, err := fleettools.GetAgentIDByHostname(info.KibanaClient, policy.ID, hostname)
+	agentID, err := fleettools.GetAgentIDByHostname(ctx, info.KibanaClient, policy.ID, hostname)
 	require.NoError(t, err)
 
 	_, err = info.KibanaClient.UnEnrollAgent(ctx, kibana.UnEnrollAgentRequest{ID: agentID})

--- a/testing/integration/endpoint_security_test.go
+++ b/testing/integration/endpoint_security_test.go
@@ -192,7 +192,10 @@ func testInstallAndCLIUninstallWithEndpointSecurity(t *testing.T, info *define.I
 
 	t.Cleanup(func() {
 		t.Log("Un-enrolling Elastic Agent...")
-		assert.NoError(t, fleettools.UnEnrollAgent(ctx, info.KibanaClient, policy.ID))
+		// Use a separate context as the one in the test body will have been cancelled at this point.
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cleanupCancel()
+		assert.NoError(t, fleettools.UnEnrollAgent(cleanupCtx, info.KibanaClient, policy.ID))
 	})
 
 	t.Log("Installing Elastic Defend")

--- a/testing/integration/fqdn_test.go
+++ b/testing/integration/fqdn_test.go
@@ -93,7 +93,7 @@ func TestFQDN(t *testing.T) {
 
 	t.Cleanup(func() {
 		t.Log("Un-enrolling Elastic Agent...")
-		assert.NoError(t, fleettools.UnEnrollAgent(info.KibanaClient, policy.ID))
+		assert.NoError(t, fleettools.UnEnrollAgent(ctx, info.KibanaClient, policy.ID))
 
 		t.Log("Restoring hostname...")
 		err := setHostname(ctx, origHostname, t.Log)
@@ -105,7 +105,7 @@ func TestFQDN(t *testing.T) {
 	})
 
 	t.Log("Verify that agent name is short hostname")
-	agent := verifyAgentName(t, policy.ID, shortName, info.KibanaClient)
+	agent := verifyAgentName(ctx, t, policy.ID, shortName, info.KibanaClient)
 
 	t.Log("Verify that hostname in `logs-*` and `metrics-*` is short hostname")
 	verifyHostNameInIndices(t, "logs-*", shortName, info.Namespace, info.ESClient)
@@ -136,7 +136,7 @@ func TestFQDN(t *testing.T) {
 	)
 
 	t.Log("Verify that agent name is FQDN")
-	verifyAgentName(t, policy.ID, fqdn, info.KibanaClient)
+	verifyAgentName(ctx, t, policy.ID, fqdn, info.KibanaClient)
 
 	t.Log("Verify that hostname in `logs-*` and `metrics-*` is FQDN")
 	verifyHostNameInIndices(t, "logs-*", fqdn, info.Namespace, info.ESClient)
@@ -167,7 +167,7 @@ func TestFQDN(t *testing.T) {
 	)
 
 	t.Log("Verify that agent name is short hostname again")
-	verifyAgentName(t, policy.ID, shortName, info.KibanaClient)
+	verifyAgentName(ctx, t, policy.ID, shortName, info.KibanaClient)
 
 	// TODO: Re-enable assertion once https://github.com/elastic/elastic-agent/issues/3078 is
 	// investigated for root cause and resolved.
@@ -176,7 +176,7 @@ func TestFQDN(t *testing.T) {
 	// verifyHostNameInIndices(t, "metrics-*", shortName, info.ESClient)
 }
 
-func verifyAgentName(t *testing.T, policyID, hostname string, kibClient *kibana.Client) *kibana.AgentExisting {
+func verifyAgentName(ctx context.Context, t *testing.T, policyID, hostname string, kibClient *kibana.Client) *kibana.AgentExisting {
 	t.Helper()
 
 	var agent *kibana.AgentExisting
@@ -185,7 +185,7 @@ func verifyAgentName(t *testing.T, policyID, hostname string, kibClient *kibana.
 	require.Eventually(
 		t,
 		func() bool {
-			agent, err = fleettools.GetAgentByPolicyIDAndHostnameFromList(kibClient, policyID, hostname)
+			agent, err = fleettools.GetAgentByPolicyIDAndHostnameFromList(ctx, kibClient, policyID, hostname)
 			return err == nil && agent != nil
 		},
 		5*time.Minute,

--- a/testing/integration/fqdn_test.go
+++ b/testing/integration/fqdn_test.go
@@ -92,11 +92,15 @@ func TestFQDN(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
+		// Use a separate context as the one in the test body will have been cancelled at this point.
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cleanupCancel()
+
 		t.Log("Un-enrolling Elastic Agent...")
-		assert.NoError(t, fleettools.UnEnrollAgent(ctx, info.KibanaClient, policy.ID))
+		assert.NoError(t, fleettools.UnEnrollAgent(cleanupCtx, info.KibanaClient, policy.ID))
 
 		t.Log("Restoring hostname...")
-		err := setHostname(ctx, origHostname, t.Log)
+		err := setHostname(cleanupCtx, origHostname, t.Log)
 		require.NoError(t, err)
 
 		t.Log("Restoring original /etc/hosts...")

--- a/testing/integration/fqdn_test.go
+++ b/testing/integration/fqdn_test.go
@@ -130,7 +130,7 @@ func TestFQDN(t *testing.T) {
 	expectedAgentPolicyRevision := agent.PolicyRevision + 1
 	require.Eventually(
 		t,
-		tools.IsPolicyRevision(t, kibClient, agent.ID, expectedAgentPolicyRevision),
+		tools.IsPolicyRevision(ctx, t, kibClient, agent.ID, expectedAgentPolicyRevision),
 		2*time.Minute,
 		1*time.Second,
 	)
@@ -161,7 +161,7 @@ func TestFQDN(t *testing.T) {
 	expectedAgentPolicyRevision++
 	require.Eventually(
 		t,
-		tools.IsPolicyRevision(t, kibClient, agent.ID, expectedAgentPolicyRevision),
+		tools.IsPolicyRevision(ctx, t, kibClient, agent.ID, expectedAgentPolicyRevision),
 		2*time.Minute,
 		1*time.Second,
 	)

--- a/testing/integration/logs_ingestion_test.go
+++ b/testing/integration/logs_ingestion_test.go
@@ -166,7 +166,7 @@ func testMonitoringLogsAreShipped(
 		t.Fatalf("could not get hostname to filter Agent: %s", err)
 	}
 
-	agentID, err := fleettools.GetAgentIDByHostname(info.KibanaClient, policy.ID, hostname)
+	agentID, err := fleettools.GetAgentIDByHostname(ctx, info.KibanaClient, policy.ID, hostname)
 	require.NoError(t, err, "could not get Agent ID by hostname")
 	t.Logf("Agent ID: %q", agentID)
 

--- a/testing/integration/logs_ingestion_test.go
+++ b/testing/integration/logs_ingestion_test.go
@@ -109,7 +109,7 @@ func testMonitoringLogsAreShipped(
 	// Stage 1: Make sure metricbeat logs are populated
 	t.Log("Making sure metricbeat logs are populated")
 	docs := findESDocs(t, func() (estools.Documents, error) {
-		return estools.GetLogsForDataset(info.ESClient, "elastic_agent.metricbeat")
+		return estools.GetLogsForDataset(ctx, info.ESClient, "elastic_agent.metricbeat")
 	})
 	t.Logf("metricbeat: Got %d documents", len(docs.Hits.Hits))
 	require.NotZero(t, len(docs.Hits.Hits),
@@ -129,7 +129,7 @@ func testMonitoringLogsAreShipped(
 	// Stage 3: Make sure there are no errors in logs
 	t.Log("Making sure there are no error logs")
 	docs = queryESDocs(t, func() (estools.Documents, error) {
-		return estools.CheckForErrorsInLogs(info.ESClient, info.Namespace, []string{
+		return estools.CheckForErrorsInLogs(ctx, info.ESClient, info.Namespace, []string{
 			// acceptable error messages (include reason)
 			"Error dialing dial tcp 127.0.0.1:9200: connect: connection refused", // beat is running default config before its config gets updated
 			"Global configuration artifact is not available",                     // Endpoint: failed to load user artifact due to connectivity issues
@@ -154,7 +154,7 @@ func testMonitoringLogsAreShipped(
 	// Stage 4: Make sure we have message confirming central management is running
 	t.Log("Making sure we have message confirming central management is running")
 	docs = findESDocs(t, func() (estools.Documents, error) {
-		return estools.FindMatchingLogLines(info.ESClient, info.Namespace,
+		return estools.FindMatchingLogLines(ctx, info.ESClient, info.Namespace,
 			"Parsed configuration and determined agent is managed by Fleet")
 	})
 	require.NotZero(t, len(docs.Hits.Hits))
@@ -175,7 +175,7 @@ func testMonitoringLogsAreShipped(
 	// https://github.com/elastic/integrations/issues/6545
 	// TODO: use runtime fields while the above issue is not resolved.
 	docs = findESDocs(t, func() (estools.Documents, error) {
-		return estools.GetLogsForAgentID(info.ESClient, agentID)
+		return estools.GetLogsForAgentID(ctx, info.ESClient, agentID)
 	})
 	require.NoError(t, err, "could not get logs from Agent ID: %q, err: %s",
 		agentID, err)

--- a/testing/integration/logs_ingestion_test.go
+++ b/testing/integration/logs_ingestion_test.go
@@ -88,7 +88,7 @@ func TestLogIngestionFleetManaged(t *testing.T) {
 		createPolicyReq)
 	require.NoError(t, err)
 	t.Logf("created policy: %s", policy.ID)
-	check.ConnectedToFleet(t, agentFixture, 5*time.Minute)
+	check.ConnectedToFleet(ctx, t, agentFixture, 5*time.Minute)
 
 	t.Run("Monitoring logs are shipped", func(t *testing.T) {
 		testMonitoringLogsAreShipped(t, ctx, info, agentFixture, policy)

--- a/testing/integration/package_version_test.go
+++ b/testing/integration/package_version_test.go
@@ -50,20 +50,20 @@ func TestPackageVersion(t *testing.T) {
 	t.Run("remove package versions file and test version again", testAfterRemovingPkgVersionFiles(ctx, f))
 }
 
-func testVersionWithRunningAgent(ctx context.Context, f *atesting.Fixture) func(*testing.T) {
+func testVersionWithRunningAgent(runCtx context.Context, f *atesting.Fixture) func(*testing.T) {
 
 	return func(t *testing.T) {
 
-		testf := func() error {
+		testf := func(ctx context.Context) error {
 			testAgentPackageVersion(ctx, f, false)
 			return nil
 		}
 
-		runAgentWithAfterTest(ctx, f, t, testf)
+		runAgentWithAfterTest(runCtx, f, t, testf)
 	}
 }
 
-func testVersionAfterUpdatingFile(ctx context.Context, f *atesting.Fixture) func(*testing.T) {
+func testVersionAfterUpdatingFile(runCtx context.Context, f *atesting.Fixture) func(*testing.T) {
 
 	return func(t *testing.T) {
 		pkgVersionFiles := findPkgVersionFiles(t, f.WorkDir())
@@ -75,16 +75,16 @@ func testVersionAfterUpdatingFile(ctx context.Context, f *atesting.Fixture) func
 			require.NoError(t, err)
 		}
 
-		testf := func() error {
+		testf := func(ctx context.Context) error {
 			testAgentPackageVersion(ctx, f, false)
 			return nil
 		}
 
-		runAgentWithAfterTest(ctx, f, t, testf)
+		runAgentWithAfterTest(runCtx, f, t, testf)
 	}
 }
 
-func testAfterRemovingPkgVersionFiles(ctx context.Context, f *atesting.Fixture) func(*testing.T) {
+func testAfterRemovingPkgVersionFiles(runCtx context.Context, f *atesting.Fixture) func(*testing.T) {
 	return func(t *testing.T) {
 		matches := findPkgVersionFiles(t, f.WorkDir())
 
@@ -93,7 +93,7 @@ func testAfterRemovingPkgVersionFiles(ctx context.Context, f *atesting.Fixture) 
 			err := os.Remove(m)
 			require.NoErrorf(t, err, "error removing package version file %q", m)
 		}
-		testf := func() error {
+		testf := func(ctx context.Context) error {
 			// check the version returned by the running agent
 			stdout, stderr, processState := getAgentVersionOutput(t, f, ctx, false)
 
@@ -108,14 +108,14 @@ func testAfterRemovingPkgVersionFiles(ctx context.Context, f *atesting.Fixture) 
 			return nil
 		}
 
-		runAgentWithAfterTest(ctx, f, t, testf)
+		runAgentWithAfterTest(runCtx, f, t, testf)
 	}
 
 }
 
-func runAgentWithAfterTest(ctx context.Context, f *atesting.Fixture, t *testing.T, testf func() error) {
+func runAgentWithAfterTest(runCtx context.Context, f *atesting.Fixture, t *testing.T, testf func(ctx context.Context) error) {
 
-	err := f.Run(ctx, atesting.State{
+	err := f.Run(runCtx, atesting.State{
 		AgentState: atesting.NewClientState(client.Healthy),
 		// we don't really need a config and a state but the testing fwk wants it anyway
 		Configure: simpleConfig2,

--- a/testing/integration/proxy_url_test.go
+++ b/testing/integration/proxy_url_test.go
@@ -138,7 +138,7 @@ func TestProxyURL_EnrollProxyAndNoProxyInThePolicy(t *testing.T) {
 		require.NoError(t, err, "failed to install agent")
 	}
 
-	check.ConnectedToFleet(t, p.fixture, 5*time.Minute)
+	check.ConnectedToFleet(ctx, t, p.fixture, 5*time.Minute)
 }
 
 func TestProxyURL_EnrollProxyAndEmptyProxyInThePolicy(t *testing.T) {
@@ -188,7 +188,7 @@ func TestProxyURL_EnrollProxyAndEmptyProxyInThePolicy(t *testing.T) {
 		require.NoError(t, err, "failed to install agent")
 	}
 
-	check.ConnectedToFleet(t, p.fixture, 5*time.Minute)
+	check.ConnectedToFleet(ctx, t, p.fixture, 5*time.Minute)
 }
 
 func TestProxyURL_ProxyInThePolicyTakesPrecedence(t *testing.T) {
@@ -238,7 +238,7 @@ func TestProxyURL_ProxyInThePolicyTakesPrecedence(t *testing.T) {
 		require.NoError(t, err, "failed to install agent")
 	}
 
-	check.ConnectedToFleet(t, p.fixture, 5*time.Minute)
+	check.ConnectedToFleet(ctx, t, p.fixture, 5*time.Minute)
 
 	// ensure the agent is communicating through the proxy set in the policy
 	want := fleetservertest.NewPathCheckin(p.policyData.AgentID)
@@ -305,7 +305,7 @@ func TestProxyURL_NoEnrollProxyAndProxyInThePolicy(t *testing.T) {
 		require.NoError(t, err, "failed to install agent")
 	}
 
-	check.ConnectedToFleet(t, p.fixture, 5*time.Minute)
+	check.ConnectedToFleet(ctx, t, p.fixture, 5*time.Minute)
 
 	// ensure the agent is communicating through the new proxy
 	if !assert.Eventually(t, func() bool {
@@ -371,7 +371,7 @@ func TestProxyURL_RemoveProxyFromThePolicy(t *testing.T) {
 	}
 
 	// assert the agent is actually connected to fleet.
-	check.ConnectedToFleet(t, p.fixture, 5*time.Minute)
+	check.ConnectedToFleet(ctx, t, p.fixture, 5*time.Minute)
 
 	// ensure the agent is communicating through the proxy set in the policy
 	if !assert.Eventually(t, func() bool {
@@ -417,7 +417,7 @@ func TestProxyURL_RemoveProxyFromThePolicy(t *testing.T) {
 	assert.Equal(t, inspect.Fleet.ProxyURL, want)
 
 	// assert, again, the agent is actually connected to fleet.
-	check.ConnectedToFleet(t, p.fixture, 5*time.Minute)
+	check.ConnectedToFleet(ctx, t, p.fixture, 5*time.Minute)
 }
 
 func (p *ProxyURL) setupFleet(t *testing.T, fleetHost string) {

--- a/testing/integration/upgrade_fleet_test.go
+++ b/testing/integration/upgrade_fleet_test.go
@@ -198,7 +198,7 @@ func testUpgradeFleetManagedElasticAgent(
 	require.NoError(t, err, "failed creating enrollment API key")
 
 	t.Log("Getting default Fleet Server URL...")
-	fleetServerURL, err := fleettools.DefaultURL(kibClient)
+	fleetServerURL, err := fleettools.DefaultURL(ctx, kibClient)
 	require.NoError(t, err, "failed getting Fleet Server URL")
 
 	t.Log("Installing Elastic Agent...")
@@ -224,7 +224,7 @@ func testUpgradeFleetManagedElasticAgent(
 	t.Log("Waiting for enrolled Agent status to be online...")
 	require.Eventually(t,
 		check.FleetAgentStatus(
-			t, kibClient, policyResp.ID, "online"),
+			ctx, t, kibClient, policyResp.ID, "online"),
 		2*time.Minute,
 		10*time.Second,
 		"Agent status is not online")
@@ -232,7 +232,7 @@ func testUpgradeFleetManagedElasticAgent(
 	t.Logf("Upgrading from version \"%s-%s\" to version \"%s-%s\"...",
 		startParsedVersion, startVersionInfo.Binary.Commit,
 		endVersionInfo.Binary.String(), endVersionInfo.Binary.Commit)
-	err = fleettools.UpgradeAgent(kibClient, policyResp.ID, endVersionInfo.Binary.String(), true)
+	err = fleettools.UpgradeAgent(ctx, kibClient, policyResp.ID, endVersionInfo.Binary.String(), true)
 	require.NoError(t, err)
 
 	t.Log("Waiting from upgrade details to show up in Fleet")
@@ -240,7 +240,7 @@ func testUpgradeFleetManagedElasticAgent(
 	require.NoError(t, err)
 	var agent *kibana.AgentExisting
 	require.Eventuallyf(t, func() bool {
-		agent, err = fleettools.GetAgentByPolicyIDAndHostnameFromList(kibClient, policy.ID, hostname)
+		agent, err = fleettools.GetAgentByPolicyIDAndHostnameFromList(ctx, kibClient, policy.ID, hostname)
 		return err == nil && agent.UpgradeDetails != nil
 	},
 		5*time.Minute, time.Second,
@@ -258,12 +258,12 @@ func testUpgradeFleetManagedElasticAgent(
 	require.NoError(t, err)
 
 	t.Log("Waiting for enrolled Agent status to be online...")
-	require.Eventually(t, check.FleetAgentStatus(t, kibClient, policyResp.ID, "online"), 10*time.Minute, 15*time.Second, "Agent status is not online")
+	require.Eventually(t, check.FleetAgentStatus(ctx, t, kibClient, policyResp.ID, "online"), 10*time.Minute, 15*time.Second, "Agent status is not online")
 
 	// wait for version
 	require.Eventually(t, func() bool {
 		t.Log("Getting Agent version...")
-		newVersion, err := fleettools.GetAgentVersion(kibClient, policyResp.ID)
+		newVersion, err := fleettools.GetAgentVersion(ctx, kibClient, policyResp.ID)
 		if err != nil {
 			t.Logf("error getting agent version: %v", err)
 			return false


### PR DESCRIPTION
We are still seeing integration tests time out after 2+ hours. This appears to be because we are making network requests without timeouts in several instances, with the root cause being that we do not propagate contexts through the calls even though we are using the `WithContext` variant of the network call.

For example https://buildkite.com/elastic/elastic-agent/builds/5302#018c2582-6e37-488c-a13f-4964c8fc51ea got stuck in a new place. It timed out in https://github.com/elastic/elastic-agent/blob/33ad31eae14026fa1151c7b42ee3cf44ead00b9b/pkg/testing/tools/tools.go#L126-L132
That eventually ends up in https://github.com/elastic/elastic-agent/blob/33ad31eae14026fa1151c7b42ee3cf44ead00b9b/pkg/testing/tools/fleettools/fleet.go#L18-L22

Which hard codes context.Background. 

I searched for `context.Background` in pkg/testing and removed every instance of it that was not already using it as an input to `context.WithTimeout`.

This will not fix the actual test timeouts, but it should tell us which specific parts of the tests are timing out instead of having to root cause it through go test execution panics.