### PR TITLE
Insert ES hosts from policy to fleet-server output

### DIFF
--- a/changelog/fragments/1711138881-Insert-ES-hosts-from-policy-to-fleet-server-output.yaml
+++ b/changelog/fragments/1711138881-Insert-ES-hosts-from-policy-to-fleet-server-output.yaml
@@ -1,0 +1,36 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Insert ES hosts from policy to fleet-server output
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  When running the fleet-server component, elastic-agent will insert
+  all Elasticsearch hosts from the policy to the component's expected
+  config. These hosts are merged with the local values that are
+  provided when the agent/server is first enrolled.
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 2784

--- a/internal/pkg/agent/application/application.go
+++ b/internal/pkg/agent/application/application.go
@@ -160,13 +160,13 @@ func New(
 		if configuration.IsFleetServerBootstrap(cfg.Fleet) {
 			log.Info("Parsed configuration and determined agent is in Fleet Server bootstrap mode")
 
-			compModifiers = append(compModifiers, FleetServerComponentModifier(cfg.Fleet.Server))
+			compModifiers = append(compModifiers, FleetServerComponentModifier(cfg.Fleet.Server, log))
 			configMgr = coordinator.NewConfigPatchManager(newFleetServerBootstrapManager(log), PatchAPMConfig(log, rawConfig))
 		} else {
 			log.Info("Parsed configuration and determined agent is managed by Fleet")
 
 			composableManaged = true
-			compModifiers = append(compModifiers, FleetServerComponentModifier(cfg.Fleet.Server),
+			compModifiers = append(compModifiers, FleetServerComponentModifier(cfg.Fleet.Server, log),
 				InjectFleetConfigComponentModifier(cfg.Fleet, agentInfo),
 				EndpointSignedComponentModifier(),
 			)

--- a/internal/pkg/agent/application/fleet_server_bootstrap.go
+++ b/internal/pkg/agent/application/fleet_server_bootstrap.go
@@ -155,7 +155,7 @@ func injectESHosts(dst, src map[string]interface{}) error {
 		}
 	}
 	hosts := make([]interface{}, 0, len(m))
-	for host, _ := range m {
+	for host := range m {
 		hosts = append(hosts, host)
 	}
 	dst["hosts"] = hosts


### PR DESCRIPTION
## What does this PR do?

When running the fleet-server component, elastic-agent will insert
all Elasticsearch hosts from the policy to the component's expected
config. These hosts are merged with the local values that are
provided when the agent/server is first enrolled.

## Why is it important?

We are not able to change the ES hosts that the fleet-server component uses without re-enrollment.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## How to test this PR locally

1. Enroll agent with a policy that contains the fleet-server integration.
2. Add another URL to the elastisearch output associated with that policy.
3. Gather diagnostics bundle from agent and inspect `fleet-server.yml`, it will now contain the additional host

## Related issues

- Closes #2784 