### PR TITLE
Re-enable resource leak tests, change timeout, improve message

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -223,15 +223,15 @@ steps:
       provider: "gcp"
       machineType: "n1-standard-8"
 
-  # - label: "Extended runtime leak tests"
-  #   key: "extended-integration-tests"
-  #   command: ".buildkite/scripts/steps/integration_tests.sh stateful integration:TestForResourceLeaks"
-  #   artifact_paths:
-  #     - "build/TEST-**"
-  #     - "build/diagnostics/*"
-  #   agents:
-  #     provider: "gcp"
-  #     machineType: "n1-standard-8"
+  - label: "Extended runtime leak tests"
+    key: "extended-integration-tests"
+    command: ".buildkite/scripts/steps/integration_tests.sh stateful integration:TestForResourceLeaks"
+    artifact_paths:
+      - "build/TEST-**"
+      - "build/diagnostics/*"
+    agents:
+      provider: "gcp"
+      machineType: "n1-standard-8"
 
   - label: "Integration tests"
     key: "integration-tests"


### PR DESCRIPTION

## What does this PR do?

Attempt to fix https://github.com/elastic/elastic-agent/issues/4447.

This increases the timeout on the health check, and improves the error message. As to why the test is flaky, my best guess right now is that the 3-minute timeout just isn't long enough on windows.

