### PR TITLE
Add wait for watcher

### DIFF
--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -138,10 +139,10 @@ func Cleanup(log *logger.Logger, topDirPath, currentVersionedHome, currentHash s
 
 // InvokeWatcher invokes an agent instance using watcher argument for watching behavior of
 // agent during upgrade period.
-func InvokeWatcher(log *logger.Logger, agentExecutable string) error {
+func InvokeWatcher(log *logger.Logger, agentExecutable string) (*exec.Cmd, error) {
 	if !IsUpgradeable() {
 		log.Info("agent is not upgradable, not starting watcher")
-		return nil
+		return nil, nil
 	}
 
 	cmd := invokeCmd(agentExecutable)
@@ -154,14 +155,14 @@ func InvokeWatcher(log *logger.Logger, agentExecutable string) error {
 
 	log.Infow("Starting upgrade watcher", "path", cmd.Path, "args", cmd.Args, "env", cmd.Env, "dir", cmd.Dir)
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start Upgrade Watcher: %w", err)
+		return nil, fmt.Errorf("failed to start Upgrade Watcher: %w", err)
 	}
 
 	upgradeWatcherPID := cmd.Process.Pid
 	agentPID := os.Getpid()
 	log.Infow("Upgrade Watcher invoked", "agent.upgrade.watcher.process.pid", upgradeWatcherPID, "agent.process.pid", agentPID)
 
-	return nil
+	return cmd, nil
 }
 
 func restartAgent(ctx context.Context, log *logger.Logger, c client.Client) error {

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -53,7 +53,7 @@ var agentArtifact = artifact.Artifact{
 	Artifact: "beats/" + agentName,
 }
 
-var ErrWatcherNotStarted = errors.New("watcher did not start in time or context expired")
+var ErrWatcherNotStarted = errors.New("watcher did not start in time")
 
 // Upgrader performs an upgrade
 type Upgrader struct {
@@ -329,7 +329,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 }
 
 func waitForWatcher(ctx context.Context, log *logger.Logger, markerFilePath string, waitTime time.Duration) error {
-	//Wait for the watcher to be up and running
+	// Wait for the watcher to be up and running
 	watcherContext, cancel := context.WithTimeout(ctx, waitTime)
 	defer cancel()
 
@@ -352,7 +352,7 @@ func waitForWatcher(ctx context.Context, log *logger.Logger, markerFilePath stri
 
 		case <-watcherContext.Done():
 			log.Error("upgrade watcher did not start watching within %s or context has expired", waitTime)
-			return ErrWatcherNotStarted
+			return goerrors.Join(ErrWatcherNotStarted, watcherContext.Err())
 		}
 	}
 }

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -53,7 +53,7 @@ var agentArtifact = artifact.Artifact{
 	Artifact: "beats/" + agentName,
 }
 
-var ErrWatcherNotStarted = errors.New(fmt.Sprintf("watcher did not start within %s or context expired", watcherMaxWaitTime))
+var ErrWatcherNotStarted = errors.New("watcher did not start in time or context expired")
 
 // Upgrader performs an upgrade
 type Upgrader struct {
@@ -339,7 +339,7 @@ func waitForWatcher(ctx context.Context, log *logger.Logger, markerFilePath stri
 		return fmt.Errorf("error starting update marker watcher: %w", err)
 	}
 
-	log.Info("waiting for upgrade watcher to set %s state in upgrade marker", details.StateWatching)
+	log.Info("waiting up to %s for upgrade watcher to set %s state in upgrade marker", waitTime, details.StateWatching)
 
 	for {
 		select {

--- a/internal/pkg/agent/application/upgrade/upgrade_test.go
+++ b/internal/pkg/agent/application/upgrade/upgrade_test.go
@@ -759,14 +759,14 @@ func TestWaitForWatcher(t *testing.T) {
 			name:                "Happy path: watcher is watching already",
 			states:              []details.State{details.StateWatching},
 			stateChangeInterval: 1 * time.Millisecond,
-			timeout:             5 * time.Millisecond,
+			timeout:             50 * time.Millisecond,
 			wantErr:             assert.NoError,
 		},
 		{
 			name:                "Sad path: watcher is never starting",
 			states:              []details.State{details.StateReplacing},
 			stateChangeInterval: 1 * time.Millisecond,
-			timeout:             5 * time.Millisecond,
+			timeout:             50 * time.Millisecond,
 			wantErr:             wantErrWatcherNotStarted,
 		},
 		{
@@ -788,7 +788,7 @@ func TestWaitForWatcher(t *testing.T) {
 			name:                "Timeout: marker is never created",
 			states:              nil,
 			stateChangeInterval: 1 * time.Millisecond,
-			timeout:             5 * time.Millisecond,
+			timeout:             50 * time.Millisecond,
 			wantErr:             wantErrWatcherNotStarted,
 		},
 		{

--- a/internal/pkg/agent/application/upgrade/upgrade_test.go
+++ b/internal/pkg/agent/application/upgrade/upgrade_test.go
@@ -781,7 +781,7 @@ func TestWaitForWatcher(t *testing.T) {
 				details.StateWatching,
 			},
 			stateChangeInterval: 1 * time.Millisecond,
-			timeout:             100 * time.Millisecond,
+			timeout:             500 * time.Millisecond,
 			wantErr:             assert.NoError,
 		},
 		{

--- a/internal/pkg/agent/application/upgrade/upgrade_test.go
+++ b/internal/pkg/agent/application/upgrade/upgrade_test.go
@@ -858,7 +858,7 @@ func TestWaitForWatcher(t *testing.T) {
 			// cancel context
 			cancel()
 
-			//wait for goroutines to finish
+			// wait for goroutines to finish
 			wg.Wait()
 		})
 	}
@@ -884,7 +884,8 @@ func writeState(t *testing.T, path string, state details.State) {
 	})
 
 	bytes, err := yaml.Marshal(ms)
-	require.NoError(t, err, "error marshaling the test upgrade marker")
-	err = os.WriteFile(path, bytes, 0770)
-	require.NoError(t, err, "error writing out the test upgrade marker")
+	if assert.NoError(t, err, "error marshaling the test upgrade marker") {
+		err = os.WriteFile(path, bytes, 0770)
+		assert.NoError(t, err, "error writing out the test upgrade marker")
+	}
 }

--- a/internal/pkg/agent/application/upgrade/upgrade_test.go
+++ b/internal/pkg/agent/application/upgrade/upgrade_test.go
@@ -17,10 +17,12 @@ import (
 	"github.com/gofrs/flock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/details"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/release"
@@ -739,4 +741,137 @@ func TestIsSameVersion(t *testing.T) {
 				log, test.args.current, test.args.metadata, test.args.version, test.want.newVersion)
 		})
 	}
+}
+
+func TestWaitForWatcher(t *testing.T) {
+	wantErrWatcherNotStarted := func(t assert.TestingT, err error, i ...interface{}) bool {
+		return assert.ErrorIs(t, err, ErrWatcherNotStarted, i)
+	}
+	tests := []struct {
+		name                string
+		states              []details.State
+		stateChangeInterval time.Duration
+		timeout             time.Duration
+		wantErr             assert.ErrorAssertionFunc
+	}{
+		{
+			name:                "Happy path: watcher is watching already",
+			states:              []details.State{details.StateWatching},
+			stateChangeInterval: 1 * time.Millisecond,
+			timeout:             5 * time.Millisecond,
+			wantErr:             assert.NoError,
+		},
+		{
+			name:                "Sad path: watcher is never starting",
+			states:              []details.State{details.StateReplacing},
+			stateChangeInterval: 1 * time.Millisecond,
+			timeout:             5 * time.Millisecond,
+			wantErr:             wantErrWatcherNotStarted,
+		},
+		{
+			name: "Runaround path: marker is jumping around and landing on watching",
+			states: []details.State{
+				details.StateRequested,
+				details.StateScheduled,
+				details.StateDownloading,
+				details.StateExtracting,
+				details.StateReplacing,
+				details.StateRestarting,
+				details.StateWatching,
+			},
+			stateChangeInterval: 1 * time.Millisecond,
+			timeout:             100 * time.Millisecond,
+			wantErr:             assert.NoError,
+		},
+		{
+			name:                "Timeout: marker is never created",
+			states:              nil,
+			stateChangeInterval: 1 * time.Millisecond,
+			timeout:             5 * time.Millisecond,
+			wantErr:             wantErrWatcherNotStarted,
+		},
+		{
+			name: "Timeout2: state doesn't get there in time",
+			states: []details.State{
+				details.StateRequested,
+				details.StateScheduled,
+				details.StateDownloading,
+				details.StateExtracting,
+				details.StateReplacing,
+				details.StateRestarting,
+				details.StateWatching,
+			},
+
+			stateChangeInterval: 5 * time.Millisecond,
+			timeout:             20 * time.Millisecond,
+			wantErr:             wantErrWatcherNotStarted,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			deadline, ok := t.Deadline()
+			if !ok {
+				deadline = time.Now().Add(5 * time.Second)
+			}
+			ctx, cancel := context.WithDeadline(context.TODO(), deadline)
+			defer cancel()
+
+			tmpDir := t.TempDir()
+			updMarkerFilePath := filepath.Join(tmpDir, markerFilename)
+
+			if len(tt.states) > 0 {
+				initialState := tt.states[0]
+				writeState(t, updMarkerFilePath, initialState)
+			}
+
+			var furtherStates []details.State
+			if len(tt.states) > 1 {
+				// we have more states to produce
+				furtherStates = tt.states[1:]
+				go func() {
+					tick := time.NewTicker(tt.stateChangeInterval)
+					defer tick.Stop()
+					for _, state := range furtherStates {
+						select {
+						case <-ctx.Done():
+							return
+						case <-tick.C:
+							writeState(t, updMarkerFilePath, state)
+						}
+					}
+
+				}()
+			}
+
+			log, _ := logger.NewTesting(tt.name)
+
+			tt.wantErr(t, waitForWatcher(ctx, log, updMarkerFilePath, tt.timeout), fmt.Sprintf("waitForWatcher %s, %v, %s, %s)", updMarkerFilePath, tt.states, tt.stateChangeInterval, tt.timeout))
+		})
+	}
+}
+
+func writeState(t *testing.T, path string, state details.State) {
+	ms := newMarkerSerializer(&UpdateMarker{
+		Version:           "version",
+		Hash:              "hash",
+		VersionedHome:     "versionedHome",
+		UpdatedOn:         time.Now(),
+		PrevVersion:       "prev_version",
+		PrevHash:          "prev_hash",
+		PrevVersionedHome: "prev_versionedhome",
+		Acked:             false,
+		Action:            nil,
+		Details: &details.Details{
+			TargetVersion: "version",
+			State:         state,
+			ActionID:      "",
+			Metadata:      details.Metadata{},
+		},
+	})
+
+	bytes, err := yaml.Marshal(ms)
+	require.NoError(t, err, "error marshaling the test upgrade marker")
+	err = os.WriteFile(path, bytes, 0770)
+	require.NoError(t, err, "error writing out the test upgrade marker")
 }

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -226,7 +226,7 @@ func runElasticAgent(ctx context.Context, cancel context.CancelFunc, override cf
 	}
 
 	// initiate agent watcher
-	if err := upgrade.InvokeWatcher(l, paths.TopBinaryPath()); err != nil {
+	if _, err := upgrade.InvokeWatcher(l, paths.TopBinaryPath()); err != nil {
 		// we should not fail because watcher is not working
 		l.Error(errors.New(err, "failed to invoke rollback watcher"))
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR adds a wait after launching the upgrade watcher to make sure that the process is up and running before restarting agent.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

We want to avoid race conditions that may happen in case of downgrade where after restart an older watcher that does not understand the new update marker format may break the whole agent installation.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #4204
- Closes #4228

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
