### PR TITLE
set SkipDaemonRestart in tryDelayEnroll

### DIFF
--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -501,7 +501,8 @@ func tryDelayEnroll(ctx context.Context, logger *logger.Logger, cfg *configurati
 	}
 	options.DelayEnroll = false
 	options.FleetServer.SpawnAgent = false
-	// enrollCmd daemonReloadWithBackoff is broken, setting
+	// enrollCmd daemonReloadWithBackoff is broken
+	// see https://github.com/elastic/elastic-agent/issues/4043
 	// SkipDaemonRestart to true avoids running that code.
 	options.SkipDaemonRestart = true
 	c, err := newEnrollCmd(

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -501,6 +501,9 @@ func tryDelayEnroll(ctx context.Context, logger *logger.Logger, cfg *configurati
 	}
 	options.DelayEnroll = false
 	options.FleetServer.SpawnAgent = false
+	// enrollCmd daemonReloadWithBackoff is broken, setting
+	// SkipDaemonRestart to true avoids running that code.
+	options.SkipDaemonRestart = true
 	c, err := newEnrollCmd(
 		ctx,
 		logger,

--- a/pkg/testing/fixture_install.go
+++ b/pkg/testing/fixture_install.go
@@ -58,6 +58,7 @@ type InstallOpts struct {
 	NonInteractive bool   // --non-interactive
 	ProxyURL       string // --proxy-url
 	Unprivileged   bool   // --unprivileged
+	DelayEnroll    bool   // --delay-enroll
 
 	EnrollOpts
 }
@@ -81,6 +82,9 @@ func (i InstallOpts) toCmdArgs() []string {
 	}
 	if i.Unprivileged {
 		args = append(args, "--unprivileged")
+	}
+	if i.DelayEnroll {
+		args = append(args, "--delay-enroll")
 	}
 
 	args = append(args, i.EnrollOpts.toCmdArgs()...)

--- a/pkg/testing/tools/tools.go
+++ b/pkg/testing/tools/tools.go
@@ -123,6 +123,11 @@ func InstallAgentForPolicy(ctx context.Context, t *testing.T,
 		timeout = time.Until(deadline)
 	}
 
+	// Don't check fleet status if --delay-enroll
+	if installOpts.DelayEnroll {
+		return nil
+	}
+
 	// Wait for Agent to be healthy
 	require.Eventually(
 		t,

--- a/testing/integration/delay_enroll_test.go
+++ b/testing/integration/delay_enroll_test.go
@@ -1,0 +1,86 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/kibana"
+	atesting "github.com/elastic/elastic-agent/pkg/testing"
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+	"github.com/elastic/elastic-agent/pkg/testing/tools"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/check"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/testcontext"
+)
+
+func TestDelayEnroll(t *testing.T) {
+	info := define.Require(t, define.Requirements{
+		Group: Fleet,
+		Stack: &define.Stack{},
+		Local: false,
+		Sudo:  true,
+		OS:    []define.OS{{Type: define.Linux}},
+	})
+
+	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	defer cancel()
+
+	agentFixture, err := define.NewFixture(t, define.Version())
+	require.NoError(t, err)
+
+	// 1. Create a policy in Fleet with monitoring enabled.
+	// To ensure there are no conflicts with previous test runs against
+	// the same ESS stack, we add the current time at the end of the policy
+	// name. This policy does not contain any integration.
+	t.Log("Enrolling agent in Fleet with a test policy")
+	createPolicyReq := kibana.AgentPolicy{
+		Name:        fmt.Sprintf("test-policy-enroll-%d", time.Now().Unix()),
+		Namespace:   info.Namespace,
+		Description: "test policy for agent enrollment",
+		MonitoringEnabled: []kibana.MonitoringEnabledOption{
+			kibana.MonitoringEnabledLogs,
+			kibana.MonitoringEnabledMetrics,
+		},
+		AgentFeatures: []map[string]interface{}{
+			{
+				"name":    "test_enroll",
+				"enabled": true,
+			},
+		},
+	}
+
+	installOpts := atesting.InstallOpts{
+		NonInteractive: true,
+		Force:          true,
+		DelayEnroll:    true,
+	}
+	// Install the Elastic-Agent with the policy that was just
+	// created.
+	_, err = tools.InstallAgentWithPolicy(
+		ctx,
+		t,
+		installOpts,
+		agentFixture,
+		info.KibanaClient,
+		createPolicyReq)
+	require.NoError(t, err)
+
+	// Start elastic-agent via service, this should do the enrollment
+	cmd := exec.Command("/usr/bin/systemctl", "start", "elastic-agent")
+	stdErrStdout, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "systemctl start elastic-agent output was %s", stdErrStdout)
+
+	// check to make sure enroll worked
+	check.ConnectedToFleet(ctx, t, agentFixture, 5*time.Minute)
+
+}


### PR DESCRIPTION
## What does this PR do?

This PR skips trying to restart the `elastic-agent` process during a delayed enroll.  Instead the process exits and is restarted by the service manager.

This is necessary because the code to restart the `elastic-agent` process requires that the control server be up, and it isn't at this point.  This restores previous behavior, where the attempt to restart the `elastic-agent` process was non-fatal.

## Why is it important?

bug that prevents `elastic-agent` from starting when `--delay-enroll` is used

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

### Without PR

1. On Windows, install elastic-agent with `--delay-enroll` option
2. attempt to start service with Services control panel
3. notice in logs that restart fails 4 times and `elastic-agent status` will fail

### With PR

1. On Windows, install elastic-agent with `--delay-enroll` option
2. attempt to start service with Services control panel
3. elastic-agent will start normally and `elastic-agent status` will work

## Related issues

- Closes #3961

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
