### PR TITLE
[Kubernetes secret provider] Send signal to agent if cache is updated

### DIFF
--- a/changelog/fragments/1709824109-k8s-secret-provider-trigger-signal.yaml
+++ b/changelog/fragments/1709824109-k8s-secret-provider-trigger-signal.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: When cache gets update, a signal gets triggered to notify the agent
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/4371
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/4168

--- a/changelog/fragments/1709824109-k8s-secret-provider-trigger-signal.yaml
+++ b/changelog/fragments/1709824109-k8s-secret-provider-trigger-signal.yaml
@@ -11,7 +11,7 @@
 kind: feature
 
 # Change summary; a 80ish characters long description of the change.
-summary: When cache gets update, a signal gets triggered to notify the agent
+summary: Kubernetes secrets provider has been improved to update a kubernetes secret  when the secret value changes.
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
@@ -129,12 +129,12 @@ func (p *contextProviderK8sSecrets) mergeWithCurrent(updatedMap map[string]*secr
 		diff := time.Since(data.lastAccess)
 		if diff < p.config.TTLDelete {
 			merged[name] = data
-		}
-		// Check if this key is part of the updatedMap. If it is not, we know the secrets cache was updated,
-		// and we need to signal that.
-		_, ok := updatedMap[name]
-		if !ok {
-			updatedCache = true
+			// Check if this key is part of the updatedMap. If it is not, we know the secrets cache was updated,
+			// and we need to signal that.
+			_, ok := updatedMap[name]
+			if !ok {
+				updatedCache = true
+			}
 		}
 	}
 
@@ -185,6 +185,8 @@ func (p *contextProviderK8sSecrets) updateCache() bool {
 					updatedCache = true
 				}
 			}
