### PR TITLE
Add TEST_PACKAGES environment variable for integration tests

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -2285,6 +2285,7 @@ func createTestRunner(matrix bool, singleTest string, goTestFlags string, batche
 		DiagnosticsDir: diagDir,
 		StateDir:       ".integration-cache",
 		Platforms:      testPlatforms(),
+		Packages:       testPackages(),
 		Groups:         testGroups(),
 		Matrix:         matrix,
 		SingleTest:     singleTest,
@@ -2378,6 +2379,23 @@ func testPlatforms() []string {
 		}
 	}
 	return platforms
+}
+
+func testPackages() []string {
+	packagesStr, defined := os.LookupEnv("TEST_PACKAGES")
+	if !defined {
+		return nil
+	}
+
+	var packages []string
+	for _, p := range strings.Split(packagesStr, ",") {
+		if p == "tar.gz" {
+			p = "targz"
+		}
+		packages = append(packages, p)
+	}
+
+	return packages
 }
 
 func testGroups() []string {

--- a/pkg/testing/runner/config.go
+++ b/pkg/testing/runner/config.go
@@ -28,6 +28,11 @@ type Config struct {
 	// defined in this list.
 	Platforms []string
 
+	// Packages filters the tests to only run on the provided list
+	// of platforms even if the tests supports more than what is
+	// defined in this list.
+	Packages []string
+
 	// BinaryName is the name of the binary package under test, i.e, elastic-agent, metricbeat, etc
 	// this is used to copy the .tar.gz to the remote host
 	BinaryName string

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -447,20 +447,36 @@ func (r *Runner) validate() error {
 
 // getBuilds returns the build for the batch.
 func (r *Runner) getBuilds(b OSBatch) []Build {
-	builds := []Build{}
+	var builds []Build
 	formats := []string{"targz", "zip", "rpm", "deb"}
 	binaryName := "elastic-agent"
 
+	var packages []string
+	for _, p := range r.cfg.Packages {
+		if slices.Contains(formats, p) {
+			packages = append(packages, p)
+		}
+	}
+	if len(packages) == 0 {
+		packages = formats
+	}
+
 	// This is for testing beats in serverless environment
 	if strings.HasSuffix(r.cfg.BinaryName, "beat") {
-		formats = []string{"targz", "zip"}
+		var serverlessPackages []string
+		for _, p := range packages {
+			if slices.Contains([]string{"targz", "zip"}, p) {
+				packages = append(packages, p)
+			}
+		}
+		packages = serverlessPackages
 	}
 
 	if r.cfg.BinaryName != "" {
 		binaryName = r.cfg.BinaryName
 	}
 
-	for _, f := range formats {
+	for _, f := range packages {
 		arch := b.OS.Arch
 		if arch == define.AMD64 {
 			arch = "x86_64"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

add TEST_PACKAGES environment variable for integration tests

## Why is it important?

It allows to select which packages the integration test will copy to the test runner

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~


## How to test this PR locally

Run an integration tests with on;y the selected agent package built. The test should run
```
AGENT_KEEP_INSTALLED=true INSTANCE_PROVISIONER="multipass" SNAPSHOT=true TEST_PLATFORMS="linux/amd64" TEST_PACKAGES="tar.gz" mage integration:single TestFleetManagedUpgradePrivileged
```

## Related issues

- Relates #4377 


## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
