### PR TITLE
Skip standalone upgrade test for versions with matching hash

### DIFF
--- a/testing/integration/upgrade_standalone_test.go
+++ b/testing/integration/upgrade_standalone_test.go
@@ -70,6 +70,15 @@ func testStandaloneUpgrade(t *testing.T, startVersion *version.ParsedSemVer, end
 	endFixture, err := define.NewFixture(t, endVersion)
 	require.NoError(t, err)
 
+	startVersionInfo, err := startFixture.ExecVersion(ctx)
+	require.NoError(t, err)
+	endVersionInfo, err := endFixture.ExecVersion(ctx)
+	require.NoError(t, err)
+	if startVersionInfo.Binary.Commit == endVersionInfo.Binary.Commit {
+		t.Skipf("both start and end versions have the same hash %q, skipping...", startVersionInfo.Binary.Commit)
+		return
+	}
+
 	err = upgradetest.PerformUpgrade(ctx, startFixture, endFixture, t, upgradetest.WithUnprivileged(unprivileged))
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
Snapshots can have matching commit hash on daily builds.

## Why is it important?

Daily builds fails without this change, here is an example https://buildkite.com/elastic/elastic-agent/builds/7601#018e1807-d558-4e96-97c7-a151b882600e

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
~~- [ ] I have added an integration test or an E2E test~~