### PR TITLE
Add in-memory logger and use it on install and uninstall

### DIFF
--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -199,7 +199,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 			return
 		}
 		fmt.Fprintf(os.Stderr, "Error uninstalling. Printing logs\n")
-		fmt.Fprintf(os.Stderr, logBuff.String())
+		fmt.Fprint(os.Stderr, logBuff.String())
 	}()
 
 	var ownership utils.FileOwner

--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/filelock"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
@@ -192,7 +193,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 
 	progBar := install.CreateAndStartNewSpinner(streams.Out, "Installing Elastic Agent...")
 
-	log, logBuff := logger.NewInMemory("install")
+	log, logBuff := logger.NewInMemory("install", logp.ConsoleEncoderConfig())
 	defer func() {
 		if err == nil {
 			return

--- a/internal/pkg/agent/cmd/uninstall.go
+++ b/internal/pkg/agent/cmd/uninstall.go
@@ -91,7 +91,7 @@ func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 			return
 		}
 		fmt.Fprintf(os.Stderr, "Error uninstalling. Printing logs\n")
-		fmt.Fprintf(os.Stderr, logBuff.String())
+		fmt.Fprint(os.Stderr, logBuff.String())
 	}()
 
 	err = install.Uninstall(paths.ConfigFile(), paths.Top(), uninstallToken, log, progBar)

--- a/internal/pkg/agent/cmd/uninstall.go
+++ b/internal/pkg/agent/cmd/uninstall.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
@@ -84,7 +85,7 @@ func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 
 	progBar := install.CreateAndStartNewSpinner(streams.Out, "Uninstalling Elastic Agent...")
 
