### PR TITLE
Make error checks in TestLogIngestionFleetManaged more resilient

### DIFF
--- a/pkg/testing/tools/estools/elasticsearch.go
+++ b/pkg/testing/tools/estools/elasticsearch.go
@@ -375,21 +375,17 @@ func CheckForErrorsInLogs(ctx context.Context, client elastictransport.Interface
 // CheckForErrorsInLogsWithContext checks to see if any error-level lines exist
 // excludeStrings can be used to remove any particular error strings from logs
 func CheckForErrorsInLogsWithContext(ctx context.Context, client elastictransport.Interface, namespace string, excludeStrings []string) (Documents, error) {
-	queryRaw := map[string]interface{}{
-		"query": map[string]interface{}{
-			"bool": map[string]interface{}{
-				"must": []map[string]interface{}{
-					{
-						"match": map[string]interface{}{
-							"log.level": "error",
-						},
-					},
-					{
-						"term": map[string]interface{}{
-							"data_stream.namespace": map[string]interface{}{
-								"value": namespace,
-							},
-						},
+	filters := map[string]interface{}{
+		"must": []map[string]interface{}{
+			{
+				"match": map[string]interface{}{
+					"log.level": "error",
+				},
+			},
+			{
+				"term": map[string]interface{}{
+					"data_stream.namespace": map[string]interface{}{
+						"value": namespace,
 					},
 				},
 			},
@@ -405,27 +401,14 @@ func CheckForErrorsInLogsWithContext(ctx context.Context, client elastictranspor
 				},
 			})
 		}
-		queryRaw = map[string]interface{}{
-			"query": map[string]interface{}{
-				"bool": map[string]interface{}{
-					"must": []map[string]interface{}{
-						{
-							"match": map[string]interface{}{
-								"log.level": "error",
-							},
-						},
-						{
-							"term": map[string]interface{}{
-								"data_stream.namespace": map[string]interface{}{
-									"value": namespace,
-								},
-							},
-						},
-					},
-					"must_not": excludeStatements,
-				},
-			},
-		}
+
+		filters["must_not"] = excludeStatements
+	}
+
+	queryRaw := map[string]interface{}{
+		"query": map[string]interface{}{
+			"bool": filters,
+		},
 	}
 
 	var buf bytes.Buffer

--- a/testing/integration/logs_ingestion_test.go
+++ b/testing/integration/logs_ingestion_test.go
@@ -274,21 +274,28 @@ func testMonitoringLogsAreShipped(
 			"Failed to initialize artifact",
 			"Failed to apply initial policy from on disk configuration",
 			"elastic-agent-client error: rpc error: code = Canceled desc = context canceled", // can happen on restart
-			"add_cloud_metadata: received error failed requesting openstack metadata: Get \\\"https://169.254.169.254/2009-04-04/meta-data/instance-id\\\": dial tcp 169.254.169.254:443: connect: connection refused",                 // okay for the openstack metadata to not work
-			"add_cloud_metadata: received error failed requesting openstack metadata: Get \\\"https://169.254.169.254/2009-04-04/meta-data/hostname\\\": dial tcp 169.254.169.254:443: connect: connection refused",                    // okay for the cloud metadata to not work
-			"add_cloud_metadata: received error failed requesting openstack metadata: Get \\\"https://169.254.169.254/2009-04-04/meta-data/placement/availability-zone\\\": dial tcp 169.254.169.254:443: connect: connection refused", // okay for the cloud metadata to not work
-			"add_cloud_metadata: received error failed requesting openstack metadata: Get \\\"https://169.254.169.254/2009-04-04/meta-data/instance-type\\\": dial tcp 169.254.169.254:443: connect: connection refused",               // okay for the cloud metadata to not work
-			"add_cloud_metadata: received error failed with http status code 404",                                                                                                                             // okay for the cloud metadata to not work
-			"add_cloud_metadata: received error failed fetching EC2 Identity Document: not found, Signing",                                                                                                    // okay for the cloud metadata to not work
-			"add_cloud_metadata: received error failed fetching EC2 Identity Document: operation error ec2imds: GetInstanceIdentityDocument, http response error StatusCode: 404, request to EC2 IMDS failed", // okay for the cloud metadata to not work
-			"failed to invoke rollback watcher: failed to start Upgrade Watcher: fork/exec /var/lib/elastic-agent/elastic-agent: no such file or directory",                                                   // on debian this happens probably need to fix.
+			"add_cloud_metadata: received error failed requesting openstack metadata",        // okay for the cloud metadata to not work
+			"add_cloud_metadata: received error failed with http status code 404",            // okay for the cloud metadata to not work
+			"add_cloud_metadata: received error failed fetching EC2 Identity Document",       // okay for the cloud metadata to not work
+			"failed to invoke rollback watcher: failed to start Upgrade Watcher",             // on debian this happens probably need to fix.
+			"falling back to IMDSv1: operation error ec2imds: getToken",                      // okay for the cloud metadata to not work
 		})
 	})
 	t.Logf("error logs: Got %d documents", len(docs.Hits.Hits))
+	messages := make([]string, 0, len(docs.Hits.Hits))
 	for _, doc := range docs.Hits.Hits {
 		t.Logf("%#v", doc.Source)
+		message, ok := doc.Source["message"]
+		if !ok {
+			continue
+		}
+		messageStr, ok := message.(string)
+		if !ok {
+			continue
+		}
+		messages = append(messages, messageStr)
 	}
-	require.Empty(t, docs.Hits.Hits)
+	require.Emptyf(t, docs.Hits.Hits, "list of error messages is expected to be empty, found:\n%s", strings.Join(messages, ", \n"))
 
 	// Stage 3: Make sure we have message confirming central management is running
 	t.Log("Making sure we have message confirming central management is running")


### PR DESCRIPTION
This check should not use exact matching but rather "contains" for accounting for know errors since details might change.