### PR TITLE
switch to consistent HasRoot method on windows and fix memory leak

### DIFF
--- a/pkg/control/v2/server/listener_windows.go
+++ b/pkg/control/v2/server/listener_windows.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net"
 	"os/user"
-	"strings"
 
 	"github.com/elastic/elastic-agent-libs/api/npipe"
 
@@ -37,14 +36,10 @@ func securityDescriptor(log *logger.Logger) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get current user: %w", err)
 	}
-	// Named pipe security and access rights.
-	// We create the pipe and the specific users should only be able to write to it.
-	// See docs: https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipe-security-and-access-rights
-	// String definition: https://docs.microsoft.com/en-us/windows/win32/secauthz/ace-strings
-	// Give generic read/write access to the specified user.
+
 	descriptor := "D:P(A;;GA;;;" + u.Uid + ")"
 
-	if isAdmin, err := isWindowsAdmin(u); err != nil {
+	if isAdmin, err := utils.HasRoot(); err != nil {
 		// do not fail, agent would end up in a loop, continue with limited permissions
 		log.Warnf("failed to detect admin: %w", err)
 	} else if isAdmin {
@@ -53,32 +48,6 @@ func securityDescriptor(log *logger.Logger) (string, error) {
 		// https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems
 		descriptor += "(A;;GA;;;" + utils.AdministratorSID + ")"
 	}
+
 	return descriptor, nil
-}
-
-func isWindowsAdmin(u *user.User) (bool, error) {
-	if u.Username == "NT AUTHORITY\\SYSTEM" {
-		return true, nil
-	}
-
-	if equalsSystemGroup(u.Uid) || equalsSystemGroup(u.Gid) {
-		return true, nil
-	}
-
-	groups, err := u.GroupIds()
-	if err != nil {
-		return false, fmt.Errorf("failed to get current user groups: %w", err)
-	}
-
-	for _, groupSid := range groups {
-		if equalsSystemGroup(groupSid) {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-func equalsSystemGroup(s string) bool {
-	return strings.EqualFold(s, utils.SystemSID) || strings.EqualFold(s, utils.AdministratorSID)
 }

--- a/pkg/utils/root_windows.go
+++ b/pkg/utils/root_windows.go
@@ -7,7 +7,8 @@
 package utils
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"golang.org/x/sys/windows"
 )
 
@@ -28,14 +29,17 @@ func HasRoot() (bool, error) {
 		0, 0, 0, 0, 0, 0,
 		&sid)
 	if err != nil {
-		return false, errors.Errorf("sid error: %s", err)
+		return false, fmt.Errorf("allocate sid error: %w", err)
 	}
+	defer func() {
+		_ = windows.FreeSid(sid)
+	}()
 
 	token := windows.Token(0)
 
 	member, err := token.IsMember(sid)
 	if err != nil {
-		return false, errors.Errorf("token membership error: %s", err)
+		return false, fmt.Errorf("token membership error: %w", err)
 	}
 
 	return member, nil


### PR DESCRIPTION
## What does this PR do?

replaces custom `isWindowsAdmin` in listener_windows.go with call to `HasRoot` implementation in `utils`.  Also fix memory leak in `HasRoot` function.

## Why is it important?

In some localized Windows installs calls to `GroupIds` for the user of the process fail, this was causing the `isWindowsAdmin` check to fail, which causes problems with the control socket for `elastic-agent`.

The `HasRoot` implementation doesn't depend on `GroupIds`

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

### Prior to this PR.

1. Run agent install command on Windows 10 French/German VM.
2. Observe agent service is not restarted itself on installation.
3. Navigate to services and manually restart the Elastic Agent service.
4. Observe agent gets Healthy under Agents tab.

### With this PR

1. Run agent install command on Windows 10 French/German VM.
2. Observe agent service is restarted on installation.
3. `elastic-agent restart` should work

## Related issues

- #3960

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
