### PR TITLE
Fix liveness reload config handling

### DIFF
--- a/_meta/config/common.p2.yml.tmpl
+++ b/_meta/config/common.p2.yml.tmpl
@@ -66,6 +66,19 @@ inputs:
 #   # The name of the output to use for monitoring data.
 #   use_output: monitoring
 #   # exposes agent metrics using http, by default sockets and named pipes are used
+#   #
+#   # `http` Also exposes a /liveness endpoint that will return an HTTP code depending on agent status:
+#   # 200: Agent is healthy
+#   # 500: A component or unit is in a failed state
+#   # 503: The agent coordinator is unresponsive
+#   #
+#   # You can pass a `failon` parameter to the /liveness endpoint to determine what component state will result in a 500.
+#   # For example: `curl 'localhost:6792/liveness?failon=degraded'` will return 500 if a component is in a degraded state.
+#   # The possible values for `failon` are:
+#   # `degraded`: return an error if a component is in a degraded state or failed state, or if the agent coordinator is unresponsive.
+#   # `failed`: return an error if a unit is in a failed state, or if the agent coordinator is unresponsive.
+#   # `heartbeat`: return an error only if the agent coordinator is unresponsive. 
+#   # If no `failon` parameter is provided, the default behavior is `failon=heartbeat`
 #   http:
 #       # enables http endpoint
 #       enabled: false

--- a/_meta/config/common.reference.p2.yml.tmpl
+++ b/_meta/config/common.reference.p2.yml.tmpl
@@ -144,7 +144,20 @@ inputs:
 #   pprof.enabled: false
 #   # The name of the output to use for monitoring data.
 #   use_output: monitoring
-#   # exposes agent metrics using http, by default sockets and named pipes are used
+#   # Exposes agent metrics using http, by default sockets and named pipes are used.
+#   #
+#   # `http` Also exposes a /liveness endpoint that will return an HTTP code depending on agent status:
+#   # 200: Agent is healthy
+#   # 500: A component or unit is in a failed state
+#   # 503: The agent coordinator is unresponsive
+#   #
+#   # You can pass a `failon` parameter to the /liveness endpoint to determine what component state will result in a 500.
+#   # For example: `curl 'localhost:6792/liveness?failon=degraded'` will return 500 if a component is in a degraded state.
+#   # The possible values for `failon` are:
+#   # `degraded`: return an error if a component is in a degraded state or failed state, or if the agent coordinator is unresponsive.
+#   # `failed`: return an error if a unit is in a failed state, or if the agent coordinator is unresponsive.
+#   # `heartbeat`: return an error only if the agent coordinator is unresponsive. 
+#   # If no `failon` parameter is provided, the default behavior is `failon=heartbeat`
 #   http:
 #       # enables http endpoint
 #       enabled: false

--- a/_meta/config/elastic-agent.docker.yml.tmpl
+++ b/_meta/config/elastic-agent.docker.yml.tmpl
@@ -116,6 +116,19 @@ inputs:
 #   # recommended that these endpoints are only enabled if the monitoring endpoint is set to localhost
 #   pprof.enabled: false
 #   # exposes agent metrics using http, by default sockets and named pipes are used
+#   #
+#   # `http` Also exposes a /liveness endpoint that will return an HTTP code depending on agent status:
+#   # 200: Agent is healthy
+#   # 500: A component or unit is in a failed state
+#   # 503: The agent coordinator is unresponsive
+#   #
+#   # You can pass a `failon` parameter to the /liveness endpoint to determine what component state will result in a 500.
+#   # For example: `curl 'localhost:6792/liveness?failon=degraded'` will return 500 if a component is in a degraded state.
+#   # The possible values for `failon` are:
+#   # `degraded`: return an error if a component is in a degraded state or failed state, or if the agent coordinator is unresponsive.
+#   # `failed`: return an error if a unit is in a failed state, or if the agent coordinator is unresponsive.
+#   # `heartbeat`: return an error only if the agent coordinator is unresponsive. 
+#   # If no `failon` parameter is provided, the default behavior is `failon=heartbeat`
 #   http:
 #       # enables http endpoint
 #       enabled: false

--- a/_meta/elastic-agent.yml
+++ b/_meta/elastic-agent.yml
@@ -103,7 +103,15 @@ inputs:
 #   logs: false
 #   # enables metrics monitoring
 #   metrics: false
-#   # exposes agent metrics using http, by default sockets and named pipes are used
+#   # Exposes agent metrics using http, by default sockets and named pipes are used.
+#   # Also exposes a /liveness endpoint that will return an HTTP code depending on agent status:
+#   # 200: Agent is healthy
+#   # 500: A component or unit is in a failed state
+#   # 503: The agent coordinator is unresponsive
+#   # You can pass a `failon` parameter to the /liveness endpoint to determine what component state will result in a 500.
+#   # For example: `curl 'localhost:6792/liveness?failon=degraded'` will return 500 if a component is in a degraded state.
+#   # The two possible values for `failon` are `degraded` and `failed`. If no `failon` parameter is provided, the default 
+#   # behavior is `failon=failed`
 #   http:
 #       # enables http endpoint
 #       enabled: false

--- a/changelog/fragments/1711653910-add-liveness-endpoint.yaml
+++ b/changelog/fragments/1711653910-add-liveness-endpoint.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add a configurable /liveness endpoint.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: Adds a liveness endpoint suitable for use as a k8s liveness probe.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: monitoring
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/4499
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/elastic-agent.docker.yml
+++ b/elastic-agent.docker.yml
@@ -116,6 +116,19 @@ inputs:
 #   # recommended that these endpoints are only enabled if the monitoring endpoint is set to localhost
 #   pprof.enabled: false
 #   # exposes agent metrics using http, by default sockets and named pipes are used
+#   #
+#   # `http` Also exposes a /liveness endpoint that will return an HTTP code depending on agent status:
+#   # 200: Agent is healthy
+#   # 500: A component or unit is in a failed state
+#   # 503: The agent coordinator is unresponsive
+#   #
+#   # You can pass a `failon` parameter to the /liveness endpoint to determine what component state will result in a 500.
+#   # For example: `curl 'localhost:6792/liveness?failon=degraded'` will return 500 if a component is in a degraded state.
+#   # The possible values for `failon` are:
+#   # `degraded`: return an error if a component is in a degraded state or failed state, or if the agent coordinator is unresponsive.
+#   # `failed`: return an error if a unit is in a failed state, or if the agent coordinator is unresponsive.
+#   # `heartbeat`: return an error only if the agent coordinator is unresponsive. 
+#   # If no `failon` parameter is provided, the default behavior is `failon=heartbeat`
 #   http:
 #       # enables http endpoint
 #       enabled: false

--- a/elastic-agent.reference.yml
+++ b/elastic-agent.reference.yml
@@ -150,7 +150,20 @@ inputs:
 #   pprof.enabled: false
 #   # The name of the output to use for monitoring data.
 #   use_output: monitoring
-#   # exposes agent metrics using http, by default sockets and named pipes are used
+#   # Exposes agent metrics using http, by default sockets and named pipes are used.
+#   #
+#   # `http` Also exposes a /liveness endpoint that will return an HTTP code depending on agent status:
+#   # 200: Agent is healthy
+#   # 500: A component or unit is in a failed state
+#   # 503: The agent coordinator is unresponsive
+#   #
+#   # You can pass a `failon` parameter to the /liveness endpoint to determine what component state will result in a 500.
+#   # For example: `curl 'localhost:6792/liveness?failon=degraded'` will return 500 if a component is in a degraded state.
+#   # The possible values for `failon` are:
+#   # `degraded`: return an error if a component is in a degraded state or failed state, or if the agent coordinator is unresponsive.
+#   # `failed`: return an error if a unit is in a failed state, or if the agent coordinator is unresponsive.
+#   # `heartbeat`: return an error only if the agent coordinator is unresponsive. 
+#   # If no `failon` parameter is provided, the default behavior is `failon=heartbeat`
 #   http:
 #       # enables http endpoint
 #       enabled: false

--- a/elastic-agent.yml
+++ b/elastic-agent.yml
@@ -72,6 +72,19 @@ inputs:
 #   # The name of the output to use for monitoring data.
 #   use_output: monitoring
 #   # exposes agent metrics using http, by default sockets and named pipes are used
