### PR TITLE
Enable unprivileged on macos

### DIFF
--- a/changelog/fragments/1710179479-Enable---unprivileged-on-Mac-OS.yaml
+++ b/changelog/fragments/1710179479-Enable---unprivileged-on-Mac-OS.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Enable --unprivileged on Mac OS, allowing elastic-agent to run as an unprivileged user
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/application.go
+++ b/internal/pkg/agent/application/application.go
@@ -211,7 +211,10 @@ func New(
 
 func mergeFleetConfig(ctx context.Context, rawConfig *config.Config) (storage.Store, *configuration.Configuration, error) {
 	path := paths.AgentConfigFile()
-	store := storage.NewEncryptedDiskStore(ctx, path)
+	store, err := storage.NewEncryptedDiskStore(ctx, path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating encrypted disk store: %w", err)
+	}
 
 	reader, err := store.Load()
 	if err != nil {

--- a/internal/pkg/agent/application/application.go
+++ b/internal/pkg/agent/application/application.go
@@ -213,7 +213,7 @@ func mergeFleetConfig(ctx context.Context, rawConfig *config.Config) (storage.St
 	path := paths.AgentConfigFile()
 	store, err := storage.NewEncryptedDiskStore(ctx, path)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error creating encrypted disk store: %w", err)
+		return nil, nil, fmt.Errorf("error instantiating encrypted disk store: %w", err)
 	}
 
 	reader, err := store.Load()

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -502,7 +502,8 @@ func newStateStore(t *testing.T, log *logger.Logger) *store.StateStore {
 	require.NoError(t, err)
 
 	filename := filepath.Join(dir, "state.enc")
-	diskStore := storage.NewDiskStore(filename)
+	diskStore, err := storage.NewDiskStore(filename)
+	require.NoError(t, err)
 	stateStore, err := store.NewStateStore(log, diskStore)
 	require.NoError(t, err)
 

--- a/internal/pkg/agent/application/info/agent_id.go
+++ b/internal/pkg/agent/application/info/agent_id.go
@@ -53,7 +53,10 @@ func updateLogLevel(ctx context.Context, level string) error {
 	}
 
 	agentConfigFile := paths.AgentConfigFile()
-	diskStore := storage.NewEncryptedDiskStore(ctx, agentConfigFile)
+	diskStore, err := storage.NewEncryptedDiskStore(ctx, agentConfigFile)
+	if err != nil {
+		return fmt.Errorf("error creating encrypted disk store: %w", err)
+	}
 
 	ai.LogLevel = level
 	return updateAgentInfo(diskStore, ai)
@@ -202,7 +205,10 @@ func loadAgentInfo(ctx context.Context, forceUpdate bool, logLevel string, creat
 	defer idLock.Unlock()
 
 	agentConfigFile := paths.AgentConfigFile()
-	diskStore := storage.NewEncryptedDiskStore(ctx, agentConfigFile)
+	diskStore, err := storage.NewEncryptedDiskStore(ctx, agentConfigFile)
+	if err != nil {
+		return nil, fmt.Errorf("error creating encrypted disk store: %w", err)
+	}
 
 	agentInfo, err := getInfoFromStore(diskStore, logLevel)
 	if err != nil {

--- a/internal/pkg/agent/application/info/agent_id.go
+++ b/internal/pkg/agent/application/info/agent_id.go
@@ -55,7 +55,7 @@ func updateLogLevel(ctx context.Context, level string) error {
 	agentConfigFile := paths.AgentConfigFile()
 	diskStore, err := storage.NewEncryptedDiskStore(ctx, agentConfigFile)
 	if err != nil {
-		return fmt.Errorf("error creating encrypted disk store: %w", err)
+		return fmt.Errorf("error instantiating encrypted disk store: %w", err)
 	}
 
 	ai.LogLevel = level
@@ -207,7 +207,7 @@ func loadAgentInfo(ctx context.Context, forceUpdate bool, logLevel string, creat
 	agentConfigFile := paths.AgentConfigFile()
 	diskStore, err := storage.NewEncryptedDiskStore(ctx, agentConfigFile)
 	if err != nil {
-		return nil, fmt.Errorf("error creating encrypted disk store: %w", err)
+		return nil, fmt.Errorf("error instantiating encrypted disk store: %w", err)
 	}
 
 	agentInfo, err := getInfoFromStore(diskStore, logLevel)

--- a/internal/pkg/agent/application/info/agent_id.go
+++ b/internal/pkg/agent/application/info/agent_id.go
@@ -21,7 +21,6 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/core/backoff"
 	monitoringConfig "github.com/elastic/elastic-agent/internal/pkg/core/monitoring/config"
-	"github.com/elastic/elastic-agent/pkg/utils"
 )
 
 // defaultAgentConfigFile is a name of file used to store agent information
@@ -54,11 +53,7 @@ func updateLogLevel(ctx context.Context, level string) error {
 	}
 
 	agentConfigFile := paths.AgentConfigFile()
-	hasRoot, err := utils.HasRoot()
-	if err != nil {
-		return fmt.Errorf("checking for root permissions: %w", err)
-	}
-	diskStore := storage.NewEncryptedDiskStore(ctx, agentConfigFile, storage.WithUnprivileged(!hasRoot))
+	diskStore := storage.NewEncryptedDiskStore(ctx, agentConfigFile)
 
 	ai.LogLevel = level
 	return updateAgentInfo(diskStore, ai)
@@ -207,11 +202,7 @@ func loadAgentInfo(ctx context.Context, forceUpdate bool, logLevel string, creat
 	defer idLock.Unlock()
 
 	agentConfigFile := paths.AgentConfigFile()
-	hasRoot, err := utils.HasRoot()
-	if err != nil {
-		return nil, fmt.Errorf("checking for root permissions: %w", err)
-	}
-	diskStore := storage.NewEncryptedDiskStore(ctx, agentConfigFile, storage.WithUnprivileged(!hasRoot))
+	diskStore := storage.NewEncryptedDiskStore(ctx, agentConfigFile)
 
 	agentInfo, err := getInfoFromStore(diskStore, logLevel)
 	if err != nil {

--- a/internal/pkg/agent/application/secret/secret.go
+++ b/internal/pkg/agent/application/secret/secret.go
@@ -16,7 +16,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/vault/aesgcm"
 )
 
-const agentSecretKey = "secret"
+const AgentSecretKey = "secret"
 
 // mutex for secret create calls
 var mxCreate sync.Mutex
@@ -29,7 +29,7 @@ type Secret struct {
 
 // CreateAgentSecret creates agent secret key if it doesn't exist
 func CreateAgentSecret(ctx context.Context, opts ...vault.OptionFunc) error {
-	return Create(ctx, agentSecretKey, opts...)
+	return Create(ctx, AgentSecretKey, opts...)
 }
 
 // Create creates secret and stores it in the vault under given key
@@ -69,13 +69,13 @@ func Create(ctx context.Context, key string, opts ...vault.OptionFunc) error {
 
 // GetAgentSecret read the agent secret from the vault
 func GetAgentSecret(ctx context.Context, opts ...vault.OptionFunc) (secret Secret, err error) {
-	return Get(ctx, agentSecretKey, opts...)
+	return Get(ctx, AgentSecretKey, opts...)
 }
 
 // SetAgentSecret saves the agent secret from the vault
 // This is needed for migration from 8.3.0-8.3.2 to higher versions
 func SetAgentSecret(ctx context.Context, secret Secret, opts ...vault.OptionFunc) error {
-	return Set(ctx, agentSecretKey, secret, opts...)
+	return Set(ctx, AgentSecretKey, secret, opts...)
 }
 
 // Get reads the secret key from the vault

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -177,7 +177,7 @@ func newEnrollCmd(
 
 	encryptedDiskStore, err := storage.NewEncryptedDiskStore(ctx, paths.AgentConfigFile())
 	if err != nil {
-		return nil, fmt.Errorf("error creating encrypted disk store: %w", err)
+		return nil, fmt.Errorf("error instantiating encrypted disk store: %w", err)
 	}
 	store := storage.NewReplaceOnSuccessStore(
 		configPath,
@@ -222,7 +222,7 @@ func (c *enrollCmd) Execute(ctx context.Context, streams *cli.IOStreams) error {
 
 	hasRoot, err := utils.HasRoot()
 	if err != nil {
-		return fmt.Errorf("checking if running with administrator privileges: %w", err)
+		return fmt.Errorf("checking if running with root/Administrator privileges: %w", err)
 	}
 
 	// Create encryption key from the agent before touching configuration

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -175,10 +175,14 @@ func newEnrollCmd(
 	configPath string,
 ) (*enrollCmd, error) {
 
+	encryptedDiskStore, err := storage.NewEncryptedDiskStore(ctx, paths.AgentConfigFile())
+	if err != nil {
+		return nil, fmt.Errorf("error creating encrypted disk store: %w", err)
+	}
 	store := storage.NewReplaceOnSuccessStore(
 		configPath,
 		application.DefaultAgentFleetConfig,
-		storage.NewEncryptedDiskStore(ctx, paths.AgentConfigFile()),
+		encryptedDiskStore,
 	)
 
 	return newEnrollCmdWithStore(

--- a/internal/pkg/agent/cmd/enroll_cmd_test.go
+++ b/internal/pkg/agent/cmd/enroll_cmd_test.go
@@ -102,6 +102,7 @@ func TestEnroll(t *testing.T) {
 				},
 				"",
 				store,
+				true,
 			)
 			require.NoError(t, err)
 
@@ -157,6 +158,7 @@ func TestEnroll(t *testing.T) {
 				},
 				"",
 				store,
+				true,
 			)
 			require.NoError(t, err)
 
@@ -219,6 +221,7 @@ func TestEnroll(t *testing.T) {
 				},
 				"",
 				store,
+				true,
 			)
 			require.NoError(t, err)
 
@@ -283,6 +286,7 @@ func TestEnroll(t *testing.T) {
 				},
 				"",
 				store,
+				true,
 			)
 			require.NoError(t, err)
 
@@ -327,6 +331,7 @@ func TestEnroll(t *testing.T) {
 				},
 				"",
 				store,
+				true,
 			)
 			require.NoError(t, err)
 

--- a/internal/pkg/agent/cmd/enroll_cmd_test.go
+++ b/internal/pkg/agent/cmd/enroll_cmd_test.go
@@ -102,7 +102,6 @@ func TestEnroll(t *testing.T) {
 				},
 				"",
 				store,
-				true,
 			)
 			require.NoError(t, err)
 
@@ -158,7 +157,6 @@ func TestEnroll(t *testing.T) {
 				},
 				"",
 				store,
-				true,
 			)
 			require.NoError(t, err)
 
@@ -221,7 +219,6 @@ func TestEnroll(t *testing.T) {
 				},
 				"",
 				store,
-				true,
 			)
 			require.NoError(t, err)
 
@@ -286,7 +283,6 @@ func TestEnroll(t *testing.T) {
 				},
 				"",
 				store,
-				true,
 			)
 			require.NoError(t, err)
 
@@ -331,7 +327,6 @@ func TestEnroll(t *testing.T) {
 				},
 				"",
 				store,
-				true,
 			)
 			require.NoError(t, err)
 

--- a/internal/pkg/agent/cmd/inspect.go
+++ b/internal/pkg/agent/cmd/inspect.go
@@ -107,6 +107,7 @@ variables for the configuration.
 
 			ctx, cancel := context.WithCancel(context.Background())
 			service.HandleSignals(func() {}, cancel)
+
 			if err := inspectComponents(ctx, paths.ConfigFile(), opts, streams); err != nil {
 				fmt.Fprintf(streams.Err, "Error: %v\n%s\n", err, troubleshootMessage())
 				os.Exit(1)

--- a/internal/pkg/agent/cmd/inspect.go
+++ b/internal/pkg/agent/cmd/inspect.go
@@ -137,7 +137,7 @@ func inspectConfig(ctx context.Context, cfgPath string, opts inspectConfigOpts, 
 
 	isAdmin, err := utils.HasRoot()
 	if err != nil {
-		return fmt.Errorf("error checking for administrator privileges: %w", err)
+		return fmt.Errorf("error checking for root/Administrator privileges: %w", err)
 	}
 	if !opts.variables && !opts.includeMonitoring {
 		fullCfg, err := operations.LoadFullAgentConfig(ctx, l, cfgPath, true, !isAdmin)
@@ -265,7 +265,7 @@ func inspectComponents(ctx context.Context, cfgPath string, opts inspectComponen
 
 	isAdmin, err := utils.HasRoot()
 	if err != nil {
-		return fmt.Errorf("error checking for administrator privileges: %w", err)
+		return fmt.Errorf("error checking for root/Administrator privileges: %w", err)
 	}
 
 	m, lvl, err := getConfigWithVariables(ctx, l, cfgPath, opts.variablesWait, !isAdmin)

--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -76,10 +76,10 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		return fmt.Errorf("unable to perform install command, not executed with %s permissions", utils.PermissionUser)
 	}
 
-	// only support Linux at the moment
+	// only support Linux and MacOS at the moment
 	unprivileged, _ := cmd.Flags().GetBool(flagInstallUnprivileged)
-	if unprivileged && runtime.GOOS != "linux" {
-		return fmt.Errorf("unable to perform install command, unprivileged is currently only supported on Linux")
+	if unprivileged && (runtime.GOOS != "linux" && runtime.GOOS != "darwin") {
+		return fmt.Errorf("unable to perform install command, unprivileged is currently only supported on Linux and MacOSß")
 	}
 	if unprivileged {
 		fmt.Fprintln(streams.Out, "Unprivileged installation mode enabled; this is an experimental and currently unsupported feature.")

--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -228,7 +228,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		defer func() {
 			if err != nil {
 				progBar.Describe("Uninstalling")
-				innerErr := install.Uninstall(cfgFile, topPath, "", log, progBar)
+				innerErr := install.Uninstall(cfgFile, topPath, "", log, progBar, unprivileged)
 				if innerErr != nil {
 					progBar.Describe("Failed to Uninstall")
 				} else {

--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -70,7 +70,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 
 	isAdmin, err := utils.HasRoot()
 	if err != nil {
-		return fmt.Errorf("unable to perform install command while checking for administrator rights, %w", err)
+		return fmt.Errorf("unable to perform install command while checking for root/Administrator rights: %w", err)
 	}
 	if !isAdmin {
 		return fmt.Errorf("unable to perform install command, not executed with %s permissions", utils.PermissionUser)

--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -228,7 +228,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		defer func() {
 			if err != nil {
 				progBar.Describe("Uninstalling")
-				innerErr := install.Uninstall(cfgFile, topPath, "", log, progBar, unprivileged)
+				innerErr := install.Uninstall(cfgFile, topPath, "", log, progBar)
 				if innerErr != nil {
 					progBar.Describe("Failed to Uninstall")
 				} else {

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -140,13 +140,7 @@ func run(override cfgOverrider, testingMode bool, fleetInitTimeout time.Duration
 }
 
 func runElasticAgent(ctx context.Context, cancel context.CancelFunc, override cfgOverrider, stop chan bool, testingMode bool, fleetInitTimeout time.Duration, runAsOtel bool, awaiters awaiters, modifiers ...component.PlatformModifier) error {
-	// try early to check if running as root
-	isRoot, err := utils.HasRoot()
-	if err != nil {
-		return fmt.Errorf("failed to check for root permissions: %w", err)
-	}
-
-	cfg, err := loadConfig(ctx, override, runAsOtel, !isRoot)
+	cfg, err := loadConfig(ctx, override, runAsOtel)
 	if err != nil {
 		return err
 	}
@@ -169,7 +163,13 @@ func runElasticAgent(ctx context.Context, cancel context.CancelFunc, override cf
 
 	l.Infow("Elastic Agent started", "process.pid", os.Getpid(), "agent.version", version.GetAgentPackageVersion())
 
-	cfg, err = tryDelayEnroll(ctx, l, cfg, override, !isRoot)
+	// try early to check if running as root
+	isRoot, err := utils.HasRoot()
+	if err != nil {
+		return fmt.Errorf("failed to check for root permissions: %w", err)
+	}
+
+	cfg, err = tryDelayEnroll(ctx, l, cfg, override)
 	if err != nil {
 		err = errors.New(err, "failed to perform delayed enrollment")
 		l.Error(err)
@@ -195,13 +195,13 @@ func runElasticAgent(ctx context.Context, cancel context.CancelFunc, override cf
 	// Migrate .yml files if the corresponding .enc does not exist
 
 	// the encrypted config does not exist but the unencrypted file does
-	err = migration.MigrateToEncryptedConfig(ctx, l, paths.AgentConfigYmlFile(), paths.AgentConfigFile(), storage.WithUnprivileged(!isRoot))
+	err = migration.MigrateToEncryptedConfig(ctx, l, paths.AgentConfigYmlFile(), paths.AgentConfigFile())
 	if err != nil {
 		return errors.New(err, "error migrating fleet config")
 	}
 
 	// the encrypted state does not exist but the unencrypted file does
-	err = migration.MigrateToEncryptedConfig(ctx, l, paths.AgentStateStoreYmlFile(), paths.AgentStateStoreFile(), storage.WithUnprivileged(!isRoot))
+	err = migration.MigrateToEncryptedConfig(ctx, l, paths.AgentStateStoreYmlFile(), paths.AgentStateStoreFile())
 	if err != nil {
 		return errors.New(err, "error migrating agent state")
 	}
@@ -373,7 +373,7 @@ LOOP:
 	return err
 }
 
-func loadConfig(ctx context.Context, override cfgOverrider, runAsOtel, unprivileged bool) (*configuration.Configuration, error) {
+func loadConfig(ctx context.Context, override cfgOverrider, runAsOtel bool) (*configuration.Configuration, error) {
 	if runAsOtel {
 		defaultCfg := configuration.DefaultConfiguration()
 		// disable monitoring to avoid injection of monitoring components
@@ -392,7 +392,7 @@ func loadConfig(ctx context.Context, override cfgOverrider, runAsOtel, unprivile
 			errors.M(errors.MetaKeyPath, pathConfigFile))
 	}
 
-	if err := getOverwrites(ctx, rawConfig, unprivileged); err != nil {
+	if err := getOverwrites(ctx, rawConfig); err != nil {
 		return nil, errors.New(err, "could not read overwrites")
 	}
 
@@ -424,7 +424,7 @@ func reexecPath() (string, error) {
 	return potentialReexec, nil
 }
 
-func getOverwrites(ctx context.Context, rawConfig *config.Config, unprivileged bool) error {
+func getOverwrites(ctx context.Context, rawConfig *config.Config) error {
 	cfg, err := configuration.NewFromConfig(rawConfig)
 	if err != nil {
 		return err
@@ -435,7 +435,7 @@ func getOverwrites(ctx context.Context, rawConfig *config.Config, unprivileged b
 		return nil
 	}
 	path := paths.AgentConfigFile()
-	store := storage.NewEncryptedDiskStore(ctx, path, storage.WithUnprivileged(unprivileged))
+	store := storage.NewEncryptedDiskStore(ctx, path)
 
 	reader, err := store.Load()
 	if err != nil && errors.Is(err, os.ErrNotExist) {
@@ -481,7 +481,7 @@ func defaultLogLevel(cfg *configuration.Configuration, currentLevel string) stri
 	return defaultLogLevel
 }
 
-func tryDelayEnroll(ctx context.Context, logger *logger.Logger, cfg *configuration.Configuration, override cfgOverrider, unprivileged bool) (*configuration.Configuration, error) {
+func tryDelayEnroll(ctx context.Context, logger *logger.Logger, cfg *configuration.Configuration, override cfgOverrider) (*configuration.Configuration, error) {
 	enrollPath := paths.AgentEnrollFile()
 	if _, err := os.Stat(enrollPath); err != nil {
 		//nolint:nilerr // ignore the error, this is expected
@@ -533,7 +533,7 @@ func tryDelayEnroll(ctx context.Context, logger *logger.Logger, cfg *configurati
 			errors.M("path", enrollPath)))
 	}
 	logger.Info("Successfully performed delayed enrollment of this Elastic Agent.")
-	return loadConfig(ctx, override, false, unprivileged)
+	return loadConfig(ctx, override, false)
 }
 
 func initTracer(agentName, version string, mcfg *monitoringCfg.MonitoringConfig) (*apm.Tracer, error) {

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -439,7 +439,10 @@ func getOverwrites(ctx context.Context, rawConfig *config.Config) error {
 		return nil
 	}
 	path := paths.AgentConfigFile()
-	store := storage.NewEncryptedDiskStore(ctx, path)
+	store, err := storage.NewEncryptedDiskStore(ctx, path)
+	if err != nil {
+		return fmt.Errorf("error creating encrypted disk store: %w", err)
+	}
 
 	reader, err := store.Load()
 	if err != nil && errors.Is(err, os.ErrNotExist) {

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -170,7 +170,7 @@ func runElasticAgent(ctx context.Context, cancel context.CancelFunc, override cf
 	// try early to check if running as root
 	isRoot, err := utils.HasRoot()
 	if err != nil {
-		return fmt.Errorf("failed to check for root permissions: %w", err)
+		return fmt.Errorf("failed to check for root/Administrator privileges: %w", err)
 	}
 
 	cfg, err = tryDelayEnroll(ctx, l, cfg, override)
@@ -441,7 +441,7 @@ func getOverwrites(ctx context.Context, rawConfig *config.Config) error {
 	path := paths.AgentConfigFile()
 	store, err := storage.NewEncryptedDiskStore(ctx, path)
 	if err != nil {
-		return fmt.Errorf("error creating encrypted disk store: %w", err)
+		return fmt.Errorf("error instantiating encrypted disk store: %w", err)
 	}
 
 	reader, err := store.Load()

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -89,7 +89,11 @@ func newRunCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
 	// feature of the Elastic Agent. On Mac OS root privileges are required to perform the disk
 	// store encryption, by setting this flag it disables that feature and allows the Elastic Agent to
 	// run as non-root.
+	//
+	// Deprecated: MacOS can be run/installed without root privileges
 	cmd.Flags().Bool("disable-encrypted-store", false, "Disable the encrypted disk storage (Only useful on Mac OS)")
+	_ = cmd.Flags().MarkHidden("disable-encrypted-store")
+	_ = cmd.Flags().MarkDeprecated("disable-encrypted-store", "agent on Mac OS can be run/installed without root privileges, see elastic-agent install --help")
 
 	// --testing-mode is a hidden flag that spawns the Elastic Agent in testing mode
 	// it is hidden because we really don't want users to execute Elastic Agent to run

--- a/internal/pkg/agent/cmd/uninstall.go
+++ b/internal/pkg/agent/cmd/uninstall.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-agent-libs/logp"
+
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
@@ -36,6 +37,8 @@ Unless -f is used this command will ask confirmation before performing removal.
 
 	cmd.Flags().BoolP("force", "f", false, "Force overwrite the current and do not prompt for confirmation")
 	cmd.Flags().String("uninstall-token", "", "Uninstall token required for protected agent uninstall")
+	cmd.Flags().Bool(flagInstallUnprivileged, false, "Installed Elastic Agent will create an 'elastic-agent' user and run as that user. (experimental)")
+	_ = cmd.Flags().MarkHidden(flagInstallUnprivileged) // Hidden until fully supported
 
 	return cmd
 }
@@ -108,8 +111,8 @@ func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 			fmt.Fprintf(os.Stderr, "%v\n", oLog.Entry)
 		}
 	}()
-
-	err = install.Uninstall(paths.ConfigFile(), paths.Top(), uninstallToken, log, progBar)
+	unprivileged, _ := cmd.Flags().GetBool(flagInstallUnprivileged)
+	err = install.Uninstall(paths.ConfigFile(), paths.Top(), uninstallToken, log, progBar, unprivileged)
 	if err != nil {
 		progBar.Describe("Failed to uninstall agent")
 		return fmt.Errorf("error uninstalling agent: %w", err)

--- a/internal/pkg/agent/cmd/uninstall.go
+++ b/internal/pkg/agent/cmd/uninstall.go
@@ -37,8 +37,6 @@ Unless -f is used this command will ask confirmation before performing removal.
 
 	cmd.Flags().BoolP("force", "f", false, "Force overwrite the current and do not prompt for confirmation")
 	cmd.Flags().String("uninstall-token", "", "Uninstall token required for protected agent uninstall")
-	cmd.Flags().Bool(flagInstallUnprivileged, false, "Installed Elastic Agent will create an 'elastic-agent' user and run as that user. (experimental)")
-	_ = cmd.Flags().MarkHidden(flagInstallUnprivileged) // Hidden until fully supported
 
 	return cmd
 }
@@ -111,8 +109,8 @@ func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 			fmt.Fprintf(os.Stderr, "%v\n", oLog.Entry)
 		}
 	}()
-	unprivileged, _ := cmd.Flags().GetBool(flagInstallUnprivileged)
-	err = install.Uninstall(paths.ConfigFile(), paths.Top(), uninstallToken, log, progBar, unprivileged)
+
+	err = install.Uninstall(paths.ConfigFile(), paths.Top(), uninstallToken, log, progBar)
 	if err != nil {
 		progBar.Describe("Failed to uninstall agent")
 		return fmt.Errorf("error uninstalling agent: %w", err)

--- a/internal/pkg/agent/install/install.go
+++ b/internal/pkg/agent/install/install.go
@@ -48,7 +48,7 @@ func Install(cfgFile, topPath string, unprivileged bool, log *logp.Logger, pt *p
 		// Uninstall will fail on protected agent.
 		// The protected Agent will need to be uninstalled first before it can be installed.
 		pt.Describe("Uninstalling current Elastic Agent")
-		err = Uninstall(cfgFile, topPath, "", log, pt)
+		err = Uninstall(cfgFile, topPath, "", log, pt, unprivileged)
 		if err != nil {
 			pt.Describe("Failed to uninstall current Elastic Agent")
 			return utils.FileOwner{}, errors.New(

--- a/internal/pkg/agent/install/install.go
+++ b/internal/pkg/agent/install/install.go
@@ -48,7 +48,7 @@ func Install(cfgFile, topPath string, unprivileged bool, log *logp.Logger, pt *p
 		// Uninstall will fail on protected agent.
 		// The protected Agent will need to be uninstalled first before it can be installed.
 		pt.Describe("Uninstalling current Elastic Agent")
-		err = Uninstall(cfgFile, topPath, "", log, pt, unprivileged)
+		err = Uninstall(cfgFile, topPath, "", log, pt)
 		if err != nil {
 			pt.Describe("Failed to uninstall current Elastic Agent")
 			return utils.FileOwner{}, errors.New(

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Uninstall uninstalls persistently Elastic Agent on the system.
-func Uninstall(cfgFile, topPath, uninstallToken string, log *logp.Logger, pt *progressbar.ProgressBar) error {
+func Uninstall(cfgFile, topPath, uninstallToken string, log *logp.Logger, pt *progressbar.ProgressBar, unprivileged bool) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("unable to get current working directory")
@@ -81,7 +81,7 @@ func Uninstall(cfgFile, topPath, uninstallToken string, log *logp.Logger, pt *pr
 	}
 
 	// Uninstall components first
-	if err := uninstallComponents(context.Background(), cfgFile, uninstallToken, log, pt); err != nil {
+	if err := uninstallComponents(context.Background(), cfgFile, uninstallToken, log, pt, unprivileged); err != nil {
 		// If service status was running it was stopped to uninstall the components.
 		// If the components uninstall failed start the service again
 		if status == service.StatusRunning {
@@ -200,7 +200,7 @@ func containsString(str string, a []string, caseSensitive bool) bool {
 	return false
 }
 
-func uninstallComponents(ctx context.Context, cfgFile string, uninstallToken string, log *logp.Logger, pt *progressbar.ProgressBar) error {
+func uninstallComponents(ctx context.Context, cfgFile string, uninstallToken string, log *logp.Logger, pt *progressbar.ProgressBar, unprivileged bool) error {
 
 	platform, err := component.LoadPlatformDetail()
 	if err != nil {
@@ -212,7 +212,7 @@ func uninstallComponents(ctx context.Context, cfgFile string, uninstallToken str
 		return fmt.Errorf("failed to detect inputs and outputs: %w", err)
 	}
 
-	cfg, err := operations.LoadFullAgentConfig(ctx, log, cfgFile, false)
+	cfg, err := operations.LoadFullAgentConfig(ctx, log, cfgFile, false, unprivileged)
 	if err != nil {
 		return fmt.Errorf("error loading agent config: %w", err)
 	}

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -142,9 +142,10 @@ func Uninstall(cfgFile, topPath, uninstallToken string, log *logp.Logger, pt *pr
 	return nil
 }
 
-func checkForUnprivilegedVault(ctx context.Context) (bool, error) {
+func checkForUnprivilegedVault(ctx context.Context, opts ...vault.OptionFunc) (bool, error) {
 	// check if we have a file vault to detect if we have to use it for reading config
-	vaultOpts := vault.ApplyOptions(vault.WithVaultPath(paths.AgentVaultPath()), vault.WithReadonly(true))
+	opts = append(opts, vault.WithReadonly(true))
+	vaultOpts := vault.ApplyOptions(opts...)
 	fileVault, fileVaultErr := vault.NewFileVault(ctx, vaultOpts)
 	if fileVaultErr == nil {
 		ok, keyErr := fileVault.Exists(ctx, secret.AgentSecretKey)

--- a/internal/pkg/agent/install/uninstall_test.go
+++ b/internal/pkg/agent/install/uninstall_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package install
 
 import (

--- a/internal/pkg/agent/install/uninstall_test.go
+++ b/internal/pkg/agent/install/uninstall_test.go
@@ -1,0 +1,115 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/secret"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/vault"
+)
+
+func Test_checkForUnprivilegedVault(t *testing.T) {
+	type postVaultInit func(t *testing.T, vaultPath string)
+
+	type setup struct {
+		createFileVault bool
+		setupKeys       map[string][]byte
+		postVaultInit   postVaultInit
+	}
+	tests := []struct {
+		name    string
+		setup   setup
+		want    bool
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "No file vault exists - unprivileged is false",
+			setup:   setup{},
+			want:    false,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "file vault exists but no secret - unprivileged is false",
+			setup: setup{
+				createFileVault: true,
+			},
+			want:    false,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "file vault exists with agent secret - unprivileged is false",
+			setup: setup{
+				createFileVault: true,
+				setupKeys:       map[string][]byte{secret.AgentSecretKey: []byte("this is the agent secret")},
+			},
+			want:    true,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "file vault exists but it's unreadable - return error",
+			setup: setup{
+				createFileVault: true,
+				setupKeys:       map[string][]byte{secret.AgentSecretKey: []byte("this is the agent secret")},
+				postVaultInit: func(t *testing.T, vaultPath string) {
+					if runtime.GOOS == "windows" {
+						t.Skip("writable-only files are not really testable on windows")
+					}
+					err := os.Chmod(vaultPath, 0222)
+					require.NoError(t, err, "error setting the file vault write-only, no exec")
+					t.Cleanup(func() {
+						err = os.Chmod(vaultPath, 0777)
+						assert.NoError(t, err, "error restoring read/execute permissions to test vault")
+					})
+				},
+			},
+			want: false,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "permission denied")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			testVaultPath := filepath.Join(tempDir, filepath.Base(paths.AgentVaultPath()))
+
+			//setup
+			if tt.setup.createFileVault {
+				initFileVault(t, ctx, testVaultPath, tt.setup.setupKeys)
+				if tt.setup.postVaultInit != nil {
+					tt.setup.postVaultInit(t, testVaultPath)
+				}
+			}
+
+			got, err := checkForUnprivilegedVault(ctx, vault.WithVaultPath(testVaultPath))
+			if !tt.wantErr(t, err, fmt.Sprintf("checkForUnprivilegedVault(ctx, vault.WithVaultPath(%q))", testVaultPath)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "checkForUnprivilegedVault(ctx, vault.WithVaultPath(%q))", testVaultPath)
+		})
+	}
+}
+
+func initFileVault(t *testing.T, ctx context.Context, testVaultPath string, keys map[string][]byte) {
+	newFileVault, err := vault.NewFileVault(ctx, vault.ApplyOptions(vault.WithVaultPath(testVaultPath)))
+	require.NoError(t, err, "setting up test file vault store")
+	defer func(newFileVault *vault.FileVault) {
+		err := newFileVault.Close()
+		require.NoError(t, err, "error closing test file vault after setup")
+	}(newFileVault)
+	for k, v := range keys {
+		err = newFileVault.Set(ctx, k, v)
+		require.NoError(t, err, "error setting up key %q = %0x", k, v)
+	}
+}

--- a/internal/pkg/agent/migration/migrate_config.go
+++ b/internal/pkg/agent/migration/migrate_config.go
@@ -23,7 +23,7 @@ import (
 //   - The contents from the unencrypted file will be copied as a byte stream without any transformation.
 //   - The function will not perform any operation if the encryptedConfigPath already exists and it's not empty to avoid overwrites.
 //   - If neither the encrypted file nor the unencrypted file exist this call is a no-op
-func MigrateToEncryptedConfig(ctx context.Context, l *logp.Logger, unencryptedConfigPath string, encryptedConfigPath string) error {
+func MigrateToEncryptedConfig(ctx context.Context, l *logp.Logger, unencryptedConfigPath string, encryptedConfigPath string, storageOpts ...storage.OptionFunc) error {
 	encStat, encFileErr := os.Stat(encryptedConfigPath)
 
 	if encFileErr != nil && !errors.Is(encFileErr, fs.ErrNotExist) {
@@ -54,7 +54,7 @@ func MigrateToEncryptedConfig(ctx context.Context, l *logp.Logger, unencryptedCo
 			l.Errorf("Error closing unencrypted store reader for %q: %v", unencryptedConfigPath, err)
 		}
 	}()
-	store := storage.NewEncryptedDiskStore(ctx, encryptedConfigPath)
+	store := storage.NewEncryptedDiskStore(ctx, encryptedConfigPath, storageOpts...)
 	err = store.Save(reader)
 	if err != nil {
 		return errors.New(err, fmt.Sprintf("error writing encrypted config from file %q to file %q", unencryptedConfigPath, encryptedConfigPath))

--- a/internal/pkg/agent/migration/migrate_config.go
+++ b/internal/pkg/agent/migration/migrate_config.go
@@ -45,7 +45,7 @@ func MigrateToEncryptedConfig(ctx context.Context, l *logp.Logger, unencryptedCo
 	l.Info("Initiating migration of %q to %q", unencryptedConfigPath, encryptedConfigPath)
 	legacyStore, err := storage.NewDiskStore(unencryptedConfigPath)
 	if err != nil {
-		return fmt.Errorf("error opening creating store: %w", err)
+		return fmt.Errorf("error instantiating disk store: %w", err)
 	}
 	reader, err := legacyStore.Load()
 	if err != nil {
@@ -59,7 +59,7 @@ func MigrateToEncryptedConfig(ctx context.Context, l *logp.Logger, unencryptedCo
 	}()
 	store, err := storage.NewEncryptedDiskStore(ctx, encryptedConfigPath, storageOpts...)
 	if err != nil {
-		return fmt.Errorf("error creating encrypted disk store: %w", err)
+		return fmt.Errorf("error instantiating encrypted disk store: %w", err)
 	}
 	err = store.Save(reader)
 	if err != nil {

--- a/internal/pkg/agent/migration/migrate_config_test.go
+++ b/internal/pkg/agent/migration/migrate_config_test.go
@@ -2,8 +2,6 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build linux || windows
-
 package migration
 
 import (
@@ -137,7 +135,7 @@ func TestMigrateToEncryptedConfig(t *testing.T) {
 			log := logp.NewLogger("test_migrate_config")
 			// setup end
 
-			err = MigrateToEncryptedConfig(ctx, log, absUnencryptedFile, absEncryptedFile)
+			err = MigrateToEncryptedConfig(ctx, log, absUnencryptedFile, absEncryptedFile, storage.WithUnprivileged(true))
 
 			assert.NoError(t, err)
 			if len(tc.expectedEncryptedContent) > 0 {
@@ -239,7 +237,7 @@ func TestErrorMigrateToEncryptedConfig(t *testing.T) {
 			log := logp.NewLogger("test_migrate_config")
 			// setup end
 
-			err = MigrateToEncryptedConfig(ctx, log, absUnencryptedFile, absEncryptedFile)
+			err = MigrateToEncryptedConfig(ctx, log, absUnencryptedFile, absEncryptedFile, storage.WithUnprivileged(true))
 
 			assert.Error(t, err)
 		})
@@ -253,7 +251,7 @@ func createAndPersistStore(t *testing.T, ctx context.Context, baseDir string, cf
 	asbFilePath := path.Join(baseDir, cf.name)
 
 	if encrypted {
-		store = storage.NewEncryptedDiskStore(ctx, asbFilePath)
+		store = storage.NewEncryptedDiskStore(ctx, asbFilePath, storage.WithUnprivileged(true))
 	} else {
 		store = storage.NewDiskStore(asbFilePath)
 	}

--- a/internal/pkg/agent/migration/migrate_config_test.go
+++ b/internal/pkg/agent/migration/migrate_config_test.go
@@ -110,7 +110,7 @@ func TestMigrateToEncryptedConfig(t *testing.T) {
 			paths.SetTop(top)
 
 			vaultPath := paths.AgentVaultPath()
-			err := secret.CreateAgentSecret(ctx, vault.WithVaultPath(vaultPath))
+			err := secret.CreateAgentSecret(ctx, vault.WithVaultPath(vaultPath), vault.WithUnprivileged(true))
 
 			require.NoError(t, err)
 
@@ -135,7 +135,7 @@ func TestMigrateToEncryptedConfig(t *testing.T) {
 			log := logp.NewLogger("test_migrate_config")
 			// setup end
 
-			err = MigrateToEncryptedConfig(ctx, log, absUnencryptedFile, absEncryptedFile, storage.WithUnprivileged(true))
+			err = MigrateToEncryptedConfig(ctx, log, absUnencryptedFile, absEncryptedFile)
 
 			assert.NoError(t, err)
 			if len(tc.expectedEncryptedContent) > 0 {
@@ -205,7 +205,7 @@ func TestErrorMigrateToEncryptedConfig(t *testing.T) {
 			paths.SetTop(top)
 
 			vaultPath := paths.AgentVaultPath()
-			err := secret.CreateAgentSecret(ctx, vault.WithVaultPath(vaultPath))
+			err := secret.CreateAgentSecret(ctx, vault.WithVaultPath(vaultPath), vault.WithUnprivileged(true))
 
 			require.NoError(t, err)
 
@@ -237,7 +237,7 @@ func TestErrorMigrateToEncryptedConfig(t *testing.T) {
 			log := logp.NewLogger("test_migrate_config")
 			// setup end
 
-			err = MigrateToEncryptedConfig(ctx, log, absUnencryptedFile, absEncryptedFile, storage.WithUnprivileged(true))
+			err = MigrateToEncryptedConfig(ctx, log, absUnencryptedFile, absEncryptedFile)
 
 			assert.Error(t, err)
 		})

--- a/internal/pkg/agent/migration/migrate_config_test.go
+++ b/internal/pkg/agent/migration/migrate_config_test.go
@@ -247,20 +247,22 @@ func TestErrorMigrateToEncryptedConfig(t *testing.T) {
 
 func createAndPersistStore(t *testing.T, ctx context.Context, baseDir string, cf configfile, encrypted bool) storage.Storage {
 	var store storage.Storage
-
+	var err error
 	asbFilePath := path.Join(baseDir, cf.name)
 
 	if encrypted {
-		store = storage.NewEncryptedDiskStore(ctx, asbFilePath, storage.WithUnprivileged(true))
+		store, err = storage.NewEncryptedDiskStore(ctx, asbFilePath, storage.WithUnprivileged(true))
+		require.NoError(t, err)
 	} else {
-		store = storage.NewDiskStore(asbFilePath)
+		store, err = storage.NewDiskStore(asbFilePath)
+		require.NoError(t, err)
 	}
 
 	if !cf.create {
 		return store
 	}
 
-	err := store.Save(bytes.NewReader(cf.content))
+	err = store.Save(bytes.NewReader(cf.content))
 	require.NoError(t, err)
 
 	err = os.Chmod(asbFilePath, cf.permissions&fs.ModePerm)

--- a/internal/pkg/agent/storage/disk_store.go
+++ b/internal/pkg/agent/storage/disk_store.go
@@ -16,8 +16,8 @@ import (
 )
 
 // NewDiskStore creates an unencrypted disk store.
-func NewDiskStore(target string) *DiskStore {
-	return &DiskStore{target: target}
+func NewDiskStore(target string) (*DiskStore, error) {
+	return &DiskStore{target: target}, nil
 }
 
 // Exists check if the store file exists on the disk

--- a/internal/pkg/agent/storage/encrypted_disk_storage_windows_linux_test.go
+++ b/internal/pkg/agent/storage/encrypted_disk_storage_windows_linux_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/secret"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/vault"
@@ -34,7 +35,8 @@ func TestEncryptedDiskStorageWindowsLinuxLoad(t *testing.T) {
 	defer cn()
 
 	fp := filepath.Join(dir, testConfigFile)
-	s := NewEncryptedDiskStore(ctx, fp, WithVaultPath(dir))
+	s, err := NewEncryptedDiskStore(ctx, fp, WithVaultPath(dir))
+	require.NoError(t, err)
 
 	// Test that the file loads and doesn't create vault
 	r, err := s.Load()

--- a/internal/pkg/agent/storage/encrypted_disk_store.go
+++ b/internal/pkg/agent/storage/encrypted_disk_store.go
@@ -52,7 +52,7 @@ func NewEncryptedDiskStore(ctx context.Context, target string, opts ...OptionFun
 
 	hasRoot, err := utils.HasRoot()
 	if err != nil {
-		return nil, fmt.Errorf("error checking for admin privileges: %w", err)
+		return nil, fmt.Errorf("error checking for root/Administrator privileges: %w", err)
 	}
 	if !hasRoot {
 		unprivileged = true

--- a/internal/pkg/agent/storage/encrypted_disk_store.go
+++ b/internal/pkg/agent/storage/encrypted_disk_store.go
@@ -55,7 +55,6 @@ func NewEncryptedDiskStore(ctx context.Context, target string, opts ...OptionFun
 		return nil, fmt.Errorf("error checking for ")
 	}
 	if !hasRoot {
-		// TODO log error
 		unprivileged = true
 		opts = append(opts, WithUnprivileged(unprivileged))
 	}

--- a/internal/pkg/agent/storage/encrypted_disk_store.go
+++ b/internal/pkg/agent/storage/encrypted_disk_store.go
@@ -52,7 +52,7 @@ func NewEncryptedDiskStore(ctx context.Context, target string, opts ...OptionFun
 
 	hasRoot, err := utils.HasRoot()
 	if err != nil {
-		return nil, fmt.Errorf("error checking for ")
+		return nil, fmt.Errorf("error checking for admin privileges: %w", err)
 	}
 	if !hasRoot {
 		unprivileged = true

--- a/internal/pkg/agent/storage/encrypted_disk_store.go
+++ b/internal/pkg/agent/storage/encrypted_disk_store.go
@@ -43,7 +43,7 @@ type OptionFunc func(s *EncryptedDiskStore)
 
 // NewEncryptedDiskStore creates an encrypted disk store.
 // Drop-in replacement for NewDiskStorage
-func NewEncryptedDiskStore(ctx context.Context, target string, opts ...OptionFunc) Storage {
+func NewEncryptedDiskStore(ctx context.Context, target string, opts ...OptionFunc) (Storage, error) {
 	if encryptionDisabled {
 		return NewDiskStore(target)
 	}
@@ -51,7 +51,10 @@ func NewEncryptedDiskStore(ctx context.Context, target string, opts ...OptionFun
 	unprivileged := false
 
 	hasRoot, err := utils.HasRoot()
-	if err != nil || !hasRoot {
+	if err != nil {
+		return nil, fmt.Errorf("error checking for ")
+	}
+	if !hasRoot {
 		// TODO log error
 		unprivileged = true
 		opts = append(opts, WithUnprivileged(unprivileged))
@@ -66,7 +69,7 @@ func NewEncryptedDiskStore(ctx context.Context, target string, opts ...OptionFun
 	for _, opt := range opts {
 		opt(s)
 	}
-	return s
+	return s, nil
 }
 
 // WithVaultPath sets the path of the vault.

--- a/internal/pkg/agent/storage/encrypted_disk_store.go
+++ b/internal/pkg/agent/storage/encrypted_disk_store.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/vault"
+	"github.com/elastic/elastic-agent/pkg/utils"
 
 	"github.com/hectane/go-acl"
 
@@ -46,11 +47,21 @@ func NewEncryptedDiskStore(ctx context.Context, target string, opts ...OptionFun
 	if encryptionDisabled {
 		return NewDiskStore(target)
 	}
+
+	unprivileged := false
+
+	hasRoot, err := utils.HasRoot()
+	if err != nil || !hasRoot {
+		// TODO log error
+		unprivileged = true
+		opts = append(opts, WithUnprivileged(unprivileged))
+	}
+
 	s := &EncryptedDiskStore{
 		ctx:          ctx,
 		target:       target,
 		vaultPath:    paths.AgentVaultPath(),
-		unprivileged: false,
+		unprivileged: unprivileged,
 	}
 	for _, opt := range opts {
 		opt(s)

--- a/internal/pkg/agent/storage/encrypted_disk_store.go
+++ b/internal/pkg/agent/storage/encrypted_disk_store.go
@@ -56,7 +56,7 @@ func NewEncryptedDiskStore(ctx context.Context, target string, opts ...OptionFun
 	}
 	if !hasRoot {
 		unprivileged = true
-		opts = append(opts, WithUnprivileged(unprivileged))
+		opts = append([]OptionFunc{WithUnprivileged(unprivileged)}, opts...)
 	}
 
 	s := &EncryptedDiskStore{

--- a/internal/pkg/agent/storage/encrypted_disk_store_test.go
+++ b/internal/pkg/agent/storage/encrypted_disk_store_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package storage
 
 import (

--- a/internal/pkg/agent/storage/encrypted_disk_store_test.go
+++ b/internal/pkg/agent/storage/encrypted_disk_store_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -62,14 +61,7 @@ func TestNewEncryptedDiskStore(t *testing.T) {
 					assert.Equal(t, paths.AgentVaultPath(), eds.vaultPath)
 				}
 			},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				if runtime.GOOS == "darwin" {
-					// on Mac OS this test will fail since we are not root and try to force instantiating a keychain vault
-					// expecting an error is still a good way to validate that the override took effect
-					return assert.Error(t, err, "on Mac OS we expect an error when instantiating an encrypted store with a privileged vault")
-				}
-				return assert.NoError(t, err)
-			},
+			wantErr: assert.NoError,
 		},
 		{
 			name: "encrypted store with custom vault path override",

--- a/internal/pkg/agent/storage/encrypted_disk_store_test.go
+++ b/internal/pkg/agent/storage/encrypted_disk_store_test.go
@@ -1,0 +1,103 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+)
+
+func TestNewEncryptedDiskStore(t *testing.T) {
+	type StoreAssertionFunction func(*testing.T, Storage)
+
+	type args struct {
+		target string
+		opts   []OptionFunc
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    StoreAssertionFunction
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "simple encrypted store",
+			args: args{
+				target: "simplestore.enc",
+				opts:   nil,
+			},
+			want: func(t *testing.T, storage Storage) {
+				if assert.IsType(t, (*EncryptedDiskStore)(nil), storage, "a *EncryptedDiskStore should have been returned") {
+					eds := storage.(*EncryptedDiskStore)
+					assert.Equal(t, "simplestore.enc", filepath.Base(eds.target))
+					// we are running unit tests as non-root so unprivileged should be true by default
+					assert.Equal(t, true, eds.unprivileged)
+					assert.Equal(t, paths.AgentVaultPath(), eds.vaultPath)
+				}
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "encrypted store with unprivileged=false override",
+			args: args{
+				target: "privilegedstore.enc",
+				opts:   []OptionFunc{WithUnprivileged(false)},
+			},
+			want: func(t *testing.T, storage Storage) {
+				if assert.IsType(t, (*EncryptedDiskStore)(nil), storage, "a *EncryptedDiskStore should have been returned") {
+					eds := storage.(*EncryptedDiskStore)
+					assert.Equal(t, "privilegedstore.enc", filepath.Base(eds.target))
+					// override should have kicked in
+					assert.Equal(t, false, eds.unprivileged)
+					assert.Equal(t, paths.AgentVaultPath(), eds.vaultPath)
+				}
+			},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				if runtime.GOOS == "darwin" {
+					// on Mac OS this test will fail since we are not root and try to force instantiating a keychain vault
+					// expecting an error is still a good way to validate that the override took effect
+					return assert.Error(t, err, "on Mac OS we expect an error when instantiating an encrypted store with a privileged vault")
+				}
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "encrypted store with custom vault path override",
+			args: args{
+				target: "customvaultpathstore.enc",
+				opts:   []OptionFunc{WithVaultPath("somecustomvault")},
+			},
+			want: func(t *testing.T, storage Storage) {
+				if assert.IsType(t, (*EncryptedDiskStore)(nil), storage, "a *EncryptedDiskStore should have been returned") {
+					eds := storage.(*EncryptedDiskStore)
+					assert.Equal(t, "customvaultpathstore.enc", filepath.Base(eds.target))
+					// we are running unit tests as non-root so unprivileged should be true by default
+					assert.Equal(t, true, eds.unprivileged)
+					assert.Equal(t, "somecustomvault", eds.vaultPath)
+				}
+			},
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			tmpDir := t.TempDir()
+			got, err := NewEncryptedDiskStore(ctx, filepath.Join(tmpDir, tt.args.target), tt.args.opts...)
+			if !tt.wantErr(t, err, fmt.Sprintf("NewEncryptedDiskStore(%v, %v, %v)", ctx, tt.args.target, tt.args.opts)) {
+				return
+			}
+			if tt.want != nil {
+				tt.want(t, got)
+			}
+		})
+	}
+}

--- a/internal/pkg/agent/storage/storage_test.go
+++ b/internal/pkg/agent/storage/storage_test.go
@@ -144,7 +144,8 @@ func TestDiskStore(t *testing.T) {
 		target, err := genFile([]byte("hello world"))
 		require.NoError(t, err)
 		defer os.Remove(target)
-		d := NewDiskStore(target)
+		d, err := NewDiskStore(target)
+		require.NoError(t, err)
 
 		msg := []byte("bonjour la famille")
 		err = d.Save(bytes.NewReader(msg))
@@ -163,7 +164,8 @@ func TestDiskStore(t *testing.T) {
 		defer os.Remove(dir)
 
 		target := filepath.Join(dir, "hello.txt")
-		d := NewDiskStore(target)
+		d, err := NewDiskStore(target)
+		require.NoError(t, err)
 
 		msg := []byte("bonjour la famille")
 		err = d.Save(bytes.NewReader(msg))
@@ -181,7 +183,9 @@ func TestDiskStore(t *testing.T) {
 		target, err := genFile(msg)
 		require.NoError(t, err)
 
-		d := NewDiskStore(target)
+		d, err := NewDiskStore(target)
+		require.NoError(t, err)
+
 		r, err := d.Load()
 		require.NoError(t, err)
 		defer r.Close()

--- a/internal/pkg/agent/storage/store/action_store_test.go
+++ b/internal/pkg/agent/storage/store/action_store_test.go
@@ -30,7 +30,8 @@ func TestActionStore(t *testing.T) {
 
 	t.Run("action returns empty when no action is saved on disk",
 		withFile(func(t *testing.T, file string) {
-			s := storage.NewDiskStore(file)
+			s, err := storage.NewDiskStore(file)
+			require.NoError(t, err)
 			store, err := newActionStore(log, s)
 			require.NoError(t, err)
 			require.Equal(t, 0, len(store.actions()))
@@ -42,7 +43,8 @@ func TestActionStore(t *testing.T) {
 				ActionID: "abc123",
 			}
 
-			s := storage.NewDiskStore(file)
+			s, err := storage.NewDiskStore(file)
+			require.NoError(t, err)
 			store, err := newActionStore(log, s)
 			require.NoError(t, err)
 
@@ -63,7 +65,8 @@ func TestActionStore(t *testing.T) {
 				},
 			}
 
-			s := storage.NewDiskStore(file)
+			s, err := storage.NewDiskStore(file)
+			require.NoError(t, err)
 			store, err := newActionStore(log, s)
 			require.NoError(t, err)
 
@@ -73,7 +76,8 @@ func TestActionStore(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 1, len(store.actions()))
 
-			s = storage.NewDiskStore(file)
+			s, err = storage.NewDiskStore(file)
+			require.NoError(t, err)
 			store1, err := newActionStore(log, s)
 			require.NoError(t, err)
 

--- a/internal/pkg/agent/storage/store/state_store.go
+++ b/internal/pkg/agent/storage/store/state_store.go
@@ -83,7 +83,7 @@ func NewStateStoreWithMigration(ctx context.Context, log *logger.Logger, actionS
 
 	encryptedDiskStore, err := storage.NewEncryptedDiskStore(ctx, stateStorePath)
 	if err != nil {
-		return nil, fmt.Errorf("error creating encrypted disk store: %w", err)
+		return nil, fmt.Errorf("error instantiating encrypted disk store: %w", err)
 	}
 	return NewStateStore(log, encryptedDiskStore)
 }
@@ -156,7 +156,7 @@ func migrateStateStore(ctx context.Context, log *logger.Logger, actionStorePath,
 
 	stateDiskStore, err := storage.NewEncryptedDiskStore(ctx, stateStorePath)
 	if err != nil {
-		return fmt.Errorf("error creating encrypted disk store: %w", err)
+		return fmt.Errorf("error instantiating encrypted disk store: %w", err)
 	}
 
 	stateStoreExits, err := stateDiskStore.Exists()

--- a/internal/pkg/agent/storage/store/state_store.go
+++ b/internal/pkg/agent/storage/store/state_store.go
@@ -81,7 +81,11 @@ func NewStateStoreWithMigration(ctx context.Context, log *logger.Logger, actionS
 		return nil, err
 	}
 
-	return NewStateStore(log, storage.NewEncryptedDiskStore(ctx, stateStorePath))
+	encryptedDiskStore, err := storage.NewEncryptedDiskStore(ctx, stateStorePath)
+	if err != nil {
+		return nil, fmt.Errorf("error creating encrypted disk store: %w", err)
+	}
+	return NewStateStore(log, encryptedDiskStore)
 }
 
 // NewStateStoreActionAcker creates a new state store backed action acker.
@@ -145,8 +149,15 @@ func NewStateStore(log *logger.Logger, store storeLoad) (*StateStore, error) {
 
 func migrateStateStore(ctx context.Context, log *logger.Logger, actionStorePath, stateStorePath string) (err error) {
 	log = log.Named("state_migration")
-	actionDiskStore := storage.NewDiskStore(actionStorePath)
-	stateDiskStore := storage.NewEncryptedDiskStore(ctx, stateStorePath)
+	actionDiskStore, err := storage.NewDiskStore(actionStorePath)
+	if err != nil {
+		return fmt.Errorf("error creating disk store: %w", err)
+	}
+
+	stateDiskStore, err := storage.NewEncryptedDiskStore(ctx, stateStorePath)
+	if err != nil {
+		return fmt.Errorf("error creating encrypted disk store: %w", err)
+	}
 
 	stateStoreExits, err := stateDiskStore.Exists()
 	if err != nil {

--- a/internal/pkg/agent/storage/store/state_store_test.go
+++ b/internal/pkg/agent/storage/store/state_store_test.go
@@ -45,7 +45,8 @@ func runTestStateStore(t *testing.T, ackToken string) {
 
 	t.Run("action returns empty when no action is saved on disk",
 		withFile(func(t *testing.T, file string) {
-			s := storage.NewDiskStore(file)
+			s, err := storage.NewDiskStore(file)
+			require.NoError(t, err)
 			store, err := NewStateStore(log, s)
 			require.NoError(t, err)
 			require.Empty(t, store.Actions())
@@ -58,7 +59,8 @@ func runTestStateStore(t *testing.T, ackToken string) {
 				ActionID: "abc123",
 			}
 
-			s := storage.NewDiskStore(file)
+			s, err := storage.NewDiskStore(file)
+			require.NoError(t, err)
 			store, err := NewStateStore(log, s)
 			require.NoError(t, err)
 
@@ -82,7 +84,8 @@ func runTestStateStore(t *testing.T, ackToken string) {
 				},
 			}
 
-			s := storage.NewDiskStore(file)
+			s, err := storage.NewDiskStore(file)
+			require.NoError(t, err)
 			store, err := NewStateStore(log, s)
 			require.NoError(t, err)
 
@@ -96,7 +99,8 @@ func runTestStateStore(t *testing.T, ackToken string) {
 			require.Empty(t, store.Queue())
 			require.Equal(t, ackToken, store.AckToken())
 
-			s = storage.NewDiskStore(file)
+			s, err = storage.NewDiskStore(file)
+			require.NoError(t, err)
 			store1, err := NewStateStore(log, s)
 			require.NoError(t, err)
 
@@ -119,7 +123,8 @@ func runTestStateStore(t *testing.T, ackToken string) {
 				SourceURI:       "https://example.com",
 			}}
 
-			s := storage.NewDiskStore(file)
+			s, err := storage.NewDiskStore(file)
+			require.NoError(t, err)
 			store, err := NewStateStore(log, s)
 			require.NoError(t, err)
 
@@ -130,7 +135,8 @@ func runTestStateStore(t *testing.T, ackToken string) {
 			require.Empty(t, store.Actions())
 			require.Len(t, store.Queue(), 1)
 
-			s = storage.NewDiskStore(file)
+			s, err = storage.NewDiskStore(file)
+			require.NoError(t, err)
 			store1, err := NewStateStore(log, s)
 			require.NoError(t, err)
 			require.Empty(t, store1.Actions())
@@ -161,7 +167,8 @@ func runTestStateStore(t *testing.T, ackToken string) {
 				},
 			}}
 
-			s := storage.NewDiskStore(file)
+			s, err := storage.NewDiskStore(file)
+			require.NoError(t, err)
 			store, err := NewStateStore(log, s)
 			require.NoError(t, err)
 
@@ -172,7 +179,8 @@ func runTestStateStore(t *testing.T, ackToken string) {
 			require.Empty(t, store.Actions())
 			require.Len(t, store.Queue(), 2)
 
-			s = storage.NewDiskStore(file)
+			s, err = storage.NewDiskStore(file)
+			require.NoError(t, err)
 			store1, err := NewStateStore(log, s)
 			require.NoError(t, err)
 			require.Empty(t, store1.Actions())
@@ -200,7 +208,8 @@ func runTestStateStore(t *testing.T, ackToken string) {
 				ActionType: "UNENROLL",
 			}
 
-			s := storage.NewDiskStore(file)
+			s, err := storage.NewDiskStore(file)
+			require.NoError(t, err)
 			store, err := NewStateStore(log, s)
 			require.NoError(t, err)
 
@@ -214,7 +223,8 @@ func runTestStateStore(t *testing.T, ackToken string) {
 			require.Empty(t, store.Queue())
 			require.Equal(t, ackToken, store.AckToken())
 
-			s = storage.NewDiskStore(file)
+			s, err = storage.NewDiskStore(file)
+			require.NoError(t, err)
 			store1, err := NewStateStore(log, s)
 			require.NoError(t, err)
 
@@ -231,7 +241,8 @@ func runTestStateStore(t *testing.T, ackToken string) {
 				ActionID: "abc123",
 			}
 
-			s := storage.NewDiskStore(file)
+			s, err := storage.NewDiskStore(file)
+			require.NoError(t, err)
 			store, err := NewStateStore(log, s)
 			require.NoError(t, err)
 			store.SetAckToken(ackToken)
@@ -250,7 +261,9 @@ func runTestStateStore(t *testing.T, ackToken string) {
 			withFile(func(t *testing.T, stateStorePath string) {
 				err := migrateStateStore(ctx, log, actionStorePath, stateStorePath)
 				require.NoError(t, err)
-				stateStore, err := NewStateStore(log, storage.NewDiskStore(stateStorePath))
+				diskStore, err := storage.NewDiskStore(stateStorePath)
+				require.NoError(t, err)
+				stateStore, err := NewStateStore(log, diskStore)
 				require.NoError(t, err)
 				stateStore.SetAckToken(ackToken)
 				require.Empty(t, stateStore.Actions())
@@ -269,7 +282,9 @@ func runTestStateStore(t *testing.T, ackToken string) {
 				},
 			}
 
-			actionStore, err := newActionStore(log, storage.NewDiskStore(actionStorePath))
+			diskStore, err := storage.NewDiskStore(actionStorePath)
+			require.NoError(t, err)
+			actionStore, err := newActionStore(log, diskStore)
 			require.NoError(t, err)
 
 			require.Empty(t, actionStore.actions())
@@ -282,7 +297,9 @@ func runTestStateStore(t *testing.T, ackToken string) {
 				err = migrateStateStore(ctx, log, actionStorePath, stateStorePath)
 				require.NoError(t, err)
 
-				stateStore, err := NewStateStore(log, storage.NewDiskStore(stateStorePath))
+				newDiskStore, err := storage.NewDiskStore(stateStorePath)
+				require.NoError(t, err)
+				stateStore, err := NewStateStore(log, newDiskStore)
 				require.NoError(t, err)
 				stateStore.SetAckToken(ackToken)
 				diff := cmp.Diff(actionStore.actions(), stateStore.Actions())

--- a/internal/pkg/config/operations/inspector.go
+++ b/internal/pkg/config/operations/inspector.go
@@ -26,8 +26,8 @@ var (
 
 // LoadFullAgentConfig load agent config based on provided paths and defined capabilities.
 // In case fleet is used, config from policy action is returned.
-func LoadFullAgentConfig(ctx context.Context, logger *logger.Logger, cfgPath string, failOnFleetMissing bool) (*config.Config, error) {
-	rawConfig, err := loadConfig(ctx, cfgPath)
+func LoadFullAgentConfig(ctx context.Context, logger *logger.Logger, cfgPath string, failOnFleetMissing, unprivileged bool) (*config.Config, error) {
+	rawConfig, err := loadConfig(ctx, cfgPath, unprivileged)
 	if err != nil {
 		return nil, fmt.Errorf("error loading raw config: %w", err)
 	}
@@ -75,7 +75,7 @@ func LoadFullAgentConfig(ctx context.Context, logger *logger.Logger, cfgPath str
 	return rawConfig, nil
 }
 
-func loadConfig(ctx context.Context, configPath string) (*config.Config, error) {
+func loadConfig(ctx context.Context, configPath string, unprivileged bool) (*config.Config, error) {
 	rawConfig, err := config.LoadFile(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("error loading config file %s: %w", configPath, err)
@@ -83,7 +83,7 @@ func loadConfig(ctx context.Context, configPath string) (*config.Config, error) 
 
 	path := paths.AgentConfigFile()
 
-	store := storage.NewEncryptedDiskStore(ctx, path)
+	store := storage.NewEncryptedDiskStore(ctx, path, storage.WithUnprivileged(unprivileged))
 	reader, err := store.Load()
 	if err != nil {
 		return nil, errors.New(err, "could not initialize config store",

--- a/internal/pkg/config/operations/inspector.go
+++ b/internal/pkg/config/operations/inspector.go
@@ -85,7 +85,7 @@ func loadConfig(ctx context.Context, configPath string, unprivileged bool) (*con
 
 	store, err := storage.NewEncryptedDiskStore(ctx, path, storage.WithUnprivileged(unprivileged))
 	if err != nil {
-		return nil, fmt.Errorf("error creating encrypted disk store: %w", err)
+		return nil, fmt.Errorf("error instantiating encrypted disk store: %w", err)
 	}
 	reader, err := store.Load()
 	if err != nil {

--- a/internal/pkg/config/operations/inspector.go
+++ b/internal/pkg/config/operations/inspector.go
@@ -83,7 +83,10 @@ func loadConfig(ctx context.Context, configPath string, unprivileged bool) (*con
 
 	path := paths.AgentConfigFile()
 
-	store := storage.NewEncryptedDiskStore(ctx, path, storage.WithUnprivileged(unprivileged))
+	store, err := storage.NewEncryptedDiskStore(ctx, path, storage.WithUnprivileged(unprivileged))
+	if err != nil {
+		return nil, fmt.Errorf("error creating encrypted disk store: %w", err)
+	}
 	reader, err := store.Load()
 	if err != nil {
 		return nil, errors.New(err, "could not initialize config store",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR allows running elastic-agent (either installed or just extracted from the package) as an unprivileged user, using a file-based vault as fallback instead of the keychain-based one.

When creating an EncryptedDiskStore, we can specify an `unprivileged` flag which will instantiate the file-based vault on Mac OS (the default value of such flag is defined as whether elastic-agent is running with administrative rights).

In most cases, such default value is enough to choose the correct vault implementation: the exception is `elastic-agent uninstall` command where a specific check for a file vault containing the agent secret has been added.
The additional check during uninstall is necessary since the command needs to run with administrative rights for both privileged and unprivileged elastic-agent installs (a simple check of the user permissions would not be useful as we would always come up with privileged permissions)

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

This change enables `elastic-agent` to be installed and run as an unprivileged user on Mac OS

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #3867

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
