### PR TITLE
Use package manifests for upgrade

### DIFF
--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -39,7 +39,7 @@ type UpdateMarker struct {
 	PrevVersion string `json:"prev_version" yaml:"prev_version"`
 	// PrevHash is a hash agent is updated from
 	PrevHash string `json:"prev_hash" yaml:"prev_hash"`
-	// PrevVersionedHome represents the path where the new agent is located relative to top path
+	// PrevVersionedHome represents the path where the old agent is located relative to top path
 	PrevVersionedHome string `json:"prev_versioned_home" yaml:"prev_versioned_home"`
 
 	// Acked is a flag marking whether or not action was acked

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -6,6 +6,7 @@ package upgrade
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -24,8 +25,13 @@ const markerFilename = ".update-marker"
 
 // UpdateMarker is a marker holding necessary information about ongoing upgrade.
 type UpdateMarker struct {
+	// Version represents the version the agent is upgraded to
+	Version string `json:"version" yaml:"version"`
 	// Hash agent is updated to
 	Hash string `json:"hash" yaml:"hash"`
+	// VersionedHome represents the path where the new agent is located relative to top path
+	VersionedHome string `json:"versioned_home" yaml:"versioned_home"`
+
 	//UpdatedOn marks a date when update happened
 	UpdatedOn time.Time `json:"updated_on" yaml:"updated_on"`
 
@@ -33,6 +39,8 @@ type UpdateMarker struct {
 	PrevVersion string `json:"prev_version" yaml:"prev_version"`
 	// PrevHash is a hash agent is updated from
 	PrevHash string `json:"prev_hash" yaml:"prev_hash"`
+	// PrevVersionedHome represents the path where the new agent is located relative to top path
+	PrevVersionedHome string `json:"prev_versioned_home" yaml:"prev_versioned_home"`
 
 	// Acked is a flag marking whether or not action was acked
 	Acked  bool                    `json:"acked" yaml:"acked"`
@@ -83,42 +91,55 @@ func convertToActionUpgrade(a *MarkerActionUpgrade) *fleetapi.ActionUpgrade {
 }
 
 type updateMarkerSerializer struct {
-	Hash        string               `yaml:"hash"`
-	UpdatedOn   time.Time            `yaml:"updated_on"`
-	PrevVersion string               `yaml:"prev_version"`
-	PrevHash    string               `yaml:"prev_hash"`
-	Acked       bool                 `yaml:"acked"`
-	Action      *MarkerActionUpgrade `yaml:"action"`
-	Details     *details.Details     `yaml:"details"`
+	Version           string               `yaml:"version"`
+	Hash              string               `yaml:"hash"`
+	VersionedHome     string               `yaml:"versioned_home"`
+	UpdatedOn         time.Time            `yaml:"updated_on"`
+	PrevVersion       string               `yaml:"prev_version"`
+	PrevHash          string               `yaml:"prev_hash"`
+	PrevVersionedHome string               `yaml:"prev_versioned_home"`
+	Acked             bool                 `yaml:"acked"`
+	Action            *MarkerActionUpgrade `yaml:"action"`
+	Details           *details.Details     `yaml:"details"`
 }
 
 func newMarkerSerializer(m *UpdateMarker) *updateMarkerSerializer {
 	return &updateMarkerSerializer{
-		Hash:        m.Hash,
-		UpdatedOn:   m.UpdatedOn,
-		PrevVersion: m.PrevVersion,
-		PrevHash:    m.PrevHash,
-		Acked:       m.Acked,
-		Action:      convertToMarkerAction(m.Action),
-		Details:     m.Details,
+		Version:           m.Version,
+		Hash:              m.Hash,
+		VersionedHome:     m.VersionedHome,
+		UpdatedOn:         m.UpdatedOn,
+		PrevVersion:       m.PrevVersion,
+		PrevHash:          m.PrevHash,
+		PrevVersionedHome: m.PrevVersionedHome,
+		Acked:             m.Acked,
+		Action:            convertToMarkerAction(m.Action),
+		Details:           m.Details,
 	}
 }
 
 // markUpgrade marks update happened so we can handle grace period
-func (u *Upgrader) markUpgrade(_ context.Context, log *logger.Logger, hash string, action *fleetapi.ActionUpgrade, upgradeDetails *details.Details) error {
-	prevVersion := release.Version()
+func (u *Upgrader) markUpgrade(_ context.Context, log *logger.Logger, version, hash, versionedHome string, action *fleetapi.ActionUpgrade, upgradeDetails *details.Details) error {
+	prevVersion := release.VersionWithSnapshot()
 	prevHash := release.Commit()
+	prevVersionedHome, err := filepath.Rel(paths.Top(), paths.Home())
+	if err != nil {
+		return fmt.Errorf("calculating home path relative to top, home: %q top: %q : %w", paths.Home(), paths.Top(), err)
+	}
 	if len(prevHash) > hashLen {
 		prevHash = prevHash[:hashLen]
 	}
 
 	marker := &UpdateMarker{
-		Hash:        hash,
-		UpdatedOn:   time.Now(),
-		PrevVersion: prevVersion,
-		PrevHash:    prevHash,
-		Action:      action,
-		Details:     upgradeDetails,
+		Version:           version,
+		Hash:              hash,
+		VersionedHome:     versionedHome,
+		UpdatedOn:         time.Now(),
+		PrevVersion:       prevVersion,
+		PrevHash:          prevHash,
+		PrevVersionedHome: prevVersionedHome,
+		Action:            action,
+		Details:           upgradeDetails,
 	}
 
 	markerBytes, err := yaml.Marshal(newMarkerSerializer(marker))
@@ -183,13 +204,16 @@ func loadMarker(markerFile string) (*UpdateMarker, error) {
 	}
 
 	return &UpdateMarker{
-		Hash:        marker.Hash,
-		UpdatedOn:   marker.UpdatedOn,
-		PrevVersion: marker.PrevVersion,
-		PrevHash:    marker.PrevHash,
-		Acked:       marker.Acked,
-		Action:      convertToActionUpgrade(marker.Action),
-		Details:     marker.Details,
+		Version:           marker.Version,
+		Hash:              marker.Hash,
+		VersionedHome:     marker.VersionedHome,
+		UpdatedOn:         marker.UpdatedOn,
+		PrevVersion:       marker.PrevVersion,
+		PrevHash:          marker.PrevHash,
+		PrevVersionedHome: marker.PrevVersionedHome,
+		Acked:             marker.Acked,
+		Action:            convertToActionUpgrade(marker.Action),
+		Details:           marker.Details,
 	}, nil
 }
 
@@ -198,13 +222,16 @@ func loadMarker(markerFile string) (*UpdateMarker, error) {
 // file is immediately flushed to persistent storage.
 func SaveMarker(marker *UpdateMarker, shouldFsync bool) error {
 	makerSerializer := &updateMarkerSerializer{
-		Hash:        marker.Hash,
-		UpdatedOn:   marker.UpdatedOn,
-		PrevVersion: marker.PrevVersion,
-		PrevHash:    marker.PrevHash,
-		Acked:       marker.Acked,
-		Action:      convertToMarkerAction(marker.Action),
-		Details:     marker.Details,
+		Version:           marker.Version,
+		Hash:              marker.Hash,
+		VersionedHome:     marker.VersionedHome,
+		UpdatedOn:         marker.UpdatedOn,
+		PrevVersion:       marker.PrevVersion,
+		PrevHash:          marker.PrevHash,
+		PrevVersionedHome: marker.PrevVersionedHome,
+		Acked:             marker.Acked,
+		Action:            convertToMarkerAction(marker.Action),
+		Details:           marker.Details,
 	}
 	markerBytes, err := yaml.Marshal(makerSerializer)
 	if err != nil {

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -32,21 +32,26 @@ func ChangeSymlink(ctx context.Context, log *logger.Logger, targetHash string) e
 	// paths.BinaryPath properly derives the binary directory depending on the platform. The path to the binary for macOS is inside of the app bundle.
 	newPath := paths.BinaryPath(filepath.Join(paths.Top(), "data", hashedDir), agentName)
 
+	return changeSymlinkInternal(log, symlinkPath, newPath)
+}
+
+func changeSymlinkInternal(log *logger.Logger, symlinkPath, newTarget string) error {
+
 	// handle windows suffixes
 	if runtime.GOOS == windows {
 		symlinkPath += exe
-		newPath += exe
+		newTarget += exe
 	}
 
 	prevNewPath := prevSymlinkPath()
-	log.Infow("Changing symlink", "symlink_path", symlinkPath, "new_path", newPath, "prev_path", prevNewPath)
+	log.Infow("Changing symlink", "symlink_path", symlinkPath, "new_path", newTarget, "prev_path", prevNewPath)
 
 	// remove symlink to avoid upgrade failures
 	if err := os.Remove(prevNewPath); !os.IsNotExist(err) {
 		return err
 	}
 
-	if err := os.Symlink(newPath, prevNewPath); err != nil {
+	if err := os.Symlink(newTarget, prevNewPath); err != nil {
 		return errors.New(err, errors.TypeFilesystem, "failed to update agent symlink")
 	}
 

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -102,7 +102,7 @@ func unzip(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error
 	}
 	hash = string(hashBytes[:hashLen])
 	if versionedHome == "" {
-		// if at this point we didn't load the manifest et the versioned to the backup value
+		// if at this point we didn't load the manifest, set the versioned to the backup value
 		versionedHome = createVersionedHomeFromHash(hash)
 	}
 

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -28,7 +28,7 @@ type UnpackResult struct {
 	Hash string `json:"hash" yaml:"hash"`
 	// TODO add mapped path of executable
 	// agentExecutable string
-	versionedHome string `json:"versioned-home" yaml:"versioned-home"`
+	VersionedHome string `json:"versioned-home" yaml:"versioned-home"`
 }
 
 // unpack unpacks archive correctly, skips root (symlink, config...) unpacks data/*
@@ -152,7 +152,7 @@ func unzip(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error
 
 	return UnpackResult{
 		Hash:          hash,
-		versionedHome: versionedHome,
+		VersionedHome: versionedHome,
 	}, nil
 }
 
@@ -177,7 +177,7 @@ func untar(log *logger.Logger, version string, archivePath, dataDir string) (Unp
 
 		// set the path mappings
 		pm.mappings = manifest.Package.PathMappings
-		versionedHome = filepath.Clean(manifest.Package.VersionedHome)
+		versionedHome = filepath.Clean(pm.Map(manifest.Package.VersionedHome))
 	}
 
 	r, err := os.Open(archivePath)
@@ -294,7 +294,7 @@ func untar(log *logger.Logger, version string, archivePath, dataDir string) (Unp
 
 	return UnpackResult{
 		Hash:          hash,
-		versionedHome: versionedHome,
+		VersionedHome: versionedHome,
 	}, nil
 }
 

--- a/internal/pkg/agent/application/upgrade/step_unpack_test.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack_test.go
@@ -6,6 +6,7 @@ package upgrade
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"compress/gzip"
 	"fmt"
 	"io"
@@ -13,7 +14,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -24,6 +24,19 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
+const agentBinaryPlaceholderContent = "Placeholder for the elastic-agent binary"
+
+const ea_123_manifest = `
+version: co.elastic.agent/v1
+kind: PackageManifest
+package:
+  version: 1.2.3
+  snapshot: true
+  versioned-home: data/elastic-agent-abcdef
+  path-mappings:
+    - data/elastic-agent-abcdef: data/elastic-agent-1.2.3-SNAPSHOT-abcdef
+      manifest.yaml: data/elastic-agent-1.2.3-SNAPSHOT-abcdef/manifest.yaml
+`
 const foo_component_spec = `
 version: 2
 inputs:
@@ -87,21 +100,22 @@ func (f files) Sys() any {
 type createArchiveFunc func(t *testing.T, archiveFiles []files) (string, error)
 type checkExtractedPath func(t *testing.T, testDataDir string)
 
-func TestUpgrader_unpack(t *testing.T) {
+func TestUpgrader_unpackTarGz(t *testing.T) {
 	type args struct {
 		version          string
 		archiveGenerator createArchiveFunc
 		archiveFiles     []files
 	}
+
 	tests := []struct {
 		name       string
 		args       args
-		want       string
+		want       UnpackResult
 		wantErr    assert.ErrorAssertionFunc
 		checkFiles checkExtractedPath
 	}{
 		{
-			name: "targz with file before containing folder",
+			name: "file before containing folder",
 			args: args{
 				version: "1.2.3",
 				archiveFiles: []files{
@@ -110,7 +124,7 @@ func TestUpgrader_unpack(t *testing.T) {
 					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/package.version", content: "1.2.3", mode: fs.ModePerm & 0o640},
 					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
 					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef", mode: fs.ModeDir | (fs.ModePerm & 0o700)},
-					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/" + agentName, content: "Placeholder for the elastic-agent binary", mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/" + agentName, content: agentBinaryPlaceholderContent, mode: fs.ModePerm & 0o750},
 					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
 					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components/comp1", content: "Placeholder for component", mode: fs.ModePerm & 0o750},
 					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components/comp1.spec.yml", content: foo_component_spec, mode: fs.ModePerm & 0o640},
@@ -120,10 +134,12 @@ func TestUpgrader_unpack(t *testing.T) {
 					return createTarArchive(t, "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64.tar.gz", i)
 				},
 			},
-			want:    "abcdef",
+			want: UnpackResult{
+				Hash:          "abcdef",
+				VersionedHome: filepath.Join("data", "elastic-agent-abcdef"),
+			},
 			wantErr: assert.NoError,
 			checkFiles: func(t *testing.T, testDataDir string) {
-
 				versionedHome := filepath.Join(testDataDir, "elastic-agent-abcdef")
 				require.DirExists(t, versionedHome, "directory for package.version does not exists")
 				stat, err := os.Stat(versionedHome)
@@ -133,30 +149,189 @@ func TestUpgrader_unpack(t *testing.T) {
 				assert.Equalf(t, expectedPermissions, actualPermissions, "Wrong permissions set on versioned home %q: expected %O, got %O", versionedHome, expectedPermissions, actualPermissions)
 			},
 		},
+		{
+			name: "package with manifest file",
+			args: args{
+				version: "1.2.3",
+				archiveFiles: []files{
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/manifest.yaml", content: ea_123_manifest, mode: fs.ModePerm & 0o640},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/" + agentCommitFile, content: "abcdefghijklmnopqrstuvwxyz", mode: fs.ModePerm & 0o640},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/" + agentName, content: agentBinaryPlaceholderContent, mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/package.version", content: "1.2.3", mode: fs.ModePerm & 0o640},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components/comp1", content: "Placeholder for component", mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components/comp1.spec.yml", content: foo_component_spec, mode: fs.ModePerm & 0o640},
+					{fType: SYMLINK, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/" + agentName, content: "data/elastic-agent-abcdef/" + agentName, mode: fs.ModeSymlink | (fs.ModePerm & 0o750)},
+				},
+				archiveGenerator: func(t *testing.T, i []files) (string, error) {
+					return createTarArchive(t, "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64.tar.gz", i)
+				},
+			},
+			want: UnpackResult{
+				Hash:          "abcdef",
+				VersionedHome: "data/elastic-agent-1.2.3-SNAPSHOT-abcdef",
+			},
+			wantErr: assert.NoError,
+			checkFiles: func(t *testing.T, testDataDir string) {
+				versionedHome := filepath.Join(testDataDir, "elastic-agent-1.2.3-SNAPSHOT-abcdef")
+				require.DirExists(t, versionedHome, "mapped versioned home directory does not exists")
+				mappedAgentExecutable := filepath.Join(versionedHome, agentName)
+				if assert.FileExistsf(t, mappedAgentExecutable, "agent executable %q is not found in mapped versioned home directory %q", mappedAgentExecutable, versionedHome) {
+					fileBytes, err := os.ReadFile(mappedAgentExecutable)
+					if assert.NoErrorf(t, err, "error reading elastic-agent executable %q", mappedAgentExecutable) {
+						assert.Equal(t, agentBinaryPlaceholderContent, string(fileBytes), "agent binary placeholder content does not match")
+					}
+				}
+				mappedPackageManifest := filepath.Join(versionedHome, "manifest.yaml")
+				if assert.FileExistsf(t, mappedPackageManifest, "package manifest %q is not found in mapped versioned home directory %q", mappedPackageManifest, versionedHome) {
+					fileBytes, err := os.ReadFile(mappedPackageManifest)
+					if assert.NoErrorf(t, err, "error reading package manifest %q", mappedPackageManifest) {
+						assert.Equal(t, ea_123_manifest, string(fileBytes), "package manifest content does not match")
+					}
+				}
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if runtime.GOOS == "windows" {
-				t.Skip("tar.gz tests only run on Linux/MacOS")
+			testTop := t.TempDir()
+			testDataDir := filepath.Join(testTop, "data")
+			err := os.MkdirAll(testDataDir, 0o777)
+			assert.NoErrorf(t, err, "error creating initial structure %q", testDataDir)
+			log, _ := logger.NewTesting(tt.name)
+
+			archiveFile, err := tt.args.archiveGenerator(t, tt.args.archiveFiles)
+			require.NoError(t, err, "creation of test archive file failed")
+
+			got, err := untar(log, tt.args.version, archiveFile, testDataDir)
+			if !tt.wantErr(t, err, fmt.Sprintf("untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)) {
+				return
 			}
+			assert.Equalf(t, tt.want, got, "untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)
+			if tt.checkFiles != nil {
+				tt.checkFiles(t, testDataDir)
+			}
+		})
+	}
+}
+
+func TestUpgrader_unpackZip(t *testing.T) {
+	type args struct {
+		archiveGenerator createArchiveFunc
+		archiveFiles     []files
+	}
+
+	tests := []struct {
+		name       string
+		args       args
+		want       UnpackResult
+		wantErr    assert.ErrorAssertionFunc
+		checkFiles checkExtractedPath
+	}{
+		{
+			name: "file before containing folder",
+			args: args{
+				archiveFiles: []files{
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/" + agentCommitFile, content: "abcdefghijklmnopqrstuvwxyz", mode: fs.ModePerm & 0o640},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/package.version", content: "1.2.3", mode: fs.ModePerm & 0o640},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef", mode: fs.ModeDir | (fs.ModePerm & 0o700)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/" + agentName, content: agentBinaryPlaceholderContent, mode: fs.ModePerm & 0o750},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components/comp1", content: "Placeholder for component", mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components/comp1.spec.yml", content: foo_component_spec, mode: fs.ModePerm & 0o640},
+				},
+				archiveGenerator: func(t *testing.T, i []files) (string, error) {
+					return createZipArchive(t, "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64.zip", i)
+				},
+			},
+			want: UnpackResult{
+				Hash:          "abcdef",
+				VersionedHome: filepath.Join("data", "elastic-agent-abcdef"),
+			},
+			wantErr: assert.NoError,
+			checkFiles: func(t *testing.T, testDataDir string) {
+				versionedHome := filepath.Join(testDataDir, "elastic-agent-abcdef")
+				require.DirExists(t, versionedHome, "directory for package.version does not exists")
+				stat, err := os.Stat(versionedHome)
+				require.NoErrorf(t, err, "error calling Stat() for versionedHome %q", versionedHome)
+				expectedPermissions := fs.ModePerm & 0o700
+				actualPermissions := fs.ModePerm & stat.Mode()
+				assert.Equalf(t, expectedPermissions, actualPermissions, "Wrong permissions set on versioned home %q: expected %O, got %O", versionedHome, expectedPermissions, actualPermissions)
+				agentExecutable := filepath.Join(versionedHome, agentName)
+				if assert.FileExistsf(t, agentExecutable, "agent executable %q is not found in versioned home directory %q", agentExecutable, versionedHome) {
+					fileBytes, err := os.ReadFile(agentExecutable)
+					if assert.NoErrorf(t, err, "error reading elastic-agent executable %q", agentExecutable) {
+						assert.Equal(t, agentBinaryPlaceholderContent, string(fileBytes), "agent binary placeholder content does not match")
+					}
+				}
+			},
+		},
+		{
+			name: "package with manifest file",
+			args: args{
+				archiveFiles: []files{
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/manifest.yaml", content: ea_123_manifest, mode: fs.ModePerm & 0o640},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/" + agentCommitFile, content: "abcdefghijklmnopqrstuvwxyz", mode: fs.ModePerm & 0o640},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/" + agentName, content: agentBinaryPlaceholderContent, mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/package.version", content: "1.2.3", mode: fs.ModePerm & 0o640},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components/comp1", content: "Placeholder for component", mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components/comp1.spec.yml", content: foo_component_spec, mode: fs.ModePerm & 0o640},
+				},
+				archiveGenerator: func(t *testing.T, i []files) (string, error) {
+					return createZipArchive(t, "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64.zip", i)
+				},
+			},
+			want: UnpackResult{
+				Hash:          "abcdef",
+				VersionedHome: filepath.Join("data", "elastic-agent-1.2.3-SNAPSHOT-abcdef"),
+			},
+			wantErr: assert.NoError,
+			checkFiles: func(t *testing.T, testDataDir string) {
+				versionedHome := filepath.Join(testDataDir, "elastic-agent-1.2.3-SNAPSHOT-abcdef")
+				require.DirExists(t, versionedHome, "mapped versioned home directory does not exists")
+				mappedAgentExecutable := filepath.Join(versionedHome, agentName)
+				if assert.FileExistsf(t, mappedAgentExecutable, "agent executable %q is not found in mapped versioned home directory %q", mappedAgentExecutable, versionedHome) {
+					fileBytes, err := os.ReadFile(mappedAgentExecutable)
+					if assert.NoErrorf(t, err, "error reading elastic-agent executable %q", mappedAgentExecutable) {
+						assert.Equal(t, agentBinaryPlaceholderContent, string(fileBytes), "agent binary placeholder content does not match")
+					}
+				}
+				mappedPackageManifest := filepath.Join(versionedHome, "manifest.yaml")
+				if assert.FileExistsf(t, mappedPackageManifest, "package manifest %q is not found in mapped versioned home directory %q", mappedPackageManifest, versionedHome) {
+					fileBytes, err := os.ReadFile(mappedPackageManifest)
+					if assert.NoErrorf(t, err, "error reading package manifest %q", mappedPackageManifest) {
+						assert.Equal(t, ea_123_manifest, string(fileBytes), "package manifest content does not match")
+					}
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 
 			testTop := t.TempDir()
 			testDataDir := filepath.Join(testTop, "data")
 			err := os.MkdirAll(testDataDir, 0o777)
 			assert.NoErrorf(t, err, "error creating initial structure %q", testDataDir)
 			log, _ := logger.NewTesting(tt.name)
-			u := &Upgrader{
-				log: log,
-			}
 
 			archiveFile, err := tt.args.archiveGenerator(t, tt.args.archiveFiles)
 			require.NoError(t, err, "creation of test archive file failed")
 
-			got, err := u.unpack(tt.args.version, archiveFile, testDataDir)
-			if !tt.wantErr(t, err, fmt.Sprintf("unpack(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)) {
+			got, err := unzip(log, archiveFile, testDataDir)
+			if !tt.wantErr(t, err, fmt.Sprintf("unzip(%v, %v)", archiveFile, testDataDir)) {
 				return
 			}
-			assert.Equalf(t, tt.want, got, "unpack(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)
+			assert.Equalf(t, tt.want, got, "unzip(%v, %v)", archiveFile, testDataDir)
 			if tt.checkFiles != nil {
 				tt.checkFiles(t, testDataDir)
 			}
@@ -165,20 +340,23 @@ func TestUpgrader_unpack(t *testing.T) {
 }
 
 func createTarArchive(t *testing.T, archiveName string, archiveFiles []files) (string, error) {
-
+	t.Helper()
 	outDir := t.TempDir()
 
 	outFilePath := filepath.Join(outDir, archiveName)
 	file, err := os.OpenFile(outFilePath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
 	require.NoErrorf(t, err, "error creating output archive %q", outFilePath)
-	defer file.Close()
+	defer func(file *os.File) {
+		err := file.Close()
+		assert.NoError(t, err, "error closing tar.gz archive file")
+	}(file)
 	zipWriter := gzip.NewWriter(file)
 	writer := tar.NewWriter(zipWriter)
 	defer func(writer *tar.Writer) {
 		err := writer.Close()
-		require.NoError(t, err, "error closing tar writer")
+		assert.NoError(t, err, "error closing tar writer")
 		err = zipWriter.Close()
-		require.NoError(t, err, "error closing gzip writer")
+		assert.NoError(t, err, "error closing gzip writer")
 	}(writer)
 
 	for _, af := range archiveFiles {
@@ -208,5 +386,64 @@ func addEntryToTarArchive(af files, writer *tar.Writer) error {
 	if _, err = io.Copy(writer, strings.NewReader(af.content)); err != nil {
 		return fmt.Errorf("copying file %q content: %w", af.path, err)
 	}
+	return nil
+}
+
+func createZipArchive(t *testing.T, archiveName string, archiveFiles []files) (string, error) {
+	t.Helper()
+	outDir := t.TempDir()
+
+	outFilePath := filepath.Join(outDir, archiveName)
+	file, err := os.OpenFile(outFilePath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
+	require.NoErrorf(t, err, "error creating output archive %q", outFilePath)
+	defer func(file *os.File) {
+		err := file.Close()
+		assert.NoError(t, err, "error closing zip archive file")
+	}(file)
+
+	w := zip.NewWriter(file)
+	defer func(writer *zip.Writer) {
+		err := writer.Close()
+		assert.NoError(t, err, "error closing tar writer")
+	}(w)
+
+	for _, af := range archiveFiles {
+		if af.fType == SYMLINK {
+			return "", fmt.Errorf("entry %q is a symlink. Not supported in .zip files", af.path)
+		}
+
+		err = addEntryToZipArchive(af, w)
+		require.NoErrorf(t, err, "error adding %q to tar archive", af.path)
+	}
+	return outFilePath, nil
+}
+
+func addEntryToZipArchive(af files, writer *zip.Writer) error {
+	header, err := zip.FileInfoHeader(&af)
+	if err != nil {
+		return fmt.Errorf("creating header for %q: %w", af.path, err)
+	}
+
+	header.SetMode(af.Mode() & os.ModePerm)
+	header.Name = af.path
+	if af.IsDir() {
+		header.Name += string(filepath.Separator)
+	} else {
+		header.Method = zip.Deflate
+	}
+
+	w, err := writer.CreateHeader(header)
+	if err != nil {
+		return err
+	}
+
+	if af.IsDir() {
+		return nil
+	}
+
+	if _, err = io.Copy(w, strings.NewReader(af.content)); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -179,17 +179,18 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	if newHash == "" {
 		return nil, errors.New("unknown hash")
 	}
-	if unpackRes.versionedHome == "" {
+
+	if unpackRes.VersionedHome == "" {
 		// FIXME this should be treated as an error
 		return nil, fmt.Errorf("versionedhome is empty: %v", unpackRes)
 	}
 
-	if strings.HasPrefix(release.Commit(), newHash) {
-		u.log.Warn("Upgrade action skipped: upgrade did not occur because its the same version")
-		return nil, nil
-	}
+	//if strings.HasPrefix(release.Commit(), newHash) {
+	//	u.log.Warn("Upgrade action skipped: upgrade did not occur because its the same version")
+	//	return nil, nil
+	//}
 
-	newHome := filepath.Join(paths.Top(), unpackRes.versionedHome)
+	newHome := filepath.Join(paths.Top(), unpackRes.VersionedHome)
 
 	if err := copyActionStore(u.log, newHome); err != nil {
 		return nil, errors.New(err, "failed to copy action store")
@@ -205,7 +206,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	det.SetState(details.StateReplacing)
 
 	// create symlink to the <new versioned-home>/elastic-agent
-	hashedDir := unpackRes.versionedHome
+	hashedDir := unpackRes.VersionedHome
 
 	symlinkPath := filepath.Join(paths.Top(), agentName)
 

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -97,7 +97,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		// if we're not within grace and marker is still there it might mean
 		// that cleanup was not performed ok, cleanup everything except current version
 		// hash is the same as hash of agent which initiated watcher.
-		if err := upgrade.Cleanup(log, release.ShortCommit(), true, false); err != nil {
+		if err := upgrade.Cleanup(log, marker.VersionedHome, release.ShortCommit(), true, false); err != nil {
 			log.Error("clean up of prior watcher run failed", err)
 		}
 		// exit nicely
@@ -114,7 +114,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		log.Error("Error detected, proceeding to rollback: %v", err)
 
 		upgradeDetails.SetState(details.StateRollback)
-		err = upgrade.Rollback(ctx, log, marker.PrevHash, marker.Hash)
+		err = upgrade.Rollback(ctx, log, marker.PrevVersionedHome, marker.PrevHash, marker.Hash)
 		if err != nil {
 			log.Error("rollback failed", err)
 			upgradeDetails.Fail(err)
@@ -132,7 +132,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 	// Why is this being skipped on Windows? The comment above is not clear.
 	// issue: https://github.com/elastic/elastic-agent/issues/3027
 	removeMarker := !isWindows()
-	err = upgrade.Cleanup(log, marker.Hash, removeMarker, false)
+	err = upgrade.Cleanup(log, marker.VersionedHome, marker.Hash, removeMarker, false)
 	if err != nil {
 		log.Error("cleanup after successful watch failed", err)
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This is a subset of a bigger PR #3950, so CI is not expected to be green, especially regarding the integration tests.

This PR uses the package manifest included in elastic-agent packages to map the package contents onto disk when upgrading . In the context of #2579 the path mapping is used to install the agent we are upgrading to in a directory like `data/elastic-agent-<package version>-<hash>`.

The upgrade process now looks for the package manifest file and copies the files in the archive after mapping the name using the path mappings in the manifest. This means that also the new agent will end up in `data/elastic-agent-<package version>-<hash>`

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This PR is needed to ensure that new versions of agents get installed to a new path containing the version from a package `data/elastic-agent-<package version>-<hash>` that still uses the legacy structure `data/elastic-agent-<hash>` for backward compatibility. In practice it allows for upgrading to an agent version built from the same commit as the existing agent as long as the package version is different (the goal of #2579)

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
To test this PR locally, we package elastic-agent twice from the same commit specifying a different AGENT_PACKAGE_VERSION like:
```
EXTERNAL=true SNAPSHOT=true PLATFORMS="linux/amd64" PACKAGES="tar.gz"  mage package
```
and
```
AGENT_PACKAGE_VERSION=8.13.0-repackaged EXTERNAL=true SNAPSHOT=true PLATFORMS="linux/amd64" PACKAGES="tar.gz"  mage package
```

Install the first agent package and verify that it's healthy and it runs from `data/elastic-agent-8.13.0-SNAPSHOT-<hash>` directory.
Upgrade this agent using the second package
```
elastic-agent upgrade 8.13.0-repackaged-SNAPSHOT --source-uri file://<directory where the package is located on disk> --skip-verify
```

Upgrade will unpack and store the new agent in `data/elastic-agent-8.13.0-repackaged-<hash>` and rotate the links.
Verify the agent directory structure contains the 2 distinct directories (you have to do it before the grace period ends).

*Known issues*:
- When the grace period expires the watcher will break the agent install since it will clean anything that does not look like `elastic-agent-<hash>`, this is addressed already in a follow-up PR
- An extra `elastic-agent-<hash>` directory is created during upgrade due to using the wrong path during copy of component states. This is addressed in a follow-up PR
- This has been tested only on Linux. MacOS and Windows fixes will come in a follow-up PR (we need small modifications to make this work mostly related to OS-dependent agent paths).
- To clean up the broken agent using uninstall (it can be done manually as well but I find this more convenient):
  1. remove the broken symlink in `/opt/Elastic/Agent`
  2. use the extracted package to force  install the agent again `./elastic-agent install --force`
  3. remove using uninstall `sudo elastic-agent uninstall`


## Related issues

- Relates #2579 
- Relates #3950 
- Requires #4173


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
