### PR TITLE
[Upgrade Details] Fix corruption when writing upgrade marker file

### DIFF
--- a/internal/pkg/agent/application/upgrade/marker_access_common.go
+++ b/internal/pkg/agent/application/upgrade/marker_access_common.go
@@ -10,7 +10,7 @@ import (
 )
 
 func writeMarkerFileCommon(markerFile string, markerBytes []byte, shouldFsync bool) error {
-	f, err := os.OpenFile(markerFile, os.O_WRONLY|os.O_CREATE, 0600)
+	f, err := os.OpenFile(markerFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to open upgrade marker file for writing: %w", err)
 	}

--- a/internal/pkg/agent/application/upgrade/marker_access_common_test.go
+++ b/internal/pkg/agent/application/upgrade/marker_access_common_test.go
@@ -1,0 +1,56 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package upgrade
+
+import (
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteMarkerFileWithTruncation(t *testing.T) {
+	tmpDir := t.TempDir()
+	testMarkerFile := filepath.Join(tmpDir, markerFilename)
+
+	// Write a long marker file
+	err := writeMarkerFileCommon(testMarkerFile, randomBytes(40), true)
+	require.NoError(t, err)
+
+	// Get length of file
+	fileInfo, err := os.Stat(testMarkerFile)
+	require.NoError(t, err)
+	originalSize := fileInfo.Size()
+
+	// Write a shorter marker file
+	err = writeMarkerFileCommon(testMarkerFile, randomBytes(25), true)
+	require.NoError(t, err)
+
+	// Get length of file
+	fileInfo, err = os.Stat(testMarkerFile)
+	require.NoError(t, err)
+	newSize := fileInfo.Size()
+
+	// Make sure shorter file has is smaller in length than
+	// the original long marker file
+	require.Less(t, newSize, originalSize)
+}
+
+func randomBytes(length int) []byte {
+	chars := []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZÅÄÖ" +
+		"abcdefghijklmnopqrstuvwxyzåäö" +
+		"0123456789" +
+		"~=+%^*/()[]{}/!@#$?|")
+
+	var b []byte
+	for i := 0; i < length; i++ {
+		rune := chars[rand.Intn(len(chars))]
+		b = append(b, byte(rune))
+	}
+
+	return b
+}


### PR DESCRIPTION
## What does this PR do?

This PR fixes the corruption that could take place when writing the Upgrade Marker file.

## Why is it important?

Agent tries to reads the Upgrade Marker file at startup to determine if the Agent is in the midst of an upgrade.  If it cannot read the Upgrade Marker file because it's corrupted, an error is returned, and Agent fails to start up.

## Note about integration/E2E tests for this PR

The bug that's being fixed in this PR was caught via an E2E test that was failing consistently: `TestFleetManagedUpgrade `.  Unfortunately, though this PR fixes the bug, this test will not pass on the PR.  That's to be expected because the non-truncating write that was causing the bug is happening from the Upgrade Watcher, which is run as part of the new (i.e. upgraded) Agent. And the Agent that's upgraded to in the test is one pulled down from the artifacts API, not the one that's locally built.

I did add a unit test to catch the truncation bug to this PR.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~ Bug was already caught by integration tests

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes https://github.com/elastic/elastic-agent/issues/3947
