### PR TITLE
Add unprivileged state to agent provider

### DIFF
--- a/internal/pkg/composable/providers/agent/agent.go
+++ b/internal/pkg/composable/providers/agent/agent.go
@@ -36,6 +36,7 @@ func (*contextProvider) Run(ctx context.Context, comm corecomp.ContextProviderCo
 			"build_time": release.BuildTime().Format("2006-01-02 15:04:05 -0700 MST"),
 			"snapshot":   release.Snapshot(),
 		},
+		"unprivileged": a.Unprivileged(),
 	})
 	if err != nil {
 		return errors.New(err, "failed to set mapping", errors.TypeUnexpected)

--- a/internal/pkg/composable/providers/agent/agent_test.go
+++ b/internal/pkg/composable/providers/agent/agent_test.go
@@ -35,4 +35,6 @@ func TestContextProvider(t *testing.T) {
 	assert.True(t, hasID, "missing id")
 	_, hasVersion := current["version"]
 	assert.True(t, hasVersion, "missing version")
+	_, hasUnprivileged := current["unprivileged"]
+	assert.True(t, hasUnprivileged, "missing unprivileged")
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds the `unprivileged` state to the `agent` context provider.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Allows inputs to use `${agent.unprivileged} == true` or `${agent.unprivileged} == false` to determine if an input or metricset should be ran on that specific Elastic Agent.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~ **(covered in unit tests)**
