### PR TITLE
Reduce agent logs by default

### DIFF
--- a/changelog/fragments/1714717717-Reduce-agent-logs-by-default.yaml
+++ b/changelog/fragments/1714717717-Reduce-agent-logs-by-default.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Reduce agent logs by default by dropping "Non-zero metrics..." logs before ES ingestion
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/4633
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/4252

--- a/docs/scripts/es/elastic-agent-logs-comparison
+++ b/docs/scripts/es/elastic-agent-logs-comparison
@@ -1,0 +1,323 @@
+# This script is used to measure the disk size of elastic-agent logs and metrics.
+# We need to run a baseline and an updated version of the agent for comparison.
+# After ingesting the logs and metrics from both runs we reindex the documents based on
+# agent ids and timestamp range and store them in dedicated indices so we can measure
+# disk size (the new indices are creates with the same mappings as the elastic-agent
+# logs and metrics datastreams)
+
+# In order to simplify running the script, a few variables have been defined.
+# Note: The *_start_ts variables seem to not always render correctly, we may
+# just replace the values as a workaround
+
+# Variables (with some sample values)
+#
+# Variable name		Sample value
+#
+# baseline_agent_id	acaf7ee8-defa-476a-bd57-2ef565809470
+# updated_agent_id	e9a7c222-172e-4d39-9dbb-311be5e24a75
+# baseline_start_ts	2024-04-29T06:40:39
+# updated_start_ts	2024-04-29T08:53:23
+# time_interval		+1h
+
+
+
+# Cleanup
+
+# Test log indices and templates
+DELETE /testlogs-elastic_agent-baseline
+DELETE /testlogs-elastic_agent-updated
+DELETE /_index_template/testlogs-elastic_agent
+
+# Test metrics indices and templates
+DELETE /testmetrics-elastic_agent.elastic_agent-baseline
+DELETE /testmetrics-elastic_agent.elastic_agent-updated
+DELETE /_index_template/testmetrics-elastic_agent.elastic_agent 
+
+DELETE /testmetrics-elastic_agent.filebeat-baseline
+DELETE /testmetrics-elastic_agent.filebeat-updated
+DELETE /_index_template/testmetrics-elastic_agent.filebeat 
+
+DELETE /testmetrics-elastic_agent.metricbeat-baseline
+DELETE /testmetrics-elastic_agent.metricbeat-updated
+DELETE /_index_template/testmetrics-elastic_agent.metricbeat 
+
+
+# Recreate index templates
+
+# Mappings we want to use in our test index templates
+# GET /_index_template/logs-elastic_agent
+# GET /_index_template/metrics-elastic_agent.elastic_agent 
+# GET /_index_template/metrics-elastic_agent.filebeat
+# GET /_index_template/metrics-elastic_agent.metricbeat
+
+
+PUT /_index_template/testlogs-elastic_agent
+{
+  "index_patterns": [
+    "testlogs-elastic_agent-*"
+  ],
+  "template": {
+    "settings": {},
+    "mappings": {
+    }
+  },
+  "composed_of": [
+    "logs@mappings",
+    "logs@settings",
+    "logs-elastic_agent@package",
+    "logs-elastic_agent@custom",
+    "ecs@mappings",
+    ".fleet_globals-1",
+    ".fleet_agent_id_verification-1"
+  ],
+  "priority": 200,
+  "ignore_missing_component_templates": [
+    "logs-elastic_agent@custom"
+  ]
+}
+
+PUT /_index_template/testmetrics-elastic_agent.elastic_agent 
+{
+  "index_patterns": [
+    "testmetrics-elastic_agent.elastic_agent-*"
+  ],
+  "template": {
+    "settings": {
+      "index": {
+        "mode": "time_series",
+        "routing_path": [
+          "component.id",
+          "agent.id",
+          "metricset.name"
+        ]
+      }
+    },
+    "mappings": {
+    }
+  },
+  "composed_of": [
+    "metrics@tsdb-settings",
+    "metrics-elastic_agent.elastic_agent@package",
+    "metrics-elastic_agent.elastic_agent@custom",
+    "ecs@mappings",
+    ".fleet_globals-1",
+    ".fleet_agent_id_verification-1"
+  ],
+  "priority": 200,
+  "ignore_missing_component_templates": [
+    "metrics-elastic_agent.elastic_agent@custom"
+  ]
+}
+
+PUT /_index_template/testmetrics-elastic_agent.filebeat 
+{
+  "index_patterns": [
+    "testmetrics-elastic_agent.filebeat-*"
+  ],
+  "template": {
+    "settings": {
+      "index": {
+        "mode": "time_series",
+        "routing_path": [
+          "component.id",
+          "agent.id",
+          "metricset.name"
+        ]
+      }
+    },
+    "mappings": {
+    }
+  },
+  "composed_of": [
+    "metrics@tsdb-settings",
+    "metrics-elastic_agent.filebeat@package",
+    "metrics-elastic_agent.filebeat@custom",
+    "ecs@mappings",
+    ".fleet_globals-1",
+    ".fleet_agent_id_verification-1"
+  ],
+  "priority": 200,
+  "ignore_missing_component_templates": [
+    "metrics-elastic_agent.filebeat@custom"
+  ]
+}
+
+PUT /_index_template/testmetrics-elastic_agent.metricbeat
+{
+  "index_patterns": [
+    "testmetrics-elastic_agent.metricbeat-*"
+  ],
+  "template": {
+    "settings": {
+      "index": {
+        "mode": "time_series",
+        "routing_path": [
+          "component.id",
+          "agent.id",
+          "metricset.name"
+        ]
+      }
+    },
+    "mappings": {
+    }
+  },
+  "composed_of": [
+    "metrics@tsdb-settings",
+    "metrics-elastic_agent.metricbeat@package",
+    "metrics-elastic_agent.metricbeat@custom",
+    "ecs@mappings",
+    ".fleet_globals-1",
+    ".fleet_agent_id_verification-1"
+  ],
+  "priority": 200,
+  "ignore_missing_component_templates": [
+    "metrics-elastic_agent.metricbeat@custom"
+  ]
+}
+
+# Reindex a subset of the elastic-agent logs in the new indices
+POST _reindex
+{
+  "source": {
+    "index": "logs-elastic_agent-default",
+    "query": {
+      "bool": {
+        "filter": [
+          {"term": {"agent.id":"${baseline_agent_id}"}},
+          {"range": {"@timestamp": {"gte": "${baseline_start_ts}", "lte": "${baseline_start_ts}||${time_interval}"}}}
+        ]
+      }
+    }
+  },
+  "dest": {
+    "index": "testlogs-elastic_agent-baseline"
+  }
+}
+
+POST _reindex
+{
+  "source": {
+    "index": "logs-elastic_agent-default",
+    "query": {
+      "bool": {
+        "filter": [
+          {"term": {"agent.id":"${updated_agent_id}"}},
+          {"range": {"@timestamp": {"gte": "${updated_start_ts}", "lte": "${updated_start_ts}||${time_interval}"}}}
+        ]
+      }
+    }
+  },
+  "dest": {
+    "index": "testlogs-elastic_agent-updated"
+  }
+}
+
+# Reindex a subset of the elastic-agent metrics in the new indices
+POST _reindex
+{
+  "source": {
+    "index": "metrics-elastic_agent.elastic_agent-default",
+    "query": {
+      "bool": {
+        "filter": [
+          {"term": {"agent.id":"${baseline_agent_id}"}},
+          {"range": {"@timestamp": {"gte": "${baseline_start_ts}", "lte": "${baseline_start_ts}||${time_interval}"}}}
+        ]
+      }
+    }
+  },
+  "dest": {
+    "index": "testmetrics-elastic_agent.elastic_agent-baseline"
+  }
+}
+
+POST _reindex
+{
+  "source": {
+    "index": "metrics-elastic_agent.elastic_agent-default",
+    "query": {
+      "bool": {
+        "filter": [
+          {"term": {"agent.id":"${updated_agent_id}"}},
+          {"range": {"@timestamp": {"gte": "${updated_start_ts}", "lte": "${updated_start_ts}||${time_interval}"}}}
+        ]
+      }
+    }
+  },
+  "dest": {
+    "index": "testmetrics-elastic_agent.elastic_agent-updated"
+  }
+}
+
+POST _reindex
+{
+  "source": {
+    "index": "metrics-elastic_agent.filebeat-default",
+    "query": {
+      "bool": {
+        "filter": [
+          {"term": {"agent.id":"${baseline_agent_id}"}},
+          {"range": {"@timestamp": {"gte": "${baseline_start_ts}", "lte": "${baseline_start_ts}||${time_interval}"}}}
+        ]
+      }
+    }
+  },
+  "dest": {
+    "index": "testmetrics-elastic_agent.filebeat-baseline"
+  }
+}
+
+
+POST _reindex
+{
+  "source": {
+    "index": "metrics-elastic_agent.filebeat-default",
+    "query": {
+      "bool": {
+        "filter": [
+          {"term": {"agent.id":"${updated_agent_id}"}},
+          {"range": {"@timestamp": {"gte": "${updated_start_ts}", "lte": "${updated_start_ts}||${time_interval}"}}}
+        ]
+      }
+    }
+  },
+  "dest": {
+    "index": "testmetrics-elastic_agent.filebeat-updated"
+  }
+}
+
+POST _reindex
+{
+  "source": {
+    "index": "metrics-elastic_agent.metricbeat-default",
+    "query": {
+      "bool": {
+        "filter": [
+          {"term": {"agent.id":"${baseline_agent_id}"}},
+          {"range": {"@timestamp": {"gte": "${baseline_start_ts}", "lte": "${baseline_start_ts}||${time_interval}"}}}
+        ]
+      }
+    }
+  },
+  "dest": {
+    "index": "testmetrics-elastic_agent.metricbeat-baseline"
+  }
+}
+
+POST _reindex
+{
+  "source": {
+    "index": "metrics-elastic_agent.metricbeat-default",
+    "query": {
+      "bool": {
+        "filter": [
+          {"term": {"agent.id":"${updated_agent_id}"}},
+          {"range": {"@timestamp": {"gte": "${updated_start_ts}", "lte": "${updated_start_ts}||${time_interval}"}}}
+        ]
+      }
+    }
+  },
+  "dest": {
+    "index": "testmetrics-elastic_agent.metricbeat-updated"
+  }
+}

