### PR TITLE
Fix panic when handling error in process dumping

### DIFF
--- a/pkg/testing/fixture_install.go
+++ b/pkg/testing/fixture_install.go
@@ -189,7 +189,7 @@ func (f *Fixture) installNoPkgManager(ctx context.Context, installOpts *InstallO
 			f.t.Logf("Dumping running processes in %s", filePath)
 			file, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 			if err != nil {
-				f.t.Logf("failed to dump process; failed to create output file %s root: %s", file.Name(), err)
+				f.t.Logf("failed to dump process; failed to create output file %s root: %s", filePath, err)
 				return
 			}
 			defer func(file *os.File) {


### PR DESCRIPTION
Cannot use the `file` variable if we failed to create/open the file.
Appeared in https://buildkite.com/elastic/elastic-agent/builds/8127#018eae91-5ab5-4b08-94a3-8bcde2881e0c