### PR TITLE
Use same version of golangci-lint in makefile as github actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ check:
 ## check-go: download and run the go linter.
 .PHONY: check-go
 check-go: ## - Run golangci-lint
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.44.2
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.55.2
 	@./bin/golangci-lint run -v
 
 ## check-no-changes : Check there is no local changes.


### PR DESCRIPTION
## What does this PR do?

The .github/workflows/golangci-lint.yml spec uses v1.55.2 for the
golangci-lint version. This commit updates the make target to use
the same version for consistency as the current version causes a
panic when running on a darwin arm64 system.

## Why is it important?

Provide a consistent local experience to CI.

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [X] I have added an integration test or an E2E test
