### PR TITLE
Endpoint outputs should be the same on Windows, Mac, and Linux

### DIFF
--- a/specs/endpoint-security.spec.yml
+++ b/specs/endpoint-security.spec.yml
@@ -52,9 +52,7 @@ inputs:
     platforms:
       - darwin/amd64
       - darwin/arm64
-    outputs:
-      - elasticsearch
-      - logstash
+    outputs: *outputs
     proxied_actions: *proxied_actions
     runtime:
       preventions:
@@ -69,9 +67,7 @@ inputs:
     description: "Endpoint Security"
     platforms:
       - windows/amd64
-    outputs:
-      - elasticsearch
-      - logstash
+    outputs: *outputs
     proxied_actions: *proxied_actions
     runtime:
       preventions:


### PR DESCRIPTION
- Closes https://github.com/elastic/elastic-agent/issues/3936

Endpoint wasn't using the anchored outputs section from its Linux definition for Windows and Mac, so it wasn't allowing use of Kafka when it should be.