--- a/docs/scripts/es/elastic-agent-logs-comparison.http
+++ b/docs/scripts/es/elastic-agent-logs-comparison.http
@@ -321,3 +321,19 @@ POST _reindex
     "index": "testmetrics-elastic_agent.metricbeat-updated"
   }
 }
+
+# Check indices disk usage
+
+## Logs
+POST /testlogs-elastic_agent-baseline/_disk_usage?run_expensive_tasks=true
+POST /testlogs-elastic_agent-updated/_disk_usage?run_expensive_tasks=true
+
+## Metrics
+POST /testmetrics-elastic_agent.elastic_agent-baseline/_disk_usage?run_expensive_tasks=true
+POST /testmetrics-elastic_agent.elastic_agent-updated/_disk_usage?run_expensive_tasks=true
+
+POST /testmetrics-elastic_agent.filebeat-baseline/_disk_usage?run_expensive_tasks=true
+POST /testmetrics-elastic_agent.filebeat-updated/_disk_usage?run_expensive_tasks=true
+
+POST /testmetrics-elastic_agent.metricbeat-baseline/_disk_usage?run_expensive_tasks=true
+POST /testmetrics-elastic_agent.metricbeat-updated/_disk_usage?run_expensive_tasks=true

--- a/docs/scripts/es/elastic-agent-logs-comparison.http
+++ b/docs/scripts/es/elastic-agent-logs-comparison.http
@@ -24,22 +24,22 @@
 # Cleanup
 
 # Test log indices and templates
