### PR TITLE
Use version in path

### DIFF
--- a/changelog/fragments/1706703918-Add-the-full-version-number-to-the-installation-directory-name.yaml
+++ b/changelog/fragments/1706703918-Add-the-full-version-number-to-the-installation-directory-name.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add the full version number to the installation directory name
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -48,6 +48,7 @@ const (
 	// Mapped functions
 	agentPackageVersionMappedFunc    = "agent_package_version"
 	agentManifestGeneratorMappedFunc = "manifest"
+	snapshotSuffix                   = "snapshot_suffix"
 )
 
 // Common settings with defaults derived from files, CWD, and environment.
@@ -108,6 +109,7 @@ var (
 		"contains":                       strings.Contains,
 		agentPackageVersionMappedFunc:    AgentPackageVersion,
 		agentManifestGeneratorMappedFunc: PackageManifest,
+		snapshotSuffix:                   SnapshotSuffix,
 	}
 )
 

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -312,6 +312,13 @@ func PackageManifest() (string, error) {
 		return "", fmt.Errorf("retrieving agent package version: %w", err)
 	}
 	m.Package.Version = packageVersion
+
+	hash, err := CommitHash()
+	if err != nil {
+		return "", fmt.Errorf("retrieving agent commit hash: %w", err)
+	}
+	m.Package.Hash = hash
+
 	commitHashShort, err := CommitHashShort()
 	if err != nil {
 		return "", fmt.Errorf("retrieving agent commit hash: %w", err)

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -320,7 +320,7 @@ func PackageManifest() (string, error) {
 	m.Package.VersionedHome = versionedHomePath
 	m.Package.PathMappings = []map[string]string{{}}
 	m.Package.PathMappings[0][versionedHomePath] = fmt.Sprintf("data/elastic-agent-%s%s-%s", m.Package.Version, SnapshotSuffix(), commitHashShort)
-	m.Package.PathMappings[0]["manifest.yaml"] = fmt.Sprintf("data/elastic-agent-%s%s-%s/manifest.yaml", m.Package.Version, SnapshotSuffix(), commitHashShort)
+	m.Package.PathMappings[0][v1.ManifestFileName] = fmt.Sprintf("data/elastic-agent-%s%s-%s/%s", m.Package.Version, SnapshotSuffix(), commitHashShort, v1.ManifestFileName)
 	yamlBytes, err := yaml.Marshal(m)
 	if err != nil {
 		return "", fmt.Errorf("marshaling manifest: %w", err)

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -255,6 +255,7 @@ repo.RootDir                 = {{ repo.RootDir }}
 repo.ImportPath              = {{ repo.ImportPath }}
 repo.SubDir                  = {{ repo.SubDir }}
 agent_package_version        = {{ agent_package_version}}
+snapshot_suffix              = {{ snapshot_suffix }}
 `
 
 	return Expand(dumpTemplate)

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -219,6 +219,9 @@ func checkManifestFileContents(t *testing.T, extractedPackageDir string) {
 	assert.Equal(t, v1.ManifestKind, m.Kind, "manifest specifies wrong kind")
 	assert.Equal(t, v1.VERSION, m.Version, "manifest specifies wrong api version")
 
+	assert.NotEmpty(t, m.Package.Version, "manifest version must not be empty")
+	assert.NotEmpty(t, m.Package.Hash, "manifest hash must not be empty")
+
 	if assert.NotEmpty(t, m.Package.PathMappings, "path mappings in manifest are empty") {
 		versionedHome := m.Package.VersionedHome
 		assert.DirExistsf(t, filepath.Join(extractedPackageDir, versionedHome), "versionedHome directory %q not found in %q", versionedHome, extractedPackageDir)

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -201,9 +201,9 @@ func checkZip(t *testing.T, file string) {
 
 func checkManifestFileContents(t *testing.T, extractedPackageDir string) {
 	t.Log("Checking file manifest.yaml")
-	manifestReadCloser, err := os.Open(filepath.Join(extractedPackageDir, "manifest.yaml"))
+	manifestReadCloser, err := os.Open(filepath.Join(extractedPackageDir, v1.ManifestFileName))
 	if err != nil {
-		t.Errorf("opening manifest %s : %v", "manifest.yaml", err)
+		t.Errorf("opening manifest %s : %v", v1.ManifestFileName, err)
 	}
 	defer func(closer io.ReadCloser) {
 		err := closer.Close()

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -62,19 +62,19 @@ shared:
       /etc/init.d/{{.BeatServiceName}}:
         template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/{{.PackageType}}/elastic-agent.init.sh.tmpl'
         mode: 0755
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ commit_short }}/{{.BeatName}}{{.BinaryExt}}:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ commit_short }}/{{.BeatName}}{{.BinaryExt}}:
         source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
         mode: 0755
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ commit_short }}/package.version:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ commit_short }}/package.version:
         content: >
           {{ agent_package_version }}
         mode: 0644
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ commit_short }}/components:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ commit_short }}/components:
         source: '{{.AgentDropPath}}/{{.GOOS}}-{{.AgentArchName}}.tar.gz/'
         mode: 0755
         config_mode: 0644
         skip_on_missing: true
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ commit_short }}/manifest.yaml:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ commit_short }}/manifest.yaml:
         mode: 0644
         content: >
           {{ manifest }}

--- a/dev-tools/packaging/templates/darwin/elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/darwin/elastic-agent.tmpl
@@ -6,6 +6,9 @@ set -e
 symlink="/Library/Elastic/Agent/elastic-agent"
 
 if test -L "$symlink"; then
-    ln -sfn "data/elastic-agent-{{ commit_short }}/elastic-agent.app/Contents/MacOS/elastic-agent" "$symlink"
+    symlinkTarget="data/elastic-agent-{{ commit_short }}/elastic-agent.app/Contents/MacOS/elastic-agent"
+    if test -f "data/elastic-agent-{{ agent_package_version }}{{ snapshot_suffix }}-{{ commit_short }}/elastic-agent.app/Contents/MacOS/elastic-agent"; then
+        symlinkTarget="data/elastic-agent-{{ agent_package_version }}{{ snapshot_suffix }}-{{ commit_short }}/elastic-agent.app/Contents/MacOS/elastic-agent"
+    ln -sfn "$symlinkTarget" "$symlink"
 fi
 

--- a/dev-tools/packaging/templates/linux/postinstall.sh.tmpl
+++ b/dev-tools/packaging/templates/linux/postinstall.sh.tmpl
@@ -16,8 +16,9 @@ if test -L "$symlink"; then
 fi
 
 commit_hash="{{ commit_short }}"
+version_dir="{{agent_package_version}}{{snapshot_suffix}}"
 
-new_agent_dir="/var/lib/elastic-agent/data/elastic-agent-$commit_hash"
+new_agent_dir="/var/lib/elastic-agent/data/elastic-agent-$version_dir-$commit_hash"
 
 # copy the state files if there was a previous agent install
 if ! [ -z "$old_agent_dir" ] && ! [ "$old_agent_dir" -ef "$new_agent_dir" ]; then

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -61,3 +61,32 @@ sequenceDiagram
        end
     end
 ```
+
+### Introducing package manifest
+
+Starting from version 8.13.0 an additional file `manifest.yaml` is present in elastic-agent packages.
+The purpose of this file is to present some metadata and package information to be used during install/upgrade operations.
+
+The [structure](../pkg/api/v1/manifest.go) of such manifest is defined in the [api/v1 package](../pkg/api/v1/).
+The manifest data is generated during packaging and the file is added to the package files. This is an example of a
+complete manifest:
+
+```yaml
+version: co.elastic.agent/v1
+kind: PackageManifest
+package:
+  version: 8.13.0
+  snapshot: true
+  hash: 15658b38b48ba4487afadc5563b1576b85ce0264
+  versioned-home: data/elastic-agent-15658b
+  path-mappings:
+    - data/elastic-agent-15658b: data/elastic-agent-8.13.0-SNAPSHOT-15658b
+      manifest.yaml: data/elastic-agent-8.13.0-SNAPSHOT-15658b/manifest.yaml
+```
+
+The package information describes the package version, whether it's a snapshot build, the elastic-agent commit hash it
+has been built from and where to find the versioned home of the elastic agent within the package.
+
+Another section lists the path mappings that must be applied by an elastic-agent that is aware of the package manifest
+(version >8.13.0): these path mappings allow the incoming agent version to have some control over where the files in
+package will be stored on disk.

--- a/internal/pkg/agent/application/paths/common.go
+++ b/internal/pkg/agent/application/paths/common.go
@@ -167,11 +167,16 @@ func ExternalInputs() string {
 
 // Data returns the data directory for Agent
 func Data() string {
+	return DataFrom(Top())
+}
+
+// DataFrom returns the data directory for Agent using the passed directory as top path
+func DataFrom(topDirPath string) string {
 	if unversionedHome {
 		// unversioned means the topPath is the data path
-		return topPath
+		return topDirPath
 	}
-	return filepath.Join(Top(), "data")
+	return filepath.Join(topDirPath, "data")
 }
 
 // Run returns the run directory for Agent

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -138,13 +138,13 @@ func Cleanup(log *logger.Logger, topDirPath, currentVersionedHome, currentHash s
 
 // InvokeWatcher invokes an agent instance using watcher argument for watching behavior of
 // agent during upgrade period.
-func InvokeWatcher(log *logger.Logger) error {
+func InvokeWatcher(log *logger.Logger, agentExecutable string) error {
 	if !IsUpgradeable() {
 		log.Info("agent is not upgradable, not starting watcher")
 		return nil
 	}
 
-	cmd := invokeCmd()
+	cmd := invokeCmd(agentExecutable)
 	defer func() {
 		if cmd.Process != nil {
 			log.Infof("releasing watcher %v", cmd.Process.Pid)

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -72,7 +72,7 @@ func Cleanup(log *logger.Logger, currentVersionedHome, currentHash string, remov
 
 	// remove upgrade marker
 	if removeMarker {
-		if err := CleanMarker(log); err != nil {
+		if err := CleanMarker(log, paths.Data()); err != nil {
 			return err
 		}
 	}
@@ -89,8 +89,8 @@ func Cleanup(log *logger.Logger, currentVersionedHome, currentHash string, remov
 	}
 
 	// remove symlink to avoid upgrade failures, ignore error
-	prevSymlink := prevSymlinkPath()
-	log.Infow("Removing previous symlink path", "file.path", prevSymlinkPath())
+	prevSymlink := prevSymlinkPath(paths.Top())
+	log.Infow("Removing previous symlink path", "file.path", prevSymlinkPath(paths.Top()))
 	_ = os.Remove(prevSymlink)
 
 	dirPrefix := fmt.Sprintf("%s-", agentName)

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -46,7 +46,7 @@ func Rollback(ctx context.Context, log *logger.Logger, c client.Client, topDirPa
 		symlinkTarget = paths.BinaryPath(filepath.Join(paths.DataFrom(topDirPath), hashedDir), agentName)
 	}
 	// change symlink
-	if err := changeSymlinkInternal(log, topDirPath, symlinkPath, symlinkTarget); err != nil {
+	if err := ChangeSymlink(log, topDirPath, symlinkPath, symlinkTarget); err != nil {
 		return err
 	}
 

--- a/internal/pkg/agent/application/upgrade/rollback_darwin.go
+++ b/internal/pkg/agent/application/upgrade/rollback_darwin.go
@@ -21,9 +21,9 @@ const (
 	afterRestartDelay = 2 * time.Second
 )
 
-func invokeCmd() *exec.Cmd {
+func invokeCmd(agentExecutable string) *exec.Cmd {
 	// #nosec G204 -- user cannot inject any parameters to this command
-	cmd := exec.Command(paths.TopBinaryPath(), watcherSubcommand,
+	cmd := exec.Command(agentExecutable, watcherSubcommand,
 		"--path.config", paths.Config(),
 		"--path.home", paths.Top(),
 	)

--- a/internal/pkg/agent/application/upgrade/rollback_linux.go
+++ b/internal/pkg/agent/application/upgrade/rollback_linux.go
@@ -21,9 +21,9 @@ const (
 	afterRestartDelay = 2 * time.Second
 )
 
-func invokeCmd() *exec.Cmd {
+func invokeCmd(agentExecutable string) *exec.Cmd {
 	// #nosec G204 -- user cannot inject any parameters to this command
-	cmd := exec.Command(paths.TopBinaryPath(), watcherSubcommand,
+	cmd := exec.Command(agentExecutable, watcherSubcommand,
 		"--path.config", paths.Config(),
 		"--path.home", paths.Top(),
 	)

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
@@ -91,26 +92,9 @@ func TestCleanup(t *testing.T) {
 			},
 			wantErr: assert.NoError,
 			checkAfterCleanup: func(t *testing.T, topDir string) {
-				// the old agent directory must not exist anymore
-				oldAgentHome := "elastic-agent-abcdef"
-				assert.NoDirExists(t, filepath.Join(topDir, "data", oldAgentHome), "old agent directory should be deleted after cleanup")
-				newAgentHome := "elastic-agent-ghijkl"
-				assert.DirExists(t, filepath.Join(topDir, "data", newAgentHome), "new agent directory should exist after cleanup")
-				agentExecutable := agentName
-				if runtime.GOOS == "windows" {
-					agentExecutable += ".exe"
-				}
-				symlinkPath := filepath.Join(topDir, agentExecutable)
-				linkTarget, err := os.Readlink(symlinkPath)
-				if assert.NoError(t, err, "unable to read symbolic link") {
-					assert.Equal(t, filepath.Join("data", newAgentHome, agentExecutable), linkTarget, "symbolic link should point to the new agent executable after cleanup")
-				}
-
-				// read the elastic agent placeholder via the symlink
-				elasticAgentBytes, err := os.ReadFile(symlinkPath)
-				if assert.NoError(t, err, "error reading elastic-agent content through the symlink") {
-					assert.Equal(t, []byte("Placeholder for agent 4.5.6-SNAPSHOT"), elasticAgentBytes, "reading elastic-agent content through symbolic link should point to the new version")
-				}
+				oldAgentHome := filepath.Join("data", "elastic-agent-abcdef")
+				newAgentHome := filepath.Join("data", "elastic-agent-ghijkl")
+				checkFilesAfterCleanup(t, topDir, oldAgentHome, newAgentHome)
 			},
 		},
 		{
@@ -138,27 +122,9 @@ func TestCleanup(t *testing.T) {
 			},
 			wantErr: assert.NoError,
 			checkAfterCleanup: func(t *testing.T, topDir string) {
-				// the old agent directory must not exist anymore
-				oldAgentHome := "elastic-agent-1.2.3-SNAPSHOT-abcdef"
-				assert.NoDirExists(t, filepath.Join(topDir, "data", oldAgentHome), "old agent directory should be deleted after cleanup")
-
-				newAgentHome := "elastic-agent-4.5.6-SNAPSHOT-ghijkl"
-				assert.DirExists(t, filepath.Join(topDir, "data", newAgentHome), "new agent directory should exist after cleanup")
-				agentExecutable := agentName
-				if runtime.GOOS == "windows" {
-					agentExecutable += ".exe"
-				}
-				symlinkPath := filepath.Join(topDir, agentExecutable)
-				linkTarget, err := os.Readlink(symlinkPath)
-				if assert.NoError(t, err, "unable to read symbolic link") {
-					assert.Equal(t, filepath.Join("data", newAgentHome, agentExecutable), linkTarget, "symbolic link should point to the new agent executable after cleanup")
-				}
-
-				// read the elastic agent placeholder via the symlink
-				elasticAgentBytes, err := os.ReadFile(symlinkPath)
-				if assert.NoError(t, err, "error reading elastic-agent content through the symlink") {
-					assert.Equal(t, []byte("Placeholder for agent 4.5.6-SNAPSHOT"), elasticAgentBytes, "reading elastic-agent content through symbolic link should point to the new version")
-				}
+				oldAgentHome := filepath.Join("data", "elastic-agent-1.2.3-SNAPSHOT-abcdef")
+				newAgentHome := filepath.Join("data", "elastic-agent-4.5.6-SNAPSHOT-ghijkl")
+				checkFilesAfterCleanup(t, topDir, oldAgentHome, newAgentHome)
 			},
 		},
 		{
@@ -186,27 +152,9 @@ func TestCleanup(t *testing.T) {
 			},
 			wantErr: assert.NoError,
 			checkAfterCleanup: func(t *testing.T, topDir string) {
-				// the old agent directory must not exist anymore
-				oldAgentHome := "elastic-agent-abcdef"
-				assert.NoDirExists(t, filepath.Join(topDir, "data", oldAgentHome), "old agent directory should be deleted after cleanup")
-
-				newAgentHome := "elastic-agent-4.5.6-SNAPSHOT-ghijkl"
-				assert.DirExists(t, filepath.Join(topDir, "data", newAgentHome), "new agent directory should exist after cleanup")
-				agentExecutable := agentName
-				if runtime.GOOS == "windows" {
-					agentExecutable += ".exe"
-				}
-				symlinkPath := filepath.Join(topDir, agentExecutable)
-				linkTarget, err := os.Readlink(symlinkPath)
-				if assert.NoError(t, err, "unable to read symbolic link") {
-					assert.Equal(t, filepath.Join("data", newAgentHome, agentExecutable), linkTarget, "symbolic link should point to the new agent executable after cleanup")
-				}
-
-				// read the elastic agent placeholder via the symlink
-				elasticAgentBytes, err := os.ReadFile(symlinkPath)
-				if assert.NoError(t, err, "error reading elastic-agent content through the symlink") {
-					assert.Equal(t, []byte("Placeholder for agent 4.5.6-SNAPSHOT"), elasticAgentBytes, "reading elastic-agent content through symbolic link should point to the new version")
-				}
+				oldAgentHome := filepath.Join("data", "elastic-agent-abcdef")
+				newAgentHome := filepath.Join("data", "elastic-agent-4.5.6-SNAPSHOT-ghijkl")
+				checkFilesAfterCleanup(t, topDir, oldAgentHome, newAgentHome)
 			},
 		},
 	}
@@ -218,7 +166,11 @@ func TestCleanup(t *testing.T) {
 				tt.additionalSetup(t, testTop)
 			}
 			testLogger, _ := logger.NewTesting(t.Name())
-			tt.wantErr(t, Cleanup(testLogger, testTop, tt.args.currentVersionedHome, tt.args.currentHash, tt.args.removeMarker, tt.args.keepLogs), fmt.Sprintf("Cleanup(%v, %v, %v, %v)", tt.args.currentVersionedHome, tt.args.currentHash, tt.args.removeMarker, tt.args.keepLogs))
+			marker, err := LoadMarker(paths.DataFrom(testTop))
+			require.NoError(t, err, "error loading update marker")
+			require.NotNil(t, marker, "loaded marker must not be nil")
+			t.Logf("Loaded update marker %+v", marker)
+			tt.wantErr(t, Cleanup(testLogger, testTop, marker.VersionedHome, marker.Hash, tt.args.removeMarker, tt.args.keepLogs), fmt.Sprintf("Cleanup(%v, %v, %v, %v)", marker.VersionedHome, marker.Hash, tt.args.removeMarker, tt.args.keepLogs))
 			tt.checkAfterCleanup(t, testTop)
 		})
 	}
@@ -233,9 +185,11 @@ func TestRollback(t *testing.T) {
 		currentHash       string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr assert.ErrorAssertionFunc
+		name               string
+		agentInstallsSetup setupAgentInstallations
+		additionalSetup    hookFunc
+		args               args
+		wantErr            assert.ErrorAssertionFunc
 	}{
 		// TODO: Add test cases.
 	}
@@ -246,6 +200,35 @@ func TestRollback(t *testing.T) {
 	}
 }
 
+// checkFilesAfterCleanup is a convenience function to check the file structure within topDir.
+// *AgentHome paths must be the expected old and new agent paths relative to topDir (typically in the form of "data/elastic-agent-*")
+func checkFilesAfterCleanup(t *testing.T, topDir, oldAgentHome, newAgentHome string) {
+	t.Helper()
+	// the old agent directory must not exist anymore
+	assert.NoDirExists(t, filepath.Join(topDir, oldAgentHome), "old agent directory should be deleted after cleanup")
+
+	// check the new agent home
+	assert.DirExists(t, filepath.Join(topDir, newAgentHome), "new agent directory should exist after cleanup")
+	agentExecutable := agentName
+	if runtime.GOOS == "windows" {
+		agentExecutable += ".exe"
+	}
+	symlinkPath := filepath.Join(topDir, agentExecutable)
+	linkTarget, err := os.Readlink(symlinkPath)
+	if assert.NoError(t, err, "unable to read symbolic link") {
+		assert.Equal(t, filepath.Join(newAgentHome, agentExecutable), linkTarget, "symbolic link should point to the new agent executable after cleanup")
+	}
+
+	// read the elastic agent placeholder via the symlink
+	elasticAgentBytes, err := os.ReadFile(symlinkPath)
+	if assert.NoError(t, err, "error reading elastic-agent content through the symlink") {
+		assert.Equal(t, []byte("Placeholder for agent 4.5.6-SNAPSHOT"), elasticAgentBytes, "reading elastic-agent content through symbolic link should point to the new version")
+	}
+
+	assert.NoFileExists(t, filepath.Join(topDir, "data", markerFilename), "update marker should have been cleaned up")
+}
+
+// setupAgents create fake agent installs, update marker file and symlink pointing to one of the installations' elastic-agent placeholder
 func setupAgents(t *testing.T, topDir string, installations setupAgentInstallations) {
 
 	var (
@@ -253,6 +236,7 @@ func setupAgents(t *testing.T, topDir string, installations setupAgentInstallati
 		oldAgentVersionedHome string
 		newAgentVersion       agentVersion
 		newAgentVersionedHome string
+		useNewMarker          bool
 	)
 	for _, ia := range installations.installedAgents {
 		versionedHome := createFakeAgentInstall(t, topDir, ia.version.version, ia.version.hash, ia.useVersionInPath)
@@ -267,6 +251,7 @@ func setupAgents(t *testing.T, topDir string, installations setupAgentInstallati
 			t.Logf("Setting version %+v as TO version for the update marker", ia.version)
 			newAgentVersion = ia.version
 			newAgentVersionedHome = versionedHome
+			useNewMarker = ia.useVersionInPath
 		}
 
 		if installations.currentAgent == ia.version {
@@ -276,9 +261,11 @@ func setupAgents(t *testing.T, topDir string, installations setupAgentInstallati
 	}
 
 	t.Logf("Creating upgrade marker from %+v located at %q to %+v located at %q", oldAgentVersion, oldAgentVersionedHome, newAgentVersion, newAgentVersionedHome)
-	createUpdateMarker(t, topDir, newAgentVersion.version, newAgentVersion.hash, newAgentVersionedHome, oldAgentVersion.version, oldAgentVersion.hash, oldAgentVersionedHome)
+	createUpdateMarker(t, topDir, newAgentVersion.version, newAgentVersion.hash, newAgentVersionedHome, oldAgentVersion.version, oldAgentVersion.hash, oldAgentVersionedHome, useNewMarker)
 }
 
+// createFakeAgentInstall will create a mock agent install within topDir, possibly using the version in the directory name, depending on useVersionInPath
+// it MUST return the path to the created versionedHome relative to topDir, to mirror what step_unpack returns
 func createFakeAgentInstall(t *testing.T, topDir, version, hash string, useVersionInPath bool) string {
 
 	// create versioned home
@@ -287,8 +274,8 @@ func createFakeAgentInstall(t *testing.T, topDir, version, hash string, useVersi
 		// use the version passed as parameter
 		versionedHome = fmt.Sprintf("elastic-agent-%s-%s", version, hash[:hashLen])
 	}
-
-	absVersionedHomePath := filepath.Join(topDir, "data", versionedHome)
+	relVersionedHomePath := filepath.Join("data", versionedHome)
+	absVersionedHomePath := filepath.Join(topDir, relVersionedHomePath)
 	err := os.MkdirAll(absVersionedHomePath, 0o750)
 	require.NoError(t, err, "error creating fake install versioned home directory %q", absVersionedHomePath)
 
@@ -314,7 +301,9 @@ func createFakeAgentInstall(t *testing.T, topDir, version, hash string, useVersi
 	require.NoErrorf(t, err, "error writing elastic agent binary placeholder %q", agentExecutableName)
 	err = os.WriteFile(filepath.Join(absLogsDirPath, "fakelog.ndjson"), []byte(fmt.Sprintf("Sample logs for agent %s", version)), 0o750)
 	require.NoErrorf(t, err, "error writing fake log placeholder %q")
-	return versionedHome
+
+	// return the path relative to top exactly like the step_unpack does
+	return relVersionedHomePath
 }
 
 func createLink(t *testing.T, topDir string, currentAgentVersionedHome string) {
@@ -324,11 +313,18 @@ func createLink(t *testing.T, topDir string, currentAgentVersionedHome string) {
 		linkTarget += ".exe"
 		linkName += ".exe"
 	}
-	err := os.Symlink(filepath.Join("data", linkTarget), filepath.Join(topDir, linkName))
+	err := os.Symlink(linkTarget, filepath.Join(topDir, linkName))
 	require.NoError(t, err, "error creating test symlink to fake agent install")
 }
 
-func createUpdateMarker(t *testing.T, topDir string, newAgentVersion string, newAgentHash string, newAgentVersionedHome string, oldAgentVersion string, oldAgentHash string, oldAgentVersionedHome string) {
+func createUpdateMarker(t *testing.T, topDir, newAgentVersion, newAgentHash, newAgentVersionedHome, oldAgentVersion, oldAgentHash, oldAgentVersionedHome string, useNewMarker bool) {
+
+	if !useNewMarker {
+		newAgentVersion = ""
+		newAgentVersionedHome = ""
+		oldAgentVersionedHome = ""
+	}
+
 	updMarker := UpdateMarker{
 		Version:           newAgentVersion,
 		Hash:              newAgentHash,

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -28,13 +28,13 @@ type testAgentVersion struct {
 	hash    string
 }
 
-type agentInstall struct {
+type testAgentInstall struct {
 	version          testAgentVersion
 	useVersionInPath bool
 }
 
 type setupAgentInstallations struct {
-	installedAgents []agentInstall
+	installedAgents []testAgentInstall
 	upgradeFrom     testAgentVersion
 	upgradeTo       testAgentVersion
 	currentAgent    testAgentVersion
@@ -76,7 +76,7 @@ func TestCleanup(t *testing.T) {
 				keepLogs:             false,
 			},
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: false,
@@ -106,7 +106,7 @@ func TestCleanup(t *testing.T) {
 				keepLogs:             false,
 			},
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: true,
@@ -136,7 +136,7 @@ func TestCleanup(t *testing.T) {
 				keepLogs:             false,
 			},
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: false,
@@ -166,7 +166,7 @@ func TestCleanup(t *testing.T) {
 				keepLogs:             false,
 			},
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version: testAgentVersion{
 							version: "0.9.9",
@@ -236,7 +236,7 @@ func TestRollback(t *testing.T) {
 		{
 			name: "rollback without versionedHome (legacy upgrade process)",
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: false,
@@ -260,7 +260,7 @@ func TestRollback(t *testing.T) {
 		{
 			name: "rollback with versionedHome (new upgrade process)",
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: true,
@@ -284,7 +284,7 @@ func TestRollback(t *testing.T) {
 		{
 			name: "rollback with versionedHome only on the new agent (new upgrade process from an old agent upgraded with legacy process)",
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: false,
@@ -502,6 +502,20 @@ func createUpdateMarker(t *testing.T, log *logger.Logger, topDir, newAgentVersio
 		oldAgentVersionedHome = ""
 	}
 
-	err := markUpgrade(log, paths.DataFrom(topDir), newAgentVersion, newAgentHash, newAgentVersionedHome, oldAgentVersion, oldAgentHash, oldAgentVersionedHome, nil, nil)
+	newAgentInstall := agentInstall{
+		version:       newAgentVersion,
+		hash:          newAgentHash,
+		versionedHome: newAgentVersionedHome,
+	}
+	oldAgentInstall := agentInstall{
+		version:       oldAgentVersion,
+		hash:          oldAgentHash,
+		versionedHome: oldAgentVersionedHome,
+	}
+	err := markUpgrade(log,
+		paths.DataFrom(topDir),
+		newAgentInstall,
+		oldAgentInstall,
+		nil, nil)
 	require.NoError(t, err, "error writing fake update marker")
 }

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -1,0 +1,350 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+)
+
+type hookFunc func(t *testing.T, topDir string)
+
+type agentVersion struct {
+	version string
+	hash    string
+}
+
+type agentInstall struct {
+	version          agentVersion
+	useVersionInPath bool
+}
+
+type setupAgentInstallations struct {
+	installedAgents []agentInstall
+	upgradeFrom     agentVersion
+	upgradeTo       agentVersion
+	currentAgent    agentVersion
+}
+
+var (
+	version123Snapshot = agentVersion{
+		version: "1.2.3-SNAPSHOT",
+		hash:    "abcdef",
+	}
+	version456Snapshot = agentVersion{
+		version: "4.5.6-SNAPSHOT",
+		hash:    "ghijkl",
+	}
+)
+
+func TestCleanup(t *testing.T) {
+	type args struct {
+		currentVersionedHome string
+		currentHash          string
+		removeMarker         bool
+		keepLogs             bool
+	}
+
+	tests := []struct {
+		name               string
+		args               args
+		agentInstallsSetup setupAgentInstallations
+		additionalSetup    hookFunc
+		wantErr            assert.ErrorAssertionFunc
+		checkAfterCleanup  hookFunc
+	}{
+		{
+			name: "cleanup without versionedHome (legacy upgrade process)",
+			args: args{
+				currentVersionedHome: "data/elastic-agent-ghijkl",
+				currentHash:          "ghijkl",
+				removeMarker:         true,
+				keepLogs:             false,
+			},
+			agentInstallsSetup: setupAgentInstallations{
+				installedAgents: []agentInstall{
+					{
+						version:          version123Snapshot,
+						useVersionInPath: false,
+					},
+					{
+						version:          version456Snapshot,
+						useVersionInPath: false,
+					},
+				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
+			},
+			wantErr: assert.NoError,
+			checkAfterCleanup: func(t *testing.T, topDir string) {
+				// the old agent directory must not exist anymore
+				oldAgentHome := "elastic-agent-abcdef"
+				assert.NoDirExists(t, filepath.Join(topDir, "data", oldAgentHome), "old agent directory should be deleted after cleanup")
+				newAgentHome := "elastic-agent-ghijkl"
+				assert.DirExists(t, filepath.Join(topDir, "data", newAgentHome), "new agent directory should exist after cleanup")
+				agentExecutable := agentName
+				if runtime.GOOS == "windows" {
+					agentExecutable += ".exe"
+				}
+				symlinkPath := filepath.Join(topDir, agentExecutable)
+				linkTarget, err := os.Readlink(symlinkPath)
+				if assert.NoError(t, err, "unable to read symbolic link") {
+					assert.Equal(t, filepath.Join("data", newAgentHome, agentExecutable), linkTarget, "symbolic link should point to the new agent executable after cleanup")
+				}
+
+				// read the elastic agent placeholder via the symlink
+				elasticAgentBytes, err := os.ReadFile(symlinkPath)
+				if assert.NoError(t, err, "error reading elastic-agent content through the symlink") {
+					assert.Equal(t, []byte("Placeholder for agent 4.5.6-SNAPSHOT"), elasticAgentBytes, "reading elastic-agent content through symbolic link should point to the new version")
+				}
+			},
+		},
+		{
+			name: "cleanup with versionedHome (new upgrade process)",
+			args: args{
+				currentVersionedHome: "data/elastic-agent-4.5.6-SNAPSHOT-ghijkl",
+				currentHash:          "ghijkl",
+				removeMarker:         true,
+				keepLogs:             false,
+			},
+			agentInstallsSetup: setupAgentInstallations{
+				installedAgents: []agentInstall{
+					{
+						version:          version123Snapshot,
+						useVersionInPath: true,
+					},
+					{
+						version:          version456Snapshot,
+						useVersionInPath: true,
+					},
+				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
+			},
+			wantErr: assert.NoError,
+			checkAfterCleanup: func(t *testing.T, topDir string) {
+				// the old agent directory must not exist anymore
+				oldAgentHome := "elastic-agent-1.2.3-SNAPSHOT-abcdef"
+				assert.NoDirExists(t, filepath.Join(topDir, "data", oldAgentHome), "old agent directory should be deleted after cleanup")
+
+				newAgentHome := "elastic-agent-4.5.6-SNAPSHOT-ghijkl"
+				assert.DirExists(t, filepath.Join(topDir, "data", newAgentHome), "new agent directory should exist after cleanup")
+				agentExecutable := agentName
+				if runtime.GOOS == "windows" {
+					agentExecutable += ".exe"
+				}
+				symlinkPath := filepath.Join(topDir, agentExecutable)
+				linkTarget, err := os.Readlink(symlinkPath)
+				if assert.NoError(t, err, "unable to read symbolic link") {
+					assert.Equal(t, filepath.Join("data", newAgentHome, agentExecutable), linkTarget, "symbolic link should point to the new agent executable after cleanup")
+				}
+
+				// read the elastic agent placeholder via the symlink
+				elasticAgentBytes, err := os.ReadFile(symlinkPath)
+				if assert.NoError(t, err, "error reading elastic-agent content through the symlink") {
+					assert.Equal(t, []byte("Placeholder for agent 4.5.6-SNAPSHOT"), elasticAgentBytes, "reading elastic-agent content through symbolic link should point to the new version")
+				}
+			},
+		},
+		{
+			name: "cleanup with versionedHome only on the new agent (new upgrade process from an old agent upgraded with legacy process)",
+			args: args{
+				currentVersionedHome: "data/elastic-agent-4.5.6-SNAPSHOT-ghijkl",
+				currentHash:          "ghijkl",
+				removeMarker:         true,
+				keepLogs:             false,
+			},
+			agentInstallsSetup: setupAgentInstallations{
+				installedAgents: []agentInstall{
+					{
+						version:          version123Snapshot,
+						useVersionInPath: false,
+					},
+					{
+						version:          version456Snapshot,
+						useVersionInPath: true,
+					},
+				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
+			},
+			wantErr: assert.NoError,
+			checkAfterCleanup: func(t *testing.T, topDir string) {
+				// the old agent directory must not exist anymore
+				oldAgentHome := "elastic-agent-abcdef"
+				assert.NoDirExists(t, filepath.Join(topDir, "data", oldAgentHome), "old agent directory should be deleted after cleanup")
+
+				newAgentHome := "elastic-agent-4.5.6-SNAPSHOT-ghijkl"
+				assert.DirExists(t, filepath.Join(topDir, "data", newAgentHome), "new agent directory should exist after cleanup")
+				agentExecutable := agentName
+				if runtime.GOOS == "windows" {
+					agentExecutable += ".exe"
+				}
+				symlinkPath := filepath.Join(topDir, agentExecutable)
+				linkTarget, err := os.Readlink(symlinkPath)
+				if assert.NoError(t, err, "unable to read symbolic link") {
+					assert.Equal(t, filepath.Join("data", newAgentHome, agentExecutable), linkTarget, "symbolic link should point to the new agent executable after cleanup")
+				}
+
+				// read the elastic agent placeholder via the symlink
+				elasticAgentBytes, err := os.ReadFile(symlinkPath)
+				if assert.NoError(t, err, "error reading elastic-agent content through the symlink") {
+					assert.Equal(t, []byte("Placeholder for agent 4.5.6-SNAPSHOT"), elasticAgentBytes, "reading elastic-agent content through symbolic link should point to the new version")
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testTop := t.TempDir()
+			setupAgents(t, testTop, tt.agentInstallsSetup)
+			if tt.additionalSetup != nil {
+				tt.additionalSetup(t, testTop)
+			}
+			testLogger, _ := logger.NewTesting(t.Name())
+			tt.wantErr(t, Cleanup(testLogger, testTop, tt.args.currentVersionedHome, tt.args.currentHash, tt.args.removeMarker, tt.args.keepLogs), fmt.Sprintf("Cleanup(%v, %v, %v, %v)", tt.args.currentVersionedHome, tt.args.currentHash, tt.args.removeMarker, tt.args.keepLogs))
+			tt.checkAfterCleanup(t, testTop)
+		})
+	}
+}
+
+func TestRollback(t *testing.T) {
+	type args struct {
+		ctx               context.Context
+		log               *logger.Logger
+		prevVersionedHome string
+		prevHash          string
+		currentHash       string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr assert.ErrorAssertionFunc
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.wantErr(t, Rollback(tt.args.ctx, tt.args.log, tt.args.prevVersionedHome, tt.args.prevHash, tt.args.currentHash), fmt.Sprintf("Rollback(%v, %v, %v, %v, %v)", tt.args.ctx, tt.args.log, tt.args.prevVersionedHome, tt.args.prevHash, tt.args.currentHash))
+		})
+	}
+}
+
+func setupAgents(t *testing.T, topDir string, installations setupAgentInstallations) {
+
+	var (
+		oldAgentVersion       agentVersion
+		oldAgentVersionedHome string
+		newAgentVersion       agentVersion
+		newAgentVersionedHome string
+	)
+	for _, ia := range installations.installedAgents {
+		versionedHome := createFakeAgentInstall(t, topDir, ia.version.version, ia.version.hash, ia.useVersionInPath)
+		t.Logf("Created fake agent install for %+v located at %q", ia, versionedHome)
+		if installations.upgradeFrom == ia.version {
+			t.Logf("Setting version %+v as FROM version for the update marker", ia.version)
+			oldAgentVersion = ia.version
+			oldAgentVersionedHome = versionedHome
+		}
+
+		if installations.upgradeTo == ia.version {
+			t.Logf("Setting version %+v as TO version for the update marker", ia.version)
+			newAgentVersion = ia.version
+			newAgentVersionedHome = versionedHome
+		}
+
+		if installations.currentAgent == ia.version {
+			t.Logf("Creating symlink pointing to %q", versionedHome)
+			createLink(t, topDir, versionedHome)
+		}
+	}
+
+	t.Logf("Creating upgrade marker from %+v located at %q to %+v located at %q", oldAgentVersion, oldAgentVersionedHome, newAgentVersion, newAgentVersionedHome)
+	createUpdateMarker(t, topDir, newAgentVersion.version, newAgentVersion.hash, newAgentVersionedHome, oldAgentVersion.version, oldAgentVersion.hash, oldAgentVersionedHome)
+}
+
+func createFakeAgentInstall(t *testing.T, topDir, version, hash string, useVersionInPath bool) string {
+
+	// create versioned home
+	versionedHome := fmt.Sprintf("elastic-agent-%s", hash[:hashLen])
+	if useVersionInPath {
+		// use the version passed as parameter
+		versionedHome = fmt.Sprintf("elastic-agent-%s-%s", version, hash[:hashLen])
+	}
+
+	absVersionedHomePath := filepath.Join(topDir, "data", versionedHome)
+	err := os.MkdirAll(absVersionedHomePath, 0o750)
+	require.NoError(t, err, "error creating fake install versioned home directory %q", absVersionedHomePath)
+
+	// place a few directories in the fake install
+	absComponentsDirPath := filepath.Join(absVersionedHomePath, "components")
+	err = os.MkdirAll(absComponentsDirPath, 0o750)
+	require.NoError(t, err, "error creating fake install components directory %q", absVersionedHomePath)
+
+	absLogsDirPath := filepath.Join(absVersionedHomePath, "logs")
+	err = os.MkdirAll(absLogsDirPath, 0o750)
+	require.NoError(t, err, "error creating fake install logs directory %q", absLogsDirPath)
+
+	absRunDirPath := filepath.Join(absVersionedHomePath, "run")
+	err = os.MkdirAll(absRunDirPath, 0o750)
+	require.NoError(t, err, "error creating fake install run directory %q", absRunDirPath)
+
+	// put some placeholder for files
+	agentExecutableName := agentName
+	if runtime.GOOS == "windows" {
+		agentExecutableName += ".exe"
+	}
+	err = os.WriteFile(filepath.Join(absVersionedHomePath, agentExecutableName), []byte(fmt.Sprintf("Placeholder for agent %s", version)), 0o750)
+	require.NoErrorf(t, err, "error writing elastic agent binary placeholder %q", agentExecutableName)
+	err = os.WriteFile(filepath.Join(absLogsDirPath, "fakelog.ndjson"), []byte(fmt.Sprintf("Sample logs for agent %s", version)), 0o750)
+	require.NoErrorf(t, err, "error writing fake log placeholder %q")
+	return versionedHome
+}
+
+func createLink(t *testing.T, topDir string, currentAgentVersionedHome string) {
+	linkTarget := filepath.Join(currentAgentVersionedHome, agentName)
+	linkName := agentName
+	if runtime.GOOS == "windows" {
+		linkTarget += ".exe"
+		linkName += ".exe"
+	}
+	err := os.Symlink(filepath.Join("data", linkTarget), filepath.Join(topDir, linkName))
+	require.NoError(t, err, "error creating test symlink to fake agent install")
+}
+
+func createUpdateMarker(t *testing.T, topDir string, newAgentVersion string, newAgentHash string, newAgentVersionedHome string, oldAgentVersion string, oldAgentHash string, oldAgentVersionedHome string) {
+	updMarker := UpdateMarker{
+		Version:           newAgentVersion,
+		Hash:              newAgentHash,
+		VersionedHome:     newAgentVersionedHome,
+		UpdatedOn:         time.Now(),
+		PrevVersion:       oldAgentVersion,
+		PrevHash:          oldAgentHash,
+		PrevVersionedHome: oldAgentVersionedHome,
+		Acked:             true,
+		Action:            nil,
+		Details:           nil,
+	}
+
+	updMarkerSerializer := newMarkerSerializer(&updMarker)
+	updMarkerBytes, err := yaml.Marshal(updMarkerSerializer)
+	require.NoError(t, err, "error marshaling fake update marker")
+	err = os.WriteFile(filepath.Join(topDir, "data", markerFilename), updMarkerBytes, 0o600)
+	require.NoError(t, err, "error writing out fake update marker")
+}

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -23,29 +23,29 @@ import (
 
 type hookFunc func(t *testing.T, topDir string)
 
-type agentVersion struct {
+type testAgentVersion struct {
 	version string
 	hash    string
 }
 
 type agentInstall struct {
-	version          agentVersion
+	version          testAgentVersion
 	useVersionInPath bool
 }
 
 type setupAgentInstallations struct {
 	installedAgents []agentInstall
-	upgradeFrom     agentVersion
-	upgradeTo       agentVersion
-	currentAgent    agentVersion
+	upgradeFrom     testAgentVersion
+	upgradeTo       testAgentVersion
+	currentAgent    testAgentVersion
 }
 
 var (
-	version123Snapshot = agentVersion{
+	version123Snapshot = testAgentVersion{
 		version: "1.2.3-SNAPSHOT",
 		hash:    "abcdef",
 	}
-	version456Snapshot = agentVersion{
+	version456Snapshot = testAgentVersion{
 		version: "4.5.6-SNAPSHOT",
 		hash:    "ghijkl",
 	}
@@ -168,14 +168,14 @@ func TestCleanup(t *testing.T) {
 			agentInstallsSetup: setupAgentInstallations{
 				installedAgents: []agentInstall{
 					{
-						version: agentVersion{
+						version: testAgentVersion{
 							version: "0.9.9",
 							hash:    "aaaaaa",
 						},
 						useVersionInPath: false,
 					},
 					{
-						version: agentVersion{
+						version: testAgentVersion{
 							version: "1.1.1",
 							hash:    "aaabbb",
 						},
@@ -405,9 +405,9 @@ func checkFilesAfterRollback(t *testing.T, topDir, oldAgentHome, newAgentHome st
 func setupAgents(t *testing.T, log *logger.Logger, topDir string, installations setupAgentInstallations) {
 
 	var (
-		oldAgentVersion       agentVersion
+		oldAgentVersion       testAgentVersion
 		oldAgentVersionedHome string
-		newAgentVersion       agentVersion
+		newAgentVersion       testAgentVersion
 		newAgentVersionedHome string
 		useNewMarker          bool
 	)

--- a/internal/pkg/agent/application/upgrade/rollback_windows.go
+++ b/internal/pkg/agent/application/upgrade/rollback_windows.go
@@ -19,9 +19,9 @@ const (
 	afterRestartDelay = 15 * time.Second
 )
 
-func invokeCmd() *exec.Cmd {
+func invokeCmd(agentExecutable string) *exec.Cmd {
 	// #nosec G204 -- user cannot inject any parameters to this command
-	cmd := exec.Command(paths.TopBinaryPath(), watcherSubcommand,
+	cmd := exec.Command(agentExecutable, watcherSubcommand,
 		"--path.config", paths.Config(),
 		"--path.home", paths.Top(),
 	)

--- a/internal/pkg/agent/application/upgrade/step_download.go
+++ b/internal/pkg/agent/application/upgrade/step_download.go
@@ -40,19 +40,14 @@ type downloaderFactory func(*agtversion.ParsedSemVer, *logger.Logger, *artifact.
 
 type downloader func(context.Context, downloaderFactory, *agtversion.ParsedSemVer, *artifact.Config, *details.Details) (string, error)
 
-func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI string, upgradeDetails *details.Details, skipVerifyOverride bool, skipDefaultPgp bool, pgpBytes ...string) (_ string, err error) {
+func (u *Upgrader) downloadArtifact(ctx context.Context, parsedVersion *agtversion.ParsedSemVer, sourceURI string, upgradeDetails *details.Details, skipVerifyOverride, skipDefaultPgp bool, pgpBytes ...string) (_ string, err error) {
 	span, ctx := apm.StartSpan(ctx, "downloadArtifact", "app.internal")
 	defer func() {
 		apm.CaptureError(ctx, err).Send()
 		span.End()
 	}()
 
-	pgpBytes = u.appendFallbackPGP(version, pgpBytes)
-
-	parsedVersion, err := agtversion.ParseVersion(version)
-	if err != nil {
-		return "", fmt.Errorf("error parsing version %q: %w", version, err)
-	}
+	pgpBytes = u.appendFallbackPGP(parsedVersion, pgpBytes)
 
 	// do not update source config
 	settings := *u.settings
@@ -82,7 +77,7 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 			}
 
 			// log that a local upgrade artifact is being used
-			u.log.Infow("Using local upgrade artifact", "version", version,
+			u.log.Infow("Using local upgrade artifact", "version", parsedVersion,
 				"drop_path", settings.DropPath,
 				"target_path", settings.TargetDirectory, "install_path", settings.InstallPath)
 		} else {
@@ -93,7 +88,7 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 	if factory == nil {
 		// set the factory to the newDownloader factory
 		factory = newDownloader
-		u.log.Infow("Downloading upgrade artifact", "version", version,
+		u.log.Infow("Downloading upgrade artifact", "version", parsedVersion,
 			"source_uri", settings.SourceURI, "drop_path", settings.DropPath,
 			"target_path", settings.TargetDirectory, "install_path", settings.InstallPath)
 	}
@@ -127,7 +122,7 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 	return path, nil
 }
 
-func (u *Upgrader) appendFallbackPGP(targetVersion string, pgpBytes []string) []string {
+func (u *Upgrader) appendFallbackPGP(tpv *agtversion.ParsedSemVer, pgpBytes []string) []string {
 	if pgpBytes == nil {
 		pgpBytes = make([]string, 0, 1)
 	}
@@ -138,21 +133,15 @@ func (u *Upgrader) appendFallbackPGP(targetVersion string, pgpBytes []string) []
 	// add a secondary fallback if fleet server is configured
 	u.log.Debugf("Considering fleet server uri for pgp check fallback %q", u.fleetServerURI)
 	if u.fleetServerURI != "" {
-		tpv, err := agtversion.ParseVersion(targetVersion)
+		secondaryPath, err := url.JoinPath(
+			u.fleetServerURI,
+			fmt.Sprintf(fleetUpgradeFallbackPGPFormat, tpv.Major(), tpv.Minor(), tpv.Patch()),
+		)
 		if err != nil {
-			// best effort, log failure
-			u.log.Warnf("failed to parse agent version (%q) for secondary GPG fallback: %v", targetVersion, err)
+			u.log.Warnf("failed to compose Fleet Server URI: %v", err)
 		} else {
-			secondaryPath, err := url.JoinPath(
-				u.fleetServerURI,
-				fmt.Sprintf(fleetUpgradeFallbackPGPFormat, tpv.Major(), tpv.Minor(), tpv.Patch()),
-			)
-			if err != nil {
-				u.log.Warnf("failed to compose Fleet Server URI: %v", err)
-			} else {
-				secondaryFallback := download.PgpSourceURIPrefix + secondaryPath
-				pgpBytes = append(pgpBytes, secondaryFallback)
-			}
+			secondaryFallback := download.PgpSourceURIPrefix + secondaryPath
+			pgpBytes = append(pgpBytes, secondaryFallback)
 		}
 	}
 

--- a/internal/pkg/agent/application/upgrade/step_download_test.go
+++ b/internal/pkg/agent/application/upgrade/step_download_test.go
@@ -40,14 +40,14 @@ func TestFallbackIsAppended(t *testing.T) {
 		expectedDefaultIdx   int
 		expectedSecondaryIdx int
 		fleetServerURI       string
-		targetVersion        string
+		targetVersion        *agtversion.ParsedSemVer
 	}{
-		{"nil input", nil, 1, 0, -1, "", ""},
-		{"empty input", []string{}, 1, 0, -1, "", ""},
-		{"valid input with pgp", []string{"pgp-bytes"}, 2, 1, -1, "", ""},
-		{"valid input with pgp and version, no fleet uri", []string{"pgp-bytes"}, 2, 1, -1, "", "1.2.3"},
-		{"valid input with pgp and version and fleet uri", []string{"pgp-bytes"}, 3, 1, 2, "some-uri", "1.2.3"},
-		{"valid input with pgp and fleet uri no version", []string{"pgp-bytes"}, 2, 1, -1, "some-uri", ""},
+		//{"nil input", nil, 1, 0, -1, "", ""},
+		//{"empty input", []string{}, 1, 0, -1, "", ""},
+		{"valid input with pgp", []string{"pgp-bytes"}, 2, 1, -1, "", nil},
+		{"valid input with pgp and version, no fleet uri", []string{"pgp-bytes"}, 2, 1, -1, "", agtversion.NewParsedSemVer(1, 2, 3, "", "")},
+		{"valid input with pgp and version and fleet uri", []string{"pgp-bytes"}, 3, 1, 2, "some-uri", agtversion.NewParsedSemVer(1, 2, 3, "", "")},
+		//{"valid input with pgp and fleet uri no version", []string{"pgp-bytes"}, 2, 1, -1, "some-uri", ""},
 	}
 
 	for _, tc := range testCases {
@@ -65,7 +65,7 @@ func TestFallbackIsAppended(t *testing.T) {
 
 			if tc.expectedSecondaryIdx >= 0 {
 				// last element is fleet uri
-				expectedPgpURI := download.PgpSourceURIPrefix + tc.fleetServerURI + strings.Replace(fleetUpgradeFallbackPGPFormat, "%d.%d.%d", tc.targetVersion, 1)
+				expectedPgpURI := download.PgpSourceURIPrefix + tc.fleetServerURI + strings.Replace(fleetUpgradeFallbackPGPFormat, "%d.%d.%d", tc.targetVersion.CoreVersion(), 1)
 				require.Equal(t, expectedPgpURI, res[len(res)-1])
 			}
 		})

--- a/internal/pkg/agent/application/upgrade/step_download_test.go
+++ b/internal/pkg/agent/application/upgrade/step_download_test.go
@@ -33,6 +33,7 @@ func (md *mockDownloader) Download(ctx context.Context, a artifact.Artifact, ver
 }
 
 func TestFallbackIsAppended(t *testing.T) {
+	testAgentVersion123 := agtversion.NewParsedSemVer(1, 2, 3, "", "")
 	testCases := []struct {
 		name                 string
 		passedBytes          []string
@@ -42,12 +43,11 @@ func TestFallbackIsAppended(t *testing.T) {
 		fleetServerURI       string
 		targetVersion        *agtversion.ParsedSemVer
 	}{
-		//{"nil input", nil, 1, 0, -1, "", ""},
-		//{"empty input", []string{}, 1, 0, -1, "", ""},
+		{"nil input", nil, 1, 0, -1, "", testAgentVersion123},
+		{"empty input", []string{}, 1, 0, -1, "", testAgentVersion123},
 		{"valid input with pgp", []string{"pgp-bytes"}, 2, 1, -1, "", nil},
-		{"valid input with pgp and version, no fleet uri", []string{"pgp-bytes"}, 2, 1, -1, "", agtversion.NewParsedSemVer(1, 2, 3, "", "")},
-		{"valid input with pgp and version and fleet uri", []string{"pgp-bytes"}, 3, 1, 2, "some-uri", agtversion.NewParsedSemVer(1, 2, 3, "", "")},
-		//{"valid input with pgp and fleet uri no version", []string{"pgp-bytes"}, 2, 1, -1, "some-uri", ""},
+		{"valid input with pgp and version, no fleet uri", []string{"pgp-bytes"}, 2, 1, -1, "", testAgentVersion123},
+		{"valid input with pgp and version and fleet uri", []string{"pgp-bytes"}, 3, 1, 2, "some-uri", testAgentVersion123},
 	}
 
 	for _, tc := range testCases {

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -172,8 +172,8 @@ func UpdateActiveCommit(log *logger.Logger, hash string) error {
 }
 
 // CleanMarker removes a marker from disk.
-func CleanMarker(log *logger.Logger) error {
-	markerFile := markerFilePath(paths.Data())
+func CleanMarker(log *logger.Logger, dataDirPath string) error {
+	markerFile := markerFilePath(dataDirPath)
 	log.Infow("Removing marker file", "file.path", markerFile)
 	if err := os.Remove(markerFile); !os.IsNotExist(err) {
 		return err

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -184,8 +184,8 @@ func CleanMarker(log *logger.Logger, dataDirPath string) error {
 
 // LoadMarker loads the update marker. If the file does not exist it returns nil
 // and no error.
-func LoadMarker() (*UpdateMarker, error) {
-	return loadMarker(markerFilePath(paths.Data()))
+func LoadMarker(dataDirPath string) (*UpdateMarker, error) {
+	return loadMarker(markerFilePath(dataDirPath))
 }
 
 func loadMarker(markerFile string) (*UpdateMarker, error) {

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -147,7 +147,7 @@ func (u *Upgrader) markUpgrade(_ context.Context, log *logger.Logger, version, h
 		return errors.New(err, errors.TypeConfig, "failed to parse marker file")
 	}
 
-	markerPath := markerFilePath()
+	markerPath := markerFilePath(paths.Data())
 	log.Infow("Writing upgrade marker file", "file.path", markerPath, "hash", marker.Hash, "prev_hash", prevHash)
 	if err := os.WriteFile(markerPath, markerBytes, 0600); err != nil {
 		return errors.New(err, errors.TypeFilesystem, "failed to create update marker file", errors.M(errors.MetaKeyPath, markerPath))
@@ -173,7 +173,7 @@ func UpdateActiveCommit(log *logger.Logger, hash string) error {
 
 // CleanMarker removes a marker from disk.
 func CleanMarker(log *logger.Logger) error {
-	markerFile := markerFilePath()
+	markerFile := markerFilePath(paths.Data())
 	log.Infow("Removing marker file", "file.path", markerFile)
 	if err := os.Remove(markerFile); !os.IsNotExist(err) {
 		return err
@@ -185,7 +185,7 @@ func CleanMarker(log *logger.Logger) error {
 // LoadMarker loads the update marker. If the file does not exist it returns nil
 // and no error.
 func LoadMarker() (*UpdateMarker, error) {
-	return loadMarker(markerFilePath())
+	return loadMarker(markerFilePath(paths.Data()))
 }
 
 func loadMarker(markerFile string) (*UpdateMarker, error) {
@@ -238,9 +238,9 @@ func SaveMarker(marker *UpdateMarker, shouldFsync bool) error {
 		return err
 	}
 
-	return writeMarkerFile(markerFilePath(), markerBytes, shouldFsync)
+	return writeMarkerFile(markerFilePath(paths.Data()), markerBytes, shouldFsync)
 }
 
-func markerFilePath() string {
-	return filepath.Join(paths.Data(), markerFilename)
+func markerFilePath(dataDirPath string) string {
+	return filepath.Join(dataDirPath, markerFilename)
 }

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -153,7 +153,7 @@ func (u *Upgrader) markUpgrade(_ context.Context, log *logger.Logger, version, h
 		return errors.New(err, errors.TypeFilesystem, "failed to create update marker file", errors.M(errors.MetaKeyPath, markerPath))
 	}
 
-	if err := UpdateActiveCommit(log, hash); err != nil {
+	if err := UpdateActiveCommit(log, paths.Top(), hash); err != nil {
 		return err
 	}
 
@@ -161,8 +161,8 @@ func (u *Upgrader) markUpgrade(_ context.Context, log *logger.Logger, version, h
 }
 
 // UpdateActiveCommit updates active.commit file to point to active version.
-func UpdateActiveCommit(log *logger.Logger, hash string) error {
-	activeCommitPath := filepath.Join(paths.Top(), agentCommitFile)
+func UpdateActiveCommit(log *logger.Logger, topDirPath, hash string) error {
+	activeCommitPath := filepath.Join(topDirPath, agentCommitFile)
 	log.Infow("Updating active commit", "file.path", activeCommitPath, "hash", hash)
 	if err := os.WriteFile(activeCommitPath, []byte(hash), 0600); err != nil {
 		return errors.New(err, errors.TypeFilesystem, "failed to update active commit", errors.M(errors.MetaKeyPath, activeCommitPath))

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -6,6 +6,7 @@ package upgrade
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -24,8 +25,13 @@ const markerFilename = ".update-marker"
 
 // UpdateMarker is a marker holding necessary information about ongoing upgrade.
 type UpdateMarker struct {
+	// Version represents the version the agent is upgraded to
+	Version string `json:"version" yaml:"version"`
 	// Hash agent is updated to
 	Hash string `json:"hash" yaml:"hash"`
+	// VersionedHome represents the path where the new agent is located relative to top path
+	VersionedHome string `json:"versioned_home" yaml:"versioned_home"`
+
 	//UpdatedOn marks a date when update happened
 	UpdatedOn time.Time `json:"updated_on" yaml:"updated_on"`
 
@@ -33,6 +39,8 @@ type UpdateMarker struct {
 	PrevVersion string `json:"prev_version" yaml:"prev_version"`
 	// PrevHash is a hash agent is updated from
 	PrevHash string `json:"prev_hash" yaml:"prev_hash"`
+	// PrevVersionedHome represents the path where the new agent is located relative to top path
+	PrevVersionedHome string `json:"prev_versioned_home" yaml:"prev_versioned_home"`
 
 	// Acked is a flag marking whether or not action was acked
 	Acked  bool                    `json:"acked" yaml:"acked"`
@@ -83,42 +91,55 @@ func convertToActionUpgrade(a *MarkerActionUpgrade) *fleetapi.ActionUpgrade {
 }
 
 type updateMarkerSerializer struct {
-	Hash        string               `yaml:"hash"`
-	UpdatedOn   time.Time            `yaml:"updated_on"`
-	PrevVersion string               `yaml:"prev_version"`
-	PrevHash    string               `yaml:"prev_hash"`
-	Acked       bool                 `yaml:"acked"`
-	Action      *MarkerActionUpgrade `yaml:"action"`
-	Details     *details.Details     `yaml:"details"`
+	Version           string               `yaml:"version"`
+	Hash              string               `yaml:"hash"`
+	VersionedHome     string               `yaml:"versioned_home"`
+	UpdatedOn         time.Time            `yaml:"updated_on"`
+	PrevVersion       string               `yaml:"prev_version"`
+	PrevHash          string               `yaml:"prev_hash"`
+	PrevVersionedHome string               `yaml:"prev_versioned_home"`
+	Acked             bool                 `yaml:"acked"`
+	Action            *MarkerActionUpgrade `yaml:"action"`
+	Details           *details.Details     `yaml:"details"`
 }
 
 func newMarkerSerializer(m *UpdateMarker) *updateMarkerSerializer {
 	return &updateMarkerSerializer{
-		Hash:        m.Hash,
-		UpdatedOn:   m.UpdatedOn,
-		PrevVersion: m.PrevVersion,
-		PrevHash:    m.PrevHash,
-		Acked:       m.Acked,
-		Action:      convertToMarkerAction(m.Action),
-		Details:     m.Details,
+		Version:           m.Version,
+		Hash:              m.Hash,
+		VersionedHome:     m.VersionedHome,
+		UpdatedOn:         m.UpdatedOn,
+		PrevVersion:       m.PrevVersion,
+		PrevHash:          m.PrevHash,
+		PrevVersionedHome: m.PrevVersionedHome,
+		Acked:             m.Acked,
+		Action:            convertToMarkerAction(m.Action),
+		Details:           m.Details,
 	}
 }
 
 // markUpgrade marks update happened so we can handle grace period
-func (u *Upgrader) markUpgrade(_ context.Context, log *logger.Logger, hash string, action *fleetapi.ActionUpgrade, upgradeDetails *details.Details) error {
-	prevVersion := release.Version()
+func (u *Upgrader) markUpgrade(_ context.Context, log *logger.Logger, version, hash, versionedHome string, action *fleetapi.ActionUpgrade, upgradeDetails *details.Details) error {
+	prevVersion := release.VersionWithSnapshot()
 	prevHash := release.Commit()
+	prevVersionedHome, err := filepath.Rel(paths.Top(), paths.Home())
+	if err != nil {
+		return fmt.Errorf("calculating home path relative to top, home: %q top: %q : %w", paths.Home(), paths.Top(), err)
+	}
 	if len(prevHash) > hashLen {
 		prevHash = prevHash[:hashLen]
 	}
 
 	marker := &UpdateMarker{
-		Hash:        hash,
-		UpdatedOn:   time.Now(),
-		PrevVersion: prevVersion,
-		PrevHash:    prevHash,
-		Action:      action,
-		Details:     upgradeDetails,
+		Version:           version,
+		Hash:              hash,
+		VersionedHome:     versionedHome,
+		UpdatedOn:         time.Now(),
+		PrevVersion:       prevVersion,
+		PrevHash:          prevHash,
+		PrevVersionedHome: prevVersionedHome,
+		Action:            action,
+		Details:           upgradeDetails,
 	}
 
 	markerBytes, err := yaml.Marshal(newMarkerSerializer(marker))
@@ -183,13 +204,16 @@ func loadMarker(markerFile string) (*UpdateMarker, error) {
 	}
 
 	return &UpdateMarker{
-		Hash:        marker.Hash,
-		UpdatedOn:   marker.UpdatedOn,
-		PrevVersion: marker.PrevVersion,
-		PrevHash:    marker.PrevHash,
-		Acked:       marker.Acked,
-		Action:      convertToActionUpgrade(marker.Action),
-		Details:     marker.Details,
+		Version:           marker.Version,
+		Hash:              marker.Hash,
+		VersionedHome:     marker.VersionedHome,
+		UpdatedOn:         marker.UpdatedOn,
+		PrevVersion:       marker.PrevVersion,
+		PrevHash:          marker.PrevHash,
+		PrevVersionedHome: marker.PrevVersionedHome,
+		Acked:             marker.Acked,
+		Action:            convertToActionUpgrade(marker.Action),
+		Details:           marker.Details,
 	}, nil
 }
 
@@ -198,13 +222,16 @@ func loadMarker(markerFile string) (*UpdateMarker, error) {
 // file is immediately flushed to persistent storage.
 func SaveMarker(marker *UpdateMarker, shouldFsync bool) error {
 	makerSerializer := &updateMarkerSerializer{
-		Hash:        marker.Hash,
-		UpdatedOn:   marker.UpdatedOn,
-		PrevVersion: marker.PrevVersion,
-		PrevHash:    marker.PrevHash,
-		Acked:       marker.Acked,
-		Action:      convertToMarkerAction(marker.Action),
-		Details:     marker.Details,
+		Version:           marker.Version,
+		Hash:              marker.Hash,
+		VersionedHome:     marker.VersionedHome,
+		UpdatedOn:         marker.UpdatedOn,
+		PrevVersion:       marker.PrevVersion,
+		PrevHash:          marker.PrevHash,
+		PrevVersionedHome: marker.PrevVersionedHome,
+		Acked:             marker.Acked,
+		Action:            convertToMarkerAction(marker.Action),
+		Details:           marker.Details,
 	}
 	markerBytes, err := yaml.Marshal(makerSerializer)
 	if err != nil {

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -43,7 +43,7 @@ func changeSymlinkInternal(log *logger.Logger, symlinkPath, newTarget string) er
 		newTarget += exe
 	}
 
-	prevNewPath := prevSymlinkPath()
+	prevNewPath := prevSymlinkPath(paths.Top())
 	log.Infow("Changing symlink", "symlink_path", symlinkPath, "new_path", newTarget, "prev_path", prevNewPath)
 
 	// remove symlink to avoid upgrade failures
@@ -59,7 +59,7 @@ func changeSymlinkInternal(log *logger.Logger, symlinkPath, newTarget string) er
 	return file.SafeFileRotate(symlinkPath, prevNewPath)
 }
 
-func prevSymlinkPath() string {
+func prevSymlinkPath(topDirPath string) string {
 	agentPrevName := agentName + ".prev"
 
 	// handle windows suffixes
@@ -67,5 +67,5 @@ func prevSymlinkPath() string {
 		agentPrevName = agentName + ".exe.prev"
 	}
 
-	return filepath.Join(paths.Top(), agentPrevName)
+	return filepath.Join(topDirPath, agentPrevName)
 }

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -23,19 +23,19 @@ const (
 )
 
 // ChangeSymlink updates symlink paths to match current version.
-func ChangeSymlink(ctx context.Context, log *logger.Logger, targetHash string) error {
+func ChangeSymlink(ctx context.Context, log *logger.Logger, topDirPath, targetHash string) error {
 	// create symlink to elastic-agent-{hash}
 	hashedDir := fmt.Sprintf("%s-%s", agentName, targetHash)
 
-	symlinkPath := filepath.Join(paths.Top(), agentName)
+	symlinkPath := filepath.Join(topDirPath, agentName)
 
 	// paths.BinaryPath properly derives the binary directory depending on the platform. The path to the binary for macOS is inside of the app bundle.
-	newPath := paths.BinaryPath(filepath.Join(paths.Top(), "data", hashedDir), agentName)
+	newPath := paths.BinaryPath(filepath.Join(paths.DataFrom(topDirPath), hashedDir), agentName)
 
-	return changeSymlinkInternal(log, symlinkPath, newPath)
+	return changeSymlinkInternal(log, topDirPath, symlinkPath, newPath)
 }
 
-func changeSymlinkInternal(log *logger.Logger, symlinkPath, newTarget string) error {
+func changeSymlinkInternal(log *logger.Logger, topDirPath, symlinkPath, newTarget string) error {
 
 	// handle windows suffixes
 	if runtime.GOOS == windows {
@@ -43,7 +43,7 @@ func changeSymlinkInternal(log *logger.Logger, symlinkPath, newTarget string) er
 		newTarget += exe
 	}
 
-	prevNewPath := prevSymlinkPath(paths.Top())
+	prevNewPath := prevSymlinkPath(topDirPath)
 	log.Infow("Changing symlink", "symlink_path", symlinkPath, "new_path", newTarget, "prev_path", prevNewPath)
 
 	// remove symlink to avoid upgrade failures

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -5,14 +5,11 @@
 package upgrade
 
 import (
-	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 
 	"github.com/elastic/elastic-agent-libs/file"
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
@@ -22,20 +19,7 @@ const (
 	exe     = ".exe"
 )
 
-// ChangeSymlink updates symlink paths to match current version.
-func ChangeSymlink(ctx context.Context, log *logger.Logger, topDirPath, targetHash string) error {
-	// create symlink to elastic-agent-{hash}
-	hashedDir := fmt.Sprintf("%s-%s", agentName, targetHash)
-
-	symlinkPath := filepath.Join(topDirPath, agentName)
-
-	// paths.BinaryPath properly derives the binary directory depending on the platform. The path to the binary for macOS is inside of the app bundle.
-	newPath := paths.BinaryPath(filepath.Join(paths.DataFrom(topDirPath), hashedDir), agentName)
-
-	return changeSymlinkInternal(log, topDirPath, symlinkPath, newPath)
-}
-
-func changeSymlinkInternal(log *logger.Logger, topDirPath, symlinkPath, newTarget string) error {
+func ChangeSymlink(log *logger.Logger, topDirPath, symlinkPath, newTarget string) error {
 
 	// handle windows suffixes
 	if runtime.GOOS == windows {

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -32,21 +32,26 @@ func ChangeSymlink(ctx context.Context, log *logger.Logger, targetHash string) e
 	// paths.BinaryPath properly derives the binary directory depending on the platform. The path to the binary for macOS is inside of the app bundle.
 	newPath := paths.BinaryPath(filepath.Join(paths.Top(), "data", hashedDir), agentName)
 
+	return changeSymlinkInternal(log, symlinkPath, newPath)
+}
+
+func changeSymlinkInternal(log *logger.Logger, symlinkPath, newTarget string) error {
+
 	// handle windows suffixes
 	if runtime.GOOS == windows {
 		symlinkPath += exe
-		newPath += exe
+		newTarget += exe
 	}
 
 	prevNewPath := prevSymlinkPath()
-	log.Infow("Changing symlink", "symlink_path", symlinkPath, "new_path", newPath, "prev_path", prevNewPath)
+	log.Infow("Changing symlink", "symlink_path", symlinkPath, "new_path", newTarget, "prev_path", prevNewPath)
 
 	// remove symlink to avoid upgrade failures
 	if err := os.Remove(prevNewPath); !os.IsNotExist(err) {
 		return err
 	}
 
-	if err := os.Symlink(newPath, prevNewPath); err != nil {
+	if err := os.Symlink(newTarget, prevNewPath); err != nil {
 		return errors.New(err, errors.TypeFilesystem, "failed to update agent symlink")
 	}
 

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -207,7 +207,7 @@ func getPackageMetadataFromZipReader(r *zip.ReadCloser, fileNamePrefix string) (
 	ret := packageMetadata{}
 
 	// Load manifest, the use of path.Join is intentional since in .zip file paths use slash ('/') as separator
-	manifestFile, err := r.Open(path.Join(fileNamePrefix, "manifest.yaml"))
+	manifestFile, err := r.Open(path.Join(fileNamePrefix, v1.ManifestFileName))
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		// we got a real error looking up for the manifest
 		return packageMetadata{}, fmt.Errorf("looking up manifest in package: %w", err)
@@ -377,14 +377,14 @@ func untar(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error
 
 func getPackageMetadataFromTar(archivePath string) (packageMetadata, error) {
 	// quickly open the archive and look up manifest.yaml file
-	fileContents, err := getFilesContentFromTar(archivePath, "manifest.yaml", agentCommitFile)
+	fileContents, err := getFilesContentFromTar(archivePath, v1.ManifestFileName, agentCommitFile)
 	if err != nil {
 		return packageMetadata{}, fmt.Errorf("looking for package metadata files: %w", err)
 	}
 
 	ret := packageMetadata{}
 
-	manifestReader, ok := fileContents["manifest.yaml"]
+	manifestReader, ok := fileContents[v1.ManifestFileName]
 	if ok && manifestReader != nil {
 		ret.manifest, err = v1.ParseManifest(manifestReader)
 		if err != nil {

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -55,6 +55,28 @@ func (u *Upgrader) unpack(version, archivePath, dataDir string) (UnpackResult, e
 	return unpackRes, nil
 }
 
+type packageMetadata struct {
+	manifest *v1.PackageManifest
+	hash     string
+}
+
+func (u *Upgrader) getPackageMetadata(archivePath string) (packageMetadata, error) {
+	ext := filepath.Ext(archivePath)
+	if ext == ".gz" {
+		// if we got gzip extension we need another extension before last
+		ext = filepath.Ext(strings.TrimSuffix(archivePath, ext)) + ext
+	}
+
+	switch ext {
+	case ".zip":
+		return getPackageMetadataFromZip(archivePath)
+	case ".tar.gz":
+		return getPackageMetadataFromTar(archivePath)
+	default:
+		return packageMetadata{}, fmt.Errorf("unknown package format %q", ext)
+	}
+}
+
 func unzip(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error) {
 	var hash, rootDir string
 	r, err := zip.OpenReader(archivePath)
@@ -68,41 +90,18 @@ func unzip(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error
 	pm := pathMapper{}
 	versionedHome := ""
 
-	// Load manifest, the use of path.Join is intentional since in .zip file paths use slash ('/') as separator
-	manifestFile, err := r.Open(path.Join(fileNamePrefix, "manifest.yaml"))
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		// we got a real error looking up for the manifest
-		return UnpackResult{}, fmt.Errorf("looking up manifest in package: %w", err)
-	}
-	if err == nil {
-		// load manifest
-		defer manifestFile.Close()
-		manifest, err := v1.ParseManifest(manifestFile)
-		if err != nil {
-			return UnpackResult{}, fmt.Errorf("parsing package manifest: %w", err)
-		}
-		pm.mappings = manifest.Package.PathMappings
-		versionedHome = filepath.FromSlash(pm.Map(manifest.Package.VersionedHome))
+	metadata, err := getPackageMetadataFromZipReader(r, fileNamePrefix)
+	if err != nil {
+		return UnpackResult{}, fmt.Errorf("retrieving package metadata from %q: %w", archivePath, err)
 	}
 
-	// Load hash, the use of path.Join is intentional since in .zip file paths use slash ('/') as separator
-	hashFile, err := r.Open(path.Join(fileNamePrefix, agentCommitFile))
-	if err != nil {
-		// we got a real error looking up for the manifest
-		return UnpackResult{}, fmt.Errorf("looking up %q in package: %w", agentCommitFile, err)
-	}
-	defer hashFile.Close()
+	hash = metadata.hash[:hashLen]
 
-	hashBytes, err := io.ReadAll(hashFile)
-	if err != nil {
-		return UnpackResult{}, fmt.Errorf("reading elastic-agent hash file content: %w", err)
-	}
-	if len(hashBytes) < hashLen {
-		return UnpackResult{}, fmt.Errorf("elastic-agent hash %q is too short (minimum %d)", string(hashBytes), hashLen)
-	}
-	hash = string(hashBytes[:hashLen])
-	if versionedHome == "" {
-		// if at this point we didn't load the manifest et the versioned to the backup value
+	if metadata.manifest != nil {
+		pm.mappings = metadata.manifest.Package.PathMappings
+		versionedHome = filepath.FromSlash(pm.Map(metadata.manifest.Package.VersionedHome))
+	} else {
+		// if at this point we didn't load the manifest set the versioned to the backup value
 		versionedHome = filepath.FromSlash(createVersionedHomeFromHash(hash))
 	}
 
@@ -194,6 +193,53 @@ func unzip(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error
 	}, nil
 }
 
+func getPackageMetadataFromZip(archivePath string) (packageMetadata, error) {
+	r, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return packageMetadata{}, fmt.Errorf("opening zip archive %q: %w", archivePath, err)
+	}
+	defer r.Close()
+	fileNamePrefix := strings.TrimSuffix(filepath.Base(archivePath), ".zip") + "/" // omitting `elastic-agent-{version}-{os}-{arch}/` in filename
+	return getPackageMetadataFromZipReader(r, fileNamePrefix)
+}
+
+func getPackageMetadataFromZipReader(r *zip.ReadCloser, fileNamePrefix string) (packageMetadata, error) {
+	ret := packageMetadata{}
+
+	// Load manifest, the use of path.Join is intentional since in .zip file paths use slash ('/') as separator
+	manifestFile, err := r.Open(path.Join(fileNamePrefix, "manifest.yaml"))
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		// we got a real error looking up for the manifest
+		return packageMetadata{}, fmt.Errorf("looking up manifest in package: %w", err)
+	}
+
+	if err == nil {
+		// load manifest
+		defer manifestFile.Close()
+		ret.manifest, err = v1.ParseManifest(manifestFile)
+		if err != nil {
+			return packageMetadata{}, fmt.Errorf("parsing package manifest: %w", err)
+		}
+	}
+
+	// Load hash, the use of path.Join is intentional since in .zip file paths use slash ('/') as separator
+	hashFile, err := r.Open(path.Join(fileNamePrefix, agentCommitFile))
+	if err != nil {
+		// we got a real error looking up for the manifest
+		return packageMetadata{}, fmt.Errorf("looking up %q in package: %w", agentCommitFile, err)
+	}
+	defer hashFile.Close()
+
+	hash, err := readCommitHash(hashFile)
+	if err != nil {
+		return packageMetadata{}, err
+	}
+
+	ret.hash = hash
+
+	return ret, nil
+}
+
 func untar(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error) {
 
 	var versionedHome string
@@ -203,39 +249,20 @@ func untar(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error
 	// Look up manifest in the archive and prepare path mappings, if any
 	pm := pathMapper{}
 
-	// quickly open the archive and look up manifest.yaml file
-	fileContents, err := getFilesContentFromTar(archivePath, "manifest.yaml", agentCommitFile)
+	metadata, err := getPackageMetadataFromTar(archivePath)
 	if err != nil {
-		return UnpackResult{}, fmt.Errorf("looking for package metadata files: %w", err)
+		return UnpackResult{}, fmt.Errorf("retrieving package metadata from %q: %w", archivePath, err)
 	}
 
-	manifestReader, ok := fileContents["manifest.yaml"]
-	if ok && manifestReader != nil {
-		manifest, err := v1.ParseManifest(manifestReader)
-		if err != nil {
-			return UnpackResult{}, fmt.Errorf("parsing package manifest: %w", err)
-		}
+	hash = metadata.hash[:hashLen]
 
+	if metadata.manifest != nil {
 		// set the path mappings
-		pm.mappings = manifest.Package.PathMappings
-		versionedHome = filepath.FromSlash(pm.Map(manifest.Package.VersionedHome))
-	}
-
-	if agentCommitReader, ok := fileContents[agentCommitFile]; ok {
-		commitBytes, err := io.ReadAll(agentCommitReader)
-		if err != nil {
-			return UnpackResult{}, fmt.Errorf("reading agent commit hash file: %w", err)
-		}
-		if len(commitBytes) < hashLen {
-			return UnpackResult{}, fmt.Errorf("hash %q is shorter than minimum length %d", string(commitBytes), hashLen)
-		}
-
-		agentCommitHash := string(commitBytes)
-		hash = agentCommitHash[:hashLen]
-		if versionedHome == "" {
-			// set default value of versioned home if it wasn't set by reading the manifest
-			versionedHome = filepath.FromSlash(createVersionedHomeFromHash(agentCommitHash))
-		}
+		pm.mappings = metadata.manifest.Package.PathMappings
+		versionedHome = filepath.FromSlash(pm.Map(metadata.manifest.Package.VersionedHome))
+	} else {
+		// set default value of versioned home if it wasn't set by reading the manifest
+		versionedHome = filepath.FromSlash(createVersionedHomeFromHash(metadata.hash))
 	}
 
 	r, err := os.Open(archivePath)
@@ -346,6 +373,46 @@ func untar(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error
 		Hash:          hash,
 		VersionedHome: versionedHome,
 	}, nil
+}
+
+func getPackageMetadataFromTar(archivePath string) (packageMetadata, error) {
+	// quickly open the archive and look up manifest.yaml file
+	fileContents, err := getFilesContentFromTar(archivePath, "manifest.yaml", agentCommitFile)
+	if err != nil {
+		return packageMetadata{}, fmt.Errorf("looking for package metadata files: %w", err)
+	}
+
+	ret := packageMetadata{}
+
+	manifestReader, ok := fileContents["manifest.yaml"]
+	if ok && manifestReader != nil {
+		ret.manifest, err = v1.ParseManifest(manifestReader)
+		if err != nil {
+			return packageMetadata{}, fmt.Errorf("parsing package manifest: %w", err)
+		}
+	}
+
+	if agentCommitReader, ok := fileContents[agentCommitFile]; ok {
+		hash, err := readCommitHash(agentCommitReader)
+		if err != nil {
+			return packageMetadata{}, err
+		}
+		ret.hash = hash
+	}
+
+	return ret, nil
+}
+
+func readCommitHash(reader io.Reader) (string, error) {
+	commitBytes, err := io.ReadAll(reader)
+	if err != nil {
+		return "", fmt.Errorf("reading agent commit hash file: %w", err)
+	}
+	hash := strings.TrimSpace(string(commitBytes))
+	if len(hash) < hashLen {
+		return "", fmt.Errorf("hash %q is shorter than minimum length %d", string(commitBytes), hashLen)
+	}
+	return hash, nil
 }
 
 func getFileNamePrefix(archivePath string) string {

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -88,7 +88,7 @@ func unzip(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error
 	fileNamePrefix := strings.TrimSuffix(filepath.Base(archivePath), ".zip") + "/" // omitting `elastic-agent-{version}-{os}-{arch}/` in filename
 
 	pm := pathMapper{}
-	versionedHome := ""
+	var versionedHome string
 
 	metadata, err := getPackageMetadataFromZipReader(r, fileNamePrefix)
 	if err != nil {

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -28,7 +28,7 @@ type UnpackResult struct {
 	Hash string `json:"hash" yaml:"hash"`
 	// TODO add mapped path of executable
 	// agentExecutable string
-	versionedHome string `json:"versioned-home" yaml:"versioned-home"`
+	VersionedHome string `json:"versioned-home" yaml:"versioned-home"`
 }
 
 // unpack unpacks archive correctly, skips root (symlink, config...) unpacks data/*
@@ -152,7 +152,7 @@ func unzip(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error
 
 	return UnpackResult{
 		Hash:          hash,
-		versionedHome: versionedHome,
+		VersionedHome: versionedHome,
 	}, nil
 }
 
@@ -177,7 +177,7 @@ func untar(log *logger.Logger, version string, archivePath, dataDir string) (Unp
 
 		// set the path mappings
 		pm.mappings = manifest.Package.PathMappings
-		versionedHome = filepath.Clean(manifest.Package.VersionedHome)
+		versionedHome = filepath.Clean(pm.Map(manifest.Package.VersionedHome))
 	}
 
 	r, err := os.Open(archivePath)
@@ -294,7 +294,7 @@ func untar(log *logger.Logger, version string, archivePath, dataDir string) (Unp
 
 	return UnpackResult{
 		Hash:          hash,
-		versionedHome: versionedHome,
+		VersionedHome: versionedHome,
 	}, nil
 }
 

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -43,7 +43,7 @@ func (u *Upgrader) unpack(version, archivePath, dataDir string) (UnpackResult, e
 	if runtime.GOOS == windows {
 		unpackRes, err = unzip(u.log, archivePath, dataDir)
 	} else {
-		unpackRes, err = untar(u.log, version, archivePath, dataDir)
+		unpackRes, err = untar(u.log, archivePath, dataDir)
 	}
 
 	if err != nil {
@@ -194,7 +194,7 @@ func unzip(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error
 	}, nil
 }
 
-func untar(log *logger.Logger, version string, archivePath, dataDir string) (UnpackResult, error) {
+func untar(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error) {
 
 	var versionedHome string
 	var rootDir string
@@ -240,7 +240,7 @@ func untar(log *logger.Logger, version string, archivePath, dataDir string) (Unp
 
 	r, err := os.Open(archivePath)
 	if err != nil {
-		return UnpackResult{}, errors.New(fmt.Sprintf("artifact for 'elastic-agent' version '%s' could not be found at '%s'", version, archivePath), errors.TypeFilesystem, errors.M(errors.MetaKeyPath, archivePath))
+		return UnpackResult{}, errors.New(fmt.Sprintf("artifact for 'elastic-agent' could not be found at '%s'", archivePath), errors.TypeFilesystem, errors.M(errors.MetaKeyPath, archivePath))
 	}
 	defer r.Close()
 

--- a/internal/pkg/agent/application/upgrade/step_unpack_test.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	v1 "github.com/elastic/elastic-agent/pkg/api/v1"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
@@ -61,7 +62,7 @@ inputs:
 
 var archiveFilesWithManifestNoSymlink = []files{
 	{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
-	{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64/manifest.yaml", content: ea_123_manifest, mode: fs.ModePerm & 0o640},
+	{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64/" + v1.ManifestFileName, content: ea_123_manifest, mode: fs.ModePerm & 0o640},
 	{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64/" + agentCommitFile, content: "abcdefghijklmnopqrstuvwxyz", mode: fs.ModePerm & 0o640},
 	{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64/data", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
 	{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64/data/elastic-agent-abcdef", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
@@ -302,7 +303,7 @@ func checkExtractedFilesWithManifest(t *testing.T, testDataDir string) {
 			assert.Equal(t, agentBinaryPlaceholderContent, string(fileBytes), "agent binary placeholder content does not match")
 		}
 	}
-	mappedPackageManifest := filepath.Join(versionedHome, "manifest.yaml")
+	mappedPackageManifest := filepath.Join(versionedHome, v1.ManifestFileName)
 	if assert.FileExistsf(t, mappedPackageManifest, "package manifest %q is not found in mapped versioned home directory %q", mappedPackageManifest, versionedHome) {
 		fileBytes, err := os.ReadFile(mappedPackageManifest)
 		if assert.NoErrorf(t, err, "error reading package manifest %q", mappedPackageManifest) {

--- a/internal/pkg/agent/application/upgrade/step_unpack_test.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack_test.go
@@ -6,6 +6,7 @@ package upgrade
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"compress/gzip"
 	"fmt"
 	"io"
@@ -13,7 +14,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -24,6 +24,19 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
+const agentBinaryPlaceholderContent = "Placeholder for the elastic-agent binary"
+
+const ea_123_manifest = `
+version: co.elastic.agent/v1
+kind: PackageManifest
+package:
+  version: 1.2.3
+  snapshot: true
+  versioned-home: data/elastic-agent-abcdef
+  path-mappings:
+    - data/elastic-agent-abcdef: data/elastic-agent-1.2.3-SNAPSHOT-abcdef
+      manifest.yaml: data/elastic-agent-1.2.3-SNAPSHOT-abcdef/manifest.yaml
+`
 const foo_component_spec = `
 version: 2
 inputs:
@@ -87,21 +100,22 @@ func (f files) Sys() any {
 type createArchiveFunc func(t *testing.T, archiveFiles []files) (string, error)
 type checkExtractedPath func(t *testing.T, testDataDir string)
 
-func TestUpgrader_unpack(t *testing.T) {
+func TestUpgrader_unpackTarGz(t *testing.T) {
 	type args struct {
 		version          string
 		archiveGenerator createArchiveFunc
 		archiveFiles     []files
 	}
+
 	tests := []struct {
 		name       string
 		args       args
-		want       string
+		want       UnpackResult
 		wantErr    assert.ErrorAssertionFunc
 		checkFiles checkExtractedPath
 	}{
 		{
-			name: "targz with file before containing folder",
+			name: "file before containing folder",
 			args: args{
 				version: "1.2.3",
 				archiveFiles: []files{
@@ -110,7 +124,7 @@ func TestUpgrader_unpack(t *testing.T) {
 					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/package.version", content: "1.2.3", mode: fs.ModePerm & 0o640},
 					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
 					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef", mode: fs.ModeDir | (fs.ModePerm & 0o700)},
-					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/" + agentName, content: "Placeholder for the elastic-agent binary", mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/" + agentName, content: agentBinaryPlaceholderContent, mode: fs.ModePerm & 0o750},
 					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
 					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components/comp1", content: "Placeholder for component", mode: fs.ModePerm & 0o750},
 					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components/comp1.spec.yml", content: foo_component_spec, mode: fs.ModePerm & 0o640},
@@ -120,10 +134,12 @@ func TestUpgrader_unpack(t *testing.T) {
 					return createTarArchive(t, "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64.tar.gz", i)
 				},
 			},
-			want:    "abcdef",
+			want: UnpackResult{
+				Hash:          "abcdef",
+				VersionedHome: filepath.Join("data", "elastic-agent-abcdef"),
+			},
 			wantErr: assert.NoError,
 			checkFiles: func(t *testing.T, testDataDir string) {
-
 				versionedHome := filepath.Join(testDataDir, "elastic-agent-abcdef")
 				require.DirExists(t, versionedHome, "directory for package.version does not exists")
 				stat, err := os.Stat(versionedHome)
@@ -133,30 +149,189 @@ func TestUpgrader_unpack(t *testing.T) {
 				assert.Equalf(t, expectedPermissions, actualPermissions, "Wrong permissions set on versioned home %q: expected %O, got %O", versionedHome, expectedPermissions, actualPermissions)
 			},
 		},
+		{
+			name: "package with manifest file",
+			args: args{
+				version: "1.2.3",
+				archiveFiles: []files{
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/manifest.yaml", content: ea_123_manifest, mode: fs.ModePerm & 0o640},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/" + agentCommitFile, content: "abcdefghijklmnopqrstuvwxyz", mode: fs.ModePerm & 0o640},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/" + agentName, content: agentBinaryPlaceholderContent, mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/package.version", content: "1.2.3", mode: fs.ModePerm & 0o640},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components/comp1", content: "Placeholder for component", mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components/comp1.spec.yml", content: foo_component_spec, mode: fs.ModePerm & 0o640},
+					{fType: SYMLINK, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/" + agentName, content: "data/elastic-agent-abcdef/" + agentName, mode: fs.ModeSymlink | (fs.ModePerm & 0o750)},
+				},
+				archiveGenerator: func(t *testing.T, i []files) (string, error) {
+					return createTarArchive(t, "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64.tar.gz", i)
+				},
+			},
+			want: UnpackResult{
+				Hash:          "abcdef",
+				VersionedHome: "data/elastic-agent-1.2.3-SNAPSHOT-abcdef",
+			},
+			wantErr: assert.NoError,
+			checkFiles: func(t *testing.T, testDataDir string) {
+				versionedHome := filepath.Join(testDataDir, "elastic-agent-1.2.3-SNAPSHOT-abcdef")
+				require.DirExists(t, versionedHome, "mapped versioned home directory does not exists")
+				mappedAgentExecutable := filepath.Join(versionedHome, agentName)
+				if assert.FileExistsf(t, mappedAgentExecutable, "agent executable %q is not found in mapped versioned home directory %q", mappedAgentExecutable, versionedHome) {
+					fileBytes, err := os.ReadFile(mappedAgentExecutable)
+					if assert.NoErrorf(t, err, "error reading elastic-agent executable %q", mappedAgentExecutable) {
+						assert.Equal(t, agentBinaryPlaceholderContent, string(fileBytes), "agent binary placeholder content does not match")
+					}
+				}
+				mappedPackageManifest := filepath.Join(versionedHome, "manifest.yaml")
+				if assert.FileExistsf(t, mappedPackageManifest, "package manifest %q is not found in mapped versioned home directory %q", mappedPackageManifest, versionedHome) {
+					fileBytes, err := os.ReadFile(mappedPackageManifest)
+					if assert.NoErrorf(t, err, "error reading package manifest %q", mappedPackageManifest) {
+						assert.Equal(t, ea_123_manifest, string(fileBytes), "package manifest content does not match")
+					}
+				}
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if runtime.GOOS == "windows" {
-				t.Skip("tar.gz tests only run on Linux/MacOS")
+			testTop := t.TempDir()
+			testDataDir := filepath.Join(testTop, "data")
+			err := os.MkdirAll(testDataDir, 0o777)
+			assert.NoErrorf(t, err, "error creating initial structure %q", testDataDir)
+			log, _ := logger.NewTesting(tt.name)
+
+			archiveFile, err := tt.args.archiveGenerator(t, tt.args.archiveFiles)
+			require.NoError(t, err, "creation of test archive file failed")
+
+			got, err := untar(log, tt.args.version, archiveFile, testDataDir)
+			if !tt.wantErr(t, err, fmt.Sprintf("untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)) {
+				return
 			}
+			assert.Equalf(t, tt.want, got, "untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)
+			if tt.checkFiles != nil {
+				tt.checkFiles(t, testDataDir)
+			}
+		})
+	}
+}
+
+func TestUpgrader_unpackZip(t *testing.T) {
+	type args struct {
+		archiveGenerator createArchiveFunc
+		archiveFiles     []files
+	}
+
+	tests := []struct {
+		name       string
+		args       args
+		want       UnpackResult
+		wantErr    assert.ErrorAssertionFunc
+		checkFiles checkExtractedPath
+	}{
+		{
+			name: "file before containing folder",
+			args: args{
+				archiveFiles: []files{
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/" + agentCommitFile, content: "abcdefghijklmnopqrstuvwxyz", mode: fs.ModePerm & 0o640},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/package.version", content: "1.2.3", mode: fs.ModePerm & 0o640},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef", mode: fs.ModeDir | (fs.ModePerm & 0o700)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/" + agentName, content: agentBinaryPlaceholderContent, mode: fs.ModePerm & 0o750},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components/comp1", content: "Placeholder for component", mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components/comp1.spec.yml", content: foo_component_spec, mode: fs.ModePerm & 0o640},
+				},
+				archiveGenerator: func(t *testing.T, i []files) (string, error) {
+					return createZipArchive(t, "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64.zip", i)
+				},
+			},
+			want: UnpackResult{
+				Hash:          "abcdef",
+				VersionedHome: filepath.Join("data", "elastic-agent-abcdef"),
+			},
+			wantErr: assert.NoError,
+			checkFiles: func(t *testing.T, testDataDir string) {
+				versionedHome := filepath.Join(testDataDir, "elastic-agent-abcdef")
+				require.DirExists(t, versionedHome, "directory for package.version does not exists")
+				stat, err := os.Stat(versionedHome)
+				require.NoErrorf(t, err, "error calling Stat() for versionedHome %q", versionedHome)
+				expectedPermissions := fs.ModePerm & 0o700
+				actualPermissions := fs.ModePerm & stat.Mode()
+				assert.Equalf(t, expectedPermissions, actualPermissions, "Wrong permissions set on versioned home %q: expected %O, got %O", versionedHome, expectedPermissions, actualPermissions)
+				agentExecutable := filepath.Join(versionedHome, agentName)
+				if assert.FileExistsf(t, agentExecutable, "agent executable %q is not found in versioned home directory %q", agentExecutable, versionedHome) {
+					fileBytes, err := os.ReadFile(agentExecutable)
+					if assert.NoErrorf(t, err, "error reading elastic-agent executable %q", agentExecutable) {
+						assert.Equal(t, agentBinaryPlaceholderContent, string(fileBytes), "agent binary placeholder content does not match")
+					}
+				}
+			},
+		},
+		{
+			name: "package with manifest file",
+			args: args{
+				archiveFiles: []files{
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/manifest.yaml", content: ea_123_manifest, mode: fs.ModePerm & 0o640},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/" + agentCommitFile, content: "abcdefghijklmnopqrstuvwxyz", mode: fs.ModePerm & 0o640},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/" + agentName, content: agentBinaryPlaceholderContent, mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/package.version", content: "1.2.3", mode: fs.ModePerm & 0o640},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components/comp1", content: "Placeholder for component", mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components/comp1.spec.yml", content: foo_component_spec, mode: fs.ModePerm & 0o640},
+				},
+				archiveGenerator: func(t *testing.T, i []files) (string, error) {
+					return createZipArchive(t, "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64.zip", i)
+				},
+			},
+			want: UnpackResult{
+				Hash:          "abcdef",
+				VersionedHome: filepath.Join("data", "elastic-agent-1.2.3-SNAPSHOT-abcdef"),
+			},
+			wantErr: assert.NoError,
+			checkFiles: func(t *testing.T, testDataDir string) {
+				versionedHome := filepath.Join(testDataDir, "elastic-agent-1.2.3-SNAPSHOT-abcdef")
+				require.DirExists(t, versionedHome, "mapped versioned home directory does not exists")
+				mappedAgentExecutable := filepath.Join(versionedHome, agentName)
+				if assert.FileExistsf(t, mappedAgentExecutable, "agent executable %q is not found in mapped versioned home directory %q", mappedAgentExecutable, versionedHome) {
+					fileBytes, err := os.ReadFile(mappedAgentExecutable)
+					if assert.NoErrorf(t, err, "error reading elastic-agent executable %q", mappedAgentExecutable) {
+						assert.Equal(t, agentBinaryPlaceholderContent, string(fileBytes), "agent binary placeholder content does not match")
+					}
+				}
+				mappedPackageManifest := filepath.Join(versionedHome, "manifest.yaml")
+				if assert.FileExistsf(t, mappedPackageManifest, "package manifest %q is not found in mapped versioned home directory %q", mappedPackageManifest, versionedHome) {
+					fileBytes, err := os.ReadFile(mappedPackageManifest)
+					if assert.NoErrorf(t, err, "error reading package manifest %q", mappedPackageManifest) {
+						assert.Equal(t, ea_123_manifest, string(fileBytes), "package manifest content does not match")
+					}
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 
 			testTop := t.TempDir()
 			testDataDir := filepath.Join(testTop, "data")
 			err := os.MkdirAll(testDataDir, 0o777)
 			assert.NoErrorf(t, err, "error creating initial structure %q", testDataDir)
 			log, _ := logger.NewTesting(tt.name)
-			u := &Upgrader{
-				log: log,
-			}
 
 			archiveFile, err := tt.args.archiveGenerator(t, tt.args.archiveFiles)
 			require.NoError(t, err, "creation of test archive file failed")
 
-			got, err := u.unpack(tt.args.version, archiveFile, testDataDir)
-			if !tt.wantErr(t, err, fmt.Sprintf("unpack(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)) {
+			got, err := unzip(log, archiveFile, testDataDir)
+			if !tt.wantErr(t, err, fmt.Sprintf("unzip(%v, %v)", archiveFile, testDataDir)) {
 				return
 			}
-			assert.Equalf(t, tt.want, got, "unpack(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)
+			assert.Equalf(t, tt.want, got, "unzip(%v, %v)", archiveFile, testDataDir)
 			if tt.checkFiles != nil {
 				tt.checkFiles(t, testDataDir)
 			}
@@ -165,20 +340,23 @@ func TestUpgrader_unpack(t *testing.T) {
 }
 
 func createTarArchive(t *testing.T, archiveName string, archiveFiles []files) (string, error) {
-
+	t.Helper()
 	outDir := t.TempDir()
 
 	outFilePath := filepath.Join(outDir, archiveName)
 	file, err := os.OpenFile(outFilePath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
 	require.NoErrorf(t, err, "error creating output archive %q", outFilePath)
-	defer file.Close()
+	defer func(file *os.File) {
+		err := file.Close()
+		assert.NoError(t, err, "error closing tar.gz archive file")
+	}(file)
 	zipWriter := gzip.NewWriter(file)
 	writer := tar.NewWriter(zipWriter)
 	defer func(writer *tar.Writer) {
 		err := writer.Close()
-		require.NoError(t, err, "error closing tar writer")
+		assert.NoError(t, err, "error closing tar writer")
 		err = zipWriter.Close()
-		require.NoError(t, err, "error closing gzip writer")
+		assert.NoError(t, err, "error closing gzip writer")
 	}(writer)
 
 	for _, af := range archiveFiles {
@@ -208,5 +386,64 @@ func addEntryToTarArchive(af files, writer *tar.Writer) error {
 	if _, err = io.Copy(writer, strings.NewReader(af.content)); err != nil {
 		return fmt.Errorf("copying file %q content: %w", af.path, err)
 	}
+	return nil
+}
+
+func createZipArchive(t *testing.T, archiveName string, archiveFiles []files) (string, error) {
+	t.Helper()
+	outDir := t.TempDir()
+
+	outFilePath := filepath.Join(outDir, archiveName)
+	file, err := os.OpenFile(outFilePath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
+	require.NoErrorf(t, err, "error creating output archive %q", outFilePath)
+	defer func(file *os.File) {
+		err := file.Close()
+		assert.NoError(t, err, "error closing zip archive file")
+	}(file)
+
+	w := zip.NewWriter(file)
+	defer func(writer *zip.Writer) {
+		err := writer.Close()
+		assert.NoError(t, err, "error closing tar writer")
+	}(w)
+
+	for _, af := range archiveFiles {
+		if af.fType == SYMLINK {
+			return "", fmt.Errorf("entry %q is a symlink. Not supported in .zip files", af.path)
+		}
+
+		err = addEntryToZipArchive(af, w)
+		require.NoErrorf(t, err, "error adding %q to tar archive", af.path)
+	}
+	return outFilePath, nil
+}
+
+func addEntryToZipArchive(af files, writer *zip.Writer) error {
+	header, err := zip.FileInfoHeader(&af)
+	if err != nil {
+		return fmt.Errorf("creating header for %q: %w", af.path, err)
+	}
+
+	header.SetMode(af.Mode() & os.ModePerm)
+	header.Name = af.path
+	if af.IsDir() {
+		header.Name += string(filepath.Separator)
+	} else {
+		header.Method = zip.Deflate
+	}
+
+	w, err := writer.CreateHeader(header)
+	if err != nil {
+		return err
+	}
+
+	if af.IsDir() {
+		return nil
+	}
+
+	if _, err = io.Copy(w, strings.NewReader(af.content)); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/internal/pkg/agent/application/upgrade/step_unpack_test.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack_test.go
@@ -189,7 +189,7 @@ func TestUpgrader_unpackTarGz(t *testing.T) {
 			archiveFile, err := tt.args.archiveGenerator(t, tt.args.archiveFiles)
 			require.NoError(t, err, "creation of test archive file failed")
 
-			got, err := untar(log, tt.args.version, archiveFile, testDataDir)
+			got, err := untar(log, archiveFile, testDataDir)
 			if !tt.wantErr(t, err, fmt.Sprintf("untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)) {
 				return
 			}

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -247,7 +247,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 // Ack acks last upgrade action
 func (u *Upgrader) Ack(ctx context.Context, acker acker.Acker) error {
 	// get upgrade action
-	marker, err := LoadMarker()
+	marker, err := LoadMarker(paths.Data())
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -74,7 +74,7 @@ func NewUpgrader(log *logger.Logger, settings *artifact.Config, agentInfo *info.
 		settings:      settings,
 		agentInfo:     agentInfo,
 		upgradeable:   IsUpgradeable(),
-		markerWatcher: newMarkerFileWatcher(markerFilePath(), log),
+		markerWatcher: newMarkerFileWatcher(markerFilePath(paths.Data()), log),
 	}, nil
 }
 

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -265,15 +265,15 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	// paths.BinaryPath properly derives the binary directory depending on the platform. The path to the binary for macOS is inside of the app bundle.
 	newPath := paths.BinaryPath(filepath.Join(paths.Top(), hashedDir), agentName)
 
-	if err := changeSymlinkInternal(u.log, paths.Top(), symlinkPath, newPath); err != nil {
-		u.log.Errorw("Rolling back: changing symlink failed", "error.message", err)
-		rollbackInstall(ctx, u.log, paths.Top(), hashedDir)
-		return nil, err
-	}
-
 	currentVersionedHome, err := filepath.Rel(paths.Top(), paths.Home())
 	if err != nil {
 		return nil, fmt.Errorf("calculating home path relative to top, home: %q top: %q : %w", paths.Home(), paths.Top(), err)
+	}
+
+	if err := ChangeSymlink(u.log, paths.Top(), symlinkPath, newPath); err != nil {
+		u.log.Errorw("Rolling back: changing symlink failed", "error.message", err)
+		rollbackInstall(ctx, u.log, paths.Top(), hashedDir, currentVersionedHome)
+		return nil, err
 	}
 
 	current := agentInstall{
@@ -294,7 +294,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 		previous,     // old agent version data
 		action, det); err != nil {
 		u.log.Errorw("Rolling back: marking upgrade failed", "error.message", err)
-		rollbackInstall(ctx, u.log, paths.Top(), hashedDir)
+		rollbackInstall(ctx, u.log, paths.Top(), hashedDir, currentVersionedHome)
 		return nil, err
 	}
 
@@ -309,7 +309,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	}
 	if err := InvokeWatcher(u.log, watcherExecutable); err != nil {
 		u.log.Errorw("Rolling back: starting watcher failed", "error.message", err)
-		rollbackInstall(ctx, u.log, paths.Top(), hashedDir)
+		rollbackInstall(ctx, u.log, paths.Top(), hashedDir, currentVersionedHome)
 		return nil, err
 	}
 
@@ -370,14 +370,18 @@ func (u *Upgrader) sourceURI(retrievedURI string) string {
 	return u.settings.SourceURI
 }
 
-func rollbackInstall(ctx context.Context, log *logger.Logger, topDirPath, versionedHome string) {
-	err := os.RemoveAll(filepath.Join(topDirPath, versionedHome))
+func rollbackInstall(ctx context.Context, log *logger.Logger, topDirPath, versionedHome, oldVersionedHome string) {
+	newAgentInstallPath := filepath.Join(topDirPath, versionedHome)
+	err := os.RemoveAll(newAgentInstallPath)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		// TODO should this be a warning or an error ?
-		log.Warnw("error rolling back install", "error.message", err)
+		log.Warnw(fmt.Sprintf("rolling back install: removing new agent install at %q failed", newAgentInstallPath), "error.message", err)
 	}
-	// FIXME update
-	_ = ChangeSymlink(ctx, log, topDirPath, release.ShortCommit())
+
+	oldAgentPath := paths.BinaryPath(filepath.Join(topDirPath, oldVersionedHome), agentName)
+	err = ChangeSymlink(log, topDirPath, filepath.Join(topDirPath, agentName), oldAgentPath)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		log.Warnw(fmt.Sprintf("rolling back install: restoring symlink to %q failed", oldAgentPath), "error.message", err)
+	}
 }
 
 func copyActionStore(log *logger.Logger, newHome string) error {

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -302,10 +302,10 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	var watcherExecutable string
 	if parsedVersion.Less(*minParsedVersionForNewUpdateMarker) {
 		// use the current agent executable for watch
-		watcherExecutable = filepath.Join(paths.VersionedHome(paths.Top()), agentName)
+		watcherExecutable = paths.BinaryPath(paths.VersionedHome(paths.Top()), agentName)
 	} else {
 		// use the new agent executable as it should be able to parse the new update marker
-		watcherExecutable = filepath.Join(paths.Top(), unpackRes.VersionedHome, agentName)
+		watcherExecutable = paths.BinaryPath(filepath.Join(paths.Top(), unpackRes.VersionedHome), agentName)
 	}
 	if err := InvokeWatcher(u.log, watcherExecutable); err != nil {
 		u.log.Errorw("Rolling back: starting watcher failed", "error.message", err)

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -445,8 +445,11 @@ func shutdownCallback(l *logger.Logger, homePath, prevVersion, newVersion, newHo
 
 		oldHome := homePath
 		for _, processDir := range processDirs {
-			newDir := strings.ReplaceAll(processDir, prevVersion, newVersion)
-			newDir = strings.ReplaceAll(newDir, oldHome, newHome)
+			relPath, _ := filepath.Rel(oldHome, processDir)
+
+			newRelPath := strings.ReplaceAll(relPath, prevVersion, newVersion)
+			newRelPath = strings.ReplaceAll(newRelPath, oldHome, newHome)
+			newDir := filepath.Join(newHome, newRelPath)
 			l.Debugf("copying %q -> %q", processDir, newDir)
 			if err := copyDir(l, processDir, newDir, true); err != nil {
 				return err

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -179,17 +179,18 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	if newHash == "" {
 		return nil, errors.New("unknown hash")
 	}
-	if unpackRes.versionedHome == "" {
+
+	if unpackRes.VersionedHome == "" {
 		// FIXME this should be treated as an error
 		return nil, fmt.Errorf("versionedhome is empty: %v", unpackRes)
 	}
 
-	if strings.HasPrefix(release.Commit(), newHash) {
-		u.log.Warn("Upgrade action skipped: upgrade did not occur because its the same version")
-		return nil, nil
-	}
+	//if strings.HasPrefix(release.Commit(), newHash) {
+	//	u.log.Warn("Upgrade action skipped: upgrade did not occur because its the same version")
+	//	return nil, nil
+	//}
 
-	newHome := filepath.Join(paths.Top(), unpackRes.versionedHome)
+	newHome := filepath.Join(paths.Top(), unpackRes.VersionedHome)
 
 	if err := copyActionStore(u.log, newHome); err != nil {
 		return nil, errors.New(err, "failed to copy action store")
@@ -205,7 +206,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	det.SetState(details.StateReplacing)
 
 	// create symlink to the <new versioned-home>/elastic-agent
-	hashedDir := unpackRes.versionedHome
+	hashedDir := unpackRes.VersionedHome
 
 	symlinkPath := filepath.Join(paths.Top(), agentName)
 

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -437,6 +437,7 @@ func shutdownCallback(l *logger.Logger, homePath, prevVersion, newVersion, newHo
 
 	return func() error {
 		runtimeDir := filepath.Join(homePath, "run")
+		l.Debugf("starting copy of run directories from %q to %q", homePath, newHome)
 		processDirs, err := readProcessDirs(runtimeDir)
 		if err != nil {
 			return err
@@ -446,6 +447,7 @@ func shutdownCallback(l *logger.Logger, homePath, prevVersion, newVersion, newHo
 		for _, processDir := range processDirs {
 			newDir := strings.ReplaceAll(processDir, prevVersion, newVersion)
 			newDir = strings.ReplaceAll(newDir, oldHome, newHome)
+			l.Debugf("copying %q -> %q", processDir, newDir)
 			if err := copyDir(l, processDir, newDir, true); err != nil {
 				return err
 			}

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -242,7 +242,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 		return nil, err
 	}
 
-	cb := shutdownCallback(u.log, paths.Home(), release.Version(), version, release.TrimCommit(newHash))
+	cb := shutdownCallback(u.log, paths.Home(), release.Version(), version, filepath.Join(paths.Top(), unpackRes.VersionedHome))
 
 	// Clean everything from the downloads dir
 	u.log.Infow("Removing downloads directory", "file.path", paths.Downloads())
@@ -358,7 +358,7 @@ func copyRunDirectory(log *logger.Logger, oldRunPath, newRunPath string) error {
 // shutdownCallback returns a callback function to be executing during shutdown once all processes are closed.
 // this goes through runtime directory of agent and copies all the state files created by processes to new versioned
 // home directory with updated process name to match new version.
-func shutdownCallback(l *logger.Logger, homePath, prevVersion, newVersion, newHash string) reexec.ShutdownCallbackFn {
+func shutdownCallback(l *logger.Logger, homePath, prevVersion, newVersion, newHome string) reexec.ShutdownCallbackFn {
 	if release.Snapshot() {
 		// SNAPSHOT is part of newVersion
 		prevVersion += "-SNAPSHOT"
@@ -372,7 +372,6 @@ func shutdownCallback(l *logger.Logger, homePath, prevVersion, newVersion, newHa
 		}
 
 		oldHome := homePath
-		newHome := filepath.Join(filepath.Dir(homePath), fmt.Sprintf("%s-%s", agentName, newHash))
 		for _, processDir := range processDirs {
 			newDir := strings.ReplaceAll(processDir, prevVersion, newVersion)
 			newDir = strings.ReplaceAll(newDir, oldHome, newHome)

--- a/internal/pkg/agent/application/upgrade/upgrade_test.go
+++ b/internal/pkg/agent/application/upgrade/upgrade_test.go
@@ -131,7 +131,7 @@ func TestShutdownCallback(t *testing.T) {
 	require.NoError(t, os.MkdirAll(sourceDir, 0755))
 	require.NoError(t, os.MkdirAll(targetDir, 0755))
 
-	cb := shutdownCallback(l, homePath, sourceVersion, targetVersion, newCommit)
+	cb := shutdownCallback(l, homePath, sourceVersion, targetVersion, newHome)
 
 	oldFilename := filepath.Join(sourceDir, filename)
 	err = os.WriteFile(oldFilename, content, 0640)

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -655,7 +655,7 @@ func isProcessStatsEnabled(cfg *monitoringCfg.MonitoringConfig) bool {
 // ongoing upgrade operation, i.e. being re-exec'd and performs
 // any upgrade-specific work, if needed.
 func handleUpgrade() error {
-	upgradeMarker, err := upgrade.LoadMarker()
+	upgradeMarker, err := upgrade.LoadMarker(paths.Data())
 	if err != nil {
 		return fmt.Errorf("unable to load upgrade marker to check if Agent is being upgraded: %w", err)
 	}

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -257,7 +257,7 @@ func runElasticAgent(ctx context.Context, cancel context.CancelFunc, override cf
 	}
 
 	// initiate agent watcher
-	if err := upgrade.InvokeWatcher(l); err != nil {
+	if err := upgrade.InvokeWatcher(l, paths.TopBinaryPath()); err != nil {
 		// we should not fail because watcher is not working
 		l.Error(errors.New(err, "failed to invoke rollback watcher"))
 	}

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -77,6 +77,8 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		return nil
 	}
 
+	log.Infof("Loaded update marker %+v", marker)
+
 	locker := filelock.NewAppLocker(paths.Top(), watcherLockFile)
 	if err := locker.TryLock(); err != nil {
 		if errors.Is(err, filelock.ErrAppAlreadyRunning) {
@@ -98,7 +100,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		// if we're not within grace and marker is still there it might mean
 		// that cleanup was not performed ok, cleanup everything except current version
 		// hash is the same as hash of agent which initiated watcher.
-		if err := upgrade.Cleanup(log, paths.Top(), marker.VersionedHome, release.ShortCommit(), true, false); err != nil {
+		if err := upgrade.Cleanup(log, paths.Top(), paths.VersionedHome(paths.Top()), release.ShortCommit(), true, false); err != nil {
 			log.Error("clean up of prior watcher run failed", err)
 		}
 		// exit nicely

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -97,7 +97,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		// if we're not within grace and marker is still there it might mean
 		// that cleanup was not performed ok, cleanup everything except current version
 		// hash is the same as hash of agent which initiated watcher.
-		if err := upgrade.Cleanup(log, marker.VersionedHome, release.ShortCommit(), true, false); err != nil {
+		if err := upgrade.Cleanup(log, paths.Top(), marker.VersionedHome, release.ShortCommit(), true, false); err != nil {
 			log.Error("clean up of prior watcher run failed", err)
 		}
 		// exit nicely
@@ -132,7 +132,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 	// Why is this being skipped on Windows? The comment above is not clear.
 	// issue: https://github.com/elastic/elastic-agent/issues/3027
 	removeMarker := !isWindows()
-	err = upgrade.Cleanup(log, marker.VersionedHome, marker.Hash, removeMarker, false)
+	err = upgrade.Cleanup(log, paths.Top(), marker.VersionedHome, marker.Hash, removeMarker, false)
 	if err != nil {
 		log.Error("cleanup after successful watch failed", err)
 	}

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -65,7 +65,7 @@ func newWatchCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command 
 
 func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 	log.Infow("Upgrade Watcher started", "process.pid", os.Getpid(), "agent.version", version.GetAgentPackageVersion())
-	marker, err := upgrade.LoadMarker()
+	marker, err := upgrade.LoadMarker(paths.Data())
 	if err != nil {
 		log.Error("failed to load marker", err)
 		return err

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -97,7 +97,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		// if we're not within grace and marker is still there it might mean
 		// that cleanup was not performed ok, cleanup everything except current version
 		// hash is the same as hash of agent which initiated watcher.
-		if err := upgrade.Cleanup(log, release.ShortCommit(), true, false); err != nil {
+		if err := upgrade.Cleanup(log, marker.VersionedHome, release.ShortCommit(), true, false); err != nil {
 			log.Error("clean up of prior watcher run failed", err)
 		}
 		// exit nicely
@@ -114,7 +114,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		log.Error("Error detected, proceeding to rollback: %v", err)
 
 		upgradeDetails.SetState(details.StateRollback)
-		err = upgrade.Rollback(ctx, log, marker.PrevHash, marker.Hash)
+		err = upgrade.Rollback(ctx, log, marker.PrevVersionedHome, marker.PrevHash, marker.Hash)
 		if err != nil {
 			log.Error("rollback failed", err)
 			upgradeDetails.Fail(err)
@@ -132,7 +132,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 	// Why is this being skipped on Windows? The comment above is not clear.
 	// issue: https://github.com/elastic/elastic-agent/issues/3027
 	removeMarker := !isWindows()
-	err = upgrade.Cleanup(log, marker.Hash, removeMarker, false)
+	err = upgrade.Cleanup(log, marker.VersionedHome, marker.Hash, removeMarker, false)
 	if err != nil {
 		log.Error("cleanup after successful watch failed", err)
 	}

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/configure"
+	"github.com/elastic/elastic-agent/pkg/control/v2/client"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/filelock"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
@@ -114,7 +115,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		log.Error("Error detected, proceeding to rollback: %v", err)
 
 		upgradeDetails.SetState(details.StateRollback)
-		err = upgrade.Rollback(ctx, log, marker.PrevVersionedHome, marker.PrevHash, marker.Hash)
+		err = upgrade.Rollback(ctx, log, client.New(), paths.Top(), marker.PrevVersionedHome, marker.PrevHash)
 		if err != nil {
 			log.Error("rollback failed", err)
 			upgradeDetails.Fail(err)

--- a/internal/pkg/agent/install/install.go
+++ b/internal/pkg/agent/install/install.go
@@ -110,20 +110,21 @@ func Install(cfgFile, topPath string, unprivileged bool, log *logp.Logger, pt *p
 			errors.M("directory", filepath.Dir(topPath)))
 	}
 
-	manifestFile, err := os.Open(filepath.Join(dir, "manifest.yaml"))
+	manifestFilePath := filepath.Join(dir, v1.ManifestFileName)
+	manifestFile, err := os.Open(manifestFilePath)
 	if err != nil {
 		return utils.FileOwner{}, errors.New(
 			err,
-			fmt.Sprintf("failed to open package manifest file (%s)", "manifest.yaml"),
-			errors.M("file", "manifest.yaml"))
+			fmt.Sprintf("failed to open package manifest file (%s)", manifestFilePath),
+			errors.M("file", v1.ManifestFileName))
 	}
 	defer manifestFile.Close()
 	manifest, err := v1.ParseManifest(manifestFile)
 	if err != nil {
 		return utils.FileOwner{}, errors.New(
 			err,
-			fmt.Sprintf("failed to parse package manifest file contents (%s)", "manifest.yaml"),
-			errors.M("file", "manifest.yaml"))
+			fmt.Sprintf("failed to parse package manifest file contents (%s)", manifestFilePath),
+			errors.M("file", v1.ManifestFileName))
 	}
 	pathMappings := manifest.Package.PathMappings
 

--- a/internal/pkg/agent/install/install_test.go
+++ b/internal/pkg/agent/install/install_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
+	v1 "github.com/elastic/elastic-agent/pkg/api/v1"
 )
 
 func TestHasAllSSDs(t *testing.T) {
@@ -110,21 +111,21 @@ func TestCopyFiles(t *testing.T) {
 		{
 			name: "simple install package mockup",
 			setupFiles: []files{
-				{fType: REGULAR, path: "manifest.yaml", content: []byte(sampleManifestContent)},
+				{fType: REGULAR, path: v1.ManifestFileName, content: []byte(sampleManifestContent)},
 				{fType: DIRECTORY, path: filepath.Join("data", "elastic-agent-fb7370"), content: nil},
 				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-fb7370", "elastic-agent"), content: []byte("this is an elastic-agent wannabe")},
 				{fType: SYMLINK, path: "elastic-agent", content: []byte(filepath.Join("data", "elastic-agent-fb7370", "elastic-agent"))},
 			},
 			expectedFiles: []files{
 				{fType: DIRECTORY, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370"), content: nil},
-				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "manifest.yaml"), content: []byte(sampleManifestContent)},
+				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", v1.ManifestFileName), content: []byte(sampleManifestContent)},
 				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "elastic-agent"), content: []byte("this is an elastic-agent wannabe")},
 				{fType: SYMLINK, path: "elastic-agent", content: []byte(filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "elastic-agent"))},
 			},
 			mappings: []map[string]string{
 				{
 					"data/elastic-agent-fb7370": "data/elastic-agent-8.13.0-SNAPSHOT-fb7370",
-					"manifest.yaml":             "data/elastic-agent-8.13.0-SNAPSHOT-fb7370/manifest.yaml",
+					v1.ManifestFileName:         "data/elastic-agent-8.13.0-SNAPSHOT-fb7370/" + v1.ManifestFileName,
 				},
 			}},
 	}

--- a/internal/pkg/agent/install/install_test.go
+++ b/internal/pkg/agent/install/install_test.go
@@ -5,11 +5,16 @@
 package install
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/jaypipes/ghw"
 	"github.com/jaypipes/ghw/pkg/block"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/internal/pkg/cli"
 )
 
 func TestHasAllSSDs(t *testing.T) {
@@ -56,4 +61,124 @@ func TestHasAllSSDs(t *testing.T) {
 			require.Equal(t, test.expected, actual)
 		})
 	}
+}
+
+var sampleManifestContent = `
+version: co.elastic.agent/v1
+kind: PackageManifest
+package:
+    version: 8.13.0
+    snapshot: true
+    versioned-home: elastic-agent-fb7370
+    path-mappings:
+        data/elastic-agent-fb7370: data/elastic-agent-8.13.0-SNAPSHOT-fb7370
+        manifest.yaml: data/elastic-agent-8.13.0-SNAPSHOT-fb7370/manifest.yaml
+`
+
+type testLogWriter struct {
+	t *testing.T
+}
+
+func (tlw testLogWriter) Write(b []byte) (n int, err error) {
+	tlw.t.Log(b)
+	return len(b), nil
+}
+
+func TestCopyFiles(t *testing.T) {
+	type fileType uint
+
+	const (
+		REGULAR fileType = iota
+		DIRECTORY
+		SYMLINK
+	)
+
+	type files struct {
+		fType   fileType
+		path    string
+		content []byte
+	}
+
+	type testcase struct {
+		name          string
+		setupFiles    []files
+		expectedFiles []files
+		mappings      map[string]string
+	}
+
+	testcases := []testcase{
+		{
+			name: "simple install package mockup",
+			setupFiles: []files{
+				{fType: REGULAR, path: "manifest.yaml", content: []byte(sampleManifestContent)},
+				{fType: DIRECTORY, path: filepath.Join("data", "elastic-agent-fb7370"), content: nil},
+				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-fb7370", "elastic-agent"), content: []byte("this is an elastic-agent wannabe")},
+				{fType: SYMLINK, path: "elastic-agent", content: []byte(filepath.Join("data", "elastic-agent-fb7370", "elastic-agent"))},
+			},
+			expectedFiles: []files{
+				{fType: DIRECTORY, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370"), content: nil},
+				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "manifest.yaml"), content: []byte(sampleManifestContent)},
+				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "elastic-agent"), content: []byte("this is an elastic-agent wannabe")},
+				{fType: SYMLINK, path: "elastic-agent", content: []byte(filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "elastic-agent"))},
+			},
+			mappings: map[string]string{
+				"data/elastic-agent-fb7370": "data/elastic-agent-8.13.0-SNAPSHOT-fb7370",
+				"manifest.yaml":             "data/elastic-agent-8.13.0-SNAPSHOT-fb7370/manifest.yaml",
+			}},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpSrc := t.TempDir()
+			tmpDst := t.TempDir()
+
+			for _, sf := range tc.setupFiles {
+				switch sf.fType {
+				case REGULAR:
+					err := os.WriteFile(filepath.Join(tmpSrc, sf.path), sf.content, 0o644)
+					require.NoErrorf(t, err, "error writing setup file %s in tempDir %s", sf.path, tmpSrc)
+
+				case DIRECTORY:
+					err := os.MkdirAll(filepath.Join(tmpSrc, sf.path), 0o755)
+					require.NoErrorf(t, err, "error creating setup directory %s in tempDir %s", sf.path, tmpSrc)
+
+				case SYMLINK:
+					err := os.Symlink(string(sf.content), filepath.Join(tmpSrc, sf.path))
+					require.NoErrorf(t, err, "error creating symlink %s in tempDir %s", sf.path, tmpSrc)
+				}
+			}
+			outWriter := &testLogWriter{t: t}
+			ioStreams := &cli.IOStreams{
+				In:  nil,
+				Out: outWriter,
+				Err: outWriter,
+			}
+			err := copyFiles(ioStreams, tc.mappings, tmpSrc, tmpDst)
+			assert.NoError(t, err)
+
+			for _, ef := range tc.expectedFiles {
+				switch ef.fType {
+				case REGULAR:
+					if assert.FileExistsf(t, filepath.Join(tmpDst, ef.path), "file %s does not exist in output directory %s", ef.path, tmpDst) {
+						// check contents
+						actualContent, err := os.ReadFile(filepath.Join(tmpDst, ef.path))
+						if assert.NoErrorf(t, err, "error reading expected file %s content", ef.path) {
+							assert.Equal(t, ef.content, actualContent, "content of expected file %s does not match", ef.path)
+						}
+					}
+
+				case DIRECTORY:
+					assert.DirExistsf(t, filepath.Join(tmpDst, ef.path), "directory %s does not exist in output directory %s", ef.path, tmpDst)
+
+				case SYMLINK:
+					actualTarget, err := os.Readlink(filepath.Join(tmpDst, ef.path))
+					if assert.NoErrorf(t, err, "error readling expected symlink %s in output dir %s", ef.path, tmpDst) {
+						assert.Equal(t, string(ef.content), actualTarget, "unexpected target for symlink %s", ef.path)
+					}
+				}
+
+			}
+		})
+	}
+
 }

--- a/internal/pkg/agent/install/install_test.go
+++ b/internal/pkg/agent/install/install_test.go
@@ -71,8 +71,8 @@ package:
     snapshot: true
     versioned-home: elastic-agent-fb7370
     path-mappings:
-        data/elastic-agent-fb7370: data/elastic-agent-8.13.0-SNAPSHOT-fb7370
-        manifest.yaml: data/elastic-agent-8.13.0-SNAPSHOT-fb7370/manifest.yaml
+        - data/elastic-agent-fb7370: data/elastic-agent-8.13.0-SNAPSHOT-fb7370
+          manifest.yaml: data/elastic-agent-8.13.0-SNAPSHOT-fb7370/manifest.yaml
 `
 
 type testLogWriter struct {
@@ -103,7 +103,7 @@ func TestCopyFiles(t *testing.T) {
 		name          string
 		setupFiles    []files
 		expectedFiles []files
-		mappings      map[string]string
+		mappings      []map[string]string
 	}
 
 	testcases := []testcase{
@@ -121,9 +121,11 @@ func TestCopyFiles(t *testing.T) {
 				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "elastic-agent"), content: []byte("this is an elastic-agent wannabe")},
 				{fType: SYMLINK, path: "elastic-agent", content: []byte(filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "elastic-agent"))},
 			},
-			mappings: map[string]string{
-				"data/elastic-agent-fb7370": "data/elastic-agent-8.13.0-SNAPSHOT-fb7370",
-				"manifest.yaml":             "data/elastic-agent-8.13.0-SNAPSHOT-fb7370/manifest.yaml",
+			mappings: []map[string]string{
+				{
+					"data/elastic-agent-fb7370": "data/elastic-agent-8.13.0-SNAPSHOT-fb7370",
+					"manifest.yaml":             "data/elastic-agent-8.13.0-SNAPSHOT-fb7370/manifest.yaml",
+				},
 			}},
 	}
 

--- a/internal/pkg/agent/install/install_windows.go
+++ b/internal/pkg/agent/install/install_windows.go
@@ -7,12 +7,10 @@
 package install
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
-	"github.com/elastic/elastic-agent/internal/pkg/release"
 	"github.com/elastic/elastic-agent/pkg/utils"
 	"github.com/elastic/elastic-agent/version"
 )
@@ -37,7 +35,7 @@ func postInstall(topPath string) error {
 	}
 
 	// create top-level symlink to nested binary
-	realBinary := filepath.Join(topPath, "data", fmt.Sprintf("elastic-agent-%s", release.ShortCommit()), paths.BinaryName)
+	realBinary := paths.BinaryPath(paths.VersionedHome(topPath), paths.BinaryName)
 	err = os.Symlink(realBinary, binary)
 	if err != nil {
 		return err

--- a/pkg/api/v1/manifest.go
+++ b/pkg/api/v1/manifest.go
@@ -17,6 +17,7 @@ const ManifestFileName = "manifest.yaml"
 type PackageDesc struct {
 	Version       string              `yaml:"version,omitempty" json:"version,omitempty"`
 	Snapshot      bool                `yaml:"snapshot,omitempty" json:"snapshot,omitempty"`
+	Hash          string              `yaml:"hash,omitempty" json:"hash,omitempty"`
 	VersionedHome string              `yaml:"versioned-home,omitempty" json:"versionedHome,omitempty"`
 	PathMappings  []map[string]string `yaml:"path-mappings,omitempty" json:"pathMappings,omitempty"`
 }

--- a/pkg/api/v1/manifest.go
+++ b/pkg/api/v1/manifest.go
@@ -12,6 +12,7 @@ import (
 )
 
 const ManifestKind = "PackageManifest"
+const ManifestFileName = "manifest.yaml"
 
 type PackageDesc struct {
 	Version       string              `yaml:"version,omitempty" json:"version,omitempty"`


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This PR introduces support for the elastic-agent package manifest during install and upgrade operations.
This implements #2579 as it will remap the legacy `elastic-agent-<hash>` directory in `elastic-agent-<version>-<hash>`

The version check during upgrade has been changed from comparing the hashes of the old and new agent version to comparing the triplets `(version, snapshot flag, hash)`: as long as at least one of these elements differs between 2 elastic agent versions, those version can be installed side-by-side without collision in their paths.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
This allows for faster releases of agent by allowing repackaging (creation of new elastic agent package versions based on the same elastic agent commit) by updating only components impacted by bugs/vulnerabilities.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Requires #3910
- Closes #2579 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
