### PR TITLE
Revert "Add TEST_PACKAGES environment variable for integration tests"

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -2285,7 +2285,6 @@ func createTestRunner(matrix bool, singleTest string, goTestFlags string, batche
 		DiagnosticsDir: diagDir,
 		StateDir:       ".integration-cache",
 		Platforms:      testPlatforms(),
-		Packages:       testPackages(),
 		Groups:         testGroups(),
 		Matrix:         matrix,
 		SingleTest:     singleTest,
@@ -2379,23 +2378,6 @@ func testPlatforms() []string {
 		}
 	}
 	return platforms
-}
-
-func testPackages() []string {
-	packagesStr, defined := os.LookupEnv("TEST_PACKAGES")
-	if !defined {
-		return nil
-	}
-
-	var packages []string
-	for _, p := range strings.Split(packagesStr, ",") {
-		if p == "tar.gz" {
-			p = "targz"
-		}
-		packages = append(packages, p)
-	}
-
-	return packages
 }
 
 func testGroups() []string {

--- a/pkg/testing/runner/config.go
+++ b/pkg/testing/runner/config.go
@@ -28,11 +28,6 @@ type Config struct {
 	// defined in this list.
 	Platforms []string
 
-	// Packages filters the tests to only run on the provided list
-	// of platforms even if the tests supports more than what is
-	// defined in this list.
-	Packages []string
-
 	// BinaryName is the name of the binary package under test, i.e, elastic-agent, metricbeat, etc
 	// this is used to copy the .tar.gz to the remote host
 	BinaryName string

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -447,36 +447,20 @@ func (r *Runner) validate() error {
 
 // getBuilds returns the build for the batch.
 func (r *Runner) getBuilds(b OSBatch) []Build {
-	var builds []Build
+	builds := []Build{}
 	formats := []string{"targz", "zip", "rpm", "deb"}
 	binaryName := "elastic-agent"
 
-	var packages []string
-	for _, p := range r.cfg.Packages {
-		if slices.Contains(formats, p) {
-			packages = append(packages, p)
-		}
-	}
-	if len(packages) == 0 {
-		packages = formats
-	}
-
 	// This is for testing beats in serverless environment
 	if strings.HasSuffix(r.cfg.BinaryName, "beat") {
-		var serverlessPackages []string
-		for _, p := range packages {
-			if slices.Contains([]string{"targz", "zip"}, p) {
-				packages = append(packages, p)
-			}
-		}
-		packages = serverlessPackages
+		formats = []string{"targz", "zip"}
 	}
 
 	if r.cfg.BinaryName != "" {
 		binaryName = r.cfg.BinaryName
 	}
 
-	for _, f := range packages {
+	for _, f := range formats {
 		arch := b.OS.Arch
 		if arch == define.AMD64 {
 			arch = "x86_64"


### PR DESCRIPTION
Reverts elastic/elastic-agent#4480

2 `Serverless Beats Tests` daily runs failed in a row:
* https://buildkite.com/elastic/elastic-agent/builds/8002#018e825d-3afd-42c8-9520-15c621dc191f
* https://buildkite.com/elastic/elastic-agent/builds/8013#018e8783-6cd4-45d8-bd41-1d14939d5864