-DELETE /testlogs-elastic_agent-baseline
-DELETE /testlogs-elastic_agent-updated
-DELETE /_index_template/testlogs-elastic_agent
+DELETE /logs-elastic_agent-disksize.baseline
+DELETE /logs-elastic_agent-disksize.updated
+DELETE /logs-elastic_agent.filebeat-disksize.baseline
+DELETE /logs-elastic_agent.filebeat-disksize.updated
+DELETE /logs-elastic_agent.metricbeat-disksize.baseline
+DELETE /logs-elastic_agent.metricbeat-disksize.updated
 
 # Test metrics indices and templates
-DELETE /testmetrics-elastic_agent.elastic_agent-baseline
-DELETE /testmetrics-elastic_agent.elastic_agent-updated
-DELETE /_index_template/testmetrics-elastic_agent.elastic_agent 
+DELETE /metrics-elastic_agent.elastic_agent-disksize.baseline
+DELETE /metrics-elastic_agent.elastic_agent-disksize.updated
 
-DELETE /testmetrics-elastic_agent.filebeat-baseline
-DELETE /testmetrics-elastic_agent.filebeat-updated
-DELETE /_index_template/testmetrics-elastic_agent.filebeat 
+DELETE /metrics-elastic_agent.filebeat-disksize.baseline
+DELETE /metrics-elastic_agent.filebeat-disksize.updated
 
