### PR TITLE
Use `go install` instead of `go get`

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -562,7 +562,7 @@ func RunGo(args ...string) error {
 
 // GoInstall installs a tool by calling `go install <link>
 func GoInstall(link string) error {
-	_, err := sh.Exec(map[string]string{"GO111MODULE": "off"}, os.Stdout, os.Stderr, "go", "install", link)
+	_, err := sh.Exec(map[string]string{}, os.Stdout, os.Stderr, "go", "install", link)
 	return err
 }
 

--- a/magefile.go
+++ b/magefile.go
@@ -66,8 +66,8 @@ import (
 )
 
 const (
-	goLintRepo        = "golang.org/x/lint/golint"
-	goLicenserRepo    = "github.com/elastic/go-licenser"
+	goLintRepo        = "golang.org/x/lint/golint@latest"
+	goLicenserRepo    = "github.com/elastic/go-licenser@latest"
 	buildDir          = "build"
 	metaDir           = "_meta"
 	snapshotEnv       = "SNAPSHOT"

--- a/magefile.go
+++ b/magefile.go
@@ -66,8 +66,8 @@ import (
 )
 
 const (
-	goLintRepo        = "golang.org/x/lint/golint@latest"
-	goLicenserRepo    = "github.com/elastic/go-licenser@latest"
+	goLintRepo        = "golang.org/x/lint/golint"
+	goLicenserRepo    = "github.com/elastic/go-licenser"
 	buildDir          = "build"
 	metaDir           = "_meta"
 	snapshotEnv       = "SNAPSHOT"

--- a/magefile.go
+++ b/magefile.go
@@ -205,12 +205,12 @@ func (Dev) Package() {
 
 // InstallGoLicenser install go-licenser to check license of the files.
 func (Prepare) InstallGoLicenser() error {
-	return GoGet(goLicenserRepo)
+	return GoInstall(goLicenserRepo)
 }
 
 // InstallGoLint for the code.
 func (Prepare) InstallGoLint() error {
-	return GoGet(goLintRepo)
+	return GoInstall(goLintRepo)
 }
 
 // All build all the things for the current projects.
@@ -560,9 +560,9 @@ func RunGo(args ...string) error {
 	return sh.RunV(mg.GoCmd(), args...)
 }
 
-// GoGet fetch a remote dependencies.
-func GoGet(link string) error {
-	_, err := sh.Exec(map[string]string{"GO111MODULE": "off"}, os.Stdout, os.Stderr, "go", "get", link)
+// GoInstall installs a tool by calling `go install <link>
+func GoInstall(link string) error {
+	_, err := sh.Exec(map[string]string{"GO111MODULE": "off"}, os.Stdout, os.Stderr, "go", "install", link)
 	return err
 }
 


### PR DESCRIPTION

## What does this PR do?

Calling `go get` was causing `mage check` to fail with:
```
go: modules disabled by GO111MODULE=off; see 'go help modules'
Error: running "go get github.com/elastic/go-licenser@latest" failed with exit code 1
```

This commit fixes it by using `go install` instead.


## Why is it important?

It makes `mage check` work again

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~

## How to test this PR locally

Run `mage check` it should succeed

~~## Related issues~~


## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
