### PR TITLE
Rename define.NewFixture to define.NewFixtureFromLocalBuild

### DIFF
--- a/pkg/testing/define/define.go
+++ b/pkg/testing/define/define.go
@@ -66,9 +66,9 @@ func Version() string {
 	return ver
 }
 
-// NewFixture returns a new Elastic Agent testing fixture with a LocalFetcher and
+// NewFixtureFromLocalBuild returns a new Elastic Agent testing fixture with a LocalFetcher and
 // the agent logging to the test logger.
-func NewFixture(t *testing.T, version string, opts ...atesting.FixtureOpt) (*atesting.Fixture, error) {
+func NewFixtureFromLocalBuild(t *testing.T, version string, opts ...atesting.FixtureOpt) (*atesting.Fixture, error) {
 	buildsDir := os.Getenv("AGENT_BUILD_DIR")
 	if buildsDir == "" {
 		projectDir, err := findProjectRoot()
@@ -82,7 +82,7 @@ func NewFixture(t *testing.T, version string, opts ...atesting.FixtureOpt) (*ate
 
 }
 
-// NewFixture returns a new Elastic Agent testing fixture with a LocalFetcher and
+// NewFixtureWithBinary returns a new Elastic Agent testing fixture with a LocalFetcher and
 // the agent logging to the test logger.
 func NewFixtureWithBinary(t *testing.T, version string, binary string, buildsDir string, opts ...atesting.FixtureOpt) (*atesting.Fixture, error) {
 	ver, err := semver.ParseVersion(version)

--- a/testing/integration/agent_long_running_leak_test.go
+++ b/testing/integration/agent_long_running_leak_test.go
@@ -103,7 +103,7 @@ func (runner *ExtendedRunner) SetupSuite() {
 		Privileged:     true,
 	}
 
-	fixture, err := define.NewFixture(runner.T(), define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(runner.T(), define.Version())
 	require.NoError(runner.T(), err)
 	runner.agentFixture = fixture
 
@@ -173,7 +173,7 @@ func (runner *ExtendedRunner) TestHandleLeak() {
 	// if the slope is increasing above a certain rate, fail the test
 	// A number of factors can change the slope during a test; shortened runtime (lots of handles allocated in the first few seconds, producing an upward slope),
 	// filebeat trying to open a large number of log files, etc
-	//handleSlopeFailure := 0.1
+	// handleSlopeFailure := 0.1
 	for _, mon := range runner.resourceWatchers {
 		handleSlopeFailure := 0.1
 
@@ -320,7 +320,7 @@ func (gm *goroutinesMonitor) Update(t *testing.T, fixture *atesting.Fixture) {
 }
 
 func (gm *goroutinesMonitor) GetSlopeHandlers() []tools.Slope {
-	//handleSlopeFailure := 0.1
+	// handleSlopeFailure := 0.1
 	slopes := []tools.Slope{}
 	for _, handle := range gm.handles {
 		slopes = append(slopes, handle.regGoroutines)

--- a/testing/integration/apm_propagation_test.go
+++ b/testing/integration/apm_propagation_test.go
@@ -56,7 +56,7 @@ func TestAPMConfig(t *testing.T) {
 		Group: Default,
 		Stack: &define.Stack{},
 	})
-	f, err := define.NewFixture(t, define.Version())
+	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	deadline := time.Now().Add(10 * time.Minute)
@@ -88,7 +88,7 @@ func TestAPMConfig(t *testing.T) {
 			return count > 0
 		}, 1*time.Minute, time.Second)
 
-		//change the configuration with a new environment and check that the update has been processed
+		// change the configuration with a new environment and check that the update has been processed
 		environment = environment + "-changed"
 		modifiedAgentConfig := generateAgentConfigForAPM(t, agentConfigTemplateString, info, environment)
 		t.Logf("Rendered agent modified config:\n%s", modifiedAgentConfig)
@@ -178,8 +178,8 @@ func countAPMTraces(ctx context.Context, t *testing.T, esClient *elasticsearch.C
 		Count int
 	}
 
-	//decoder := json.NewDecoder(response.Body)
-	//err = decoder.Decode(&body)
+	// decoder := json.NewDecoder(response.Body)
+	// err = decoder.Decode(&body)
 	bodyBytes, _ := io.ReadAll(response.Body)
 
 	t.Logf("received ES response: %s", bodyBytes)

--- a/testing/integration/container_cmd_test.go
+++ b/testing/integration/container_cmd_test.go
@@ -38,7 +38,7 @@ func TestContainerCMD(t *testing.T) {
 	})
 	ctx := context.Background()
 
-	agentFixture, err := define.NewFixture(t, define.Version())
+	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	createPolicyReq := kibana.AgentPolicy{

--- a/testing/integration/delay_enroll_test.go
+++ b/testing/integration/delay_enroll_test.go
@@ -36,7 +36,7 @@ func TestDelayEnroll(t *testing.T) {
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
-	agentFixture, err := define.NewFixture(t, define.Version())
+	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	// 1. Create a policy in Fleet with monitoring enabled.

--- a/testing/integration/diagnostics_test.go
+++ b/testing/integration/diagnostics_test.go
@@ -93,7 +93,7 @@ func TestDiagnosticsOptionalValues(t *testing.T) {
 		Local: false,
 	})
 
-	fixture, err := define.NewFixture(t, define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
@@ -119,7 +119,7 @@ func TestDiagnosticsCommand(t *testing.T) {
 		Local: false,
 	})
 
-	f, err := define.NewFixture(t, define.Version())
+	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))

--- a/testing/integration/endpoint_security_test.go
+++ b/testing/integration/endpoint_security_test.go
@@ -166,7 +166,7 @@ func testInstallAndCLIUninstallWithEndpointSecurity(t *testing.T, info *define.I
 	defer cancel()
 
 	// Get path to agent executable.
-	fixture, err := define.NewFixture(t, define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err, "could not create agent fixture")
 
 	t.Log("Enrolling the agent in Fleet")
@@ -226,7 +226,7 @@ func testInstallAndCLIUninstallWithEndpointSecurity(t *testing.T, info *define.I
 
 func testInstallAndUnenrollWithEndpointSecurity(t *testing.T, info *define.Info, protected bool) {
 	// Get path to agent executable.
-	fixture, err := define.NewFixture(t, define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	t.Log("Enrolling the agent in Fleet")
@@ -339,7 +339,7 @@ func testInstallAndUnenrollWithEndpointSecurity(t *testing.T, info *define.Info,
 
 func testInstallWithEndpointSecurityAndRemoveEndpointIntegration(t *testing.T, info *define.Info, protected bool) {
 	// Get path to agent executable.
-	fixture, err := define.NewFixture(t, define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	t.Log("Enrolling the agent in Fleet")
@@ -511,7 +511,7 @@ func TestEndpointSecurityNonDefaultBasePath(t *testing.T) {
 	defer cn()
 
 	// Get path to agent executable.
-	fixture, err := define.NewFixture(t, define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	t.Log("Enrolling the agent in Fleet")
@@ -589,7 +589,7 @@ func TestEndpointSecurityUnprivileged(t *testing.T) {
 	defer cn()
 
 	// Get path to agent executable.
-	fixture, err := define.NewFixture(t, define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	t.Log("Enrolling the agent in Fleet")
@@ -665,7 +665,7 @@ func TestEndpointLogsAreCollectedInDiagnostics(t *testing.T) {
 	defer cn()
 
 	// Get path to agent executable.
-	fixture, err := define.NewFixture(t, define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	t.Log("Enrolling the agent in Fleet")

--- a/testing/integration/fake_test.go
+++ b/testing/integration/fake_test.go
@@ -49,7 +49,7 @@ func TestFakeComponent(t *testing.T) {
 		Local: true,
 	})
 
-	f, err := define.NewFixture(t, define.Version())
+	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))

--- a/testing/integration/fqdn_test.go
+++ b/testing/integration/fqdn_test.go
@@ -42,7 +42,7 @@ func TestFQDN(t *testing.T) {
 		Sudo:  true,
 	})
 
-	agentFixture, err := define.NewFixture(t, define.Version())
+	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	externalIP, err := getExternalIP()

--- a/testing/integration/install_privileged_test.go
+++ b/testing/integration/install_privileged_test.go
@@ -35,7 +35,7 @@ func TestInstallPrivilegedWithoutBasePath(t *testing.T) {
 	})
 
 	// Get path to Elastic Agent executable
-	fixture, err := define.NewFixture(t, define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
@@ -87,7 +87,7 @@ func TestInstallPrivilegedWithBasePath(t *testing.T) {
 	})
 
 	// Get path to Elastic Agent executable
-	fixture, err := define.NewFixture(t, define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))

--- a/testing/integration/install_test.go
+++ b/testing/integration/install_test.go
@@ -38,7 +38,7 @@ func TestInstallWithoutBasePath(t *testing.T) {
 	})
 
 	// Get path to Elastic Agent executable
-	fixture, err := define.NewFixture(t, define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
@@ -105,7 +105,7 @@ func TestInstallWithBasePath(t *testing.T) {
 	})
 
 	// Get path to Elastic Agent executable
-	fixture, err := define.NewFixture(t, define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
@@ -200,7 +200,7 @@ func TestRepeatedInstallUninstall(t *testing.T) {
 
 			topPath := filepath.Join(defaultBasePath, "Elastic", "Agent")
 			// Get path to Elastic Agent executable
-			fixture, err := define.NewFixture(t, define.Version())
+			fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 			require.NoError(t, err)
 
 			ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(maxRunTime))

--- a/testing/integration/logs_ingestion_test.go
+++ b/testing/integration/logs_ingestion_test.go
@@ -49,7 +49,7 @@ func TestLogIngestionFleetManaged(t *testing.T) {
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
-	agentFixture, err := define.NewFixture(t, define.Version())
+	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	// 1. Create a policy in Fleet with monitoring enabled.
@@ -117,7 +117,7 @@ func TestDebLogIngestFleetManaged(t *testing.T) {
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
-	agentFixture, err := define.NewFixture(t, define.Version(), atesting.WithPackageFormat("deb"))
+	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), atesting.WithPackageFormat("deb"))
 	require.NoError(t, err)
 
 	// 1. Create a policy in Fleet with monitoring enabled.
@@ -185,7 +185,7 @@ func TestRpmLogIngestFleetManaged(t *testing.T) {
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
-	agentFixture, err := define.NewFixture(t, define.Version(), atesting.WithPackageFormat("rpm"))
+	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), atesting.WithPackageFormat("rpm"))
 	require.NoError(t, err)
 
 	// 1. Create a policy in Fleet with monitoring enabled.
@@ -280,7 +280,7 @@ func testMonitoringLogsAreShipped(
 			"add_cloud_metadata: received error failed requesting openstack metadata: Get \\\"https://169.254.169.254/2009-04-04/meta-data/instance-type\\\": dial tcp 169.254.169.254:443: connect: connection refused",               // okay for the cloud metadata to not work
 			"add_cloud_metadata: received error failed with http status code 404", // okay for the cloud metadata to not work
 			"add_cloud_metadata: received error failed fetching EC2 Identity Document: operation error ec2imds: GetInstanceIdentityDocument, http response error StatusCode: 404, request to EC2 IMDS failed", // okay for the cloud metadata to not work
-			"failed to invoke rollback watcher: failed to start Upgrade Watcher: fork/exec /var/lib/elastic-agent/elastic-agent: no such file or directory",                                                   //on debian this happens probably need to fix.
+			"failed to invoke rollback watcher: failed to start Upgrade Watcher: fork/exec /var/lib/elastic-agent/elastic-agent: no such file or directory",                                                   // on debian this happens probably need to fix.
 		})
 	})
 	t.Logf("error logs: Got %d documents", len(docs.Hits.Hits))

--- a/testing/integration/metrics_monitoring_test.go
+++ b/testing/integration/metrics_monitoring_test.go
@@ -47,7 +47,7 @@ func TestMetricsMonitoringCorrectBinaries(t *testing.T) {
 }
 
 func (runner *MetricsRunner) SetupSuite() {
-	fixture, err := define.NewFixture(runner.T(), define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(runner.T(), define.Version())
 	require.NoError(runner.T(), err)
 	runner.agentFixture = fixture
 

--- a/testing/integration/otel_test.go
+++ b/testing/integration/otel_test.go
@@ -128,7 +128,7 @@ func TestOtelFileProcessing(t *testing.T) {
 	cfgFilePath := filepath.Join(tempDir, "otel.yml")
 	require.NoError(t, os.WriteFile(cfgFilePath, []byte(fileProcessingConfig), 0600))
 
-	fixture, err := define.NewFixture(t, define.Version(), aTesting.WithAdditionalArgs([]string{"--config", cfgFilePath}))
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), aTesting.WithAdditionalArgs([]string{"--config", cfgFilePath}))
 	require.NoError(t, err)
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
@@ -245,7 +245,7 @@ func TestOtelAPMIngestion(t *testing.T) {
 	require.NoError(t, os.WriteFile(cfgFilePath, []byte(apmConfig), 0600))
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, fileName), []byte{}, 0600))
 
-	fixture, err := define.NewFixture(t, define.Version(), aTesting.WithAdditionalArgs([]string{"--config", cfgFilePath}))
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), aTesting.WithAdditionalArgs([]string{"--config", cfgFilePath}))
 	require.NoError(t, err)
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))

--- a/testing/integration/package_version_test.go
+++ b/testing/integration/package_version_test.go
@@ -37,7 +37,7 @@ func TestPackageVersion(t *testing.T) {
 		Local: true,
 	})
 
-	f, err := define.NewFixture(t, define.Version())
+	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
@@ -68,7 +68,7 @@ func TestComponentBuildHashInDiagnostics(t *testing.T) {
 	})
 	ctx := context.Background()
 
-	f, err := define.NewFixture(t, define.Version())
+	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err, "could not create new fixture")
 
 	err = f.Prepare(ctx)