-DELETE /testmetrics-elastic_agent.metricbeat-baseline
-DELETE /testmetrics-elastic_agent.metricbeat-updated
-DELETE /_index_template/testmetrics-elastic_agent.metricbeat 
+DELETE /metrics-elastic_agent.metricbeat-disksize.baseline
+DELETE /metrics-elastic_agent.metricbeat-disksize.updated
 
 
 # Recreate index templates
@@ -49,131 +49,6 @@ DELETE /_index_template/testmetrics-elastic_agent.metricbeat
 # GET /_index_template/metrics-elastic_agent.elastic_agent 
 # GET /_index_template/metrics-elastic_agent.filebeat
 # GET /_index_template/metrics-elastic_agent.metricbeat
-
-
-PUT /_index_template/testlogs-elastic_agent
-{
-  "index_patterns": [
-    "testlogs-elastic_agent-*"
-  ],
-  "template": {
-    "settings": {},
-    "mappings": {
-    }
-  },
-  "composed_of": [
-    "logs@mappings",
-    "logs@settings",
-    "logs-elastic_agent@package",
-    "logs-elastic_agent@custom",
-    "ecs@mappings",
-    ".fleet_globals-1",
-    ".fleet_agent_id_verification-1"
-  ],
-  "priority": 200,
-  "ignore_missing_component_templates": [
-    "logs-elastic_agent@custom"
-  ]
-}
-
-PUT /_index_template/testmetrics-elastic_agent.elastic_agent 
-{
-  "index_patterns": [
-    "testmetrics-elastic_agent.elastic_agent-*"
-  ],
-  "template": {
-    "settings": {
-      "index": {
-        "mode": "time_series",
-        "routing_path": [
-          "component.id",
-          "agent.id",
-          "metricset.name"
-        ]
-      }
-    },
-    "mappings": {
-    }
-  },
-  "composed_of": [
-    "metrics@tsdb-settings",
-    "metrics-elastic_agent.elastic_agent@package",
-    "metrics-elastic_agent.elastic_agent@custom",
-    "ecs@mappings",
-    ".fleet_globals-1",
-    ".fleet_agent_id_verification-1"
-  ],
-  "priority": 200,
-  "ignore_missing_component_templates": [
-    "metrics-elastic_agent.elastic_agent@custom"
-  ]
-}
-
-PUT /_index_template/testmetrics-elastic_agent.filebeat 
-{
-  "index_patterns": [
-    "testmetrics-elastic_agent.filebeat-*"
-  ],
-  "template": {
-    "settings": {
-      "index": {
-        "mode": "time_series",
-        "routing_path": [
-          "component.id",
-          "agent.id",
-          "metricset.name"
-        ]
-      }
-    },
-    "mappings": {
-    }
-  },
-  "composed_of": [
-    "metrics@tsdb-settings",
-    "metrics-elastic_agent.filebeat@package",
-    "metrics-elastic_agent.filebeat@custom",
-    "ecs@mappings",
-    ".fleet_globals-1",
-    ".fleet_agent_id_verification-1"
-  ],
-  "priority": 200,
-  "ignore_missing_component_templates": [
-    "metrics-elastic_agent.filebeat@custom"
-  ]
-}
-
-PUT /_index_template/testmetrics-elastic_agent.metricbeat
-{
-  "index_patterns": [
-    "testmetrics-elastic_agent.metricbeat-*"
-  ],
-  "template": {
-    "settings": {
-      "index": {
-        "mode": "time_series",
-        "routing_path": [
-          "component.id",
-          "agent.id",
-          "metricset.name"
-        ]
-      }
-    },
-    "mappings": {
-    }
-  },
-  "composed_of": [
-    "metrics@tsdb-settings",
-    "metrics-elastic_agent.metricbeat@package",
-    "metrics-elastic_agent.metricbeat@custom",
-    "ecs@mappings",
-    ".fleet_globals-1",
-    ".fleet_agent_id_verification-1"
-  ],
-  "priority": 200,
-  "ignore_missing_component_templates": [
-    "metrics-elastic_agent.metricbeat@custom"
-  ]
-}
 
 # Reindex a subset of the elastic-agent logs in the new indices
 POST _reindex
