### PR TITLE
Optionally cancel context in TestWaitForWatcher to test timeouts

### DIFF
--- a/internal/pkg/agent/application/upgrade/upgrade_test.go
+++ b/internal/pkg/agent/application/upgrade/upgrade_test.go
@@ -748,27 +748,25 @@ func TestWaitForWatcher(t *testing.T) {
 	wantErrWatcherNotStarted := func(t assert.TestingT, err error, i ...interface{}) bool {
 		return assert.ErrorIs(t, err, ErrWatcherNotStarted, i)
 	}
+
 	tests := []struct {
-		name                     string
-		states                   []details.State
-		stateChangeInterval      time.Duration
-		timeout                  time.Duration
-		expirationAfterLastState time.Duration
-		wantErr                  assert.ErrorAssertionFunc
+		name                string
+		states              []details.State
+		stateChangeInterval time.Duration
+		cancelWaitContext   bool
+		wantErr             assert.ErrorAssertionFunc
 	}{
 		{
-			name:                     "Happy path: watcher is watching already",
-			states:                   []details.State{details.StateWatching},
-			stateChangeInterval:      1 * time.Millisecond,
-			timeout:                  500 * time.Millisecond,
-			expirationAfterLastState: 100 * time.Millisecond,
-			wantErr:                  assert.NoError,
+			name:                "Happy path: watcher is watching already",
+			states:              []details.State{details.StateWatching},
+			stateChangeInterval: 1 * time.Millisecond,
+			wantErr:             assert.NoError,
 		},
 		{
 			name:                "Sad path: watcher is never starting",
 			states:              []details.State{details.StateReplacing},
 			stateChangeInterval: 1 * time.Millisecond,
-			timeout:             50 * time.Millisecond,
+			cancelWaitContext:   true,
 			wantErr:             wantErrWatcherNotStarted,
 		},
 		{
@@ -782,16 +780,14 @@ func TestWaitForWatcher(t *testing.T) {
 				details.StateRestarting,
 				details.StateWatching,
 			},
-			stateChangeInterval:      1 * time.Millisecond,
-			timeout:                  500 * time.Millisecond,
-			expirationAfterLastState: 10 * time.Millisecond,
-			wantErr:                  assert.NoError,
+			stateChangeInterval: 1 * time.Millisecond,
+			wantErr:             assert.NoError,
 		},
 		{
 			name:                "Timeout: marker is never created",
 			states:              nil,
 			stateChangeInterval: 1 * time.Millisecond,
-			timeout:             50 * time.Millisecond,
+			cancelWaitContext:   true,
 			wantErr:             wantErrWatcherNotStarted,
 		},
 		{
@@ -805,8 +801,8 @@ func TestWaitForWatcher(t *testing.T) {
 				details.StateRestarting,
 			},
 
-			stateChangeInterval: 5 * time.Millisecond,
-			timeout:             20 * time.Millisecond,
+			stateChangeInterval: 1 * time.Millisecond,
+			cancelWaitContext:   true,
 			wantErr:             wantErrWatcherNotStarted,
 		},
 	}
@@ -817,18 +813,22 @@ func TestWaitForWatcher(t *testing.T) {
 			if !ok {
 				deadline = time.Now().Add(5 * time.Second)
 			}
-			testCtx, cancel := context.WithDeadline(context.TODO(), deadline)
-			defer cancel()
+			testCtx, testCancel := context.WithDeadline(context.Background(), deadline)
+			defer testCancel()
 
 			tmpDir := t.TempDir()
 			updMarkerFilePath := filepath.Join(tmpDir, markerFilename)
 
 			waitContext, waitCancel := context.WithCancel(testCtx)
+			defer waitCancel()
+
+			fakeTimeout := 30 * time.Second
+
 			// in order to take timing out of the equation provide a context that we can cancel manually
 			// still assert that the parent context and timeout passed are correct
 			var createContextFunc createContextWithTimeout = func(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 				assert.Same(t, testCtx, ctx, "parent context should be the same as the waitForWatcherCall")
-				assert.Equal(t, tt.timeout, timeout, "timeout used in new context should be the same as testcase")
+				assert.Equal(t, fakeTimeout, timeout, "timeout used in new context should be the same as testcase")
 
 				return waitContext, waitCancel
 			}
@@ -848,6 +848,8 @@ func TestWaitForWatcher(t *testing.T) {
 
 			wg.Add(1)
 
+			// worker goroutine: writes out additional states while the test is blocked on waitOnWatcher() call and expires
+			// the wait context if cancelWaitContext is set to true. Timing of the goroutine is driven by stateChangeInterval.
 			go func() {
 				defer wg.Done()
 				tick := time.NewTicker(tt.stateChangeInterval)
@@ -860,16 +862,15 @@ func TestWaitForWatcher(t *testing.T) {
 						writeState(t, updMarkerFilePath, state)
 					}
 				}
-				<-time.After(tt.expirationAfterLastState)
-				waitCancel()
+				if tt.cancelWaitContext {
+					<-tick.C
+					waitCancel()
+				}
 			}()
 
 			log, _ := logger.NewTesting(tt.name)
 
-			tt.wantErr(t, waitForWatcherWithTimeoutCreationFunc(testCtx, log, updMarkerFilePath, tt.timeout, createContextFunc), fmt.Sprintf("waitForWatcher %s, %v, %s, %s)", updMarkerFilePath, tt.states, tt.stateChangeInterval, tt.timeout))
-
-			// cancel context
-			cancel()
+			tt.wantErr(t, waitForWatcherWithTimeoutCreationFunc(testCtx, log, updMarkerFilePath, fakeTimeout, createContextFunc), fmt.Sprintf("waitForWatcher %s, %v, %s, %s)", updMarkerFilePath, tt.states, tt.stateChangeInterval, fakeTimeout))
 
 			// wait for goroutines to finish
 			wg.Wait()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Refactor TestWaitForWatcher removing timeouts altogether. 
Context canceling is now done with an explicit call to a `context.CancelFunc`. This should help with timing issue when the test is running on a very slow machine.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
TestWaitForWatcher should no longer be flaky
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #4385

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
