### PR TITLE
Make policy names unique in integration tests

### DIFF
--- a/testing/integration/container_cmd_test.go
+++ b/testing/integration/container_cmd_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/kibana"
@@ -41,7 +42,7 @@ func TestContainerCMD(t *testing.T) {
 	require.NoError(t, err)
 
 	createPolicyReq := kibana.AgentPolicy{
-		Name:        fmt.Sprintf("test-policy-enroll-%d", time.Now().Unix()),
+		Name:        fmt.Sprintf("test-policy-enroll-%s", uuid.New().String()),
 		Namespace:   info.Namespace,
 		Description: "test policy for agent enrollment",
 		MonitoringEnabled: []kibana.MonitoringEnabledOption{

--- a/testing/integration/delay_enroll_test.go
+++ b/testing/integration/delay_enroll_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/kibana"
@@ -44,7 +45,7 @@ func TestDelayEnroll(t *testing.T) {
 	// name. This policy does not contain any integration.
 	t.Log("Enrolling agent in Fleet with a test policy")
 	createPolicyReq := kibana.AgentPolicy{
-		Name:        fmt.Sprintf("test-policy-enroll-%d", time.Now().Unix()),
+		Name:        fmt.Sprintf("test-policy-enroll-%s", uuid.New().String()),
 		Namespace:   info.Namespace,
 		Description: "test policy for agent enrollment",
 		MonitoringEnabled: []kibana.MonitoringEnabledOption{

--- a/testing/integration/logs_ingestion_test.go
+++ b/testing/integration/logs_ingestion_test.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -22,6 +21,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -57,7 +57,7 @@ func TestLogIngestionFleetManaged(t *testing.T) {
 	// name. This policy does not contain any integration.
 	t.Log("Enrolling agent in Fleet with a test policy")
 	createPolicyReq := kibana.AgentPolicy{
-		Name:        fmt.Sprintf("test-policy-enroll-%d", time.Now().Unix()),
+		Name:        fmt.Sprintf("test-policy-enroll-%s", uuid.New().String()),
 		Namespace:   info.Namespace,
 		Description: "test policy for agent enrollment",
 		MonitoringEnabled: []kibana.MonitoringEnabledOption{
@@ -253,7 +253,7 @@ func testFlattenedDatastreamFleetPolicy(
 	policy kibana.PolicyResponse,
 ) {
 	dsType := "logs"
-	dsNamespace := cleanString(fmt.Sprintf("%snamespace%d", t.Name(), rand.Uint64()))
+	dsNamespace := cleanString(fmt.Sprintf("%s-namespace-%s", t.Name(), uuid.New().String()))
 	dsDataset := cleanString(fmt.Sprintf("%s-dataset", t.Name()))
 	numEvents := 60
 

--- a/testing/integration/logs_ingestion_test.go
+++ b/testing/integration/logs_ingestion_test.go
@@ -253,8 +253,9 @@ func testFlattenedDatastreamFleetPolicy(
 	policy kibana.PolicyResponse,
 ) {
 	dsType := "logs"
-	dsNamespace := cleanString(fmt.Sprintf("%s-namespace-%s", t.Name(), uuid.New().String()))
-	dsDataset := cleanString(fmt.Sprintf("%s-dataset", t.Name()))
+	id := uuid.New().String()
+	dsNamespace := cleanString(fmt.Sprintf("namespace-%s", id))
+	dsDataset := cleanString(fmt.Sprintf("dataset-%s", id))
 	numEvents := 60
 
 	// tempDir is not deleted to help with debugging issues


### PR DESCRIPTION
Otherwise we have name collisions and errors from the Fleet server.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes https://github.com/elastic/elastic-agent/issues/4393