### PR TITLE
Use the right HTTP client

### DIFF
--- a/pkg/testing/tools/artifacts_api.go
+++ b/pkg/testing/tools/artifacts_api.go
@@ -200,7 +200,7 @@ func (aac ArtifactAPIClient) RemoveUnreleasedVersions(ctx context.Context, vList
 			return fmt.Errorf("failed to create an HTTP request to %q: %w", url, err)
 		}
 
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := aac.c.Do(req)
 		if err != nil {
 			return fmt.Errorf("failed to request %q: %w", url, err)
 		}


### PR DESCRIPTION
## What does this PR do?

Using the default HTTP client was incorrect.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

So, we can correctly configure this request.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
~~- [ ] I have added an integration test or an E2E test~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/pull/4276