### PR TITLE
Fix flaky TestCoordinatorReportsInvalidPolicy

### DIFF
--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -408,7 +408,7 @@ agent.download.sourceURI:
 
 		// The component model update happens on a goroutine, thus the new state
 		// might not have been sent yet. Therefore, a timeout is required.
-	case <-time.After(time.Second):
+	case <-time.After(stateChangeTimeout):
 		t.Fatalf("timedout after %s waiting Coordinator's state to change", stateChangeTimeout)
 	}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fixes flakyness of `TestCoordinatorReportsInvalidPolicy` by increasing the state change timeout, failing fast and having better error messages and printing the coordinator logs if the test fails.

## Why is it important?

The test is flaky

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~


## How to test this PR locally

 - N/A

## Related issues


- Closes #4117 


## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
