### PR TITLE
Unconditionally cleanup severless projects in buildkite pre-exit hook

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -10,11 +10,8 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-agent" && "$BUILDKITE_STEP_KEY" == 
 
   # Perform cleanup of integration tests resources
   echo "--- Cleaning up integration test resources"
-  if [[ "$BUILDKITE_STEP_KEY" == "serverless-integration-tests" ]]; then
-    STACK_PROVISIONER=serverless SNAPSHOT=true mage integration:clean
-  else
-    SNAPSHOT=true mage integration:clean
-  fi
+  STACK_PROVISIONER=serverless SNAPSHOT=true mage integration:clean
+  SNAPSHOT=true mage integration:clean
 fi
 
 if [ -n "$GOOGLE_APPLICATION_CREDENTIALS" ]; then


### PR DESCRIPTION
Hopefully this works and makes it so we can't forget if we add another serverless step.

- Relates https://github.com/elastic/ingest-dev/issues/3164