### PR TITLE
Fix failing upgrade command when gRPC server interrupts connection

### DIFF
--- a/changelog/fragments/1712305270-fix-upgrade-cmd-fail-when-disconnected.yaml
+++ b/changelog/fragments/1712305270-fix-upgrade-cmd-fail-when-disconnected.yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+summary: Fix failing upgrade command when gRPC server interrupts connection
+component: "elastic-agent"
+pr: https://github.com/elastic/elastic-agent/pull/4519
+issue: https://github.com/elastic/elastic-agent/issues/3890

--- a/internal/pkg/agent/cmd/upgrade.go
+++ b/internal/pkg/agent/cmd/upgrade.go
@@ -58,10 +58,14 @@ func newUpgradeCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Comman
 }
 
 func upgradeCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error {
+	c := client.New()
+	return upgradeCmdWithClient(streams, cmd, args, c)
+}
+
+func upgradeCmdWithClient(streams *cli.IOStreams, cmd *cobra.Command, args []string, c client.Client) error {
 	version := args[0]
 	sourceURI, _ := cmd.Flags().GetString(flagSourceURI)
 
-	c := client.New()
 	err := c.Connect(context.Background())
 	if err != nil {
 		return errors.New(err, "Failed communicating to running daemon", errors.TypeNetwork, errors.M("socket", control.Address()))

--- a/internal/pkg/agent/cmd/upgrade.go
+++ b/internal/pkg/agent/cmd/upgrade.go
@@ -8,8 +8,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/elastic/elastic-agent/pkg/control"
 	"github.com/elastic/elastic-agent/pkg/control/v2/client"
@@ -106,7 +109,14 @@ func upgradeCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error
 	skipDefaultPgp, _ := cmd.Flags().GetBool(flagSkipDefaultPgp)
 	version, err = c.Upgrade(context.Background(), version, sourceURI, skipVerification, skipDefaultPgp, pgpChecks...)
 	if err != nil {
-		return errors.New(err, "Failed trigger upgrade of daemon")
+		s, ok := status.FromError(err)
+		// Sometimes the gRPC server shuts down before replying to the command which is expected
+		// we can determine this state by the EOF error coming from the server.
+		// If the server is just unavailable/not running, we should not succeed.
+		isConnectionInterrupted := ok && s.Code() == codes.Unavailable && strings.Contains(s.Message(), "EOF")
+		if !isConnectionInterrupted {
+			return errors.New(err, "Failed trigger upgrade of daemon")
+		}
 	}
 	fmt.Fprintf(streams.Out, "Upgrade triggered to version %s, Elastic Agent is currently restarting\n", version)
 	return nil

--- a/internal/pkg/agent/cmd/upgrade_test.go
+++ b/internal/pkg/agent/cmd/upgrade_test.go
@@ -11,12 +11,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/elastic-agent/internal/pkg/cli"
-	"github.com/elastic/elastic-agent/pkg/control/v2/client"
-	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+
+	"github.com/elastic/elastic-agent/internal/pkg/cli"
+	"github.com/elastic/elastic-agent/pkg/control/v2/client"
+	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
 )
 
 func TestUpgradeCmd(t *testing.T) {

--- a/internal/pkg/agent/cmd/upgrade_test.go
+++ b/internal/pkg/agent/cmd/upgrade_test.go
@@ -53,7 +53,8 @@ func TestUpgradeCmd(t *testing.T) {
 
 		// we will know that the client reached the server watching the `mock.upgrades` counter
 		require.Eventually(t, func() bool {
-			return mock.upgrades > 0
+			counter := atomic.LoadInt32(&mock.upgrades)
+			return counter > 0
 		}, 5*time.Second, 100*time.Millisecond)
 
 		// then we close the tcp server which is supposed to interrupt the connection

--- a/internal/pkg/agent/cmd/upgrade_test.go
+++ b/internal/pkg/agent/cmd/upgrade_test.go
@@ -1,0 +1,84 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent/internal/pkg/cli"
+	"github.com/elastic/elastic-agent/pkg/control/v2/client"
+	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestUpgradeCmd(t *testing.T) {
+	t.Run("no error when connection gets interrupted", func(t *testing.T) {
+		tcpServer, err := net.Listen("unix", "test-upgrade-cmd.sock")
+		require.NoError(t, err)
+		defer tcpServer.Close()
+
+		s := grpc.NewServer()
+		serverStop := make(chan struct{})
+		mock := &mockServer{upgradeStop: serverStop}
+		cproto.RegisterElasticAgentControlServer(s, mock)
+		go func() {
+			err := s.Serve(tcpServer)
+			assert.NoError(t, err)
+		}()
+
+		clientStop := make(chan struct{})
+		c := client.New(client.WithAddress(tcpServer.Addr().String()))
+		args := []string{"--skip-verify", "8.13.0"}
+		streams := cli.NewIOStreams()
+		cmd := newUpgradeCommandWithArgs(args, streams)
+
+		// the upgrade command will hang until the server shut down
+		go func() {
+			err = upgradeCmdWithClient(streams, cmd, args, c)
+			assert.NoError(t, err)
+			// verify that we actually talked to the server
+			assert.Equal(t, int32(1), mock.upgrades, "server should have handled one upgrade")
+			// unblock the test execution
+			close(clientStop)
+		}()
+
+		// we will know that the client reached the server watching the `mock.upgrades` counter
+		require.Eventually(t, func() bool {
+			return mock.upgrades > 0
+		}, 5*time.Second, 100*time.Millisecond)
+
+		// then we close the tcp server which is supposed to interrupt the connection
+		s.Stop()
+		// this stops the mock server
+		close(serverStop)
+		// this makes sure all client assertions are done
+		<-clientStop
+	})
+}
+
+type mockServer struct {
+	cproto.ElasticAgentControlServer
+	upgradeStop chan struct{}
+	upgrades    int32
+}
+
+func (s *mockServer) Upgrade(ctx context.Context, r *cproto.UpgradeRequest) (resp *cproto.UpgradeResponse, err error) {
+	atomic.AddInt32(&s.upgrades, 1)
+	<-s.upgradeStop
+	return nil, nil
+}
+
+func (s *mockServer) State(ctx context.Context, r *cproto.Empty) (resp *cproto.StateResponse, err error) {
+	return &cproto.StateResponse{
+		State: cproto.State_HEALTHY,
+		Info:  &cproto.StateAgentInfo{},
+	}, nil
+}

--- a/internal/pkg/agent/cmd/upgrade_test.go
+++ b/internal/pkg/agent/cmd/upgrade_test.go
@@ -46,7 +46,8 @@ func TestUpgradeCmd(t *testing.T) {
 			err = upgradeCmdWithClient(streams, cmd, args, c)
 			assert.NoError(t, err)
 			// verify that we actually talked to the server
-			assert.Equal(t, int32(1), mock.upgrades, "server should have handled one upgrade")
+			counter := atomic.LoadInt32(&mock.upgrades)
+			assert.Equal(t, int32(1), counter, "server should have handled one upgrade")
 			// unblock the test execution
 			close(clientStop)
 		}()

--- a/testing/upgradetest/upgrader.go
+++ b/testing/upgradetest/upgrader.go
@@ -12,9 +12,12 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/otiai10/copy"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/details"
 	v1client "github.com/elastic/elastic-agent/pkg/control/v1/client"
@@ -325,7 +328,15 @@ func PerformUpgrade(
 
 	upgradeOutput, err := startFixture.Exec(ctx, upgradeCmdArgs)
 	if err != nil {
-		return fmt.Errorf("failed to start agent upgrade to version %q: %w\n%s", endVersionInfo.Binary.Version, err, upgradeOutput)
+		s, ok := status.FromError(err)
+		// Sometimes the gRPC server shuts down before replying to the command which is expected
+		// we can determine this state by the EOF error coming from the server.
+		// If the server is just unavailable/not running, we should not succeed.
+		// Starting with version 8.13.2, this is handled by the upgrade command itself.
+		isConnectionInterrupted := ok && s.Code() == codes.Unavailable && strings.Contains(s.Message(), "EOF")
+		if !isConnectionInterrupted {
+			return fmt.Errorf("failed to start agent upgrade to version %q: %w\n%s", endVersionInfo.Binary.Version, err, upgradeOutput)
+		}
 	}
 
 	// wait for the watcher to show up


### PR DESCRIPTION
## What does this PR do?

The upgrade CLI command creates a client, connects to the Elastic Agent server and triggers the upgrade process which is supposed to shut down the agent and start the upgrade. Sometimes, this happens before the client gets a successful response and the upgrade command returns an error code although the upgrade succeeded.

This change checks if the connection was interrupted and treats it as a successful result instead of error.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
This race condition occasionally fails our integration tests.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
~~- [ ] I have added an integration test or an E2E test~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes https://github.com/elastic/elastic-agent/issues/3890