### PR TITLE
Check if the Fleet API version is different between request and response to detect an api version switch request

### DIFF
--- a/changelog/fragments/1711474205-Reduce-false-positives-in-logging-an-API-switch-request-from-Fleet-server.yaml
+++ b/changelog/fragments/1711474205-Reduce-false-positives-in-logging-an-API-switch-request-from-Fleet-server.yaml
@@ -8,7 +8,7 @@
 # - security: impacts on the security of a product or a user’s deployment.
 # - upgrade: important information for someone upgrading from a prior version
 # - other: does not fit into any of the other categories
-kind: feature
+kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
 summary: Reduce false positives in logging an API switch request from Fleet server
@@ -26,7 +26,9 @@ component: elastic-agent
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
 #pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/elastic-agent/pull/4481
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.
 #issue: https://github.com/owner/repo/1234
+issue: https://github.com/elastic/elastic-agent/issues/4477

--- a/changelog/fragments/1711474205-Reduce-false-positives-in-logging-an-API-switch-request-from-Fleet-server.yaml
+++ b/changelog/fragments/1711474205-Reduce-false-positives-in-logging-an-API-switch-request-from-Fleet-server.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Reduce false positives in logging an API switch request from Fleet server
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/fleetapi/client/client_test.go
+++ b/internal/pkg/fleetapi/client/client_test.go
@@ -183,6 +183,37 @@ func TestElasticApiVersion(t *testing.T) {
 		}
 	})
 
+	t.Run("verify that we don't log a generic 400 status as a downgrade request", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/someotheroperationreturnsbadrequest", func(writer http.ResponseWriter, request *http.Request) {
+			assert.Equal(t, request.Header.Get(elasticApiVersionHeaderKey), defaultFleetApiVersion)
+			// request return a 400 with the defaultFleetApiVersion (just testing that we don't log that as a downgrade request)
+			writer.Header().Add(elasticApiVersionHeaderKey, defaultFleetApiVersion)
+			writer.WriteHeader(http.StatusBadRequest)
+		})
+
+		ts := httptest.NewServer(mux)
+		defer ts.Close()
+
+		testLogger, obsLogs := logger.NewTesting("testElasticApiVersion")
+
+		clt, err := NewWithConfig(testLogger, remote.Config{
+			Hosts: []string{ts.URL},
+		})
+		require.NoError(t, err)
+
+		resp, err := clt.Send(ctx, http.MethodGet, "/someotheroperationreturnsbadrequest", nil, nil, nil)
+		if assert.NoError(t, err) {
+			defer resp.Body.Close()
+		}
+		logs := obsLogs.FilterMessageSnippet("fleet requested a different api version").All()
+		t.Logf("retrieved logs: %v", logs)
+		assert.Empty(t, logs, "downgrade response should not be logged when the fleet api version is the same as the request")
+	})
+
 	t.Run("verify that we log a downgrade request", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/internal/pkg/fleetapi/client/client_test.go
+++ b/internal/pkg/fleetapi/client/client_test.go
@@ -188,7 +188,7 @@ func TestElasticApiVersion(t *testing.T) {
 		defer cancel()
 
 		mux := http.NewServeMux()
-		mux.HandleFunc("/someotheroperationreturnsbadrequest", func(writer http.ResponseWriter, request *http.Request) {
+		mux.HandleFunc("/genericbadrequest", func(writer http.ResponseWriter, request *http.Request) {
 			assert.Equal(t, request.Header.Get(elasticApiVersionHeaderKey), defaultFleetApiVersion)
 			// request return a 400 with the defaultFleetApiVersion (just testing that we don't log that as a downgrade request)
 			writer.Header().Add(elasticApiVersionHeaderKey, defaultFleetApiVersion)
@@ -205,7 +205,7 @@ func TestElasticApiVersion(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		resp, err := clt.Send(ctx, http.MethodGet, "/someotheroperationreturnsbadrequest", nil, nil, nil)
+		resp, err := clt.Send(ctx, http.MethodGet, "/genericbadrequest", nil, nil, nil)
 		if assert.NoError(t, err) {
 			defer resp.Body.Close()
 		}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This PR adds a check before logging a `400 - Bad request` status code in Fleet response as a request to change `Elastic-Api-Version`.
Before this change any response indicating a bad request, containing an Elastic-Api-Version would be considered (and logged) as a switch version request.
With this change we log only if Fleet answered with an api version that is *different* from what was sent in the request.

This part of the code did not influence the response processing even before this change and the error message extraction is left to the command layer (CheckinCmd, EnrollCmd, AckCmd).

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

This should reduce the noise in the logs and avoid misleading during investigation of issues by indicating a request to switch version when in reality there was none.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

To test this fix we need either a Fleet server that returns 400 (may be a mock one) or simply run the `TestElasticApiVersion` unit tests in `internal/pkg/fleetapi/client/client_test.go`

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #4477

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