@@ -190,7 +65,8 @@ POST _reindex
     }
   },
   "dest": {
-    "index": "testlogs-elastic_agent-baseline"
+    "index": "logs-elastic_agent-disksize.baseline",
+    "op_type": "create"
   }
 }
 
@@ -208,7 +84,84 @@ POST _reindex
     }
   },
   "dest": {
-    "index": "testlogs-elastic_agent-updated"
+    "index": "logs-elastic_agent-disksize.updated",
+    "op_type": "create"
+  }
+}
+
+POST _reindex
+{
+  "source": {
+    "index": "logs-elastic_agent.filebeat-default",
+    "query": {
+      "bool": {
+        "filter": [
+          {"term": {"agent.id":"${baseline_agent_id}"}},
+          {"range": {"@timestamp": {"gte": "${baseline_start_ts}", "lte": "${baseline_start_ts}||${time_interval}"}}}
+        ]
+      }
+    }
+  },
+  "dest": {
+    "index": "logs-elastic_agent.filebeat-disksize.baseline",
+    "op_type": "create"
+  }
+}
+
+POST _reindex
+{
+  "source": {
+    "index": "logs-elastic_agent.filebeat-default",
+    "query": {
+      "bool": {
+        "filter": [
+          {"term": {"agent.id":"${updated_agent_id}"}},
+          {"range": {"@timestamp": {"gte": "${updated_start_ts}", "lte": "${updated_start_ts}||${time_interval}"}}}
+        ]
+      }
+    }
+  },
+  "dest": {
+    "index": "logs-elastic_agent.filebeat-disksize.updated",
+    "op_type": "create"
+  }
+}
+
+POST _reindex
+{
+  "source": {
+    "index": "logs-elastic_agent.metricbeat-default",
+    "query": {
+      "bool": {
+        "filter": [
+          {"term": {"agent.id":"${baseline_agent_id}"}},
+          {"range": {"@timestamp": {"gte": "${baseline_start_ts}", "lte": "${baseline_start_ts}||${time_interval}"}}}
+        ]
+      }
+    }
+  },
+  "dest": {
+    "index": "logs-elastic_agent.metricbeat-disksize.baseline",
+    "op_type": "create"
+  }
+}
+
+POST _reindex
+{
+  "source": {
+    "index": "logs-elastic_agent.metricbeat-default",
+    "query": {
+      "bool": {
+        "filter": [
+          {"term": {"agent.id":"${updated_agent_id}"}},
+          {"range": {"@timestamp": {"gte": "${updated_start_ts}", "lte": "${updated_start_ts}||${time_interval}"}}}
+        ]
+      }
+    }
+  },
+  "dest": {
+    "index": "logs-elastic_agent.metricbeat-disksize.updated",
+    "op_type": "create"
   }
 }
 
