### PR TITLE
Refactor state store

### DIFF
--- a/internal/pkg/agent/application/actions/handlers/handler_action_unenroll.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_unenroll.go
@@ -22,11 +22,11 @@ const (
 )
 
 type stateStore interface {
-	Add(fleetapi.Action)
+	SetAction(fleetapi.Action)
 	AckToken() string
 	SetAckToken(ackToken string)
 	Save() error
-	Actions() []fleetapi.Action
+	Action() fleetapi.Action
 }
 
 // Unenroll results in  running agent entering idle state, non managed non standalone.
@@ -94,7 +94,7 @@ func (h *Unenroll) Handle(ctx context.Context, a fleetapi.Action, acker acker.Ac
 
 	if h.stateStore != nil {
 		// backup action for future start to avoid starting fleet gateway loop
-		h.stateStore.Add(a)
+		h.stateStore.SetAction(a)
 		if err := h.stateStore.Save(); err != nil {
 			h.log.Warnf("Failed to update state store: %v", err)
 		}

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -58,11 +58,11 @@ type agentInfo interface {
 }
 
 type stateStore interface {
-	Add(fleetapi.Action)
+	SetAction(fleetapi.Action)
 	AckToken() string
 	SetAckToken(ackToken string)
 	Save() error
-	Actions() []fleetapi.Action
+	Action() fleetapi.Action
 }
 
 type FleetGateway struct {

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -58,11 +58,9 @@ type agentInfo interface {
 }
 
 type stateStore interface {
-	SetAction(fleetapi.Action)
 	AckToken() string
 	SetAckToken(ackToken string)
 	Save() error
-	Action() fleetapi.Action
 }
 
 type FleetGateway struct {

--- a/internal/pkg/agent/application/managed_mode.go
+++ b/internal/pkg/agent/application/managed_mode.go
@@ -268,7 +268,8 @@ func (m *managedConfigManager) Watch() <-chan coordinator.ConfigChange {
 }
 
 func (m *managedConfigManager) wasUnenrolled() bool {
-	return m.stateStore.Action().Type() == fleetapi.ActionTypeUnenroll
+	return m.stateStore.Action() != nil &&
+		m.stateStore.Action().Type() == fleetapi.ActionTypeUnenroll
 }
 
 func (m *managedConfigManager) initFleetServer(ctx context.Context, cfg *configuration.FleetServerConfig) error {

--- a/internal/pkg/agent/application/managed_mode.go
+++ b/internal/pkg/agent/application/managed_mode.go
@@ -159,7 +159,7 @@ func (m *managedConfigManager) Run(ctx context.Context) error {
 
 	action := m.stateStore.Action()
 	stateRestored := false
-	if action == nil && !m.wasUnenrolled() {
+	if action != nil && !m.wasUnenrolled() {
 		// TODO(ph) We will need an improvement on fleet, if there is an error while dispatching a
 		// persisted action on disk we should be able to ask Fleet to get the latest configuration.
 		// But at the moment this is not possible because the policy change was acked.

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -201,10 +201,7 @@ func runElasticAgent(ctx context.Context, cancel context.CancelFunc, override cf
 
 	// the encrypted state does not exist but the unencrypted file does
 	err = migration.MigrateToEncryptedConfig(ctx, l,
-		paths.AgentStateStoreYmlFile(), // TODO: doubleckeck if we need it and
-		// how it interferes with the state store migration. Make an upgrade from:
-		//   - 7.17 -> 8.13
-		//   - 8.state_store.plain -> 8.state_store.enc
+		paths.AgentStateStoreYmlFile(),
 		paths.AgentStateStoreFile())
 	if err != nil {
 		return errors.New(err, "error migrating agent state")

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -200,7 +200,12 @@ func runElasticAgent(ctx context.Context, cancel context.CancelFunc, override cf
 	}
 
 	// the encrypted state does not exist but the unencrypted file does
-	err = migration.MigrateToEncryptedConfig(ctx, l, paths.AgentStateStoreYmlFile(), paths.AgentStateStoreFile())
+	err = migration.MigrateToEncryptedConfig(ctx, l,
+		paths.AgentStateStoreYmlFile(), // TODO: doubleckeck if we need it and
+		// how it interferes with the state store migration. Make an upgrade from:
+		//   - 7.17 -> 8.13
+		//   - 8.state_store.plain -> 8.state_store.enc
+		paths.AgentStateStoreFile())
 	if err != nil {
 		return errors.New(err, "error migrating agent state")
 	}

--- a/internal/pkg/agent/storage/store/action_store.go
+++ b/internal/pkg/agent/storage/store/action_store.go
@@ -23,13 +23,13 @@ import (
 // Deprecated.
 type actionStore struct {
 	log    *logger.Logger
-	store  storeLoad
+	store  saveLoader
 	dirty  bool
-	action action
+	action fleetapi.Action
 }
 
 // newActionStore creates a new action store.
-func newActionStore(log *logger.Logger, store storeLoad) (*actionStore, error) {
+func newActionStore(log *logger.Logger, store saveLoader) (*actionStore, error) {
 	// If the store exists we will read it, if an error is returned we log it
 	// and return an empty store.
 	reader, err := store.Load()
@@ -64,7 +64,7 @@ func newActionStore(log *logger.Logger, store storeLoad) (*actionStore, error) {
 
 // add is only taking care of ActionPolicyChange for now and will only keep the last one it receive,
 // any other type of action will be silently ignored.
-func (s *actionStore) add(a action) {
+func (s *actionStore) add(a fleetapi.Action) {
 	switch v := a.(type) {
 	case *fleetapi.ActionPolicyChange, *fleetapi.ActionUnenroll:
 		// Only persist the action if the action is different.
@@ -117,12 +117,12 @@ func (s *actionStore) save() error {
 
 // actions returns a slice of action to execute in order, currently only a action policy change is
 // persisted.
-func (s *actionStore) actions() []action {
+func (s *actionStore) actions() fleetapi.Actions {
 	if s.action == nil {
-		return []action{}
+		return fleetapi.Actions{}
 	}
 
-	return []action{s.action}
+	return fleetapi.Actions{s.action}
 }
 
 // actionPolicyChangeSerializer is a struct that adds a YAML serialization, I don't think serialization

--- a/internal/pkg/agent/storage/store/state_store.go
+++ b/internal/pkg/agent/storage/store/state_store.go
@@ -19,6 +19,10 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
+// Version is the current StateStore version. If any breaking change is
+// introduced, it should be increased and a migration added.
+const Version = "1"
+
 type saver interface {
 	Save(io.Reader) error
 }
@@ -144,16 +148,17 @@ func NewStateStore(log *logger.Logger, store saveLoader) (*StateStore, error) {
 		return &StateStore{
 			log:   log,
 			store: store,
-			state: state{Version: "1"},
+			state: state{Version: Version},
 		}, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("could not JSON unmarshal state store: %w", err)
 	}
 
-	if st.Version != "1" {
-		return nil, fmt.Errorf("invalid state store version, got \"%s\" isntead of 1",
-			st.Version)
+	if st.Version != Version {
+		return nil, fmt.Errorf(
+			"invalid state store version, got %q isntead of %s",
+			st.Version, Version)
 	}
 
 	return &StateStore{

--- a/internal/pkg/agent/storage/store/state_store.go
+++ b/internal/pkg/agent/storage/store/state_store.go
@@ -103,7 +103,6 @@ func (aq *actionQueue) UnmarshalJSON(data []byte) error {
 				"cannot unmarshal it to actionQueue", a.Type())
 		}
 		scheduledActions = append(scheduledActions, sa)
-		_ = sa
 	}
 
 	*aq = scheduledActions

--- a/internal/pkg/agent/storage/store/state_store.go
+++ b/internal/pkg/agent/storage/store/state_store.go
@@ -45,9 +45,9 @@ type StateStore struct {
 }
 
 type state struct {
-	ActionSerializer actionSerializer `json:"action,omitempty"`
-	AckToken         string           `json:"ack_token,omitempty"`
-	Queue            fleetapi.Actions `json:"action_queue,omitempty"`
+	ActionSerializer actionSerializer           `json:"action,omitempty"`
+	AckToken         string                     `json:"ack_token,omitempty"`
+	Queue            []fleetapi.ScheduledAction `json:"action_queue,omitempty"`
 }
 
 func (as *actionSerializer) MarshalJSON() ([]byte, error) {
@@ -232,7 +232,7 @@ func (s *StateStore) SetAckToken(ackToken string) {
 // SetQueue sets the action_queue to agent state
 // TODO: receive only scheduled actions. It might break something. Needs to
 // investigate it better.
-func (s *StateStore) SetQueue(q fleetapi.Actions) {
+func (s *StateStore) SetQueue(q []fleetapi.ScheduledAction) {
 	s.mx.Lock()
 	defer s.mx.Unlock()
 	s.state.Queue = q
@@ -274,10 +274,10 @@ func (s *StateStore) Save() error {
 }
 
 // Queue returns a copy of the queue
-func (s *StateStore) Queue() fleetapi.Actions {
+func (s *StateStore) Queue() []fleetapi.ScheduledAction {
 	s.mx.RLock()
 	defer s.mx.RUnlock()
-	q := make([]fleetapi.Action, len(s.state.Queue))
+	q := make([]fleetapi.ScheduledAction, len(s.state.Queue))
 	copy(q, s.state.Queue)
 	return q
 }

--- a/internal/pkg/agent/storage/store/state_store.go
+++ b/internal/pkg/agent/storage/store/state_store.go
@@ -230,6 +230,8 @@ func (s *StateStore) SetAckToken(ackToken string) {
 }
 
 // SetQueue sets the action_queue to agent state
+// TODO: receive only scheduled actions. It might break something. Needs to
+// investigate it better.
 func (s *StateStore) SetQueue(q fleetapi.Actions) {
 	s.mx.Lock()
 	defer s.mx.Unlock()

--- a/internal/pkg/agent/storage/store/state_store_test.go
+++ b/internal/pkg/agent/storage/store/state_store_test.go
@@ -138,9 +138,7 @@ func runTestStateStore(t *testing.T, ackToken string) {
 		assert.Len(t, store.Queue(), 1)
 		assert.Equal(t, "test", store.Queue()[0].ID())
 
-		scheduledAction, ok := store.Queue()[0].(fleetapi.ScheduledAction)
-		assert.True(t, ok, "expected to be able to cast Action as ScheduledAction")
-		start, err := scheduledAction.StartTime()
+		start, err := store.Queue()[0].StartTime()
 		assert.NoError(t, err)
 		assert.Equal(t, ts, start)
 	})
@@ -188,11 +186,7 @@ func runTestStateStore(t *testing.T, ackToken string) {
 
 		got := store.Queue()
 		for i, want := range queue {
-			_, ok := got[i].(fleetapi.ScheduledAction)
-			assert.True(t, ok,
-				"expected to be able to cast Action as ScheduledAction")
-
-			upgradeAction := got[i].(*fleetapi.ActionUpgrade)
+			upgradeAction, ok := got[i].(*fleetapi.ActionUpgrade)
 			assert.True(t, ok,
 				"expected to be able to cast Action as ActionUpgrade")
 

--- a/internal/pkg/config/operations/inspector.go
+++ b/internal/pkg/config/operations/inspector.go
@@ -113,18 +113,16 @@ func loadConfig(ctx context.Context, configPath string) (*config.Config, error) 
 }
 
 func loadFleetConfig(ctx context.Context, l *logger.Logger) (map[string]interface{}, error) {
-	stateStore, err := store.NewStateStoreWithMigration(ctx, l, paths.AgentActionStoreFile(), paths.AgentStateStoreFile())
+	stateStore, err := store.NewStateStoreWithMigration(
+		ctx, l, paths.AgentActionStoreFile(), paths.AgentStateStoreFile())
 	if err != nil {
 		return nil, err
 	}
 
-	for _, c := range stateStore.Actions() {
-		cfgChange, ok := c.(*fleetapi.ActionPolicyChange)
-		if !ok {
-			continue
-		}
-
+	cfgChange, ok := stateStore.Action().(*fleetapi.ActionPolicyChange)
+	if ok {
 		return cfgChange.Data.Policy, nil
 	}
+
 	return nil, nil
 }

--- a/internal/pkg/fleetapi/action.go
+++ b/internal/pkg/fleetapi/action.go
@@ -91,6 +91,9 @@ type Signed struct {
 	Signature string `json:"signature" yaml:"signature"  mapstructure:"signature"`
 }
 
+// NewAction returns a new, zero-value, action of the type defined by 'actionType'
+// or an ActionUnknown with the 'OriginalType' field set to 'actionType' if the
+// type is not valid.
 func NewAction(actionType string) Action {
 	var action Action
 

--- a/internal/pkg/fleetapi/action.go
+++ b/internal/pkg/fleetapi/action.go
@@ -50,6 +50,10 @@ type Action interface {
 	AckEvent() AckEvent
 }
 
+// Actions is a slice of Actions to executes and allow to unmarshal
+// heterogeneous action types.
+type Actions []Action
+
 // ScheduledAction is an Action that may be executed at a later date
 // Only ActionUpgrade implements this at the moment
 type ScheduledAction interface {
@@ -563,9 +567,6 @@ func (a *ActionApp) MarshalMap() (map[string]interface{}, error) {
 	err := mapstructure.Decode(a, &res)
 	return res, err
 }
-
-// Actions is a list of Actions to executes and allow to unmarshal heterogenous action type.
-type Actions []Action
 
 // UnmarshalJSON takes every raw representation of an action and try to decode them.
 func (a *Actions) UnmarshalJSON(data []byte) error {

--- a/internal/pkg/queue/actionqueue.go
+++ b/internal/pkg/queue/actionqueue.go
@@ -11,9 +11,9 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
 )
 
-// saver is an the minimal interface needed for state storage.
+// saver is the minimal interface needed for state storage.
 type saver interface {
-	SetQueue(a []fleetapi.Action)
+	SetQueue(a fleetapi.Actions)
 	Save() error
 }
 
@@ -95,7 +95,7 @@ func newQueue(actions []fleetapi.Action) (*queue, error) {
 	return &q, nil
 }
 
-// NewActionQueue creates a new queue with the passed actions using the persistor for state storage.
+// NewActionQueue creates a new queue with the passed actions using the saver for state storage.
 func NewActionQueue(actions []fleetapi.Action, s saver) (*ActionQueue, error) {
 	q, err := newQueue(actions)
 	if err != nil {

--- a/internal/pkg/queue/actionqueue.go
+++ b/internal/pkg/queue/actionqueue.go
@@ -13,7 +13,7 @@ import (
 
 // saver is the minimal interface needed for state storage.
 type saver interface {
-	SetQueue(a fleetapi.Actions)
+	SetQueue(a []fleetapi.ScheduledAction)
 	Save() error
 }
 
@@ -74,13 +74,9 @@ func (q *queue) Pop() interface{} {
 
 // newQueue creates a new priority queue using container/heap.
 // Will return an error if StartTime fails for any action.
-func newQueue(actions []fleetapi.Action) (*queue, error) {
+func newQueue(actions []fleetapi.ScheduledAction) (*queue, error) {
 	q := make(queue, len(actions))
-	for i, a := range actions {
-		action, ok := a.(fleetapi.ScheduledAction)
-		if !ok {
-			continue
-		}
+	for i, action := range actions {
 		ts, err := action.StartTime()
 		if err != nil {
 			return nil, err
@@ -96,7 +92,7 @@ func newQueue(actions []fleetapi.Action) (*queue, error) {
 }
 
 // NewActionQueue creates a new queue with the passed actions using the saver for state storage.
-func NewActionQueue(actions []fleetapi.Action, s saver) (*ActionQueue, error) {
+func NewActionQueue(actions []fleetapi.ScheduledAction, s saver) (*ActionQueue, error) {
 	q, err := newQueue(actions)
 	if err != nil {
 		return nil, err
@@ -149,8 +145,8 @@ func (q *ActionQueue) Cancel(actionID string) int {
 }
 
 // Actions returns all actions in the queue, item 0 is garunteed to be the min, the rest may not be in sorted order.
-func (q *ActionQueue) Actions() []fleetapi.Action {
-	actions := make([]fleetapi.Action, q.q.Len())
+func (q *ActionQueue) Actions() []fleetapi.ScheduledAction {
+	actions := make([]fleetapi.ScheduledAction, q.q.Len())
 	for i, item := range *q.q {
 		actions[i] = item.action
 	}

--- a/internal/pkg/queue/actionqueue_test.go
+++ b/internal/pkg/queue/actionqueue_test.go
@@ -56,7 +56,7 @@ type mockSaver struct {
 	mock.Mock
 }
 
-func (m *mockSaver) SetQueue(a fleetapi.Actions) {
+func (m *mockSaver) SetQueue(a []fleetapi.ScheduledAction) {
 	m.Called(a)
 }
 
@@ -85,14 +85,14 @@ func TestNewQueue(t *testing.T) {
 	})
 
 	t.Run("empty actions slice", func(t *testing.T) {
-		q, err := newQueue([]fleetapi.Action{})
+		q, err := newQueue([]fleetapi.ScheduledAction{})
 		require.NoError(t, err)
 		assert.NotNil(t, q)
 		assert.Empty(t, q)
 	})
 
 	t.Run("ordered actions list", func(t *testing.T) {
-		q, err := newQueue([]fleetapi.Action{a1, a2, a3})
+		q, err := newQueue([]fleetapi.ScheduledAction{a1, a2, a3})
 		assert.NotNil(t, q)
 		require.NoError(t, err)
 		assert.Len(t, *q, 3)
@@ -107,7 +107,7 @@ func TestNewQueue(t *testing.T) {
 	})
 
 	t.Run("unordered actions list", func(t *testing.T) {
-		q, err := newQueue([]fleetapi.Action{a3, a2, a1})
+		q, err := newQueue([]fleetapi.ScheduledAction{a3, a2, a1})
 		require.NoError(t, err)
 		assert.NotNil(t, q)
 		assert.Len(t, *q, 3)
@@ -124,7 +124,7 @@ func TestNewQueue(t *testing.T) {
 	t.Run("start time error", func(t *testing.T) {
 		a := &mockAction{}
 		a.On("StartTime").Return(time.Time{}, errors.New("oh no"))
-		q, err := newQueue([]fleetapi.Action{a})
+		q, err := newQueue([]fleetapi.ScheduledAction{a})
 		assert.EqualError(t, err, "oh no")
 		assert.Nil(t, q)
 	})

--- a/internal/pkg/queue/actionqueue_test.go
+++ b/internal/pkg/queue/actionqueue_test.go
@@ -56,7 +56,7 @@ type mockSaver struct {
 	mock.Mock
 }
 
-func (m *mockSaver) SetQueue(a []fleetapi.Action) {
+func (m *mockSaver) SetQueue(a fleetapi.Actions) {
 	m.Called(a)
 }
 


### PR DESCRIPTION
## What does this PR do?

It refactors the state store to:
 - Have an interface that better reflects what it actually does
   - methods do not return a slice of action when only 1 action is involved
   - action queue only accepts ScheduledAction
 - Add a `Version` field to the state store state
 - Test for saving 2 actions in the queue uses 2 upgrade actions as it's the only scheduled action so far.

## Why is it important?

So the state store API reflects its actual usage and purpose.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Relates #3912 

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
