### PR TITLE
[Flaky test] Skip TestEndpointLogsAreCollectedInDiagnostics

### DIFF
--- a/testing/integration/endpoint_security_test.go
+++ b/testing/integration/endpoint_security_test.go
@@ -731,6 +731,8 @@ func TestEndpointLogsAreCollectedInDiagnostics(t *testing.T) {
 }
 
 func checkDiagnosticsForEndpointFiles(t *testing.T, diagsPath string) {
+	t.Skipf("flaky test: https://github.com/elastic/elastic-agent/issues/4449")
+
 	zipReader, err := zip.OpenReader(diagsPath)
 	require.NoError(t, err, "error opening diagnostics archive")
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Skip TestEndpointLogsAreCollectedInDiagnostics

## Why is it important?

By skipping flaky tests, we're ushering in a new era of productivity, where teams can focus on delivering high-quality features without the hindrance of unreliable testing outcomes. Streamlining the development process, we optimize resource utilization, ensuring that valuable time and computing power are directed towards areas that truly matter. Our commitment to fostering a culture of trust means stakeholders can rely on accurate testing results to make informed decisions, accelerating time-to-market and giving your product a competitive edge. With increased confidence in testing outcomes, improved developer morale, and aligned testing strategies, we're not just skipping tests – we're embracing continuous improvement and shaping the future of software testing.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

 - run the integration tests
 - `TestEndpointLogsAreCollectedInDiagnostics` will be skipped

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/4449


## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
