### PR TITLE
Serverless: switch to _reset-internal-credentials.

### DIFF
--- a/pkg/testing/ess/serverless.go
+++ b/pkg/testing/ess/serverless.go
@@ -250,7 +250,7 @@ func (srv *ServerlessClient) WaitForKibana(ctx context.Context) error {
 
 // ResetCredentials resets the credentials for the given ESS instance
 func (srv *ServerlessClient) ResetCredentials(ctx context.Context) (CredResetResponse, error) {
-	resetURL := fmt.Sprintf("%s/api/v1/serverless/projects/%s/%s/_reset-credentials", serverlessURL, srv.projectType, srv.proj.ID)
+	resetURL := fmt.Sprintf("%s/api/v1/serverless/projects/%s/%s/_reset-internal-credentials", serverlessURL, srv.projectType, srv.proj.ID)
 
 	resetHandler, err := http.NewRequestWithContext(ctx, "POST", resetURL, nil)
 	if err != nil {


### PR DESCRIPTION
The previous _reset-credentials endpoint will soon return a less privileged user. The internal variant returns one with operator privileges to allow inspecting cluster health for testing purposes.


