### PR TITLE
Start state watch after starting process.

### DIFF
--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -483,13 +483,6 @@ func (f *Fixture) RunWithClient(ctx context.Context, shouldWatchState bool, stat
 		return fmt.Errorf("failed to get control protcol address: %w", err)
 	}
 
-	if shouldWatchState {
-		agentClient = client.New(client.WithAddress(cAddr))
-		f.setClient(agentClient)
-		defer f.setClient(nil)
-		stateCh, stateErrCh = watchState(ctx, f.t, agentClient, f.connectTimout)
-	}
-
 	var logProxy Logger
 	if f.logOutput {
 		logProxy = f.t
@@ -514,6 +507,13 @@ func (f *Fixture) RunWithClient(ctx context.Context, shouldWatchState bool, stat
 	killProc := func() {
 		_ = proc.Kill()
 		<-proc.Wait()
+	}
+
+	if shouldWatchState {
+		agentClient = client.New(client.WithAddress(cAddr))
+		f.setClient(agentClient)
+		defer f.setClient(nil)
+		stateCh, stateErrCh = watchState(ctx, f.t, agentClient, f.connectTimout)
 	}
 
 	var doneChan <-chan time.Time


### PR DESCRIPTION
Observed another failure attempting to connect to the gRPC pipe with marginal timing. It shouldn't take us 15 seconds to connect, I suspect we might be starting too connect to early. 

This PR doesn't start the state watch until after we actually launch the agent process.

Here is the failure from https://buildkite.com/elastic/elastic-agent/builds/6393 for reference:

```
=== RUN   TestFakeComponent
    fixture.go:261: Extracting artifact elastic-agent-8.13.0-SNAPSHOT-windows-x86_64.zip to C:\Users\windows\AppData\Local\Temp\TestFakeComponent3737372147\001
    fixture.go:274: Completed extraction of artifact elastic-agent-8.13.0-SNAPSHOT-windows-x86_64.zip to C:\Users\windows\AppData\Local\Temp\TestFakeComponent3737372147\001
    fixture.go:880: All component specifications where removed
    fixture.go:921: Placed component specifications: fake, fake-shipper
    fixture.go:1055: 2024-01-19T01:41:52.0958556Z: StateWatch failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: open \\\\.\\pipe\\hi0LcmXQaGqV9eTiVEpr3Kg-bBHo_M8A.sock: The system cannot find the file specified." retrying: 134.100269ms
    fixture.go:1055: 2024-01-19T01:41:52.2334811Z: StateWatch failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: open \\\\.\\pipe\\hi0LcmXQaGqV9eTiVEpr3Kg-bBHo_M8A.sock: The system cannot find the file specified." retrying: 187.792745ms
    fixture.go:1055: 2024-01-19T01:41:52.4244161Z: StateWatch failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: open \\\\.\\pipe\\hi0LcmXQaGqV9eTiVEpr3Kg-bBHo_M8A.sock: The system cannot find the file specified." retrying: 276.720629ms
    fixture.go:1055: 2024-01-19T01:41:52.7087524Z: StateWatch failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: open \\\\.\\pipe\\hi0LcmXQaGqV9eTiVEpr3Kg-bBHo_M8A.sock: The system cannot find the file specified." retrying: 354.753782ms
    fixture.go:1055: 2024-01-19T01:41:53.0725921Z: StateWatch failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: open \\\\.\\pipe\\hi0LcmXQaGqV9eTiVEpr3Kg-bBHo_M8A.sock: The system cannot find the file specified." retrying: 404.533458ms
    fixture.go:1055: 2024-01-19T01:41:53.4831466Z: StateWatch failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: open \\\\.\\pipe\\hi0LcmXQaGqV9eTiVEpr3Kg-bBHo_M8A.sock: The system cannot find the file specified." retrying: 494.597904ms
    fixture.go:1055: 2024-01-19T01:41:53.9885452Z: StateWatch failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: open \\\\.\\pipe\\hi0LcmXQaGqV9eTiVEpr3Kg-bBHo_M8A.sock: The system cannot find the file specified." retrying: 1.425000833s
    fixture.go:1055: 2024-01-19T01:41:55.4370614Z: StateWatch failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: open \\\\.\\pipe\\hi0LcmXQaGqV9eTiVEpr3Kg-bBHo_M8A.sock: The system cannot find the file specified." retrying: 887.805908ms
    fixture.go:1055: 2024-01-19T01:41:56.3348791Z: StateWatch failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: open \\\\.\\pipe\\hi0LcmXQaGqV9eTiVEpr3Kg-bBHo_M8A.sock: The system cannot find the file specified." retrying: 2.434492042s
    fixture.go:1055: 2024-01-19T01:41:58.7892008Z: StateWatch failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: open \\\\.\\pipe\\hi0LcmXQaGqV9eTiVEpr3Kg-bBHo_M8A.sock: The system cannot find the file specified." retrying: 1.800364952s
    fixture.go:1055: 2024-01-19T01:42:00.6108843Z: StateWatch failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: open \\\\.\\pipe\\hi0LcmXQaGqV9eTiVEpr3Kg-bBHo_M8A.sock: The system cannot find the file specified." retrying: 2.358797106s
    log.go:96: {"log.level":"info","@timestamp":"2024-01-19T01:42:01.429Z","log.origin":{"file.name":"cmd/run.go","file.line":170},"message":"Elastic Agent started","log":{"source":"elastic-agent"},"process.pid":4136,"agent.version":"8.13.0","ecs.version":"1.6.0"}
    log.go:96: {"log.level":"info","@timestamp":"2024-01-19T01:42:01.710Z","log.origin":{"file.name":"upgrade/rollback.go","file.line":126},"message":"Starting upgrade watcher","log":{"source":"elastic-agent"},"path":"C:\\Users\\windows\\AppData\\Local\\Temp\\TestFakeComponent3737372147\\001\\elastic-agent-8.13.0-SNAPSHOT-windows-x86_64\\elastic-agent.exe","args":["C:\\Users\\windows\\AppData\\Local\\Temp\\TestFakeComponent3737372147\\001\\elastic-agent-8.13.0-SNAPSHOT-windows-x86_64\\elastic-agent.exe","watch","--path.config","C:\\Users\\windows\\AppData\\Local\\Temp\\TestFakeComponent3737372147\\001\\elastic-agent-8.13.0-SNAPSHOT-windows-x86_64","--path.home","C:\\Users\\windows\\AppData\\Local\\Temp\\TestFakeComponent3737372147\\001\\elastic-agent-8.13.0-SNAPSHOT-windows-x86_64"],"env":[],"dir":"","ecs.version":"1.6.0"}
    log.go:96: {"log.level":"info","@timestamp":"2024-01-19T01:42:01.718Z","log.origin":{"file.name":"upgrade/rollback.go","file.line":133},"message":"Upgrade Watcher invoked","log":{"source":"elastic-agent"},"agent.upgrade.watcher.process.pid":5500,"agent.process.pid":4136,"ecs.version":"1.6.0"}
    log.go:96: {"log.level":"info","@timestamp":"2024-01-19T01:42:01.718Z","log.origin":{"file.name":"upgrade/rollback.go","file.line":121},"message":"releasing watcher 5500","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
    log.go:96: {"log.level":"info","@timestamp":"2024-01-19T01:42:01.718Z","log.origin":{"file.name":"cmd/run.go","file.line":259},"message":"APM instrumentation disabled","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
    log.go:96: {"log.level":"info","@timestamp":"2024-01-19T01:42:01.743Z","log.origin":{"file.name":"application/application.go","file.line":62},"message":"Gathered system information","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
    log.go:96: {"log.level":"info","@timestamp":"2024-01-19T01:42:01.774Z","log.origin":{"file.name":"application/application.go","file.line":68},"message":"Detected available inputs and outputs","log":{"source":"elastic-agent"},"inputs":["fake","fake-apm"],"ecs.version":"1.6.0"}
    log.go:96: {"log.level":"info","@timestamp":"2024-01-19T01:42:01.775Z","log.origin":{"file.name":"capabilities/capabilities.go","file.line":48},"message":"Capabilities file not found in C:\\Users\\windows\\AppData\\Local\\Temp\\TestFakeComponent3737372147\\001\\elastic-agent-8.13.0-SNAPSHOT-windows-x86_64\\capabilities.yml","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
    log.go:96: {"log.level":"info","@timestamp":"2024-01-19T01:42:01.775Z","log.origin":{"file.name":"application/application.go","file.line":74},"message":"Determined allowed capabilities","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
    log.go:96: {"log.level":"info","@timestamp":"2024-01-19T01:42:02.694Z","log.origin":{"file.name":"application/application.go","file.line":131},"message":"Elastic Agent has been started in testing mode and is managed through the control protocol","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
    log.go:96: {"log.level":"info","@timestamp":"2024-01-19T01:42:02.718Z","log.logger":"control","log.origin":{"file.name":"server/server.go","file.line":88},"message":"GRPC control socket listening at npipe:///hi0LcmXQaGqV9eTiVEpr3Kg-bBHo_M8A.sock","log":{"source":"elastic-agent"},"address":"npipe:///hi0LcmXQaGqV9eTiVEpr3Kg-bBHo_M8A.sock","ecs.version":"1.6.0"}
    log.go:96: {"log.level":"info","@timestamp":"2024-01-19T01:42:02.726Z","log.logger":"composable.providers.docker","log.origin":{"file.name":"docker/docker.go","file.line":44},"message":"Docker provider skipped, unable to connect: protocol not available","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
    log.go:96: {"log.level":"info","@timestamp":"2024-01-19T01:42:02.759Z","log.origin":{"file.name":"runtime/manager.go","file.line":209},"message":"Starting grpc control protocol listener on port 6789 with max_message_size 104857600","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
    fixture.go:1055: 2024-01-19T01:42:02.9801541Z: StateWatch failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: open \\\\.\\pipe\\hi0LcmXQaGqV9eTiVEpr3Kg-bBHo_M8A.sock: The system cannot find the file specified." retrying: 1.676916455s
    fixture.go:1055: 2024-01-19T01:42:04.6668009Z: StateWatch failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: open \\\\.\\pipe\\hi0LcmXQaGqV9eTiVEpr3Kg-bBHo_M8A.sock: The system cannot find the file specified." retrying: 1.465015543s
    fake_test.go:104: 
        	Error Trace:	C:/Users/windows/agent/testing/integration/fake_test.go:104
        	Error:      	Received unexpected error:
        	            	elastic-agent client received unexpected error: StateWatch() failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: open \\\\.\\pipe\\hi0LcmXQaGqV9eTiVEpr3Kg-bBHo_M8A.sock: The system cannot find the file specified."
        	Test:       	TestFakeComponent
--- FAIL: TestFakeComponent (37.47s)
```