### PR TITLE
Revert "Unskip the proxy URL tests. (#4321)"

### DIFF
--- a/testing/integration/proxy_url_test.go
+++ b/testing/integration/proxy_url_test.go
@@ -99,6 +99,7 @@ func TestProxyURL_EnrollProxyAndNoProxyInThePolicy(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/3154")
 
 	p := SetupTest(t)
 	t.Cleanup(func() {
@@ -146,6 +147,7 @@ func TestProxyURL_EnrollProxyAndEmptyProxyInThePolicy(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/3154")
 
 	p := SetupTest(t)
 	t.Cleanup(func() {
@@ -195,6 +197,7 @@ func TestProxyURL_ProxyInThePolicyTakesPrecedence(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/3154")
 
 	p := SetupTest(t)
 	t.Cleanup(func() {
@@ -258,6 +261,7 @@ func TestProxyURL_NoEnrollProxyAndProxyInThePolicy(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/3154")
 
 	p := SetupTest(t)
 	t.Cleanup(func() {
@@ -325,6 +329,7 @@ func TestProxyURL_RemoveProxyFromThePolicy(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/3154")
 
 	p := SetupTest(t)
 	t.Cleanup(func() {


### PR DESCRIPTION
This reverts commit 5e17bc222dfa1475bbdf8cade30d67a44dceb436.

See comments on the original PR:

* https://github.com/elastic/elastic-agent/pull/4321#issuecomment-1963812732
* https://github.com/elastic/elastic-agent/pull/4321#issuecomment-1963926056