### PR TITLE
Remove reviewers from the update agent versions automation

### DIFF
--- a/.github/workflows/bump-agent-versions.yml
+++ b/.github/workflows/bump-agent-versions.yml
@@ -54,6 +54,5 @@ jobs:
               --head "update-agent-versions-$GITHUB_RUN_ID" \
               --label 'Team:Elastic-Agent' \
               --label 'update-versions' \
-              --reviewer 'elastic/elastic-agent-control-plane' \
               --repo $GITHUB_REPOSITORY
           fi


### PR DESCRIPTION
Due to permissions of the GITHUB_TOKEN the list of teams is not available to the workflow. So, it cannot assign a team for review.

Failure sample https://github.com/elastic/elastic-agent/actions/runs/8257409021/job/22587904612