### PR TITLE
Allow opentelemetry dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     allow:
       # Only update internal dependencies for now while we evaluate this workflow.
       - dependency-name: "github.com/elastic/*"
+      - dependency-name: "go.opentelemetry.io/*"
+      - dependency-name: "github.com/open-telemetry/*"
     reviewers:
       - "elastic/elastic-agent-control-plane"
     open-pull-requests-limit: 10


### PR DESCRIPTION
This PR updates dependabot rules and allows updating dependencies from
- `go.opentelemetry.io/*`
- `github.com/open-telemetry/*`