### PR TITLE
[Linter] Flag usage of weak PRNG

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -149,9 +149,10 @@ linters-settings:
     go: "1.21.9"
 
   gosec:
+    includes:
+    - G404 # Use of weak random number generator
     excludes:
     - G306 # Expect WriteFile permissions to be 0600 or less
-    - G404 # Use of weak random number generator
     - G401 # Detect the usage of DES, RC4, MD5 or SHA1: Used in non-crypto contexts.
     - G501 # Import blocklist: crypto/md5: Used in non-crypto contexts.
     - G505 # Import blocklist: crypto/sha1: Used in non-crypto contexts.

--- a/magefile.go
+++ b/magefile.go
@@ -2817,3 +2817,13 @@ func getOtelDependencies() (*dependencies, error) {
 		Extensions: extensions,
 	}, nil
 }
+
+// TODO: remove after testing linter for https://github.com/elastic/elastic-agent/pull/4514
+func RandomPassword(passwordLength int) string {
+	runes := []rune("abcdefghijklmnopqrstuvwxyz1234567890!@#$%^&*ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	var sb strings.Builder
+	for i := 0; i < passwordLength; i++ {
+		sb.WriteRune(runes[rand.Intn(len(runes))])
+	}
+	return sb.String()
+}


### PR DESCRIPTION
## What does this PR do?

This PR implements a linter check that will raise a flag wherever we use a weak pseudorandom number generator in the code.  

## Why is it important?

To ensure we don't use a weak PRNG in security contexts, e.g. generating random passwords or tokens.

Note that it's perfectly OK to use a weak PRNG in non-security contexts, e.g. generating a random number to use in tests.  In fact, we expect that such uses will be more common than security-related uses.  Still, we want to have this linter rule in place to err on the side of caution.

To prevent the linter from flagging such non-security-related uses, add the following annotation above the corresponding line of code:

```go
//nolint:gosec // G404 <reason>
```