### PR TITLE
Make enroll command more stable

### DIFF
--- a/changelog/fragments/1712324173-improve-enroll-stability.yaml
+++ b/changelog/fragments/1712324173-improve-enroll-stability.yaml
@@ -1,0 +1,5 @@
+kind: enhancement
+summary: Make enroll command more stable by handling temporary server errors
+component: elastic-agent
+pr: https://github.com/elastic/elastic-agent/pull/4523
+issue: https://github.com/elastic/elastic-agent/issues/4513

--- a/internal/pkg/fleetapi/enroll_cmd_test.go
+++ b/internal/pkg/fleetapi/enroll_cmd_test.go
@@ -131,7 +131,7 @@ func TestEnroll(t *testing.T) {
 			mux.HandleFunc("/api/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusServiceUnavailable)
 				w.Header().Set("Content-Type", "application/json")
-				_, err := w.Write([]byte(`{"statusCode": 503, "error":"maintainence"}`))
+				_, err := w.Write([]byte(`{"statusCode": 503, "error":"maintenance"}`))
 				assert.NoError(t, err)
 			})
 			return mux

--- a/internal/pkg/fleetapi/enroll_cmd_test.go
+++ b/internal/pkg/fleetapi/enroll_cmd_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
@@ -58,7 +59,8 @@ func TestEnroll(t *testing.T) {
 				b, err := json.Marshal(response)
 				require.NoError(t, err)
 
-				w.Write(b)
+				_, err = w.Write(b)
+				assert.NoError(t, err)
 			})
 			return mux
 		}, func(t *testing.T, host string) {
@@ -93,7 +95,8 @@ func TestEnroll(t *testing.T) {
 			mux.HandleFunc("/api/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 				w.Header().Set("Content-Type", "application/json")
-				w.Write([]byte(`{"statusCode": 500, "error":"Something is really bad here"}`))
+				_, err := w.Write([]byte(`{"statusCode": 500, "error":"Something is really bad here"}`))
+				assert.NoError(t, err)
 			})
 			return mux
 		}, func(t *testing.T, host string) {
@@ -128,7 +131,8 @@ func TestEnroll(t *testing.T) {
 			mux.HandleFunc("/api/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusServiceUnavailable)
 				w.Header().Set("Content-Type", "application/json")
-				w.Write([]byte(`{"statusCode": 503, "error":"maintainence"}`))
+				_, err := w.Write([]byte(`{"statusCode": 503, "error":"maintainence"}`))
+				assert.NoError(t, err)
 			})
 			return mux
 		}, func(t *testing.T, host string) {


### PR DESCRIPTION
## What does this PR do?

* Fixed incorrect backoff configuration that could cause every retry iteration to last 10 minutes
* Add support for temporary/recoverable server errors when doing requests to Fleet

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
We have our integration tests failing without these improvements that means our customers are likely experiencing this too.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
~~- [ ] I have added an integration test or an E2E test~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/4513