### PR TITLE
Use watcher that supports paths in update marker

### DIFF
--- a/changelog/fragments/1706703918-Add-the-full-version-number-to-the-installation-directory-name.yaml
+++ b/changelog/fragments/1706703918-Add-the-full-version-number-to-the-installation-directory-name.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add the full version number to the installation directory name
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -312,6 +312,13 @@ func PackageManifest() (string, error) {
 		return "", fmt.Errorf("retrieving agent package version: %w", err)
 	}
 	m.Package.Version = packageVersion
+
+	hash, err := CommitHash()
+	if err != nil {
+		return "", fmt.Errorf("retrieving agent commit hash: %w", err)
+	}
+	m.Package.Hash = hash
+
 	commitHashShort, err := CommitHashShort()
 	if err != nil {
 		return "", fmt.Errorf("retrieving agent commit hash: %w", err)

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -320,7 +320,7 @@ func PackageManifest() (string, error) {
 	m.Package.VersionedHome = versionedHomePath
 	m.Package.PathMappings = []map[string]string{{}}
 	m.Package.PathMappings[0][versionedHomePath] = fmt.Sprintf("data/elastic-agent-%s%s-%s", m.Package.Version, SnapshotSuffix(), commitHashShort)
-	m.Package.PathMappings[0]["manifest.yaml"] = fmt.Sprintf("data/elastic-agent-%s%s-%s/manifest.yaml", m.Package.Version, SnapshotSuffix(), commitHashShort)
+	m.Package.PathMappings[0][v1.ManifestFileName] = fmt.Sprintf("data/elastic-agent-%s%s-%s/%s", m.Package.Version, SnapshotSuffix(), commitHashShort, v1.ManifestFileName)
 	yamlBytes, err := yaml.Marshal(m)
 	if err != nil {
 		return "", fmt.Errorf("marshaling manifest: %w", err)

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -255,6 +255,7 @@ repo.RootDir                 = {{ repo.RootDir }}
 repo.ImportPath              = {{ repo.ImportPath }}
 repo.SubDir                  = {{ repo.SubDir }}
 agent_package_version        = {{ agent_package_version}}
+snapshot_suffix              = {{ snapshot_suffix }}
 `
 
 	return Expand(dumpTemplate)

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -219,6 +219,9 @@ func checkManifestFileContents(t *testing.T, extractedPackageDir string) {
 	assert.Equal(t, v1.ManifestKind, m.Kind, "manifest specifies wrong kind")
 	assert.Equal(t, v1.VERSION, m.Version, "manifest specifies wrong api version")
 
+	assert.NotEmpty(t, m.Package.Version, "manifest version must not be empty")
+	assert.NotEmpty(t, m.Package.Hash, "manifest hash must not be empty")
+
 	if assert.NotEmpty(t, m.Package.PathMappings, "path mappings in manifest are empty") {
 		versionedHome := m.Package.VersionedHome
 		assert.DirExistsf(t, filepath.Join(extractedPackageDir, versionedHome), "versionedHome directory %q not found in %q", versionedHome, extractedPackageDir)

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -201,9 +201,9 @@ func checkZip(t *testing.T, file string) {
 
 func checkManifestFileContents(t *testing.T, extractedPackageDir string) {
 	t.Log("Checking file manifest.yaml")
-	manifestReadCloser, err := os.Open(filepath.Join(extractedPackageDir, "manifest.yaml"))
+	manifestReadCloser, err := os.Open(filepath.Join(extractedPackageDir, v1.ManifestFileName))
 	if err != nil {
-		t.Errorf("opening manifest %s : %v", "manifest.yaml", err)
+		t.Errorf("opening manifest %s : %v", v1.ManifestFileName, err)
 	}
 	defer func(closer io.ReadCloser) {
 		err := closer.Close()

--- a/dev-tools/packaging/templates/darwin/elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/darwin/elastic-agent.tmpl
@@ -6,6 +6,9 @@ set -e
 symlink="/Library/Elastic/Agent/elastic-agent"
 
 if test -L "$symlink"; then
-    ln -sfn "data/elastic-agent-{{ commit_short }}/elastic-agent.app/Contents/MacOS/elastic-agent" "$symlink"
+    symlinkTarget="data/elastic-agent-{{ commit_short }}/elastic-agent.app/Contents/MacOS/elastic-agent"
+    if test -f "data/elastic-agent-{{ agent_package_version }}{{ snapshot_suffix }}-{{ commit_short }}/elastic-agent.app/Contents/MacOS/elastic-agent"; then
+        symlinkTarget="data/elastic-agent-{{ agent_package_version }}{{ snapshot_suffix }}-{{ commit_short }}/elastic-agent.app/Contents/MacOS/elastic-agent"
+    ln -sfn "$symlinkTarget" "$symlink"
 fi
 

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -67,6 +67,12 @@ sequenceDiagram
 Starting from version 8.13.0 an additional file `manifest.yaml` is present in elastic-agent packages.
 The purpose of this file is to present some metadata and package information to be used during install/upgrade operations.
 
+The first enhancement that makes use of this package manifest is [#2579](https://github.com/elastic/elastic-agent/issues/2579)
+as we use the manifest to map the package directory structure (based on agent commit hash) into one that takes also the
+agent version into account. This allows releasing versions of the agent package where only the component versions change,
+with the agent commit unchanged.
+
+
 The [structure](../pkg/api/v1/manifest.go) of such manifest is defined in the [api/v1 package](../pkg/api/v1/).
 The manifest data is generated during packaging and the file is added to the package files. This is an example of a
 complete manifest:

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -61,3 +61,32 @@ sequenceDiagram
        end
     end
 ```
+
+### Introducing package manifest
+
+Starting from version 8.13.0 an additional file `manifest.yaml` is present in elastic-agent packages.
+The purpose of this file is to present some metadata and package information to be used during install/upgrade operations.
+
+The [structure](../pkg/api/v1/manifest.go) of such manifest is defined in the [api/v1 package](../pkg/api/v1/).
+The manifest data is generated during packaging and the file is added to the package files. This is an example of a
+complete manifest:
+
+```yaml
+version: co.elastic.agent/v1
+kind: PackageManifest
+package:
+  version: 8.13.0
+  snapshot: true
+  hash: 15658b38b48ba4487afadc5563b1576b85ce0264
+  versioned-home: data/elastic-agent-15658b
+  path-mappings:
+    - data/elastic-agent-15658b: data/elastic-agent-8.13.0-SNAPSHOT-15658b
+      manifest.yaml: data/elastic-agent-8.13.0-SNAPSHOT-15658b/manifest.yaml
+```
+
+The package information describes the package version, whether it's a snapshot build, the elastic-agent commit hash it
+has been built from and where to find the versioned home of the elastic agent within the package.
+
+Another section lists the path mappings that must be applied by an elastic-agent that is aware of the package manifest
+(version >8.13.0): these path mappings allow the incoming agent version to have some control over where the files in
+package will be stored on disk.

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -90,3 +90,21 @@ has been built from and where to find the versioned home of the elastic agent wi
 Another section lists the path mappings that must be applied by an elastic-agent that is aware of the package manifest
 (version >8.13.0): these path mappings allow the incoming agent version to have some control over where the files in
 package will be stored on disk.
+
+#### Upgrading without the manifest
+
+Legacy elastic-agent upgrade is a pretty straightforward affair:
+- Download the agent package to use for upgrade
+- Open the .zip or .tar.gz archive and iterate over the files
+  - Look for the elastic-agent commit file to retrieve the actual hash of the agent version we want to install
+  - Extract any package file under `/data` under the installed agent `/data` directory
+- After extraction check if the hash we read from the package matches with the one from the current agent:
+  - if it's the same hash the upgrade fails because we are trying to upgrade to the same version
+  - if we extracted a package with a different hash, the upgrade keeps going
+- Copy the elastic agent action store and components run directory into the new agent directories
+- Rotate the symlink in the top directory to point to the new agent executable
+- Write the update marker containing the information about the new and old agent versions in `data` directory
+- Invoke the watcher `elastic-agent watch` command to ensure that the new version of agent works correctly after restart
+- Shutdown current agent and its command components, copy components state once again and restart
+
+#### Upgrading using the manifest

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -138,13 +138,13 @@ func Cleanup(log *logger.Logger, topDirPath, currentVersionedHome, currentHash s
 
 // InvokeWatcher invokes an agent instance using watcher argument for watching behavior of
 // agent during upgrade period.
-func InvokeWatcher(log *logger.Logger) error {
+func InvokeWatcher(log *logger.Logger, agentExecutable string) error {
 	if !IsUpgradeable() {
 		log.Info("agent is not upgradable, not starting watcher")
 		return nil
 	}
 
-	cmd := invokeCmd()
+	cmd := invokeCmd(agentExecutable)
 	defer func() {
 		if cmd.Process != nil {
 			log.Infof("releasing watcher %v", cmd.Process.Pid)

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -46,7 +46,7 @@ func Rollback(ctx context.Context, log *logger.Logger, c client.Client, topDirPa
 		symlinkTarget = paths.BinaryPath(filepath.Join(paths.DataFrom(topDirPath), hashedDir), agentName)
 	}
 	// change symlink
-	if err := changeSymlinkInternal(log, topDirPath, symlinkPath, symlinkTarget); err != nil {
+	if err := ChangeSymlink(log, topDirPath, symlinkPath, symlinkTarget); err != nil {
 		return err
 	}
 

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -46,7 +46,7 @@ func Rollback(ctx context.Context, log *logger.Logger, c client.Client, topDirPa
 		symlinkTarget = paths.BinaryPath(filepath.Join(paths.DataFrom(topDirPath), hashedDir), agentName)
 	}
 	// change symlink
-	if err := ChangeSymlink(log, topDirPath, symlinkPath, symlinkTarget); err != nil {
+	if err := changeSymlink(log, topDirPath, symlinkPath, symlinkTarget); err != nil {
 		return err
 	}
 

--- a/internal/pkg/agent/application/upgrade/rollback_darwin.go
+++ b/internal/pkg/agent/application/upgrade/rollback_darwin.go
@@ -21,9 +21,9 @@ const (
 	afterRestartDelay = 2 * time.Second
 )
 
-func invokeCmd() *exec.Cmd {
+func invokeCmd(agentExecutable string) *exec.Cmd {
 	// #nosec G204 -- user cannot inject any parameters to this command
-	cmd := exec.Command(paths.TopBinaryPath(), watcherSubcommand,
+	cmd := exec.Command(agentExecutable, watcherSubcommand,
 		"--path.config", paths.Config(),
 		"--path.home", paths.Top(),
 	)

--- a/internal/pkg/agent/application/upgrade/rollback_linux.go
+++ b/internal/pkg/agent/application/upgrade/rollback_linux.go
@@ -21,9 +21,9 @@ const (
 	afterRestartDelay = 2 * time.Second
 )
 
-func invokeCmd() *exec.Cmd {
+func invokeCmd(agentExecutable string) *exec.Cmd {
 	// #nosec G204 -- user cannot inject any parameters to this command
-	cmd := exec.Command(paths.TopBinaryPath(), watcherSubcommand,
+	cmd := exec.Command(agentExecutable, watcherSubcommand,
 		"--path.config", paths.Config(),
 		"--path.home", paths.Top(),
 	)

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -28,13 +28,13 @@ type testAgentVersion struct {
 	hash    string
 }
 
-type agentInstall struct {
+type testAgentInstall struct {
 	version          testAgentVersion
 	useVersionInPath bool
 }
 
 type setupAgentInstallations struct {
-	installedAgents []agentInstall
+	installedAgents []testAgentInstall
 	upgradeFrom     testAgentVersion
 	upgradeTo       testAgentVersion
 	currentAgent    testAgentVersion
@@ -74,7 +74,7 @@ func TestCleanup(t *testing.T) {
 				keepLogs:             false,
 			},
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: false,
@@ -103,7 +103,7 @@ func TestCleanup(t *testing.T) {
 				keepLogs:             false,
 			},
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: true,
@@ -132,7 +132,7 @@ func TestCleanup(t *testing.T) {
 				keepLogs:             false,
 			},
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: false,
@@ -161,7 +161,7 @@ func TestCleanup(t *testing.T) {
 				keepLogs:             false,
 			},
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version: testAgentVersion{
 							version: "0.9.9",
@@ -229,7 +229,7 @@ func TestRollback(t *testing.T) {
 	}{
 		"rollback without versionedHome (legacy upgrade process)": {
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: false,
@@ -252,7 +252,7 @@ func TestRollback(t *testing.T) {
 		},
 		"rollback with versionedHome (new upgrade process)": {
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: true,
@@ -275,7 +275,7 @@ func TestRollback(t *testing.T) {
 		},
 		"rollback with versionedHome only on the new agent (new upgrade process from an old agent upgraded with legacy process)": {
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: false,
@@ -493,6 +493,20 @@ func createUpdateMarker(t *testing.T, log *logger.Logger, topDir, newAgentVersio
 		oldAgentVersionedHome = ""
 	}
 
-	err := markUpgrade(log, paths.DataFrom(topDir), newAgentVersion, newAgentHash, newAgentVersionedHome, oldAgentVersion, oldAgentHash, oldAgentVersionedHome, nil, nil)
+	newAgentInstall := agentInstall{
+		version:       newAgentVersion,
+		hash:          newAgentHash,
+		versionedHome: newAgentVersionedHome,
+	}
+	oldAgentInstall := agentInstall{
+		version:       oldAgentVersion,
+		hash:          oldAgentHash,
+		versionedHome: oldAgentVersionedHome,
+	}
+	err := markUpgrade(log,
+		paths.DataFrom(topDir),
+		newAgentInstall,
+		oldAgentInstall,
+		nil, nil)
 	require.NoError(t, err, "error writing fake update marker")
 }

--- a/internal/pkg/agent/application/upgrade/rollback_windows.go
+++ b/internal/pkg/agent/application/upgrade/rollback_windows.go
@@ -19,9 +19,9 @@ const (
 	afterRestartDelay = 15 * time.Second
 )
 
-func invokeCmd() *exec.Cmd {
+func invokeCmd(agentExecutable string) *exec.Cmd {
 	// #nosec G204 -- user cannot inject any parameters to this command
-	cmd := exec.Command(paths.TopBinaryPath(), watcherSubcommand,
+	cmd := exec.Command(agentExecutable, watcherSubcommand,
 		"--path.config", paths.Config(),
 		"--path.home", paths.Top(),
 	)

--- a/internal/pkg/agent/application/upgrade/step_download.go
+++ b/internal/pkg/agent/application/upgrade/step_download.go
@@ -122,7 +122,7 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, parsedVersion *agtversi
 	return path, nil
 }
 
-func (u *Upgrader) appendFallbackPGP(tpv *agtversion.ParsedSemVer, pgpBytes []string) []string {
+func (u *Upgrader) appendFallbackPGP(targetVersion *agtversion.ParsedSemVer, pgpBytes []string) []string {
 	if pgpBytes == nil {
 		pgpBytes = make([]string, 0, 1)
 	}
@@ -135,7 +135,7 @@ func (u *Upgrader) appendFallbackPGP(tpv *agtversion.ParsedSemVer, pgpBytes []st
 	if u.fleetServerURI != "" {
 		secondaryPath, err := url.JoinPath(
 			u.fleetServerURI,
-			fmt.Sprintf(fleetUpgradeFallbackPGPFormat, tpv.Major(), tpv.Minor(), tpv.Patch()),
+			fmt.Sprintf(fleetUpgradeFallbackPGPFormat, targetVersion.Major(), targetVersion.Minor(), targetVersion.Patch()),
 		)
 		if err != nil {
 			u.log.Warnf("failed to compose Fleet Server URI: %v", err)

--- a/internal/pkg/agent/application/upgrade/step_download.go
+++ b/internal/pkg/agent/application/upgrade/step_download.go
@@ -40,19 +40,14 @@ type downloaderFactory func(*agtversion.ParsedSemVer, *logger.Logger, *artifact.
 
 type downloader func(context.Context, downloaderFactory, *agtversion.ParsedSemVer, *artifact.Config, *details.Details) (string, error)
 
-func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI string, upgradeDetails *details.Details, skipVerifyOverride bool, skipDefaultPgp bool, pgpBytes ...string) (_ string, err error) {
+func (u *Upgrader) downloadArtifact(ctx context.Context, parsedVersion *agtversion.ParsedSemVer, sourceURI string, upgradeDetails *details.Details, skipVerifyOverride, skipDefaultPgp bool, pgpBytes ...string) (_ string, err error) {
 	span, ctx := apm.StartSpan(ctx, "downloadArtifact", "app.internal")
 	defer func() {
 		apm.CaptureError(ctx, err).Send()
 		span.End()
 	}()
 
-	pgpBytes = u.appendFallbackPGP(version, pgpBytes)
-
-	parsedVersion, err := agtversion.ParseVersion(version)
-	if err != nil {
-		return "", fmt.Errorf("error parsing version %q: %w", version, err)
-	}
+	pgpBytes = u.appendFallbackPGP(parsedVersion, pgpBytes)
 
 	// do not update source config
 	settings := *u.settings
@@ -82,7 +77,7 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 			}
 
 			// log that a local upgrade artifact is being used
-			u.log.Infow("Using local upgrade artifact", "version", version,
+			u.log.Infow("Using local upgrade artifact", "version", parsedVersion,
 				"drop_path", settings.DropPath,
 				"target_path", settings.TargetDirectory, "install_path", settings.InstallPath)
 		} else {
@@ -93,7 +88,7 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 	if factory == nil {
 		// set the factory to the newDownloader factory
 		factory = newDownloader
-		u.log.Infow("Downloading upgrade artifact", "version", version,
+		u.log.Infow("Downloading upgrade artifact", "version", parsedVersion,
 			"source_uri", settings.SourceURI, "drop_path", settings.DropPath,
 			"target_path", settings.TargetDirectory, "install_path", settings.InstallPath)
 	}
@@ -127,7 +122,7 @@ func (u *Upgrader) downloadArtifact(ctx context.Context, version, sourceURI stri
 	return path, nil
 }
 
-func (u *Upgrader) appendFallbackPGP(targetVersion string, pgpBytes []string) []string {
+func (u *Upgrader) appendFallbackPGP(tpv *agtversion.ParsedSemVer, pgpBytes []string) []string {
 	if pgpBytes == nil {
 		pgpBytes = make([]string, 0, 1)
 	}
@@ -138,21 +133,15 @@ func (u *Upgrader) appendFallbackPGP(targetVersion string, pgpBytes []string) []
 	// add a secondary fallback if fleet server is configured
 	u.log.Debugf("Considering fleet server uri for pgp check fallback %q", u.fleetServerURI)
 	if u.fleetServerURI != "" {
-		tpv, err := agtversion.ParseVersion(targetVersion)
+		secondaryPath, err := url.JoinPath(
+			u.fleetServerURI,
+			fmt.Sprintf(fleetUpgradeFallbackPGPFormat, tpv.Major(), tpv.Minor(), tpv.Patch()),
+		)
 		if err != nil {
-			// best effort, log failure
-			u.log.Warnf("failed to parse agent version (%q) for secondary GPG fallback: %v", targetVersion, err)
+			u.log.Warnf("failed to compose Fleet Server URI: %v", err)
 		} else {
-			secondaryPath, err := url.JoinPath(
-				u.fleetServerURI,
-				fmt.Sprintf(fleetUpgradeFallbackPGPFormat, tpv.Major(), tpv.Minor(), tpv.Patch()),
-			)
-			if err != nil {
-				u.log.Warnf("failed to compose Fleet Server URI: %v", err)
-			} else {
-				secondaryFallback := download.PgpSourceURIPrefix + secondaryPath
-				pgpBytes = append(pgpBytes, secondaryFallback)
-			}
+			secondaryFallback := download.PgpSourceURIPrefix + secondaryPath
+			pgpBytes = append(pgpBytes, secondaryFallback)
 		}
 	}
 

--- a/internal/pkg/agent/application/upgrade/step_download_test.go
+++ b/internal/pkg/agent/application/upgrade/step_download_test.go
@@ -40,14 +40,14 @@ func TestFallbackIsAppended(t *testing.T) {
 		expectedDefaultIdx   int
 		expectedSecondaryIdx int
 		fleetServerURI       string
-		targetVersion        string
+		targetVersion        *agtversion.ParsedSemVer
 	}{
-		{"nil input", nil, 1, 0, -1, "", ""},
-		{"empty input", []string{}, 1, 0, -1, "", ""},
-		{"valid input with pgp", []string{"pgp-bytes"}, 2, 1, -1, "", ""},
-		{"valid input with pgp and version, no fleet uri", []string{"pgp-bytes"}, 2, 1, -1, "", "1.2.3"},
-		{"valid input with pgp and version and fleet uri", []string{"pgp-bytes"}, 3, 1, 2, "some-uri", "1.2.3"},
-		{"valid input with pgp and fleet uri no version", []string{"pgp-bytes"}, 2, 1, -1, "some-uri", ""},
+		//{"nil input", nil, 1, 0, -1, "", ""},
+		//{"empty input", []string{}, 1, 0, -1, "", ""},
+		{"valid input with pgp", []string{"pgp-bytes"}, 2, 1, -1, "", nil},
+		{"valid input with pgp and version, no fleet uri", []string{"pgp-bytes"}, 2, 1, -1, "", agtversion.NewParsedSemVer(1, 2, 3, "", "")},
+		{"valid input with pgp and version and fleet uri", []string{"pgp-bytes"}, 3, 1, 2, "some-uri", agtversion.NewParsedSemVer(1, 2, 3, "", "")},
+		//{"valid input with pgp and fleet uri no version", []string{"pgp-bytes"}, 2, 1, -1, "some-uri", ""},
 	}
 
 	for _, tc := range testCases {
@@ -65,7 +65,7 @@ func TestFallbackIsAppended(t *testing.T) {
 
 			if tc.expectedSecondaryIdx >= 0 {
 				// last element is fleet uri
-				expectedPgpURI := download.PgpSourceURIPrefix + tc.fleetServerURI + strings.Replace(fleetUpgradeFallbackPGPFormat, "%d.%d.%d", tc.targetVersion, 1)
+				expectedPgpURI := download.PgpSourceURIPrefix + tc.fleetServerURI + strings.Replace(fleetUpgradeFallbackPGPFormat, "%d.%d.%d", tc.targetVersion.CoreVersion(), 1)
 				require.Equal(t, expectedPgpURI, res[len(res)-1])
 			}
 		})

--- a/internal/pkg/agent/application/upgrade/step_download_test.go
+++ b/internal/pkg/agent/application/upgrade/step_download_test.go
@@ -33,6 +33,7 @@ func (md *mockDownloader) Download(ctx context.Context, a artifact.Artifact, ver
 }
 
 func TestFallbackIsAppended(t *testing.T) {
+	testAgentVersion123 := agtversion.NewParsedSemVer(1, 2, 3, "", "")
 	testCases := []struct {
 		name                 string
 		passedBytes          []string
@@ -42,12 +43,11 @@ func TestFallbackIsAppended(t *testing.T) {
 		fleetServerURI       string
 		targetVersion        *agtversion.ParsedSemVer
 	}{
-		//{"nil input", nil, 1, 0, -1, "", ""},
-		//{"empty input", []string{}, 1, 0, -1, "", ""},
+		{"nil input", nil, 1, 0, -1, "", testAgentVersion123},
+		{"empty input", []string{}, 1, 0, -1, "", testAgentVersion123},
 		{"valid input with pgp", []string{"pgp-bytes"}, 2, 1, -1, "", nil},
-		{"valid input with pgp and version, no fleet uri", []string{"pgp-bytes"}, 2, 1, -1, "", agtversion.NewParsedSemVer(1, 2, 3, "", "")},
-		{"valid input with pgp and version and fleet uri", []string{"pgp-bytes"}, 3, 1, 2, "some-uri", agtversion.NewParsedSemVer(1, 2, 3, "", "")},
-		//{"valid input with pgp and fleet uri no version", []string{"pgp-bytes"}, 2, 1, -1, "some-uri", ""},
+		{"valid input with pgp and version, no fleet uri", []string{"pgp-bytes"}, 2, 1, -1, "", testAgentVersion123},
+		{"valid input with pgp and version and fleet uri", []string{"pgp-bytes"}, 3, 1, 2, "some-uri", testAgentVersion123},
 	}
 
 	for _, tc := range testCases {

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -5,14 +5,11 @@
 package upgrade
 
 import (
-	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 
 	"github.com/elastic/elastic-agent-libs/file"
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
@@ -22,20 +19,7 @@ const (
 	exe     = ".exe"
 )
 
-// ChangeSymlink updates symlink paths to match current version.
-func ChangeSymlink(ctx context.Context, log *logger.Logger, topDirPath, targetHash string) error {
-	// create symlink to elastic-agent-{hash}
-	hashedDir := fmt.Sprintf("%s-%s", agentName, targetHash)
-
-	symlinkPath := filepath.Join(topDirPath, agentName)
-
-	// paths.BinaryPath properly derives the binary directory depending on the platform. The path to the binary for macOS is inside of the app bundle.
-	newPath := paths.BinaryPath(filepath.Join(paths.DataFrom(topDirPath), hashedDir), agentName)
-
-	return changeSymlinkInternal(log, topDirPath, symlinkPath, newPath)
-}
-
-func changeSymlinkInternal(log *logger.Logger, topDirPath, symlinkPath, newTarget string) error {
+func ChangeSymlink(log *logger.Logger, topDirPath, symlinkPath, newTarget string) error {
 
 	// handle windows suffixes
 	if runtime.GOOS == windows {

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -19,7 +19,7 @@ const (
 	exe     = ".exe"
 )
 
-func ChangeSymlink(log *logger.Logger, topDirPath, symlinkPath, newTarget string) error {
+func changeSymlink(log *logger.Logger, topDirPath, symlinkPath, newTarget string) error {
 
 	// handle windows suffixes
 	if runtime.GOOS == windows {

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -208,7 +208,7 @@ func getPackageMetadataFromZipReader(r *zip.ReadCloser, fileNamePrefix string) (
 	ret := packageMetadata{}
 
 	// Load manifest, the use of path.Join is intentional since in .zip file paths use slash ('/') as separator
-	manifestFile, err := r.Open(path.Join(fileNamePrefix, "manifest.yaml"))
+	manifestFile, err := r.Open(path.Join(fileNamePrefix, v1.ManifestFileName))
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		// we got a real error looking up for the manifest
 		return packageMetadata{}, fmt.Errorf("looking up manifest in package: %w", err)
@@ -380,14 +380,14 @@ func untar(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error
 
 func getPackageMetadataFromTar(archivePath string) (packageMetadata, error) {
 	// quickly open the archive and look up manifest.yaml file
-	fileContents, err := getFilesContentFromTar(archivePath, "manifest.yaml", agentCommitFile)
+	fileContents, err := getFilesContentFromTar(archivePath, v1.ManifestFileName, agentCommitFile)
 	if err != nil {
 		return packageMetadata{}, fmt.Errorf("looking for package metadata files: %w", err)
 	}
 
 	ret := packageMetadata{}
 
-	manifestReader, ok := fileContents["manifest.yaml"]
+	manifestReader, ok := fileContents[v1.ManifestFileName]
 	if ok && manifestReader != nil {
 		ret.manifest, err = v1.ParseManifest(manifestReader)
 		if err != nil {

--- a/internal/pkg/agent/application/upgrade/step_unpack_test.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	v1 "github.com/elastic/elastic-agent/pkg/api/v1"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
@@ -61,7 +62,7 @@ inputs:
 
 var archiveFilesWithManifestNoSymlink = []files{
 	{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
-	{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64/manifest.yaml", content: ea_123_manifest, mode: fs.ModePerm & 0o640},
+	{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64/" + v1.ManifestFileName, content: ea_123_manifest, mode: fs.ModePerm & 0o640},
 	{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64/" + agentCommitFile, content: "abcdefghijklmnopqrstuvwxyz", mode: fs.ModePerm & 0o640},
 	{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64/data", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
 	{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64/data/elastic-agent-abcdef", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
@@ -302,7 +303,7 @@ func checkExtractedFilesWithManifest(t *testing.T, testDataDir string) {
 			assert.Equal(t, agentBinaryPlaceholderContent, string(fileBytes), "agent binary placeholder content does not match")
 		}
 	}
-	mappedPackageManifest := filepath.Join(versionedHome, "manifest.yaml")
+	mappedPackageManifest := filepath.Join(versionedHome, v1.ManifestFileName)
 	if assert.FileExistsf(t, mappedPackageManifest, "package manifest %q is not found in mapped versioned home directory %q", mappedPackageManifest, versionedHome) {
 		fileBytes, err := os.ReadFile(mappedPackageManifest)
 		if assert.NoErrorf(t, err, "error reading package manifest %q", mappedPackageManifest) {

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -262,6 +262,10 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 		return nil, err
 	}
 
+	// We rotated the symlink successfully: prepare the current and previous agent installation details for the update marker
+	// In update marker the `current` agent install is the one where the symlink is pointing (the new one we didn't start yet)
+	// while the `previous` install is the currently executing elastic-agent that is no longer reachable via the symlink.
+	// After the restart at the end of the function, everything lines up correctly.
 	current := agentInstall{
 		version:       version,
 		hash:          unpackRes.Hash,

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -442,6 +442,7 @@ func shutdownCallback(l *logger.Logger, homePath, prevVersion, newVersion, newHo
 
 	return func() error {
 		runtimeDir := filepath.Join(homePath, "run")
+		l.Debugf("starting copy of run directories from %q to %q", homePath, newHome)
 		processDirs, err := readProcessDirs(runtimeDir)
 		if err != nil {
 			return err
@@ -451,6 +452,7 @@ func shutdownCallback(l *logger.Logger, homePath, prevVersion, newVersion, newHo
 		for _, processDir := range processDirs {
 			newDir := strings.ReplaceAll(processDir, prevVersion, newVersion)
 			newDir = strings.ReplaceAll(newDir, oldHome, newHome)
+			l.Debugf("copying %q -> %q", processDir, newDir)
 			if err := copyDir(l, processDir, newDir, true); err != nil {
 				return err
 			}

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -287,7 +287,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	minParsedVersionForNewUpdateMarker := agtversion.NewParsedSemVer(8, 13, 0, "", "")
 	var watcherExecutable string
 	if parsedVersion.Less(*minParsedVersionForNewUpdateMarker) {
-		// use the current agent executable for watch
+		// use the current agent executable for watch, if downgrading the old agent doesn't understand the current agent's path structure.
 		watcherExecutable = paths.BinaryPath(paths.VersionedHome(paths.Top()), agentName)
 	} else {
 		// use the new agent executable as it should be able to parse the new update marker

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -174,7 +174,13 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	det.SetState(details.StateDownloading)
 
 	sourceURI = u.sourceURI(sourceURI)
-	archivePath, err := u.downloadArtifact(ctx, version, sourceURI, det, skipVerifyOverride, skipDefaultPgp, pgpBytes...)
+
+	parsedVersion, err := agtversion.ParseVersion(version)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing version %q: %w", version, err)
+	}
+
+	archivePath, err := u.downloadArtifact(ctx, parsedVersion, sourceURI, det, skipVerifyOverride, skipDefaultPgp, pgpBytes...)
 	if err != nil {
 		// Run the same pre-upgrade cleanup task to get rid of any newly downloaded files
 		// This may have an issue if users are upgrading to the same version number.
@@ -265,7 +271,16 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 		return nil, err
 	}
 
-	if err := InvokeWatcher(u.log); err != nil {
+	minParsedVersionForNewUpdateMarker := agtversion.NewParsedSemVer(8, 13, 0, "", "")
+	var watcherExecutable string
+	if parsedVersion.Less(*minParsedVersionForNewUpdateMarker) {
+		// use the current agent executable for watch
+		watcherExecutable = filepath.Join(paths.VersionedHome(paths.Top()), agentName)
+	} else {
+		// use the new agent executable as it should be able to parse the new update marker
+		watcherExecutable = filepath.Join(paths.Top(), unpackRes.VersionedHome, agentName)
+	}
+	if err := InvokeWatcher(u.log, watcherExecutable); err != nil {
 		u.log.Errorw("Rolling back: starting watcher failed", "error.message", err)
 		rollbackInstall(ctx, u.log, paths.Top(), hashedDir)
 		return nil, err

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -256,7 +256,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 		return nil, fmt.Errorf("calculating home path relative to top, home: %q top: %q : %w", paths.Home(), paths.Top(), err)
 	}
 
-	if err := ChangeSymlink(u.log, paths.Top(), symlinkPath, newPath); err != nil {
+	if err := changeSymlink(u.log, paths.Top(), symlinkPath, newPath); err != nil {
 		u.log.Errorw("Rolling back: changing symlink failed", "error.message", err)
 		rollbackInstall(ctx, u.log, paths.Top(), hashedDir, currentVersionedHome)
 		return nil, err
@@ -387,7 +387,7 @@ func rollbackInstall(ctx context.Context, log *logger.Logger, topDirPath, versio
 	}
 
 	oldAgentPath := paths.BinaryPath(filepath.Join(topDirPath, oldVersionedHome), agentName)
-	err = ChangeSymlink(log, topDirPath, filepath.Join(topDirPath, agentName), oldAgentPath)
+	err = changeSymlink(log, topDirPath, filepath.Join(topDirPath, agentName), oldAgentPath)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		log.Warnw(fmt.Sprintf("rolling back install: restoring symlink to %q failed", oldAgentPath), "error.message", err)
 	}

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -450,8 +450,11 @@ func shutdownCallback(l *logger.Logger, homePath, prevVersion, newVersion, newHo
 
 		oldHome := homePath
 		for _, processDir := range processDirs {
-			newDir := strings.ReplaceAll(processDir, prevVersion, newVersion)
-			newDir = strings.ReplaceAll(newDir, oldHome, newHome)
+			relPath, _ := filepath.Rel(oldHome, processDir)
+
+			newRelPath := strings.ReplaceAll(relPath, prevVersion, newVersion)
+			newRelPath = strings.ReplaceAll(newRelPath, oldHome, newHome)
+			newDir := filepath.Join(newHome, newRelPath)
 			l.Debugf("copying %q -> %q", processDir, newDir)
 			if err := copyDir(l, processDir, newDir, true); err != nil {
 				return err

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -288,10 +288,10 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	var watcherExecutable string
 	if parsedVersion.Less(*minParsedVersionForNewUpdateMarker) {
 		// use the current agent executable for watch
-		watcherExecutable = filepath.Join(paths.VersionedHome(paths.Top()), agentName)
+		watcherExecutable = paths.BinaryPath(paths.VersionedHome(paths.Top()), agentName)
 	} else {
 		// use the new agent executable as it should be able to parse the new update marker
-		watcherExecutable = filepath.Join(paths.Top(), unpackRes.VersionedHome, agentName)
+		watcherExecutable = paths.BinaryPath(filepath.Join(paths.Top(), unpackRes.VersionedHome), agentName)
 	}
 	if err := InvokeWatcher(u.log, watcherExecutable); err != nil {
 		u.log.Errorw("Rolling back: starting watcher failed", "error.message", err)

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -40,6 +40,7 @@ const (
 	hashLen         = 6
 	agentCommitFile = ".elastic-agent.active.commit"
 	runDirMod       = 0770
+	snapshotSuffix  = "-SNAPSHOT"
 )
 
 var agentArtifact = artifact.Artifact{
@@ -142,7 +143,7 @@ func (av agentVersion) String() string {
 	buf := strings.Builder{}
 	buf.WriteString(av.version)
 	if av.snapshot {
-		buf.WriteString("-SNAPSHOT")
+		buf.WriteString(snapshotSuffix)
 	}
 	buf.WriteString(" (hash: ")
 	buf.WriteString(av.hash)
@@ -260,11 +261,23 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	if err != nil {
 		return nil, fmt.Errorf("calculating home path relative to top, home: %q top: %q : %w", paths.Home(), paths.Top(), err)
 	}
-	if err := markUpgrade(
-		u.log,
-		paths.Data(),                                     //data dir to place the marker in
-		version, unpackRes.Hash, unpackRes.VersionedHome, //new agent version data
-		release.VersionWithSnapshot(), release.Commit(), currentVersionedHome, // old agent version data
+
+	current := agentInstall{
+		version:       version,
+		hash:          unpackRes.Hash,
+		versionedHome: unpackRes.VersionedHome,
+	}
+
+	previous := agentInstall{
+		version:       release.VersionWithSnapshot(),
+		hash:          release.Commit(),
+		versionedHome: currentVersionedHome,
+	}
+
+	if err := markUpgrade(u.log,
+		paths.Data(), //data dir to place the marker in
+		current,      //new agent version data
+		previous,     // old agent version data
 		action, det); err != nil {
 		u.log.Errorw("Rolling back: marking upgrade failed", "error.message", err)
 		rollbackInstall(ctx, u.log, paths.Top(), hashedDir)
@@ -352,7 +365,7 @@ func isSameVersion(log *logger.Logger, current agentVersion, metadata packageMet
 	} else {
 		// extract version info from the version string (we can ignore parsing errors as it would have never passed the download step)
 		parsedVersion, _ := agtversion.ParseVersion(upgradeVersion)
-		newVersion.version = strings.TrimSuffix(parsedVersion.VersionWithPrerelease(), "-SNAPSHOT")
+		newVersion.version = strings.TrimSuffix(parsedVersion.VersionWithPrerelease(), snapshotSuffix)
 		newVersion.snapshot = parsedVersion.IsSnapshot()
 	}
 	newVersion.hash = metadata.hash
@@ -424,7 +437,7 @@ func copyRunDirectory(log *logger.Logger, oldRunPath, newRunPath string) error {
 func shutdownCallback(l *logger.Logger, homePath, prevVersion, newVersion, newHome string) reexec.ShutdownCallbackFn {
 	if release.Snapshot() {
 		// SNAPSHOT is part of newVersion
-		prevVersion += "-SNAPSHOT"
+		prevVersion += snapshotSuffix
 	}
 
 	return func() error {

--- a/internal/pkg/agent/application/upgrade/upgrade_test.go
+++ b/internal/pkg/agent/application/upgrade/upgrade_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -111,40 +110,80 @@ func Test_CopyFile(t *testing.T) {
 }
 
 func TestShutdownCallback(t *testing.T) {
-	l, _ := logger.New("test", false)
-	tmpDir, err := os.MkdirTemp("", "shutdown-test-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
 
-	// make homepath agent consistent (in a form of elastic-agent-hash)
-	homePath := filepath.Join(tmpDir, fmt.Sprintf("%s-%s", agentName, release.ShortCommit()))
+	type testcase struct {
+		name                  string
+		agentHomeDirectory    string
+		newAgentHomeDirectory string
+		agentVersion          string
+		newAgentVersion       string
+		oldRunFile            string
+		newRunFile            string
+	}
 
-	filename := "file.test"
-	newCommit := "abc123"
-	sourceVersion := "7.14.0"
-	targetVersion := "7.15.0"
+	testcases := []testcase{
+		{
+			name:                  "legacy run directories",
+			agentHomeDirectory:    fmt.Sprintf("%s-%s", agentName, release.ShortCommit()),
+			newAgentHomeDirectory: fmt.Sprintf("%s-%s", agentName, "abc123"),
+			agentVersion:          "7.14.0",
+			newAgentVersion:       "7.15.0",
+			oldRunFile:            filepath.Join("run", "default", "process-7.14.0", "file.test"),
+			newRunFile:            filepath.Join("run", "default", "process-7.15.0", "file.test"),
+		},
+		{
+			name:                  "new run directories",
+			agentHomeDirectory:    "elastic-agent-abcdef",
+			newAgentHomeDirectory: "elastic-agent-ghijkl",
+			agentVersion:          "1.2.3",
+			newAgentVersion:       "4.5.6",
+			oldRunFile:            filepath.Join("run", "component", "unit", "file.test"),
+			newRunFile:            filepath.Join("run", "component", "unit", "file.test"),
+		},
+		{
+			name:                  "new run directories, agents with version in path",
+			agentHomeDirectory:    "elastic-agent-1.2.3-abcdef",
+			newAgentHomeDirectory: "elastic-agent-4.5.6-ghijkl",
+			agentVersion:          "1.2.3",
+			newAgentVersion:       "4.5.6",
+			oldRunFile:            filepath.Join("run", "component", "unit", "file.test"),
+			newRunFile:            filepath.Join("run", "component", "unit", "file.test"),
+		},
+	}
 
-	content := []byte("content")
-	newHome := strings.ReplaceAll(homePath, release.ShortCommit(), newCommit)
-	sourceDir := filepath.Join(homePath, "run", "default", "process-"+sourceVersion)
-	targetDir := filepath.Join(newHome, "run", "default", "process-"+targetVersion)
+	for _, tt := range testcases {
 
-	require.NoError(t, os.MkdirAll(sourceDir, 0755))
-	require.NoError(t, os.MkdirAll(targetDir, 0755))
+		t.Run(tt.name, func(t *testing.T) {
+			l, _ := logger.New(tt.name, false)
+			tmpDir := t.TempDir()
 
-	cb := shutdownCallback(l, homePath, sourceVersion, targetVersion, newHome)
+			// make homepath agent consistent
+			homePath := filepath.Join(tmpDir, tt.agentHomeDirectory)
+			newHome := filepath.Join(tmpDir, tt.newAgentHomeDirectory)
 
-	oldFilename := filepath.Join(sourceDir, filename)
-	err = os.WriteFile(oldFilename, content, 0640)
-	require.NoError(t, err, "preparing file failed")
+			content := []byte("content")
+			sourceDir := filepath.Join(homePath, filepath.Dir(tt.oldRunFile))
+			targetDir := filepath.Join(newHome, filepath.Dir(tt.newRunFile))
 
-	err = cb()
-	require.NoError(t, err, "callback failed")
+			require.NoError(t, os.MkdirAll(sourceDir, 0755))
+			require.NoError(t, os.MkdirAll(targetDir, 0755))
 
-	newFilename := filepath.Join(targetDir, filename)
-	newContent, err := os.ReadFile(newFilename)
-	require.NoError(t, err, "reading file failed")
-	require.Equal(t, content, newContent, "contents are not equal")
+			cb := shutdownCallback(l, homePath, tt.agentVersion, tt.newAgentVersion, newHome)
+
+			oldFilename := filepath.Join(homePath, tt.oldRunFile)
+			err := os.WriteFile(oldFilename, content, 0640)
+			require.NoError(t, err, "preparing file failed")
+
+			err = cb()
+			require.NoError(t, err, "callback failed")
+
+			newFilename := filepath.Join(newHome, tt.newRunFile)
+			newContent, err := os.ReadFile(newFilename)
+			require.NoError(t, err, "reading file failed")
+			require.Equal(t, content, newContent, "contents are not equal")
+		})
+	}
+
 }
 
 func TestIsInProgress(t *testing.T) {

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -226,7 +226,7 @@ func runElasticAgent(ctx context.Context, cancel context.CancelFunc, override cf
 	}
 
 	// initiate agent watcher
-	if err := upgrade.InvokeWatcher(l); err != nil {
+	if err := upgrade.InvokeWatcher(l, paths.TopBinaryPath()); err != nil {
 		// we should not fail because watcher is not working
 		l.Error(errors.New(err, "failed to invoke rollback watcher"))
 	}

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -77,6 +77,8 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		return nil
 	}
 
+	log.Infof("Loaded update marker %+v", marker)
+
 	locker := filelock.NewAppLocker(paths.Top(), watcherLockFile)
 	if err := locker.TryLock(); err != nil {
 		if errors.Is(err, filelock.ErrAppAlreadyRunning) {
@@ -98,7 +100,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		// if we're not within grace and marker is still there it might mean
 		// that cleanup was not performed ok, cleanup everything except current version
 		// hash is the same as hash of agent which initiated watcher.
-		if err := upgrade.Cleanup(log, paths.Top(), marker.VersionedHome, release.ShortCommit(), true, false); err != nil {
+		if err := upgrade.Cleanup(log, paths.Top(), paths.VersionedHome(paths.Top()), release.ShortCommit(), true, false); err != nil {
 			log.Error("clean up of prior watcher run failed", err)
 		}
 		// exit nicely

--- a/internal/pkg/agent/install/install.go
+++ b/internal/pkg/agent/install/install.go
@@ -217,7 +217,7 @@ func Install(cfgFile, topPath string, unprivileged bool, log *logp.Logger, pt *p
 }
 
 func readPackageManifest(extractedPackageDir string) (*v1.PackageManifest, error) {
-	manifestFilePath := filepath.Join(extractedPackageDir, "manifest.yaml")
+	manifestFilePath := filepath.Join(extractedPackageDir, v1.ManifestFileName)
 	manifestFile, err := os.Open(manifestFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open package manifest file (%s): %w", manifestFilePath, err)

--- a/internal/pkg/agent/install/install_test.go
+++ b/internal/pkg/agent/install/install_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
+	v1 "github.com/elastic/elastic-agent/pkg/api/v1"
 )
 
 func TestHasAllSSDs(t *testing.T) {
@@ -110,21 +111,21 @@ func TestCopyFiles(t *testing.T) {
 		{
 			name: "simple install package mockup",
 			setupFiles: []files{
-				{fType: REGULAR, path: "manifest.yaml", content: []byte(sampleManifestContent)},
+				{fType: REGULAR, path: v1.ManifestFileName, content: []byte(sampleManifestContent)},
 				{fType: DIRECTORY, path: filepath.Join("data", "elastic-agent-fb7370"), content: nil},
 				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-fb7370", "elastic-agent"), content: []byte("this is an elastic-agent wannabe")},
 				{fType: SYMLINK, path: "elastic-agent", content: []byte(filepath.Join("data", "elastic-agent-fb7370", "elastic-agent"))},
 			},
 			expectedFiles: []files{
 				{fType: DIRECTORY, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370"), content: nil},
-				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "manifest.yaml"), content: []byte(sampleManifestContent)},
+				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", v1.ManifestFileName), content: []byte(sampleManifestContent)},
 				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "elastic-agent"), content: []byte("this is an elastic-agent wannabe")},
 				{fType: SYMLINK, path: "elastic-agent", content: []byte(filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "elastic-agent"))},
 			},
 			mappings: []map[string]string{
 				{
 					"data/elastic-agent-fb7370": "data/elastic-agent-8.13.0-SNAPSHOT-fb7370",
-					"manifest.yaml":             "data/elastic-agent-8.13.0-SNAPSHOT-fb7370/manifest.yaml",
+					v1.ManifestFileName:         "data/elastic-agent-8.13.0-SNAPSHOT-fb7370/" + v1.ManifestFileName,
 				},
 			}},
 	}

--- a/pkg/api/v1/manifest.go
+++ b/pkg/api/v1/manifest.go
@@ -17,6 +17,7 @@ const ManifestFileName = "manifest.yaml"
 type PackageDesc struct {
 	Version       string              `yaml:"version,omitempty" json:"version,omitempty"`
 	Snapshot      bool                `yaml:"snapshot,omitempty" json:"snapshot,omitempty"`
+	Hash          string              `yaml:"hash,omitempty" json:"hash,omitempty"`
 	VersionedHome string              `yaml:"versioned-home,omitempty" json:"versionedHome,omitempty"`
 	PathMappings  []map[string]string `yaml:"path-mappings,omitempty" json:"pathMappings,omitempty"`
 }

--- a/pkg/api/v1/manifest.go
+++ b/pkg/api/v1/manifest.go
@@ -12,6 +12,7 @@ import (
 )
 
 const ManifestKind = "PackageManifest"
+const ManifestFileName = "manifest.yaml"
 
 type PackageDesc struct {
 	Version       string              `yaml:"version,omitempty" json:"version,omitempty"`


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This is the last subset of a bigger PR #3950, so CI should be green.

This change checks if the target version of the upgrade is at least 8.13.0 to decide which upgrade watcher to launch. This is needed to ensure that the watcher performs correct cleanup and rollbacks by reading paths in the update marker.

In this PR it's also included a necessary fix to the shutdownCallback since we do some path manipulation to support the legacy structure of component run directory where we replace versions from old to new.

This PR includes also a set of minor fixes to fix the elastic-agent upgrade on MacOS and Windows.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

This is the final block of code necessary to implement #2579 on Linux, MacOS and Windows. It will make use of the mapping described in the package manifest to correctly place agent files in directories containing the agent version and the hash in the name.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

To test this PR we can create multiple packages from the same agent commit and test if we can upgrade between them. The procedure is the same as described in #4174 but without the OS limitation and the known issues.

This change is supposed to be backward compatible so it can be tested also using older agent versions (like we do in our integration tests)

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #2579 
- Relates #3950 
- Requires #4173
- Requires #4174
- Requires #4176 
- Requires #4177 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