-	log, logBuff := logger.NewInMemory("uninstall")
+	log, logBuff := logger.NewInMemory("uninstall", logp.ConsoleEncoderConfig())
 	defer func() {
 		if err == nil {
 			return

--- a/internal/pkg/agent/cmd/uninstall.go
+++ b/internal/pkg/agent/cmd/uninstall.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/elastic/elastic-agent-libs/logp"
-
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
@@ -86,28 +84,13 @@ func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 
 	progBar := install.CreateAndStartNewSpinner(streams.Out, "Uninstalling Elastic Agent...")
 
-	logCfg := logp.DefaultConfig(logp.DefaultEnvironment)
-	logCfg.Level = logp.DebugLevel
-	// Using in memory logger, so we don't write logs to the
-	// directory we are trying to delete
-	logp.ToObserverOutput()(&logCfg)
-
-	err = logp.Configure(logCfg)
-	if err != nil {
-		return fmt.Errorf("error creating logging config: %w", err)
-	}
-
-	log := logger.NewWithoutConfig("")
-
+	log, logBuff := logger.NewInMemory("uninstall")
 	defer func() {
 		if err == nil {
 			return
 		}
-		oLogs := logp.ObserverLogs().TakeAll()
 		fmt.Fprintf(os.Stderr, "Error uninstalling. Printing logs\n")
-		for _, oLog := range oLogs {
-			fmt.Fprintf(os.Stderr, "%v\n", oLog.Entry)
-		}
+		fmt.Fprintf(os.Stderr, logBuff.String())
 	}()
 
 	err = install.Uninstall(paths.ConfigFile(), paths.Top(), uninstallToken, log, progBar)

--- a/pkg/core/logger/logger.go
+++ b/pkg/core/logger/logger.go
@@ -75,12 +75,12 @@ func NewWithoutConfig(name string) *Logger {
 
 // NewInMemory returns a new in-memory logger along with the buffer to which i
 // logs.
-// This logger utilizes a console format; for details, refer to
-// ecszap.ECSCompatibleEncoderConfig and logp.ConsoleEncoderConfig.
-func NewInMemory(selector string) (*Logger, *bytes.Buffer) {
+// encCfg configures the log format, use logp.ConsoleEncoderConfig for console
+// format, logp.JSONEncoderConfig for JSON or any other valid zapcore.EncoderConfig.
+func NewInMemory(selector string, encCfg zapcore.EncoderConfig) (*Logger, *bytes.Buffer) {
 	buff := bytes.Buffer{}
 
-	encoderConfig := ecszap.ECSCompatibleEncoderConfig(logp.ConsoleEncoderConfig())
+	encoderConfig := ecszap.ECSCompatibleEncoderConfig(encCfg)
 	encoderConfig.EncodeTime = UtcTimestampEncode
 	encoder := zapcore.NewConsoleEncoder(encoderConfig)
 

--- a/pkg/core/logger/logger.go
+++ b/pkg/core/logger/logger.go
@@ -5,6 +5,7 @@
 package logger
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -70,6 +71,31 @@ func NewFromConfig(name string, cfg *Config, logInternal bool) (*Logger, error) 
 // Use only when a clean logger is needed, and it is known that the logging configuration has already been performed.
 func NewWithoutConfig(name string) *Logger {
 	return logp.NewLogger(name)
+}
+
+// NewInMemory returns a new in-memory logger along with the buffer to which i
+// logs.
+// This logger utilizes a console format; for details, refer to
+// ecszap.ECSCompatibleEncoderConfig and logp.ConsoleEncoderConfig.
+func NewInMemory(selector string) (*Logger, *bytes.Buffer) {
+	buff := bytes.Buffer{}
+
+	encoderConfig := ecszap.ECSCompatibleEncoderConfig(logp.ConsoleEncoderConfig())
+	encoderConfig.EncodeTime = UtcTimestampEncode
+	encoder := zapcore.NewConsoleEncoder(encoderConfig)
+
+	core := zapcore.NewCore(
+		encoder,
+		zapcore.AddSync(&buff),
+		zap.NewAtomicLevelAt(zap.DebugLevel))
+	ecszap.ECSCompatibleEncoderConfig(logp.ConsoleEncoderConfig())
+
+	logger := logp.NewLogger(
+		selector,
+		zap.WrapCore(func(in zapcore.Core) zapcore.Core {
+			return core
+		}))
+	return logger, &buff
 }
 
 // AddCallerSkip returns new logger with incremented stack frames to skip.
@@ -147,7 +173,7 @@ func DefaultLoggingConfig() *Config {
 	return &cfg
 }
 
-// makeInternalFileOutput creates a zapcore.Core logger that cannot be changed with configuration.
+// MakeInternalFileOutput creates a zapcore.Core logger that cannot be changed with configuration.
 //
 // This is the logger that the spawned filebeat expects to read the log file from and ship to ES.
 func MakeInternalFileOutput(cfg *Config) (zapcore.Core, error) {

--- a/pkg/core/logger/logger_test.go
+++ b/pkg/core/logger/logger_test.go
@@ -60,7 +60,7 @@ func Test_SetLevel(t *testing.T) {
 }
 
 func TestNewInMemory(t *testing.T) {
-	log, buff := NewInMemory("in_memory")
+	log, buff := NewInMemory("in_memory", logp.ConsoleEncoderConfig())
 
 	log.Debugw("a debug message", "debug_key", "debug_val")
 	log.Infow("a info message", "info_key", "info_val")

--- a/pkg/core/logger/logger_test.go
+++ b/pkg/core/logger/logger_test.go
@@ -5,8 +5,10 @@
 package logger
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
@@ -55,4 +57,32 @@ func Test_SetLevel(t *testing.T) {
 		require.Equal(t, tc.WarnEnabled, internalLevelEnabler.Enabled(zapcore.WarnLevel))
 		require.Equal(t, tc.ErrEnabled, internalLevelEnabler.Enabled(zapcore.ErrorLevel))
 	}
+}
+
+func TestNewInMemory(t *testing.T) {
+	log, buff := NewInMemory("in_memory")
+
+	log.Debugw("a debug message", "debug_key", "debug_val")
+	log.Infow("a info message", "info_key", "info_val")
+	log.Warnw("a warn message", "warn_key", "warn_val")
+	log.Errorw("an error message", "error_key", "error_val")
+
+	logs := strings.Split(strings.TrimSpace(buff.String()), "\n")
+	assert.Len(t, logs, 4, "expected 4 log entries")
+
+	assert.Contains(t, logs[0], "a debug message")
+	assert.Contains(t, logs[0], "debug_key")
+	assert.Contains(t, logs[0], "debug_val")
+
+	assert.Contains(t, logs[1], "a info message")
+	assert.Contains(t, logs[1], "info_key")
+	assert.Contains(t, logs[1], "info_val")
+
+	assert.Contains(t, logs[2], "a warn message")
+	assert.Contains(t, logs[2], "warn_key")
+	assert.Contains(t, logs[2], "warn_val")
+
+	assert.Contains(t, logs[3], "an error message")
+	assert.Contains(t, logs[3], "error_key")
+	assert.Contains(t, logs[3], "error_val")
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

It adds an in memory logger to the `pkg/core/logger` package and replaces the observer used during install and uninstall by the new in memory logger

## Why is it important?

The zap observer isn't intended to be logged, it's an feature designed for tests and when printed without any processing it is just raw Go structs, making it hard to read and understand the logs.
Those logs are printed on install or uninstall failures, where the clarity of the logs are rather important for us or the user trying to understand what went wrong.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~


## How to test this PR locally

 - run install with invalid flag values to force it to fail

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- N/A

## Logs

 - with the new in-memory logger:
```
root@elastic-agent:~# ./elastic-agent-8.14.0-SNAPSHOT-linux-x86_64/elastic-agent install -nf --url=https://REDACTED.elastic-cloud.com:443 --enrollment-token=Wrong_token
Installing in non-interactive mode.
[   =] Service Started  [1m41s] Elastic Agent successfully installed, starting enrollment.
[=== ] Waiting For Enroll...  [1m42s] {"log.level":"info","@timestamp":"2024-03-27T08:50:35.927+0100","log.origin":{"file.name":"cmd/enroll_cmd.go","file.line":530},"message":"Starting enrollment to URL: https://580c77ac20b347779aaa3c7a63a97827.fleet.us-west2.gcp.elastic-cloud.com:443/","ecs.version":"1.6.0"}
[=== ] Waiting For Enroll...  [1m42s] {"log.level":"info","@timestamp":"2024-03-27T08:50:36.804+0100","log.origin":{"file.name":"cmd/enroll_cmd.go","file.line":539},"message":"1st enrollment attempt failed, retrying for 10m0s, every 1m0s enrolling to URL: https://580c77ac20b347779aaa3c7a63a97827.fleet.us-west2.gcp.elastic-cloud.com:443/","ecs.version":"1.6.0"}
Error: fail to enroll: fail to execute request to fleet-server: status code: 401, fleet-server returned an error: ErrInvalidToken, message: token not valid utf8
For help, please see our troubleshooting guide at https://www.elastic.co/guide/en/fleet/8.14/fleet-troubleshooting.html
[ ===] Uninstalled  [1m44s] Error uninstalling. Printing logs
2024-03-27T07:48:58.882Z	DEBUG	[install]	Loaded configuration from /root/elastic-agent-8.14.0-SNAPSHOT-linux-x86_64/elastic-agent.yml
2024-03-27T07:48:58.882Z	DEBUG	[install]	Merged configuration from /root/elastic-agent-8.14.0-SNAPSHOT-linux-x86_64/elastic-agent.yml into result
2024-03-27T07:48:58.882Z	DEBUG	[install]	Merged all configuration files from [/root/elastic-agent-8.14.0-SNAPSHOT-linux-x86_64/elastic-agent.yml], no external input files
2024-03-27T07:48:58.882Z	DEBUG	[install.composable]	Starting controller for composable inputs
2024-03-27T07:48:58.882Z	DEBUG	[install.composable]	Started controller for composable inputs
2024-03-27T07:48:58.882Z	DEBUG	[install.composable]	Variable state changed for composable inputs; debounce started
2024-03-27T07:48:58.883Z	DEBUG	[install.composable]	Kubernetes leaderelection provider skipped, unable to connect: unable to build kube config due to error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
2024-03-27T07:48:58.883Z	DEBUG	[install.composable.providers.kubernetes]	Kubernetes provider for resource pod skipped, unable to connect: unable to build kube config due to error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
2024-03-27T07:48:58.883Z	DEBUG	[install.composable]	kubernetes_secrets provider skipped, unable to connect: unable to build kube config due to error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
2024-03-27T07:48:58.883Z	DEBUG	[install.composable.providers.kubernetes]	Kubernetes provider for resource node skipped, unable to connect: unable to build kube config due to error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
2024-03-27T07:48:58.894Z	DEBUG	[install.composable.providers.docker]	Start docker containers scanner
2024-03-27T07:48:58.894Z	DEBUG	[install.composable.providers.docker]	List containers
2024-03-27T07:48:58.895Z	DEBUG	[install.composable.providers.docker]	Fetching events since 2024-03-27 08:48:58.895535555 +0100 CET m=+5.211006626
2024-03-27T07:48:58.983Z	DEBUG	[install.composable]	Computing new variable state for composable inputs
2024-03-27T07:48:58.983Z	DEBUG	[install.composable.providers.docker]	Watcher stopped
2024-03-27T07:48:58.983Z	DEBUG	[install.composable]	Stopping controller for composable inputs
2024-03-27T07:48:59.084Z	DEBUG	[install.composable]	Stopped controller for composable inputs
2024-03-27T07:50:37.398Z	DEBUG	[install]	Loaded configuration from /root/elastic-agent-8.14.0-SNAPSHOT-linux-x86_64/elastic-agent.yml
2024-03-27T07:50:37.398Z	DEBUG	[install]	Merged configuration from /root/elastic-agent-8.14.0-SNAPSHOT-linux-x86_64/elastic-agent.yml into result
2024-03-27T07:50:37.398Z	DEBUG	[install]	Merged all configuration files from [/root/elastic-agent-8.14.0-SNAPSHOT-linux-x86_64/elastic-agent.yml], no external input files
2024-03-27T07:50:37.399Z	DEBUG	[install.composable]	Starting controller for composable inputs
2024-03-27T07:50:37.399Z	DEBUG	[install.composable]	Started controller for composable inputs
2024-03-27T07:50:37.399Z	DEBUG	[install.composable]	Variable state changed for composable inputs; debounce started
2024-03-27T07:50:37.399Z	DEBUG	[install.composable.providers.kubernetes]	Kubernetes provider for resource pod skipped, unable to connect: unable to build kube config due to error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
2024-03-27T07:50:37.399Z	DEBUG	[install.composable.providers.kubernetes]	Kubernetes provider for resource node skipped, unable to connect: unable to build kube config due to error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
2024-03-27T07:50:37.399Z	DEBUG	[install.composable]	kubernetes_secrets provider skipped, unable to connect: unable to build kube config due to error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
2024-03-27T07:50:37.399Z	DEBUG	[install.composable]	Kubernetes leaderelection provider skipped, unable to connect: unable to build kube config due to error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
2024-03-27T07:50:37.405Z	DEBUG	[install.composable.providers.docker]	Start docker containers scanner
2024-03-27T07:50:37.405Z	DEBUG	[install.composable.providers.docker]	List containers
2024-03-27T07:50:37.406Z	DEBUG	[install.composable.providers.docker]	Fetching events since 2024-03-27 08:50:37.406110265 +0100 CET m=+103.721581291
2024-03-27T07:50:37.499Z	DEBUG	[install.composable]	Computing new variable state for composable inputs
2024-03-27T07:50:37.499Z	DEBUG	[install.composable]	Stopping controller for composable inputs
2024-03-27T07:50:37.500Z	DEBUG	[install.composable.providers.docker]	Watcher stopped
2024-03-27T07:50:37.600Z	DEBUG	[install.composable]	Stopped controller for composable inputs
Error: enroll command failed for unknown reason: exit status 1
For help, please see our troubleshooting guide at https://www.elastic.co/guide/en/fleet/8.14/fleet-troubleshooting.html
```

 - how it's currently is:
```
root@elastic-agent:~# ./elastic-agent-8.12.2-linux-x86_64/elastic-agent  install -nf --url=https://580c77ac20b347779aaa3c7a63a97827.fleet.us-west2.gcp.elastic-cloud.com:443 --enrollment-token=REpuaGZvNEI4MmY0LUJCZzFySnM6TjZ2TEQ0bUFRN2lJSmRZOXo4TXFyUQ
Installing in non-interactive mode.
[   =] Service Started  [35s] Elastic Agent successfully installed, starting enrollment.
[==  ] Waiting For Enroll...  [36s] {"log.level":"info","@timestamp":"2024-03-27T08:53:39.751+0100","log.origin":{"file.name":"cmd/enroll_cmd.go","file.line":496},"message":"Starting enrollment to URL: https://580c77ac20b347779aaa3c7a63a97827.fleet.us-west2.gcp.elastic-cloud.com:443/","ecs.version":"1.6.0"}
[=   ] Waiting For Enroll...  [37s] {"log.level":"info","@timestamp":"2024-03-27T08:53:40.719+0100","log.origin":{"file.name":"cmd/enroll_cmd.go","file.line":505},"message":"1st enrollment attempt failed, retrying for 10m0s, every 1m0s enrolling to URL: https://580c77ac20b347779aaa3c7a63a97827.fleet.us-west2.gcp.elastic-cloud.com:443/","ecs.version":"1.6.0"}
Error: fail to enroll: fail to execute request to fleet-server: status code: 401, fleet-server returned an error: ErrInvalidToken, message: token not valid utf8
For help, please see our troubleshooting guide at https://www.elastic.co/guide/en/fleet/8.12/fleet-troubleshooting.html
[  ==] Uninstalled  [38s] Error uninstalling.  Printing logs
{debug 2024-03-27 08:53:40.957116065 +0100 CET m=+37.882332759 processes Error fetching PID info for 2, skipping: FillPidMetrics: error getting metadata for pid 2: error fetching exe from pid 2: readlink /proc/2/exe: no such file or directory github.com/elastic/elastic-agent-system-metrics@v0.9.1/metric/system/process/process.go:173 }
{debug 2024-03-27 08:53:40.957325274 +0100 CET m=+37.882541968 processes Error fetching PID info for 3, skipping: FillPidMetrics: error getting metadata for pid 3: error fetching exe from pid 3: readlink /proc/3/exe: no such file or directory github.com/elastic/elastic-agent-system-metrics@v0.9.1/metric/system/process/process.go:173 }

[...]

{debug 2024-03-27 08:53:40.972595852 +0100 CET m=+37.897812550 processes Error fetching PID info for 5582, skipping: FillPidMetrics: error getting metadata for pid 5582: error fetching exe from pid 5582: readlink /proc/5582/exe: no such file or directory github.com/elastic/elastic-agent-system-metrics@v0.9.1/metric/system/process/process.go:173 }
{debug 2024-03-27 08:53:40.987384521 +0100 CET m=+37.912601225  Loaded configuration from /root/elastic-agent-8.12.2-linux-x86_64/elastic-agent.yml github.com/elastic/elastic-agent/internal/pkg/config/loader.go:45 }
{debug 2024-03-27 08:53:40.987410892 +0100 CET m=+37.912627599  Merged configuration from /root/elastic-agent-8.12.2-linux-x86_64/elastic-agent.yml into result github.com/elastic/elastic-agent/internal/pkg/config/loader.go:57 }
{debug 2024-03-27 08:53:40.987427958 +0100 CET m=+37.912644664  Merged all configuration files from [/root/elastic-agent-8.12.2-linux-x86_64/elastic-agent.yml], no external input files github.com/elastic/elastic-agent/internal/pkg/config/loader.go:64 }
{debug 2024-03-27 08:53:40.987673866 +0100 CET m=+37.912890565 composable Starting controller for composable inputs github.com/elastic/elastic-agent/internal/pkg/composable/controller.go:112 }
{debug 2024-03-27 08:53:40.98769278 +0100 CET m=+37.912909486 composable Started controller for composable inputs github.com/elastic/elastic-agent/internal/pkg/composable/controller.go:155 }
{debug 2024-03-27 08:53:40.987734369 +0100 CET m=+37.912951054 composable Variable state changed for composable inputs; debounce started github.com/elastic/elastic-agent/internal/pkg/composable/controller.go:191 }
{debug 2024-03-27 08:53:40.988254504 +0100 CET m=+37.913471211 composable.providers.kubernetes Kubernetes provider for resource pod skipped, unable to connect: unable to build kube config due to error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable github.com/elastic/elastic-agent/internal/pkg/composable/providers/kubernetes/kubernetes.go:106 }
{debug 2024-03-27 08:53:40.988215108 +0100 CET m=+37.913431809 composable Kubernetes_secrets provider skipped, unable to connect: unable to build kube config due to error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable github.com/elastic/elastic-agent/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go:97 }
{debug 2024-03-27 08:53:40.988262372 +0100 CET m=+37.913479079 composable Kubernetes leaderelection provider skipped, unable to connect: unable to build kube config due to error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable github.com/elastic/elastic-agent/internal/pkg/composable/providers/kubernetesleaderelection/kubernetes_leaderelection.go:53 }
{debug 2024-03-27 08:53:40.988525229 +0100 CET m=+37.913741942 composable.providers.kubernetes Kubernetes provider for resource node skipped, unable to connect: unable to build kube config due to error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable github.com/elastic/elastic-agent/internal/pkg/composable/providers/kubernetes/kubernetes.go:106 }
{debug 2024-03-27 08:53:40.988535588 +0100 CET m=+37.913752286 docker Docker client will negotiate the API version on the first request. github.com/elastic/elastic-agent-autodiscover@v0.6.6/docker/client.go:49 }
{debug 2024-03-27 08:53:40.995681656 +0100 CET m=+37.920898362 composable.providers.docker Start docker containers scanner github.com/elastic/elastic-agent-autodiscover@v0.6.6/docker/watcher.go:213 }
{debug 2024-03-27 08:53:40.995697137 +0100 CET m=+37.920913838 composable.providers.docker List containers github.com/elastic/elastic-agent-autodiscover@v0.6.6/docker/watcher.go:375 }
{debug 2024-03-27 08:53:40.996064703 +0100 CET m=+37.921281423 composable.providers.docker Fetching events since 2024-03-27 08:53:40.996020388 +0100 CET m=+37.921237078 github.com/elastic/elastic-agent-autodiscover@v0.6.6/docker/watcher.go:266 }
{debug 2024-03-27 08:53:41.088208428 +0100 CET m=+38.013425144 composable Computing new variable state for composable inputs github.com/elastic/elastic-agent/internal/pkg/composable/controller.go:207 }
{debug 2024-03-27 08:53:41.088364541 +0100 CET m=+38.013581227 composable Stopping controller for composable inputs github.com/elastic/elastic-agent/internal/pkg/composable/controller.go:159 }
{debug 2024-03-27 08:53:41.088415264 +0100 CET m=+38.013631997 composable.providers.docker Watcher stopped github.com/elastic/elastic-agent-autodiscover@v0.6.6/docker/watcher.go:313 }
{debug 2024-03-27 08:53:41.188806021 +0100 CET m=+38.114022705 composable Stopped controller for composable inputs github.com/elastic/elastic-agent/internal/pkg/composable/controller.go:188 }
Error: enroll command failed for unknown reason: exit status 1
For help, please see our troubleshooting guide at https://www.elastic.co/guide/en/fleet/8.12/fleet-troubleshooting.html
```

as a side note, the absence of the `Error fetching PID` are unrelated to this change. It was fixed by another PR.

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
