### PR TITLE
[8.14] Remove `8.12.3-SNAPSHOT` from `.agent-version.json`

### DIFF
--- a/.agent-versions.json
+++ b/.agent-versions.json
@@ -2,7 +2,6 @@
   "testVersions": [
     "8.13.3-SNAPSHOT",
     "8.13.2",
-    "8.12.3-SNAPSHOT",
     "8.12.2",
     "7.17.21-SNAPSHOT",
     "7.17.20"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Removes `8.12.3-SNAPSHOT` from `.agent-version.json`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

`8.12.3-SNAPSHOT`  has expired and no longer exists.
