### PR TITLE
Skip APM propagation test on Windows.

### DIFF
--- a/testing/integration/apm_propagation_test.go
+++ b/testing/integration/apm_propagation_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"runtime"
 	"strings"
 	"testing"
 	"text/template"
@@ -56,6 +57,12 @@ func TestAPMConfig(t *testing.T) {
 		Group: Default,
 		Stack: &define.Stack{},
 	})
+
+	if runtime.GOOS == "windows" {
+		// This test hangs indefinitely on Windows. Root cause is TBD.
+		t.Skip("Flaky test: https://github.com/elastic/ingest-dev/issues/2668")
+	}
+
 	f, err := define.NewFixture(t, define.Version())
 	require.NoError(t, err)
 


### PR DESCRIPTION
This test causes the Windows tests to hang for 2 hours until they time out. While we investigate the root cause skip the test. The test will still run on Linux.