### PR TITLE
Integration Testing Framework: Add retries for artifacts API call

### DIFF
--- a/pkg/testing/tools/artifacts_api.go
+++ b/pkg/testing/tools/artifacts_api.go
@@ -328,6 +328,7 @@ func (aac ArtifactAPIClient) createAndPerformRequest(ctx context.Context, URL st
 	if numAttempts == maxAttemptsForArtifactsAPICall {
 		return nil, fmt.Errorf("failed executing http request %v after %d retries: %w", req, numAttempts, err)
 	}
+
 	return resp, nil
 }
 

--- a/pkg/testing/tools/artifacts_api.go
+++ b/pkg/testing/tools/artifacts_api.go
@@ -323,7 +323,10 @@ func (aac ArtifactAPIClient) createAndPerformRequest(ctx context.Context, URL st
 	for ; numAttempts < maxAttemptsForArtifactsAPICall; numAttempts++ {
 		resp, err = aac.c.Do(req)
 		if err != nil {
-			aac.logger.Logf("failed attempt %d of %d executing http request %v: %s; retrying...", numAttempts+1, maxAttemptsForArtifactsAPICall, err.Error())
+			aac.logger.Logf(
+				"failed attempt %d of %d executing http request %v: %s; retrying...",
+				numAttempts+1, maxAttemptsForArtifactsAPICall, req, err.Error(),
+			)
 			time.Sleep(retryIntervalForArtifactsAPICall)
 		}
 	}

--- a/pkg/testing/tools/artifacts_api.go
+++ b/pkg/testing/tools/artifacts_api.go
@@ -328,6 +328,14 @@ func (aac ArtifactAPIClient) createAndPerformRequest(ctx context.Context, URL st
 			break
 		}
 
+		// If the context was cancelled or timed out, return early
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf(
+				"executing http request %s %s (attempt %d of %d) cancelled or timed out: %w",
+				req.Method, req.URL, numAttempts+1, maxAttemptsForArtifactsAPICall, err,
+			)
+		}
+
 		aac.logger.Logf(
 			"failed attempt %d of %d executing http request %s %s: %s; retrying after %v...",
 			numAttempts+1, maxAttemptsForArtifactsAPICall, req.Method, req.URL, err.Error(), retryIntervalForArtifactsAPICall,

--- a/pkg/testing/tools/artifacts_api.go
+++ b/pkg/testing/tools/artifacts_api.go
@@ -141,14 +141,17 @@ type ArtifactAPIClient struct {
 	c      httpDoer
 	url    string
 	cdnURL string
+
+	logger logger
 }
 
 // NewArtifactAPIClient creates a new Artifact API client
-func NewArtifactAPIClient(opts ...ArtifactAPIClientOpt) *ArtifactAPIClient {
+func NewArtifactAPIClient(logger logger, opts ...ArtifactAPIClientOpt) *ArtifactAPIClient {
 	c := &ArtifactAPIClient{
 		url:    defaultArtifactAPIURL,
 		cdnURL: artifactReleaseCDN,
 		c:      new(http.Client),
+		logger: logger,
 	}
 
 	for _, opt := range opts {
@@ -159,13 +162,13 @@ func NewArtifactAPIClient(opts ...ArtifactAPIClientOpt) *ArtifactAPIClient {
 }
 
 // GetVersions returns a list of versions as server by the Artifact API along with some aliases and manifest information
-func (aac ArtifactAPIClient) GetVersions(ctx context.Context, log logger) (list *VersionList, err error) {
+func (aac ArtifactAPIClient) GetVersions(ctx context.Context) (list *VersionList, err error) {
 	joinedURL, err := aac.composeURL(artifactsAPIV1VersionsEndpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := aac.createAndPerformRequest(ctx, joinedURL, log)
+	resp, err := aac.createAndPerformRequest(ctx, joinedURL)
 	if err != nil {
 		return nil, fmt.Errorf("getting versions: %w", err)
 	}
@@ -239,13 +242,13 @@ func (aac ArtifactAPIClient) RemoveUnreleasedVersions(ctx context.Context, vList
 // GetBuildsForVersion returns a list of builds for a specific version.
 // version should be one of the version strings returned by the GetVersions (expected format is semver
 // with optional prerelease but no build metadata, for example 8.9.0-SNAPSHOT)
-func (aac ArtifactAPIClient) GetBuildsForVersion(ctx context.Context, version string, log logger) (builds *VersionBuilds, err error) {
+func (aac ArtifactAPIClient) GetBuildsForVersion(ctx context.Context, version string) (builds *VersionBuilds, err error) {
 	joinedURL, err := aac.composeURL(fmt.Sprintf(artifactsAPIV1VersionBuildsEndpoint, version))
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := aac.createAndPerformRequest(ctx, joinedURL, log)
+	resp, err := aac.createAndPerformRequest(ctx, joinedURL)
 	if err != nil {
 		return nil, fmt.Errorf("getting builds for version %s: %w", version, err)
 	}
@@ -259,8 +262,8 @@ func (aac ArtifactAPIClient) GetBuildsForVersion(ctx context.Context, version st
 // to the oldest, starting the search at the `offset` index in the list of builds.
 // Setting `offset` to 0 includes all builds, 1 skips the latest, and so forth.
 // If there are no builds matching these conditions, returns `ErrBuildNotFound`.
-func (aac ArtifactAPIClient) FindBuild(ctx context.Context, version, excludeHash string, offset int, log logger) (buildDetails *BuildDetails, err error) {
-	resp, err := aac.GetBuildsForVersion(ctx, version, log)
+func (aac ArtifactAPIClient) FindBuild(ctx context.Context, version, excludeHash string, offset int) (buildDetails *BuildDetails, err error) {
+	resp, err := aac.GetBuildsForVersion(ctx, version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get a list of builds: %w", err)
 	}
@@ -268,7 +271,7 @@ func (aac ArtifactAPIClient) FindBuild(ctx context.Context, version, excludeHash
 		return nil, ErrBuildNotFound
 	}
 	for _, buildID := range resp.Builds[offset:] {
-		details, err := aac.GetBuildDetails(ctx, version, buildID, log)
+		details, err := aac.GetBuildDetails(ctx, version, buildID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get build information for %q: %w", buildID, err)
 		}
@@ -283,13 +286,13 @@ func (aac ArtifactAPIClient) FindBuild(ctx context.Context, version, excludeHash
 // GetBuildDetails returns the list of project and artifacts related to a specific build.
 // Version parameter format follows semver (without build metadata) and buildID format is <major>.<minor>.<patch>-<buildhash> as returned by
 // GetBuildsForVersion()
-func (aac ArtifactAPIClient) GetBuildDetails(ctx context.Context, version string, buildID string, log logger) (buildDetails *BuildDetails, err error) {
+func (aac ArtifactAPIClient) GetBuildDetails(ctx context.Context, version string, buildID string) (buildDetails *BuildDetails, err error) {
 	joinedURL, err := aac.composeURL(fmt.Sprintf(artifactAPIV1BuildDetailsEndpoint, version, buildID))
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := aac.createAndPerformRequest(ctx, joinedURL, log)
+	resp, err := aac.createAndPerformRequest(ctx, joinedURL)
 	if err != nil {
 		return nil, fmt.Errorf("getting build details for version %s buildID %s: %w", version, buildID, err)
 	}
@@ -307,7 +310,7 @@ func (aac ArtifactAPIClient) composeURL(relativePath string) (string, error) {
 	return joinedURL, nil
 }
 
-func (aac ArtifactAPIClient) createAndPerformRequest(ctx context.Context, URL string, log logger) (*http.Response, error) {
+func (aac ArtifactAPIClient) createAndPerformRequest(ctx context.Context, URL string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, URL, nil)
 	if err != nil {
 		err = fmt.Errorf("composing request: %w", err)
@@ -320,7 +323,7 @@ func (aac ArtifactAPIClient) createAndPerformRequest(ctx context.Context, URL st
 	for ; numAttempts < maxAttemptsForArtifactsAPICall; numAttempts++ {
 		resp, err = aac.c.Do(req)
 		if err != nil {
-			log.Logf("failed attempt %d of %d executing http request %v: %s; retrying...", numAttempts+1, maxAttemptsForArtifactsAPICall, err.Error())
+			aac.logger.Logf("failed attempt %d of %d executing http request %v: %s; retrying...", numAttempts+1, maxAttemptsForArtifactsAPICall, err.Error())
 			time.Sleep(retryIntervalForArtifactsAPICall)
 		}
 	}
@@ -355,8 +358,8 @@ type logger interface {
 	Logf(format string, args ...any)
 }
 
-func (aac ArtifactAPIClient) GetLatestSnapshotVersion(ctx context.Context, log logger) (*version.ParsedSemVer, error) {
-	vList, err := aac.GetVersions(ctx, log)
+func (aac ArtifactAPIClient) GetLatestSnapshotVersion(ctx context.Context) (*version.ParsedSemVer, error) {
+	vList, err := aac.GetVersions(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -369,7 +372,7 @@ func (aac ArtifactAPIClient) GetLatestSnapshotVersion(ctx context.Context, log l
 	for _, v := range vList.Versions {
 		pv, err := version.ParseVersion(v)
 		if err != nil {
-			log.Logf("invalid version retrieved from artifact API: %q", v)
+			aac.logger.Logf("invalid version retrieved from artifact API: %q", v)
 			return nil, ErrInvalidVersionRetrieved
 		}
 		sortedParsedVersions = append(sortedParsedVersions, pv)

--- a/pkg/testing/tools/artifacts_api.go
+++ b/pkg/testing/tools/artifacts_api.go
@@ -322,6 +322,8 @@ func (aac ArtifactAPIClient) createAndPerformRequest(ctx context.Context, URL st
 	// TODO (once we're on Go 1.22): replace with for numAttempts := range maxAttemptsForArtifactsAPICall {
 	for numAttempts := 0; numAttempts < maxAttemptsForArtifactsAPICall; numAttempts++ {
 		resp, err = aac.c.Do(req)
+
+		// If there is no error, no need to retry the request.
 		if err == nil {
 			break
 		}

--- a/pkg/testing/tools/artifacts_api_test.go
+++ b/pkg/testing/tools/artifacts_api_test.go
@@ -171,12 +171,12 @@ func TestDefaultArtifactAPIClientErrorHttpStatus(t *testing.T) {
 			testSrv := httptest.NewServer(errorHandler)
 			defer testSrv.Close()
 
-			aac := NewArtifactAPIClient(WithUrl(testSrv.URL))
-			_, err := aac.GetVersions(context.Background(), t)
+			aac := NewArtifactAPIClient(t, WithUrl(testSrv.URL))
+			_, err := aac.GetVersions(context.Background())
 			assert.ErrorIs(t, err, ErrBadHTTPStatusCode, "Expected ErrBadHTTPStatusCode for status code %d", httpErrorCode)
-			_, err = aac.GetBuildsForVersion(context.Background(), "1.2.3-SNAPSHOT", t)
+			_, err = aac.GetBuildsForVersion(context.Background(), "1.2.3-SNAPSHOT")
 			assert.ErrorIs(t, err, ErrBadHTTPStatusCode, "Expected ErrBadHTTPStatusCode for status code %d", httpErrorCode)
-			_, err = aac.GetBuildDetails(context.Background(), "1.2.3", "abcdefg", t)
+			_, err = aac.GetBuildDetails(context.Background(), "1.2.3", "abcdefg")
 			assert.ErrorIs(t, err, ErrBadHTTPStatusCode, "Expected ErrBadHTTPStatusCode for status code %d", httpErrorCode)
 		})
 	}
@@ -201,18 +201,18 @@ func TestDefaultArtifactAPIClient(t *testing.T) {
 	testSrv := httptest.NewServer(cannedRespHandler)
 	defer testSrv.Close()
 
-	aac := NewArtifactAPIClient(WithUrl(testSrv.URL))
-	versions, err := aac.GetVersions(context.Background(), t)
+	aac := NewArtifactAPIClient(t, WithUrl(testSrv.URL))
+	versions, err := aac.GetVersions(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, versions)
 	assert.NotEmpty(t, versions.Versions)
 
-	builds, err := aac.GetBuildsForVersion(context.Background(), "8.9.0-SNAPSHOT", t)
+	builds, err := aac.GetBuildsForVersion(context.Background(), "8.9.0-SNAPSHOT")
 	assert.NoError(t, err)
 	assert.NotNil(t, builds)
 	assert.NotEmpty(t, builds.Builds)
 
-	buildDetails, err := aac.GetBuildDetails(context.Background(), "8.9.0-SNAPSHOT", "8.9.0-abcdefgh", t)
+	buildDetails, err := aac.GetBuildDetails(context.Background(), "8.9.0-SNAPSHOT", "8.9.0-abcdefgh")
 	assert.NoError(t, err)
 	assert.NotNil(t, buildDetails)
 	assert.NotEmpty(t, buildDetails.Build)
@@ -245,7 +245,7 @@ func TestRemoveUnreleasedVersions(t *testing.T) {
 		resp.WriteHeader(http.StatusOK)
 	}))
 
-	client := NewArtifactAPIClient(WithCDNUrl(server.URL))
+	client := NewArtifactAPIClient(t, WithCDNUrl(server.URL))
 
 	t.Run("removes unreleased versions", func(t *testing.T) {
 		unreleasedVersions = map[string]struct{}{

--- a/pkg/testing/tools/artifacts_api_test.go
+++ b/pkg/testing/tools/artifacts_api_test.go
@@ -172,11 +172,11 @@ func TestDefaultArtifactAPIClientErrorHttpStatus(t *testing.T) {
 			defer testSrv.Close()
 
 			aac := NewArtifactAPIClient(WithUrl(testSrv.URL))
-			_, err := aac.GetVersions(context.Background())
+			_, err := aac.GetVersions(context.Background(), t)
 			assert.ErrorIs(t, err, ErrBadHTTPStatusCode, "Expected ErrBadHTTPStatusCode for status code %d", httpErrorCode)
-			_, err = aac.GetBuildsForVersion(context.Background(), "1.2.3-SNAPSHOT")
+			_, err = aac.GetBuildsForVersion(context.Background(), "1.2.3-SNAPSHOT", t)
 			assert.ErrorIs(t, err, ErrBadHTTPStatusCode, "Expected ErrBadHTTPStatusCode for status code %d", httpErrorCode)
-			_, err = aac.GetBuildDetails(context.Background(), "1.2.3", "abcdefg")
+			_, err = aac.GetBuildDetails(context.Background(), "1.2.3", "abcdefg", t)
 			assert.ErrorIs(t, err, ErrBadHTTPStatusCode, "Expected ErrBadHTTPStatusCode for status code %d", httpErrorCode)
 		})
 	}
@@ -202,17 +202,17 @@ func TestDefaultArtifactAPIClient(t *testing.T) {
 	defer testSrv.Close()
 
 	aac := NewArtifactAPIClient(WithUrl(testSrv.URL))
-	versions, err := aac.GetVersions(context.Background())
+	versions, err := aac.GetVersions(context.Background(), t)
 	assert.NoError(t, err)
 	assert.NotNil(t, versions)
 	assert.NotEmpty(t, versions.Versions)
 
-	builds, err := aac.GetBuildsForVersion(context.Background(), "8.9.0-SNAPSHOT")
+	builds, err := aac.GetBuildsForVersion(context.Background(), "8.9.0-SNAPSHOT", t)
 	assert.NoError(t, err)
 	assert.NotNil(t, builds)
 	assert.NotEmpty(t, builds.Builds)
 
-	buildDetails, err := aac.GetBuildDetails(context.Background(), "8.9.0-SNAPSHOT", "8.9.0-abcdefgh")
+	buildDetails, err := aac.GetBuildDetails(context.Background(), "8.9.0-SNAPSHOT", "8.9.0-abcdefgh", t)
 	assert.NoError(t, err)
 	assert.NotNil(t, buildDetails)
 	assert.NotEmpty(t, buildDetails.Build)

--- a/testing/integration/upgrade_broken_package_test.go
+++ b/testing/integration/upgrade_broken_package_test.go
@@ -41,7 +41,7 @@ func TestUpgradeBrokenPackageVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	// Upgrade to an old build.
-	upgradeToVersion, err := upgradetest.PreviousMinor(ctx, define.Version())
+	upgradeToVersion, err := upgradetest.PreviousMinor(ctx, define.Version(), t)
 	require.NoError(t, err)
 	endFixture, err := atesting.NewFixture(
 		t,

--- a/testing/integration/upgrade_downgrade_test.go
+++ b/testing/integration/upgrade_downgrade_test.go
@@ -42,8 +42,8 @@ func TestStandaloneDowngradeToSpecificSnapshotBuild(t *testing.T) {
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
-	aac := tools.NewArtifactAPIClient()
-	latestSnapshotVersion, err := aac.GetLatestSnapshotVersion(ctx, t)
+	aac := tools.NewArtifactAPIClient(t)
+	latestSnapshotVersion, err := aac.GetLatestSnapshotVersion(ctx)
 	require.NoError(t, err)
 
 	// start at the build version as we want to test the retry
@@ -58,7 +58,7 @@ func TestStandaloneDowngradeToSpecificSnapshotBuild(t *testing.T) {
 	// as the currently running binary (so, we don't have a file system collision).
 	// Multiple builds can have different IDs but the same commit hash.
 	preReleaseVersion := latestSnapshotVersion.VersionWithPrerelease()
-	buildInfo, err := aac.FindBuild(ctx, preReleaseVersion, startVersion.Binary.Commit, 1, t)
+	buildInfo, err := aac.FindBuild(ctx, preReleaseVersion, startVersion.Binary.Commit, 1)
 	if errors.Is(err, tools.ErrBuildNotFound) {
 		t.Skipf("there is no other build with a non-matching commit hash in the given version %s", latestSnapshotVersion.VersionWithPrerelease())
 		return

--- a/testing/integration/upgrade_downgrade_test.go
+++ b/testing/integration/upgrade_downgrade_test.go
@@ -58,7 +58,7 @@ func TestStandaloneDowngradeToSpecificSnapshotBuild(t *testing.T) {
 	// as the currently running binary (so, we don't have a file system collision).
 	// Multiple builds can have different IDs but the same commit hash.
 	preReleaseVersion := latestSnapshotVersion.VersionWithPrerelease()
-	buildInfo, err := aac.FindBuild(ctx, preReleaseVersion, startVersion.Binary.Commit, 1)
+	buildInfo, err := aac.FindBuild(ctx, preReleaseVersion, startVersion.Binary.Commit, 1, t)
 	if errors.Is(err, tools.ErrBuildNotFound) {
 		t.Skipf("there is no other build with a non-matching commit hash in the given version %s", latestSnapshotVersion.VersionWithPrerelease())
 		return

--- a/testing/integration/upgrade_gpg_test.go
+++ b/testing/integration/upgrade_gpg_test.go
@@ -114,7 +114,7 @@ func TestStandaloneUpgradeWithGPGFallbackOneRemoteFailing(t *testing.T) {
 	require.NoError(t, err)
 
 	// Upgrade to an old build.
-	upgradeToVersion, err := upgradetest.PreviousMinor(ctx, define.Version())
+	upgradeToVersion, err := upgradetest.PreviousMinor(ctx, define.Version(), t)
 	require.NoError(t, err)
 	endFixture, err := atesting.NewFixture(
 		t,

--- a/testing/integration/upgrade_rollback_test.go
+++ b/testing/integration/upgrade_rollback_test.go
@@ -51,7 +51,7 @@ func TestStandaloneUpgradeRollback(t *testing.T) {
 
 	// Upgrade from an old build because the new watcher from the new build will
 	// be ran. Otherwise the test will run the old watcher from the old build.
-	upgradeFromVersion, err := upgradetest.PreviousMinor(ctx, define.Version())
+	upgradeFromVersion, err := upgradetest.PreviousMinor(ctx, define.Version(), t)
 	require.NoError(t, err)
 	startFixture, err := atesting.NewFixture(
 		t,
@@ -166,7 +166,7 @@ func TestStandaloneUpgradeRollbackOnRestarts(t *testing.T) {
 
 	// Upgrade from an old build because the new watcher from the new build will
 	// be ran. Otherwise the test will run the old watcher from the old build.
-	upgradeFromVersion, err := upgradetest.PreviousMinor(ctx, define.Version())
+	upgradeFromVersion, err := upgradetest.PreviousMinor(ctx, define.Version(), t)
 	require.NoError(t, err)
 	startFixture, err := atesting.NewFixture(
 		t,

--- a/testing/integration/upgrade_standalone_inprogress_test.go
+++ b/testing/integration/upgrade_standalone_inprogress_test.go
@@ -39,7 +39,7 @@ func TestStandaloneUpgradeFailsWhenUpgradeIsInProgress(t *testing.T) {
 	// than the current version and upgrade to the current version. Then we attempt
 	// upgrading to the current version again, expecting Elastic Agent to disallow
 	// this second upgrade.
-	upgradeFromVersion, err := upgradetest.PreviousMinor(ctx, define.Version())
+	upgradeFromVersion, err := upgradetest.PreviousMinor(ctx, define.Version(), t)
 	require.NoError(t, err)
 	startFixture, err := atesting.NewFixture(
 		t,

--- a/testing/integration/upgrade_standalone_retry_test.go
+++ b/testing/integration/upgrade_standalone_retry_test.go
@@ -50,7 +50,7 @@ func TestStandaloneUpgradeRetryDownload(t *testing.T) {
 
 	// Upgrade to an older snapshot build of same version but with a different commit hash
 	aac := tools.NewArtifactAPIClient()
-	buildInfo, err := aac.FindBuild(ctx, startVersion.VersionWithPrerelease(), startVersionInfo.Binary.Commit, 0)
+	buildInfo, err := aac.FindBuild(ctx, startVersion.VersionWithPrerelease(), startVersionInfo.Binary.Commit, 0, t)
 	if errors.Is(err, tools.ErrBuildNotFound) {
 		t.Skipf("there is no other build with a non-matching commit hash in the given version %s", define.Version())
 		return

--- a/testing/integration/upgrade_standalone_retry_test.go
+++ b/testing/integration/upgrade_standalone_retry_test.go
@@ -49,8 +49,8 @@ func TestStandaloneUpgradeRetryDownload(t *testing.T) {
 	require.NoError(t, err, "failed to get end agent build version info")
 
 	// Upgrade to an older snapshot build of same version but with a different commit hash
-	aac := tools.NewArtifactAPIClient()
-	buildInfo, err := aac.FindBuild(ctx, startVersion.VersionWithPrerelease(), startVersionInfo.Binary.Commit, 0, t)
+	aac := tools.NewArtifactAPIClient(t)
+	buildInfo, err := aac.FindBuild(ctx, startVersion.VersionWithPrerelease(), startVersionInfo.Binary.Commit, 0)
 	if errors.Is(err, tools.ErrBuildNotFound) {
 		t.Skipf("there is no other build with a non-matching commit hash in the given version %s", define.Version())
 		return

--- a/testing/integration/upgrade_standalone_test.go
+++ b/testing/integration/upgrade_standalone_test.go
@@ -33,7 +33,7 @@ func TestStandaloneUpgrade(t *testing.T) {
 	// test 2 current 8.x version and 1 previous 7.x version
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(1*time.Minute))
 	defer cancel()
-	versionList, err := upgradetest.GetUpgradableVersions(ctx, define.Version(), 2, 1)
+	versionList, err := upgradetest.GetUpgradableVersions(ctx, define.Version(), 2, 1, t)
 	require.NoError(t, err)
 	endVersion, err := version.ParseVersion(define.Version())
 	require.NoError(t, err)

--- a/testing/integration/upgrade_uninstall_test.go
+++ b/testing/integration/upgrade_uninstall_test.go
@@ -52,7 +52,7 @@ func TestStandaloneUpgradeUninstallKillWatcher(t *testing.T) {
 	// build to ensure that the uninstall will kill the watcher.
 	// We need a snapshot with a non-matching commit hash to perform the upgrade
 	aac := tools.NewArtifactAPIClient()
-	buildInfo, err := aac.FindBuild(ctx, endVersion.VersionWithPrerelease(), endVersionInfo.Binary.Commit, 0)
+	buildInfo, err := aac.FindBuild(ctx, endVersion.VersionWithPrerelease(), endVersionInfo.Binary.Commit, 0, t)
 	if errors.Is(err, tools.ErrBuildNotFound) {
 		t.Skipf("there is no other build with a non-matching commit hash in the given version %s", endVersion.VersionWithPrerelease())
 		return

--- a/testing/integration/upgrade_uninstall_test.go
+++ b/testing/integration/upgrade_uninstall_test.go
@@ -51,8 +51,8 @@ func TestStandaloneUpgradeUninstallKillWatcher(t *testing.T) {
 	// Start on a snapshot build, we want this test to upgrade to our
 	// build to ensure that the uninstall will kill the watcher.
 	// We need a snapshot with a non-matching commit hash to perform the upgrade
-	aac := tools.NewArtifactAPIClient()
-	buildInfo, err := aac.FindBuild(ctx, endVersion.VersionWithPrerelease(), endVersionInfo.Binary.Commit, 0, t)
+	aac := tools.NewArtifactAPIClient(t)
+	buildInfo, err := aac.FindBuild(ctx, endVersion.VersionWithPrerelease(), endVersionInfo.Binary.Commit, 0)
 	if errors.Is(err, tools.ErrBuildNotFound) {
 		t.Skipf("there is no other build with a non-matching commit hash in the given version %s", endVersion.VersionWithPrerelease())
 		return

--- a/testing/upgradetest/versions.go
+++ b/testing/upgradetest/versions.go
@@ -39,8 +39,8 @@ var (
 
 // GetUpgradableVersions returns the version that the upgradeToVersion can upgrade from.
 func GetUpgradableVersions(ctx context.Context, upgradeToVersion string, currentMajorVersions int, previousMajorVersions int, t *testing.T) ([]*version.ParsedSemVer, error) {
-	aac := tools.NewArtifactAPIClient()
-	vList, err := aac.GetVersions(ctx, t)
+	aac := tools.NewArtifactAPIClient(t)
+	vList, err := aac.GetVersions(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving versions from Artifact API: %w", err)
 	}

--- a/testing/upgradetest/versions.go
+++ b/testing/upgradetest/versions.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"testing"
 
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
 	"github.com/elastic/elastic-agent/pkg/version"
@@ -37,9 +38,9 @@ var (
 )
 
 // GetUpgradableVersions returns the version that the upgradeToVersion can upgrade from.
-func GetUpgradableVersions(ctx context.Context, upgradeToVersion string, currentMajorVersions int, previousMajorVersions int) ([]*version.ParsedSemVer, error) {
+func GetUpgradableVersions(ctx context.Context, upgradeToVersion string, currentMajorVersions int, previousMajorVersions int, t *testing.T) ([]*version.ParsedSemVer, error) {
 	aac := tools.NewArtifactAPIClient()
-	vList, err := aac.GetVersions(ctx)
+	vList, err := aac.GetVersions(ctx, t)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving versions from Artifact API: %w", err)
 	}
@@ -134,8 +135,8 @@ func getUpgradableVersions(ctx context.Context, vList *tools.VersionList, upgrad
 // PreviousMinor gets the previous minor version of the provided version.
 //
 // This checks with the artifact API to ensure to only return version that have actual builds.
-func PreviousMinor(ctx context.Context, version string) (string, error) {
-	versions, err := GetUpgradableVersions(ctx, version, 1, 0)
+func PreviousMinor(ctx context.Context, version string, t *testing.T) (string, error) {
+	versions, err := GetUpgradableVersions(ctx, version, 1, 0, t)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## What does this PR do?

This PR adds retries to the Artifacts API call in the integration testing framework, as recommended by @DaveSys911.

## Why is it important?

The Artifacts API can sometimes be flaky. 

## Related issues
- Resolves #4345
