### PR TITLE
Fix ability for unprivileged Windows to upgrade

### DIFF
--- a/internal/pkg/agent/install/user_windows.go
+++ b/internal/pkg/agent/install/user_windows.go
@@ -39,6 +39,8 @@ const (
 	USER_UF_SCRIPT             = 1
 	USER_UF_NORMAL_ACCOUNT     = 512
 	USER_UF_DONT_EXPIRE_PASSWD = 65536
+
+	accountRightCreateSymbolicLink gowin32.AccountRightName = "SeCreateSymbolicLinkPrivilege"
 )
 
 // FindGID returns the group's GID on the machine.
@@ -150,6 +152,10 @@ func CreateUser(name string, _ string) (string, error) {
 	err = sp.AddAccountRight(sid, gowin32.AccountRightServiceLogon)
 	if err != nil {
 		return "", fmt.Errorf("failed to set service logon: %w", err)
+	}
+	err = sp.AddAccountRight(sid, accountRightCreateSymbolicLink)
+	if err != nil {
+		return "", fmt.Errorf("failed to add right to create symbolic link: %w", err)
 	}
 
 	return FindUID(name)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds the `SeCreateSymbolicLinkPrivilege` to the created `elastic-agent-user` when installing in unprivileged mode.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This privilege is required on the `elastic-agent-user. With out the privilege upgrade fails to update symlinks between the current and previous versions of Elastic Agent.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ **integration tests**
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [x] I have added an integration test or an E2E test

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #4646 