@@ -227,7 +180,8 @@ POST _reindex
     }
   },
   "dest": {
-    "index": "testmetrics-elastic_agent.elastic_agent-baseline"
+    "index": "metrics-elastic_agent.elastic_agent-disksize.baseline",
+    "op_type": "create"
   }
 }
 
@@ -245,7 +199,8 @@ POST _reindex
     }
   },
   "dest": {
-    "index": "testmetrics-elastic_agent.elastic_agent-updated"
+    "index": "metrics-elastic_agent.elastic_agent-disksize.updated",
+    "op_type": "create"
   }
 }
 
@@ -263,7 +218,8 @@ POST _reindex
     }
   },
   "dest": {
-    "index": "testmetrics-elastic_agent.filebeat-baseline"
+    "index": "metrics-elastic_agent.filebeat-disksize.baseline",
+    "op_type": "create"
   }
 }
 
@@ -282,7 +238,8 @@ POST _reindex
     }
   },
   "dest": {
-    "index": "testmetrics-elastic_agent.filebeat-updated"
+    "index": "metrics-elastic_agent.filebeat-disksize.updated",
+    "op_type": "create"
   }
 }
 
@@ -300,7 +257,8 @@ POST _reindex
     }
   },
   "dest": {
-    "index": "testmetrics-elastic_agent.metricbeat-baseline"
+    "index": "metrics-elastic_agent.metricbeat-disksize.baseline",
+    "op_type": "create"
   }
 }
 
@@ -318,22 +276,29 @@ POST _reindex
     }
   },
   "dest": {
-    "index": "testmetrics-elastic_agent.metricbeat-updated"
+    "index": "metrics-elastic_agent.metricbeat-disksize.updated",
+    "op_type": "create"
   }
 }
 
 # Check indices disk usage
 
 ## Logs
-POST /testlogs-elastic_agent-baseline/_disk_usage?run_expensive_tasks=true
-POST /testlogs-elastic_agent-updated/_disk_usage?run_expensive_tasks=true
+POST /logs-elastic_agent-disksize.baseline/_disk_usage?run_expensive_tasks=true
+POST /logs-elastic_agent-disksize.updated/_disk_usage?run_expensive_tasks=true
+
+POST /logs-elastic_agent.filebeat-disksize.baseline/_disk_usage?run_expensive_tasks=true
+POST /logs-elastic_agent.filebeat-disksize.updated/_disk_usage?run_expensive_tasks=true
+
+POST /logs-elastic_agent.metricbeat-disksize.baseline/_disk_usage?run_expensive_tasks=true
+POST /logs-elastic_agent.metricbeat-disksize.updated/_disk_usage?run_expensive_tasks=true
 
 ## Metrics
-POST /testmetrics-elastic_agent.elastic_agent-baseline/_disk_usage?run_expensive_tasks=true
-POST /testmetrics-elastic_agent.elastic_agent-updated/_disk_usage?run_expensive_tasks=true
+POST /metrics-elastic_agent.elastic_agent-disksize.baseline/_disk_usage?run_expensive_tasks=true
+POST /metrics-elastic_agent.elastic_agent-disksize.updated/_disk_usage?run_expensive_tasks=true
 
-POST /testmetrics-elastic_agent.filebeat-baseline/_disk_usage?run_expensive_tasks=true
-POST /testmetrics-elastic_agent.filebeat-updated/_disk_usage?run_expensive_tasks=true
+POST /metrics-elastic_agent.filebeat-disksize.baseline/_disk_usage?run_expensive_tasks=true
+POST /metrics-elastic_agent.filebeat-disksize.updated/_disk_usage?run_expensive_tasks=true
 
