### PR TITLE
Fix typo in the variable name when sending a Slack message

### DIFF
--- a/.github/workflows/bump-agent-versions.yml
+++ b/.github/workflows/bump-agent-versions.yml
@@ -61,5 +61,5 @@ jobs:
           url: ${{ secrets.VAULT_ADDR }}
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
-          message: "Update for Elastic Agent versions file has been created: ${{ steps.update.output.pr }}"
+          message: "Update for Elastic Agent versions file has been created: ${{ steps.update.outputs.pr }}"
           channel: "#ingest-notifications"


### PR DESCRIPTION
When an update for the versions file is created, the automation should send a Slack notification with the link to the PR. Due to the typo in the variable name, no PR link was rendered.