### PR TITLE
Fix YAML formatting in the flaky-test form

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky-test.yml
+++ b/.github/ISSUE_TEMPLATE/flaky-test.yml
@@ -1,8 +1,8 @@
 name: "Flaky Test"
-about: "Report a flaky test (one that doesn't pass consistently)"
+description: "Report a flaky test (one that doesn't pass consistently)"
 title: "[Flaky Test]: <test_case> – <short_error_message>"
 labels: ["Team:Elastic-Agent", "flaky-test"]
-projects: ["elastic/1457"]
+projects: ["elastic/979", "elastic/1457"]
 body:
   - type: markdown
     attributes:
@@ -36,18 +36,18 @@ body:
     attributes:
       label: OS
       description: "On which OS the test is failing"
-    multiple: true
-    options:
-      - Linux
-      - Mac
-      - Windows
-    default: 0
+      multiple: true
+      options:
+        - Linux
+        - Mac
+        - Windows
+      default: 0
     validations:
       required: true
   - type: textarea
     attributes:
       label: "Stacktrace and notes"
       description: "Detailed output of the test failure and your notes about possible cause."
-    render: markdown
+      render: markdown
     validations:
       required: true


### PR DESCRIPTION
* There were wrong indentations
* A wrong `about` key was used instead of `description`
* I added the Platform Ingest Project too

Reported errors (interestingly enough the Github editor didn't catch them):

<img width="537" alt="Screenshot 2024-01-20 at 09 42 57" src="https://github.com/elastic/elastic-agent/assets/887952/5ed9af6b-4c3a-428d-8f4c-889f30615192">

Now I tested this YAML in my personal private repository and it looks like this:

<img width="1010" alt="Screenshot 2024-01-20 at 09 42 07" src="https://github.com/elastic/elastic-agent/assets/887952/fd699943-e8a4-4e56-b515-10ecf974c264">



