### PR TITLE
[Automation] Add the `Team:Elastic-Agent-Control-Plane` label to "Update .agent-versions.json" PRs

### DIFF
--- a/.github/workflows/bump-agent-versions.sh
+++ b/.github/workflows/bump-agent-versions.sh
@@ -27,6 +27,7 @@ else
        --fill-first \
        --head "update-agent-versions-$GITHUB_RUN_ID" \
        --label 'Team:Elastic-Agent' \
+       --label 'Team:Elastic-Agent-Control-Plane' \
        --label 'update-versions' \
        --label 'skip-changelog' \
        --label 'backport-skip' \


### PR DESCRIPTION
## What does this PR do?

The changes made by this PR ensure that "Update .agent-versions.json" PRs ([example](https://github.com/elastic/elastic-agent/pull/4663)) created going forward will be labeled with the `Team:Elastic-Agent-Control-Plane` label.

## Why is it important?

To ensure the correct team gets pinged on the update version PRs and these PRs show up in relevant triage lists.
