### PR TITLE
fix branch_configuration location in catalog-info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -130,8 +130,8 @@ spec:
     metadata:
       name: elastic-agent-binary-dra
       description: Buildkite pipeline for packaging Elastic Agent core binary and publish it to DRA
-    branch_configuration: "main 7.* 8.* v7.* v8.*"
     spec:
+      branch_configuration: "main 7.* 8.* v7.* v8.*"
       pipeline_file: ".buildkite/pipeline.elastic-agent-binary-dra.yml"
       provider_settings:
         build_pull_request_forks: false


### PR DESCRIPTION
The `branch_configuration` property needs to be under the `spec` block, otherwise terrazzo refuses to parse the config because it's invalid.

Related: https://github.com/elastic/elastic-agent/pull/4550