### PR TITLE
Remove pin to 8.12.0 stack.

### DIFF
--- a/.buildkite/scripts/steps/integration_tests.sh
+++ b/.buildkite/scripts/steps/integration_tests.sh
@@ -11,7 +11,7 @@ MAGE_SUBTARGET="${3:-""}"
 # Override the agent package version using a string with format <major>.<minor>.<patch>
 # NOTE: use only after version bump when the new version is not yet available, for example:
 # OVERRIDE_AGENT_PACKAGE_VERSION="8.10.3" otherwise OVERRIDE_AGENT_PACKAGE_VERSION="".
-OVERRIDE_AGENT_PACKAGE_VERSION="8.12.0"
+OVERRIDE_AGENT_PACKAGE_VERSION=""
 
 if [[ -n "$OVERRIDE_AGENT_PACKAGE_VERSION" ]]; then
   OVERRIDE_TEST_AGENT_VERSION=${OVERRIDE_AGENT_PACKAGE_VERSION}"-SNAPSHOT"


### PR DESCRIPTION
Stop pinning the version to 8.12.0 in the 8.12 branch. This should only be merged after https://github.com/elastic/elastic-agent/pull/4195 once the first 8.12.2 snapshot is produced.