### PR TITLE
Feature/add agent version to installation directory name

### DIFF
--- a/changelog/fragments/1706703918-Add-the-full-version-number-to-the-installation-directory-name.yaml
+++ b/changelog/fragments/1706703918-Add-the-full-version-number-to-the-installation-directory-name.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add the full version number to the installation directory name
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -23,7 +23,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/magefile/mage/sh"
-	"golang.org/x/tools/go/vcs"
+	"golang.org/x/tools/go/vcs" //nolint:staticcheck // this deprecation will be handled in https://github.com/elastic/elastic-agent/issues/4138
 
 	"github.com/elastic/elastic-agent/dev-tools/mage/gotool"
 	v1 "github.com/elastic/elastic-agent/pkg/api/v1"
@@ -48,6 +48,7 @@ const (
 	// Mapped functions
 	agentPackageVersionMappedFunc    = "agent_package_version"
 	agentManifestGeneratorMappedFunc = "manifest"
+	snapshotSuffix                   = "snapshot_suffix"
 )
 
 // Common settings with defaults derived from files, CWD, and environment.
@@ -108,6 +109,7 @@ var (
 		"contains":                       strings.Contains,
 		agentPackageVersionMappedFunc:    AgentPackageVersion,
 		agentManifestGeneratorMappedFunc: PackageManifest,
+		snapshotSuffix:                   SnapshotSuffix,
 	}
 )
 

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -255,6 +255,7 @@ repo.RootDir                 = {{ repo.RootDir }}
 repo.ImportPath              = {{ repo.ImportPath }}
 repo.SubDir                  = {{ repo.SubDir }}
 agent_package_version        = {{ agent_package_version}}
+snapshot_suffix              = {{ snapshot_suffix }}
 `
 
 	return Expand(dumpTemplate)
@@ -311,6 +312,13 @@ func PackageManifest() (string, error) {
 		return "", fmt.Errorf("retrieving agent package version: %w", err)
 	}
 	m.Package.Version = packageVersion
+
+	hash, err := CommitHash()
+	if err != nil {
+		return "", fmt.Errorf("retrieving agent commit hash: %w", err)
+	}
+	m.Package.Hash = hash
+
 	commitHashShort, err := CommitHashShort()
 	if err != nil {
 		return "", fmt.Errorf("retrieving agent commit hash: %w", err)
@@ -320,7 +328,7 @@ func PackageManifest() (string, error) {
 	m.Package.VersionedHome = versionedHomePath
 	m.Package.PathMappings = []map[string]string{{}}
 	m.Package.PathMappings[0][versionedHomePath] = fmt.Sprintf("data/elastic-agent-%s%s-%s", m.Package.Version, SnapshotSuffix(), commitHashShort)
-	m.Package.PathMappings[0]["manifest.yaml"] = fmt.Sprintf("data/elastic-agent-%s%s-%s/manifest.yaml", m.Package.Version, SnapshotSuffix(), commitHashShort)
+	m.Package.PathMappings[0][v1.ManifestFileName] = fmt.Sprintf("data/elastic-agent-%s%s-%s/%s", m.Package.Version, SnapshotSuffix(), commitHashShort, v1.ManifestFileName)
 	yamlBytes, err := yaml.Marshal(m)
 	if err != nil {
 		return "", fmt.Errorf("marshaling manifest: %w", err)

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -201,9 +201,9 @@ func checkZip(t *testing.T, file string) {
 
 func checkManifestFileContents(t *testing.T, extractedPackageDir string) {
 	t.Log("Checking file manifest.yaml")
-	manifestReadCloser, err := os.Open(filepath.Join(extractedPackageDir, "manifest.yaml"))
+	manifestReadCloser, err := os.Open(filepath.Join(extractedPackageDir, v1.ManifestFileName))
 	if err != nil {
-		t.Errorf("opening manifest %s : %v", "manifest.yaml", err)
+		t.Errorf("opening manifest %s : %v", v1.ManifestFileName, err)
 	}
 	defer func(closer io.ReadCloser) {
 		err := closer.Close()
@@ -218,6 +218,9 @@ func checkManifestFileContents(t *testing.T, extractedPackageDir string) {
 
 	assert.Equal(t, v1.ManifestKind, m.Kind, "manifest specifies wrong kind")
 	assert.Equal(t, v1.VERSION, m.Version, "manifest specifies wrong api version")
+
+	assert.NotEmpty(t, m.Package.Version, "manifest version must not be empty")
+	assert.NotEmpty(t, m.Package.Hash, "manifest hash must not be empty")
 
 	if assert.NotEmpty(t, m.Package.PathMappings, "path mappings in manifest are empty") {
 		versionedHome := m.Package.VersionedHome

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -62,19 +62,19 @@ shared:
       /etc/init.d/{{.BeatServiceName}}:
         template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/{{.PackageType}}/elastic-agent.init.sh.tmpl'
         mode: 0755
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ commit_short }}/{{.BeatName}}{{.BinaryExt}}:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ commit_short }}/{{.BeatName}}{{.BinaryExt}}:
         source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
         mode: 0755
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ commit_short }}/package.version:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ commit_short }}/package.version:
         content: >
           {{ agent_package_version }}
         mode: 0644
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ commit_short }}/components:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ commit_short }}/components:
         source: '{{.AgentDropPath}}/{{.GOOS}}-{{.AgentArchName}}.tar.gz/'
         mode: 0755
         config_mode: 0644
         skip_on_missing: true
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ commit_short }}/manifest.yaml:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ commit_short }}/manifest.yaml:
         mode: 0644
         content: >
           {{ manifest }}

--- a/dev-tools/packaging/templates/darwin/elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/darwin/elastic-agent.tmpl
@@ -6,6 +6,9 @@ set -e
 symlink="/Library/Elastic/Agent/elastic-agent"
 
 if test -L "$symlink"; then
-    ln -sfn "data/elastic-agent-{{ commit_short }}/elastic-agent.app/Contents/MacOS/elastic-agent" "$symlink"
+    symlinkTarget="data/elastic-agent-{{ commit_short }}/elastic-agent.app/Contents/MacOS/elastic-agent"
+    if test -f "data/elastic-agent-{{ agent_package_version }}{{ snapshot_suffix }}-{{ commit_short }}/elastic-agent.app/Contents/MacOS/elastic-agent"; then
+        symlinkTarget="data/elastic-agent-{{ agent_package_version }}{{ snapshot_suffix }}-{{ commit_short }}/elastic-agent.app/Contents/MacOS/elastic-agent"
+    ln -sfn "$symlinkTarget" "$symlink"
 fi
 

--- a/dev-tools/packaging/templates/linux/postinstall.sh.tmpl
+++ b/dev-tools/packaging/templates/linux/postinstall.sh.tmpl
@@ -16,8 +16,9 @@ if test -L "$symlink"; then
 fi
 
 commit_hash="{{ commit_short }}"
+version_dir="{{agent_package_version}}{{snapshot_suffix}}"
 
-new_agent_dir="/var/lib/elastic-agent/data/elastic-agent-$commit_hash"
+new_agent_dir="/var/lib/elastic-agent/data/elastic-agent-$version_dir-$commit_hash"
 
 # copy the state files if there was a previous agent install
 if ! [ -z "$old_agent_dir" ] && ! [ "$old_agent_dir" -ef "$new_agent_dir" ]; then

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -61,3 +61,74 @@ sequenceDiagram
        end
     end
 ```
