### PR TITLE
Use correct 8.12 version for watcher details checks.

### DIFF
--- a/testing/upgradetest/upgrader.go
+++ b/testing/upgradetest/upgrader.go
@@ -34,7 +34,7 @@ type upgradeOpts struct {
 	customPgp        *CustomPGP
 	customWatcherCfg string
 
-	// TODO: should be removed along with all references once 8.13.0 has been released.
+	// Used to disable upgrade details checks for versions that don't support them, like 7.17.x.
 	// See also WithDisableUpgradeWatcherUpgradeDetailsCheck.
 	disableUpgradeWatcherUpgradeDetailsCheck bool
 
@@ -116,7 +116,6 @@ func WithCustomWatcherConfig(cfg string) upgradeOpt {
 // upgrade details that are being set by the Upgrade Watcher. This option is
 // useful in upgrade tests where the end Agent version does not contain changes
 // in the Upgrade Watcher whose effects are being asserted upon in PerformUpgrade.
-// TODO: should be removed along with all references once 8.13.0 has been released.
 func WithDisableUpgradeWatcherUpgradeDetailsCheck() upgradeOpt {
 	return func(opts *upgradeOpts) {
 		opts.disableUpgradeWatcherUpgradeDetailsCheck = true
@@ -175,17 +174,17 @@ func PerformUpgrade(
 		return fmt.Errorf("failed to get end agent build version info: %w", err)
 	}
 
-	// For asserting on the effects of any Upgrade Watcher changes made in 8.13.0, we need
-	// the endVersion to be >= 8.13.0.  Otherwise, these assertions will fail as those changes
+	// For asserting on the effects of any Upgrade Watcher changes made in 8.12.0, we need
+	// the endVersion to be >= 8.12.0.  Otherwise, these assertions will fail as those changes
 	// won't be present in the Upgrade Watcher. So we disable these assertions if the endVersion
-	// is < 8.13.0.
+	// is < 8.12.0.
 	endVersion, err := version.ParseVersion(endVersionInfo.Binary.Version)
 	if err != nil {
 		return fmt.Errorf("failed to parse version of upgraded Agent binary: %w", err)
 	}
 
 	upgradeOpts.disableUpgradeWatcherUpgradeDetailsCheck = upgradeOpts.disableUpgradeWatcherUpgradeDetailsCheck ||
-		endVersion.Less(*version.NewParsedSemVer(8, 13, 0, "", ""))
+		endVersion.Less(*version.NewParsedSemVer(8, 12, 0, "", ""))
 
 	if upgradeOpts.preInstallHook != nil {
 		if err := upgradeOpts.preInstallHook(); err != nil {

--- a/testing/upgradetest/upgrader.go
+++ b/testing/upgradetest/upgrader.go
@@ -178,13 +178,19 @@ func PerformUpgrade(
 	// the endVersion to be >= 8.12.0.  Otherwise, these assertions will fail as those changes
 	// won't be present in the Upgrade Watcher. So we disable these assertions if the endVersion
 	// is < 8.12.0.
+	//
+	// The start version also needs to be >= 8.10.0. Versions before 8.10.0 will launch the watcher
+	// process from the starting version of the agent and not the ending version of the agent. So
+	// even though an 8.12.0 watcher knows to write the upgrade details, prior to 8.10.0 the 8.12.0
+	// watcher version never executes and the upgrade details are never populated.
 	endVersion, err := version.ParseVersion(endVersionInfo.Binary.Version)
 	if err != nil {
 		return fmt.Errorf("failed to parse version of upgraded Agent binary: %w", err)
 	}
 
 	upgradeOpts.disableUpgradeWatcherUpgradeDetailsCheck = upgradeOpts.disableUpgradeWatcherUpgradeDetailsCheck ||
-		endVersion.Less(*version.NewParsedSemVer(8, 12, 0, "", ""))
+		endVersion.Less(*version.NewParsedSemVer(8, 12, 0, "", "")) ||
+		startParsedVersion.Less(*version.NewParsedSemVer(8, 10, 0, "", ""))
 
 	if upgradeOpts.preInstallHook != nil {
 		if err := upgradeOpts.preInstallHook(); err != nil {


### PR DESCRIPTION
- Relates https://github.com/elastic/elastic-agent/pull/3901

In https://github.com/elastic/elastic-agent/pull/3901 when we switched the agent package version from 8.12.0 to 8.13.0 it had the side effect of enabling the upgrade details checks for watching state:

https://github.com/elastic/elastic-agent/blob/602a2b4587a8050b38881ad9e5811be79b4562c1/testing/upgradetest/upgrader.go#L178-L188

There are two problems with this:
1. That check should be against 8.12.0 and not 8.13.0, since we backported the code involved.
2. Versions older than 8.10.0 start their version of the watcher, and not the version of the watcher from the new agent. This means this check was enabled for 7.17 and causing the tests that upgrade from 7.17 to fail. This is expected, we need to consider the version we are upgrading from as well as the version we are upgrading to when enabling this check.