### PR TITLE
Add some deployment tags for helping with tracing

### DIFF
--- a/pkg/testing/ess/statful_provisioner.go
+++ b/pkg/testing/ess/statful_provisioner.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -71,14 +72,21 @@ func (p *statefulProvisioner) Create(ctx context.Context, request runner.StackRe
 	// allow up to 2 minutes for request
 	createCtx, createCancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer createCancel()
-	resp, err := p.createDeployment(createCtx, request,
-		map[string]string{
-			"division":          "engineering",
-			"org":               "ingest",
-			"team":              "elastic-agent",
-			"project":           "elastic-agent",
-			"integration-tests": "true",
-		})
+	deploymentTags := map[string]string{
+		"division":          "engineering",
+		"org":               "ingest",
+		"team":              "elastic-agent",
+		"project":           "elastic-agent",
+		"integration-tests": "true",
+	}
+	// If the CI env var is set, this mean we are running inside the CI pipeline and some expected env vars are exposed
+	if _, e := os.LookupEnv("CI"); e {
+		deploymentTags["buildkite_id"] = os.Getenv("BUILDKITE_BUILD_NUMBER")
+		deploymentTags["creator"] = os.Getenv("BUILDKITE_BUILD_CREATOR")
+		deploymentTags["buildkite_url"] = os.Getenv("BUILDKITE_BUILD_URL")
+		deploymentTags["ci"] = os.Getenv("BUILDKITE_BUILD_URL")
+	}
+	resp, err := p.createDeployment(createCtx, request, deploymentTags)
 	if err != nil {
 		return runner.Stack{}, err
 	}

--- a/pkg/testing/ess/statful_provisioner.go
+++ b/pkg/testing/ess/statful_provisioner.go
@@ -84,7 +84,7 @@ func (p *statefulProvisioner) Create(ctx context.Context, request runner.StackRe
 		deploymentTags["buildkite_id"] = os.Getenv("BUILDKITE_BUILD_NUMBER")
 		deploymentTags["creator"] = os.Getenv("BUILDKITE_BUILD_CREATOR")
 		deploymentTags["buildkite_url"] = os.Getenv("BUILDKITE_BUILD_URL")
-		deploymentTags["ci"] = os.Getenv("BUILDKITE_BUILD_URL")
+		deploymentTags["ci"] = "true"
 	}
 	resp, err := p.createDeployment(createCtx, request, deploymentTags)
 	if err != nil {


### PR DESCRIPTION
## What does this PR do?
These new tags will help when deployments are left lingering to trace back the build that left them like that and identify how we can implement better clean-up strategies for them.


## Why is it important?

This is going to help us trace lingering ess deployments to builds and see why we did not clean them up.

This is similar to the tagging we did for [fleet-server](https://github.com/elastic/fleet-server/blob/main/dev-tools/cloud/terraform/main.tf) 

This change should not have any impact on the elastic-agent codebase. 