-POST /testmetrics-elastic_agent.metricbeat-baseline/_disk_usage?run_expensive_tasks=true
-POST /testmetrics-elastic_agent.metricbeat-updated/_disk_usage?run_expensive_tasks=true
+POST /metrics-elastic_agent.metricbeat-disksize.baseline/_disk_usage?run_expensive_tasks=true
+POST /metrics-elastic_agent.metricbeat-disksize.updated/_disk_usage?run_expensive_tasks=true

--- a/docs/scripts/es/elastic-agent-logs-comparison.http
+++ b/docs/scripts/es/elastic-agent-logs-comparison.http
@@ -24,31 +24,134 @@
 # Cleanup
 
 # Test log indices and templates
-DELETE /logs-elastic_agent-disksize.baseline
-DELETE /logs-elastic_agent-disksize.updated
-DELETE /logs-elastic_agent.filebeat-disksize.baseline
-DELETE /logs-elastic_agent.filebeat-disksize.updated
-DELETE /logs-elastic_agent.metricbeat-disksize.baseline
-DELETE /logs-elastic_agent.metricbeat-disksize.updated
+DELETE /_data_stream/logs-elastic_agent-disksize.baseline
+DELETE /_data_stream/logs-elastic_agent-disksize.updated
+DELETE /_data_stream/logs-elastic_agent.filebeat-disksize.baseline
+DELETE /_data_stream/logs-elastic_agent.filebeat-disksize.updated
+DELETE /_data_stream/logs-elastic_agent.metricbeat-disksize.baseline
+DELETE /_data_stream/logs-elastic_agent.metricbeat-disksize.updated
 
 # Test metrics indices and templates
 DELETE /metrics-elastic_agent.elastic_agent-disksize.baseline
 DELETE /metrics-elastic_agent.elastic_agent-disksize.updated
+DELETE /_index_template/metrics-elastic_agent.elastic_agent-disksize
 
 DELETE /metrics-elastic_agent.filebeat-disksize.baseline
 DELETE /metrics-elastic_agent.filebeat-disksize.updated
+DELETE /_index_template/metrics-elastic_agent.filebeat-disksize
 
 DELETE /metrics-elastic_agent.metricbeat-disksize.baseline
 DELETE /metrics-elastic_agent.metricbeat-disksize.updated
+DELETE /_index_template/metrics-elastic_agent.metricbeat-disksize
 
 
 # Recreate index templates
 
 # Mappings we want to use in our test index templates
 # GET /_index_template/logs-elastic_agent
-# GET /_index_template/metrics-elastic_agent.elastic_agent 
+# GET /_index_template/metrics-elastic_agent.elastic_agent
 # GET /_index_template/metrics-elastic_agent.filebeat
 # GET /_index_template/metrics-elastic_agent.metricbeat
