### PR TITLE
Support version in watcher cleanup rollback

### DIFF
--- a/internal/pkg/agent/application/paths/common.go
+++ b/internal/pkg/agent/application/paths/common.go
@@ -167,11 +167,16 @@ func ExternalInputs() string {
 
 // Data returns the data directory for Agent
 func Data() string {
+	return DataFrom(Top())
+}
+
+// DataFrom returns the data directory for Agent using the passed directory as top path
+func DataFrom(topDirPath string) string {
 	if unversionedHome {
 		// unversioned means the topPath is the data path
-		return topPath
+		return topDirPath
 	}
-	return filepath.Join(Top(), "data")
+	return filepath.Join(topDirPath, "data")
 }
 
 // Run returns the run directory for Agent

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -72,7 +72,7 @@ func Cleanup(log *logger.Logger, currentVersionedHome, currentHash string, remov
 
 	// remove upgrade marker
 	if removeMarker {
-		if err := CleanMarker(log); err != nil {
+		if err := CleanMarker(log, paths.Data()); err != nil {
 			return err
 		}
 	}
@@ -89,8 +89,8 @@ func Cleanup(log *logger.Logger, currentVersionedHome, currentHash string, remov
 	}
 
 	// remove symlink to avoid upgrade failures, ignore error
-	prevSymlink := prevSymlinkPath()
-	log.Infow("Removing previous symlink path", "file.path", prevSymlinkPath())
+	prevSymlink := prevSymlinkPath(paths.Top())
+	log.Infow("Removing previous symlink path", "file.path", prevSymlinkPath(paths.Top()))
 	_ = os.Remove(prevSymlink)
 
 	dirPrefix := fmt.Sprintf("%s-", agentName)

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
@@ -91,26 +92,9 @@ func TestCleanup(t *testing.T) {
 			},
 			wantErr: assert.NoError,
 			checkAfterCleanup: func(t *testing.T, topDir string) {
-				// the old agent directory must not exist anymore
-				oldAgentHome := "elastic-agent-abcdef"
-				assert.NoDirExists(t, filepath.Join(topDir, "data", oldAgentHome), "old agent directory should be deleted after cleanup")
-				newAgentHome := "elastic-agent-ghijkl"
-				assert.DirExists(t, filepath.Join(topDir, "data", newAgentHome), "new agent directory should exist after cleanup")
-				agentExecutable := agentName
-				if runtime.GOOS == "windows" {
-					agentExecutable += ".exe"
-				}
-				symlinkPath := filepath.Join(topDir, agentExecutable)
-				linkTarget, err := os.Readlink(symlinkPath)
-				if assert.NoError(t, err, "unable to read symbolic link") {
-					assert.Equal(t, filepath.Join("data", newAgentHome, agentExecutable), linkTarget, "symbolic link should point to the new agent executable after cleanup")
-				}
-
-				// read the elastic agent placeholder via the symlink
-				elasticAgentBytes, err := os.ReadFile(symlinkPath)
-				if assert.NoError(t, err, "error reading elastic-agent content through the symlink") {
-					assert.Equal(t, []byte("Placeholder for agent 4.5.6-SNAPSHOT"), elasticAgentBytes, "reading elastic-agent content through symbolic link should point to the new version")
-				}
+				oldAgentHome := filepath.Join("data", "elastic-agent-abcdef")
+				newAgentHome := filepath.Join("data", "elastic-agent-ghijkl")
+				checkFilesAfterCleanup(t, topDir, oldAgentHome, newAgentHome)
 			},
 		},
 		{
@@ -138,27 +122,9 @@ func TestCleanup(t *testing.T) {
 			},
 			wantErr: assert.NoError,
 			checkAfterCleanup: func(t *testing.T, topDir string) {
-				// the old agent directory must not exist anymore
-				oldAgentHome := "elastic-agent-1.2.3-SNAPSHOT-abcdef"
-				assert.NoDirExists(t, filepath.Join(topDir, "data", oldAgentHome), "old agent directory should be deleted after cleanup")
-
-				newAgentHome := "elastic-agent-4.5.6-SNAPSHOT-ghijkl"
-				assert.DirExists(t, filepath.Join(topDir, "data", newAgentHome), "new agent directory should exist after cleanup")
-				agentExecutable := agentName
-				if runtime.GOOS == "windows" {
-					agentExecutable += ".exe"
-				}
-				symlinkPath := filepath.Join(topDir, agentExecutable)
-				linkTarget, err := os.Readlink(symlinkPath)
-				if assert.NoError(t, err, "unable to read symbolic link") {
-					assert.Equal(t, filepath.Join("data", newAgentHome, agentExecutable), linkTarget, "symbolic link should point to the new agent executable after cleanup")
-				}
-
-				// read the elastic agent placeholder via the symlink
-				elasticAgentBytes, err := os.ReadFile(symlinkPath)
-				if assert.NoError(t, err, "error reading elastic-agent content through the symlink") {
-					assert.Equal(t, []byte("Placeholder for agent 4.5.6-SNAPSHOT"), elasticAgentBytes, "reading elastic-agent content through symbolic link should point to the new version")
-				}
+				oldAgentHome := filepath.Join("data", "elastic-agent-1.2.3-SNAPSHOT-abcdef")
+				newAgentHome := filepath.Join("data", "elastic-agent-4.5.6-SNAPSHOT-ghijkl")
+				checkFilesAfterCleanup(t, topDir, oldAgentHome, newAgentHome)
 			},
 		},
 		{
@@ -186,27 +152,9 @@ func TestCleanup(t *testing.T) {
 			},
 			wantErr: assert.NoError,
 			checkAfterCleanup: func(t *testing.T, topDir string) {
-				// the old agent directory must not exist anymore
-				oldAgentHome := "elastic-agent-abcdef"
-				assert.NoDirExists(t, filepath.Join(topDir, "data", oldAgentHome), "old agent directory should be deleted after cleanup")
-
-				newAgentHome := "elastic-agent-4.5.6-SNAPSHOT-ghijkl"
-				assert.DirExists(t, filepath.Join(topDir, "data", newAgentHome), "new agent directory should exist after cleanup")
-				agentExecutable := agentName
-				if runtime.GOOS == "windows" {
-					agentExecutable += ".exe"
-				}
-				symlinkPath := filepath.Join(topDir, agentExecutable)
-				linkTarget, err := os.Readlink(symlinkPath)
-				if assert.NoError(t, err, "unable to read symbolic link") {
-					assert.Equal(t, filepath.Join("data", newAgentHome, agentExecutable), linkTarget, "symbolic link should point to the new agent executable after cleanup")
-				}
-
-				// read the elastic agent placeholder via the symlink
-				elasticAgentBytes, err := os.ReadFile(symlinkPath)
-				if assert.NoError(t, err, "error reading elastic-agent content through the symlink") {
-					assert.Equal(t, []byte("Placeholder for agent 4.5.6-SNAPSHOT"), elasticAgentBytes, "reading elastic-agent content through symbolic link should point to the new version")
-				}
+				oldAgentHome := filepath.Join("data", "elastic-agent-abcdef")
+				newAgentHome := filepath.Join("data", "elastic-agent-4.5.6-SNAPSHOT-ghijkl")
+				checkFilesAfterCleanup(t, topDir, oldAgentHome, newAgentHome)
 			},
 		},
 	}
@@ -218,7 +166,11 @@ func TestCleanup(t *testing.T) {
 				tt.additionalSetup(t, testTop)
 			}
 			testLogger, _ := logger.NewTesting(t.Name())
-			tt.wantErr(t, Cleanup(testLogger, testTop, tt.args.currentVersionedHome, tt.args.currentHash, tt.args.removeMarker, tt.args.keepLogs), fmt.Sprintf("Cleanup(%v, %v, %v, %v)", tt.args.currentVersionedHome, tt.args.currentHash, tt.args.removeMarker, tt.args.keepLogs))
+			marker, err := LoadMarker(paths.DataFrom(testTop))
+			require.NoError(t, err, "error loading update marker")
+			require.NotNil(t, marker, "loaded marker must not be nil")
+			t.Logf("Loaded update marker %+v", marker)
+			tt.wantErr(t, Cleanup(testLogger, testTop, marker.VersionedHome, marker.Hash, tt.args.removeMarker, tt.args.keepLogs), fmt.Sprintf("Cleanup(%v, %v, %v, %v)", marker.VersionedHome, marker.Hash, tt.args.removeMarker, tt.args.keepLogs))
 			tt.checkAfterCleanup(t, testTop)
 		})
 	}
