### PR TITLE
Add disruptive change mitigations section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,7 +41,7 @@ List here all the items you have verified BEFORE sending this PR. Please DO NOT 
 <!--
 Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
 could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
-when using Beats.
+when using Elastic Agent.
 -->
 
 ## How to test this PR locally

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,6 +35,15 @@ List here all the items you have verified BEFORE sending this PR. Please DO NOT 
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
 - [ ] I have added an integration test or an E2E test
+- [ ] If this PR introduces a breaking change, I've populated the Breaking Change Mitigations section below.
+
+## Breaking Change Mitigations
+
+<!--
+If this PR introduces a breaking change for end users, describe what changes they could make on
+their end to nullify or minimize the impacts of this change. Consider impacts in related systems, not
+just directly when using Elastic Agent.
+-->
 
 ## How to test this PR locally
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,7 +36,7 @@ List here all the items you have verified BEFORE sending this PR. Please DO NOT 
 - [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
 - [ ] I have added an integration test or an E2E test
 
-## Breaking Change Mitigations
+## Disruptive User Impact
 
 <!--
 Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,7 +35,6 @@ List here all the items you have verified BEFORE sending this PR. Please DO NOT 
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
 - [ ] I have added an integration test or an E2E test
-- [ ] If this PR introduces a breaking change, I've populated the Breaking Change Mitigations section below.
 
 ## Breaking Change Mitigations
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,9 +39,9 @@ List here all the items you have verified BEFORE sending this PR. Please DO NOT 
 ## Breaking Change Mitigations
 
 <!--
-If this PR introduces a breaking change for end users, describe what changes they could make on
-their end to nullify or minimize the impacts of this change. Consider impacts in related systems, not
-just directly when using Elastic Agent.
+Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
+could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
+when using Beats.
 -->
 
 ## How to test this PR locally


### PR DESCRIPTION
This PR adds a new section to the PR template for describing any steps users could take to mitigate disruptive changes, when a PR introduces such changes.  