### PR TITLE
Fix GRPC server shutdown sequence

### DIFF
--- a/pkg/component/runtime/manager.go
+++ b/pkg/component/runtime/manager.go
@@ -231,7 +231,7 @@ func (m *Manager) Run(ctx context.Context) error {
 	wgServer.Add(1)
 	go func() {
 		defer wgServer.Done()
-		go m.serverLoop(ctx, listener, server)
+		m.serverLoop(ctx, listener, server)
 	}()
 
 	// Start the run loop, which continues on the main goroutine


### PR DESCRIPTION
## What does this PR do?

While working on the agent I noticed that the gRPC server shutdown sequence is not working as expected, the 
```m.serverLoop``` is executed as a go routine within go routine. Thus the ```defer wgServer.Done()``` is called right away without waiting for the server loop to exit. 
So when the shutdown sequence is called at:
https://github.com/elastic/elastic-agent/blame/main/pkg/component/runtime/manager.go#L244
the ```wgServer.Wait()``` doesn't wait because it is already ```wgServer.Done()```.

This change seems only went in into 8.12. 
https://github.com/elastic/elastic-agent/commit/112f61896951f738c98f0a46c6df4160d31b718f#diff-ca07503cdc90a78b407b2bbf402f63604226ce4b1ec042a58ceb5f79bd325012R226

## Why is it important?

Fixed grpc server shutdown sequence.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## How to test this PR locally

Regression testing.