@@ -233,9 +185,11 @@ func TestRollback(t *testing.T) {
 		currentHash       string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr assert.ErrorAssertionFunc
+		name               string
+		agentInstallsSetup setupAgentInstallations
+		additionalSetup    hookFunc
+		args               args
+		wantErr            assert.ErrorAssertionFunc
 	}{
 		// TODO: Add test cases.
 	}
@@ -246,6 +200,35 @@ func TestRollback(t *testing.T) {
 	}
 }
 
+// checkFilesAfterCleanup is a convenience function to check the file structure within topDir.
+// *AgentHome paths must be the expected old and new agent paths relative to topDir (typically in the form of "data/elastic-agent-*")
+func checkFilesAfterCleanup(t *testing.T, topDir, oldAgentHome, newAgentHome string) {
+	t.Helper()
+	// the old agent directory must not exist anymore
+	assert.NoDirExists(t, filepath.Join(topDir, oldAgentHome), "old agent directory should be deleted after cleanup")
+
+	// check the new agent home
+	assert.DirExists(t, filepath.Join(topDir, newAgentHome), "new agent directory should exist after cleanup")
+	agentExecutable := agentName
+	if runtime.GOOS == "windows" {
+		agentExecutable += ".exe"
+	}
+	symlinkPath := filepath.Join(topDir, agentExecutable)
+	linkTarget, err := os.Readlink(symlinkPath)
+	if assert.NoError(t, err, "unable to read symbolic link") {
+		assert.Equal(t, filepath.Join(newAgentHome, agentExecutable), linkTarget, "symbolic link should point to the new agent executable after cleanup")
+	}
+
+	// read the elastic agent placeholder via the symlink
+	elasticAgentBytes, err := os.ReadFile(symlinkPath)
+	if assert.NoError(t, err, "error reading elastic-agent content through the symlink") {
+		assert.Equal(t, []byte("Placeholder for agent 4.5.6-SNAPSHOT"), elasticAgentBytes, "reading elastic-agent content through symbolic link should point to the new version")
+	}
+
+	assert.NoFileExists(t, filepath.Join(topDir, "data", markerFilename), "update marker should have been cleaned up")
+}
+
+// setupAgents create fake agent installs, update marker file and symlink pointing to one of the installations' elastic-agent placeholder
 func setupAgents(t *testing.T, topDir string, installations setupAgentInstallations) {
 
 	var (
@@ -253,6 +236,7 @@ func setupAgents(t *testing.T, topDir string, installations setupAgentInstallati
 		oldAgentVersionedHome string
 		newAgentVersion       agentVersion
 		newAgentVersionedHome string
+		useNewMarker          bool
 	)
 	for _, ia := range installations.installedAgents {
 		versionedHome := createFakeAgentInstall(t, topDir, ia.version.version, ia.version.hash, ia.useVersionInPath)
@@ -267,6 +251,7 @@ func setupAgents(t *testing.T, topDir string, installations setupAgentInstallati
 			t.Logf("Setting version %+v as TO version for the update marker", ia.version)
 			newAgentVersion = ia.version
 			newAgentVersionedHome = versionedHome
+			useNewMarker = ia.useVersionInPath
 		}
 
 		if installations.currentAgent == ia.version {
@@ -276,9 +261,11 @@ func setupAgents(t *testing.T, topDir string, installations setupAgentInstallati
 	}
 
 	t.Logf("Creating upgrade marker from %+v located at %q to %+v located at %q", oldAgentVersion, oldAgentVersionedHome, newAgentVersion, newAgentVersionedHome)
-	createUpdateMarker(t, topDir, newAgentVersion.version, newAgentVersion.hash, newAgentVersionedHome, oldAgentVersion.version, oldAgentVersion.hash, oldAgentVersionedHome)
+	createUpdateMarker(t, topDir, newAgentVersion.version, newAgentVersion.hash, newAgentVersionedHome, oldAgentVersion.version, oldAgentVersion.hash, oldAgentVersionedHome, useNewMarker)
 }
 
+// createFakeAgentInstall will create a mock agent install within topDir, possibly using the version in the directory name, depending on useVersionInPath
+// it MUST return the path to the created versionedHome relative to topDir, to mirror what step_unpack returns
 func createFakeAgentInstall(t *testing.T, topDir, version, hash string, useVersionInPath bool) string {
 
 	// create versioned home
@@ -287,8 +274,8 @@ func createFakeAgentInstall(t *testing.T, topDir, version, hash string, useVersi
 		// use the version passed as parameter
 		versionedHome = fmt.Sprintf("elastic-agent-%s-%s", version, hash[:hashLen])
 	}
-
-	absVersionedHomePath := filepath.Join(topDir, "data", versionedHome)
+	relVersionedHomePath := filepath.Join("data", versionedHome)
+	absVersionedHomePath := filepath.Join(topDir, relVersionedHomePath)
 	err := os.MkdirAll(absVersionedHomePath, 0o750)
 	require.NoError(t, err, "error creating fake install versioned home directory %q", absVersionedHomePath)
 
@@ -314,7 +301,9 @@ func createFakeAgentInstall(t *testing.T, topDir, version, hash string, useVersi
 	require.NoErrorf(t, err, "error writing elastic agent binary placeholder %q", agentExecutableName)
 	err = os.WriteFile(filepath.Join(absLogsDirPath, "fakelog.ndjson"), []byte(fmt.Sprintf("Sample logs for agent %s", version)), 0o750)
 	require.NoErrorf(t, err, "error writing fake log placeholder %q")
-	return versionedHome
+
+	// return the path relative to top exactly like the step_unpack does
+	return relVersionedHomePath
 }
 
 func createLink(t *testing.T, topDir string, currentAgentVersionedHome string) {
@@ -324,11 +313,18 @@ func createLink(t *testing.T, topDir string, currentAgentVersionedHome string) {
 		linkTarget += ".exe"
 		linkName += ".exe"
 	}
-	err := os.Symlink(filepath.Join("data", linkTarget), filepath.Join(topDir, linkName))
+	err := os.Symlink(linkTarget, filepath.Join(topDir, linkName))
 	require.NoError(t, err, "error creating test symlink to fake agent install")
 }
 
-func createUpdateMarker(t *testing.T, topDir string, newAgentVersion string, newAgentHash string, newAgentVersionedHome string, oldAgentVersion string, oldAgentHash string, oldAgentVersionedHome string) {
+func createUpdateMarker(t *testing.T, topDir, newAgentVersion, newAgentHash, newAgentVersionedHome, oldAgentVersion, oldAgentHash, oldAgentVersionedHome string, useNewMarker bool) {
+
+	if !useNewMarker {
+		newAgentVersion = ""
+		newAgentVersionedHome = ""
+		oldAgentVersionedHome = ""
+	}
+
 	updMarker := UpdateMarker{
 		Version:           newAgentVersion,
 		Hash:              newAgentHash,

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -1,0 +1,350 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+)
+
+type hookFunc func(t *testing.T, topDir string)
+
+type agentVersion struct {
+	version string
+	hash    string
+}
+
+type agentInstall struct {
+	version          agentVersion
+	useVersionInPath bool
+}
+
+type setupAgentInstallations struct {
+	installedAgents []agentInstall
+	upgradeFrom     agentVersion
+	upgradeTo       agentVersion
+	currentAgent    agentVersion
+}
+
+var (
+	version123Snapshot = agentVersion{
+		version: "1.2.3-SNAPSHOT",
+		hash:    "abcdef",
+	}
+	version456Snapshot = agentVersion{
+		version: "4.5.6-SNAPSHOT",
+		hash:    "ghijkl",
+	}
+)
+
+func TestCleanup(t *testing.T) {
+	type args struct {
+		currentVersionedHome string
+		currentHash          string
+		removeMarker         bool
+		keepLogs             bool
+	}
+
+	tests := []struct {
+		name               string
+		args               args
+		agentInstallsSetup setupAgentInstallations
+		additionalSetup    hookFunc
+		wantErr            assert.ErrorAssertionFunc
+		checkAfterCleanup  hookFunc
+	}{
+		{
+			name: "cleanup without versionedHome (legacy upgrade process)",
+			args: args{
+				currentVersionedHome: "data/elastic-agent-ghijkl",
+				currentHash:          "ghijkl",
+				removeMarker:         true,
+				keepLogs:             false,
+			},
+			agentInstallsSetup: setupAgentInstallations{
+				installedAgents: []agentInstall{
+					{
+						version:          version123Snapshot,
+						useVersionInPath: false,
+					},
+					{
+						version:          version456Snapshot,
+						useVersionInPath: false,
+					},
+				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
+			},
+			wantErr: assert.NoError,
+			checkAfterCleanup: func(t *testing.T, topDir string) {
+				// the old agent directory must not exist anymore
+				oldAgentHome := "elastic-agent-abcdef"
+				assert.NoDirExists(t, filepath.Join(topDir, "data", oldAgentHome), "old agent directory should be deleted after cleanup")
+				newAgentHome := "elastic-agent-ghijkl"
+				assert.DirExists(t, filepath.Join(topDir, "data", newAgentHome), "new agent directory should exist after cleanup")
+				agentExecutable := agentName
+				if runtime.GOOS == "windows" {
+					agentExecutable += ".exe"
+				}
+				symlinkPath := filepath.Join(topDir, agentExecutable)
+				linkTarget, err := os.Readlink(symlinkPath)
+				if assert.NoError(t, err, "unable to read symbolic link") {
+					assert.Equal(t, filepath.Join("data", newAgentHome, agentExecutable), linkTarget, "symbolic link should point to the new agent executable after cleanup")
+				}
+
+				// read the elastic agent placeholder via the symlink
+				elasticAgentBytes, err := os.ReadFile(symlinkPath)
+				if assert.NoError(t, err, "error reading elastic-agent content through the symlink") {
+					assert.Equal(t, []byte("Placeholder for agent 4.5.6-SNAPSHOT"), elasticAgentBytes, "reading elastic-agent content through symbolic link should point to the new version")
+				}
+			},
+		},
+		{
+			name: "cleanup with versionedHome (new upgrade process)",
+			args: args{
+				currentVersionedHome: "data/elastic-agent-4.5.6-SNAPSHOT-ghijkl",
+				currentHash:          "ghijkl",
+				removeMarker:         true,
+				keepLogs:             false,
+			},
+			agentInstallsSetup: setupAgentInstallations{
+				installedAgents: []agentInstall{
+					{
+						version:          version123Snapshot,
+						useVersionInPath: true,
+					},
+					{
+						version:          version456Snapshot,
+						useVersionInPath: true,
+					},
+				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
+			},
+			wantErr: assert.NoError,
+			checkAfterCleanup: func(t *testing.T, topDir string) {
+				// the old agent directory must not exist anymore
+				oldAgentHome := "elastic-agent-1.2.3-SNAPSHOT-abcdef"
+				assert.NoDirExists(t, filepath.Join(topDir, "data", oldAgentHome), "old agent directory should be deleted after cleanup")
+
+				newAgentHome := "elastic-agent-4.5.6-SNAPSHOT-ghijkl"
+				assert.DirExists(t, filepath.Join(topDir, "data", newAgentHome), "new agent directory should exist after cleanup")
+				agentExecutable := agentName
+				if runtime.GOOS == "windows" {
+					agentExecutable += ".exe"
+				}
+				symlinkPath := filepath.Join(topDir, agentExecutable)
+				linkTarget, err := os.Readlink(symlinkPath)
+				if assert.NoError(t, err, "unable to read symbolic link") {
+					assert.Equal(t, filepath.Join("data", newAgentHome, agentExecutable), linkTarget, "symbolic link should point to the new agent executable after cleanup")
+				}
+
+				// read the elastic agent placeholder via the symlink
+				elasticAgentBytes, err := os.ReadFile(symlinkPath)
+				if assert.NoError(t, err, "error reading elastic-agent content through the symlink") {
+					assert.Equal(t, []byte("Placeholder for agent 4.5.6-SNAPSHOT"), elasticAgentBytes, "reading elastic-agent content through symbolic link should point to the new version")
+				}
+			},
+		},
+		{
+			name: "cleanup with versionedHome only on the new agent (new upgrade process from an old agent upgraded with legacy process)",
+			args: args{
+				currentVersionedHome: "data/elastic-agent-4.5.6-SNAPSHOT-ghijkl",
+				currentHash:          "ghijkl",
+				removeMarker:         true,
+				keepLogs:             false,
+			},
+			agentInstallsSetup: setupAgentInstallations{
+				installedAgents: []agentInstall{
+					{
+						version:          version123Snapshot,
+						useVersionInPath: false,
+					},
+					{
+						version:          version456Snapshot,
+						useVersionInPath: true,
+					},
+				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
+			},
+			wantErr: assert.NoError,
+			checkAfterCleanup: func(t *testing.T, topDir string) {
+				// the old agent directory must not exist anymore
+				oldAgentHome := "elastic-agent-abcdef"
+				assert.NoDirExists(t, filepath.Join(topDir, "data", oldAgentHome), "old agent directory should be deleted after cleanup")
+
+				newAgentHome := "elastic-agent-4.5.6-SNAPSHOT-ghijkl"
+				assert.DirExists(t, filepath.Join(topDir, "data", newAgentHome), "new agent directory should exist after cleanup")
+				agentExecutable := agentName
+				if runtime.GOOS == "windows" {
+					agentExecutable += ".exe"
+				}
+				symlinkPath := filepath.Join(topDir, agentExecutable)
+				linkTarget, err := os.Readlink(symlinkPath)
+				if assert.NoError(t, err, "unable to read symbolic link") {
+					assert.Equal(t, filepath.Join("data", newAgentHome, agentExecutable), linkTarget, "symbolic link should point to the new agent executable after cleanup")
+				}
+
+				// read the elastic agent placeholder via the symlink
+				elasticAgentBytes, err := os.ReadFile(symlinkPath)
+				if assert.NoError(t, err, "error reading elastic-agent content through the symlink") {
+					assert.Equal(t, []byte("Placeholder for agent 4.5.6-SNAPSHOT"), elasticAgentBytes, "reading elastic-agent content through symbolic link should point to the new version")
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testTop := t.TempDir()
+			setupAgents(t, testTop, tt.agentInstallsSetup)
+			if tt.additionalSetup != nil {
+				tt.additionalSetup(t, testTop)
+			}
+			testLogger, _ := logger.NewTesting(t.Name())
+			tt.wantErr(t, Cleanup(testLogger, testTop, tt.args.currentVersionedHome, tt.args.currentHash, tt.args.removeMarker, tt.args.keepLogs), fmt.Sprintf("Cleanup(%v, %v, %v, %v)", tt.args.currentVersionedHome, tt.args.currentHash, tt.args.removeMarker, tt.args.keepLogs))
+			tt.checkAfterCleanup(t, testTop)
+		})
+	}
+}
+
+func TestRollback(t *testing.T) {
+	type args struct {
+		ctx               context.Context
+		log               *logger.Logger
+		prevVersionedHome string
+		prevHash          string
+		currentHash       string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr assert.ErrorAssertionFunc
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.wantErr(t, Rollback(tt.args.ctx, tt.args.log, tt.args.prevVersionedHome, tt.args.prevHash, tt.args.currentHash), fmt.Sprintf("Rollback(%v, %v, %v, %v, %v)", tt.args.ctx, tt.args.log, tt.args.prevVersionedHome, tt.args.prevHash, tt.args.currentHash))
+		})
+	}
+}
+
+func setupAgents(t *testing.T, topDir string, installations setupAgentInstallations) {
+
+	var (
+		oldAgentVersion       agentVersion
+		oldAgentVersionedHome string
+		newAgentVersion       agentVersion
+		newAgentVersionedHome string
+	)
+	for _, ia := range installations.installedAgents {
+		versionedHome := createFakeAgentInstall(t, topDir, ia.version.version, ia.version.hash, ia.useVersionInPath)
+		t.Logf("Created fake agent install for %+v located at %q", ia, versionedHome)
+		if installations.upgradeFrom == ia.version {
+			t.Logf("Setting version %+v as FROM version for the update marker", ia.version)
+			oldAgentVersion = ia.version
+			oldAgentVersionedHome = versionedHome
+		}
+
+		if installations.upgradeTo == ia.version {
+			t.Logf("Setting version %+v as TO version for the update marker", ia.version)
+			newAgentVersion = ia.version
+			newAgentVersionedHome = versionedHome
+		}
+
+		if installations.currentAgent == ia.version {
+			t.Logf("Creating symlink pointing to %q", versionedHome)
+			createLink(t, topDir, versionedHome)
+		}
+	}
+
+	t.Logf("Creating upgrade marker from %+v located at %q to %+v located at %q", oldAgentVersion, oldAgentVersionedHome, newAgentVersion, newAgentVersionedHome)
+	createUpdateMarker(t, topDir, newAgentVersion.version, newAgentVersion.hash, newAgentVersionedHome, oldAgentVersion.version, oldAgentVersion.hash, oldAgentVersionedHome)
+}
+
+func createFakeAgentInstall(t *testing.T, topDir, version, hash string, useVersionInPath bool) string {
+
+	// create versioned home
+	versionedHome := fmt.Sprintf("elastic-agent-%s", hash[:hashLen])
+	if useVersionInPath {
+		// use the version passed as parameter
+		versionedHome = fmt.Sprintf("elastic-agent-%s-%s", version, hash[:hashLen])
+	}
+
+	absVersionedHomePath := filepath.Join(topDir, "data", versionedHome)
+	err := os.MkdirAll(absVersionedHomePath, 0o750)
+	require.NoError(t, err, "error creating fake install versioned home directory %q", absVersionedHomePath)
+
+	// place a few directories in the fake install
+	absComponentsDirPath := filepath.Join(absVersionedHomePath, "components")
+	err = os.MkdirAll(absComponentsDirPath, 0o750)
+	require.NoError(t, err, "error creating fake install components directory %q", absVersionedHomePath)
+
+	absLogsDirPath := filepath.Join(absVersionedHomePath, "logs")
+	err = os.MkdirAll(absLogsDirPath, 0o750)
+	require.NoError(t, err, "error creating fake install logs directory %q", absLogsDirPath)
+
+	absRunDirPath := filepath.Join(absVersionedHomePath, "run")
+	err = os.MkdirAll(absRunDirPath, 0o750)
+	require.NoError(t, err, "error creating fake install run directory %q", absRunDirPath)
+
+	// put some placeholder for files
+	agentExecutableName := agentName
+	if runtime.GOOS == "windows" {
+		agentExecutableName += ".exe"
+	}
+	err = os.WriteFile(filepath.Join(absVersionedHomePath, agentExecutableName), []byte(fmt.Sprintf("Placeholder for agent %s", version)), 0o750)
+	require.NoErrorf(t, err, "error writing elastic agent binary placeholder %q", agentExecutableName)
+	err = os.WriteFile(filepath.Join(absLogsDirPath, "fakelog.ndjson"), []byte(fmt.Sprintf("Sample logs for agent %s", version)), 0o750)
+	require.NoErrorf(t, err, "error writing fake log placeholder %q")
+	return versionedHome
+}
+
+func createLink(t *testing.T, topDir string, currentAgentVersionedHome string) {
+	linkTarget := filepath.Join(currentAgentVersionedHome, agentName)
+	linkName := agentName
+	if runtime.GOOS == "windows" {
+		linkTarget += ".exe"
+		linkName += ".exe"
+	}
+	err := os.Symlink(filepath.Join("data", linkTarget), filepath.Join(topDir, linkName))
+	require.NoError(t, err, "error creating test symlink to fake agent install")
+}
+
+func createUpdateMarker(t *testing.T, topDir string, newAgentVersion string, newAgentHash string, newAgentVersionedHome string, oldAgentVersion string, oldAgentHash string, oldAgentVersionedHome string) {
+	updMarker := UpdateMarker{
+		Version:           newAgentVersion,
+		Hash:              newAgentHash,
+		VersionedHome:     newAgentVersionedHome,
+		UpdatedOn:         time.Now(),
+		PrevVersion:       oldAgentVersion,
+		PrevHash:          oldAgentHash,
+		PrevVersionedHome: oldAgentVersionedHome,
+		Acked:             true,
+		Action:            nil,
+		Details:           nil,
+	}
+
+	updMarkerSerializer := newMarkerSerializer(&updMarker)
+	updMarkerBytes, err := yaml.Marshal(updMarkerSerializer)
+	require.NoError(t, err, "error marshaling fake update marker")
+	err = os.WriteFile(filepath.Join(topDir, "data", markerFilename), updMarkerBytes, 0o600)
+	require.NoError(t, err, "error writing out fake update marker")
+}

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -59,16 +59,14 @@ func TestCleanup(t *testing.T) {
 		keepLogs             bool
 	}
 
-	tests := []struct {
-		name               string
+	tests := map[string]struct {
 		args               args
 		agentInstallsSetup setupAgentInstallations
 		additionalSetup    hookFunc
 		wantErr            assert.ErrorAssertionFunc
 		checkAfterCleanup  hookFunc
 	}{
-		{
-			name: "cleanup without versionedHome (legacy upgrade process)",
+		"cleanup without versionedHome (legacy upgrade process)": {
 			args: args{
 				currentVersionedHome: "data/elastic-agent-ghijkl",
 				currentHash:          "ghijkl",
@@ -97,8 +95,7 @@ func TestCleanup(t *testing.T) {
 				checkFilesAfterCleanup(t, topDir, newAgentHome, oldAgentHome)
 			},
 		},
-		{
-			name: "cleanup with versionedHome (new upgrade process)",
+		"cleanup with versionedHome (new upgrade process)": {
 			args: args{
 				currentVersionedHome: "data/elastic-agent-4.5.6-SNAPSHOT-ghijkl",
 				currentHash:          "ghijkl",
@@ -127,8 +124,7 @@ func TestCleanup(t *testing.T) {
 				checkFilesAfterCleanup(t, topDir, newAgentHome, oldAgentHome)
 			},
 		},
-		{
-			name: "cleanup with versionedHome only on the new agent (new upgrade process from an old agent upgraded with legacy process)",
+		"cleanup with versionedHome only on the new agent (new upgrade process from an old agent upgraded with legacy process)": {
 			args: args{
 				currentVersionedHome: "data/elastic-agent-4.5.6-SNAPSHOT-ghijkl",
 				currentHash:          "ghijkl",
@@ -157,8 +153,7 @@ func TestCleanup(t *testing.T) {
 				checkFilesAfterCleanup(t, topDir, newAgentHome, oldAgentHome)
 			},
 		},
-		{
-			name: "cleanup with versionedHome only on the new agent + extra old agent installs",
+		"cleanup with versionedHome only on the new agent + extra old agent installs": {
 			args: args{
 				currentVersionedHome: "data/elastic-agent-4.5.6-SNAPSHOT-ghijkl",
 				currentHash:          "ghijkl",
@@ -207,8 +202,8 @@ func TestCleanup(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
 			testLogger, _ := logger.NewTesting(t.Name())
 			testTop := t.TempDir()
 			setupAgents(t, testLogger, testTop, tt.agentInstallsSetup)
@@ -226,15 +221,13 @@ func TestCleanup(t *testing.T) {
 }
 
 func TestRollback(t *testing.T) {
-	tests := []struct {
-		name               string
+	tests := map[string]struct {
 		agentInstallsSetup setupAgentInstallations
 		additionalSetup    hookFunc
 		wantErr            assert.ErrorAssertionFunc
 		checkAfterRollback hookFunc
 	}{
-		{
-			name: "rollback without versionedHome (legacy upgrade process)",
+		"rollback without versionedHome (legacy upgrade process)": {
 			agentInstallsSetup: setupAgentInstallations{
 				installedAgents: []agentInstall{
 					{
@@ -257,8 +250,7 @@ func TestRollback(t *testing.T) {
 				checkFilesAfterRollback(t, topDir, oldAgentHome, newAgentHome)
 			},
 		},
-		{
-			name: "rollback with versionedHome (new upgrade process)",
+		"rollback with versionedHome (new upgrade process)": {
 			agentInstallsSetup: setupAgentInstallations{
 				installedAgents: []agentInstall{
 					{
@@ -281,8 +273,7 @@ func TestRollback(t *testing.T) {
 				checkFilesAfterRollback(t, topDir, oldAgentHome, newAgentHome)
 			},
 		},
-		{
-			name: "rollback with versionedHome only on the new agent (new upgrade process from an old agent upgraded with legacy process)",
+		"rollback with versionedHome only on the new agent (new upgrade process from an old agent upgraded with legacy process)": {
 			agentInstallsSetup: setupAgentInstallations{
 				installedAgents: []agentInstall{
 					{
@@ -306,8 +297,8 @@ func TestRollback(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
 			testLogger, _ := logger.NewTesting(t.Name())
 			testTop := t.TempDir()
 			setupAgents(t, testLogger, testTop, tt.agentInstallsSetup)

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -172,8 +172,8 @@ func UpdateActiveCommit(log *logger.Logger, hash string) error {
 }
 
 // CleanMarker removes a marker from disk.
-func CleanMarker(log *logger.Logger) error {
-	markerFile := markerFilePath(paths.Data())
+func CleanMarker(log *logger.Logger, dataDirPath string) error {
+	markerFile := markerFilePath(dataDirPath)
 	log.Infow("Removing marker file", "file.path", markerFile)
 	if err := os.Remove(markerFile); !os.IsNotExist(err) {
 		return err

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -184,8 +184,8 @@ func CleanMarker(log *logger.Logger, dataDirPath string) error {
 
 // LoadMarker loads the update marker. If the file does not exist it returns nil
 // and no error.
-func LoadMarker() (*UpdateMarker, error) {
-	return loadMarker(markerFilePath(paths.Data()))
+func LoadMarker(dataDirPath string) (*UpdateMarker, error) {
+	return loadMarker(markerFilePath(dataDirPath))
 }
 
 func loadMarker(markerFile string) (*UpdateMarker, error) {

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -147,7 +147,7 @@ func (u *Upgrader) markUpgrade(_ context.Context, log *logger.Logger, version, h
 		return errors.New(err, errors.TypeConfig, "failed to parse marker file")
 	}
 
-	markerPath := markerFilePath()
+	markerPath := markerFilePath(paths.Data())
 	log.Infow("Writing upgrade marker file", "file.path", markerPath, "hash", marker.Hash, "prev_hash", prevHash)
 	if err := os.WriteFile(markerPath, markerBytes, 0600); err != nil {
 		return errors.New(err, errors.TypeFilesystem, "failed to create update marker file", errors.M(errors.MetaKeyPath, markerPath))
@@ -173,7 +173,7 @@ func UpdateActiveCommit(log *logger.Logger, hash string) error {
 
 // CleanMarker removes a marker from disk.
 func CleanMarker(log *logger.Logger) error {
-	markerFile := markerFilePath()
+	markerFile := markerFilePath(paths.Data())
 	log.Infow("Removing marker file", "file.path", markerFile)
 	if err := os.Remove(markerFile); !os.IsNotExist(err) {
 		return err
@@ -185,7 +185,7 @@ func CleanMarker(log *logger.Logger) error {
 // LoadMarker loads the update marker. If the file does not exist it returns nil
 // and no error.
 func LoadMarker() (*UpdateMarker, error) {
-	return loadMarker(markerFilePath())
+	return loadMarker(markerFilePath(paths.Data()))
 }
 
 func loadMarker(markerFile string) (*UpdateMarker, error) {
@@ -238,9 +238,9 @@ func SaveMarker(marker *UpdateMarker, shouldFsync bool) error {
 		return err
 	}
 
-	return writeMarkerFile(markerFilePath(), markerBytes, shouldFsync)
+	return writeMarkerFile(markerFilePath(paths.Data()), markerBytes, shouldFsync)
 }
 
-func markerFilePath() string {
-	return filepath.Join(paths.Data(), markerFilename)
+func markerFilePath(dataDirPath string) string {
+	return filepath.Join(dataDirPath, markerFilename)
 }

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -153,7 +153,7 @@ func (u *Upgrader) markUpgrade(_ context.Context, log *logger.Logger, version, h
 		return errors.New(err, errors.TypeFilesystem, "failed to create update marker file", errors.M(errors.MetaKeyPath, markerPath))
 	}
 
-	if err := UpdateActiveCommit(log, hash); err != nil {
+	if err := UpdateActiveCommit(log, paths.Top(), hash); err != nil {
 		return err
 	}
 
@@ -161,8 +161,8 @@ func (u *Upgrader) markUpgrade(_ context.Context, log *logger.Logger, version, h
 }
 
 // UpdateActiveCommit updates active.commit file to point to active version.
-func UpdateActiveCommit(log *logger.Logger, hash string) error {
-	activeCommitPath := filepath.Join(paths.Top(), agentCommitFile)
+func UpdateActiveCommit(log *logger.Logger, topDirPath, hash string) error {
+	activeCommitPath := filepath.Join(topDirPath, agentCommitFile)
 	log.Infow("Updating active commit", "file.path", activeCommitPath, "hash", hash)
 	if err := os.WriteFile(activeCommitPath, []byte(hash), 0600); err != nil {
 		return errors.New(err, errors.TypeFilesystem, "failed to update active commit", errors.M(errors.MetaKeyPath, activeCommitPath))

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -43,7 +43,7 @@ func changeSymlinkInternal(log *logger.Logger, symlinkPath, newTarget string) er
 		newTarget += exe
 	}
 
-	prevNewPath := prevSymlinkPath()
+	prevNewPath := prevSymlinkPath(paths.Top())
 	log.Infow("Changing symlink", "symlink_path", symlinkPath, "new_path", newTarget, "prev_path", prevNewPath)
 
 	// remove symlink to avoid upgrade failures
@@ -59,7 +59,7 @@ func changeSymlinkInternal(log *logger.Logger, symlinkPath, newTarget string) er
 	return file.SafeFileRotate(symlinkPath, prevNewPath)
 }
 
-func prevSymlinkPath() string {
+func prevSymlinkPath(topDirPath string) string {
 	agentPrevName := agentName + ".prev"
 
 	// handle windows suffixes
@@ -67,5 +67,5 @@ func prevSymlinkPath() string {
 		agentPrevName = agentName + ".exe.prev"
 	}
 
-	return filepath.Join(paths.Top(), agentPrevName)
+	return filepath.Join(topDirPath, agentPrevName)
 }

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -23,19 +23,19 @@ const (
 )
 
 // ChangeSymlink updates symlink paths to match current version.
-func ChangeSymlink(ctx context.Context, log *logger.Logger, targetHash string) error {
+func ChangeSymlink(ctx context.Context, log *logger.Logger, topDirPath, targetHash string) error {
 	// create symlink to elastic-agent-{hash}
 	hashedDir := fmt.Sprintf("%s-%s", agentName, targetHash)
 
-	symlinkPath := filepath.Join(paths.Top(), agentName)
+	symlinkPath := filepath.Join(topDirPath, agentName)
 
 	// paths.BinaryPath properly derives the binary directory depending on the platform. The path to the binary for macOS is inside of the app bundle.
-	newPath := paths.BinaryPath(filepath.Join(paths.Top(), "data", hashedDir), agentName)
+	newPath := paths.BinaryPath(filepath.Join(paths.DataFrom(topDirPath), hashedDir), agentName)
 
-	return changeSymlinkInternal(log, symlinkPath, newPath)
+	return changeSymlinkInternal(log, topDirPath, symlinkPath, newPath)
 }
 
-func changeSymlinkInternal(log *logger.Logger, symlinkPath, newTarget string) error {
+func changeSymlinkInternal(log *logger.Logger, topDirPath, symlinkPath, newTarget string) error {
 
 	// handle windows suffixes
 	if runtime.GOOS == windows {
@@ -43,7 +43,7 @@ func changeSymlinkInternal(log *logger.Logger, symlinkPath, newTarget string) er
 		newTarget += exe
 	}
 
-	prevNewPath := prevSymlinkPath(paths.Top())
+	prevNewPath := prevSymlinkPath(topDirPath)
 	log.Infow("Changing symlink", "symlink_path", symlinkPath, "new_path", newTarget, "prev_path", prevNewPath)
 
 	// remove symlink to avoid upgrade failures

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -28,7 +28,7 @@ import (
 type UnpackResult struct {
 	// Hash contains the unpacked agent commit hash, limited to a length of 6 for backward compatibility
 	Hash string `json:"hash" yaml:"hash"`
-	// VersionedHome indicates the path (forward slash separated) where to find the unpacked agent files
+	// VersionedHome indicates the path (relative to topPath, formatted in os-dependent fashion) where to find the unpacked agent files
 	// The value depends on the mappings specified in manifest.yaml, if no manifest is found it assumes the legacy data/elastic-agent-<hash> format
 	VersionedHome string `json:"versioned-home" yaml:"versioned-home"`
 }
@@ -81,7 +81,7 @@ func unzip(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error
 			return UnpackResult{}, fmt.Errorf("parsing package manifest: %w", err)
 		}
 		pm.mappings = manifest.Package.PathMappings
-		versionedHome = path.Clean(pm.Map(manifest.Package.VersionedHome))
+		versionedHome = filepath.Clean(pm.Map(manifest.Package.VersionedHome))
 	}
 
 	// Load hash, the use of path.Join is intentional since in .zip file paths use slash ('/') as separator
@@ -210,8 +210,8 @@ func untar(log *logger.Logger, version string, archivePath, dataDir string) (Unp
 		return UnpackResult{}, fmt.Errorf("looking for package metadata files: %w", err)
 	}
 
-	manifestReader := fileContents["manifest.yaml"]
-	if manifestReader != nil {
+	manifestReader, ok := fileContents["manifest.yaml"]
+	if ok && manifestReader != nil {
 		manifest, err := v1.ParseManifest(manifestReader)
 		if err != nil {
 			return UnpackResult{}, fmt.Errorf("parsing package manifest: %w", err)
@@ -466,5 +466,5 @@ func getFilesContentFromTar(archivePath string, files ...string) (map[string]io.
 }
 
 func createVersionedHomeFromHash(hash string) string {
-	return fmt.Sprintf("data/elastic-agent-%s", hash[:hashLen])
+	return filepath.Join("data", fmt.Sprintf("elastic-agent-%s", hash[:hashLen]))
 }

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -247,7 +247,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 // Ack acks last upgrade action
 func (u *Upgrader) Ack(ctx context.Context, acker acker.Acker) error {
 	// get upgrade action
-	marker, err := LoadMarker()
+	marker, err := LoadMarker(paths.Data())
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -74,7 +74,7 @@ func NewUpgrader(log *logger.Logger, settings *artifact.Config, agentInfo *info.
 		settings:      settings,
 		agentInfo:     agentInfo,
 		upgradeable:   IsUpgradeable(),
-		markerWatcher: newMarkerFileWatcher(markerFilePath(), log),
+		markerWatcher: newMarkerFileWatcher(markerFilePath(paths.Data()), log),
 	}, nil
 }
 

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -655,7 +655,7 @@ func isProcessStatsEnabled(cfg *monitoringCfg.MonitoringConfig) bool {
 // ongoing upgrade operation, i.e. being re-exec'd and performs
 // any upgrade-specific work, if needed.
 func handleUpgrade() error {
-	upgradeMarker, err := upgrade.LoadMarker()
+	upgradeMarker, err := upgrade.LoadMarker(paths.Data())
 	if err != nil {
 		return fmt.Errorf("unable to load upgrade marker to check if Agent is being upgraded: %w", err)
 	}

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -97,7 +97,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		// if we're not within grace and marker is still there it might mean
 		// that cleanup was not performed ok, cleanup everything except current version
 		// hash is the same as hash of agent which initiated watcher.
-		if err := upgrade.Cleanup(log, marker.VersionedHome, release.ShortCommit(), true, false); err != nil {
+		if err := upgrade.Cleanup(log, paths.Top(), marker.VersionedHome, release.ShortCommit(), true, false); err != nil {
 			log.Error("clean up of prior watcher run failed", err)
 		}
 		// exit nicely
@@ -132,7 +132,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 	// Why is this being skipped on Windows? The comment above is not clear.
 	// issue: https://github.com/elastic/elastic-agent/issues/3027
 	removeMarker := !isWindows()
-	err = upgrade.Cleanup(log, marker.VersionedHome, marker.Hash, removeMarker, false)
+	err = upgrade.Cleanup(log, paths.Top(), marker.VersionedHome, marker.Hash, removeMarker, false)
 	if err != nil {
 		log.Error("cleanup after successful watch failed", err)
 	}

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -65,7 +65,7 @@ func newWatchCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command 
 
 func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 	log.Infow("Upgrade Watcher started", "process.pid", os.Getpid(), "agent.version", version.GetAgentPackageVersion())
-	marker, err := upgrade.LoadMarker()
+	marker, err := upgrade.LoadMarker(paths.Data())
 	if err != nil {
 		log.Error("failed to load marker", err)
 		return err

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/configure"
+	"github.com/elastic/elastic-agent/pkg/control/v2/client"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/filelock"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
@@ -114,7 +115,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		log.Error("Error detected, proceeding to rollback: %v", err)
 
 		upgradeDetails.SetState(details.StateRollback)
-		err = upgrade.Rollback(ctx, log, marker.PrevVersionedHome, marker.PrevHash, marker.Hash)
+		err = upgrade.Rollback(ctx, log, client.New(), paths.Top(), marker.PrevVersionedHome, marker.PrevHash)
 		if err != nil {
 			log.Error("rollback failed", err)
 			upgradeDetails.Fail(err)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This is a subset of a bigger PR #3950, so CI is not expected to be green, especially regarding the integration tests.

This PR adds new fields in the update marker so that the upgrade watcher Cleanup and Rollback processes can operate correctly with the new `elastic-agent-<version>-<hash>`.

There is some refactoring to make Cleanup() and Rollback() testable that involves injecting paths rather than obtaining through `paths.*` functions: this is needed to be able to write unit tests without calling `paths.SetTop()` which already created flakiness and introduced race conditions in our tests in the past

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Now the agent installation is correctly cleaned up leaving only the new or old version of agent installed, since the watcher is reading the correct paths from the new update marker

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Testing this PR is mostly the same as the test procedure for #4174, but now the watcher cleans the installation correctly
After the end of grace period the new agent directory should be the only left inside `/opt/Elastic/Agent/data`.
If we want to trigger a rollback, it's enough to kill the new agent a few times and then only the old agent installation will be left inside `/opt/Elastic/Agent/data`.

*Known issues*:
- This has been tested only on Linux. MacOS and Windows fixes will come in a follow-up PR (we need small modifications to make this work mostly related to OS-dependent agent paths).

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

- Relates #2579 
- Supersedes #3950 
- Requires #4173
- Requires #4174


## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