+
+
+PUT /_index_template/metrics-elastic_agent.elastic_agent-disksize
+{
+  "index_patterns": [
+    "metrics-elastic_agent.elastic_agent-disksize*"
+  ],
+  "template": {
+    "settings": {
+      "index": {
+        "mode": "time_series",
+        "routing_path": [
+          "component.id",
+          "agent.id",
+          "metricset.name"
+        ]
+      }
+    },
+    "mappings": {
+    }
+  },
+  "composed_of": [
+    "metrics@tsdb-settings",
+    "metrics-elastic_agent.elastic_agent@package",
+    "metrics-elastic_agent.elastic_agent@custom",
+    "ecs@mappings",
+    ".fleet_globals-1",
+    ".fleet_agent_id_verification-1"
+  ],
+  "priority": 201,
+  "ignore_missing_component_templates": [
+    "metrics-elastic_agent.elastic_agent@custom"
+  ]
+}
+
+PUT /_index_template/metrics-elastic_agent.filebeat-disksize
+{
+  "index_patterns": [
+    "metrics-elastic_agent.filebeat-disksize*"
+  ],
+  "template": {
+    "settings": {
+      "index": {
+        "mode": "time_series",
+        "routing_path": [
+          "component.id",
+          "agent.id",
+          "metricset.name"
+        ]
+      }
+    },
+    "mappings": {
+    }
+  },
+  "composed_of": [
+    "metrics@tsdb-settings",
+    "metrics-elastic_agent.filebeat@package",
+    "metrics-elastic_agent.filebeat@custom",
+    "ecs@mappings",
+    ".fleet_globals-1",
+    ".fleet_agent_id_verification-1"
+  ],
+  "priority": 201,
+  "ignore_missing_component_templates": [
+    "metrics-elastic_agent.filebeat@custom"
+  ]
+}
+
+PUT /_index_template/metrics-elastic_agent.metricbeat-disksize
+{
+  "index_patterns": [
+    "metrics-elastic_agent.metricbeat-disksize*"
+  ],
+  "template": {
+    "settings": {
+      "index": {
+        "mode": "time_series",
+        "routing_path": [
+          "component.id",
+          "agent.id",
+          "metricset.name"
+        ]
+      }
+    },
+    "mappings": {
+    }
+  },
+  "composed_of": [
+    "metrics@tsdb-settings",
+    "metrics-elastic_agent.metricbeat@package",
+    "metrics-elastic_agent.metricbeat@custom",
+    "ecs@mappings",
+    ".fleet_globals-1",
+    ".fleet_agent_id_verification-1"
+  ],
+  "priority": 201,
+  "ignore_missing_component_templates": [
+    "metrics-elastic_agent.metricbeat@custom"
+  ]
+}
 
 # Reindex a subset of the elastic-agent logs in the new indices
 POST _reindex

--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -349,6 +349,16 @@ func (b *BeatsMonitor) injectLogsInput(cfg map[string]interface{}, components []
 						},
 					},
 				},
+				// drop periodic metrics logs (those are useful mostly in diagnostic dumps where we collect log files)
+				map[string]interface{}{
+					"drop_event": map[string]interface{}{
+						"when": map[string]interface{}{
+							"regexp": map[string]interface{}{
+								"message": "^Non-zero metrics in the last",
+							},
+						},
+					},
+				},
 				// copy original dataset so we can drop the dataset field
 				map[string]interface{}{
 					"copy_fields": map[string]interface{}{

--- a/internal/pkg/agent/application/upgrade/artifact/download/composed/verifier.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/composed/verifier.go
@@ -49,9 +49,8 @@ func (v *Verifier) Verify(a artifact.Artifact, version agtversion.ParsedSemVer, 
 			return nil
 		}
 
+		v.log.Debugw("Verifier failed!", "verifier", verifier.Name(), "error", e)
 		err = multierror.Append(err, e)
-
-		v.log.Warnw("Verifier failed!", "verifier", verifier.Name(), "error", e)
 	}
 
 	return err


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This PR drops the `Non-zero metrics after 30s...` logs before they get sent to Elasticsearch.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
The goal is to reduce the amount of elastic-agent monitoring events ingested in Elasticsearch in order to reduce index disk size.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally
Run an elastic agent with and without this change on a deployment making a note of the start times and elastic-agent id of both.
Using the included ES script we then extract the documents ingested during those runs and store them in dedicated indices.

In my tests I ran 2 elastic agents managed by fleet with a default policy including system integration, first without this change and then including this change, then sliced the first 10 minutes of logs and metrics from startup using the included script.

This is a screenshot from the Index management page were we can see the disk sizes and document count for each index:
![Screenshot 2024-05-02 at 18-48-16 Index Management - Elastic](https://github.com/elastic/elastic-agent/assets/96178987/ff5e1e4d-e044-47df-a924-3758a6ce7ba0)

The measured impact on `*logs-elastic_agent.filebeat*` and `*logs-elastic_agent.metricbeat*` is:
- reduction of ~27% of document count for `*logs-elastic_agent.filebeat*` with a disk size reduction of ~18%
- reduction of ~21% of document count for `*logs-elastic_agent.metricbeat*` with a disk size reduction of ~16% 

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #4252 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Questions to ask yourself

- How are we going to support this in production? 
- How are we going to measure its adoption? 
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
