### PR TITLE
Setup mage for post dependabot action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,29 +9,16 @@ updates:
       - automation
       - skip-changelog
       - Team:Elastic-Agent
-    allow:
-      # Only update internal dependencies for now while we evaluate this workflow.
-      - dependency-name: "github.com/elastic/*"
-    reviewers:
-      - "elastic/elastic-agent-control-plane"
-    open-pull-requests-limit: 10
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    labels:
-      - automation
-      - skip-changelog
-      - Team:Elastic-Agent
     groups:
         otel-dependencies:
-            patterns:
-             - "*"
+            exclude-patterns:
+             - "github.com/elastic/*"
             update-types:
              - "minor"
              - "patch"
     allow:
       # Only update internal dependencies for now while we evaluate this workflow.
+      - dependency-name: "github.com/elastic/*"
       - dependency-name: "go.opentelemetry.io/collector/*"
       - dependency-name: "github.com/open-telemetry/opentelemetry-collector-contrib/*"
     reviewers:

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -43,7 +43,7 @@ jobs:
           git commit -m "Update NOTICE.txt"
           git push
 
-      - name: update otel README.MD
+      - name: update otel README.md
         run: mage otel:readme 
 
       - name: check for modified otel README.md

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -42,3 +42,20 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git commit -m "Update NOTICE.txt"
           git push
+
+      - name: update otel README.MD
+        run: mage otel:readme 
+
+      - name: check for modified otel README.md
+        id: otel-readme-check
+        run: echo "modified=$(if git diff-index --quiet HEAD -- internal/pkg/otel/README.md; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
+
+      - name: commit otel README.md
+        if: steps.otel-readme-check.outputs.modified == 'true'
+        run: |
+          git config --global user.name 'dependabot[bot]'
+          git config --global user.email 'dependabot[bot]@users.noreply.github.com'
+          git add internal/pkg/otel/README.md
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git commit -m "Update otel README.md"
+          git push

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           go-version-file: .go-version
 
+      - uses: magefile/mage-action@v3
+        with:
+          install-only: true
+
       - name: update NOTICE.txt
         run: make notice
 


### PR DESCRIPTION
post dependabot is failing on make notice.
`make notice` proxies to `mage notice` ( since #3772 ) which is not present at the time


In addition this PR adds commit steps for otel readme introduced in #3992 