### PR TITLE
Refactor EncryptedDiskStore to return io.Reader instead of io.ReadCloser

### DIFF
--- a/internal/pkg/agent/application/info/agent_id.go
+++ b/internal/pkg/agent/application/info/agent_id.go
@@ -37,7 +37,7 @@ type persistentAgentInfo struct {
 
 type ioStore interface {
 	Save(io.Reader) error
-	Load() (io.ReadCloser, error)
+	Load() (io.Reader, error)
 }
 
 // updateLogLevel updates log level and persists it to disk.

--- a/internal/pkg/agent/storage/disk_store.go
+++ b/internal/pkg/agent/storage/disk_store.go
@@ -97,7 +97,7 @@ func (d *DiskStore) Save(in io.Reader) error {
 }
 
 // Load return a io.ReadCloser for the target file.
-func (d *DiskStore) Load() (io.ReadCloser, error) {
+func (d *DiskStore) Load() (io.Reader, error) {
 	fd, err := os.OpenFile(d.target, os.O_RDONLY|os.O_CREATE, perms)
 	if err != nil {
 		return nil, errors.New(err,

--- a/internal/pkg/agent/storage/encrypted_disk_storage_windows_linux_test.go
+++ b/internal/pkg/agent/storage/encrypted_disk_storage_windows_linux_test.go
@@ -41,7 +41,6 @@ func TestEncryptedDiskStorageWindowsLinuxLoad(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
 
 	b, err := io.ReadAll(r)
 	if err != nil {
@@ -98,7 +97,6 @@ func TestEncryptedDiskStorageWindowsLinuxLoad(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer nr.Close()
 
 	b, err = io.ReadAll(nr)
 	if err != nil {

--- a/internal/pkg/agent/storage/storage.go
+++ b/internal/pkg/agent/storage/storage.go
@@ -23,7 +23,7 @@ type Storage interface {
 	Store
 
 	// Load return an io.ReadCloser for the target store.
-	Load() (io.ReadCloser, error)
+	Load() (io.Reader, error)
 
 	// Exists checks if the store exists.
 	Exists() (bool, error)

--- a/internal/pkg/agent/storage/storage_test.go
+++ b/internal/pkg/agent/storage/storage_test.go
@@ -184,7 +184,6 @@ func TestDiskStore(t *testing.T) {
 		d := NewDiskStore(target)
 		r, err := d.Load()
 		require.NoError(t, err)
-		defer r.Close()
 
 		content, err := io.ReadAll(r)
 		require.NoError(t, err)

--- a/internal/pkg/agent/storage/store/state_store.go
+++ b/internal/pkg/agent/storage/store/state_store.go
@@ -27,7 +27,7 @@ type store interface {
 
 type storeLoad interface {
 	store
-	Load() (io.ReadCloser, error)
+	Load() (io.Reader, error)
 }
 
 type action = fleetapi.Action


### PR DESCRIPTION
## What does this PR do?

Refactors EncryptedDiskStore to return io.Reader instead of io.ReadCloser

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files
- ~~[ ] I have added tests that prove my fix is effective or that my feature work~~s~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~


## Related issues

- Relates #3912

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
