### PR TITLE
Do not fail tests when interrupted connection during upgrade

### DIFF
--- a/testing/upgradetest/upgrader.go
+++ b/testing/upgradetest/upgrader.go
@@ -330,7 +330,8 @@ func PerformUpgrade(
 		// we can determine this state by the EOF error coming from the server.
 		// If the server is just unavailable/not running, we should not succeed.
 		// Starting with version 8.13.2, this is handled by the upgrade command itself.
-		isConnectionInterrupted := strings.Contains(err.Error(), "Unavailable") && strings.Contains(err.Error(), "EOF")
+		outputString := string(upgradeOutput)
+		isConnectionInterrupted := strings.Contains(outputString, "Unavailable") && strings.Contains(outputString, "EOF")
 		if !isConnectionInterrupted {
 			return fmt.Errorf("failed to start agent upgrade to version %q: %w\n%s", endVersionInfo.Binary.Version, err, upgradeOutput)
 		}


### PR DESCRIPTION
Older agent versions don't properly handle an interrupted connection during the upgrade. So, we need to handle it in tests.

The check was introduced in 4ad7824108ef29ec911efddb7f5f847a8c186ae2 however it checked a wrong string, it was supposed to check the output of the command not the actual error string.

Closes https://github.com/elastic/elastic-agent/issues/3890