### PR TITLE
Add more labels to the bump-agent-versions.yml automation

### DIFF
--- a/.github/workflows/bump-agent-versions.yml
+++ b/.github/workflows/bump-agent-versions.yml
@@ -54,5 +54,7 @@ jobs:
               --head "update-agent-versions-$GITHUB_RUN_ID" \
               --label 'Team:Elastic-Agent' \
               --label 'update-versions' \
+              --label 'skip-changelog' \
+              --label 'backport-skip' \
               --repo $GITHUB_REPOSITORY
           fi


### PR DESCRIPTION
So, we don't have to set them manually.