### PR TITLE
[8.12] Stop pinning tests to 8.12.0 version now that latest snapshot exists

### DIFF
--- a/.buildkite/scripts/steps/integration_tests.sh
+++ b/.buildkite/scripts/steps/integration_tests.sh
@@ -11,7 +11,7 @@ MAGE_SUBTARGET="${3:-""}"
 # Override the agent package version using a string with format <major>.<minor>.<patch>
 # NOTE: use only after version bump when the new version is not yet available, for example:
 # OVERRIDE_AGENT_PACKAGE_VERSION="8.10.3" otherwise OVERRIDE_AGENT_PACKAGE_VERSION="".
-OVERRIDE_AGENT_PACKAGE_VERSION="8.12.0"
+OVERRIDE_AGENT_PACKAGE_VERSION=""
 
 if [[ -n "$OVERRIDE_AGENT_PACKAGE_VERSION" ]]; then
   OVERRIDE_TEST_AGENT_VERSION=${OVERRIDE_AGENT_PACKAGE_VERSION}"-SNAPSHOT"


### PR DESCRIPTION
What the title says, remove the pin to the 8.12.0 version in the 8.12 branch integration tests as it is no longer needed.