### PR TITLE
Check if non-snapshot version is released before using for testing

### DIFF
--- a/pkg/testing/tools/artifacts_api_test.go
+++ b/pkg/testing/tools/artifacts_api_test.go
@@ -6,12 +6,15 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -215,4 +218,75 @@ func TestDefaultArtifactAPIClient(t *testing.T) {
 	assert.NotEmpty(t, buildDetails.Build)
 	assert.NotEmpty(t, buildDetails.Build.Projects)
 	assert.Contains(t, buildDetails.Build.Projects, "elastic-agent")
+}
+
+func createVersionList(t *testing.T) *VersionList {
+	var list VersionList
+	err := json.Unmarshal([]byte(cannedVersions), &list)
+	require.NoError(t, err)
+	return &list
+}
+
+func TestRemoveUnreleasedVersions(t *testing.T) {
+	versionRegExp := regexp.MustCompile(`/elastic-agent-(\d+\.\d+\.\d+)-.+$`)
+	var unreleasedVersions map[string]struct{}
+	server := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		matches := versionRegExp.FindAllStringSubmatch(req.URL.Path, 2)
+		if len(matches) == 0 || len(matches[0]) < 2 {
+			resp.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		version := matches[0][1]
+		if _, unreleased := unreleasedVersions[version]; unreleased {
+			resp.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		resp.WriteHeader(http.StatusOK)
+	}))
+
+	client := NewArtifactAPIClient(WithCDNUrl(server.URL))
+
+	t.Run("removes unreleased versions", func(t *testing.T) {
+		unreleasedVersions = map[string]struct{}{
+			"8.6.1": {},
+			"8.8.0": {},
+		}
+
+		versionList := createVersionList(t)
+		err := client.RemoveUnreleasedVersions(context.Background(), versionList)
+		require.NoError(t, err)
+		exp := []string{
+			"7.17.9",
+			"7.17.10",
+			"8.6.0",
+			"8.6.2",
+			"8.7.0",
+			"8.7.1",
+			"8.8.1",
+			"8.9.0-SNAPSHOT",
+		}
+		require.Equal(t, exp, versionList.Versions)
+	})
+
+	t.Run("does not change the list if all released", func(t *testing.T) {
+		unreleasedVersions = map[string]struct{}{} // everything is released
+
+		versionList := createVersionList(t)
+		err := client.RemoveUnreleasedVersions(context.Background(), versionList)
+		require.NoError(t, err)
+		exp := []string{
+			"7.17.9",
+			"7.17.10",
+			"8.6.0",
+			"8.6.1",
+			"8.6.2",
+			"8.7.0",
+			"8.7.1",
+			"8.8.0",
+			"8.8.1",
+			"8.9.0-SNAPSHOT",
+		}
+		require.Equal(t, exp, versionList.Versions)
+	})
 }

--- a/testing/upgradetest/versions.go
+++ b/testing/upgradetest/versions.go
@@ -44,6 +44,10 @@ func GetUpgradableVersions(ctx context.Context, upgradeToVersion string, current
 	if len(vList.Versions) == 0 {
 		return nil, errors.New("retrieved versions list from Artifact API is empty")
 	}
+	err = aac.RemoveUnreleasedVersions(ctx, vList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to remove unreleased versions: %w", err)
+	}
 
 	return getUpgradableVersions(ctx, vList, upgradeToVersion, currentMajorVersions, previousMajorVersions)
 }


### PR DESCRIPTION
## What does this PR do?

Currently, we don't check whether a version without the `-SNAPSHOT` suffix is actually released and available on our public CDN.

The version is present on the artifact API once the first BC is built, however, this does not mean the version is published on the CDN.

This leads to failing upgrade attempts by the agent in our integration tests.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Our integration tests are not passing.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
~~- [ ] I have added an integration test or an E2E test~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes https://github.com/elastic/elastic-agent/issues/4275