+#   #
+#   # `http` Also exposes a /liveness endpoint that will return an HTTP code depending on agent status:
+#   # 200: Agent is healthy
+#   # 500: A component or unit is in a failed state
+#   # 503: The agent coordinator is unresponsive
+#   #
+#   # You can pass a `failon` parameter to the /liveness endpoint to determine what component state will result in a 500.
+#   # For example: `curl 'localhost:6792/liveness?failon=degraded'` will return 500 if a component is in a degraded state.
+#   # The possible values for `failon` are:
+#   # `degraded`: return an error if a component is in a degraded state or failed state, or if the agent coordinator is unresponsive.
+#   # `failed`: return an error if a unit is in a failed state, or if the agent coordinator is unresponsive.
+#   # `heartbeat`: return an error only if the agent coordinator is unresponsive. 
+#   # If no `failon` parameter is provided, the default behavior is `failon=heartbeat`
 #   http:
 #       # enables http endpoint
 #       enabled: false

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -279,6 +279,11 @@ type Coordinator struct {
 
 	// mx         sync.RWMutex
 	// protection protection.Config
+
+	// a sync channel that can be called by other components to check if the main coordinator
+	// loop in runLoopIteration() is active and listening.
+	// Should only be interacted with via CoordinatorActive() or runLoopIteration()
+	heartbeatChan chan struct{}
 }
 
 // The channels Coordinator reads to receive updates from the various managers.
@@ -372,6 +377,7 @@ func New(logger *logger.Logger, cfg *configuration.Configuration, logLevel logp.
 		logLevelCh:         make(chan logp.Level),
 		overrideStateChan:  make(chan *coordinatorOverrideState),
 		upgradeDetailsChan: make(chan *details.Details),
+		heartbeatChan:      make(chan struct{}),
 	}
 	// Setup communication channels for any non-nil components. This pattern
 	// lets us transparently accept nil managers / simulated events during
