### PR TITLE
Add CPU profile collection to diagnostics handler

### DIFF
--- a/changelog/fragments/1710153529-Add-CPU-profile-collection-to-diagnostics-action-handler.yaml
+++ b/changelog/fragments/1710153529-Add-CPU-profile-collection-to-diagnostics-action-handler.yaml
@@ -11,7 +11,7 @@
 kind: enhancement
 
 # Change summary; a 80ish characters long description of the change.
-summary: Add CPU profile collection to diagnostics action handler
+summary: Add CPU profile collection to the Fleet diagnostics action handler
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.

--- a/changelog/fragments/1710153529-Add-CPU-profile-collection-to-diagnostics-action-handler.yaml
+++ b/changelog/fragments/1710153529-Add-CPU-profile-collection-to-diagnostics-action-handler.yaml
@@ -1,0 +1,35 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add CPU profile collection to diagnostics action handler
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Add the optional CPU profile collection to the diagnostic action handler.
+  CPU profiles will be collected if the REQUEST_DIAGNOSTICS action has the
+  optional additional_metrics parameter list contains "CPU".
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 4394
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 3491

--- a/internal/pkg/agent/application/actions/handlers/handler_action_diagnostics.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_diagnostics.go
@@ -31,6 +31,11 @@ import (
 // In either case the 1st action will succeed and the others will ack with an the error.
 var ErrRateLimit = fmt.Errorf("rate limit exceeded")
 
+// getCPUDiag is a wrapper around diagnostics.CreateCPUProfile so it can be replaced in unit-tests.
+var getCPUDiag = func(ctx context.Context, d time.Duration) ([]byte, error) {
+	return diagnostics.CreateCPUProfile(ctx, d)
+}
+
 // Uploader is the interface used to upload a diagnostics bundle to fleet-server.
 type Uploader interface {
 	UploadDiagnostics(context.Context, string, string, int64, io.Reader) (string, error)
@@ -223,7 +228,7 @@ func (h *Diagnostics) runHooks(ctx context.Context, action *fleetapi.ActionDiagn
 		h.log.Debugw(fmt.Sprintf("Hook %s execution complete, took %s", hook.Name, elapsed.String()), "hook", hook.Name, "filename", hook.Filename, "elapsed", elapsed.String())
 	}
 	if collectCPU {
-		p, err := diagnostics.CreateCPUProfile(ctx, diagnostics.DiagCPUDuration)
+		p, err := getCPUDiag(ctx, diagnostics.DiagCPUDuration)
 		if err != nil {
 			return diags, fmt.Errorf("unable to gather CPU profile: %w", err)
 		}

--- a/internal/pkg/agent/application/actions/handlers/handler_action_diagnostics.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_diagnostics.go
@@ -193,6 +193,7 @@ func (h *Diagnostics) runHooks(ctx context.Context, action *fleetapi.ActionDiagn
 	collectCPU := false
 	for _, metric := range action.AdditionalMetrics {
 		if metric == "CPU" {
+			h.log.Debug("Diagnostics will collect CPU profile.")
 			collectCPU = true
 			break
 		}

--- a/internal/pkg/agent/application/actions/handlers/handler_action_diagnostics.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_diagnostics.go
@@ -122,7 +122,7 @@ func (h *Diagnostics) collectDiag(ctx context.Context, action *fleetapi.ActionDi
 	}
 
 	h.log.Debug("Gathering agent diagnostics.")
-	aDiag, err := h.runHooks(ctx)
+	aDiag, err := h.runHooks(ctx, action)
 	if err != nil {
 		action.Err = err
 		h.log.Errorw("diagnostics action handler failed to run diagnostics hooks",
@@ -134,7 +134,7 @@ func (h *Diagnostics) collectDiag(ctx context.Context, action *fleetapi.ActionDi
 	uDiag := h.diagUnits(ctx)
 
 	h.log.Debug("Gathering component diagnostics.")
-	cDiag := h.diagComponents(ctx)
+	cDiag := h.diagComponents(ctx, action)
 
 	var r io.Reader
 	// attempt to create the a temporary diagnostics file on disk in order to avoid loading a
@@ -185,9 +185,25 @@ func (h *Diagnostics) collectDiag(ctx context.Context, action *fleetapi.ActionDi
 }
 
 // runHooks runs the agent diagnostics hooks.
-func (h *Diagnostics) runHooks(ctx context.Context) ([]client.DiagnosticFileResult, error) {
+func (h *Diagnostics) runHooks(ctx context.Context, action *fleetapi.ActionDiagnostics) ([]client.DiagnosticFileResult, error) {
 	hooks := append(h.diagProvider.DiagnosticHooks(), diagnostics.GlobalHooks()...)
-	diags := make([]client.DiagnosticFileResult, 0, len(hooks))
+
+	// Currently CPU is the only additional metric we can collect.
+	// If this changes we would need to change how we scan AdditionalMetrics.
+	collectCPU := false
+	for _, metric := range action.AdditionalMetrics {
+		if metric == "CPU" {
+			collectCPU = true
+			break
+		}
+	}
+
+	resultLen := len(hooks)
+	if collectCPU {
+		resultLen++
+	}
+	diags := make([]client.DiagnosticFileResult, 0, resultLen)
+
 	for _, hook := range hooks {
 		if ctx.Err() != nil {
 			return diags, ctx.Err()
@@ -204,6 +220,20 @@ func (h *Diagnostics) runHooks(ctx context.Context) ([]client.DiagnosticFileResu
 		})
 		elapsed := time.Since(startTime)
 		h.log.Debugw(fmt.Sprintf("Hook %s execution complete, took %s", hook.Name, elapsed.String()), "hook", hook.Name, "filename", hook.Filename, "elapsed", elapsed.String())
+	}
+	if collectCPU {
+		p, err := diagnostics.CreateCPUProfile(ctx, 30*time.Second)
+		if err != nil {
+			return diags, fmt.Errorf("unable to gather CPU profile: %w", err)
+		}
+		diags = append(diags, client.DiagnosticFileResult{
+			Name:        "cpuprofile",
+			Filename:    "cpu.pprof",
+			Description: "CPU profile",
+			ContentType: "application/octet-stream",
+			Content:     p,
+			Generated:   time.Now().UTC(),
+		})
 	}
 	return diags, nil
 }
@@ -246,14 +276,20 @@ func (h *Diagnostics) diagUnits(ctx context.Context) []client.DiagnosticUnitResu
 }
 
 // diagUnits gathers diagnostics from components.
-func (h *Diagnostics) diagComponents(ctx context.Context) []client.DiagnosticComponentResult {
+func (h *Diagnostics) diagComponents(ctx context.Context, action *fleetapi.ActionDiagnostics) []client.DiagnosticComponentResult {
 	cDiag := make([]client.DiagnosticComponentResult, 0)
 	h.log.Debug("Performing component diagnostics")
 	startTime := time.Now()
 	defer func() {
 		h.log.Debugf("Component diagnostics complete. Took: %s", time.Since(startTime))
 	}()
-	rr, err := h.diagProvider.PerformComponentDiagnostics(ctx, []cproto.AdditionalDiagnosticRequest{})
+	additionalMetrics := []cproto.AdditionalDiagnosticRequest{}
+	for _, metric := range action.AdditionalMetrics {
+		if metric == "CPU" {
+			additionalMetrics = append(additionalMetrics, cproto.AdditionalDiagnosticRequest_CPU)
+		}
+	}
+	rr, err := h.diagProvider.PerformComponentDiagnostics(ctx, additionalMetrics)
 	if err != nil {
 		h.log.Errorf("Error fetching component-level diagnostics: %w", err)
 	}

--- a/internal/pkg/agent/application/actions/handlers/handler_action_diagnostics.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_diagnostics.go
@@ -223,15 +223,15 @@ func (h *Diagnostics) runHooks(ctx context.Context, action *fleetapi.ActionDiagn
 		h.log.Debugw(fmt.Sprintf("Hook %s execution complete, took %s", hook.Name, elapsed.String()), "hook", hook.Name, "filename", hook.Filename, "elapsed", elapsed.String())
 	}
 	if collectCPU {
-		p, err := diagnostics.CreateCPUProfile(ctx, 30*time.Second)
+		p, err := diagnostics.CreateCPUProfile(ctx, diagnostics.DiagCPUDuration)
 		if err != nil {
 			return diags, fmt.Errorf("unable to gather CPU profile: %w", err)
 		}
 		diags = append(diags, client.DiagnosticFileResult{
-			Name:        "cpuprofile",
-			Filename:    "cpu.pprof",
-			Description: "CPU profile",
-			ContentType: "application/octet-stream",
+			Name:        diagnostics.DiagCPUName,
+			Filename:    diagnostics.DiagCPUFilename,
+			Description: diagnostics.DiagCPUDescription,
+			ContentType: diagnostics.DiagCPUContentType,
 			Content:     p,
 			Generated:   time.Now().UTC(),
 		})

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -37,6 +37,15 @@ const (
 	agentName = "elastic-agent"
 )
 
+// DiagCPU* are contstants to describe the CPU profile that is collected when the --cpu-profile flag is used with the diagnostics command, or the diagnostics action contains "CPU" in the additional_metrics list.
+const (
+	DiagCPUName        = "cpuprofile"
+	DiagCPUFilename    = "cpu.pprof"
+	DiagCPUDescription = "CPU profile"
+	DiagCPUContentType = "application/octet-stream"
+	DiagCPUDuration    = 30 * time.Second
+)
+
 // Hook is a hook that gets used when diagnostic information is requested from the Elastic Agent.
 type Hook struct {
 	Name        string

--- a/internal/pkg/fleetapi/action.go
+++ b/internal/pkg/fleetapi/action.go
@@ -434,10 +434,11 @@ func (a *ActionCancel) AckEvent() AckEvent {
 
 // ActionDiagnostics is a request to gather and upload a diagnostics bundle.
 type ActionDiagnostics struct {
-	ActionID   string `json:"action_id"`
-	ActionType string `json:"type"`
-	UploadID   string `json:"-"`
-	Err        error  `json:"-"`
+	ActionID          string   `json:"action_id"`
+	ActionType        string   `json:"type"`
+	AdditionalMetrics []string `json:"additional_metrics"`
+	UploadID          string   `json:"-"`
+	Err               error    `json:"-"`
 }
 
 // ID returns the ID of the action.

--- a/internal/pkg/fleetapi/action_test.go
+++ b/internal/pkg/fleetapi/action_test.go
@@ -152,6 +152,29 @@ func TestActionsUnmarshalJSON(t *testing.T) {
 		assert.Equal(t, "http://example.com", action.SourceURI)
 		assert.Equal(t, 1, action.Retry)
 	})
+	t.Run("ActionDiagnostics with no additional metrics", func(t *testing.T) {
+		p := []byte(`[{"id":"testid","type":"REQUEST_DIAGNOSTICS","data":{}}]`)
+		a := &Actions{}
+		err := a.UnmarshalJSON(p)
+		require.Nil(t, err)
+		action, ok := (*a)[0].(*ActionDiagnostics)
+		require.True(t, ok, "unable to cast action to specific type")
+		assert.Equal(t, "testid", action.ActionID)
+		assert.Equal(t, ActionTypeDiagnostics, action.ActionType)
+		assert.Empty(t, action.AdditionalMetrics)
+	})
+	t.Run("ActionDiagnostics with additional CPU metrics", func(t *testing.T) {
+		p := []byte(`[{"id":"testid","type":"REQUEST_DIAGNOSTICS","data":{"additional_metrics":["CPU"]}}]`)
+		a := &Actions{}
+		err := a.UnmarshalJSON(p)
+		require.Nil(t, err)
+		action, ok := (*a)[0].(*ActionDiagnostics)
+		require.True(t, ok, "unable to cast action to specific type")
+		assert.Equal(t, "testid", action.ActionID)
+		assert.Equal(t, ActionTypeDiagnostics, action.ActionType)
+		require.Len(t, action.AdditionalMetrics, 1)
+		assert.Equal(t, "CPU", action.AdditionalMetrics[0])
+	})
 }
 
 func TestActionUnenrollMarshalMap(t *testing.T) {

--- a/pkg/control/v2/server/server.go
+++ b/pkg/control/v2/server/server.go
@@ -205,17 +205,17 @@ func (s *Server) DiagnosticAgent(ctx context.Context, req *cproto.DiagnosticAgen
 	for _, metric := range req.AdditionalMetrics {
 		switch metric {
 		case cproto.AdditionalDiagnosticRequest_CPU:
-			duration := time.Second * 30
+			duration := diagnostics.DiagCPUDuration
 			s.logger.Infof("Collecting CPU metrics, waiting for %s", duration)
 			cpuResults, err := diagnostics.CreateCPUProfile(ctx, duration)
 			if err != nil {
 				return nil, fmt.Errorf("error gathering CPU profile: %w", err)
 			}
 			res = append(res, &cproto.DiagnosticFileResult{
-				Name:        "cpuprofile",
-				Filename:    "cpu.pprof",
-				Description: "CPU profile",
-				ContentType: "application/octet-stream",
+				Name:        diagnostics.DiagCPUName,
+				Filename:    diagnostics.DiagCPUFilename,
+				Description: diagnostics.DiagCPUDescription,
+				ContentType: diagnostics.DiagCPUContentType,
 				Content:     cpuResults,
 				Generated:   timestamppb.New(time.Now().UTC()),
 			})


### PR DESCRIPTION
## What does this PR do?

Add the optional CPU profile collection to the diagnostic action handler.
CPU profiles will be collected if the REQUEST_DIAGNOSTICS action has the
optional additional_metrics parameter list contains "CPU".

## Why is it important?

Will make diagnostics requested through fleet feature-complete (compared to cli options)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~I have added an integration test or an E2E test~~

## Testing

Changes have been tested with an e2e workflow, see https://github.com/elastic/fleet-server/pull/3333#issuecomment-1988924338

## Related issues

- Closes #3491 