### PR TITLE
Use IgnoreCommas in default config options

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2434,11 +2434,11 @@ Contents of probable licence file $GOMODCACHE/github.com/elastic/go-sysinfo@v1.1
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/go-ucfg
-Version: v0.8.6
+Version: v0.8.8
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/go-ucfg@v0.8.6/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/go-ucfg@v0.8.8/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/changelog/fragments/1710868294-ucfg-parser-fix.yaml
+++ b/changelog/fragments/1710868294-ucfg-parser-fix.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: ucfg-parser-fix
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: Fix config unpacking when config strings contain list-like passages
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/4436
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/elastic/go-elasticsearch/v8 v8.12.1
 	github.com/elastic/go-licenser v0.4.1
 	github.com/elastic/go-sysinfo v1.13.1
-	github.com/elastic/go-ucfg v0.8.6
+	github.com/elastic/go-ucfg v0.8.8
 	github.com/fatih/color v1.15.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gofrs/flock v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -820,7 +820,6 @@ github.com/elastic/go-sysinfo v1.1.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6
 github.com/elastic/go-sysinfo v1.7.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=
 github.com/elastic/go-sysinfo v1.13.1 h1:U5Jlx6c/rLkR72O8wXXXo1abnGlWGJU/wbzNJ2AfQa4=
 github.com/elastic/go-sysinfo v1.13.1/go.mod h1:GKqR8bbMK/1ITnez9NIsIfXQr25aLhRJa7AfT8HpBFQ=
-github.com/elastic/go-ucfg v0.8.6 h1:stUeyh2goTgGX+/wb9gzKvTv0YB0231LTpKUgCKj4U0=
 github.com/elastic/go-ucfg v0.8.6/go.mod h1:4E8mPOLSUV9hQ7sgLEJ4bvt0KhMuDJa8joDT2QGAEKA=
 github.com/elastic/go-ucfg v0.8.8 h1:54KIF/2zFKfl0MzsSOCGOsZ3O2bnjFQJ0nDJcLhviyk=
 github.com/elastic/go-ucfg v0.8.8/go.mod h1:4E8mPOLSUV9hQ7sgLEJ4bvt0KhMuDJa8joDT2QGAEKA=

--- a/go.sum
+++ b/go.sum
@@ -822,6 +822,8 @@ github.com/elastic/go-sysinfo v1.13.1 h1:U5Jlx6c/rLkR72O8wXXXo1abnGlWGJU/wbzNJ2A
 github.com/elastic/go-sysinfo v1.13.1/go.mod h1:GKqR8bbMK/1ITnez9NIsIfXQr25aLhRJa7AfT8HpBFQ=
 github.com/elastic/go-ucfg v0.8.6 h1:stUeyh2goTgGX+/wb9gzKvTv0YB0231LTpKUgCKj4U0=
 github.com/elastic/go-ucfg v0.8.6/go.mod h1:4E8mPOLSUV9hQ7sgLEJ4bvt0KhMuDJa8joDT2QGAEKA=
+github.com/elastic/go-ucfg v0.8.8 h1:54KIF/2zFKfl0MzsSOCGOsZ3O2bnjFQJ0nDJcLhviyk=
+github.com/elastic/go-ucfg v0.8.8/go.mod h1:4E8mPOLSUV9hQ7sgLEJ4bvt0KhMuDJa8joDT2QGAEKA=
 github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=
 github.com/elastic/go-windows v1.0.1 h1:AlYZOldA+UJ0/2nBuqWdo90GFCgG9xuyw9SYzGUtJm0=
 github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQEGa3c814Ss=

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -155,9 +155,8 @@ func (c *Config) ToMapStr(opts ...interface{}) (map[string]interface{}, error) {
 	}
 	ucfgOpts, local, err := getOptions(opts...)
 	if err != nil {
-		return nil, fmt.Errorf("error unpacking logs: %w", err)
+		return nil, fmt.Errorf("error unpacking config: %w", err)
 	}
-
 	// remove and unpack each skip keys into its own map with no resolve
 	// so that variables are not substituted
 	skippedKeys := map[string]interface{}{}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -38,6 +38,7 @@ var DefaultOptions = []interface{}{
 	ucfg.ResolveEnv,
 	ucfg.VarExp,
 	VarSkipKeys("inputs"),
+	ucfg.IgnoreCommas,
 }
 
 // Config custom type over a ucfg.Config to add new methods on the object.

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -91,7 +91,7 @@ func TestCommaParsing(t *testing.T) {
 	parsedMap, err := c.ToMapStr()
 	require.NoError(t, err)
 	t.Logf("got :%#v", parsedMap)
-	assert.True(t, reflect.DeepEqual(outMap, parsedMap))
+	require.Equal(t, outMap, parsedMap)
 }
 
 func testLoadFiles(t *testing.T) {

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -78,6 +78,22 @@ func testToMapStr(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(m, nm))
 }
 
+func TestCommaParsing(t *testing.T) {
+	_ = os.Setenv("testname", "motmot")
+	// test to make sure that we don't blow up the parsers when we have a `,` in a string
+	inMap := map[string]interface{}{
+		"test": "startsWith('${testname}','motmot')",
+	}
+	outMap := map[string]interface{}{
+		"test": "startsWith('motmot','motmot')",
+	}
+	c := MustNewConfigFrom(inMap)
+	parsedMap, err := c.ToMapStr()
+	require.NoError(t, err)
+	t.Logf("got :%#v", parsedMap)
+	assert.True(t, reflect.DeepEqual(outMap, parsedMap))
+}
+
 func testLoadFiles(t *testing.T) {
 	tmp, err := os.MkdirTemp("", "watch")
 	require.NoError(t, err)


### PR DESCRIPTION

## What does this PR do?

This is the final round of fixes for https://github.com/elastic/go-ucfg/issues/196. This imports the `IgnoreCommas` option added to go-ucfg and places it as a default option.

I'm a little paranoid about this, and open to alternate suggestions as for how to fix this. I'm fairly sure that the only legitimate use case for the "original" behavior is for parsing command line args (probably like `-E list,of,things`), and I don't see anywhere in agent where this is being used. The alternative fix for this would be to make the `IgnoreCommas` option opt-in, but then we have to play whack-a-mole with the dozens of instances of `NewConfigFrom()` and `ToMapStr()` instead.

## Why is it important?

Right now, the config setup process is breaking under certain conditions where a user passes a config that looks like `'a', 'b'`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test
