### PR TITLE
Add mTLS env vars for container mode

### DIFF
--- a/changelog/fragments/1707935415-Add-mTLS-env-var-settings-for-containers.yaml
+++ b/changelog/fragments/1707935415-Add-mTLS-env-var-settings-for-containers.yaml
@@ -1,0 +1,34 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add mTLS env var settings for containers
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Add env var bindings so fleet-server/elastic-agents started in container mode
+  can specify mTLS variables.
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -458,7 +458,7 @@ func buildEnrollArgs(cfg setupConfig, token string, policyID string) ([]string, 
 		if cfg.FleetServer.PassphrasePath != "" {
 			args = append(args, "--fleet-server-cert-key-passphrase", cfg.FleetServer.PassphrasePath)
 		}
-		if cfg.FleetServer.ClientAuth != nil {
+		if cfg.FleetServer.ClientAuth != "" {
 			args = append(args, "--fleet-server-client-auth", cfg.FleetServer.ClientAuth)
 		}
 

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -72,6 +72,8 @@ The following actions are possible and grouped based on the actions.
   FLEET_ENROLLMENT_TOKEN - token to use for enrollment. This is not needed in case FLEET_SERVER_ENABLED and FLEET_ENROLL is set. Then the token is fetched from Kibana.
   FLEET_CA - path to certificate authority to use with communicate with Fleet Server [$KIBANA_CA]
   FLEET_INSECURE - communicate with Fleet with either insecure HTTP or unverified HTTPS
+  ELASTIC_AGENT_CERT - path to certificate to use for connecting to fleet-server.
+  ELASTIC_AGENT_CERT_KEY - path to private key use for connecting to fleet-server.
 
 
   The following vars are need in the scenario that Elastic Agent should automatically fetch its own token.
@@ -100,6 +102,9 @@ The following actions are possible and grouped based on the actions.
   FLEET_SERVER_CERT - path to certificate to use for HTTPS endpoint
   FLEET_SERVER_CERT_KEY - path to private key for certificate to use for HTTPS endpoint
   FLEET_SERVER_CERT_KEY_PASSPHRASE - path to private key passphrase file for certificate to use for HTTPS endpoint
+  FLEET_SERVER_ES_CERT - path to certificate to use for connecting to Elasticsearch
+  FLEET_SERVER_ES_CERT_KEY - path to private key for certificate to use for connecting to Elasticsearch
+  FLEET_SERVER_CLIENT_AUTH - fleet-server mTLS client authentication for connecting elastic-agents. Must be one of [none, optional, required]. A default of none is used.
   FLEET_SERVER_INSECURE_HTTP - expose Fleet Server over HTTP (not recommended; insecure)
   FLEET_SERVER_INIT_TIMEOUT - Sets the initial timeout when starting up the fleet server under agent. Default: 30s.
 
@@ -432,6 +437,12 @@ func buildEnrollArgs(cfg setupConfig, token string, policyID string) ([]string, 
 		if cfg.FleetServer.Elasticsearch.CATrustedFingerprint != "" {
 			args = append(args, "--fleet-server-es-ca-trusted-fingerprint", cfg.FleetServer.Elasticsearch.CATrustedFingerprint)
 		}
+		if cfg.FleetServer.Elasticsearch.Cert != "" {
+			args = append(args, "--fleet-server-es-cert", cfg.FleetServer.Elasticsearch.Cert)
+		}
+		if cfg.FleetServer.Elasticsearch.CertKey != "" {
+			args = append(args, "--fleet-server-es-cert-key", cfg.FleetServer.Elasticsearch.CertKey)
+		}
 		if cfg.FleetServer.Host != "" {
 			args = append(args, "--fleet-server-host", cfg.FleetServer.Host)
 		}
@@ -446,6 +457,9 @@ func buildEnrollArgs(cfg setupConfig, token string, policyID string) ([]string, 
 		}
 		if cfg.FleetServer.PassphrasePath != "" {
 			args = append(args, "--fleet-server-cert-key-passphrase", cfg.FleetServer.PassphrasePath)
+		}
+		if cfg.FleetServer.ClientAuth != nil {
+			args = append(args, "--fleet-server-client-auth", cfg.FleetServer.ClientAuth)
 		}
 
 		for k, v := range cfg.FleetServer.Headers {
@@ -486,6 +500,12 @@ func buildEnrollArgs(cfg setupConfig, token string, policyID string) ([]string, 
 	if cfg.Fleet.DaemonTimeout != 0 {
 		args = append(args, "--daemon-timeout")
 		args = append(args, cfg.Fleet.DaemonTimeout.String())
+	}
+	if cfg.Fleet.Cert != "" {
+		args = append(args, "--elastic-agent-cert", cfg.Fleet.Cert)
+	}
+	if cfg.Fleet.CertKey != "" {
+		args = append(args, "--elastic-agent-cert-key", cfg.Fleet.CertKey)
 	}
 	return args, nil
 }

--- a/internal/pkg/agent/cmd/container_test.go
+++ b/internal/pkg/agent/cmd/container_test.go
@@ -152,6 +152,24 @@ func TestBuildEnrollArgs(t *testing.T) {
 			expect: []string{"--fleet-server-service-token-path", "/path/to/token"},
 			err:    nil,
 		},
+		"mTLS flags": {
+			cfg: setupConfig{
+				Fleet: fleetConfig{
+					Cert:    "/path/to/agent.crt",
+					CertKey: "/path/to/agent.key",
+				},
+				FleetServer: fleetServerConfig{
+					Enable:     true,
+					ClientAuth: "optional",
+					Elasticsearch: elasticsearchConfig{
+						Cert:    "/path/to/es.crt",
+						CertKey: "/path/to/es.key",
+					},
+				},
+			},
+			expect: []string{"--fleet-server-es-cert", "/path/to/es.crt", "--fleet-server-es-cert-key", "/path/to/es.key", "--fleet-server-client-auth", "optional", "--elastic-agent-cert", "/path/to/agent.crt", "--elastic-agent-cert-key", "/path/to/agent.key"},
+			err:    nil,
+		},
 	}
 
 	for name, tc := range cases {

--- a/internal/pkg/agent/cmd/setup_config.go
+++ b/internal/pkg/agent/cmd/setup_config.go
@@ -24,12 +24,15 @@ type fleetConfig struct {
 	TokenPolicyName string        `config:"token_policy_name"`
 	URL             string        `config:"url"`
 	DaemonTimeout   time.Duration `config:"daemon_timeout"`
+	Cert            string        `config:"cert"`
+	CertKey         string        `config:"cert_key"`
 }
 
 type fleetServerConfig struct {
 	Cert           string              `config:"cert"`
 	CertKey        string              `config:"cert_key"`
 	PassphrasePath string              `config:"key_passphrase_path"`
+	ClientAuth     string              `config:"client_authentication"`
 	Elasticsearch  elasticsearchConfig `config:"elasticsearch"`
 	Enable         bool                `config:"enable"`
 	Host           string              `config:"host"`
@@ -47,6 +50,8 @@ type elasticsearchConfig struct {
 	ServiceToken         string `config:"service_token"`
 	ServiceTokenPath     string `config:"service_token_path"`
 	Insecure             bool   `config:"insecure"`
+	Cert                 string `config:"cert"`
+	CertKey              string `config:"cert_key"`
 }
 
 type kibanaConfig struct {
@@ -87,11 +92,14 @@ func defaultAccessConfig() (setupConfig, error) {
 			TokenPolicyName: envWithDefault("", "FLEET_TOKEN_POLICY_NAME"),
 			URL:             envWithDefault("", "FLEET_URL"),
 			DaemonTimeout:   envTimeout("FLEET_DAEMON_TIMEOUT"),
+			Cert:            envWithDefault("", "ELASTIC_AGENT_CERT"),
+			CertKey:         envWithDefault("", "ELASTIC_AGENT_CERT_KEY"),
 		},
 		FleetServer: fleetServerConfig{
 			Cert:           envWithDefault("", "FLEET_SERVER_CERT"),
 			CertKey:        envWithDefault("", "FLEET_SERVER_CERT_KEY"),
 			PassphrasePath: envWithDefault("", "FLEET_SERVER_CERT_KEY_PASSPHRASE"),
+			ClientAuth:     envWithDefault("none", "FLEET_SERVER_CLIENT_AUTH"),
 			Elasticsearch: elasticsearchConfig{
 				Host:                 envWithDefault("http://elasticsearch:9200", "FLEET_SERVER_ELASTICSEARCH_HOST", "ELASTICSEARCH_HOST"),
 				ServiceToken:         envWithDefault("", "FLEET_SERVER_SERVICE_TOKEN"),
@@ -99,6 +107,8 @@ func defaultAccessConfig() (setupConfig, error) {
 				CA:                   envWithDefault("", "FLEET_SERVER_ELASTICSEARCH_CA", "ELASTICSEARCH_CA"),
 				CATrustedFingerprint: envWithDefault("", "FLEET_SERVER_ELASTICSEARCH_CA_TRUSTED_FINGERPRINT"),
 				Insecure:             envBool("FLEET_SERVER_ELASTICSEARCH_INSECURE"),
+				Cert:                 envWithDefault("", "FLEET_SERVER_ES_CERT"),
+				CertKey:              envWithDefault("", "FLEET_SERVER_ES_CERT_KEY"),
 			},
 			Enable:       envBool("FLEET_SERVER_ENABLE"),
 			Host:         envWithDefault("", "FLEET_SERVER_HOST"),


### PR DESCRIPTION
## What does this PR do?

Add env var bindings so fleet-server/elastic-agents started in container mode can specify mTLS variables.

## Why is it important?

Missed adding container env vars in #4007, this will allow users to start fleet-server instances with mTLS support.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~I have added an integration test or an E2E test~~