### PR TITLE
Avoid drainErrChan hanging forever if the channel is closed

### DIFF
--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -141,7 +141,11 @@ func newDebugLogger(t *testing.T) *logger.Logger {
 func drainErrChan(ch chan error) {
 	for {
 		select {
-		case <-ch:
+		case _, ok := <-ch:
+			// channel is closed, nothing to drain
+			if !ok {
+				return
+			}
 		default:
 			return
 		}


### PR DESCRIPTION
## What does this PR do?

Makes `drainErrChan` to return if the channel is closed.
As it's possible to read from a closed channel, if the channel passed to `drainErrChan` is closed it'd never exit.

## Why is it important?

`drainErrChan` would never return if received a closed channel and therefore would hang the test until it times out.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~


## How to test this PR locally

check the behaviour here: https://go.dev/play/p/WVM-P8RwJaM

## Related issues

 - N/A

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
