### PR TITLE
[main] Bugfix for Independent Agent version parsing

### DIFF
--- a/.buildkite/scripts/steps/dra-publish.sh
+++ b/.buildkite/scripts/steps/dra-publish.sh
@@ -8,6 +8,9 @@ COMMIT="${DRA_COMMIT:="${BUILDKITE_COMMIT:=""}"}"
 BRANCH="${DRA_BRANCH:="${BUILDKITE_BRANCH:=""}"}"
 PACKAGE_VERSION="${DRA_VERSION:="${BEAT_VERSION:=""}"}"
 
+# XXX: Do not merge, for testing w/ Ind. Agent Release for PR
+BRANCH="main"
+
 # force main branch on PR's or it won't execute
 # because the PR branch does not have a project folder in release-manager
 if [[ "${BUILDKITE_PULL_REQUEST:="false"}" != "false" ]]; then

--- a/.buildkite/scripts/steps/dra-publish.sh
+++ b/.buildkite/scripts/steps/dra-publish.sh
@@ -8,9 +8,6 @@ COMMIT="${DRA_COMMIT:="${BUILDKITE_COMMIT:=""}"}"
 BRANCH="${DRA_BRANCH:="${BUILDKITE_BRANCH:=""}"}"
 PACKAGE_VERSION="${DRA_VERSION:="${BEAT_VERSION:=""}"}"
 
-# XXX: Do not merge, for testing w/ Ind. Agent Release for PR
-BRANCH="main"
-
 # force main branch on PR's or it won't execute
 # because the PR branch does not have a project folder in release-manager
 if [[ "${BUILDKITE_PULL_REQUEST:="false"}" != "false" ]]; then

--- a/dev-tools/mage/manifest/manifest.go
+++ b/dev-tools/mage/manifest/manifest.go
@@ -106,7 +106,9 @@ func DownloadComponentsFromManifest(manifest string, platforms []string, platfor
 	}
 
 	// For resolving manifest package name and version, just use the Major.Minor.Patch part of the version
-	majorMinorPatchVersion := fmt.Sprintf("%d.%d.%d", parsedManifestVersion.Major(), parsedManifestVersion.Minor(), parsedManifestVersion.Patch())
+	// for Staging builds, and Major.Minor.Patch-SNAPSHOT for snapshots.
+	// This eliminates the "+buildYYYYMMDDHHMM" suffix on Independent Agent Release builds
+	majorMinorPatchVersion := parsedManifestVersion.VersionWithPrerelease()
 
 	errGrp, downloadsCtx := errgroup.WithContext(context.Background())
 	for component, pkgs := range componentSpec {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
It fixes a bug that was made in this PR: https://github.com/elastic/elastic-agent/pull/4222

The bug is that I didn't account for the `-SNAPSHOT` prerelease suffix in parsing the versions in the manifests.

For the Independent Agent Release, we want to leave off the `+buildYYYYMMDDHHMM` suffix when pulling previously-release artifacts that don't have that suffix.

The fix is to use the `Version.VersionWithPrerelease()` value, which will include any prerelease value, which starts with `-`.  The `+buildYYYYMMDDHHMM` is a `metadata` value in semver, so it should never be part of the `VersionWithPrerelease()` value.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
It fixes a bug where SNAPSHOT versions were not downloading the proper artifacts since the versions were `8.14.0-SNAPSHOT` and not just `8.14.0`.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
