### PR TITLE
Use pre-defined Github actions, enable Slack notifications

### DIFF
--- a/.github/workflows/bump-agent-versions.sh
+++ b/.github/workflows/bump-agent-versions.sh
@@ -15,8 +15,6 @@ else
         exit 0
     fi
     git diff -p
-    git config --global user.name 'apmmachine'
-    git config --global user.email 'apmmachine@users.noreply.github.com'
     git add ".agent-versions.json"
     git commit -m "[$GITHUB_REF_NAME](automation) Update .agent-versions.json" -m "This file is used for picking agent versions in integration tests.\n\nThe file's content is based on responses from https://www.elastic.co/api/product_versions and https://snapshots.elastic.co\n\nThe current update is generated based on the following requirements:\n\`\`\`json\n$version_requirements\n\`\`\`"
     git push --set-upstream origin "update-agent-versions-$GITHUB_RUN_ID"

--- a/.github/workflows/bump-agent-versions.yml
+++ b/.github/workflows/bump-agent-versions.yml
@@ -9,6 +9,15 @@ jobs:
   update_versions:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Git
+        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+
+      - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -32,5 +41,23 @@ jobs:
 
       - name: Update versions file
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ env.GITHUB_TOKEN }}
         run: ./.github/workflows/bump-agent-versions.sh
+
+      - if: ${{ failure() }}
+        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          message: ":traffic_cone: Elastic Agent versions file update failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          channel: "#ingest-notifications"
+
+      - if: ${{ success() }}
+        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          message: "Update for Elastic Agent versions file has been created https://github.com/elastic/elastic-agent/pulls?q=is%3Aopen+is%3Apr+label%3Aupdate-versions"
+          channel: "#ingest-notifications"


### PR DESCRIPTION
This should solve permission issues with triggering buildkite builds and will notify our team about failed and successful attempts to update the version file.
