### PR TITLE
[Upgrade Integration/E2E tests] Update version in guard for running upgrade details assertions

### DIFF
--- a/testing/integration/upgrade_downgrade_test.go
+++ b/testing/integration/upgrade_downgrade_test.go
@@ -88,7 +88,7 @@ func TestStandaloneDowngradeToSpecificSnapshotBuild(t *testing.T) {
 	// We pass the upgradetest.WithDisableUpgradeWatcherUpgradeDetailsCheck option here because the endFixture
 	// is fetched from the artifacts API and it may not contain changes in the Upgrade Watcher whose effects are
 	// being asserted upon in upgradetest.PerformUpgrade.
-	// TODO: Stop passing this option and remove these comments once 8.13.0 has been released.
+	// TODO: Stop passing this option and remove these comments once 8.12.0 has been released.
 	err = upgradetest.PerformUpgrade(ctx, startFixture, endFixture, t, upgradetest.WithDisableUpgradeWatcherUpgradeDetailsCheck())
 	assert.NoError(t, err)
 }

--- a/testing/upgradetest/upgrader.go
+++ b/testing/upgradetest/upgrader.go
@@ -34,7 +34,7 @@ type upgradeOpts struct {
 	customPgp        *CustomPGP
 	customWatcherCfg string
 
-	// TODO: should be removed along with all references once 8.13.0 has been released.
+	// TODO: should be removed along with all references once 8.12.0 has been released.
 	// See also WithDisableUpgradeWatcherUpgradeDetailsCheck.
 	disableUpgradeWatcherUpgradeDetailsCheck bool
 
@@ -116,7 +116,7 @@ func WithCustomWatcherConfig(cfg string) upgradeOpt {
 // upgrade details that are being set by the Upgrade Watcher. This option is
 // useful in upgrade tests where the end Agent version does not contain changes
 // in the Upgrade Watcher whose effects are being asserted upon in PerformUpgrade.
-// TODO: should be removed along with all references once 8.13.0 has been released.
+// TODO: should be removed along with all references once 8.12.0 has been released.
 func WithDisableUpgradeWatcherUpgradeDetailsCheck() upgradeOpt {
 	return func(opts *upgradeOpts) {
 		opts.disableUpgradeWatcherUpgradeDetailsCheck = true
@@ -175,17 +175,17 @@ func PerformUpgrade(
 		return fmt.Errorf("failed to get end agent build version info: %w", err)
 	}
 
-	// For asserting on the effects of any Upgrade Watcher changes made in 8.13.0, we need
-	// the endVersion to be >= 8.13.0.  Otherwise, these assertions will fail as those changes
+	// For asserting on the effects of any Upgrade Watcher changes made in 8.12.0, we need
+	// the endVersion to be >= 8.12.0.  Otherwise, these assertions will fail as those changes
 	// won't be present in the Upgrade Watcher. So we disable these assertions if the endVersion
-	// is < 8.13.0.
+	// is < 8.12.0.
 	endVersion, err := version.ParseVersion(endVersionInfo.Binary.Version)
 	if err != nil {
 		return fmt.Errorf("failed to parse version of upgraded Agent binary: %w", err)
 	}
 
 	upgradeOpts.disableUpgradeWatcherUpgradeDetailsCheck = upgradeOpts.disableUpgradeWatcherUpgradeDetailsCheck ||
-		endVersion.Less(*version.NewParsedSemVer(8, 13, 0, "", ""))
+		endVersion.Less(*version.NewParsedSemVer(8, 12, 0, "", ""))
 
 	if upgradeOpts.preInstallHook != nil {
 		if err := upgradeOpts.preInstallHook(); err != nil {


### PR DESCRIPTION
## What does this PR do?

This PR makes it so the upgrade integration/E2E tests run assertions about upgrade details being present or absent (as expected) from the upgrade marker file IF the target Agent version is >= 8.12.0.

## Why is it important?

When the version guard was originally introduced, the code being exercised by the test was not yet present in `8.12.0` builds. That's because the code being exercised was in the same PR as the version guards, that PR was targetting `main`, and hadn't yet been backported to `8.12`.  To get tests passing on that PR the guard only ran the relevant assertions if the version of the upgraded Agent was >= 8.13.0.  

Now that PR has been merged AND backported to `8.12` as well, the code being exercised is in `8.12` and `main` both.  So now we can update the guard to run the relevant assertions if the version of the upgraded Agent is >= 8.12.0.

## Related issues

Related to https://github.com/elastic/elastic-agent/pull/3901