--- a/testing/integration/proxy_url_test.go
+++ b/testing/integration/proxy_url_test.go
@@ -58,11 +58,11 @@ func SetupTest(t *testing.T) *ProxyURL {
 		proxytest.WithRequestLog("proxy-2", t.Logf),
 		proxytest.WithVerboseLog())
 
-	f, err := define.NewFixture(t,
+	f, err := define.NewFixtureFromLocalBuild(t,
 		p.agentVersion,
 		integrationtest.WithAllowErrors(),
 		integrationtest.WithLogOutput())
-	require.NoError(t, err, "SetupTest: NewFixture failed")
+	require.NoError(t, err, "SetupTest: NewFixtureFromLocalBuild failed")
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
 	defer cancel()

--- a/testing/integration/upgrade_broken_package_test.go
+++ b/testing/integration/upgrade_broken_package_test.go
@@ -37,7 +37,7 @@ func TestUpgradeBrokenPackageVersion(t *testing.T) {
 
 	// Start at the build version as we want to test the retry
 	// logic that is in the build.
-	startFixture, err := define.NewFixture(t, define.Version())
+	startFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	// Upgrade to an old build.

--- a/testing/integration/upgrade_downgrade_test.go
+++ b/testing/integration/upgrade_downgrade_test.go
@@ -47,7 +47,7 @@ func TestStandaloneDowngradeToSpecificSnapshotBuild(t *testing.T) {
 
 	// start at the build version as we want to test the retry
 	// logic that is in the build.
-	startFixture, err := define.NewFixture(t, define.Version())
+	startFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 	startVersion, err := startFixture.ExecVersion(ctx)
 	require.NoError(t, err)

--- a/testing/integration/upgrade_fleet_test.go
+++ b/testing/integration/upgrade_fleet_test.go
@@ -69,7 +69,7 @@ func testFleetManagedUpgrade(t *testing.T, info *define.Info, unprivileged bool)
 
 	// Start at the build version as we want to test the retry
 	// logic that is in the build.
-	startFixture, err := define.NewFixture(t, define.Version())
+	startFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 	err = startFixture.Prepare(ctx)
 	require.NoError(t, err)
@@ -171,7 +171,7 @@ func testFleetAirGappedUpgrade(t *testing.T, stack *define.Info, unprivileged bo
 			"It should not affect the connection to the stack. Host: %s, response body: %s",
 		stack.KibanaClient.URL, host, body)
 
-	fixture, err := define.NewFixture(t, define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 	err = fixture.Prepare(ctx)
 	require.NoError(t, err)

--- a/testing/integration/upgrade_gpg_test.go
+++ b/testing/integration/upgrade_gpg_test.go
@@ -42,7 +42,7 @@ func TestStandaloneUpgradeWithGPGFallback(t *testing.T) {
 
 	// Start at the build version as we want to test the retry
 	// logic that is in the build.
-	startFixture, err := define.NewFixture(t, define.Version())
+	startFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 	startVersionInfo, err := startFixture.ExecVersion(ctx)
 	require.NoError(t, err)
@@ -111,7 +111,7 @@ func TestStandaloneUpgradeWithGPGFallbackOneRemoteFailing(t *testing.T) {
 
 	// Start at the build version as we want to test the retry
 	// logic that is in the build.
-	startFixture, err := define.NewFixture(t, define.Version())
+	startFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	// Upgrade to an old build.

--- a/testing/integration/upgrade_rollback_test.go
+++ b/testing/integration/upgrade_rollback_test.go
@@ -63,7 +63,7 @@ func TestStandaloneUpgradeRollback(t *testing.T) {
 	require.NoError(t, err, "failed to get start agent build version info")
 
 	// Upgrade to the build under test.
-	endFixture, err := define.NewFixture(t, define.Version())
+	endFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	t.Logf("Testing Elastic Agent upgrade from %s to %s...", upgradeFromVersion, define.Version())
@@ -178,7 +178,7 @@ func TestStandaloneUpgradeRollbackOnRestarts(t *testing.T) {
 	require.NoError(t, err, "failed to get start agent build version info")
 
 	// Upgrade to the build under test.
-	endFixture, err := define.NewFixture(t, define.Version())
+	endFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	t.Logf("Testing Elastic Agent upgrade from %s to %s...", upgradeFromVersion, define.Version())

--- a/testing/integration/upgrade_standalone_inprogress_test.go
+++ b/testing/integration/upgrade_standalone_inprogress_test.go
@@ -48,7 +48,7 @@ func TestStandaloneUpgradeFailsWhenUpgradeIsInProgress(t *testing.T) {
 	)
 	require.NoError(t, err, "error creating previous agent fixture")
 
-	endFixture, err := define.NewFixture(t, define.Version())
+	endFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 	endVersionInfo, err := endFixture.ExecVersion(ctx)
 	require.NoError(t, err)

--- a/testing/integration/upgrade_standalone_retry_test.go
+++ b/testing/integration/upgrade_standalone_retry_test.go
@@ -38,7 +38,7 @@ func TestStandaloneUpgradeRetryDownload(t *testing.T) {
 
 	// Start at the build version as we want to test the retry
 	// logic that is in the build.
-	startFixture, err := define.NewFixture(t, define.Version())
+	startFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	// The end version does not matter much but it must not match

--- a/testing/integration/upgrade_standalone_same_commit_test.go
+++ b/testing/integration/upgrade_standalone_same_commit_test.go
@@ -73,7 +73,7 @@ func TestStandaloneUpgradeSameCommit(t *testing.T) {
 		defer cancel()
 
 		// ensure we use the same package version
-		startFixture, err := define.NewFixture(
+		startFixture, err := define.NewFixtureFromLocalBuild(
 			t,
 			currentVersion.String(),
 		)
@@ -89,7 +89,7 @@ func TestStandaloneUpgradeSameCommit(t *testing.T) {
 		ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
 		defer cancel()
 
-		startFixture, err := define.NewFixture(
+		startFixture, err := define.NewFixtureFromLocalBuild(
 			t,
 			currentVersion.String(),
 		)
@@ -231,7 +231,7 @@ func hackTarGzPackage(t *testing.T, reader *tar.Reader, writer *tar.Writer, oldT
 		// tar format uses forward slash as path separator, make sure we use only "path" package for checking and manipulation
 		switch path.Base(f.Name) {
 		case v1.ManifestFileName:
-			//read old content and generate the new manifest based on that
+			// read old content and generate the new manifest based on that
 			newManifest := generateNewManifestContent(t, reader, newVersion)
 			newManifestBytes := []byte(newManifest)
 
@@ -317,7 +317,7 @@ func hackZipPackage(t *testing.T, reader *zip.ReadCloser, writer *zip.Writer, ol
 		// zip format uses forward slash as path separator, make sure we use only "path" package for checking and manipulation
 		switch path.Base(zippedFile.Name) {
 		case v1.ManifestFileName:
-			//read old content
+			// read old content
 			manifestReader, err := zippedFile.Open()
 			require.NoError(t, err, "error opening manifest file in zipped package")
 

--- a/testing/integration/upgrade_standalone_test.go
+++ b/testing/integration/upgrade_standalone_test.go
@@ -67,7 +67,7 @@ func testStandaloneUpgrade(t *testing.T, startVersion *version.ParsedSemVer, end
 	)
 	require.NoError(t, err, "error creating previous agent fixture")
 
-	endFixture, err := define.NewFixture(t, endVersion)
+	endFixture, err := define.NewFixtureFromLocalBuild(t, endVersion)
 	require.NoError(t, err)
 
 	startVersionInfo, err := startFixture.ExecVersion(ctx)

--- a/testing/integration/upgrade_uninstall_test.go
+++ b/testing/integration/upgrade_uninstall_test.go
@@ -40,7 +40,7 @@ func TestStandaloneUpgradeUninstallKillWatcher(t *testing.T) {
 	defer cancel()
 
 	// Upgrades to build under test.
-	endFixture, err := define.NewFixture(t, define.Version())
+	endFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 	endVersionInfo, err := endFixture.ExecVersion(ctx)
 	require.NoError(t, err, "failed to get end agent build version info")


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Rename define.NewFixture to define.NewFixtureFromLocalBuild

## Why is it important?

There were two `NewFixture` functions returning the same fixture: `testing.NewFixture` and `define.NewFixture`. They basically differ on where the agent package comes from. This is rather confusing and easily lead to mistakes.
`testing.NewFixture` is the one which actually creates the fixture, whereas `define.NewFixture` is a wrapper around `testing.NewFixture` so it'll use the locally built agent artifact. Therefore `define.NewFixture` was renamed to `define.NewFixtureFromLocalBuild`, better reflecting what it does.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~



## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- N/A


## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
