### PR TITLE
pass unprivileged flag to store migration

### DIFF
--- a/internal/pkg/agent/storage/store/state_store.go
+++ b/internal/pkg/agent/storage/store/state_store.go
@@ -75,13 +75,13 @@ type stateSerializer struct {
 }
 
 // NewStateStoreWithMigration creates a new state store and migrates the old one.
-func NewStateStoreWithMigration(ctx context.Context, log *logger.Logger, actionStorePath, stateStorePath string) (*StateStore, error) {
-	err := migrateStateStore(ctx, log, actionStorePath, stateStorePath)
+func NewStateStoreWithMigration(ctx context.Context, log *logger.Logger, actionStorePath, stateStorePath string, storageOpts ...storage.EncryptedOptionFunc) (*StateStore, error) {
+	err := migrateStateStore(ctx, log, actionStorePath, stateStorePath, storageOpts...)
 	if err != nil {
 		return nil, err
 	}
 
-	encryptedDiskStore, err := storage.NewEncryptedDiskStore(ctx, stateStorePath)
+	encryptedDiskStore, err := storage.NewEncryptedDiskStore(ctx, stateStorePath, storageOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error instantiating encrypted disk store: %w", err)
 	}
@@ -147,14 +147,14 @@ func NewStateStore(log *logger.Logger, store storeLoad) (*StateStore, error) {
 	}, nil
 }
 
-func migrateStateStore(ctx context.Context, log *logger.Logger, actionStorePath, stateStorePath string) (err error) {
+func migrateStateStore(ctx context.Context, log *logger.Logger, actionStorePath, stateStorePath string, storageOpts ...storage.EncryptedOptionFunc) (err error) {
 	log = log.Named("state_migration")
 	actionDiskStore, err := storage.NewDiskStore(actionStorePath)
 	if err != nil {
 		return fmt.Errorf("error creating disk store: %w", err)
 	}
 
-	stateDiskStore, err := storage.NewEncryptedDiskStore(ctx, stateStorePath)
+	stateDiskStore, err := storage.NewEncryptedDiskStore(ctx, stateStorePath, storageOpts...)
 	if err != nil {
 		return fmt.Errorf("error instantiating encrypted disk store: %w", err)
 	}

--- a/internal/pkg/config/operations/inspector.go
+++ b/internal/pkg/config/operations/inspector.go
@@ -55,7 +55,7 @@ func LoadFullAgentConfig(ctx context.Context, logger *logger.Logger, cfgPath str
 		return c, nil
 	}
 
-	fleetConfig, err := loadFleetConfig(ctx, logger)
+	fleetConfig, err := loadFleetConfig(ctx, logger, unprivileged)
 	if err != nil {
 		return nil, fmt.Errorf("error obtaining fleet config: %w", err)
 	} else if fleetConfig == nil {
@@ -115,8 +115,8 @@ func loadConfig(ctx context.Context, configPath string, unprivileged bool) (*con
 	return rawConfig, nil
 }
 
-func loadFleetConfig(ctx context.Context, l *logger.Logger) (map[string]interface{}, error) {
-	stateStore, err := store.NewStateStoreWithMigration(ctx, l, paths.AgentActionStoreFile(), paths.AgentStateStoreFile())
+func loadFleetConfig(ctx context.Context, l *logger.Logger, unprivileged bool) (map[string]interface{}, error) {
+	stateStore, err := store.NewStateStoreWithMigration(ctx, l, paths.AgentActionStoreFile(), paths.AgentStateStoreFile(), storage.WithUnprivileged(unprivileged))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
Pass the unprivileged flag from the uninstall command down to to the state store migration so that we select the correct encryption key in case of unprivileged install.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
To make `elastic-agent uninstall` work for an elastic-agent installed as unprivileged even if an old key from a previous privileged install is present in the system keychain
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Test this on MacOS only (other OSes are not impacted by the issue)

1. Make sure you have a co.elastic.elastic-agent key in the MacOS Keychain (using the Keychain app). If there's none, install and then uninstall elastic-agent in privileged mode (**without the `--unprivileged` flag**) so that after the uninstall the key is left behind.
1. Install a managed elastic-agent (enrolled into Fleet) using the `--unprivileged` flag this time (`sudo elastic-agent install --unprivileged ...`) and check that the `vault` directory is created within `/Library/Elastic/Agent`
1. Perform `sudo elastic-agent uninstall` and verify that the agent is correctly uninstalled.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #4655 

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
