### PR TITLE
[CI] Disables win 10 unit tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -130,7 +130,7 @@ steps:
         agents:
           provider: "gcp"
           # TODO create own image
-          image: "family/endpoint-windows-10-tester-rel"
+          image: "family/elastic-beats-ci-windows-10"
           machine_type: "n2-standard-8"
           disk_type: "pd-ssd"
         retry:
@@ -147,7 +147,7 @@ steps:
         agents:
           provider: "gcp"
           # TODO create own image
-          image: "family/endpoint-windows-11-tester-rel"
+          image: "family/elastic-beats-ci-windows-11"
           machine_type: "n2-standard-8"
           disk_type: "pd-ssd"
         retry:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -118,7 +118,7 @@ steps:
 
   - group: "Desktop Windows tests"
     key: "extended-windows"
-    steps:      
+    steps:
       - label: "Unit tests - Windows 11"
         key: "unit-tests-win11"
         command: ".\\.buildkite\\scripts\\steps\\unit-tests.ps1"
@@ -148,7 +148,6 @@ steps:
       unit-tests-win2016
       unit-tests-win2022
       unit-tests-macos-13
-      unit-tests-win10
       unit-tests-win11
       "
     artifact_paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -118,24 +118,7 @@ steps:
 
   - group: "Desktop Windows tests"
     key: "extended-windows"
-    steps:
-      - label: "Unit tests - Windows 10"
-        key: "unit-tests-win10"
-        command: ".\\.buildkite\\scripts\\steps\\unit-tests.ps1"
-        artifact_paths:
-          - "build/TEST-go-unit.html"
-          - "build/TEST-go-unit.xml"
-          - "build/diagnostics/*"
-          - "coverage.out"
-        agents:
-          provider: "gcp"
-          # TODO create own image
-          image: "family/elastic-beats-ci-windows-10"
-          machine_type: "n2-standard-8"
-          disk_type: "pd-ssd"
-        retry:
-          manual:
-            allowed: true
+    steps:      
       - label: "Unit tests - Windows 11"
         key: "unit-tests-win11"
         command: ".\\.buildkite\\scripts\\steps\\unit-tests.ps1"
@@ -147,7 +130,7 @@ steps:
         agents:
           provider: "gcp"
           # TODO create own image
-          image: "family/elastic-beats-ci-windows-11"
+          image: "family/endpoint-windows-11-tester-rel"
           machine_type: "n2-standard-8"
           disk_type: "pd-ssd"
         retry:


### PR DESCRIPTION
## What does this PR do?

Temporarily disables windows 10 tests
## Why is it important?

Previous images caused failures for unit tests on windows 10 