@@ -410,6 +416,22 @@ func New(logger *logger.Logger, cfg *configuration.Configuration, logLevel logp.
 // Called by external goroutines.
 func (c *Coordinator) State() State {
 	return c.stateBroadcaster.Get()
+}
+
+// CoordinatorActive is a blocking method that waits for a channel response
+// from the coordinator loop. This can be used to as a basic health check,
+// as we'll timeout and return false if the coordinator run loop doesn't
+// respond to our channel.
+func (c *Coordinator) CoordinatorActive(timeout time.Duration) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	select {
+	case <-c.heartbeatChan:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 func (c *Coordinator) RegisterMonitoringServer(s configReloader) {
@@ -976,6 +998,8 @@ func (c *Coordinator) runLoopIteration(ctx context.Context) {
 
 	case upgradeDetails := <-c.upgradeDetailsChan:
 		c.setUpgradeDetails(upgradeDetails)
+
+	case c.heartbeatChan <- struct{}{}:
 
 	case componentState := <-c.managerChans.runtimeManagerUpdate:
 		// New component change reported by the runtime manager via

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -418,11 +418,11 @@ func (c *Coordinator) State() State {
 	return c.stateBroadcaster.Get()
 }
 
-// CoordinatorActive is a blocking method that waits for a channel response
+// IsActive is a blocking method that waits for a channel response
 // from the coordinator loop. This can be used to as a basic health check,
 // as we'll timeout and return false if the coordinator run loop doesn't
 // respond to our channel.
-func (c *Coordinator) CoordinatorActive(timeout time.Duration) bool {
+func (c *Coordinator) IsActive(timeout time.Duration) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -570,7 +571,7 @@ func TestCoordinatorPolicyChangeUpdatesMonitorReloader(t *testing.T) {
 	}
 
 	monitoringServer := &fakeMonitoringServer{}
-	newServerFn := func() (reload.ServerController, error) {
+	newServerFn := func(*monitoringCfg.MonitoringConfig) (reload.ServerController, error) {
 		return monitoringServer, nil
 	}
 	monitoringReloader := reload.NewServerReloader(newServerFn, logger, monitoringCfg.DefaultConfig())
@@ -1053,4 +1054,8 @@ func (fs *fakeMonitoringServer) Stop() error {
 func (fs *fakeMonitoringServer) Reset() {
 	fs.stopTriggered = false
 	fs.startTriggered = false
+}
+
+func (fs *fakeMonitoringServer) Addr() net.Addr {
+	return nil
 }

--- a/internal/pkg/agent/application/monitoring/handler.go
+++ b/internal/pkg/agent/application/monitoring/handler.go
@@ -8,12 +8,22 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
 )
 
 const errTypeUnexpected = "UNEXPECTED"
 
 type apiError interface {
 	Status() int
+}
+
+// CoordinatorState is used by the HTTP handlers that take a coordinator object.
+// This interface exists to help make testing easier.
+type CoordinatorState interface {
+	State() coordinator.State
+	CoordinatorActive(timeout time.Duration) bool
 }
 
 func createHandler(fn func(w http.ResponseWriter, r *http.Request) error) *apiHandler {
@@ -30,7 +40,7 @@ type apiHandler struct {
 func (h *apiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := h.innerFn(w, r)
 	if err != nil {
-		switch e := err.(type) { // nolint:errorlint // Will need refactor.
+		switch e := err.(type) { //nolint:errorlint // Will need refactor.
 		case apiError:
 			w.WriteHeader(e.Status())
 		default:

--- a/internal/pkg/agent/application/monitoring/handler.go
+++ b/internal/pkg/agent/application/monitoring/handler.go
@@ -23,7 +23,7 @@ type apiError interface {
 // This interface exists to help make testing easier.
 type CoordinatorState interface {
 	State() coordinator.State
-	CoordinatorActive(timeout time.Duration) bool
+	IsActive(timeout time.Duration) bool
 }
 
 func createHandler(fn func(w http.ResponseWriter, r *http.Request) error) *apiHandler {

--- a/internal/pkg/agent/application/monitoring/liveness.go
+++ b/internal/pkg/agent/application/monitoring/liveness.go
@@ -1,0 +1,88 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package monitoring
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+)
+
+const formValueKey = "failon"
+
+type LivenessFailConfig struct {
+	Degraded  bool `yaml:"degraded" config:"degraded"`
+	Failed    bool `yaml:"failed" config:"failed"`
+	Heartbeat bool `yaml:"heartbeat" config:"heartbeat"`
+}
+
+// process the form values we get via HTTP
+func handleFormValues(req *http.Request) (LivenessFailConfig, error) {
+	err := req.ParseForm()
+	if err != nil {
+		return LivenessFailConfig{}, fmt.Errorf("Error parsing form: %w", err)
+	}
+
+	defaultUserCfg := LivenessFailConfig{Degraded: false, Failed: false, Heartbeat: true}
+
+	for formKey := range req.Form {
+		if formKey != formValueKey {
+			return defaultUserCfg, fmt.Errorf("got invalid HTTP form key: '%s'", formKey)
+		}
+	}
+
+	userConfig := req.Form.Get(formValueKey)
+	switch userConfig {
+	case "failed":
+		return LivenessFailConfig{Degraded: false, Failed: true, Heartbeat: true}, nil
+	case "degraded":
+		return LivenessFailConfig{Failed: true, Degraded: true, Heartbeat: true}, nil
+	case "heartbeat", "":
+		return defaultUserCfg, nil
+	default:
+		return defaultUserCfg, fmt.Errorf("got unexpected value for `%s` attribute: %s", formValueKey, userConfig)
+	}
+}
+
+func livenessHandler(coord CoordinatorState) func(http.ResponseWriter, *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+		state := coord.State()
+		isUp := coord.CoordinatorActive(time.Second * 10)
+		// the coordinator check is always on, so if that fails, always return false
+		if !isUp {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return nil
+		}
+
+		failConfig, err := handleFormValues(r)
+		if err != nil {
+			return fmt.Errorf("error handling form values: %w", err)
+		}
+
+		// if user has requested `coordinator` mode, just revert to that, skip everything else
+		if !failConfig.Degraded && !failConfig.Failed && failConfig.Heartbeat {
+			if !isUp {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return nil
+			}
+		}
+
+		unhealthyComponent := false
+		for _, comp := range state.Components {
+			if (failConfig.Failed && comp.State.State == client.UnitStateFailed) || (failConfig.Degraded && comp.State.State == client.UnitStateDegraded) {
+				unhealthyComponent = true
+			}
+		}
+		// bias towards the coordinator check, since it can be otherwise harder to diagnose
+		if unhealthyComponent {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		return nil
+	}
+}

--- a/internal/pkg/agent/application/monitoring/liveness.go
+++ b/internal/pkg/agent/application/monitoring/liveness.go
@@ -53,7 +53,7 @@ func livenessHandler(coord CoordinatorState) func(http.ResponseWriter, *http.Req
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 
 		state := coord.State()
-		isUp := coord.CoordinatorActive(time.Second * 10)
+		isUp := coord.IsActive(time.Second * 10)
 		// the coordinator check is always on, so if that fails, always return false
 		if !isUp {
 			w.WriteHeader(http.StatusServiceUnavailable)

--- a/internal/pkg/agent/application/monitoring/liveness_test.go
+++ b/internal/pkg/agent/application/monitoring/liveness_test.go
@@ -1,0 +1,373 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package monitoring
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
+	"github.com/elastic/elastic-agent/pkg/component"
+	"github.com/elastic/elastic-agent/pkg/component/runtime"
+)
+
+type mockCoordinator struct {
+	state coordinator.State
+	isUp  bool
+}
+
+func (mc mockCoordinator) State() coordinator.State {
+	return mc.state
+}
+
+func (mc mockCoordinator) CoordinatorActive(_ time.Duration) bool {
+	return mc.isUp
+}
+
+func TestProcessHTTPHandler(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	testCases := []struct {
+		name         string
+		coord        mockCoordinator
+		expectedCode int
+		liveness     bool
+		failon       string
+	}{
+		{
+			name: "default-failed",
+			coord: mockCoordinator{
+				isUp: true,
+				state: coordinator.State{
+					Components: []runtime.ComponentComponentState{
+						{
+							LegacyPID: "2",
+							State:     runtime.ComponentState{State: client.UnitStateFailed},
+							Component: component.Component{
+								ID: "test-component",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCode: 200,
+			liveness:     true,
+			failon:       "heartbeat",
+		},
+		{
+			name: "default-healthy",
+			coord: mockCoordinator{
+				isUp: true,
+				state: coordinator.State{
+					Components: []runtime.ComponentComponentState{
+						{
+							LegacyPID: "2",
+							State:     runtime.ComponentState{State: client.UnitStateHealthy},
+							Component: component.Component{
+								ID: "test-component",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCode: 200,
+			liveness:     true,
+			failon:       "heartbeat",
+		},
+		{
+			name: "degraded",
+			coord: mockCoordinator{
+				isUp: true,
+				state: coordinator.State{
+					Components: []runtime.ComponentComponentState{
+						{
+							LegacyPID: "2",
+							State:     runtime.ComponentState{State: client.UnitStateDegraded},
+							Component: component.Component{
+								ID: "test-component",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCode: 500,
+			liveness:     true,
+			failon:       "degraded",
+		},
+		{
+			name: "degraded-check-off",
+			coord: mockCoordinator{
+				isUp: true,
+				state: coordinator.State{
+					Components: []runtime.ComponentComponentState{
+						{
+							LegacyPID: "2",
+							State:     runtime.ComponentState{State: client.UnitStateDegraded},
+							Component: component.Component{
+								ID: "test-component",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCode: 200,
+			liveness:     true,
+			failon:       "failed",
+		},
+		{
+			name: "degraded-liveness-off",
+			coord: mockCoordinator{
+				isUp: true,
+				state: coordinator.State{
+					Components: []runtime.ComponentComponentState{
+						{
+							LegacyPID: "2",
+							State:     runtime.ComponentState{State: client.UnitStateDegraded},
+							Component: component.Component{
+								ID: "test-component",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCode: 200,
+			liveness:     false,
+			failon:       "degraded",
+		},
+		{
+			name: "healthy",
+			coord: mockCoordinator{
+				isUp: true,
+				state: coordinator.State{
+					Components: []runtime.ComponentComponentState{
+						{
+							LegacyPID: "5",
+							State:     runtime.ComponentState{State: client.UnitStateHealthy},
+							Component: component.Component{
+								ID: "test-component3",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCode: 200,
+			liveness:     true,
+			failon:       "degraded",
+		},
+		{
+			name: "coord-fail-only-healthy",
+			coord: mockCoordinator{
+				isUp: false,
+				state: coordinator.State{
+					Components: []runtime.ComponentComponentState{
+						{
+							LegacyPID: "5",
+							State:     runtime.ComponentState{State: client.UnitStateHealthy},
+							Component: component.Component{
+								ID: "test-component3",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCode: 503,
+			liveness:     true,
+			failon:       "heartbeat",
+		},
+		{
+			name: "coord-fail-only-failed",
+			coord: mockCoordinator{
+				isUp: false,
+				state: coordinator.State{
+					Components: []runtime.ComponentComponentState{
+						{
+							LegacyPID: "5",
+							State:     runtime.ComponentState{State: client.UnitStateFailed},
+							Component: component.Component{
+								ID: "test-component3",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCode: 503,
+			liveness:     true,
+			failon:       "heartbeat",
+		},
+		{
+			name: "degraded-coordinator-down",
+			coord: mockCoordinator{
+				isUp: false,
+				state: coordinator.State{
+					Components: []runtime.ComponentComponentState{
+						{
+							LegacyPID: "5",
+							State:     runtime.ComponentState{State: client.UnitStateDegraded},
+							Component: component.Component{
+								ID: "test-component3",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCode: 503,
+			liveness:     true,
+			failon:       "degraded",
+		},
+		{
+			name: "unhealthy-coordinator-down",
+			coord: mockCoordinator{
+				isUp: false,
+				state: coordinator.State{
+					Components: []runtime.ComponentComponentState{
+						{
+							LegacyPID: "5",
+							State:     runtime.ComponentState{State: client.UnitStateFailed},
+							Component: component.Component{
+								ID: "test-component3",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCode: 503,
+			liveness:     true,
+			failon:       "degraded",
+		},
+		{
+			name: "healthy-coordinator-down",
+			coord: mockCoordinator{
+				isUp: false,
+				state: coordinator.State{
+					Components: []runtime.ComponentComponentState{
+						{
+							LegacyPID: "5",
+							State:     runtime.ComponentState{State: client.UnitStateHealthy},
+							Component: component.Component{
+								ID: "test-component3",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCode: 503,
+			liveness:     true,
+			failon:       "degraded",
+		},
+		{
+			name: "healthy-liveness-off",
+			coord: mockCoordinator{
+				isUp: true,
+				state: coordinator.State{
+					Components: []runtime.ComponentComponentState{
+						{
+							LegacyPID: "5",
+							State:     runtime.ComponentState{State: client.UnitStateHealthy},
+							Component: component.Component{
+								ID: "test-component3",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCode: 200,
+			liveness:     false,
+			failon:       "degraded",
+		},
+		{
+			name: "degraded-and-healthy",
+			coord: mockCoordinator{
+				isUp: true,
+				state: coordinator.State{
+					Components: []runtime.ComponentComponentState{
+						{
+							LegacyPID: "2",
+							State:     runtime.ComponentState{State: client.UnitStateDegraded},
+							Component: component.Component{
+								ID: "test-component",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+						{
+							LegacyPID: "3",
+							State:     runtime.ComponentState{State: client.UnitStateHealthy},
+							Component: component.Component{
+								ID: "test-component2",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCode: 500,
+			liveness:     true,
+			failon:       "degraded",
+		},
+	}
+
+	// test with processesHandler
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			testSrv := httptest.NewServer(createHandler(livenessHandler(test.coord)))
+			defer testSrv.Close()
+
+			path := fmt.Sprintf("%s?failon=%s", testSrv.URL, test.failon)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, path, nil)
+			require.NoError(t, err)
+			res, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			res.Body.Close()
+
+		})
+	}
+
+}

--- a/internal/pkg/agent/application/monitoring/liveness_test.go
+++ b/internal/pkg/agent/application/monitoring/liveness_test.go
@@ -29,7 +29,7 @@ func (mc mockCoordinator) State() coordinator.State {
 	return mc.state
 }
 
-func (mc mockCoordinator) CoordinatorActive(_ time.Duration) bool {
+func (mc mockCoordinator) IsActive(_ time.Duration) bool {
 	return mc.isUp
 }
 

--- a/internal/pkg/agent/application/monitoring/process.go
+++ b/internal/pkg/agent/application/monitoring/process.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/pkg/utils"
@@ -44,7 +43,7 @@ var redirectableProcesses = []string{
 	profilingServicePrefix,
 }
 
-func processHandler(coord *coordinator.Coordinator, statsHandler func(http.ResponseWriter, *http.Request) error, operatingSystem string) func(http.ResponseWriter, *http.Request) error {
+func processHandler(coord CoordinatorState, statsHandler func(http.ResponseWriter, *http.Request) error, operatingSystem string) func(http.ResponseWriter, *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 
@@ -82,8 +81,9 @@ func processHandler(coord *coordinator.Coordinator, statsHandler func(http.Respo
 
 		state := coord.State()
 
-		for _, c := range state.Components {
-			if matchesCloudProcessID(&c.Component, componentID) {
+		for iter, c := range state.Components {
+			// access the components array manually to avoid a memory aliasing error. This is fixed in go 1.22
+			if matchesCloudProcessID(&state.Components[iter].Component, componentID) {
 				data := struct {
 					State   string `json:"state"`
 					Message string `json:"message"`

--- a/internal/pkg/agent/application/monitoring/processes.go
+++ b/internal/pkg/agent/application/monitoring/processes.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
 )
 
 type source struct {
@@ -40,7 +38,7 @@ func sourceFromComponentID(procID string) source {
 	return s
 }
 
-func processesHandler(coord *coordinator.Coordinator) func(http.ResponseWriter, *http.Request) error {
+func processesHandler(coord CoordinatorState) func(http.ResponseWriter, *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 
@@ -48,10 +46,11 @@ func processesHandler(coord *coordinator.Coordinator) func(http.ResponseWriter, 
 
 		state := coord.State()
 
-		for _, c := range state.Components {
+		for iter, c := range state.Components {
 			if c.Component.InputSpec != nil {
 				procs = append(procs, process{
-					ID:     expectedCloudProcessID(&c.Component),
+					// access the components array manually to avoid a memory aliasing error. This is fixed in go 1.22
+					ID:     expectedCloudProcessID(&state.Components[iter].Component),
 					PID:    c.LegacyPID,
 					Binary: c.Component.InputSpec.BinaryName,
 					Source: sourceFromComponentID(c.Component.ID),

--- a/internal/pkg/agent/application/monitoring/reload/reload.go
+++ b/internal/pkg/agent/application/monitoring/reload/reload.go
@@ -102,7 +102,8 @@ func (sr *ServerReloader) Reload(rawConfig *aConfig.Config) error {
 	// currently, fleet does not expect the monitoring to be reloadable.
 	// If it was set in the original init config (which includes overrides), and it wasn't explicitly disabled
 	// then pretend the HTTP monitoring is enabled
-	if sr.originalHTTPState.Enabled && !newConfig.Settings.MonitoringConfig.HTTP.EnabledIsSet {
+	if sr.originalHTTPState != nil && sr.originalHTTPState.Enabled &&
+		newConfig.Settings.MonitoringConfig != nil && !newConfig.Settings.MonitoringConfig.HTTP.EnabledIsSet {
 		sr.log.Infof("http monitoring server is enabled in hard-coded config, but HTTP config is unset. Leaving enabled.")
 		newConfig.Settings.MonitoringConfig.HTTP = sr.originalHTTPState
 	}

--- a/internal/pkg/agent/application/monitoring/reload/reload.go
+++ b/internal/pkg/agent/application/monitoring/reload/reload.go
@@ -106,7 +106,7 @@ func (sr *ServerReloader) Reload(rawConfig *aConfig.Config) error {
 	// currently, fleet does not expect the monitoring to be reloadable.
 	// If it's currently running and the monitoring.http.enabled value hasn't been set,
 	// then pretend the HTTP monitoring is enabled
-	if sr.httpIsRunning.Load() && !newConfig.Settings.MonitoringConfig.HTTP.IsSet {
+	if sr.httpIsRunning.Load() && !newConfig.Settings.MonitoringConfig.HTTP.EnabledIsSet {
 		newConfig.Settings.MonitoringConfig.HTTP.Enabled = true
 	}
 

--- a/internal/pkg/agent/application/monitoring/reload/reload_test.go
+++ b/internal/pkg/agent/application/monitoring/reload/reload_test.go
@@ -67,6 +67,12 @@ agent.monitoring.enabled: false
 `,
 			false, false, false,
 		},
+		{
+			"remain-running-with-blank-config",
+			true, true, true,
+			``,
+			true, true, true,
+		},
 	}
 
 	for _, tc := range tcs {

--- a/internal/pkg/agent/application/monitoring/server.go
+++ b/internal/pkg/agent/application/monitoring/server.go
@@ -17,9 +17,7 @@ import (
 	"go.elastic.co/apm/module/apmgorilla"
 
 	"github.com/elastic/elastic-agent-libs/api"
-	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/monitoring"
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/monitoring/reload"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	monitoringCfg "github.com/elastic/elastic-agent/internal/pkg/core/monitoring/config"
@@ -32,8 +30,7 @@ func NewServer(
 	endpointConfig api.Config,
 	ns func(string) *monitoring.Namespace,
 	tracer *apm.Tracer,
-	coord *coordinator.Coordinator,
-	enableProcessStats bool,
+	coord CoordinatorState,
 	operatingSystem string,
 	mcfg *monitoringCfg.MonitoringConfig,
 ) (*reload.ServerReloader, error) {
@@ -42,47 +39,54 @@ func NewServer(
 		log.Warnf("failed to create monitoring drop: %v", err)
 	}
 
-	if strings.TrimSpace(endpointConfig.Host) == "" {
-		endpointConfig.Host = monitoringCfg.DefaultHost
-	}
-
-	cfg, err := config.NewConfigFrom(endpointConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	return exposeMetricsEndpoint(log, cfg, ns, tracer, coord, enableProcessStats, operatingSystem, mcfg)
+	return exposeMetricsEndpoint(log, ns, tracer, coord, operatingSystem, mcfg)
 }
 
 func exposeMetricsEndpoint(
 	log *logger.Logger,
-	config *config.C,
 	ns func(string) *monitoring.Namespace,
 	tracer *apm.Tracer,
-	coord *coordinator.Coordinator,
-	enableProcessStats bool,
+	coord CoordinatorState,
 	operatingSystem string,
 	mcfg *monitoringCfg.MonitoringConfig,
 ) (*reload.ServerReloader, error) {
-	r := mux.NewRouter()
-	if tracer != nil {
-		r.Use(apmgorilla.Middleware(apmgorilla.WithTracer(tracer)))
-	}
-	statsHandler := statsHandler(ns("stats"))
-	r.Handle("/stats", createHandler(statsHandler))
 
-	if enableProcessStats {
-		r.Handle("/processes", createHandler(processesHandler(coord)))
-		r.Handle("/processes/{componentID}", createHandler(processHandler(coord, statsHandler, operatingSystem)))
-		r.Handle("/processes/{componentID}/", createHandler(processHandler(coord, statsHandler, operatingSystem)))
-		r.Handle("/processes/{componentID}/{metricsPath}", createHandler(processHandler(coord, statsHandler, operatingSystem)))
-	}
+	newServerFn := func(cfg *monitoringCfg.MonitoringConfig) (reload.ServerController, error) {
+		r := mux.NewRouter()
+		if tracer != nil {
+			r.Use(apmgorilla.Middleware(apmgorilla.WithTracer(tracer)))
+		}
 
-	mux := http.NewServeMux()
-	mux.Handle("/", r)
+		// This will probably only be nil in tests.
+		statNs := &monitoring.Namespace{}
+		if ns != nil {
+			statNs = ns("stats")
+		}
 
-	newServerFn := func() (reload.ServerController, error) {
-		apiServer, err := api.New(log, mux, config)
+		statsHandler := statsHandler(statNs)
+		r.Handle("/stats", createHandler(statsHandler))
+
+		if isProcessStatsEnabled(cfg) {
+			r.Handle("/processes", createHandler(processesHandler(coord)))
+			r.Handle("/processes/{componentID}", createHandler(processHandler(coord, statsHandler, operatingSystem)))
+			r.Handle("/processes/{componentID}/", createHandler(processHandler(coord, statsHandler, operatingSystem)))
+			r.Handle("/processes/{componentID}/{metricsPath}", createHandler(processHandler(coord, statsHandler, operatingSystem)))
+
+			r.Handle("/liveness", createHandler(livenessHandler(coord)))
+		}
+
+		mux := http.NewServeMux()
+		mux.Handle("/", r)
+
+		if strings.TrimSpace(cfg.HTTP.Host) == "" {
+			cfg.HTTP.Host = monitoringCfg.DefaultHost
+		}
+
+		srvCfg := api.DefaultConfig()
+		srvCfg.Enabled = cfg.Enabled
+		srvCfg.Host = AgentMonitoringEndpoint(operatingSystem, cfg)
+		srvCfg.Port = cfg.HTTP.Port
+		apiServer, err := api.NewFromConfig(log, mux, srvCfg)
 		if err != nil {
 			return nil, errors.New(err, "failed to create api server")
 		}
@@ -120,4 +124,8 @@ func createAgentMonitoringDrop(drop string) error {
 func isHttpUrl(s string) bool {
 	u, err := url.Parse(strings.TrimSpace(s))
 	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
+}
+
+func isProcessStatsEnabled(cfg *monitoringCfg.MonitoringConfig) bool {
+	return cfg != nil && cfg.HTTP.Enabled
 }

--- a/internal/pkg/agent/application/monitoring/server.go
+++ b/internal/pkg/agent/application/monitoring/server.go
@@ -67,6 +67,7 @@ func exposeMetricsEndpoint(
 		r.Handle("/stats", createHandler(statsHandler))
 
 		if isProcessStatsEnabled(cfg) {
+			log.Infof("process monitoring is enabled, creating monitoring endpoints")
 			r.Handle("/processes", createHandler(processesHandler(coord)))
 			r.Handle("/processes/{componentID}", createHandler(processHandler(coord, statsHandler, operatingSystem)))
 			r.Handle("/processes/{componentID}/", createHandler(processHandler(coord, statsHandler, operatingSystem)))
@@ -86,6 +87,7 @@ func exposeMetricsEndpoint(
 		srvCfg.Enabled = cfg.Enabled
 		srvCfg.Host = AgentMonitoringEndpoint(operatingSystem, cfg)
 		srvCfg.Port = cfg.HTTP.Port
+		log.Infof("creating monitoring API with cfg %#v", srvCfg)
 		apiServer, err := api.NewFromConfig(log, mux, srvCfg)
 		if err != nil {
 			return nil, errors.New(err, "failed to create api server")

--- a/internal/pkg/agent/application/monitoring/server_test.go
+++ b/internal/pkg/agent/application/monitoring/server_test.go
@@ -46,7 +46,6 @@ var fakeCoordCfg = mockCoordinator{
 func TestHTTPReloadEnableBehavior(t *testing.T) {
 	// see https://github.com/elastic/elastic-agent/issues/4582
 	// This tests how the reloader behaves depending on what config values are set.
-	logp.DevelopmentSetup()
 	type reloadCase struct {
 		name              string
 		initConfig        *config.MonitoringConfig

--- a/internal/pkg/agent/application/monitoring/server_test.go
+++ b/internal/pkg/agent/application/monitoring/server_test.go
@@ -7,7 +7,6 @@ package monitoring
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -19,31 +18,107 @@ import (
 	"github.com/elastic/elastic-agent-libs/api"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/monitoring/reload"
+	aConfig "github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/core/monitoring/config"
 	"github.com/elastic/elastic-agent/pkg/component"
 	"github.com/elastic/elastic-agent/pkg/component/runtime"
 )
 
-func TestBasicLivenessConfig(t *testing.T) {
-	_ = logp.DevelopmentSetup()
-	testAPIConfig := api.Config{}
-	mockCoord := mockCoordinator{
-		isUp: true,
-		state: coordinator.State{
-			Components: []runtime.ComponentComponentState{
-				{
-					LegacyPID: "2",
-					State:     runtime.ComponentState{State: client.UnitStateDegraded},
-					Component: component.Component{
-						ID: "test-component",
-						InputSpec: &component.InputRuntimeSpec{
-							BinaryName: "testbeat",
-						},
+var fakeCoordCfg = mockCoordinator{
+	isUp: true,
+	state: coordinator.State{
+		Components: []runtime.ComponentComponentState{
+			{
+				LegacyPID: "2",
+				State:     runtime.ComponentState{State: client.UnitStateDegraded},
+				Component: component.Component{
+					ID: "test-component",
+					InputSpec: &component.InputRuntimeSpec{
+						BinaryName: "testbeat",
 					},
 				},
 			},
 		},
+	},
+}
+
+func TestHTTPReloadEnableBehavior(t *testing.T) {
+	// see https://github.com/elastic/elastic-agent/issues/4582
+	// This tests how the reloader behaves depending on what config values are set.
+	logp.DevelopmentSetup()
+	type reloadCase struct {
+		name              string
+		initConfig        *config.MonitoringConfig
+		secondConfig      *aConfig.Config
+		httpOnAtInit      bool
+		httpOnAfterReload bool
 	}
+
+	cases := []reloadCase{
+		{
+			name:       "enabled-with-reload-empty",
+			initConfig: &config.MonitoringConfig{Enabled: true, HTTP: &config.MonitoringHTTPConfig{Enabled: true}},
+			// use a map so we can specify port 0 with out setting `enabled`
+			secondConfig: aConfig.MustNewConfigFrom(map[string]interface{}{"agent": map[string]interface{}{
+				"monitoring": map[string]interface{}{"enabled": true, "http": map[string]interface{}{"port": 0}}}}),
+			httpOnAtInit:      true,
+			httpOnAfterReload: true,
+		},
+		{
+			name:       "disabled-with-reload-empty",
+			initConfig: &config.MonitoringConfig{Enabled: true, HTTP: &config.MonitoringHTTPConfig{Enabled: false}},
+			secondConfig: aConfig.MustNewConfigFrom(map[string]interface{}{"agent": map[string]interface{}{
+				"monitoring": map[string]interface{}{"enabled": true, "http": map[string]interface{}{"port": 0}}}}),
+			httpOnAtInit:      false,
+			httpOnAfterReload: false,
+		},
+		{
+			name:       "disabled-with-reload-disabled",
+			initConfig: &config.MonitoringConfig{Enabled: true, HTTP: &config.MonitoringHTTPConfig{Enabled: false}},
+			secondConfig: aConfig.MustNewConfigFrom(map[string]interface{}{"agent": map[string]interface{}{
+				"monitoring": map[string]interface{}{"enabled": true, "http": map[string]interface{}{"port": 0, "enabled": false}}}}),
+			httpOnAtInit:      false,
+			httpOnAfterReload: false,
+		},
+		{
+			name:       "enabled-with-reload-disabled",
+			initConfig: &config.MonitoringConfig{Enabled: true, HTTP: &config.MonitoringHTTPConfig{Enabled: true}},
+			secondConfig: aConfig.MustNewConfigFrom(map[string]interface{}{"agent": map[string]interface{}{
+				"monitoring": map[string]interface{}{"enabled": true, "http": map[string]interface{}{"port": 0, "enabled": false}}}}),
+			httpOnAtInit:      true,
+			httpOnAfterReload: false,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			serverReloader, err := NewServer(logp.L(), api.Config{}, nil, nil, fakeCoordCfg, "linux", testCase.initConfig)
+			require.NoError(t, err)
+
+			t.Logf("starting server...")
+			serverReloader.Start()
+			if testCase.httpOnAtInit {
+				waitOnReturnCode(t, http.StatusOK, "?failon=failed", serverReloader)
+			} else {
+				waitOnReturnCode(t, http.StatusNotFound, "?failon=failed", serverReloader)
+			}
+
+			serverReloader.Reload(testCase.secondConfig)
+
+			if testCase.httpOnAfterReload {
+				waitOnReturnCode(t, http.StatusOK, "?failon=failed", serverReloader)
+			} else {
+				waitOnReturnCode(t, http.StatusNotFound, "?failon=failed", serverReloader)
+			}
+
+		})
+	}
+}
+
+func TestBasicLivenessConfig(t *testing.T) {
+	_ = logp.DevelopmentSetup()
+	testAPIConfig := api.Config{}
 	testConfig := config.MonitoringConfig{
 		Enabled: true,
 		HTTP: &config.MonitoringHTTPConfig{
@@ -51,15 +126,15 @@ func TestBasicLivenessConfig(t *testing.T) {
 			Port:    0,
 		},
 	}
-	serverReloader, err := NewServer(logp.L(), testAPIConfig, nil, nil, mockCoord, "linux", &testConfig)
+	serverReloader, err := NewServer(logp.L(), testAPIConfig, nil, nil, fakeCoordCfg, "linux", &testConfig)
 	require.NoError(t, err)
 
 	t.Logf("starting server...")
 	serverReloader.Start()
 
-	waitOnReturnCode(t, http.StatusInternalServerError, "?failon=degraded", serverReloader.Addr())
+	waitOnReturnCode(t, http.StatusInternalServerError, "?failon=degraded", serverReloader)
 
-	waitOnReturnCode(t, http.StatusOK, "?failon=failed", serverReloader.Addr())
+	waitOnReturnCode(t, http.StatusOK, "?failon=failed", serverReloader)
 
 	t.Logf("stopping server...")
 	err = serverReloader.Stop()
@@ -67,16 +142,16 @@ func TestBasicLivenessConfig(t *testing.T) {
 
 }
 
-func waitOnReturnCode(t *testing.T, expectedReturnCode int, formValue string, addr net.Addr) {
+func waitOnReturnCode(t *testing.T, expectedReturnCode int, formValue string, rel *reload.ServerReloader) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 	client := &http.Client{}
-	path := fmt.Sprintf("http://%s/liveness%s", addr.String(), formValue)
-	t.Logf("checking %s", path)
-	req, err := http.NewRequestWithContext(ctx, "GET", path, nil)
-	require.NoError(t, err)
-
 	require.Eventually(t, func() bool {
+		path := fmt.Sprintf("http://%s/liveness%s", rel.Addr().String(), formValue)
+		t.Logf("checking %s", path)
+		req, err := http.NewRequestWithContext(ctx, "GET", path, nil)
+		require.NoError(t, err)
+
 		resp, err := client.Do(req)
 		if err != nil {
 			t.Logf("error fetching endpoint: %s", err)

--- a/internal/pkg/agent/application/monitoring/server_test.go
+++ b/internal/pkg/agent/application/monitoring/server_test.go
@@ -5,10 +5,88 @@
 package monitoring
 
 import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	"github.com/elastic/elastic-agent-libs/api"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
+	"github.com/elastic/elastic-agent/internal/pkg/core/monitoring/config"
+	"github.com/elastic/elastic-agent/pkg/component"
+	"github.com/elastic/elastic-agent/pkg/component/runtime"
 )
+
+func TestBasicLivenessConfig(t *testing.T) {
+	_ = logp.DevelopmentSetup()
+	testAPIConfig := api.Config{}
+	mockCoord := mockCoordinator{
+		isUp: true,
+		state: coordinator.State{
+			Components: []runtime.ComponentComponentState{
+				{
+					LegacyPID: "2",
+					State:     runtime.ComponentState{State: client.UnitStateDegraded},
+					Component: component.Component{
+						ID: "test-component",
+						InputSpec: &component.InputRuntimeSpec{
+							BinaryName: "testbeat",
+						},
+					},
+				},
+			},
+		},
+	}
+	testConfig := config.MonitoringConfig{
+		Enabled: true,
+		HTTP: &config.MonitoringHTTPConfig{
+			Enabled: true,
+			Port:    0,
+		},
+	}
+	serverReloader, err := NewServer(logp.L(), testAPIConfig, nil, nil, mockCoord, "linux", &testConfig)
+	require.NoError(t, err)
+
+	t.Logf("starting server...")
+	serverReloader.Start()
+
+	waitOnReturnCode(t, http.StatusInternalServerError, "?failon=degraded", serverReloader.Addr())
+
+	waitOnReturnCode(t, http.StatusOK, "?failon=failed", serverReloader.Addr())
+
+	t.Logf("stopping server...")
+	err = serverReloader.Stop()
+	require.NoError(t, err)
+
+}
+
+func waitOnReturnCode(t *testing.T, expectedReturnCode int, formValue string, addr net.Addr) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+	client := &http.Client{}
+	path := fmt.Sprintf("http://%s/liveness%s", addr.String(), formValue)
+	t.Logf("checking %s", path)
+	req, err := http.NewRequestWithContext(ctx, "GET", path, nil)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Logf("error fetching endpoint: %s", err)
+			return false
+		}
+		defer resp.Body.Close()
+		// should return 500 as we have one component set to UnitStateDegraded
+		return resp.StatusCode == expectedReturnCode
+	}, time.Second*30, time.Second*3)
+}
 
 func TestIsHTTPUrl(t *testing.T) {
 

--- a/internal/pkg/agent/application/monitoring/server_test.go
+++ b/internal/pkg/agent/application/monitoring/server_test.go
@@ -103,7 +103,8 @@ func TestHTTPReloadEnableBehavior(t *testing.T) {
 				waitOnReturnCode(t, http.StatusNotFound, "?failon=failed", serverReloader)
 			}
 
-			serverReloader.Reload(testCase.secondConfig)
+			err = serverReloader.Reload(testCase.secondConfig)
+			require.NoError(t, err)
 
 			if testCase.httpOnAfterReload {
 				waitOnReturnCode(t, http.StatusOK, "?failon=failed", serverReloader)

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -638,16 +638,12 @@ func setupMetrics(
 		Host:    monitoring.AgentMonitoringEndpoint(operatingSystem, cfg),
 	}
 
-	s, err := monitoring.NewServer(logger, endpointConfig, monitoringLib.GetNamespace, tracer, coord, isProcessStatsEnabled(cfg), operatingSystem, cfg)
+	s, err := monitoring.NewServer(logger, endpointConfig, monitoringLib.GetNamespace, tracer, coord, operatingSystem, cfg)
 	if err != nil {
 		return nil, errors.New(err, "could not start the HTTP server for the API")
 	}
 
 	return s, nil
-}
-
-func isProcessStatsEnabled(cfg *monitoringCfg.MonitoringConfig) bool {
-	return cfg != nil && cfg.HTTP.Enabled
 }
 
 // handleUpgrade checks if agent is being run as part of an

--- a/internal/pkg/core/monitoring/config/config.go
+++ b/internal/pkg/core/monitoring/config/config.go
@@ -74,7 +74,7 @@ func (c *MonitoringHTTPConfig) Unpack(cfg *c.C) error {
 		Buffer: tmp.Buffer,
 	}
 
-	// this logic is here to help us distingush between `http.enabled` being manually set after unpacking,
+	// this logic is here to help us distinguish between `http.enabled` being manually set after unpacking,
 	// and whatever a user-specified default may be.
 	// This is needed in order to prevent a larger set of breaking changes where fleet doesn't expect the HTTP monitor to be live-reloadable
 	// see https://github.com/elastic/elastic-agent/issues/4582

--- a/internal/pkg/core/monitoring/config/config.go
+++ b/internal/pkg/core/monitoring/config/config.go
@@ -39,7 +39,7 @@ type MonitoringConfig struct {
 type MonitoringHTTPConfig struct {
 	Enabled bool          `yaml:"enabled" config:"enabled"`
 	Host    string        `yaml:"host" config:"host"`
-	Port    int           `yaml:"port" config:"port" validate:"min=0,max=65535,nonzero"`
+	Port    int           `yaml:"port" config:"port" validate:"min=0,max=65535"`
 	Buffer  *BufferConfig `yaml:"buffer" config:"buffer"`
 }
 
@@ -49,7 +49,7 @@ func (c *MonitoringHTTPConfig) Unpack(cfg *c.C) error {
 	tmp := struct {
 		Enabled bool          `yaml:"enabled" config:"enabled"`
 		Host    string        `yaml:"host" config:"host"`
-		Port    int           `yaml:"port" config:"port" validate:"min=0,max=65535,nonzero"`
+		Port    int           `yaml:"port" config:"port" validate:"min=0,max=65535"`
 		Buffer  *BufferConfig `yaml:"buffer" config:"buffer"`
 	}{
 		Enabled: c.Enabled,

--- a/internal/pkg/core/monitoring/config/config.go
+++ b/internal/pkg/core/monitoring/config/config.go
@@ -41,8 +41,9 @@ type MonitoringHTTPConfig struct {
 	Host    string        `yaml:"host" config:"host"`
 	Port    int           `yaml:"port" config:"port" validate:"min=0,max=65535"`
 	Buffer  *BufferConfig `yaml:"buffer" config:"buffer"`
-	// IsSet will be set to true if `enabled` was manually set in the raw YAML config
-	IsSet bool `yaml:"-" config:"-"`
+	// EnabledIsSet is set during the Unpack() operation, and will be set to true if `Enabled` has been manually set by the incoming yaml
+	// This is done so we can distinguish between a default value supplied by the code, and a user-supplied value
+	EnabledIsSet bool `yaml:"-" config:"-"`
 }
 
 // Unpack reads a config object into the settings.
@@ -78,10 +79,10 @@ func (c *MonitoringHTTPConfig) Unpack(cfg *c.C) error {
 	// This is needed in order to prevent a larger set of breaking changes where fleet doesn't expect the HTTP monitor to be live-reloadable
 	// see https://github.com/elastic/elastic-agent/issues/4582
 	if tmp.Enabled == nil {
-		set.IsSet = false
+		set.EnabledIsSet = false
 		set.Enabled = c.Enabled
 	} else {
-		set.IsSet = true
+		set.EnabledIsSet = true
 		set.Enabled = *tmp.Enabled
 	}
 

--- a/internal/pkg/core/monitoring/config/config.go
+++ b/internal/pkg/core/monitoring/config/config.go
@@ -41,21 +41,22 @@ type MonitoringHTTPConfig struct {
 	Host    string        `yaml:"host" config:"host"`
 	Port    int           `yaml:"port" config:"port" validate:"min=0,max=65535"`
 	Buffer  *BufferConfig `yaml:"buffer" config:"buffer"`
+	// IsSet will be set to true if `enabled` was manually set in the raw YAML config
+	IsSet bool `yaml:"-" config:"-"`
 }
 
 // Unpack reads a config object into the settings.
 func (c *MonitoringHTTPConfig) Unpack(cfg *c.C) error {
 	// do not use MonitoringHTTPConfig, it will end up in a loop
 	tmp := struct {
-		Enabled bool          `yaml:"enabled" config:"enabled"`
+		Enabled *bool         `yaml:"enabled" config:"enabled"`
 		Host    string        `yaml:"host" config:"host"`
 		Port    int           `yaml:"port" config:"port" validate:"min=0,max=65535"`
 		Buffer  *BufferConfig `yaml:"buffer" config:"buffer"`
 	}{
-		Enabled: c.Enabled,
-		Host:    c.Host,
-		Port:    c.Port,
-		Buffer:  c.Buffer,
+		Host:   c.Host,
+		Port:   c.Port,
+		Buffer: c.Buffer,
 	}
 
 	if err := cfg.Unpack(&tmp); err != nil {
@@ -66,12 +67,25 @@ func (c *MonitoringHTTPConfig) Unpack(cfg *c.C) error {
 		tmp.Host = DefaultHost
 	}
 
-	*c = MonitoringHTTPConfig{
-		Enabled: tmp.Enabled,
-		Host:    tmp.Host,
-		Port:    tmp.Port,
-		Buffer:  tmp.Buffer,
+	set := MonitoringHTTPConfig{
+		Host:   tmp.Host,
+		Port:   tmp.Port,
+		Buffer: tmp.Buffer,
 	}
+
+	// this logic is here to help us distingush between `http.enabled` being manually set after unpacking,
+	// and whatever a user-specified default may be.
+	// This is needed in order to prevent a larger set of breaking changes where fleet doesn't expect the HTTP monitor to be live-reloadable
+	// see https://github.com/elastic/elastic-agent/issues/4582
+	if tmp.Enabled == nil {
+		set.IsSet = false
+		set.Enabled = c.Enabled
+	} else {
+		set.IsSet = true
+		set.Enabled = *tmp.Enabled
+	}
+
+	*c = set
 
 	return nil
 }

--- a/internal/pkg/core/monitoring/config/config_test.go
+++ b/internal/pkg/core/monitoring/config/config_test.go
@@ -103,7 +103,7 @@ metrics: true`,
 			require.NoError(t, err, "failed to unpack config")
 
 			assert.Equal(t, testCase.expectedEnabled, cfg.HTTP.Enabled, "enabled incorrect")
-			assert.Equal(t, testCase.expectedIsSet, cfg.HTTP.IsSet, "IsSet incorrect")
+			assert.Equal(t, testCase.expectedIsSet, cfg.HTTP.EnabledIsSet, "IsSet incorrect")
 		})
 	}
 }

--- a/internal/pkg/core/monitoring/config/config_test.go
+++ b/internal/pkg/core/monitoring/config/config_test.go
@@ -13,6 +13,101 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/config"
 )
 
+func TestIsSetLogic(t *testing.T) {
+	testCases := []struct {
+		name            string
+		config          string
+		startingCfg     *MonitoringConfig
+		expectedEnabled bool
+		expectedIsSet   bool
+	}{
+		{
+			"explicitly-disabled",
+			`enabled: true
+logs: true
+metrics: true
+http:
+  enabled: false`,
+			DefaultConfig(),
+			false, true,
+		},
+		{
+			"explicitly-enabled",
+			`enabled: true
+logs: true
+metrics: true
+http:
+  enabled: true`,
+			DefaultConfig(),
+			true, true,
+		},
+		{
+			"not-set",
+			`enabled: true
+logs: true
+metrics: true`,
+			DefaultConfig(),
+			false, false,
+		},
+		{
+			"not-set-default-enabled",
+			`enabled: true
+logs: true
+metrics: true
+http:
+  port: 1234`,
+			&MonitoringConfig{
+				Enabled:     true,
+				HTTP:        &MonitoringHTTPConfig{Enabled: true, Host: DefaultHost, Port: defaultPort},
+				Namespace:   defaultNamespace,
+				APM:         defaultAPMConfig(),
+				Diagnostics: defaultDiagnostics(),
+			},
+			true, false,
+		},
+		{
+			"no-http-field-default-enabled",
+			`enabled: true
+logs: true
+metrics: true`,
+			&MonitoringConfig{
+				Enabled:     true,
+				HTTP:        &MonitoringHTTPConfig{Enabled: true, Host: DefaultHost, Port: defaultPort},
+				Namespace:   defaultNamespace,
+				APM:         defaultAPMConfig(),
+				Diagnostics: defaultDiagnostics(),
+			},
+			true, false,
+		},
+		{
+			"empty-cfg",
+			``,
+			&MonitoringConfig{
+				Enabled:     true,
+				HTTP:        &MonitoringHTTPConfig{Enabled: true, Host: DefaultHost, Port: defaultPort},
+				Namespace:   defaultNamespace,
+				APM:         defaultAPMConfig(),
+				Diagnostics: defaultDiagnostics(),
+			},
+			true, false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			c, err := config.NewConfigFrom(testCase.config)
+			require.NoError(t, err, "failed to create config")
+
+			cfg := testCase.startingCfg
+			err = c.Unpack(&cfg)
+			require.NoError(t, err, "failed to unpack config")
+
+			assert.Equal(t, testCase.expectedEnabled, cfg.HTTP.Enabled, "enabled incorrect")
+			assert.Equal(t, testCase.expectedIsSet, cfg.HTTP.IsSet, "IsSet incorrect")
+		})
+	}
+}
+
 func TestHost(t *testing.T) {
 	testCases := []struct {
 		name         string

--- a/testing/integration/monitoring_probe_preserve_text_cfg_test.go
+++ b/testing/integration/monitoring_probe_preserve_text_cfg_test.go
@@ -1,0 +1,202 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/elastic/elastic-agent-libs/kibana"
+	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
+	atesting "github.com/elastic/elastic-agent/pkg/testing"
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+	"github.com/elastic/elastic-agent/pkg/testing/tools"
+)
+
+var defaultTextCfg = `
+outputs:
+  default:
+    type: elasticsearch
+    hosts: [127.0.0.1:9200]
+    api_key: "example-key"
+    preset: balanced
+    allow_older_versions: true
+
+inputs:
+  - type: system/metrics
+    id: unique-system-metrics-input
+    data_stream.namespace: default
+    use_output: default
+    streams:
+      - metricsets:
+        - cpu
+        data_stream.dataset: system.cpu
+      - metricsets:
+        - memory
+        data_stream.dataset: system.memory
+      - metricsets:
+        - network
+        data_stream.dataset: system.network
+      - metricsets:
+        - filesystem
+        data_stream.dataset: system.filesystem
+agent.monitoring:
+  http:
+    enabled: true
+    port: 6791
+agent.logging.level: debug
+agent.logging.to_stderr: true
+`
+
+type MonitoringTextRunner struct {
+	suite.Suite
+	info         *define.Info
+	agentFixture *atesting.Fixture
+
+	ESHost string
+
+	healthCheckTime        time.Duration
+	healthCheckRefreshTime time.Duration
+
+	policyID   string
+	policyName string
+}
+
+func TestMonitoringPreserveTextConfig(t *testing.T) {
+	info := define.Require(t, define.Requirements{
+		Group: "fleet",
+		Stack: &define.Stack{},
+		Local: false, // requires Agent installation
+		Sudo:  true,  // requires Agent installation
+		OS: []define.OS{
+			{Type: define.Linux},
+			{Type: define.Windows},
+		},
+	})
+
+	suite.Run(t, &MonitoringTextRunner{info: info, healthCheckTime: time.Minute * 5, healthCheckRefreshTime: time.Second * 5})
+}
+
+func (runner *MonitoringTextRunner) SetupSuite() {
+	fixture, err := define.NewFixture(runner.T(), define.Version())
+	require.NoError(runner.T(), err)
+	runner.agentFixture = fixture
+
+	policyUUID := uuid.New().String()
+	basePolicy := kibana.AgentPolicy{
+		Name:        "test-policy-" + policyUUID,
+		Namespace:   "default",
+		Description: "Test policy " + policyUUID,
+		MonitoringEnabled: []kibana.MonitoringEnabledOption{
+			kibana.MonitoringEnabledLogs,
+			kibana.MonitoringEnabledMetrics,
+		},
+	}
+
+	installOpts := atesting.InstallOpts{
+		NonInteractive: true,
+		Force:          true,
+		Privileged:     true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	// write a default config file that enables monitoring
+	err = runner.agentFixture.WriteFileToWorkDir(ctx, defaultTextCfg, "elastic-agent.yml")
+	require.NoError(runner.T(), err)
+
+	policyResp, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
+	require.NoError(runner.T(), err)
+
+	runner.policyID = policyResp.ID
+	runner.policyName = basePolicy.Name
+
+	_, err = tools.InstallPackageFromDefaultFile(ctx, runner.info.KibanaClient, "system", "1.53.1", "system_integration_setup.json", uuid.New().String(), policyResp.ID)
+	require.NoError(runner.T(), err)
+}
+
+func (runner *MonitoringTextRunner) TestMonitoringLiveness() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
+	defer cancel()
+
+	runner.AllComponentsHealthy(ctx)
+
+	client := http.Client{Timeout: time.Second * 4}
+	endpoint := "http://localhost:6791/processes"
+	// first stage: ensure the HTTP config has remained up post-install
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
+	require.NoError(runner.T(), err)
+
+	initResp, err := client.Do(req)
+	require.NoError(runner.T(), err)
+	require.Equal(runner.T(), http.StatusOK, initResp.StatusCode)
+
+	// use the fleet override API to change the port that we're running on.
+	override := map[string]interface{}{
+		"name":      runner.policyName,
+		"namespace": "default",
+		"overrides": map[string]interface{}{
+			"agent": map[string]interface{}{
+				"monitoring": map[string]interface{}{
+					"http": map[string]interface{}{
+						"enabled": true,
+						"host":    "localhost",
+						"port":    6792,
+					},
+				},
+			},
+		},
+	}
+
+	raw, err := json.Marshal(override)
+	require.NoError(runner.T(), err)
+	reader := bytes.NewBuffer(raw)
+	overrideEndpoint := fmt.Sprintf("/api/fleet/agent_policies/%s", runner.policyID)
+	statusCode, overrideResp, err := runner.info.KibanaClient.Request("PUT", overrideEndpoint, nil, nil, reader)
+	require.NoError(runner.T(), err)
+	require.Equal(runner.T(), http.StatusOK, statusCode, "non-200 status code; got response: %s", string(overrideResp))
+
+	runner.AllComponentsHealthy(ctx)
+
+	updatedEndpoint := "http://localhost:6792/processes"
+	// second stage: ensure the HTTP config has updated
+	req, err = http.NewRequestWithContext(ctx, "GET", updatedEndpoint, nil)
+	require.NoError(runner.T(), err)
+
+	initResp, err = client.Do(req)
+	require.NoError(runner.T(), err)
+	require.Equal(runner.T(), http.StatusOK, initResp.StatusCode)
+}
+
+// AllComponentsHealthy ensures all the beats and agent are healthy and working before we continue
+func (runner *MonitoringTextRunner) AllComponentsHealthy(ctx context.Context) {
+	compDebugName := ""
+	require.Eventually(runner.T(), func() bool {
+		allHealthy := true
+		status, err := runner.agentFixture.ExecStatus(ctx)
+
+		require.NoError(runner.T(), err)
+		for _, comp := range status.Components {
+			runner.T().Logf("component state: %s", comp.Message)
+			if comp.State != int(cproto.State_HEALTHY) {
+				compDebugName = comp.Name
+				allHealthy = false
+			}
+		}
+		return allHealthy
+	}, runner.healthCheckTime, runner.healthCheckRefreshTime, "install never became healthy: components did not return a healthy state: %s", compDebugName)
+}

--- a/testing/integration/monitoring_probe_reload_test.go
+++ b/testing/integration/monitoring_probe_reload_test.go
@@ -1,0 +1,180 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/elastic/elastic-agent-libs/kibana"
+	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
+	atesting "github.com/elastic/elastic-agent/pkg/testing"
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+	"github.com/elastic/elastic-agent/pkg/testing/tools"
+)
+
+type MonitoringRunner struct {
+	suite.Suite
+	info         *define.Info
+	agentFixture *atesting.Fixture
+
+	ESHost string
+
+	healthCheckTime        time.Duration
+	healthCheckRefreshTime time.Duration
+
+	policyID   string
+	policyName string
+}
+
+func TestMonitoringLivenessReloadable(t *testing.T) {
+	info := define.Require(t, define.Requirements{
+		Group: "fleet",
+		Stack: &define.Stack{},
+		Local: false, // requires Agent installation
+		Sudo:  true,  // requires Agent installation
+		OS: []define.OS{
+			{Type: define.Linux},
+			{Type: define.Windows},
+		},
+	})
+
+	suite.Run(t, &MonitoringRunner{info: info, healthCheckTime: time.Minute * 5, healthCheckRefreshTime: time.Second * 5})
+}
+
+func (runner *MonitoringRunner) SetupSuite() {
+	fixture, err := define.NewFixture(runner.T(), define.Version())
+	require.NoError(runner.T(), err)
+	runner.agentFixture = fixture
+
+	policyUUID := uuid.New().String()
+	basePolicy := kibana.AgentPolicy{
+		Name:        "test-policy-" + policyUUID,
+		Namespace:   "default",
+		Description: "Test policy " + policyUUID,
+		MonitoringEnabled: []kibana.MonitoringEnabledOption{
+			kibana.MonitoringEnabledLogs,
+			kibana.MonitoringEnabledMetrics,
+		},
+	}
+
+	installOpts := atesting.InstallOpts{
+		NonInteractive: true,
+		Force:          true,
+		Privileged:     true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	policyResp, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
+	require.NoError(runner.T(), err)
+
+	runner.policyID = policyResp.ID
+	runner.policyName = basePolicy.Name
+
+	_, err = tools.InstallPackageFromDefaultFile(ctx, runner.info.KibanaClient, "system", "1.53.1", "system_integration_setup.json", uuid.New().String(), policyResp.ID)
+	require.NoError(runner.T(), err)
+}
+
+func (runner *MonitoringRunner) TestMonitoringLiveness() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
+	defer cancel()
+
+	runner.AllComponentsHealthy(ctx)
+
+	client := http.Client{Timeout: time.Second * 4}
+	endpoint := "http://localhost:6792/liveness"
+	// first stage: ensure the default behavior, http monitoring is off. This should return an error
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
+	require.NoError(runner.T(), err)
+
+	_, err = client.Do(req)
+	require.Error(runner.T(), err)
+
+	// use the fleet override API to enable http monitoring.
+	// This tests both the http server itself, and tests that the agent reloader actually reloads the agent config.
+	override := map[string]interface{}{
+		"name":      runner.policyName,
+		"namespace": "default",
+		"overrides": map[string]interface{}{
+			"agent": map[string]interface{}{
+				"monitoring": map[string]interface{}{
+					"http": map[string]interface{}{
+						"enabled": true,
+						"host":    "localhost",
+						"port":    6792,
+					},
+				},
+			},
+		},
+	}
+
+	raw, err := json.Marshal(override)
+	require.NoError(runner.T(), err)
+	reader := bytes.NewBuffer(raw)
+	overrideEndpoint := fmt.Sprintf("/api/fleet/agent_policies/%s", runner.policyID)
+	statusCode, overrideResp, err := runner.info.KibanaClient.Request("PUT", overrideEndpoint, nil, nil, reader)
+	require.NoError(runner.T(), err)
+	require.Equal(runner.T(), http.StatusOK, statusCode, "non-200 status code; got response: %s", string(overrideResp))
+
+	runner.AllComponentsHealthy(ctx)
+
+	// check to make sure that we now have a liveness probe response
+	req, err = http.NewRequestWithContext(ctx, "GET", endpoint, nil)
+	require.NoError(runner.T(), err)
+
+	// second check: the /liveness endpoint should now be responding
+	runner.CheckResponse(ctx, endpoint)
+
+	runner.CheckResponse(ctx, fmt.Sprintf("%s?failon=degraded", endpoint))
+
+	runner.CheckResponse(ctx, fmt.Sprintf("%s?failon=failed", endpoint))
+
+	runner.CheckResponse(ctx, fmt.Sprintf("%s?failon=heartbeat", endpoint))
+}
+
+// CheckResponse checks to see if the liveness probe returns a 200
+func (runner *MonitoringRunner) CheckResponse(ctx context.Context, endpoint string) {
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
+	require.NoError(runner.T(), err)
+
+	client := http.Client{Timeout: time.Second * 4}
+
+	livenessResp, err := client.Do(req)
+	require.NoError(runner.T(), err)
+	defer livenessResp.Body.Close()
+	require.Equal(runner.T(), http.StatusOK, livenessResp.StatusCode) // this is effectively the check for the test
+}
+
+// AllComponentsHealthy ensures all the beats and agent are healthy and working before we continue
+func (runner *MonitoringRunner) AllComponentsHealthy(ctx context.Context) {
+	compDebugName := ""
+	require.Eventually(runner.T(), func() bool {
+		allHealthy := true
+		status, err := runner.agentFixture.ExecStatus(ctx)
+
+		require.NoError(runner.T(), err)
+		for _, comp := range status.Components {
+			runner.T().Logf("component state: %s", comp.Message)
+			if comp.State != int(cproto.State_HEALTHY) {
+				compDebugName = comp.Name
+				allHealthy = false
+			}
+		}
+		return allHealthy
+	}, runner.healthCheckTime, runner.healthCheckRefreshTime, "install never became healthy: components did not return a healthy state: %s", compDebugName)
+}


### PR DESCRIPTION
## What does this PR do?

Closes https://github.com/elastic/elastic-agent/issues/4582

This reverts the revert in https://github.com/elastic/elastic-agent/pull/4583 and adds some extra logic so that if the HTTP monitoring server is enabled, and we get a config reload that _does not explicitly set it to disabled_ we keep it enabled.

This also adds a ton of tests, because now I'm paranoid.

## Why is it important?

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test
