### PR TITLE
Finish rename started in #4562

### DIFF
--- a/testing/integration/diagnostics_test.go
+++ b/testing/integration/diagnostics_test.go
@@ -158,7 +158,7 @@ func TestIsolatedUnitsDiagnosticsOptionalValues(t *testing.T) {
 		Local: false,
 	})
 
-	fixture, err := define.NewFixture(t, define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
@@ -207,7 +207,7 @@ func TestIsolatedUnitsDiagnosticsCommand(t *testing.T) {
 		Local: false,
 	})
 
-	f, err := define.NewFixture(t, define.Version())
+	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))

--- a/testing/integration/fake_test.go
+++ b/testing/integration/fake_test.go
@@ -138,7 +138,7 @@ func TestFakeIsolatedUnitsComponent(t *testing.T) {
 		Local: true,
 	})
 
-	f, err := define.NewFixture(t, define.Version())
+	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))

--- a/testing/integration/monitoring_probe_preserve_text_cfg_test.go
+++ b/testing/integration/monitoring_probe_preserve_text_cfg_test.go
@@ -91,7 +91,7 @@ func TestMonitoringPreserveTextConfig(t *testing.T) {
 }
 
 func (runner *MonitoringTextRunner) SetupSuite() {
-	fixture, err := define.NewFixture(runner.T(), define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(runner.T(), define.Version())
 	require.NoError(runner.T(), err)
 	runner.agentFixture = fixture
 

--- a/testing/integration/monitoring_probe_reload_test.go
+++ b/testing/integration/monitoring_probe_reload_test.go
@@ -56,7 +56,7 @@ func TestMonitoringLivenessReloadable(t *testing.T) {
 }
 
 func (runner *MonitoringRunner) SetupSuite() {
-	fixture, err := define.NewFixture(runner.T(), define.Version())
+	fixture, err := define.NewFixtureFromLocalBuild(runner.T(), define.Version())
 	require.NoError(runner.T(), err)
 	runner.agentFixture = fixture
 


### PR DESCRIPTION
Rename from #4562 skipped few places now tests are failing on:

```

Error: failed to determine batches: error running go test: (exit status 1), got:
# github.com/elastic/elastic-agent/testing/integration [github.com/elastic/elastic-agent/testing/integration.test]
testing/integration/diagnostics_test.go:161:25: undefined: define.NewFixture
testing/integration/diagnostics_test.go:210:19: undefined: define.NewFixture
testing/integration/fake_test.go:141:19: undefined: define.NewFixture
testing/integration/monitoring_probe_preserve_text_cfg_test.go:94:25: undefined: define.NewFixture
testing/integration/monitoring_probe_reload_test.go:59:25: undefined: define.NewFixture
FAIL	github.com/elastic/elastic-agent/testing/integration [build failed]
```


cc @belimawr @ycombinator 