### PR TITLE
Re-enable TestFQDN

### DIFF
--- a/pkg/testing/tools/testcontext/testcontext.go
+++ b/pkg/testing/tools/testcontext/testcontext.go
@@ -22,3 +22,14 @@ func WithDeadline(
 	ctx, cancel := context.WithDeadline(parent, deadline)
 	return ctx, cancel
 }
+
+// WithTimeout returns a context with a deadline calculated from the provided
+// timeout duration. It is the equivalent of calling WithDeadline with the
+// deadline specified as time.Now() + timeout.
+func WithTimeout(
+	t *testing.T,
+	parentCtx context.Context,
+	timeout time.Duration,
+) (context.Context, context.CancelFunc) {
+	return WithDeadline(t, parentCtx, time.Now().Add(timeout))
+}

--- a/testing/integration/fqdn_test.go
+++ b/testing/integration/fqdn_test.go
@@ -95,6 +95,9 @@ func TestFQDN(t *testing.T) {
 		assert.NoError(t, fleettools.UnEnrollAgent(info.KibanaClient, policy.ID))
 
 		t.Log("Restoring hostname...")
+		ctx, cancel := testcontext.WithTimeout(t, context.Background(), 1*time.Minute)
+		defer cancel()
+
 		err := setHostname(ctx, origHostname, t.Log)
 		require.NoError(t, err)
 

--- a/testing/integration/fqdn_test.go
+++ b/testing/integration/fqdn_test.go
@@ -41,7 +41,6 @@ func TestFQDN(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
-	t.Skip("Flaky test, see https://github.com/elastic/elastic-agent/issues/3154")
 
 	agentFixture, err := define.NewFixture(t, define.Version())
 	require.NoError(t, err)

--- a/testing/integration/fqdn_test.go
+++ b/testing/integration/fqdn_test.go
@@ -54,9 +54,6 @@ func TestFQDN(t *testing.T) {
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
 	defer cancel()
-	defer func() {
-		t.Log("DEBUGGING: After context has been cancelled")
-	}()
 
 	// Save original hostname so we can restore it at the end of each test
 	origHostname, err := getHostname(ctx)

--- a/testing/integration/fqdn_test.go
+++ b/testing/integration/fqdn_test.go
@@ -54,6 +54,9 @@ func TestFQDN(t *testing.T) {
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
 	defer cancel()
+	defer func() {
+		t.Log("DEBUGGING: After context has been cancelled")
+	}()
 
 	// Save original hostname so we can restore it at the end of each test
 	origHostname, err := getHostname(ctx)


### PR DESCRIPTION
This PR re-enables the `TestFQDN` integration test as the flaky test issue referenced in the skip directive (https://github.com/elastic/elastic-agent/issues/3154) has been resolved. 