### PR TITLE
Re-enable the ProxyURL tests.

### DIFF
--- a/testing/integration/proxy_url_test.go
+++ b/testing/integration/proxy_url_test.go
@@ -99,7 +99,6 @@ func TestProxyURL_EnrollProxyAndNoProxyInThePolicy(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
-	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/3154")
 
 	p := SetupTest(t)
 	t.Cleanup(func() {
@@ -147,7 +146,6 @@ func TestProxyURL_EnrollProxyAndEmptyProxyInThePolicy(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
-	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/3154")
 
 	p := SetupTest(t)
 	t.Cleanup(func() {
@@ -197,7 +195,6 @@ func TestProxyURL_ProxyInThePolicyTakesPrecedence(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
-	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/3154")
 
 	p := SetupTest(t)
 	t.Cleanup(func() {
@@ -261,7 +258,6 @@ func TestProxyURL_NoEnrollProxyAndProxyInThePolicy(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
-	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/3154")
 
 	p := SetupTest(t)
 	t.Cleanup(func() {
@@ -329,7 +325,6 @@ func TestProxyURL_RemoveProxyFromThePolicy(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
-	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/3154")
 
 	p := SetupTest(t)
 	t.Cleanup(func() {


### PR DESCRIPTION
These tests have been disabled for some time now, but the issue they are linked to was closed: https://github.com/elastic/elastic-agent/issues/3154

Let's re-enable these tests and see if they pass now.