+
+### Introducing package manifest
+
+Starting from version 8.13.0 an additional file `manifest.yaml` is present in elastic-agent packages.
+The purpose of this file is to present some metadata and package information to be used during install/upgrade operations.
+
+The first enhancement that makes use of this package manifest is [#2579](https://github.com/elastic/elastic-agent/issues/2579)
+as we use the manifest to map the package directory structure (based on agent commit hash) into one that takes also the
+agent version into account. This allows releasing versions of the agent package where only the component versions change,
+with the agent commit unchanged.
+
+
+The [structure](../pkg/api/v1/manifest.go) of such manifest is defined in the [api/v1 package](../pkg/api/v1/).
+The manifest data is generated during packaging and the file is added to the package files. This is an example of a
+complete manifest:
+
+```yaml
+version: co.elastic.agent/v1
+kind: PackageManifest
+package:
+  version: 8.13.0
+  snapshot: true
+  hash: 15658b38b48ba4487afadc5563b1576b85ce0264
+  versioned-home: data/elastic-agent-15658b
+  path-mappings:
+    - data/elastic-agent-15658b: data/elastic-agent-8.13.0-SNAPSHOT-15658b
+      manifest.yaml: data/elastic-agent-8.13.0-SNAPSHOT-15658b/manifest.yaml
+```
+
+The package information describes the package version, whether it's a snapshot build, the elastic-agent commit hash it
+has been built from and where to find the versioned home of the elastic agent within the package.
+
+Another section lists the path mappings that must be applied by an elastic-agent that is aware of the package manifest
+(version >8.13.0): these path mappings allow the incoming agent version to have some control over where the files in
+package will be stored on disk.
+
+#### Upgrading without the manifest
+
+Legacy elastic-agent upgrade is a pretty straightforward affair:
+- Download the agent package to use for upgrade
+- Open the .zip or .tar.gz archive and iterate over the files
+  - Look for the elastic-agent commit file to retrieve the actual hash of the agent version we want to install
+  - Extract any package file under `/data` under the installed agent `/data` directory
+- After extraction check if the hash we read from the package matches with the one from the current agent:
+  - if it's the same hash the upgrade fails because we are trying to upgrade to the same version
+  - if we extracted a package with a different hash, the upgrade keeps going
+- Copy the elastic agent action store and components run directory into the new agent directories `elastic-agent-<hash>`
+- Rotate the symlink in the top directory to point to the new agent executable `data/elastic-agent-<hash>/elastic-agent`
+- Write the update marker containing the information about the new and old agent versions/hashes in `data` directory
+- Invoke the watcher `elastic-agent watch` command to ensure that the new version of agent works correctly after restart
+- Shutdown current agent and its command components, copy components state once again and restart
+
+#### Upgrading using the manifest
+
+Upgrading using the manifest allows for the new version to pass along some information about the package to the upgrading agent.
+The new process looks like this:
+- Download the elastic-agent package to use for upgrade
+- Extract package metadata from the new elastic-agent package (manifest and hash):
+  - if the package has a manifest we extract `version` and `snapshot` flag as declared by the package
+  - if there is no manifest for the package we extract the version and snapshot for the version passed to the upgrade
+  - hash from the agent commit file (always present in the package)
+- compare the tuple of new `(version, snapshot, hash)` to the current `(version, snapshot, hash)`: if they are the same
+  the upgrade fails because we are trying to upgrade to the same version as current
+- Extract any package file (after mapping it using file mappings in manifest if present) that should go under `/data`.
+  Return the new versionedHome (where the new version of agent has its files, returned as path relative to the top directory)
+- Copy the elastic agent action store and components run directory into the new agent in `<versionedHome>/run`
+- Write the update marker containing the information about the new and old agent version, hash and home in `data` directory
+- Invoke the watcher `elastic-agent watch` command to ensure that the new version of agent works correctly after restart:
+  - we invoke the current agent binary if the new version < 8.13.0 (needed to make sure it supports the paths written in the update marker)
+  - we invoke the new agent binary if the new version > 8.13.0
+- Shutdown current agent and its command components, copy components state once again and restart

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -118,10 +118,10 @@ Legacy elastic-agent upgrade is a pretty straightforward affair:
 Upgrading using the manifest allows for the new version to pass along some information about the package to the upgrading agent.
 The new process looks like this:
 - Download the elastic-agent package to use for upgrade
-- Extract package metadata from the new elastic-agent package (manifest and hash):
-  - if the package has a manifest we extract `version` and `snapshot` flag as declared by the package
-  - if there is no manifest for the package we extract the version and snapshot for the version passed to the upgrade
-  - hash from the agent commit file (always present in the package)
+- Extract package metadata from the new elastic-agent package (`version`, `snapshot` and `hash`):
+  - if the package has a manifest we extract `version` and `snapshot` flag as declared by the package manifest
+  - if there is no manifest for the package we extract `version` and `snapshot` from the version string passed to the upgrader
+  - the `hash` is always retrieved from the agent commit file (this is always present in the package)
 - compare the tuple of new `(version, snapshot, hash)` to the current `(version, snapshot, hash)`: if they are the same
   the upgrade fails because we are trying to upgrade to the same version as current
 - Extract any package file (after mapping it using file mappings in manifest if present) that should go under `/data`.

--- a/internal/pkg/agent/application/paths/common.go
+++ b/internal/pkg/agent/application/paths/common.go
@@ -180,11 +180,16 @@ func ExternalInputs() string {
 
 // Data returns the data directory for Agent
 func Data() string {
+	return DataFrom(Top())
+}
+
+// DataFrom returns the data directory for Agent using the passed directory as top path
+func DataFrom(topDirPath string) string {
 	if unversionedHome {
 		// unversioned means the topPath is the data path
-		return topPath
+		return topDirPath
 	}
-	return filepath.Join(Top(), "data")
+	return filepath.Join(topDirPath, "data")
 }
 
 // Run returns the run directory for Agent

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -46,7 +46,7 @@ func Rollback(ctx context.Context, log *logger.Logger, c client.Client, topDirPa
 		symlinkTarget = paths.BinaryPath(filepath.Join(paths.DataFrom(topDirPath), hashedDir), agentName)
 	}
 	// change symlink
-	if err := changeSymlinkInternal(log, topDirPath, symlinkPath, symlinkTarget); err != nil {
+	if err := changeSymlink(log, topDirPath, symlinkPath, symlinkTarget); err != nil {
 		return err
 	}
 
@@ -138,13 +138,13 @@ func Cleanup(log *logger.Logger, topDirPath, currentVersionedHome, currentHash s
 
 // InvokeWatcher invokes an agent instance using watcher argument for watching behavior of
 // agent during upgrade period.
-func InvokeWatcher(log *logger.Logger) error {
+func InvokeWatcher(log *logger.Logger, agentExecutable string) error {
 	if !IsUpgradeable() {
 		log.Info("agent is not upgradable, not starting watcher")
 		return nil
 	}
 
-	cmd := invokeCmd()
+	cmd := invokeCmd(agentExecutable)
 	defer func() {
 		if cmd.Process != nil {
 			log.Infof("releasing watcher %v", cmd.Process.Pid)

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -138,10 +139,10 @@ func Cleanup(log *logger.Logger, topDirPath, currentVersionedHome, currentHash s
 
 // InvokeWatcher invokes an agent instance using watcher argument for watching behavior of
 // agent during upgrade period.
-func InvokeWatcher(log *logger.Logger, agentExecutable string) error {
+func InvokeWatcher(log *logger.Logger, agentExecutable string) (*exec.Cmd, error) {
 	if !IsUpgradeable() {
 		log.Info("agent is not upgradable, not starting watcher")
-		return nil
+		return nil, nil
 	}
 
 	cmd := invokeCmd(agentExecutable)
@@ -154,14 +155,14 @@ func InvokeWatcher(log *logger.Logger, agentExecutable string) error {
 
 	log.Infow("Starting upgrade watcher", "path", cmd.Path, "args", cmd.Args, "env", cmd.Env, "dir", cmd.Dir)
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start Upgrade Watcher: %w", err)
+		return nil, fmt.Errorf("failed to start Upgrade Watcher: %w", err)
 	}
 
 	upgradeWatcherPID := cmd.Process.Pid
 	agentPID := os.Getpid()
 	log.Infow("Upgrade Watcher invoked", "agent.upgrade.watcher.process.pid", upgradeWatcherPID, "agent.process.pid", agentPID)
 
-	return nil
+	return cmd, nil
 }
 
 func restartAgent(ctx context.Context, log *logger.Logger, c client.Client) error {

--- a/internal/pkg/agent/application/upgrade/rollback_darwin.go
+++ b/internal/pkg/agent/application/upgrade/rollback_darwin.go
@@ -21,9 +21,9 @@ const (
 	afterRestartDelay = 2 * time.Second
 )
 
-func invokeCmd() *exec.Cmd {
+func invokeCmd(agentExecutable string) *exec.Cmd {
 	// #nosec G204 -- user cannot inject any parameters to this command
-	cmd := exec.Command(paths.TopBinaryPath(), watcherSubcommand,
+	cmd := exec.Command(agentExecutable, watcherSubcommand,
 		"--path.config", paths.Config(),
 		"--path.home", paths.Top(),
 	)

--- a/internal/pkg/agent/application/upgrade/rollback_linux.go
+++ b/internal/pkg/agent/application/upgrade/rollback_linux.go
@@ -21,9 +21,9 @@ const (
 	afterRestartDelay = 2 * time.Second
 )
 
-func invokeCmd() *exec.Cmd {
+func invokeCmd(agentExecutable string) *exec.Cmd {
 	// #nosec G204 -- user cannot inject any parameters to this command
-	cmd := exec.Command(paths.TopBinaryPath(), watcherSubcommand,
+	cmd := exec.Command(agentExecutable, watcherSubcommand,
 		"--path.config", paths.Config(),
 		"--path.home", paths.Top(),
 	)

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -28,13 +28,13 @@ type testAgentVersion struct {
 	hash    string
 }
 
-type agentInstall struct {
+type testAgentInstall struct {
 	version          testAgentVersion
 	useVersionInPath bool
 }
 
 type setupAgentInstallations struct {
-	installedAgents []agentInstall
+	installedAgents []testAgentInstall
 	upgradeFrom     testAgentVersion
 	upgradeTo       testAgentVersion
 	currentAgent    testAgentVersion
@@ -74,7 +74,7 @@ func TestCleanup(t *testing.T) {
 				keepLogs:             false,
 			},
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: false,
@@ -103,7 +103,7 @@ func TestCleanup(t *testing.T) {
 				keepLogs:             false,
 			},
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: true,
@@ -132,7 +132,7 @@ func TestCleanup(t *testing.T) {
 				keepLogs:             false,
 			},
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: false,
@@ -161,7 +161,7 @@ func TestCleanup(t *testing.T) {
 				keepLogs:             false,
 			},
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version: testAgentVersion{
 							version: "0.9.9",
@@ -229,7 +229,7 @@ func TestRollback(t *testing.T) {
 	}{
 		"rollback without versionedHome (legacy upgrade process)": {
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: false,
@@ -252,7 +252,7 @@ func TestRollback(t *testing.T) {
 		},
 		"rollback with versionedHome (new upgrade process)": {
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: true,
@@ -275,7 +275,7 @@ func TestRollback(t *testing.T) {
 		},
 		"rollback with versionedHome only on the new agent (new upgrade process from an old agent upgraded with legacy process)": {
 			agentInstallsSetup: setupAgentInstallations{
-				installedAgents: []agentInstall{
+				installedAgents: []testAgentInstall{
 					{
 						version:          version123Snapshot,
 						useVersionInPath: false,
@@ -493,6 +493,20 @@ func createUpdateMarker(t *testing.T, log *logger.Logger, topDir, newAgentVersio
 		oldAgentVersionedHome = ""
 	}
 
-	err := markUpgrade(log, paths.DataFrom(topDir), newAgentVersion, newAgentHash, newAgentVersionedHome, oldAgentVersion, oldAgentHash, oldAgentVersionedHome, nil, nil)
+	newAgentInstall := agentInstall{
+		version:       newAgentVersion,
+		hash:          newAgentHash,
+		versionedHome: newAgentVersionedHome,
+	}
+	oldAgentInstall := agentInstall{
+		version:       oldAgentVersion,
+		hash:          oldAgentHash,
+		versionedHome: oldAgentVersionedHome,
+	}
+	err := markUpgrade(log,
+		paths.DataFrom(topDir),
+		newAgentInstall,
+		oldAgentInstall,
+		nil, nil)
 	require.NoError(t, err, "error writing fake update marker")
 }

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -1,0 +1,498 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/pkg/control/v2/client/mocks"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+)
+
+type hookFunc func(t *testing.T, topDir string)
+
+type agentVersion struct {
+	version string
+	hash    string
+}
+
+type agentInstall struct {
+	version          agentVersion
+	useVersionInPath bool
+}
+
+type setupAgentInstallations struct {
+	installedAgents []agentInstall
+	upgradeFrom     agentVersion
+	upgradeTo       agentVersion
+	currentAgent    agentVersion
+}
+
+var (
+	version123Snapshot = agentVersion{
+		version: "1.2.3-SNAPSHOT",
+		hash:    "abcdef",
+	}
+	version456Snapshot = agentVersion{
+		version: "4.5.6-SNAPSHOT",
+		hash:    "ghijkl",
+	}
+)
+
+func TestCleanup(t *testing.T) {
+	type args struct {
+		currentVersionedHome string
+		currentHash          string
+		removeMarker         bool
+		keepLogs             bool
+	}
+
+	tests := map[string]struct {
+		args               args
+		agentInstallsSetup setupAgentInstallations
+		additionalSetup    hookFunc
+		wantErr            assert.ErrorAssertionFunc
+		checkAfterCleanup  hookFunc
+	}{
+		"cleanup without versionedHome (legacy upgrade process)": {
+			args: args{
+				currentVersionedHome: "data/elastic-agent-ghijkl",
+				currentHash:          "ghijkl",
+				removeMarker:         true,
+				keepLogs:             false,
+			},
+			agentInstallsSetup: setupAgentInstallations{
+				installedAgents: []agentInstall{
+					{
+						version:          version123Snapshot,
+						useVersionInPath: false,
+					},
+					{
+						version:          version456Snapshot,
+						useVersionInPath: false,
+					},
+				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
+			},
+			wantErr: assert.NoError,
+			checkAfterCleanup: func(t *testing.T, topDir string) {
+				oldAgentHome := filepath.Join("data", "elastic-agent-abcdef")
+				newAgentHome := filepath.Join("data", "elastic-agent-ghijkl")
+				checkFilesAfterCleanup(t, topDir, newAgentHome, oldAgentHome)
+			},
+		},
+		"cleanup with versionedHome (new upgrade process)": {
+			args: args{
+				currentVersionedHome: "data/elastic-agent-4.5.6-SNAPSHOT-ghijkl",
+				currentHash:          "ghijkl",
+				removeMarker:         true,
+				keepLogs:             false,
+			},
+			agentInstallsSetup: setupAgentInstallations{
+				installedAgents: []agentInstall{
+					{
+						version:          version123Snapshot,
+						useVersionInPath: true,
+					},
+					{
+						version:          version456Snapshot,
+						useVersionInPath: true,
+					},
+				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
+			},
+			wantErr: assert.NoError,
+			checkAfterCleanup: func(t *testing.T, topDir string) {
+				oldAgentHome := filepath.Join("data", "elastic-agent-1.2.3-SNAPSHOT-abcdef")
+				newAgentHome := filepath.Join("data", "elastic-agent-4.5.6-SNAPSHOT-ghijkl")
+				checkFilesAfterCleanup(t, topDir, newAgentHome, oldAgentHome)
+			},
+		},
+		"cleanup with versionedHome only on the new agent (new upgrade process from an old agent upgraded with legacy process)": {
+			args: args{
+				currentVersionedHome: "data/elastic-agent-4.5.6-SNAPSHOT-ghijkl",
+				currentHash:          "ghijkl",
+				removeMarker:         true,
+				keepLogs:             false,
+			},
+			agentInstallsSetup: setupAgentInstallations{
+				installedAgents: []agentInstall{
+					{
+						version:          version123Snapshot,
+						useVersionInPath: false,
+					},
+					{
+						version:          version456Snapshot,
+						useVersionInPath: true,
+					},
+				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
+			},
+			wantErr: assert.NoError,
+			checkAfterCleanup: func(t *testing.T, topDir string) {
+				oldAgentHome := filepath.Join("data", "elastic-agent-abcdef")
+				newAgentHome := filepath.Join("data", "elastic-agent-4.5.6-SNAPSHOT-ghijkl")
+				checkFilesAfterCleanup(t, topDir, newAgentHome, oldAgentHome)
+			},
+		},
+		"cleanup with versionedHome only on the new agent + extra old agent installs": {
+			args: args{
+				currentVersionedHome: "data/elastic-agent-4.5.6-SNAPSHOT-ghijkl",
+				currentHash:          "ghijkl",
+				removeMarker:         true,
+				keepLogs:             false,
+			},
+			agentInstallsSetup: setupAgentInstallations{
+				installedAgents: []agentInstall{
+					{
+						version: agentVersion{
+							version: "0.9.9",
+							hash:    "aaaaaa",
+						},
+						useVersionInPath: false,
+					},
+					{
+						version: agentVersion{
+							version: "1.1.1",
+							hash:    "aaabbb",
+						},
+						useVersionInPath: false,
+					},
+					{
+						version:          version123Snapshot,
+						useVersionInPath: false,
+					},
+					{
+						version:          version456Snapshot,
+						useVersionInPath: true,
+					},
+				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
+			},
+			wantErr: assert.NoError,
+			checkAfterCleanup: func(t *testing.T, topDir string) {
+				newAgentHome := filepath.Join("data", "elastic-agent-4.5.6-SNAPSHOT-ghijkl")
+				oldAgentHomes := []string{
+					filepath.Join("data", "elastic-agent-abcdef"),
+					filepath.Join("data", "elastic-agent-aaabbb"),
+					filepath.Join("data", "elastic-agent-aaaaaa"),
+				}
+
+				checkFilesAfterCleanup(t, topDir, newAgentHome, oldAgentHomes...)
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			testLogger, _ := logger.NewTesting(t.Name())
+			testTop := t.TempDir()
+			setupAgents(t, testLogger, testTop, tt.agentInstallsSetup)
+			if tt.additionalSetup != nil {
+				tt.additionalSetup(t, testTop)
+			}
+			marker, err := LoadMarker(paths.DataFrom(testTop))
+			require.NoError(t, err, "error loading update marker")
+			require.NotNil(t, marker, "loaded marker must not be nil")
+			t.Logf("Loaded update marker %+v", marker)
+			tt.wantErr(t, Cleanup(testLogger, testTop, marker.VersionedHome, marker.Hash, tt.args.removeMarker, tt.args.keepLogs), fmt.Sprintf("Cleanup(%v, %v, %v, %v)", marker.VersionedHome, marker.Hash, tt.args.removeMarker, tt.args.keepLogs))
+			tt.checkAfterCleanup(t, testTop)
+		})
+	}
+}
+
+func TestRollback(t *testing.T) {
+	tests := map[string]struct {
+		agentInstallsSetup setupAgentInstallations
+		additionalSetup    hookFunc
+		wantErr            assert.ErrorAssertionFunc
+		checkAfterRollback hookFunc
+	}{
+		"rollback without versionedHome (legacy upgrade process)": {
+			agentInstallsSetup: setupAgentInstallations{
+				installedAgents: []agentInstall{
+					{
+						version:          version123Snapshot,
+						useVersionInPath: false,
+					},
+					{
+						version:          version456Snapshot,
+						useVersionInPath: false,
+					},
+				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
+			},
+			wantErr: assert.NoError,
+			checkAfterRollback: func(t *testing.T, topDir string) {
+				oldAgentHome := filepath.Join("data", "elastic-agent-abcdef")
+				newAgentHome := filepath.Join("data", "elastic-agent-ghijkl")
+				checkFilesAfterRollback(t, topDir, oldAgentHome, newAgentHome)
+			},
+		},
+		"rollback with versionedHome (new upgrade process)": {
+			agentInstallsSetup: setupAgentInstallations{
+				installedAgents: []agentInstall{
+					{
+						version:          version123Snapshot,
+						useVersionInPath: true,
+					},
+					{
+						version:          version456Snapshot,
+						useVersionInPath: true,
+					},
+				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
+			},
+			wantErr: assert.NoError,
+			checkAfterRollback: func(t *testing.T, topDir string) {
+				oldAgentHome := filepath.Join("data", "elastic-agent-1.2.3-SNAPSHOT-abcdef")
+				newAgentHome := filepath.Join("data", "elastic-agent-4.5.6-SNAPSHOT-ghijkl")
+				checkFilesAfterRollback(t, topDir, oldAgentHome, newAgentHome)
+			},
+		},
+		"rollback with versionedHome only on the new agent (new upgrade process from an old agent upgraded with legacy process)": {
+			agentInstallsSetup: setupAgentInstallations{
+				installedAgents: []agentInstall{
+					{
+						version:          version123Snapshot,
+						useVersionInPath: false,
+					},
+					{
+						version:          version456Snapshot,
+						useVersionInPath: true,
+					},
+				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
+			},
+			wantErr: assert.NoError,
+			checkAfterRollback: func(t *testing.T, topDir string) {
+				oldAgentHome := filepath.Join("data", "elastic-agent-abcdef")
+				newAgentHome := filepath.Join("data", "elastic-agent-4.5.6-SNAPSHOT-ghijkl")
+				checkFilesAfterRollback(t, topDir, oldAgentHome, newAgentHome)
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			testLogger, _ := logger.NewTesting(t.Name())
+			testTop := t.TempDir()
+			setupAgents(t, testLogger, testTop, tt.agentInstallsSetup)
+			if tt.additionalSetup != nil {
+				tt.additionalSetup(t, testTop)
+			}
+			marker, err := LoadMarker(paths.DataFrom(testTop))
+			require.NoError(t, err, "error loading update marker")
+			require.NotNil(t, marker, "loaded marker must not be nil")
+			t.Logf("Loaded update marker %+v", marker)
+
+			// mock client
+			mockClient := mocks.NewClient(t)
+			mockClient.EXPECT().Connect(
+				mock.AnythingOfType("*context.timerCtx"),
+				mock.AnythingOfType("*grpc.funcDialOption"),
+				mock.AnythingOfType("*grpc.funcDialOption"),
+			).Return(nil)
+			mockClient.EXPECT().Disconnect().Return()
+			mockClient.EXPECT().Restart(mock.Anything).Return(nil).Once()
+
+			ctx := context.TODO()
+			tt.wantErr(t, Rollback(ctx, testLogger, mockClient, testTop, marker.PrevVersionedHome, marker.PrevHash), fmt.Sprintf("Rollback(%v, %v, %v, %v, %v, %v)", ctx, testLogger, mockClient, testTop, marker.PrevVersionedHome, marker.PrevHash))
+			tt.checkAfterRollback(t, testTop)
+		})
+	}
+}
+
+// checkFilesAfterCleanup is a convenience function to check the file structure within topDir.
+// *AgentHome paths must be the expected old and new agent paths relative to topDir (typically in the form of "data/elastic-agent-*")
+func checkFilesAfterCleanup(t *testing.T, topDir, newAgentHome string, oldAgentHomes ...string) {
+	t.Helper()
+	// the old agent directories must not exist anymore
+	for _, oldAgentHome := range oldAgentHomes {
+		assert.NoDirExistsf(t, filepath.Join(topDir, oldAgentHome), "old agent directory %q should be deleted after cleanup", oldAgentHome)
+	}
+
+	// check the new agent home
+	assert.DirExists(t, filepath.Join(topDir, newAgentHome), "new agent directory should exist after cleanup")
+	agentExecutable := agentName
+	if runtime.GOOS == "windows" {
+		agentExecutable += ".exe"
+	}
+	symlinkPath := filepath.Join(topDir, agentExecutable)
+	linkTarget, err := os.Readlink(symlinkPath)
+	if assert.NoError(t, err, "unable to read symbolic link") {
+		assert.Equal(t, paths.BinaryPath(newAgentHome, agentExecutable), linkTarget, "symbolic link should point to the new agent executable after cleanup")
+	}
+
+	// read the elastic agent placeholder via the symlink
+	elasticAgentBytes, err := os.ReadFile(symlinkPath)
+	if assert.NoError(t, err, "error reading elastic-agent content through the symlink") {
+		assert.Equal(t, []byte("Placeholder for agent 4.5.6-SNAPSHOT"), elasticAgentBytes, "reading elastic-agent content through symbolic link should point to the new version")
+	}
+
+	assert.NoFileExists(t, filepath.Join(topDir, "data", markerFilename), "update marker should have been cleaned up")
+}
+
+// checkFilesAfterRollback is a convenience function to check the file structure within topDir.
+// *AgentHome paths must be the expected old and new agent paths relative to topDir (typically in the form of "data/elastic-agent-*")
+func checkFilesAfterRollback(t *testing.T, topDir, oldAgentHome, newAgentHome string) {
+	t.Helper()
+	// the new agent directory must still exist (for the logs)
+	assert.DirExists(t, filepath.Join(topDir, newAgentHome), "new agent directory should still exist after rollback")
+	assert.DirExists(t, filepath.Join(topDir, newAgentHome, "logs"), "new agent logs directory should still exist after rollback")
+	// some things should have been removed from the new agent directory
+	assert.NoDirExists(t, filepath.Join(topDir, newAgentHome, "components"), "new agent components directory should have been cleaned up in the rollback")
+	assert.NoDirExists(t, filepath.Join(topDir, newAgentHome, "run"), "new agent run directory should have been cleaned up in the rollback")
+	assert.NoFileExists(t, filepath.Join(topDir, newAgentHome, agentName), "new agent binary should have been cleaned up in the rollback")
+
+	// check the old agent home
+	assert.DirExists(t, filepath.Join(topDir, oldAgentHome), "old agent directory should exist after rollback")
+	agentExecutable := agentName
+	if runtime.GOOS == "windows" {
+		agentExecutable += ".exe"
+	}
+	symlinkPath := filepath.Join(topDir, agentExecutable)
+	linkTarget, err := os.Readlink(symlinkPath)
+	if assert.NoError(t, err, "unable to read symbolic link") {
+		// Due to the unique way the rollback process works we end up with an absolute path in the link
+		expectedLinkTargetAfterRollback := paths.BinaryPath(filepath.Join(topDir, oldAgentHome), agentExecutable)
+		assert.Equal(t, expectedLinkTargetAfterRollback, linkTarget, "symbolic link should point to the old agent executable after rollback")
+	}
+
+	// read the elastic agent placeholder via the symlink
+	elasticAgentBytes, err := os.ReadFile(symlinkPath)
+	if assert.NoError(t, err, "error reading elastic-agent content through the symlink") {
+		assert.Equal(t, []byte("Placeholder for agent 1.2.3-SNAPSHOT"), elasticAgentBytes, "reading elastic-agent content through symbolic link should point to the old version")
+	}
+
+	assert.NoFileExists(t, filepath.Join(topDir, "data", markerFilename), "update marker should have been cleaned up")
+}
+
+// setupAgents create fake agent installs, update marker file and symlink pointing to one of the installations' elastic-agent placeholder
+func setupAgents(t *testing.T, log *logger.Logger, topDir string, installations setupAgentInstallations) {
+
+	var (
+		oldAgentVersion       agentVersion
+		oldAgentVersionedHome string
+		newAgentVersion       agentVersion
+		newAgentVersionedHome string
+		useNewMarker          bool
+	)
+	for _, ia := range installations.installedAgents {
+		versionedHome := createFakeAgentInstall(t, topDir, ia.version.version, ia.version.hash, ia.useVersionInPath)
+		t.Logf("Created fake agent install for %+v located at %q", ia, versionedHome)
+		if installations.upgradeFrom == ia.version {
+			t.Logf("Setting version %+v as FROM version for the update marker", ia.version)
+			oldAgentVersion = ia.version
+			oldAgentVersionedHome = versionedHome
+		}
+
+		if installations.upgradeTo == ia.version {
+			t.Logf("Setting version %+v as TO version for the update marker", ia.version)
+			newAgentVersion = ia.version
+			newAgentVersionedHome = versionedHome
+			useNewMarker = ia.useVersionInPath
+		}
+
+		if installations.currentAgent == ia.version {
+			t.Logf("Creating symlink pointing to %q", versionedHome)
+			createLink(t, topDir, versionedHome)
+		}
+	}
+
+	t.Logf("Creating upgrade marker from %+v located at %q to %+v located at %q", oldAgentVersion, oldAgentVersionedHome, newAgentVersion, newAgentVersionedHome)
+	createUpdateMarker(t, log, topDir, newAgentVersion.version, newAgentVersion.hash, newAgentVersionedHome, oldAgentVersion.version, oldAgentVersion.hash, oldAgentVersionedHome, useNewMarker)
+}
+
+// createFakeAgentInstall will create a mock agent install within topDir, possibly using the version in the directory name, depending on useVersionInPath
+// it MUST return the path to the created versionedHome relative to topDir, to mirror what step_unpack returns
+func createFakeAgentInstall(t *testing.T, topDir, version, hash string, useVersionInPath bool) string {
+
+	// create versioned home
+	versionedHome := fmt.Sprintf("elastic-agent-%s", hash[:hashLen])
+	if useVersionInPath {
+		// use the version passed as parameter
+		versionedHome = fmt.Sprintf("elastic-agent-%s-%s", version, hash[:hashLen])
+	}
+	relVersionedHomePath := filepath.Join("data", versionedHome)
+	absVersionedHomePath := filepath.Join(topDir, relVersionedHomePath)
+
+	// recalculate the binary path and launch a mkDirAll to account for MacOS weirdness
+	// (the extra nesting of elastic agent binary within versionedHome)
+	absVersioneHomeBinaryPath := paths.BinaryPath(absVersionedHomePath, "")
+	err := os.MkdirAll(absVersioneHomeBinaryPath, 0o750)
+	require.NoError(t, err, "error creating fake install versioned home directory (including binary path) %q", absVersioneHomeBinaryPath)
+
+	// place a few directories in the fake install
+	absComponentsDirPath := filepath.Join(absVersionedHomePath, "components")
+	err = os.MkdirAll(absComponentsDirPath, 0o750)
+	require.NoError(t, err, "error creating fake install components directory %q", absVersionedHomePath)
+
+	absLogsDirPath := filepath.Join(absVersionedHomePath, "logs")
+	err = os.MkdirAll(absLogsDirPath, 0o750)
+	require.NoError(t, err, "error creating fake install logs directory %q", absLogsDirPath)
+
+	absRunDirPath := filepath.Join(absVersionedHomePath, "run")
+	err = os.MkdirAll(absRunDirPath, 0o750)
+	require.NoError(t, err, "error creating fake install run directory %q", absRunDirPath)
+
+	// put some placeholder for files
+	agentExecutableName := agentName
+	if runtime.GOOS == "windows" {
+		agentExecutableName += ".exe"
+	}
+	err = os.WriteFile(paths.BinaryPath(absVersionedHomePath, agentExecutableName), []byte(fmt.Sprintf("Placeholder for agent %s", version)), 0o750)
+	require.NoErrorf(t, err, "error writing elastic agent binary placeholder %q", agentExecutableName)
+	err = os.WriteFile(filepath.Join(absLogsDirPath, "fakelog.ndjson"), []byte(fmt.Sprintf("Sample logs for agent %s", version)), 0o750)
+	require.NoErrorf(t, err, "error writing fake log placeholder %q")
+
+	// return the path relative to top exactly like the step_unpack does
+	return relVersionedHomePath
+}
+
+func createLink(t *testing.T, topDir string, currentAgentVersionedHome string) {
+	linkTarget := paths.BinaryPath(currentAgentVersionedHome, agentName)
+	linkName := agentName
+	if runtime.GOOS == "windows" {
+		linkTarget += ".exe"
+		linkName += ".exe"
+	}
+	err := os.Symlink(linkTarget, filepath.Join(topDir, linkName))
+	require.NoError(t, err, "error creating test symlink to fake agent install")
+}
+
+func createUpdateMarker(t *testing.T, log *logger.Logger, topDir, newAgentVersion, newAgentHash, newAgentVersionedHome, oldAgentVersion, oldAgentHash, oldAgentVersionedHome string, useNewMarker bool) {
+
+	if !useNewMarker {
+		newAgentVersion = ""
+		newAgentVersionedHome = ""
+		oldAgentVersionedHome = ""
+	}
+
+	err := markUpgrade(log, paths.DataFrom(topDir), newAgentVersion, newAgentHash, newAgentVersionedHome, oldAgentVersion, oldAgentHash, oldAgentVersionedHome, nil, nil)
+	require.NoError(t, err, "error writing fake update marker")
+}

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -23,29 +23,29 @@ import (
 
 type hookFunc func(t *testing.T, topDir string)
 
-type agentVersion struct {
+type testAgentVersion struct {
 	version string
 	hash    string
 }
 
 type agentInstall struct {
-	version          agentVersion
+	version          testAgentVersion
 	useVersionInPath bool
 }
 
 type setupAgentInstallations struct {
 	installedAgents []agentInstall
-	upgradeFrom     agentVersion
-	upgradeTo       agentVersion
-	currentAgent    agentVersion
+	upgradeFrom     testAgentVersion
+	upgradeTo       testAgentVersion
+	currentAgent    testAgentVersion
 }
 
 var (
-	version123Snapshot = agentVersion{
+	version123Snapshot = testAgentVersion{
 		version: "1.2.3-SNAPSHOT",
 		hash:    "abcdef",
 	}
-	version456Snapshot = agentVersion{
+	version456Snapshot = testAgentVersion{
 		version: "4.5.6-SNAPSHOT",
 		hash:    "ghijkl",
 	}
@@ -163,14 +163,14 @@ func TestCleanup(t *testing.T) {
 			agentInstallsSetup: setupAgentInstallations{
 				installedAgents: []agentInstall{
 					{
-						version: agentVersion{
+						version: testAgentVersion{
 							version: "0.9.9",
 							hash:    "aaaaaa",
 						},
 						useVersionInPath: false,
 					},
 					{
-						version: agentVersion{
+						version: testAgentVersion{
 							version: "1.1.1",
 							hash:    "aaabbb",
 						},
@@ -396,9 +396,9 @@ func checkFilesAfterRollback(t *testing.T, topDir, oldAgentHome, newAgentHome st
 func setupAgents(t *testing.T, log *logger.Logger, topDir string, installations setupAgentInstallations) {
 
 	var (
-		oldAgentVersion       agentVersion
+		oldAgentVersion       testAgentVersion
 		oldAgentVersionedHome string
-		newAgentVersion       agentVersion
+		newAgentVersion       testAgentVersion
 		newAgentVersionedHome string
 		useNewMarker          bool
 	)

--- a/internal/pkg/agent/application/upgrade/rollback_windows.go
+++ b/internal/pkg/agent/application/upgrade/rollback_windows.go
@@ -19,9 +19,9 @@ const (
 	afterRestartDelay = 15 * time.Second
 )
 
-func invokeCmd() *exec.Cmd {
+func invokeCmd(agentExecutable string) *exec.Cmd {
 	// #nosec G204 -- user cannot inject any parameters to this command
-	cmd := exec.Command(paths.TopBinaryPath(), watcherSubcommand,
+	cmd := exec.Command(agentExecutable, watcherSubcommand,
 		"--path.config", paths.Config(),
 		"--path.home", paths.Top(),
 	)

--- a/internal/pkg/agent/application/upgrade/step_download_test.go
+++ b/internal/pkg/agent/application/upgrade/step_download_test.go
@@ -33,6 +33,7 @@ func (md *mockDownloader) Download(ctx context.Context, a artifact.Artifact, ver
 }
 
 func TestFallbackIsAppended(t *testing.T) {
+	testAgentVersion123 := agtversion.NewParsedSemVer(1, 2, 3, "", "")
 	testCases := []struct {
 		name                 string
 		passedBytes          []string
@@ -40,14 +41,13 @@ func TestFallbackIsAppended(t *testing.T) {
 		expectedDefaultIdx   int
 		expectedSecondaryIdx int
 		fleetServerURI       string
-		targetVersion        string
+		targetVersion        *agtversion.ParsedSemVer
 	}{
-		{"nil input", nil, 1, 0, -1, "", ""},
-		{"empty input", []string{}, 1, 0, -1, "", ""},
-		{"valid input with pgp", []string{"pgp-bytes"}, 2, 1, -1, "", ""},
-		{"valid input with pgp and version, no fleet uri", []string{"pgp-bytes"}, 2, 1, -1, "", "1.2.3"},
-		{"valid input with pgp and version and fleet uri", []string{"pgp-bytes"}, 3, 1, 2, "some-uri", "1.2.3"},
-		{"valid input with pgp and fleet uri no version", []string{"pgp-bytes"}, 2, 1, -1, "some-uri", ""},
+		{"nil input", nil, 1, 0, -1, "", testAgentVersion123},
+		{"empty input", []string{}, 1, 0, -1, "", testAgentVersion123},
+		{"valid input with pgp", []string{"pgp-bytes"}, 2, 1, -1, "", nil},
+		{"valid input with pgp and version, no fleet uri", []string{"pgp-bytes"}, 2, 1, -1, "", testAgentVersion123},
+		{"valid input with pgp and version and fleet uri", []string{"pgp-bytes"}, 3, 1, 2, "some-uri", testAgentVersion123},
 	}
 
 	for _, tc := range testCases {
@@ -65,7 +65,7 @@ func TestFallbackIsAppended(t *testing.T) {
 
 			if tc.expectedSecondaryIdx >= 0 {
 				// last element is fleet uri
-				expectedPgpURI := download.PgpSourceURIPrefix + tc.fleetServerURI + strings.Replace(fleetUpgradeFallbackPGPFormat, "%d.%d.%d", tc.targetVersion, 1)
+				expectedPgpURI := download.PgpSourceURIPrefix + tc.fleetServerURI + strings.Replace(fleetUpgradeFallbackPGPFormat, "%d.%d.%d", tc.targetVersion.CoreVersion(), 1)
 				require.Equal(t, expectedPgpURI, res[len(res)-1])
 			}
 		})

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -5,14 +5,11 @@
 package upgrade
 
 import (
-	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 
 	"github.com/elastic/elastic-agent-libs/file"
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
@@ -22,20 +19,7 @@ const (
 	exe     = ".exe"
 )
 
-// ChangeSymlink updates symlink paths to match current version.
-func ChangeSymlink(ctx context.Context, log *logger.Logger, topDirPath, targetHash string) error {
-	// create symlink to elastic-agent-{hash}
-	hashedDir := fmt.Sprintf("%s-%s", agentName, targetHash)
-
-	symlinkPath := filepath.Join(topDirPath, agentName)
-
-	// paths.BinaryPath properly derives the binary directory depending on the platform. The path to the binary for macOS is inside of the app bundle.
-	newPath := paths.BinaryPath(filepath.Join(paths.DataFrom(topDirPath), hashedDir), agentName)
-
-	return changeSymlinkInternal(log, topDirPath, symlinkPath, newPath)
-}
-
-func changeSymlinkInternal(log *logger.Logger, topDirPath, symlinkPath, newTarget string) error {
+func changeSymlink(log *logger.Logger, topDirPath, symlinkPath, newTarget string) error {
 
 	// handle windows suffixes
 	if runtime.GOOS == windows {

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -23,19 +23,19 @@ const (
 )
 
 // ChangeSymlink updates symlink paths to match current version.
-func ChangeSymlink(ctx context.Context, log *logger.Logger, targetHash string) error {
+func ChangeSymlink(ctx context.Context, log *logger.Logger, topDirPath, targetHash string) error {
 	// create symlink to elastic-agent-{hash}
 	hashedDir := fmt.Sprintf("%s-%s", agentName, targetHash)
 
-	symlinkPath := filepath.Join(paths.Top(), agentName)
+	symlinkPath := filepath.Join(topDirPath, agentName)
 
 	// paths.BinaryPath properly derives the binary directory depending on the platform. The path to the binary for macOS is inside of the app bundle.
-	newPath := paths.BinaryPath(filepath.Join(paths.Top(), "data", hashedDir), agentName)
+	newPath := paths.BinaryPath(filepath.Join(paths.DataFrom(topDirPath), hashedDir), agentName)
 
-	return changeSymlinkInternal(log, symlinkPath, newPath)
+	return changeSymlinkInternal(log, topDirPath, symlinkPath, newPath)
 }
 
-func changeSymlinkInternal(log *logger.Logger, symlinkPath, newTarget string) error {
+func changeSymlinkInternal(log *logger.Logger, topDirPath, symlinkPath, newTarget string) error {
 
 	// handle windows suffixes
 	if runtime.GOOS == windows {
@@ -43,7 +43,7 @@ func changeSymlinkInternal(log *logger.Logger, symlinkPath, newTarget string) er
 		newTarget += exe
 	}
 
-	prevNewPath := prevSymlinkPath()
+	prevNewPath := prevSymlinkPath(topDirPath)
 	log.Infow("Changing symlink", "symlink_path", symlinkPath, "new_path", newTarget, "prev_path", prevNewPath)
 
 	// remove symlink to avoid upgrade failures
@@ -59,7 +59,7 @@ func changeSymlinkInternal(log *logger.Logger, symlinkPath, newTarget string) er
 	return file.SafeFileRotate(symlinkPath, prevNewPath)
 }
 
-func prevSymlinkPath() string {
+func prevSymlinkPath(topDirPath string) string {
 	agentPrevName := agentName + ".prev"
 
 	// handle windows suffixes
@@ -67,5 +67,5 @@ func prevSymlinkPath() string {
 		agentPrevName = agentName + ".exe.prev"
 	}
 
-	return filepath.Join(paths.Top(), agentPrevName)
+	return filepath.Join(topDirPath, agentPrevName)
 }

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -32,21 +32,26 @@ func ChangeSymlink(ctx context.Context, log *logger.Logger, targetHash string) e
 	// paths.BinaryPath properly derives the binary directory depending on the platform. The path to the binary for macOS is inside of the app bundle.
 	newPath := paths.BinaryPath(filepath.Join(paths.Top(), "data", hashedDir), agentName)
 
+	return changeSymlinkInternal(log, symlinkPath, newPath)
+}
+
+func changeSymlinkInternal(log *logger.Logger, symlinkPath, newTarget string) error {
+
 	// handle windows suffixes
 	if runtime.GOOS == windows {
 		symlinkPath += exe
-		newPath += exe
+		newTarget += exe
 	}
 
 	prevNewPath := prevSymlinkPath()
-	log.Infow("Changing symlink", "symlink_path", symlinkPath, "new_path", newPath, "prev_path", prevNewPath)
+	log.Infow("Changing symlink", "symlink_path", symlinkPath, "new_path", newTarget, "prev_path", prevNewPath)
 
 	// remove symlink to avoid upgrade failures
 	if err := os.Remove(prevNewPath); !os.IsNotExist(err) {
 		return err
 	}
 
-	if err := os.Symlink(newPath, prevNewPath); err != nil {
+	if err := os.Symlink(newTarget, prevNewPath); err != nil {
 		return errors.New(err, errors.TypeFilesystem, "failed to update agent symlink")
 	}
 

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -208,7 +208,7 @@ func getPackageMetadataFromZipReader(r *zip.ReadCloser, fileNamePrefix string) (
 	ret := packageMetadata{}
 
 	// Load manifest, the use of path.Join is intentional since in .zip file paths use slash ('/') as separator
-	manifestFile, err := r.Open(path.Join(fileNamePrefix, "manifest.yaml"))
+	manifestFile, err := r.Open(path.Join(fileNamePrefix, v1.ManifestFileName))
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		// we got a real error looking up for the manifest
 		return packageMetadata{}, fmt.Errorf("looking up manifest in package: %w", err)
@@ -380,14 +380,14 @@ func untar(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error
 
 func getPackageMetadataFromTar(archivePath string) (packageMetadata, error) {
 	// quickly open the archive and look up manifest.yaml file
-	fileContents, err := getFilesContentFromTar(archivePath, "manifest.yaml", agentCommitFile)
+	fileContents, err := getFilesContentFromTar(archivePath, v1.ManifestFileName, agentCommitFile)
 	if err != nil {
 		return packageMetadata{}, fmt.Errorf("looking for package metadata files: %w", err)
 	}
 
 	ret := packageMetadata{}
 
-	manifestReader, ok := fileContents["manifest.yaml"]
+	manifestReader, ok := fileContents[v1.ManifestFileName]
 	if ok && manifestReader != nil {
 		ret.manifest, err = v1.ParseManifest(manifestReader)
 		if err != nil {

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -28,7 +28,7 @@ import (
 type UnpackResult struct {
 	// Hash contains the unpacked agent commit hash, limited to a length of 6 for backward compatibility
 	Hash string `json:"hash" yaml:"hash"`
-	// VersionedHome indicates the path (forward slash separated) where to find the unpacked agent files
+	// VersionedHome indicates the path (relative to topPath, formatted in os-dependent fashion) where to find the unpacked agent files
 	// The value depends on the mappings specified in manifest.yaml, if no manifest is found it assumes the legacy data/elastic-agent-<hash> format
 	VersionedHome string `json:"versioned-home" yaml:"versioned-home"`
 }
@@ -81,7 +81,7 @@ func unzip(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error
 			return UnpackResult{}, fmt.Errorf("parsing package manifest: %w", err)
 		}
 		pm.mappings = manifest.Package.PathMappings
-		versionedHome = path.Clean(pm.Map(manifest.Package.VersionedHome))
+		versionedHome = filepath.Clean(pm.Map(manifest.Package.VersionedHome))
 	}
 
 	// Load hash, the use of path.Join is intentional since in .zip file paths use slash ('/') as separator
@@ -210,8 +210,8 @@ func untar(log *logger.Logger, version string, archivePath, dataDir string) (Unp
 		return UnpackResult{}, fmt.Errorf("looking for package metadata files: %w", err)
 	}
 
-	manifestReader := fileContents["manifest.yaml"]
-	if manifestReader != nil {
+	manifestReader, ok := fileContents["manifest.yaml"]
+	if ok && manifestReader != nil {
 		manifest, err := v1.ParseManifest(manifestReader)
 		if err != nil {
 			return UnpackResult{}, fmt.Errorf("parsing package manifest: %w", err)
@@ -466,5 +466,5 @@ func getFilesContentFromTar(archivePath string, files ...string) (map[string]io.
 }
 
 func createVersionedHomeFromHash(hash string) string {
-	return fmt.Sprintf("data/elastic-agent-%s", hash[:hashLen])
+	return filepath.Join("data", fmt.Sprintf("elastic-agent-%s", hash[:hashLen]))
 }

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -7,51 +7,103 @@ package upgrade
 import (
 	"archive/tar"
 	"archive/zip"
+	"bytes"
 	"compress/gzip"
+	goerrors "errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	v1 "github.com/elastic/elastic-agent/pkg/api/v1"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
+// UnpackResult contains the location and hash of the unpacked agent files
+type UnpackResult struct {
+	// Hash contains the unpacked agent commit hash, limited to a length of 6 for backward compatibility
+	Hash string `json:"hash" yaml:"hash"`
+	// VersionedHome indicates the path (forward slash separated) where to find the unpacked agent files
+	// The value depends on the mappings specified in manifest.yaml, if no manifest is found it assumes the legacy data/elastic-agent-<hash> format
+	VersionedHome string `json:"versioned-home" yaml:"versioned-home"`
+}
+
 // unpack unpacks archive correctly, skips root (symlink, config...) unpacks data/*
-func (u *Upgrader) unpack(version, archivePath, dataDir string) (string, error) {
+func (u *Upgrader) unpack(version, archivePath, dataDir string) (UnpackResult, error) {
 	// unpack must occur in directory that holds the installation directory
 	// or the extraction will be double nested
-	var hash string
+	var unpackRes UnpackResult
 	var err error
 	if runtime.GOOS == windows {
-		hash, err = unzip(u.log, archivePath, dataDir)
+		unpackRes, err = unzip(u.log, archivePath, dataDir)
 	} else {
-		hash, err = untar(u.log, version, archivePath, dataDir)
+		unpackRes, err = untar(u.log, version, archivePath, dataDir)
 	}
 
 	if err != nil {
-		u.log.Errorw("Failed to unpack upgrade artifact", "error.message", err, "version", version, "file.path", archivePath, "hash", hash)
-		return "", err
+		u.log.Errorw("Failed to unpack upgrade artifact", "error.message", err, "version", version, "file.path", archivePath, "unpackResult", unpackRes)
+		return UnpackResult{}, err
 	}
 
-	u.log.Infow("Unpacked upgrade artifact", "version", version, "file.path", archivePath, "hash", hash)
-	return hash, nil
+	u.log.Infow("Unpacked upgrade artifact", "version", version, "file.path", archivePath, "unpackResult", unpackRes)
+	return unpackRes, nil
 }
 
-func unzip(log *logger.Logger, archivePath, dataDir string) (string, error) {
+func unzip(log *logger.Logger, archivePath, dataDir string) (UnpackResult, error) {
 	var hash, rootDir string
 	r, err := zip.OpenReader(archivePath)
 	if err != nil {
-		return "", err
+		return UnpackResult{}, err
 	}
 	defer r.Close()
 
 	fileNamePrefix := strings.TrimSuffix(filepath.Base(archivePath), ".zip") + "/" // omitting `elastic-agent-{version}-{os}-{arch}/` in filename
+
+	pm := pathMapper{}
+	versionedHome := ""
+
+	// Load manifest, the use of path.Join is intentional since in .zip file paths use slash ('/') as separator
+	manifestFile, err := r.Open(path.Join(fileNamePrefix, "manifest.yaml"))
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		// we got a real error looking up for the manifest
+		return UnpackResult{}, fmt.Errorf("looking up manifest in package: %w", err)
+	}
+	if err == nil {
+		// load manifest
+		defer manifestFile.Close()
+		manifest, err := v1.ParseManifest(manifestFile)
+		if err != nil {
+			return UnpackResult{}, fmt.Errorf("parsing package manifest: %w", err)
+		}
+		pm.mappings = manifest.Package.PathMappings
+		versionedHome = path.Clean(pm.Map(manifest.Package.VersionedHome))
+	}
+
+	// Load hash, the use of path.Join is intentional since in .zip file paths use slash ('/') as separator
+	hashFile, err := r.Open(path.Join(fileNamePrefix, agentCommitFile))
+	if err != nil {
+		// we got a real error looking up for the manifest
+		return UnpackResult{}, fmt.Errorf("looking up %q in package: %w", agentCommitFile, err)
+	}
+	defer hashFile.Close()
+
+	hashBytes, err := io.ReadAll(hashFile)
+	if err != nil {
+		return UnpackResult{}, fmt.Errorf("reading elastic-agent hash file content: %w", err)
+	}
+	if len(hashBytes) < hashLen {
+		return UnpackResult{}, fmt.Errorf("elastic-agent hash %q is too short (minimum %d)", string(hashBytes), hashLen)
+	}
+	hash = string(hashBytes[:hashLen])
+	if versionedHome == "" {
+		// if at this point we didn't load the manifest, set the versioned to the backup value
+		versionedHome = createVersionedHomeFromHash(hash)
+	}
 
 	unpackFile := func(f *zip.File) (err error) {
 		rc, err := f.Open()
@@ -60,44 +112,58 @@ func unzip(log *logger.Logger, archivePath, dataDir string) (string, error) {
 		}
 		defer func() {
 			if cerr := rc.Close(); cerr != nil {
-				err = multierror.Append(err, cerr)
+				err = goerrors.Join(err, cerr)
 			}
 		}()
 
-		//get hash
 		fileName := strings.TrimPrefix(f.Name, fileNamePrefix)
 		if fileName == agentCommitFile {
-			hashBytes, err := io.ReadAll(rc)
-			if err != nil || len(hashBytes) < hashLen {
-				return err
-			}
-
-			hash = string(hashBytes[:hashLen])
+			// we already loaded the hash, skip this one
 			return nil
 		}
+
+		mappedPackagePath := pm.Map(fileName)
 
 		// skip everything outside data/
-		if !strings.HasPrefix(fileName, "data/") {
+		if !strings.HasPrefix(mappedPackagePath, "data/") {
 			return nil
 		}
 
-		path := filepath.Join(dataDir, strings.TrimPrefix(fileName, "data/"))
+		dstPath := strings.TrimPrefix(mappedPackagePath, "data/")
+		dstPath = filepath.Join(dataDir, dstPath)
 
 		if f.FileInfo().IsDir() {
-			log.Debugw("Unpacking directory", "archive", "zip", "file.path", path)
-			// remove any world permissions from the directory
-			_ = os.MkdirAll(path, f.Mode()&0770)
+			log.Debugw("Unpacking directory", "archive", "zip", "file.path", dstPath)
+			// check if the directory already exists
+			_, err = os.Stat(dstPath)
+			if errors.Is(err, fs.ErrNotExist) {
+				// the directory does not exist, create it and any non-existing parent directory with the same permissions
+				if err := os.MkdirAll(dstPath, f.Mode().Perm()&0770); err != nil {
+					return fmt.Errorf("creating directory %q: %w", dstPath, err)
+				}
+			} else if err != nil {
+				return fmt.Errorf("stat() directory %q: %w", dstPath, err)
+			} else {
+				// directory already exists, set the appropriate permissions
+				err = os.Chmod(dstPath, f.Mode().Perm()&0770)
+				if err != nil {
+					return fmt.Errorf("setting permissions %O for directory %q: %w", f.Mode().Perm()&0770, dstPath, err)
+				}
+			}
+
+			_ = os.MkdirAll(dstPath, f.Mode()&0770)
 		} else {
-			log.Debugw("Unpacking file", "archive", "zip", "file.path", path)
-			// remove any world permissions from the directory/file
-			_ = os.MkdirAll(filepath.Dir(path), f.Mode()&0770)
-			f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode()&0770)
+			log.Debugw("Unpacking file", "archive", "zip", "file.path", dstPath)
+			// create non-existing containing folders with 0770 permissions right now, we'll fix the permission of each
+			// directory as we come across them while processing the other package entries
+			_ = os.MkdirAll(filepath.Dir(dstPath), 0770)
+			f, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode()&0770)
 			if err != nil {
 				return err
 			}
 			defer func() {
 				if cerr := f.Close(); cerr != nil {
-					err = multierror.Append(err, cerr)
+					err = goerrors.Join(err, cerr)
 				}
 			}()
 
@@ -119,29 +185,74 @@ func unzip(log *logger.Logger, archivePath, dataDir string) (string, error) {
 		}
 
 		if err := unpackFile(f); err != nil {
-			return "", err
+			return UnpackResult{}, err
 		}
 	}
 
-	return hash, nil
+	return UnpackResult{
+		Hash:          hash,
+		VersionedHome: versionedHome,
+	}, nil
 }
 
-func untar(log *logger.Logger, version string, archivePath, dataDir string) (string, error) {
+func untar(log *logger.Logger, version string, archivePath, dataDir string) (UnpackResult, error) {
+
+	var versionedHome string
+	var rootDir string
+	var hash string
+
+	// Look up manifest in the archive and prepare path mappings, if any
+	pm := pathMapper{}
+
+	// quickly open the archive and look up manifest.yaml file
+	fileContents, err := getFilesContentFromTar(archivePath, "manifest.yaml", agentCommitFile)
+	if err != nil {
+		return UnpackResult{}, fmt.Errorf("looking for package metadata files: %w", err)
+	}
+
+	manifestReader := fileContents["manifest.yaml"]
+	if manifestReader != nil {
+		manifest, err := v1.ParseManifest(manifestReader)
+		if err != nil {
+			return UnpackResult{}, fmt.Errorf("parsing package manifest: %w", err)
+		}
+
+		// set the path mappings
+		pm.mappings = manifest.Package.PathMappings
+		versionedHome = path.Clean(pm.Map(manifest.Package.VersionedHome))
+	}
+
+	if agentCommitReader, ok := fileContents[agentCommitFile]; ok {
+		commitBytes, err := io.ReadAll(agentCommitReader)
+		if err != nil {
+			return UnpackResult{}, fmt.Errorf("reading agent commit hash file: %w", err)
+		}
+		if len(commitBytes) < hashLen {
+			return UnpackResult{}, fmt.Errorf("hash %q is shorter than minimum length %d", string(commitBytes), hashLen)
+		}
+
+		agentCommitHash := string(commitBytes)
+		hash = agentCommitHash[:hashLen]
+		if versionedHome == "" {
+			// set default value of versioned home if it wasn't set by reading the manifest
+			versionedHome = createVersionedHomeFromHash(agentCommitHash)
+		}
+	}
+
 	r, err := os.Open(archivePath)
 	if err != nil {
-		return "", errors.New(fmt.Sprintf("artifact for 'elastic-agent' version '%s' could not be found at '%s'", version, archivePath), errors.TypeFilesystem, errors.M(errors.MetaKeyPath, archivePath))
+		return UnpackResult{}, errors.New(fmt.Sprintf("artifact for 'elastic-agent' version '%s' could not be found at '%s'", version, archivePath), errors.TypeFilesystem, errors.M(errors.MetaKeyPath, archivePath))
 	}
 	defer r.Close()
 
 	zr, err := gzip.NewReader(r)
 	if err != nil {
-		return "", errors.New("requires gzip-compressed body", err, errors.TypeFilesystem)
+		return UnpackResult{}, errors.New("requires gzip-compressed body", err, errors.TypeFilesystem)
 	}
 
 	tr := tar.NewReader(zr)
-	var rootDir string
-	var hash string
-	fileNamePrefix := strings.TrimSuffix(filepath.Base(archivePath), ".tar.gz") + "/" // omitting `elastic-agent-{version}-{os}-{arch}/` in filename
+
+	fileNamePrefix := getFileNamePrefix(archivePath)
 
 	// go through all the content of a tar archive
 	// if elastic-agent.active.commit file is found, get commit of the version unpacked
@@ -153,25 +264,25 @@ func untar(log *logger.Logger, version string, archivePath, dataDir string) (str
 			break
 		}
 		if err != nil {
-			return "", err
+			return UnpackResult{}, err
 		}
 
 		if !validFileName(f.Name) {
-			return "", errors.New("tar contained invalid filename: %q", f.Name, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, f.Name))
+			return UnpackResult{}, errors.New("tar contained invalid filename: %q", f.Name, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, f.Name))
 		}
 
-		//get hash
 		fileName := strings.TrimPrefix(f.Name, fileNamePrefix)
 
 		if fileName == agentCommitFile {
-			hashBytes, err := io.ReadAll(tr)
-			if err != nil || len(hashBytes) < hashLen {
-				return "", err
-			}
-
-			hash = string(hashBytes[:hashLen])
+			// we already loaded the hash, skip this one
 			continue
 		}
+
+		// map the filename
+		fileName = pm.Map(fileName)
+
+		// we should check that the path is a local one but since we discard anything that is not under "data/" we can
+		// skip the additional check
 
 		// skip everything outside data/
 		if !strings.HasPrefix(fileName, "data/") {
@@ -191,16 +302,16 @@ func untar(log *logger.Logger, version string, archivePath, dataDir string) (str
 		switch {
 		case mode.IsRegular():
 			log.Debugw("Unpacking file", "archive", "tar", "file.path", abs)
-			// just to be sure, it should already be created by Dir type
-			// remove any world permissions from the directory
-			if err = os.MkdirAll(filepath.Dir(abs), 0o750); err != nil {
-				return "", errors.New(err, "TarInstaller: creating directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
+			// create non-existing containing folders with 0750 permissions right now, we'll fix the permission of each
+			// directory as we come across them while processing the other package entries
+			if err = os.MkdirAll(filepath.Dir(abs), 0750); err != nil {
+				return UnpackResult{}, errors.New(err, "TarInstaller: creating directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
 			}
 
 			// remove any world permissions from the file
 			wf, err := os.OpenFile(abs, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode.Perm()&0770)
 			if err != nil {
-				return "", errors.New(err, "TarInstaller: creating file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
+				return UnpackResult{}, errors.New(err, "TarInstaller: creating file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
 			}
 
 			//nolint:gosec // legacy
@@ -209,31 +320,39 @@ func untar(log *logger.Logger, version string, archivePath, dataDir string) (str
 				err = closeErr
 			}
 			if err != nil {
-				return "", fmt.Errorf("TarInstaller: error writing to %s: %w", abs, err)
+				return UnpackResult{}, fmt.Errorf("TarInstaller: error writing to %s: %w", abs, err)
 			}
 		case mode.IsDir():
 			log.Debugw("Unpacking directory", "archive", "tar", "file.path", abs)
-			// remove any world permissions from the directory
+			// check if the directory already exists
 			_, err = os.Stat(abs)
 			if errors.Is(err, fs.ErrNotExist) {
+				// the directory does not exist, create it and any non-existing parent directory with the same permissions
 				if err := os.MkdirAll(abs, mode.Perm()&0770); err != nil {
-					return "", errors.New(err, "TarInstaller: creating directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
+					return UnpackResult{}, errors.New(err, "TarInstaller: creating directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
 				}
 			} else if err != nil {
-				return "", errors.New(err, "TarInstaller: stat() directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
+				return UnpackResult{}, errors.New(err, "TarInstaller: stat() directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
 			} else {
-				// set the appropriate permissions
-				err = os.Chmod(abs, mode.Perm()&0o770)
+				// directory already exists, set the appropriate permissions
+				err = os.Chmod(abs, mode.Perm()&0770)
 				if err != nil {
-					return "", errors.New(err, fmt.Sprintf("TarInstaller: setting permissions %O for directory %q", mode.Perm()&0o770, abs), errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
+					return UnpackResult{}, errors.New(err, fmt.Sprintf("TarInstaller: setting permissions %O for directory %q", mode.Perm()&0770, abs), errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
 				}
 			}
 		default:
-			return "", errors.New(fmt.Sprintf("tar file entry %s contained unsupported file type %v", fileName, mode), errors.TypeFilesystem, errors.M(errors.MetaKeyPath, fileName))
+			return UnpackResult{}, errors.New(fmt.Sprintf("tar file entry %s contained unsupported file type %v", fileName, mode), errors.TypeFilesystem, errors.M(errors.MetaKeyPath, fileName))
 		}
 	}
 
-	return hash, nil
+	return UnpackResult{
+		Hash:          hash,
+		VersionedHome: versionedHome,
+	}, nil
+}
+
+func getFileNamePrefix(archivePath string) string {
+	return strings.TrimSuffix(filepath.Base(archivePath), ".tar.gz") + "/" // omitting `elastic-agent-{version}-{os}-{arch}/` in filename
 }
 
 func validFileName(p string) bool {
@@ -241,4 +360,111 @@ func validFileName(p string) bool {
 		return false
 	}
 	return true
+}
+
+type pathMapper struct {
+	mappings []map[string]string
+}
+
+func (pm pathMapper) Map(path string) string {
+	for _, mapping := range pm.mappings {
+		for pkgPath, mappedPath := range mapping {
+			if strings.HasPrefix(path, pkgPath) {
+				return filepath.Join(mappedPath, path[len(pkgPath):])
+			}
+		}
+	}
+	return path
+}
+
+type tarCloser struct {
+	tarFile    *os.File
+	gzipReader *gzip.Reader
+}
+
+func (tc *tarCloser) Close() error {
+	var err error
+	if tc.gzipReader != nil {
+		err = goerrors.Join(err, tc.gzipReader.Close())
+	}
+	// prevent double Close() call to fzip reader
+	tc.gzipReader = nil
+	if tc.tarFile != nil {
+		err = goerrors.Join(err, tc.tarFile.Close())
+	}
+	// prevent double Close() call the underlying file
+	tc.tarFile = nil
+	return err
+}
+
+// openTar is a convenience function to open a tar.gz file.
+// It returns a *tar.Reader, an io.Closer implementation to be called to release resources and an error
+// In case of errors the *tar.Reader will be nil, but the io.Closer is always returned and must be called also in case
+// of errors to close the underlying readers.
+func openTar(archivePath string) (*tar.Reader, io.Closer, error) {
+	tc := new(tarCloser)
+	r, err := os.Open(archivePath)
+	if err != nil {
+		return nil, tc, fmt.Errorf("opening package %s: %w", archivePath, err)
+	}
+	tc.tarFile = r
+
+	zr, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, tc, fmt.Errorf("package %s does not seem to have a valid gzip compression: %w", archivePath, err)
+	}
+	tc.gzipReader = zr
+
+	return tar.NewReader(zr), tc, nil
+}
+
+// getFilesContentFromTar is a small utility function which will load in memory the contents of a list of files from the tar archive.
+// It's meant to be used to load package information/metadata stored in small files within the .tar.gz archive
+func getFilesContentFromTar(archivePath string, files ...string) (map[string]io.Reader, error) {
+	tr, tc, err := openTar(archivePath)
+	if err != nil {
+		return nil, fmt.Errorf("opening tar.gz package %s: %w", archivePath, err)
+	}
+	defer tc.Close()
+
+	prefix := getFileNamePrefix(archivePath)
+
+	result := make(map[string]io.Reader, len(files))
+	fileset := make(map[string]struct{}, len(files))
+	// load the fileset with the names we are looking for
+	for _, fName := range files {
+		fileset[fName] = struct{}{}
+	}
+
+	// go through all the content of a tar archive
+	// if one of the listed files is found, read the contents and set a byte reader into the result map
+	for {
+		f, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("reading archive: %w", err)
+		}
+
+		fileName := strings.TrimPrefix(f.Name, prefix)
+		if _, ok := fileset[fileName]; ok {
+			// it's one of the files we are looking for, retrieve the content and set a reader into the result map
+			manifestBytes, err := io.ReadAll(tr)
+			if err != nil {
+				return nil, fmt.Errorf("reading manifest bytes: %w", err)
+			}
+
+			reader := bytes.NewReader(manifestBytes)
+			result[fileName] = reader
+		}
+
+	}
+
+	return result, nil
+}
+
+func createVersionedHomeFromHash(hash string) string {
+	return fmt.Sprintf("data/elastic-agent-%s", hash[:hashLen])
 }

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -46,11 +46,11 @@ func (u *Upgrader) unpack(version, archivePath, dataDir string) (UnpackResult, e
 	}
 
 	if err != nil {
-		u.log.Errorw("Failed to unpack upgrade artifact", "error.message", err, "version", version, "file.path", archivePath, "unpackResult", unpackRes)
+		u.log.Errorw("Failed to unpack upgrade artifact", "error.message", err, "version", version, "file.path", archivePath, "unpack_result", unpackRes)
 		return UnpackResult{}, err
 	}
 
-	u.log.Infow("Unpacked upgrade artifact", "version", version, "file.path", archivePath, "unpackResult", unpackRes)
+	u.log.Infow("Unpacked upgrade artifact", "version", version, "file.path", archivePath, "unpack_result", unpackRes)
 	return unpackRes, nil
 }
 

--- a/internal/pkg/agent/application/upgrade/step_unpack_test.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	v1 "github.com/elastic/elastic-agent/pkg/api/v1"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
@@ -61,7 +62,7 @@ inputs:
 
 var archiveFilesWithManifestNoSymlink = []files{
 	{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
-	{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64/manifest.yaml", content: ea_123_manifest, mode: fs.ModePerm & 0o640},
+	{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64/" + v1.ManifestFileName, content: ea_123_manifest, mode: fs.ModePerm & 0o640},
 	{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64/" + agentCommitFile, content: "abcdefghijklmnopqrstuvwxyz", mode: fs.ModePerm & 0o640},
 	{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64/data", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
 	{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64/data/elastic-agent-abcdef", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
@@ -302,7 +303,7 @@ func checkExtractedFilesWithManifest(t *testing.T, testDataDir string) {
 			assert.Equal(t, agentBinaryPlaceholderContent, string(fileBytes), "agent binary placeholder content does not match")
 		}
 	}
-	mappedPackageManifest := filepath.Join(versionedHome, "manifest.yaml")
+	mappedPackageManifest := filepath.Join(versionedHome, v1.ManifestFileName)
 	if assert.FileExistsf(t, mappedPackageManifest, "package manifest %q is not found in mapped versioned home directory %q", mappedPackageManifest, versionedHome) {
 		fileBytes, err := os.ReadFile(mappedPackageManifest)
 		if assert.NoErrorf(t, err, "error reading package manifest %q", mappedPackageManifest) {

--- a/internal/pkg/agent/application/upgrade/step_unpack_test.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack_test.go
@@ -6,6 +6,7 @@ package upgrade
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"compress/gzip"
 	"fmt"
 	"io"
@@ -13,7 +14,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -24,6 +24,19 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
+const agentBinaryPlaceholderContent = "Placeholder for the elastic-agent binary"
+
+const ea_123_manifest = `
+version: co.elastic.agent/v1
+kind: PackageManifest
+package:
+  version: 1.2.3
+  snapshot: true
+  versioned-home: data/elastic-agent-abcdef
+  path-mappings:
+    - data/elastic-agent-abcdef: data/elastic-agent-1.2.3-SNAPSHOT-abcdef
+      manifest.yaml: data/elastic-agent-1.2.3-SNAPSHOT-abcdef/manifest.yaml
+`
 const foo_component_spec = `
 version: 2
 inputs:
@@ -87,21 +100,22 @@ func (f files) Sys() any {
 type createArchiveFunc func(t *testing.T, archiveFiles []files) (string, error)
 type checkExtractedPath func(t *testing.T, testDataDir string)
 
-func TestUpgrader_unpack(t *testing.T) {
+func TestUpgrader_unpackTarGz(t *testing.T) {
 	type args struct {
 		version          string
 		archiveGenerator createArchiveFunc
 		archiveFiles     []files
 	}
+
 	tests := []struct {
 		name       string
 		args       args
-		want       string
+		want       UnpackResult
 		wantErr    assert.ErrorAssertionFunc
 		checkFiles checkExtractedPath
 	}{
 		{
-			name: "targz with file before containing folder",
+			name: "file before containing folder",
 			args: args{
 				version: "1.2.3",
 				archiveFiles: []files{
@@ -110,7 +124,7 @@ func TestUpgrader_unpack(t *testing.T) {
 					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/package.version", content: "1.2.3", mode: fs.ModePerm & 0o640},
 					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
 					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef", mode: fs.ModeDir | (fs.ModePerm & 0o700)},
-					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/" + agentName, content: "Placeholder for the elastic-agent binary", mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/" + agentName, content: agentBinaryPlaceholderContent, mode: fs.ModePerm & 0o750},
 					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
 					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components/comp1", content: "Placeholder for component", mode: fs.ModePerm & 0o750},
 					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components/comp1.spec.yml", content: foo_component_spec, mode: fs.ModePerm & 0o640},
@@ -120,10 +134,12 @@ func TestUpgrader_unpack(t *testing.T) {
 					return createTarArchive(t, "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64.tar.gz", i)
 				},
 			},
-			want:    "abcdef",
+			want: UnpackResult{
+				Hash:          "abcdef",
+				VersionedHome: filepath.Join("data", "elastic-agent-abcdef"),
+			},
 			wantErr: assert.NoError,
 			checkFiles: func(t *testing.T, testDataDir string) {
-
 				versionedHome := filepath.Join(testDataDir, "elastic-agent-abcdef")
 				require.DirExists(t, versionedHome, "directory for package.version does not exists")
 				stat, err := os.Stat(versionedHome)
@@ -133,30 +149,189 @@ func TestUpgrader_unpack(t *testing.T) {
 				assert.Equalf(t, expectedPermissions, actualPermissions, "Wrong permissions set on versioned home %q: expected %O, got %O", versionedHome, expectedPermissions, actualPermissions)
 			},
 		},
+		{
+			name: "package with manifest file",
+			args: args{
+				version: "1.2.3",
+				archiveFiles: []files{
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/manifest.yaml", content: ea_123_manifest, mode: fs.ModePerm & 0o640},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/" + agentCommitFile, content: "abcdefghijklmnopqrstuvwxyz", mode: fs.ModePerm & 0o640},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/" + agentName, content: agentBinaryPlaceholderContent, mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/package.version", content: "1.2.3", mode: fs.ModePerm & 0o640},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components/comp1", content: "Placeholder for component", mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/data/elastic-agent-abcdef/components/comp1.spec.yml", content: foo_component_spec, mode: fs.ModePerm & 0o640},
+					{fType: SYMLINK, path: "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64/" + agentName, content: "data/elastic-agent-abcdef/" + agentName, mode: fs.ModeSymlink | (fs.ModePerm & 0o750)},
+				},
+				archiveGenerator: func(t *testing.T, i []files) (string, error) {
+					return createTarArchive(t, "elastic-agent-1.2.3-SNAPSHOT-linux-x86_64.tar.gz", i)
+				},
+			},
+			want: UnpackResult{
+				Hash:          "abcdef",
+				VersionedHome: "data/elastic-agent-1.2.3-SNAPSHOT-abcdef",
+			},
+			wantErr: assert.NoError,
+			checkFiles: func(t *testing.T, testDataDir string) {
+				versionedHome := filepath.Join(testDataDir, "elastic-agent-1.2.3-SNAPSHOT-abcdef")
+				require.DirExists(t, versionedHome, "mapped versioned home directory does not exists")
+				mappedAgentExecutable := filepath.Join(versionedHome, agentName)
+				if assert.FileExistsf(t, mappedAgentExecutable, "agent executable %q is not found in mapped versioned home directory %q", mappedAgentExecutable, versionedHome) {
+					fileBytes, err := os.ReadFile(mappedAgentExecutable)
+					if assert.NoErrorf(t, err, "error reading elastic-agent executable %q", mappedAgentExecutable) {
+						assert.Equal(t, agentBinaryPlaceholderContent, string(fileBytes), "agent binary placeholder content does not match")
+					}
+				}
+				mappedPackageManifest := filepath.Join(versionedHome, "manifest.yaml")
+				if assert.FileExistsf(t, mappedPackageManifest, "package manifest %q is not found in mapped versioned home directory %q", mappedPackageManifest, versionedHome) {
+					fileBytes, err := os.ReadFile(mappedPackageManifest)
+					if assert.NoErrorf(t, err, "error reading package manifest %q", mappedPackageManifest) {
+						assert.Equal(t, ea_123_manifest, string(fileBytes), "package manifest content does not match")
+					}
+				}
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if runtime.GOOS == "windows" {
-				t.Skip("tar.gz tests only run on Linux/MacOS")
+			testTop := t.TempDir()
+			testDataDir := filepath.Join(testTop, "data")
+			err := os.MkdirAll(testDataDir, 0o777)
+			assert.NoErrorf(t, err, "error creating initial structure %q", testDataDir)
+			log, _ := logger.NewTesting(tt.name)
+
+			archiveFile, err := tt.args.archiveGenerator(t, tt.args.archiveFiles)
+			require.NoError(t, err, "creation of test archive file failed")
+
+			got, err := untar(log, tt.args.version, archiveFile, testDataDir)
+			if !tt.wantErr(t, err, fmt.Sprintf("untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)) {
+				return
 			}
+			assert.Equalf(t, tt.want, got, "untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)
+			if tt.checkFiles != nil {
+				tt.checkFiles(t, testDataDir)
+			}
+		})
+	}
+}
+
+func TestUpgrader_unpackZip(t *testing.T) {
+	type args struct {
+		archiveGenerator createArchiveFunc
+		archiveFiles     []files
+	}
+
+	tests := []struct {
+		name       string
+		args       args
+		want       UnpackResult
+		wantErr    assert.ErrorAssertionFunc
+		checkFiles checkExtractedPath
+	}{
+		{
+			name: "file before containing folder",
+			args: args{
+				archiveFiles: []files{
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/" + agentCommitFile, content: "abcdefghijklmnopqrstuvwxyz", mode: fs.ModePerm & 0o640},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/package.version", content: "1.2.3", mode: fs.ModePerm & 0o640},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef", mode: fs.ModeDir | (fs.ModePerm & 0o700)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/" + agentName, content: agentBinaryPlaceholderContent, mode: fs.ModePerm & 0o750},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components/comp1", content: "Placeholder for component", mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components/comp1.spec.yml", content: foo_component_spec, mode: fs.ModePerm & 0o640},
+				},
+				archiveGenerator: func(t *testing.T, i []files) (string, error) {
+					return createZipArchive(t, "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64.zip", i)
+				},
+			},
+			want: UnpackResult{
+				Hash:          "abcdef",
+				VersionedHome: filepath.Join("data", "elastic-agent-abcdef"),
+			},
+			wantErr: assert.NoError,
+			checkFiles: func(t *testing.T, testDataDir string) {
+				versionedHome := filepath.Join(testDataDir, "elastic-agent-abcdef")
+				require.DirExists(t, versionedHome, "directory for package.version does not exists")
+				stat, err := os.Stat(versionedHome)
+				require.NoErrorf(t, err, "error calling Stat() for versionedHome %q", versionedHome)
+				expectedPermissions := fs.ModePerm & 0o700
+				actualPermissions := fs.ModePerm & stat.Mode()
+				assert.Equalf(t, expectedPermissions, actualPermissions, "Wrong permissions set on versioned home %q: expected %O, got %O", versionedHome, expectedPermissions, actualPermissions)
+				agentExecutable := filepath.Join(versionedHome, agentName)
+				if assert.FileExistsf(t, agentExecutable, "agent executable %q is not found in versioned home directory %q", agentExecutable, versionedHome) {
+					fileBytes, err := os.ReadFile(agentExecutable)
+					if assert.NoErrorf(t, err, "error reading elastic-agent executable %q", agentExecutable) {
+						assert.Equal(t, agentBinaryPlaceholderContent, string(fileBytes), "agent binary placeholder content does not match")
+					}
+				}
+			},
+		},
+		{
+			name: "package with manifest file",
+			args: args{
+				archiveFiles: []files{
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/manifest.yaml", content: ea_123_manifest, mode: fs.ModePerm & 0o640},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/" + agentCommitFile, content: "abcdefghijklmnopqrstuvwxyz", mode: fs.ModePerm & 0o640},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/" + agentName, content: agentBinaryPlaceholderContent, mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/package.version", content: "1.2.3", mode: fs.ModePerm & 0o640},
+					{fType: DIRECTORY, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components", mode: fs.ModeDir | (fs.ModePerm & 0o750)},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components/comp1", content: "Placeholder for component", mode: fs.ModePerm & 0o750},
+					{fType: REGULAR, path: "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64/data/elastic-agent-abcdef/components/comp1.spec.yml", content: foo_component_spec, mode: fs.ModePerm & 0o640},
+				},
+				archiveGenerator: func(t *testing.T, i []files) (string, error) {
+					return createZipArchive(t, "elastic-agent-1.2.3-SNAPSHOT-windows-x86_64.zip", i)
+				},
+			},
+			want: UnpackResult{
+				Hash:          "abcdef",
+				VersionedHome: filepath.Join("data", "elastic-agent-1.2.3-SNAPSHOT-abcdef"),
+			},
+			wantErr: assert.NoError,
+			checkFiles: func(t *testing.T, testDataDir string) {
+				versionedHome := filepath.Join(testDataDir, "elastic-agent-1.2.3-SNAPSHOT-abcdef")
+				require.DirExists(t, versionedHome, "mapped versioned home directory does not exists")
+				mappedAgentExecutable := filepath.Join(versionedHome, agentName)
+				if assert.FileExistsf(t, mappedAgentExecutable, "agent executable %q is not found in mapped versioned home directory %q", mappedAgentExecutable, versionedHome) {
+					fileBytes, err := os.ReadFile(mappedAgentExecutable)
+					if assert.NoErrorf(t, err, "error reading elastic-agent executable %q", mappedAgentExecutable) {
+						assert.Equal(t, agentBinaryPlaceholderContent, string(fileBytes), "agent binary placeholder content does not match")
+					}
+				}
+				mappedPackageManifest := filepath.Join(versionedHome, "manifest.yaml")
+				if assert.FileExistsf(t, mappedPackageManifest, "package manifest %q is not found in mapped versioned home directory %q", mappedPackageManifest, versionedHome) {
+					fileBytes, err := os.ReadFile(mappedPackageManifest)
+					if assert.NoErrorf(t, err, "error reading package manifest %q", mappedPackageManifest) {
+						assert.Equal(t, ea_123_manifest, string(fileBytes), "package manifest content does not match")
+					}
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 
 			testTop := t.TempDir()
 			testDataDir := filepath.Join(testTop, "data")
 			err := os.MkdirAll(testDataDir, 0o777)
 			assert.NoErrorf(t, err, "error creating initial structure %q", testDataDir)
 			log, _ := logger.NewTesting(tt.name)
-			u := &Upgrader{
-				log: log,
-			}
 
 			archiveFile, err := tt.args.archiveGenerator(t, tt.args.archiveFiles)
 			require.NoError(t, err, "creation of test archive file failed")
 
-			got, err := u.unpack(tt.args.version, archiveFile, testDataDir)
-			if !tt.wantErr(t, err, fmt.Sprintf("unpack(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)) {
+			got, err := unzip(log, archiveFile, testDataDir)
+			if !tt.wantErr(t, err, fmt.Sprintf("unzip(%v, %v)", archiveFile, testDataDir)) {
 				return
 			}
-			assert.Equalf(t, tt.want, got, "unpack(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)
+			assert.Equalf(t, tt.want, got, "unzip(%v, %v)", archiveFile, testDataDir)
 			if tt.checkFiles != nil {
 				tt.checkFiles(t, testDataDir)
 			}
@@ -165,20 +340,23 @@ func TestUpgrader_unpack(t *testing.T) {
 }
 
 func createTarArchive(t *testing.T, archiveName string, archiveFiles []files) (string, error) {
-
+	t.Helper()
 	outDir := t.TempDir()
 
 	outFilePath := filepath.Join(outDir, archiveName)
 	file, err := os.OpenFile(outFilePath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
 	require.NoErrorf(t, err, "error creating output archive %q", outFilePath)
-	defer file.Close()
+	defer func(file *os.File) {
+		err := file.Close()
+		assert.NoError(t, err, "error closing tar.gz archive file")
+	}(file)
 	zipWriter := gzip.NewWriter(file)
 	writer := tar.NewWriter(zipWriter)
 	defer func(writer *tar.Writer) {
 		err := writer.Close()
-		require.NoError(t, err, "error closing tar writer")
+		assert.NoError(t, err, "error closing tar writer")
 		err = zipWriter.Close()
-		require.NoError(t, err, "error closing gzip writer")
+		assert.NoError(t, err, "error closing gzip writer")
 	}(writer)
 
 	for _, af := range archiveFiles {
@@ -208,5 +386,64 @@ func addEntryToTarArchive(af files, writer *tar.Writer) error {
 	if _, err = io.Copy(writer, strings.NewReader(af.content)); err != nil {
 		return fmt.Errorf("copying file %q content: %w", af.path, err)
 	}
+	return nil
+}
+
+func createZipArchive(t *testing.T, archiveName string, archiveFiles []files) (string, error) {
+	t.Helper()
+	outDir := t.TempDir()
+
+	outFilePath := filepath.Join(outDir, archiveName)
+	file, err := os.OpenFile(outFilePath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
+	require.NoErrorf(t, err, "error creating output archive %q", outFilePath)
+	defer func(file *os.File) {
+		err := file.Close()
+		assert.NoError(t, err, "error closing zip archive file")
+	}(file)
+
+	w := zip.NewWriter(file)
+	defer func(writer *zip.Writer) {
+		err := writer.Close()
+		assert.NoError(t, err, "error closing tar writer")
+	}(w)
+
+	for _, af := range archiveFiles {
+		if af.fType == SYMLINK {
+			return "", fmt.Errorf("entry %q is a symlink. Not supported in .zip files", af.path)
+		}
+
+		err = addEntryToZipArchive(af, w)
+		require.NoErrorf(t, err, "error adding %q to tar archive", af.path)
+	}
+	return outFilePath, nil
+}
+
+func addEntryToZipArchive(af files, writer *zip.Writer) error {
+	header, err := zip.FileInfoHeader(&af)
+	if err != nil {
+		return fmt.Errorf("creating header for %q: %w", af.path, err)
+	}
+
+	header.SetMode(af.Mode() & os.ModePerm)
+	header.Name = af.path
+	if af.IsDir() {
+		header.Name += string(filepath.Separator)
+	} else {
+		header.Method = zip.Deflate
+	}
+
+	w, err := writer.CreateHeader(header)
+	if err != nil {
+		return err
+	}
+
+	if af.IsDir() {
+		return nil
+	}
+
+	if _, err = io.Copy(w, strings.NewReader(af.content)); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/internal/pkg/agent/application/upgrade/step_unpack_test.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack_test.go
@@ -189,7 +189,7 @@ func TestUpgrader_unpackTarGz(t *testing.T) {
 			archiveFile, err := tt.args.archiveGenerator(t, tt.args.archiveFiles)
 			require.NoError(t, err, "creation of test archive file failed")
 
-			got, err := untar(log, tt.args.version, archiveFile, testDataDir)
+			got, err := untar(log, archiveFile, testDataDir)
 			if !tt.wantErr(t, err, fmt.Sprintf("untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)) {
 				return
 			}

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -224,7 +224,6 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	}
 
 	if unpackRes.VersionedHome == "" {
-		// FIXME this should be treated as an error
 		return nil, fmt.Errorf("versionedhome is empty: %v", unpackRes)
 	}
 
@@ -279,8 +278,8 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	}
 
 	if err := markUpgrade(u.log,
-		paths.Data(), //data dir to place the marker in
-		current,      //new agent version data
+		paths.Data(), // data dir to place the marker in
+		current,      // new agent version data
 		previous,     // old agent version data
 		action, det); err != nil {
 		u.log.Errorw("Rolling back: marking upgrade failed", "error.message", err)

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -32,6 +32,7 @@ import (
 	"github.com/elastic/elastic-agent/pkg/control/v2/client"
 	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
+	agtversion "github.com/elastic/elastic-agent/pkg/version"
 )
 
 const (
@@ -46,9 +47,6 @@ var agentArtifact = artifact.Artifact{
 	Cmd:      agentName,
 	Artifact: "beats/" + agentName,
 }
-
-// ErrSameVersion error is returned when the upgrade results in the same installed version.
-var ErrSameVersion = errors.New("upgrade did not occur because its the same version")
 
 // Upgrader performs an upgrade
 type Upgrader struct {
@@ -134,6 +132,24 @@ func (u *Upgrader) Upgradeable() bool {
 	return u.upgradeable
 }
 
+type agentVersion struct {
+	version  string
+	snapshot bool
+	hash     string
+}
+
+func (av agentVersion) String() string {
+	buf := strings.Builder{}
+	buf.WriteString(av.version)
+	if av.snapshot {
+		buf.WriteString("-SNAPSHOT")
+	}
+	buf.WriteString(" (hash: ")
+	buf.WriteString(av.hash)
+	buf.WriteString(")")
+	return buf.String()
+}
+
 // Upgrade upgrades running agent, function returns shutdown callback that must be called by reexec.
 func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string, action *fleetapi.ActionUpgrade, det *details.Details, skipVerifyOverride bool, skipDefaultPgp bool, pgpBytes ...string) (_ reexec.ShutdownCallbackFn, err error) {
 	u.log.Infow("Upgrading agent", "version", version, "source_uri", sourceURI)
@@ -170,7 +186,26 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	}
 
 	det.SetState(details.StateExtracting)
-	// TODO: add check that no archive files end up in the current versioned home
+
+	metadata, err := u.getPackageMetadata(archivePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading metadata for elastic agent version %s package %q: %w", version, archivePath, err)
+	}
+
+	currentVersion := agentVersion{
+		version:  release.Version(),
+		snapshot: release.Snapshot(),
+		hash:     release.Commit(),
+	}
+
+	same, newVersion := isSameVersion(u.log, currentVersion, metadata, version)
+	if same {
+		return nil, fmt.Errorf("agent version is already %s", currentVersion)
+	}
+
+	u.log.Infow("Unpacking agent package", "version", newVersion)
+
+	// Nice to have: add check that no archive files end up in the current versioned home
 	unpackRes, err := u.unpack(version, archivePath, paths.Data())
 	if err != nil {
 		return nil, err
@@ -185,12 +220,6 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 		// FIXME this should be treated as an error
 		return nil, fmt.Errorf("versionedhome is empty: %v", unpackRes)
 	}
-
-	// TODO reintroduce the version check
-	//if strings.HasPrefix(release.Commit(), newHash) {
-	//	u.log.Warn("Upgrade action skipped: upgrade did not occur because its the same version")
-	//	return nil, nil
-	//}
 
 	newHome := filepath.Join(paths.Top(), unpackRes.VersionedHome)
 
@@ -242,7 +271,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 		return nil, err
 	}
 
-	cb := shutdownCallback(u.log, paths.Home(), release.Version(), version, release.TrimCommit(newHash))
+	cb := shutdownCallback(u.log, paths.Home(), release.Version(), version, filepath.Join(paths.Top(), unpackRes.VersionedHome))
 
 	// Clean everything from the downloads dir
 	u.log.Infow("Removing downloads directory", "file.path", paths.Downloads())
@@ -297,6 +326,25 @@ func (u *Upgrader) sourceURI(retrievedURI string) string {
 	}
 
 	return u.settings.SourceURI
+}
+
+func isSameVersion(log *logger.Logger, current agentVersion, metadata packageMetadata, upgradeVersion string) (bool, agentVersion) {
+	newVersion := agentVersion{}
+	if metadata.manifest != nil {
+		packageDesc := metadata.manifest.Package
+		newVersion.version = packageDesc.Version
+		newVersion.snapshot = packageDesc.Snapshot
+	} else {
+		// extract version info from the version string (we can ignore parsing errors as it would have never passed the download step)
+		parsedVersion, _ := agtversion.ParseVersion(upgradeVersion)
+		newVersion.version = strings.TrimSuffix(parsedVersion.VersionWithPrerelease(), "-SNAPSHOT")
+		newVersion.snapshot = parsedVersion.IsSnapshot()
+	}
+	newVersion.hash = metadata.hash
+
+	log.Debugw("Comparing current and new agent version", "current_version", current, "new_version", newVersion)
+
+	return current == newVersion, newVersion
 }
 
 func rollbackInstall(ctx context.Context, log *logger.Logger, topDirPath, versionedHome string) {
@@ -358,7 +406,7 @@ func copyRunDirectory(log *logger.Logger, oldRunPath, newRunPath string) error {
 // shutdownCallback returns a callback function to be executing during shutdown once all processes are closed.
 // this goes through runtime directory of agent and copies all the state files created by processes to new versioned
 // home directory with updated process name to match new version.
-func shutdownCallback(l *logger.Logger, homePath, prevVersion, newVersion, newHash string) reexec.ShutdownCallbackFn {
+func shutdownCallback(l *logger.Logger, homePath, prevVersion, newVersion, newHome string) reexec.ShutdownCallbackFn {
 	if release.Snapshot() {
 		// SNAPSHOT is part of newVersion
 		prevVersion += "-SNAPSHOT"
@@ -372,7 +420,6 @@ func shutdownCallback(l *logger.Logger, homePath, prevVersion, newVersion, newHa
 		}
 
 		oldHome := homePath
-		newHome := filepath.Join(filepath.Dir(homePath), fmt.Sprintf("%s-%s", agentName, newHash))
 		for _, processDir := range processDirs {
 			newDir := strings.ReplaceAll(processDir, prevVersion, newVersion)
 			newDir = strings.ReplaceAll(newDir, oldHome, newHome)

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -74,7 +74,7 @@ func NewUpgrader(log *logger.Logger, settings *artifact.Config, agentInfo info.A
 		settings:      settings,
 		agentInfo:     agentInfo,
 		upgradeable:   IsUpgradeable(),
-		markerWatcher: newMarkerFileWatcher(markerFilePath(), log),
+		markerWatcher: newMarkerFileWatcher(markerFilePath(paths.Data()), log),
 	}, nil
 }
 
@@ -186,6 +186,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 		return nil, fmt.Errorf("versionedhome is empty: %v", unpackRes)
 	}
 
+	// TODO reintroduce the version check
 	//if strings.HasPrefix(release.Commit(), newHash) {
 	//	u.log.Warn("Upgrade action skipped: upgrade did not occur because its the same version")
 	//	return nil, nil
@@ -214,21 +215,30 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	// paths.BinaryPath properly derives the binary directory depending on the platform. The path to the binary for macOS is inside of the app bundle.
 	newPath := paths.BinaryPath(filepath.Join(paths.Top(), hashedDir), agentName)
 
-	if err := changeSymlinkInternal(u.log, symlinkPath, newPath); err != nil {
+	if err := changeSymlinkInternal(u.log, paths.Top(), symlinkPath, newPath); err != nil {
 		u.log.Errorw("Rolling back: changing symlink failed", "error.message", err)
-		rollbackInstall(ctx, u.log, hashedDir)
+		rollbackInstall(ctx, u.log, paths.Top(), hashedDir)
 		return nil, err
 	}
 
-	if err := u.markUpgrade(ctx, u.log, version, unpackRes.Hash, unpackRes.VersionedHome, action, det); err != nil {
+	currentVersionedHome, err := filepath.Rel(paths.Top(), paths.Home())
+	if err != nil {
+		return nil, fmt.Errorf("calculating home path relative to top, home: %q top: %q : %w", paths.Home(), paths.Top(), err)
+	}
+	if err := markUpgrade(
+		u.log,
+		paths.Data(),                                     //data dir to place the marker in
+		version, unpackRes.Hash, unpackRes.VersionedHome, //new agent version data
+		release.VersionWithSnapshot(), release.Commit(), currentVersionedHome, // old agent version data
+		action, det); err != nil {
 		u.log.Errorw("Rolling back: marking upgrade failed", "error.message", err)
-		rollbackInstall(ctx, u.log, hashedDir)
+		rollbackInstall(ctx, u.log, paths.Top(), hashedDir)
 		return nil, err
 	}
 
 	if err := InvokeWatcher(u.log); err != nil {
 		u.log.Errorw("Rolling back: starting watcher failed", "error.message", err)
-		rollbackInstall(ctx, u.log, hashedDir)
+		rollbackInstall(ctx, u.log, paths.Top(), hashedDir)
 		return nil, err
 	}
 
@@ -247,7 +257,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 // Ack acks last upgrade action
 func (u *Upgrader) Ack(ctx context.Context, acker acker.Acker) error {
 	// get upgrade action
-	marker, err := LoadMarker()
+	marker, err := LoadMarker(paths.Data())
 	if err != nil {
 		return err
 	}
@@ -289,14 +299,14 @@ func (u *Upgrader) sourceURI(retrievedURI string) string {
 	return u.settings.SourceURI
 }
 
-func rollbackInstall(ctx context.Context, log *logger.Logger, versionedHome string) {
-	err := os.RemoveAll(filepath.Join(paths.Top(), versionedHome))
+func rollbackInstall(ctx context.Context, log *logger.Logger, topDirPath, versionedHome string) {
+	err := os.RemoveAll(filepath.Join(topDirPath, versionedHome))
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		// TODO should this be a warning or an error ?
 		log.Warnw("error rolling back install", "error.message", err)
 	}
 	// FIXME update
-	_ = ChangeSymlink(ctx, log, release.ShortCommit())
+	_ = ChangeSymlink(ctx, log, topDirPath, release.ShortCommit())
 }
 
 func copyActionStore(log *logger.Logger, newHome string) error {

--- a/internal/pkg/agent/application/upgrade/upgrade_test.go
+++ b/internal/pkg/agent/application/upgrade/upgrade_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -111,40 +110,80 @@ func Test_CopyFile(t *testing.T) {
 }
 
 func TestShutdownCallback(t *testing.T) {
-	l, _ := logger.New("test", false)
-	tmpDir, err := os.MkdirTemp("", "shutdown-test-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
 
-	// make homepath agent consistent (in a form of elastic-agent-hash)
-	homePath := filepath.Join(tmpDir, fmt.Sprintf("%s-%s", agentName, release.ShortCommit()))
+	type testcase struct {
+		name                  string
+		agentHomeDirectory    string
+		newAgentHomeDirectory string
+		agentVersion          string
+		newAgentVersion       string
+		oldRunFile            string
+		newRunFile            string
+	}
 
-	filename := "file.test"
-	newCommit := "abc123"
-	sourceVersion := "7.14.0"
-	targetVersion := "7.15.0"
+	testcases := []testcase{
+		{
+			name:                  "legacy run directories",
+			agentHomeDirectory:    fmt.Sprintf("%s-%s", agentName, release.ShortCommit()),
+			newAgentHomeDirectory: fmt.Sprintf("%s-%s", agentName, "abc123"),
+			agentVersion:          "7.14.0",
+			newAgentVersion:       "7.15.0",
+			oldRunFile:            filepath.Join("run", "default", "process-7.14.0", "file.test"),
+			newRunFile:            filepath.Join("run", "default", "process-7.15.0", "file.test"),
+		},
+		{
+			name:                  "new run directories",
+			agentHomeDirectory:    "elastic-agent-abcdef",
+			newAgentHomeDirectory: "elastic-agent-ghijkl",
+			agentVersion:          "1.2.3",
+			newAgentVersion:       "4.5.6",
+			oldRunFile:            filepath.Join("run", "component", "unit", "file.test"),
+			newRunFile:            filepath.Join("run", "component", "unit", "file.test"),
+		},
+		{
+			name:                  "new run directories, agents with version in path",
+			agentHomeDirectory:    "elastic-agent-1.2.3-abcdef",
+			newAgentHomeDirectory: "elastic-agent-4.5.6-ghijkl",
+			agentVersion:          "1.2.3",
+			newAgentVersion:       "4.5.6",
+			oldRunFile:            filepath.Join("run", "component", "unit", "file.test"),
+			newRunFile:            filepath.Join("run", "component", "unit", "file.test"),
+		},
+	}
 
-	content := []byte("content")
-	newHome := strings.ReplaceAll(homePath, release.ShortCommit(), newCommit)
-	sourceDir := filepath.Join(homePath, "run", "default", "process-"+sourceVersion)
-	targetDir := filepath.Join(newHome, "run", "default", "process-"+targetVersion)
+	for _, tt := range testcases {
 
-	require.NoError(t, os.MkdirAll(sourceDir, 0755))
-	require.NoError(t, os.MkdirAll(targetDir, 0755))
+		t.Run(tt.name, func(t *testing.T) {
+			l, _ := logger.New(tt.name, false)
+			tmpDir := t.TempDir()
 
-	cb := shutdownCallback(l, homePath, sourceVersion, targetVersion, newHome)
+			// make homepath agent consistent
+			homePath := filepath.Join(tmpDir, tt.agentHomeDirectory)
+			newHome := filepath.Join(tmpDir, tt.newAgentHomeDirectory)
 
-	oldFilename := filepath.Join(sourceDir, filename)
-	err = os.WriteFile(oldFilename, content, 0640)
-	require.NoError(t, err, "preparing file failed")
+			content := []byte("content")
+			sourceDir := filepath.Join(homePath, filepath.Dir(tt.oldRunFile))
+			targetDir := filepath.Join(newHome, filepath.Dir(tt.newRunFile))
 
-	err = cb()
-	require.NoError(t, err, "callback failed")
+			require.NoError(t, os.MkdirAll(sourceDir, 0755))
+			require.NoError(t, os.MkdirAll(targetDir, 0755))
 
-	newFilename := filepath.Join(targetDir, filename)
-	newContent, err := os.ReadFile(newFilename)
-	require.NoError(t, err, "reading file failed")
-	require.Equal(t, content, newContent, "contents are not equal")
+			cb := shutdownCallback(l, homePath, tt.agentVersion, tt.newAgentVersion, newHome)
+
+			oldFilename := filepath.Join(homePath, tt.oldRunFile)
+			err := os.WriteFile(oldFilename, content, 0640)
+			require.NoError(t, err, "preparing file failed")
+
+			err = cb()
+			require.NoError(t, err, "callback failed")
+
+			newFilename := filepath.Join(newHome, tt.newRunFile)
+			newContent, err := os.ReadFile(newFilename)
+			require.NoError(t, err, "reading file failed")
+			require.Equal(t, content, newContent, "contents are not equal")
+		})
+	}
+
 }
 
 func TestIsInProgress(t *testing.T) {

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -226,7 +226,7 @@ func runElasticAgent(ctx context.Context, cancel context.CancelFunc, override cf
 	}
 
 	// initiate agent watcher
-	if err := upgrade.InvokeWatcher(l, paths.TopBinaryPath()); err != nil {
+	if _, err := upgrade.InvokeWatcher(l, paths.TopBinaryPath()); err != nil {
 		// we should not fail because watcher is not working
 		l.Error(errors.New(err, "failed to invoke rollback watcher"))
 	}

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -629,7 +629,7 @@ func isProcessStatsEnabled(cfg *monitoringCfg.MonitoringConfig) bool {
 // ongoing upgrade operation, i.e. being re-exec'd and performs
 // any upgrade-specific work, if needed.
 func handleUpgrade() error {
-	upgradeMarker, err := upgrade.LoadMarker()
+	upgradeMarker, err := upgrade.LoadMarker(paths.Data())
 	if err != nil {
 		return fmt.Errorf("unable to load upgrade marker to check if Agent is being upgraded: %w", err)
 	}

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -226,7 +226,7 @@ func runElasticAgent(ctx context.Context, cancel context.CancelFunc, override cf
 	}
 
 	// initiate agent watcher
-	if err := upgrade.InvokeWatcher(l); err != nil {
+	if err := upgrade.InvokeWatcher(l, paths.TopBinaryPath()); err != nil {
 		// we should not fail because watcher is not working
 		l.Error(errors.New(err, "failed to invoke rollback watcher"))
 	}

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -77,6 +77,8 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		return nil
 	}
 
+	log.Infof("Loaded update marker %+v", marker)
+
 	locker := filelock.NewAppLocker(paths.Top(), watcherLockFile)
 	if err := locker.TryLock(); err != nil {
 		if errors.Is(err, filelock.ErrAppAlreadyRunning) {
@@ -98,7 +100,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		// if we're not within grace and marker is still there it might mean
 		// that cleanup was not performed ok, cleanup everything except current version
 		// hash is the same as hash of agent which initiated watcher.
-		if err := upgrade.Cleanup(log, paths.Top(), marker.VersionedHome, release.ShortCommit(), true, false); err != nil {
+		if err := upgrade.Cleanup(log, paths.Top(), paths.VersionedHome(paths.Top()), release.ShortCommit(), true, false); err != nil {
 			log.Error("clean up of prior watcher run failed", err)
 		}
 		// exit nicely

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/configure"
+	"github.com/elastic/elastic-agent/pkg/control/v2/client"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/filelock"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
@@ -65,7 +66,7 @@ func newWatchCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command 
 
 func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 	log.Infow("Upgrade Watcher started", "process.pid", os.Getpid(), "agent.version", version.GetAgentPackageVersion())
-	marker, err := upgrade.LoadMarker()
+	marker, err := upgrade.LoadMarker(paths.Data())
 	if err != nil {
 		log.Error("failed to load marker", err)
 		return err
@@ -97,7 +98,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		// if we're not within grace and marker is still there it might mean
 		// that cleanup was not performed ok, cleanup everything except current version
 		// hash is the same as hash of agent which initiated watcher.
-		if err := upgrade.Cleanup(log, marker.VersionedHome, release.ShortCommit(), true, false); err != nil {
+		if err := upgrade.Cleanup(log, paths.Top(), marker.VersionedHome, release.ShortCommit(), true, false); err != nil {
 			log.Error("clean up of prior watcher run failed", err)
 		}
 		// exit nicely
@@ -114,7 +115,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		log.Error("Error detected, proceeding to rollback: %v", err)
 
 		upgradeDetails.SetState(details.StateRollback)
-		err = upgrade.Rollback(ctx, log, marker.PrevVersionedHome, marker.PrevHash, marker.Hash)
+		err = upgrade.Rollback(ctx, log, client.New(), paths.Top(), marker.PrevVersionedHome, marker.PrevHash)
 		if err != nil {
 			log.Error("rollback failed", err)
 			upgradeDetails.Fail(err)
@@ -132,7 +133,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 	// Why is this being skipped on Windows? The comment above is not clear.
 	// issue: https://github.com/elastic/elastic-agent/issues/3027
 	removeMarker := !isWindows()
-	err = upgrade.Cleanup(log, marker.VersionedHome, marker.Hash, removeMarker, false)
+	err = upgrade.Cleanup(log, paths.Top(), marker.VersionedHome, marker.Hash, removeMarker, false)
 	if err != nil {
 		log.Error("cleanup after successful watch failed", err)
 	}

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -97,7 +97,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		// if we're not within grace and marker is still there it might mean
 		// that cleanup was not performed ok, cleanup everything except current version
 		// hash is the same as hash of agent which initiated watcher.
-		if err := upgrade.Cleanup(log, release.ShortCommit(), true, false); err != nil {
+		if err := upgrade.Cleanup(log, marker.VersionedHome, release.ShortCommit(), true, false); err != nil {
 			log.Error("clean up of prior watcher run failed", err)
 		}
 		// exit nicely
@@ -114,7 +114,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 		log.Error("Error detected, proceeding to rollback: %v", err)
 
 		upgradeDetails.SetState(details.StateRollback)
-		err = upgrade.Rollback(ctx, log, marker.PrevHash, marker.Hash)
+		err = upgrade.Rollback(ctx, log, marker.PrevVersionedHome, marker.PrevHash, marker.Hash)
 		if err != nil {
 			log.Error("rollback failed", err)
 			upgradeDetails.Fail(err)
@@ -132,7 +132,7 @@ func watchCmd(log *logp.Logger, cfg *configuration.Configuration) error {
 	// Why is this being skipped on Windows? The comment above is not clear.
 	// issue: https://github.com/elastic/elastic-agent/issues/3027
 	removeMarker := !isWindows()
-	err = upgrade.Cleanup(log, marker.Hash, removeMarker, false)
+	err = upgrade.Cleanup(log, marker.VersionedHome, marker.Hash, removeMarker, false)
 	if err != nil {
 		log.Error("cleanup after successful watch failed", err)
 	}

--- a/internal/pkg/agent/install/install.go
+++ b/internal/pkg/agent/install/install.go
@@ -5,6 +5,7 @@
 package install
 
 import (
+	goerrors "errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,6 +21,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
+	v1 "github.com/elastic/elastic-agent/pkg/api/v1"
 	"github.com/elastic/elastic-agent/pkg/utils"
 )
 
@@ -109,35 +111,20 @@ func Install(cfgFile, topPath string, unprivileged bool, log *logp.Logger, pt *p
 			errors.M("directory", filepath.Dir(topPath)))
 	}
 
-	// copy source into install path
-	//
-	// Try to detect if we are running with SSDs. If we are increase the copy concurrency,
-	// otherwise fall back to the default.
-	copyConcurrency := 1
-	hasSSDs, detectHWErr := HasAllSSDs()
-	if detectHWErr != nil {
-		fmt.Fprintf(streams.Out, "Could not determine block hardware type, disabling copy concurrency: %s\n", detectHWErr)
-	}
-	if hasSSDs {
-		copyConcurrency = runtime.NumCPU() * 4
+	manifest, err := readPackageManifest(dir)
+	if err != nil {
+		return utils.FileOwner{}, fmt.Errorf("reading package manifest: %w", err)
 	}
 
+	pathMappings := manifest.Package.PathMappings
+
 	pt.Describe("Copying install files")
-	err = copy.Copy(dir, topPath, copy.Options{
-		OnSymlink: func(_ string) copy.SymlinkAction {
-			return copy.Shallow
-		},
-		Sync:         true,
-		NumOfWorkers: int64(copyConcurrency),
-	})
+	err = copyFiles(streams, pathMappings, dir, topPath)
 	if err != nil {
 		pt.Describe("Error copying files")
-		return utils.FileOwner{}, errors.New(
-			err,
-			fmt.Sprintf("failed to copy source directory (%s) to destination (%s)", dir, topPath),
-			errors.M("source", dir), errors.M("destination", topPath),
-		)
+		return utils.FileOwner{}, err
 	}
+
 	pt.Describe("Successfully copied files")
 
 	// place shell wrapper, if present on platform
@@ -227,6 +214,131 @@ func Install(cfgFile, topPath string, unprivileged bool, log *logp.Logger, pt *p
 	pt.Describe("Installed service")
 
 	return ownership, nil
+}
+
+func readPackageManifest(extractedPackageDir string) (*v1.PackageManifest, error) {
+	manifestFilePath := filepath.Join(extractedPackageDir, "manifest.yaml")
+	manifestFile, err := os.Open(manifestFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open package manifest file (%s): %w", manifestFilePath, err)
+	}
+	defer manifestFile.Close()
+	manifest, err := v1.ParseManifest(manifestFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse package manifest file %q contents: %w", manifestFilePath, err)
+	}
+
+	return manifest, nil
+}
+
+func copyFiles(streams *cli.IOStreams, pathMappings []map[string]string, srcDir string, topPath string) error {
+	// copy source into install path
+	//
+	// Try to detect if we are running with SSDs. If we are increase the copy concurrency,
+	// otherwise fall back to the default.
+	copyConcurrency := 1
+	hasSSDs, detectHWErr := HasAllSSDs()
+	if detectHWErr != nil {
+		fmt.Fprintf(streams.Out, "Could not determine block hardware type, disabling copy concurrency: %s\n", detectHWErr)
+	}
+	if hasSSDs {
+		copyConcurrency = runtime.NumCPU() * 4
+	}
+
+	// these are needed to keep track of what we already copied
+	copiedFiles := map[string]struct{}{}
+	// collect any symlink we found that need remapping
+	symlinks := map[string]string{}
+
+	var copyErrors []error
+
+	// Start copying the remapped paths first
+	for _, pathMapping := range pathMappings {
+		for packagePath, installedPath := range pathMapping {
+			// flag the original path as handled
+			copiedFiles[packagePath] = struct{}{}
+			err := copy.Copy(filepath.Join(srcDir, packagePath), filepath.Join(topPath, installedPath), copy.Options{
+				OnSymlink: func(_ string) copy.SymlinkAction {
+					return copy.Shallow
+				},
+				Sync:         true,
+				NumOfWorkers: int64(copyConcurrency),
+			})
+			if err != nil {
+				return errors.New(
+					err,
+					fmt.Sprintf("failed to copy source directory (%s) to destination (%s)", packagePath, installedPath),
+					errors.M("source", packagePath), errors.M("destination", installedPath),
+				)
+			}
+		}
+	}
+
+	// copy the remaining files excluding overlaps with the mapped paths
+	err := copy.Copy(srcDir, topPath, copy.Options{
+		OnSymlink: func(source string) copy.SymlinkAction {
+			target, err := os.Readlink(source)
+			if err != nil {
+				// error reading the link, not much choice to leave it unchanged and collect the error
+				copyErrors = append(copyErrors, fmt.Errorf("unable to read link %q for remapping", source))
+				return copy.Skip
+			}
+
+			// if we find a link, check if its target need to be remapped, in which case skip it for now and save it for
+			// later creation with the remapped target
+			for _, pathMapping := range pathMappings {
+				for srcPath, dstPath := range pathMapping {
+					if strings.HasPrefix(target, srcPath) {
+						newTarget := strings.Replace(target, srcPath, dstPath, 1)
+						rel, err := filepath.Rel(srcDir, source)
+						if err != nil {
+							copyErrors = append(copyErrors, fmt.Errorf("extracting relative path for %q using %q as base: %w", source, srcDir, err))
+							return copy.Skip
+						}
+						symlinks[rel] = newTarget
+						return copy.Skip
+					}
+				}
+			}
+
+			return copy.Shallow
+		},
+		Skip: func(srcinfo os.FileInfo, src, dest string) (bool, error) {
+			relPath, err := filepath.Rel(srcDir, src)
+			if err != nil {
+				return false, fmt.Errorf("calculating relative path for %s: %w", src, err)
+			}
+			// check if we already handled this path as part of the mappings: if we did, skip it
+			_, ok := copiedFiles[relPath]
+			return ok, nil
+		},
+		Sync:         true,
+		NumOfWorkers: int64(copyConcurrency),
+	})
+	if err != nil {
+		return errors.New(
+			err,
+			fmt.Sprintf("failed to copy source directory (%s) to destination (%s)", srcDir, topPath),
+			errors.M("source", srcDir), errors.M("destination", topPath),
+		)
+	}
+
+	if len(copyErrors) > 0 {
+		return fmt.Errorf("errors encountered during copy from %q to %q: %w", srcDir, topPath, goerrors.Join(copyErrors...))
+	}
+
+	// Create the remapped symlinks
+	for src, target := range symlinks {
+		absSrcPath := filepath.Join(topPath, src)
+		err := os.Symlink(target, absSrcPath)
+		if err != nil {
+			return errors.New(
+				err,
+				fmt.Sprintf("failed to link source %q to destination %q", absSrcPath, target),
+			)
+		}
+	}
+	return nil
 }
 
 // StartService starts the installed service.

--- a/internal/pkg/agent/install/install.go
+++ b/internal/pkg/agent/install/install.go
@@ -217,7 +217,7 @@ func Install(cfgFile, topPath string, unprivileged bool, log *logp.Logger, pt *p
 }
 
 func readPackageManifest(extractedPackageDir string) (*v1.PackageManifest, error) {
-	manifestFilePath := filepath.Join(extractedPackageDir, "manifest.yaml")
+	manifestFilePath := filepath.Join(extractedPackageDir, v1.ManifestFileName)
 	manifestFile, err := os.Open(manifestFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open package manifest file (%s): %w", manifestFilePath, err)

--- a/internal/pkg/agent/install/install_test.go
+++ b/internal/pkg/agent/install/install_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
+	v1 "github.com/elastic/elastic-agent/pkg/api/v1"
 )
 
 func TestHasAllSSDs(t *testing.T) {
@@ -110,21 +111,21 @@ func TestCopyFiles(t *testing.T) {
 		{
 			name: "simple install package mockup",
 			setupFiles: []files{
-				{fType: REGULAR, path: "manifest.yaml", content: []byte(sampleManifestContent)},
+				{fType: REGULAR, path: v1.ManifestFileName, content: []byte(sampleManifestContent)},
 				{fType: DIRECTORY, path: filepath.Join("data", "elastic-agent-fb7370"), content: nil},
 				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-fb7370", "elastic-agent"), content: []byte("this is an elastic-agent wannabe")},
 				{fType: SYMLINK, path: "elastic-agent", content: []byte(filepath.Join("data", "elastic-agent-fb7370", "elastic-agent"))},
 			},
 			expectedFiles: []files{
 				{fType: DIRECTORY, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370"), content: nil},
-				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "manifest.yaml"), content: []byte(sampleManifestContent)},
+				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", v1.ManifestFileName), content: []byte(sampleManifestContent)},
 				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "elastic-agent"), content: []byte("this is an elastic-agent wannabe")},
 				{fType: SYMLINK, path: "elastic-agent", content: []byte(filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "elastic-agent"))},
 			},
 			mappings: []map[string]string{
 				{
 					"data/elastic-agent-fb7370": "data/elastic-agent-8.13.0-SNAPSHOT-fb7370",
-					"manifest.yaml":             "data/elastic-agent-8.13.0-SNAPSHOT-fb7370/manifest.yaml",
+					v1.ManifestFileName:         "data/elastic-agent-8.13.0-SNAPSHOT-fb7370/" + v1.ManifestFileName,
 				},
 			}},
 	}

--- a/internal/pkg/agent/install/install_test.go
+++ b/internal/pkg/agent/install/install_test.go
@@ -5,11 +5,16 @@
 package install
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/jaypipes/ghw"
 	"github.com/jaypipes/ghw/pkg/block"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/internal/pkg/cli"
 )
 
 func TestHasAllSSDs(t *testing.T) {
@@ -56,4 +61,126 @@ func TestHasAllSSDs(t *testing.T) {
 			require.Equal(t, test.expected, actual)
 		})
 	}
+}
+
+var sampleManifestContent = `
+version: co.elastic.agent/v1
+kind: PackageManifest
+package:
+    version: 8.13.0
+    snapshot: true
+    versioned-home: elastic-agent-fb7370
+    path-mappings:
+        - data/elastic-agent-fb7370: data/elastic-agent-8.13.0-SNAPSHOT-fb7370
+          manifest.yaml: data/elastic-agent-8.13.0-SNAPSHOT-fb7370/manifest.yaml
+`
+
+type testLogWriter struct {
+	t *testing.T
+}
+
+func (tlw testLogWriter) Write(b []byte) (n int, err error) {
+	tlw.t.Log(b)
+	return len(b), nil
+}
+
+func TestCopyFiles(t *testing.T) {
+	type fileType uint
+
+	const (
+		REGULAR fileType = iota
+		DIRECTORY
+		SYMLINK
+	)
+
+	type files struct {
+		fType   fileType
+		path    string
+		content []byte
+	}
+
+	type testcase struct {
+		name          string
+		setupFiles    []files
+		expectedFiles []files
+		mappings      []map[string]string
+	}
+
+	testcases := []testcase{
+		{
+			name: "simple install package mockup",
+			setupFiles: []files{
+				{fType: REGULAR, path: "manifest.yaml", content: []byte(sampleManifestContent)},
+				{fType: DIRECTORY, path: filepath.Join("data", "elastic-agent-fb7370"), content: nil},
+				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-fb7370", "elastic-agent"), content: []byte("this is an elastic-agent wannabe")},
+				{fType: SYMLINK, path: "elastic-agent", content: []byte(filepath.Join("data", "elastic-agent-fb7370", "elastic-agent"))},
+			},
+			expectedFiles: []files{
+				{fType: DIRECTORY, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370"), content: nil},
+				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "manifest.yaml"), content: []byte(sampleManifestContent)},
+				{fType: REGULAR, path: filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "elastic-agent"), content: []byte("this is an elastic-agent wannabe")},
+				{fType: SYMLINK, path: "elastic-agent", content: []byte(filepath.Join("data", "elastic-agent-8.13.0-SNAPSHOT-fb7370", "elastic-agent"))},
+			},
+			mappings: []map[string]string{
+				{
+					"data/elastic-agent-fb7370": "data/elastic-agent-8.13.0-SNAPSHOT-fb7370",
+					"manifest.yaml":             "data/elastic-agent-8.13.0-SNAPSHOT-fb7370/manifest.yaml",
+				},
+			}},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpSrc := t.TempDir()
+			tmpDst := t.TempDir()
+
+			for _, sf := range tc.setupFiles {
+				switch sf.fType {
+				case REGULAR:
+					err := os.WriteFile(filepath.Join(tmpSrc, sf.path), sf.content, 0o644)
+					require.NoErrorf(t, err, "error writing setup file %s in tempDir %s", sf.path, tmpSrc)
+
+				case DIRECTORY:
+					err := os.MkdirAll(filepath.Join(tmpSrc, sf.path), 0o755)
+					require.NoErrorf(t, err, "error creating setup directory %s in tempDir %s", sf.path, tmpSrc)
+
+				case SYMLINK:
+					err := os.Symlink(string(sf.content), filepath.Join(tmpSrc, sf.path))
+					require.NoErrorf(t, err, "error creating symlink %s in tempDir %s", sf.path, tmpSrc)
+				}
+			}
+			outWriter := &testLogWriter{t: t}
+			ioStreams := &cli.IOStreams{
+				In:  nil,
+				Out: outWriter,
+				Err: outWriter,
+			}
+			err := copyFiles(ioStreams, tc.mappings, tmpSrc, tmpDst)
+			assert.NoError(t, err)
+
+			for _, ef := range tc.expectedFiles {
+				switch ef.fType {
+				case REGULAR:
+					if assert.FileExistsf(t, filepath.Join(tmpDst, ef.path), "file %s does not exist in output directory %s", ef.path, tmpDst) {
+						// check contents
+						actualContent, err := os.ReadFile(filepath.Join(tmpDst, ef.path))
+						if assert.NoErrorf(t, err, "error reading expected file %s content", ef.path) {
+							assert.Equal(t, ef.content, actualContent, "content of expected file %s does not match", ef.path)
+						}
+					}
+
+				case DIRECTORY:
+					assert.DirExistsf(t, filepath.Join(tmpDst, ef.path), "directory %s does not exist in output directory %s", ef.path, tmpDst)
+
+				case SYMLINK:
+					actualTarget, err := os.Readlink(filepath.Join(tmpDst, ef.path))
+					if assert.NoErrorf(t, err, "error readling expected symlink %s in output dir %s", ef.path, tmpDst) {
+						assert.Equal(t, string(ef.content), actualTarget, "unexpected target for symlink %s", ef.path)
+					}
+				}
+
+			}
+		})
+	}
+
 }

--- a/internal/pkg/agent/install/install_windows.go
+++ b/internal/pkg/agent/install/install_windows.go
@@ -7,12 +7,10 @@
 package install
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
-	"github.com/elastic/elastic-agent/internal/pkg/release"
 	"github.com/elastic/elastic-agent/pkg/utils"
 	"github.com/elastic/elastic-agent/version"
 )
@@ -37,7 +35,7 @@ func postInstall(topPath string) error {
 	}
 
 	// create top-level symlink to nested binary
-	realBinary := filepath.Join(topPath, "data", fmt.Sprintf("elastic-agent-%s", release.ShortCommit()), paths.BinaryName)
+	realBinary := paths.BinaryPath(paths.VersionedHome(topPath), paths.BinaryName)
 	err = os.Symlink(realBinary, binary)
 	if err != nil {
 		return err

--- a/pkg/api/v1/manifest.go
+++ b/pkg/api/v1/manifest.go
@@ -12,10 +12,12 @@ import (
 )
 
 const ManifestKind = "PackageManifest"
+const ManifestFileName = "manifest.yaml"
 
 type PackageDesc struct {
 	Version       string              `yaml:"version,omitempty" json:"version,omitempty"`
 	Snapshot      bool                `yaml:"snapshot,omitempty" json:"snapshot,omitempty"`
+	Hash          string              `yaml:"hash,omitempty" json:"hash,omitempty"`
 	VersionedHome string              `yaml:"versioned-home,omitempty" json:"versionedHome,omitempty"`
 	PathMappings  []map[string]string `yaml:"path-mappings,omitempty" json:"pathMappings,omitempty"`
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This PR uses the package manifest included in elastic-agent packages to map the package contents onto disk when installing/upgrading agent.
In the context of https://github.com/elastic/elastic-agent/issues/2579 the path mapping is used to install or upgrade agent in a directory like data/elastic-agent-<package version>-<hash> while we maintain backward compatibility for the package structure using the previous `elastic-agent-<hash>`.

This PR is the aggregation of #4173 #4174 #4176 #4177 #4178 that have been used to split the change in reviewable fragments.

With this change elastic-agent will use the path mappings present in the package manifest to remap package files before writing them on disk in the install directory.

There is no integration test in this change as that requires some hacking of the agent packages due to current limitations of integration test framework. This will be tackled in #2780 

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

This changes implements #2579 allowing different versions of agent built from the same git commit (for example a repackaged agent version containing patched components) to upgrade between themselves.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

To test this PR locally, we package elastic-agent twice from the same commit specifying a different AGENT_PACKAGE_VERSION like:
```
EXTERNAL=true SNAPSHOT=true PLATFORMS="linux/amd64" PACKAGES="tar.gz"  mage package
```
and
```
AGENT_PACKAGE_VERSION=8.13.0-repackaged EXTERNAL=true SNAPSHOT=true PLATFORMS="linux/amd64" PACKAGES="tar.gz"  mage package
```

Install the first agent package and verify that it's healthy and it runs from `data/elastic-agent-8.13.0-SNAPSHOT-<hash>` directory.
Upgrade this agent using the second package
```
elastic-agent upgrade 8.13.0-repackaged-SNAPSHOT --source-uri file://<directory where the package is located on disk> --skip-verify
```

Upgrade will unpack and store the new agent in `data/elastic-agent-8.13.0-repackaged-<hash>` and rotate the links.
Verify the agent directory structure contains the 2 distinct directories.

If we want to test the rollback functionality it's enough to kill the new agent a few times after the upgrade or break the new agent install in some way.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #2579
- Supersedes #3950 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
