### PR TITLE
Add commit hashes to logged versions in upgrader

### DIFF
--- a/testing/upgradetest/upgrader.go
+++ b/testing/upgradetest/upgrader.go
@@ -233,7 +233,7 @@ func PerformUpgrade(
 		}
 	}
 
-	logger.Logf("Upgrading from version %q to version %q", startParsedVersion, endVersionInfo.Binary.String())
+	logger.Logf("Upgrading from version %q (%s) to version %q (%s)", startParsedVersion, startVersionInfo.Binary.Commit, endVersionInfo.Binary.String(), endVersionInfo.Binary.Commit)
 
 	upgradeCmdArgs := []string{"upgrade", endVersionInfo.Binary.String()}
 	if upgradeOpts.sourceURI == nil {


### PR DESCRIPTION
So, we know that we upgrade from and to different builds/snapshots, not the same.

Related to https://github.com/elastic/elastic-agent/issues/4089