### PR TITLE
Remove unused sections in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,13 +36,6 @@ List here all the items you have verified BEFORE sending this PR. Please DO NOT 
 - [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
 - [ ] I have added an integration test or an E2E test
 
-## Author's Checklist
-
-<!-- Recommended
-Add a checklist of things that are required to be reviewed in order to have the PR approved
--->
-- [ ]
-
 ## How to test this PR locally
 
 <!-- Recommended
@@ -59,32 +52,12 @@ Link related issues below. Insert the issue link or reference after the word "Cl
 - Requires #123
 - Superseds #123
 -->
-- 
-
-## Use cases
-
-<!-- Recommended
-Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.
-
-If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
--->
-
-## Screenshots
-
-<!-- Optional
-Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
--->
-
-## Logs
-
-<!-- Recommended
-Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
--->
+-
 
 ## Questions to ask yourself
 
-- How are we going to support this in production? 
-- How are we going to measure its adoption? 
+- How are we going to support this in production?
+- How are we going to measure its adoption?
 - How are we going to debug this?
 - What are the metrics I should take care of?
 - ...


### PR DESCRIPTION
Looking through the past couple of dozen PRs created by humans (as opposed to bots) in this repository, it's clear that certain sections in the PR template are never used.  This PR updates the PR template to remove those sections and reduce noise.