### PR TITLE
Update Windows Defend Support

### DIFF
--- a/docs/component-specs.md
+++ b/docs/component-specs.md
@@ -89,7 +89,7 @@ The variables that can be accessed by a condition are:
 - `runtime.arch`: the CPU architecture, either `"amd64"` or `"arm64"`.
 - `runtime.platform`: a string combining the OS and architecture, e.g. `"windows/amd64"`, `"darwin/arm64"`.
 - `runtime.family`: OS family, e.g. `"debian"`, `"redhat"`, `"windows"`, `"darwin"`
-- `runtime.major`, `runtime.minor`: the operating system version. Note that these are strings not integers, so they must be converted in order to use numeric comparison. For example to check if the OS major version is at most 12, use `number(runtime.major) <= 12`.
+- `runtime.major`, `runtime.minor`: the operating system version. Note that these are strings not integers, so they must be converted in order to use numeric comparison. For example to check if the OS major version is at most 12, use `number(${runtime.major}) <= 12`.
 - `user.root`: true if Agent is being run with root / administrator permissions.
 - `install.in_default`: true if the Agent is installed in the default location or has been installed via deb or rpm.
 

--- a/specs/endpoint-security.spec.yml
+++ b/specs/endpoint-security.spec.yml
@@ -77,6 +77,8 @@ inputs:
           message: "Elastic Defend requires Elastic Agent be running as Administrator or SYSTEM"
         - condition: ${install.in_default} == false
           message: "Elastic Defend requires Elastic Agent be installed at the default installation path"
+        - condition: number(${runtime.major}) <= 6
+          message: "Elastic Defend requires Windows 10 / Server 2016 or newer."
     service:
       cport: 6788
       log:


### PR DESCRIPTION
## What does this PR do?
This PR prevents Elastic Defend form being installed on Windows versions earlier than Windows 10 and Server 2016.

## Why is it important?
Newer version of Elastic Defend integration will not be supporting earlier versions of Windows, so this ensures Agent will not install the integration on unsupported versions of Windows and will provide a message explaining this to the user.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## How to test this PR locally

This has been locally tested to produce the expected results and behaviors on Windows 8.1 (no longer installs), Server 2012R2 (no longer installs), Server 2016 (still installs), Server 2019 (still installs),  and Windows 10 (still installs).

## Screenshots
![win81_defend_not_supported](https://github.com/elastic/elastic-agent/assets/3613004/abfe5584-3874-42e1-9571-0e525a8214f8)

