### PR TITLE
Fix wrong permissions when installation with enrollment on Windows in privileged mode

### DIFF
--- a/internal/pkg/agent/cmd/enroll_windows.go
+++ b/internal/pkg/agent/cmd/enroll_windows.go
@@ -32,7 +32,7 @@ func getFileOwnerFromCmd(cmd *cobra.Command) (utils.FileOwner, error) {
 	if err != nil {
 		return utils.FileOwner{}, err
 	}
-	ownership := utils.CurrentFileOwner()
+	var ownership utils.FileOwner
 	if userSID != nil {
 		ownership.UID = userSID.String()
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes an installation issue on Windows in privileged mode where the wrong permissions are given to the Elastic Agent installation directory.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Otherwise it would allow any non-Administrator to read/modify/delete a file in the Elastic Agent installation directory.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

Fixes a disruptive user issue of invalid permissions.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Install without `--unprivileged` and with enrollment.
2. Verify the permissions of the installation directory only have access by Administrators.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/ingest-dev/issues/3339

