### PR TITLE
Temporary skip `Extended runtime leak tests`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -223,15 +223,15 @@ steps:
       provider: "gcp"
       machineType: "n1-standard-8"
 
-  - label: "Extended runtime leak tests"
-    key: "extended-integration-tests"
-    command: ".buildkite/scripts/steps/integration_tests.sh stateful integration:TestForResourceLeaks"
-    artifact_paths:
-      - "build/TEST-**"
-      - "build/diagnostics/*"
-    agents:
-      provider: "gcp"
-      machineType: "n1-standard-8"    
+  # - label: "Extended runtime leak tests"
+  #   key: "extended-integration-tests"
+  #   command: ".buildkite/scripts/steps/integration_tests.sh stateful integration:TestForResourceLeaks"
+  #   artifact_paths:
+  #     - "build/TEST-**"
+  #     - "build/diagnostics/*"
+  #   agents:
+  #     provider: "gcp"
+  #     machineType: "n1-standard-8"
 
   - label: "Integration tests"
     key: "integration-tests"


### PR DESCRIPTION
The tests started failing. Disabling the tests while the failures are being investigated.

Related to https://github.com/elastic/elastic-agent/issues/4447