+		} else {
+			updatedCache = true
 		}
 	}
 

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
@@ -86,7 +86,7 @@ func (p *contextProviderK8sSecrets) Run(ctx context.Context, comm corecomp.Conte
 	p.clientMx.Unlock()
 
 	if !p.config.DisableCache {
-		go p.updateSecrets(ctx)
+		go p.updateSecrets(ctx, comm)
 	}
 
 	<-comm.Done()
@@ -102,14 +102,18 @@ func getK8sClient(kubeconfig string, opt kubernetes.KubeClientOptions) (k8sclien
 }
 
 // Update the secrets in the cache every RefreshInterval
-func (p *contextProviderK8sSecrets) updateSecrets(ctx context.Context) {
+func (p *contextProviderK8sSecrets) updateSecrets(ctx context.Context, comm corecomp.ContextProviderComm) {
 	timer := time.NewTimer(p.config.RefreshInterval)
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-timer.C:
-			p.updateCache()
+			updatedCache := p.updateCache()
+			if updatedCache {
+				p.logger.Info("Secrets cache was updated, the agent will be notified.")
+				comm.Signal()
+			}
 			timer.Reset(p.config.RefreshInterval)
 		}
 	}
@@ -117,13 +121,20 @@ func (p *contextProviderK8sSecrets) updateSecrets(ctx context.Context) {
 
 // mergeWithCurrent merges the updated map with the cache map.
 // This function needs to be called between the mutex lock for the map.
-func (p *contextProviderK8sSecrets) mergeWithCurrent(updatedMap map[string]*secretsData) map[string]*secretsData {
+func (p *contextProviderK8sSecrets) mergeWithCurrent(updatedMap map[string]*secretsData) (map[string]*secretsData, bool) {
 	merged := make(map[string]*secretsData)
+	updatedCache := false
 
 	for name, data := range p.secretsCache {
 		diff := time.Since(data.lastAccess)
 		if diff < p.config.TTLDelete {
 			merged[name] = data
+		}
+		// Check if this key is part of the updatedMap. If it is not, we know the secrets cache was updated,
+		// and we need to signal that.
+		_, ok := updatedMap[name]
+		if !ok {
+			updatedCache = true
 		}
 	}
 
@@ -132,14 +143,20 @@ func (p *contextProviderK8sSecrets) mergeWithCurrent(updatedMap map[string]*secr
 		// it could have been updated when trying to fetch the secret at the same time we are running update cache.
 		// In that case, we only update the value.
 		if _, ok := merged[name]; ok {
-			merged[name].value = data.value
+			if merged[name].value != data.value {
+				merged[name].value = data.value
+				updatedCache = true
+			}
 		}
 	}
 
-	return merged
+	return merged, updatedCache
 }
 
-func (p *contextProviderK8sSecrets) updateCache() {
+func (p *contextProviderK8sSecrets) updateCache() bool {
+	// Keep track whether the cache had values changing, so we can notify the agent
+	updatedCache := false
+
 	// deleting entries does not free the memory, so we need to create a new map
 	// to place the secrets we want to keep
 	cacheTmp := make(map[string]*secretsData)
@@ -152,6 +169,8 @@ func (p *contextProviderK8sSecrets) updateCache() {
 	}
 	p.secretsCacheMx.RUnlock()
 
+	// The only way to update an entry in the cache is through the last access time (to delete the key)
+	// or if the value gets updated.
 	for name, data := range copyMap {
 		diff := time.Since(data.lastAccess)
 		if diff < p.config.TTLDelete {
@@ -162,17 +181,22 @@ func (p *contextProviderK8sSecrets) updateCache() {
 					lastAccess: data.lastAccess,
 				}
 				cacheTmp[name] = newData
+				if value != data.value {
+					updatedCache = true
+				}
 			}
-
 		}
 	}
 
 	// While the cache was updated, it is possible that some secret was added through another go routine.
 	// We need to merge the updated map with the current cache map to catch the new entries and avoid
 	// loss of data.
+	var updated bool
 	p.secretsCacheMx.Lock()
-	p.secretsCache = p.mergeWithCurrent(cacheTmp)
+	p.secretsCache, updated = p.mergeWithCurrent(cacheTmp)
 	p.secretsCacheMx.Unlock()
+
+	return updatedCache || updated
 }
 
 func (p *contextProviderK8sSecrets) getFromCache(key string) (string, bool) {

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
@@ -404,7 +404,7 @@ func Test_MergeWitchCurrent(t *testing.T) {
 		fp.secretsCache = test.secretsCache
 		merged, updated := fp.mergeWithCurrent(test.updatedMap)
 
-		require.Equalf(t, len(test.mergedMap), len(merged), "Resulting merged map does not have the expected lenght.")
+		require.Equalf(t, len(test.mergedMap), len(merged), "Resulting merged map does not have the expected length.")
 		for key, data1 := range test.mergedMap {
 			data2, ok := merged[key]
 			if ok {
@@ -507,7 +507,7 @@ func Test_UpdateCache(t *testing.T) {
 		fp.secretsCache = test.secretsCache
 		updated := fp.updateCache()
 
-		require.Equalf(t, len(test.expectedCache), len(fp.secretsCache), "Resulting updated map does not have the expected lenght.")
+		require.Equalf(t, len(test.expectedCache), len(fp.secretsCache), "Resulting updated map does not have the expected length.")
 		for key, data1 := range test.expectedCache {
 			data2, ok := fp.secretsCache[key]
 			if ok {


### PR DESCRIPTION
## What does this PR do?

If the secrets in the cache get updated, then we notify the agent.

## Why is it important?

See issue https://github.com/elastic/elastic-agent/issues/4168 and the comments there.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## How to test this PR locally

Check the README file in the root directory to see how to build your own custom image and loaded to kind cluster.



<details>
<summary>Example secret.</summary>

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: my-secret
data:
  extra: bXktc2VjcmV0LW1lc3NhZ2UK
```
</details>

<details>
<summary>Example input that you can add to EA standalone using the secret.</summary>


```yaml
      - id: kubernetes-node-metrics
        type: kubernetes/metrics
        use_output: default
        meta:
          package:
            name: kubernetes
            version: 1.52.0
        data_stream:
          namespace: default
        streams:
          - data_stream:
              dataset: kubernetes.proxy
              type: metrics
            metricsets:
              - proxy
            hosts:
              - 'localhost:10249'
            period: 10s
            processors:
              - add_fields:
                  target: myfield
                  fields:
                    value: ${kubernetes_secrets.default.my-secret.extra}
```
</details>


## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/4168



## Screenshots

Using the setup as in the section on how to test locally, we can check that the new field has the correct value associated with the secret:

![image](https://github.com/elastic/elastic-agent/assets/113898685/8cfad5f3-38df-4512-a538-d73a029fd637)


## Logs

If a secret gets updated, then the cache will be updated and this wall cause the signal to get triggered. Logs:

```
{"log.level":"info","@timestamp":"2024-03-07T12:07:46.095Z","log.logger":"composable","log.origin":{"file.name":"kubernetessecrets/kubernetes_secrets.go","file.line":119},"message":"Secrets cache was updated, the agent will be notified.","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2024-03-07T12:07:46.273Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":1382},"message":"component model updated","log":{"source":"elastic-agent"},"changes":{"components":{"updated":["kubernetes/metrics-default: [(kubernetes/metrics-default-kubernetes-node-metrics: updated)]"],"count":4},"outputs":{}},"ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2024-03-07T12:07:46.273Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":1181},"message":"Updating running component model","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
```

