### PR TITLE
Send Slack notifications only when versions file PR is created

### DIFF
--- a/.github/workflows/bump-agent-versions.sh
+++ b/.github/workflows/bump-agent-versions.sh
@@ -17,10 +17,10 @@ else
     git diff -p
     git add ".agent-versions.json"
 
-		nl=$'\n' # otherwise the new line character is not recognized properly
-		commit_desc="This file is used for picking agent versions in integration tests.${nl}${nl}The file's content is based on responses from https://www.elastic.co/api/product_versions and https://snapshots.elastic.co${nl}${nl}The current update is generated based on the following requirements:${nl}${nl}\`\`\`json${nl}${version_requirements}${nl}\`\`\`"
+    nl=$'\n' # otherwise the new line character is not recognized properly
+    commit_desc="This file is used for picking agent versions in integration tests.${nl}${nl}The file's content is based on responses from https://www.elastic.co/api/product_versions and https://snapshots.elastic.co${nl}${nl}The current update is generated based on the following requirements:${nl}${nl}\`\`\`json${nl}${version_requirements}${nl}\`\`\`"
 
-		git commit -m "[$GITHUB_REF_NAME][Automation] Update .agent-versions.json" -m "$commit_desc"
+    git commit -m "[$GITHUB_REF_NAME][Automation] Update .agent-versions.json" -m "$commit_desc"
     git push --set-upstream origin "update-agent-versions-$GITHUB_RUN_ID"
     gh pr create \
        --base "$GITHUB_REF_NAME" \
@@ -31,4 +31,5 @@ else
        --label 'skip-changelog' \
        --label 'backport-skip' \
        --repo $GITHUB_REPOSITORY
+    echo "::set-output name=pr::true" # set step output for notifications
 fi

--- a/.github/workflows/bump-agent-versions.yml
+++ b/.github/workflows/bump-agent-versions.yml
@@ -40,6 +40,7 @@ jobs:
           install-only: true
 
       - name: Update versions file
+        id: update
         env:
           GH_TOKEN: ${{ env.GITHUB_TOKEN }}
         run: ./.github/workflows/bump-agent-versions.sh
@@ -53,7 +54,7 @@ jobs:
           message: ":traffic_cone: Elastic Agent versions file update failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           channel: "#ingest-notifications"
 
-      - if: ${{ success() }}
+      - if: ${{ success() && steps.update.output.pr == true}}
         uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
         with:
           url: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
Currently, the Slack message is sent on every successful job run which is incorrect. The message should be sent only when a new PR is created.