### PR TITLE
Keep `go.mod` toolchain version in sync with `.go-version` contents

### DIFF
--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -123,8 +123,8 @@ targets:
         - Dockerfile
         - Dockerfile.skaffold
       matchpattern: 'ARG GO_VERSION=\d+.\d+.\d+'
-  update-gomod:
-    name: "Update go.mod"
+  update-gomod-minor-version:
+    name: "Update go.mod minor version"
     sourceid: gomod
     scmid: githubConfig
     kind: file
@@ -132,3 +132,12 @@ targets:
       content: 'go {{ source "gomod" }}'
       file: go.mod
       matchpattern: 'go \d+.\d+'
+  update-gomod-toolchain-version:
+    name: "Update go.mod toolchain version"
+    sourceid: latestGoVersion
+    scmid: githubConfig
+    kind: file
+    spec:
+      content: 'toolchain go{{ source "latestGoVersion" }}'
+      file: go.mod
+      matchpattern: 'toolchain go\d+.\d+.\d+'


### PR DESCRIPTION
## What does this PR do?

This PR updates the `toolchain` version, if specified, in the `go.mod` file with the contents of `.go-version`.

## Why is it important?

To keep all Go version references in this repository the same.

See also: https://github.com/elastic/elastic-agent/pull/4623#discussion_r1582668435