### PR TITLE
Remove accidental debug lines

### DIFF
--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -15,7 +15,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent/pkg/component"
 	"github.com/elastic/elastic-agent/pkg/utils"
 
@@ -606,10 +605,6 @@ func (b *BeatsMonitor) injectMetricsInput(cfg map[string]interface{}, componentI
 				},
 			},
 		},
-	}
-	dbgLog := logp.L()
-	for _, comp := range componentList {
-		dbgLog.Infof("component: %#v\n\t componentData: %#v", comp, comp.Component.String())
 	}
 	for unit, binaryName := range componentIDToBinary {
 		if !isSupportedMetricsBinary(binaryName) {


### PR DESCRIPTION

## What does this PR do 
https://github.com/elastic/elastic-agent/pull/4150 added some debug lines that I put in while I was tinkering with the monitoring code. This removes them.

## Why is it important?

The lines shouldn't be there.
