### PR TITLE
fix for initialisation of the kubernetes provider

### DIFF
--- a/internal/pkg/composable/providers/kubernetes/config.go
+++ b/internal/pkg/composable/providers/kubernetes/config.go
@@ -86,3 +86,17 @@ func (c *Config) Validate() error {
 
 	return nil
 }
+
+// defaultConfig initializes the default values for the config.
+func defaultConfig() Config {
+	return Config{
+		CleanupTimeout:      60 * time.Second,
+		SyncPeriod:          10 * time.Minute,
+		Scope:               nodeScope,
+		LabelsDedot:         true,
+		AnnotationsDedot:    true,
+		AddResourceMetadata: metadata.GetDefaultResourceMetadataConfig(),
+		Prefix:              "co.elastic",
+		Hints:               Hints{DefaultContainerLogs: true},
+	}
+}

--- a/internal/pkg/composable/providers/kubernetes/kubernetes.go
+++ b/internal/pkg/composable/providers/kubernetes/kubernetes.go
@@ -42,11 +42,15 @@ type dynamicProvider struct {
 
 // DynamicProviderBuilder builds the dynamic provider.
 func DynamicProviderBuilder(logger *logger.Logger, c *config.Config, managed bool) (composable.DynamicProvider, error) {
-	var cfg Config
+	cfg := defaultConfig()
+	err := cfg.Validate()
+	if err != nil {
+		return nil, errors.New(err, "failed to unpack default configuration")
+	}
 	if c == nil {
 		c = config.New()
 	}
-	err := c.Unpack(&cfg)
+	err = c.Unpack(&cfg)
 	if err != nil {
 		return nil, errors.New(err, "failed to unpack configuration")
 	}


### PR DESCRIPTION
- Bug

## What does this PR do?
The bug was identified here: https://github.com/elastic/elastic-agent/issues/3346#issuecomment-1892470472
It addresses the correct initialisation of kubernetes provider when user in elastic-agent configures the 
Sample of elastic-agent standalone configuraton manifest:

```yaml
data:
  agent.yml: |-
    id: bea46550-8652-49e5-bfa2-7016cb60816c
    outputs:
      default:
        type: elasticsearch
        hosts:
          - 'https://elasticsearch:9200'
        username: '${ES_USERNAME}'
        password: '${ES_PASSWORD}'
    providers.kubernetes:
      node: ${NODE_NAME}
      add_resource_metadata:
        node: 
          enabled: false
        namespace:
          use_regex_include: true
          include_labels: ["pas"]
```
## Why is it important?

It is important because this affects the correct initialisation of Kubernetes provider and finally affects the correct metadata enrichment of logs

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## How to test this PR locally

1. Clone code 
2. Build elastic-agent image according to https://github.com/elastic/elastic-agent#testing-elastic-agent-on-kubernetes
3. Apply label in specific namespace: `kubectl label namespace default pas2=pas`
4. Apply standalone elastic-agent with:
```yaml
providers.kubernetes:
      node: ${NODE_NAME}
      add_resource_metadata:
        node: 
          enabled: false
        namespace:
          use_regex_include: true
          include_labels: ["pas"]
```
5. Produce logs and verify that only namespace labels are present


## Related issues

- Closes #https://github.com/elastic/elastic-agent/issues/3346


## Screenshots

![Screenshot 2024-01-18 at 4 37 38 PM](https://github.com/elastic/elastic-agent/assets/1685415/20a8a072-c204-4d89-8eb1-13427e320074)

