### PR TITLE
Apply mTLS config from policy

### DIFF
--- a/changelog/fragments/1716490302-Load-fleet.ssl.certificate_authorities-from-agent-policy.yaml
+++ b/changelog/fragments/1716490302-Load-fleet.ssl.certificate_authorities-from-agent-policy.yaml
@@ -1,0 +1,35 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Load Certificate Authorities from Fleet policy
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: >
+  Loads Certificate Authorities (CA) file paths from Fleet policy's key `fleet.ssl.certificate_authorities` and pass it to
+  elastic-agent HTTP client used for connecting to Fleet server. The CAs will be used to validate server or proxy certificates
+  presented when connecting to `HTTPs` endpoints.
+
+# Affected component; a word indicating the component this changeset affects.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/4770
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/2247

--- a/changelog/fragments/1716490302-Load-fleet.ssl.certificate_authorities-from-agent-policy.yaml
+++ b/changelog/fragments/1716490302-Load-fleet.ssl.certificate_authorities-from-agent-policy.yaml
@@ -8,7 +8,7 @@
 # - security: impacts on the security of a product or a user’s deployment.
 # - upgrade: important information for someone upgrading from a prior version
 # - other: does not fit into any of the other categories
-kind: bug-fix
+kind: enhancement
 
 # Change summary; a 80ish characters long description of the change.
 summary: Load Certificate Authorities from Fleet policy

--- a/changelog/fragments/1716490302-Load-fleet.ssl.certificate_authorities-from-agent-policy.yaml
+++ b/changelog/fragments/1716490302-Load-fleet.ssl.certificate_authorities-from-agent-policy.yaml
@@ -17,7 +17,7 @@ summary: Load Certificate Authorities from Fleet policy
 # this field accommodate a description without length limits.
 # NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
 description: >
-  Loads Certificate Authorities (CA) file paths from Fleet policy's key `fleet.ssl.certificate_authorities` and pass it to
+  Loads Certificate Authorities (CA) from Fleet policy's key `fleet.ssl.certificate_authorities` and pass it to
   elastic-agent HTTP client used for connecting to Fleet server. The CAs will be used to validate server or proxy certificates
   presented when connecting to `HTTPs` endpoints.
 

--- a/changelog/fragments/1716490372-Load-fleet.ssl.certificate-and-fleet.ssl.key-from-agent-policy.yaml
+++ b/changelog/fragments/1716490372-Load-fleet.ssl.certificate-and-fleet.ssl.key-from-agent-policy.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Load fleet.ssl.certificate and fleet.ssl.key from agent policy
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/4770
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/2248

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
+	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/actions"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
@@ -122,23 +123,33 @@ func (h *PolicyChangeHandler) Watch() <-chan coordinator.ConfigChange {
 	return h.ch
 }
 
-func (h *PolicyChangeHandler) validateFleetServerHosts(ctx context.Context, cfg *configuration.Configuration) (*remote.Config, error) {
+func (h *PolicyChangeHandler) validateFleetServerHosts(ctx context.Context, cfg *config.Config) (*remote.Config, error) {
 	// do not update fleet-server host from policy; no setters provided with local Fleet Server
 	if len(h.setters) == 0 {
 		return nil, nil
 	}
 
-	if clientEqual(h.config.Fleet.Client, cfg.Fleet.Client) {
+	parsedConfig, err := configuration.NewPartialFromConfigNoDefaults(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("parsing fleet config: %w", err)
+	}
+
+	if parsedConfig.Fleet == nil {
+		// there is no client config (weird)
+		return nil, nil
+	}
+
+	if clientEqual(h.config.Fleet.Client, parsedConfig.Fleet.Client) {
 		// already the same hosts
 		return nil, nil
 	}
 
-	// make a copy the current client config and apply the changes in place on this copy
+	// make a copy the current client config and apply the changes on this copy
 	newFleetClientConfig := h.config.Fleet.Client
-	updateFleetConfig(h.log, cfg.Fleet.Client, &newFleetClientConfig)
+	updateFleetConfig(h.log, parsedConfig.Fleet.Client, &newFleetClientConfig)
 
 	// Test new config
-	err := testFleetConfig(ctx, h.log, newFleetClientConfig, h.config.Fleet.AccessAPIKey)
+	err = testFleetConfig(ctx, h.log, newFleetClientConfig, h.config.Fleet.AccessAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("validating fleet client config: %w", err)
 	}
@@ -177,10 +188,16 @@ func testFleetConfig(ctx context.Context, log *logger.Logger, clientConfig remot
 
 // updateFleetConfig copies the relevant Fleet client settings from src on dst. The destination struct is modified in-place
 func updateFleetConfig(log *logger.Logger, src remote.Config, dst *remote.Config) {
-	dst.Protocol = src.Protocol
-	dst.Path = src.Path
-	dst.Host = src.Host
-	dst.Hosts = src.Hosts
+
+	// Hosts is the only connectivity field sent Fleet, let's clear everything else aside from Hosts
+	if len(src.Hosts) > 0 {
+		dst.Hosts = make([]string, len(src.Hosts))
+		copy(dst.Hosts, src.Hosts)
+
+		dst.Host = ""
+		dst.Protocol = ""
+		dst.Path = ""
+	}
 
 	// Empty proxies from fleet are ignored. That way a proxy set by --proxy-url
 	// it won't be overridden by an absent or empty proxy from fleet-server.
@@ -189,8 +206,9 @@ func updateFleetConfig(log *logger.Logger, src remote.Config, dst *remote.Config
 
 	if src.Transport.Proxy.URL == nil ||
 		src.Transport.Proxy.URL.String() == "" {
-		log.Debug("proxy from fleet is empty or null, the proxy will not be changed")
+		log.Debugw("proxy from fleet is empty or null, the proxy will not be changed", "current proxy", dst.Transport.Proxy.URL)
 	} else {
+		log.Debugw("received proxy from fleet, applying it", "old proxy", dst.Transport.Proxy.URL, "new proxy", src.Transport.Proxy.URL)
 		// copy the proxy struct
 		dst.Transport.Proxy = src.Transport.Proxy
 
@@ -206,21 +224,47 @@ func updateFleetConfig(log *logger.Logger, src remote.Config, dst *remote.Config
 		urlCopy := *src.Transport.Proxy.URL
 		dst.Transport.Proxy.URL = &urlCopy
 
-		log.Debug("received proxy from fleet, applying it")
+	}
+
+	if src.Transport.TLS != nil {
+
+		if dst.Transport.TLS == nil {
+			dst.Transport.TLS = new(tlscommon.Config)
+		} else {
+			// copy the TLS struct
+			tlsCopy := *dst.Transport.TLS
+			dst.Transport.TLS = &tlsCopy
+		}
+
+		emptyCertificate := tlscommon.CertificateConfig{}
+		if src.Transport.TLS.Certificate == emptyCertificate {
+			log.Debug("TLS certificates from fleet are empty or null, the TLS config will not be changed")
+		} else {
+			dst.Transport.TLS.Certificate = src.Transport.TLS.Certificate
+			log.Debug("received TLS certificate/key from fleet, applying it")
+		}
+
+		if len(src.Transport.TLS.CAs) == 0 {
+			log.Debug("TLS CAs from fleet are empty or null, the TLS config will not be changed")
+		} else {
+			dst.Transport.TLS.CAs = make([]string, len(src.Transport.TLS.CAs))
+			copy(dst.Transport.TLS.CAs, src.Transport.TLS.CAs)
+			log.Debug("received TLS CAs from fleet, applying it")
+		}
 	}
 }
 
 func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.Config) (err error) {
-	cfg, err := configuration.NewFromConfig(c)
-	if err != nil {
-		return errors.New(err, "could not parse the configuration from the policy", errors.TypeConfig)
-	}
+	//cfg, err := configuration.NewFromConfig(c)
+	//if err != nil {
+	//	return errors.New(err, "could not parse the configuration from the policy", errors.TypeConfig)
+	//}
 
 	var validationErr error
 
 	// validate Fleet connectivity with the new configuration
 	var validatedConfig *remote.Config
-	validatedConfig, err = h.validateFleetServerHosts(ctx, cfg)
+	validatedConfig, err = h.validateFleetServerHosts(ctx, c)
 	if err != nil {
 		validationErr = goerrors.Join(validationErr, fmt.Errorf("validating Fleet client config: %w", err))
 	}
@@ -352,6 +396,10 @@ func clientEqual(k1 remote.Config, k2 remote.Config) bool {
 		return false
 	}
 	if k1.Path != k2.Path {
+		return false
+	}
+
+	if k1.Host != k2.Host {
 		return false
 	}
 

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -223,33 +223,29 @@ func updateFleetConfig(log *logger.Logger, src remote.Config, dst *remote.Config
 		// Proxy URL
 		urlCopy := *src.Transport.Proxy.URL
 		dst.Transport.Proxy.URL = &urlCopy
-
 	}
 
 	if src.Transport.TLS != nil {
 
-		if dst.Transport.TLS == nil {
-			dst.Transport.TLS = new(tlscommon.Config)
-		} else {
-			// copy the TLS struct
-			tlsCopy := *dst.Transport.TLS
-			dst.Transport.TLS = &tlsCopy
-		}
+		// copy the TLS struct
+		tlsCopy := *src.Transport.TLS
 
 		if src.Transport.TLS.Certificate == emptyCertificateConfig() {
 			log.Debug("TLS certificates from fleet are empty or null, the TLS config will not be changed")
 		} else {
-			dst.Transport.TLS.Certificate = src.Transport.TLS.Certificate
+			tlsCopy.Certificate = src.Transport.TLS.Certificate
 			log.Debug("received TLS certificate/key from fleet, applying it")
 		}
 
 		if len(src.Transport.TLS.CAs) == 0 {
 			log.Debug("TLS CAs from fleet are empty or null, the TLS config will not be changed")
 		} else {
-			dst.Transport.TLS.CAs = make([]string, len(src.Transport.TLS.CAs))
-			copy(dst.Transport.TLS.CAs, src.Transport.TLS.CAs)
+			tlsCopy.CAs = make([]string, len(src.Transport.TLS.CAs))
+			copy(tlsCopy.CAs, src.Transport.TLS.CAs)
 			log.Debug("received TLS CAs from fleet, applying it")
 		}
+
+		dst.Transport.TLS = &tlsCopy
 	}
 }
 

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -206,9 +206,9 @@ func updateFleetConfig(log *logger.Logger, src remote.Config, dst *remote.Config
 
 	if src.Transport.Proxy.URL == nil ||
 		src.Transport.Proxy.URL.String() == "" {
-		log.Debugw("proxy from fleet is empty or null, the proxy will not be changed", "current proxy", dst.Transport.Proxy.URL)
+		log.Debugw("proxy from fleet is empty or null, the proxy will not be changed", "current_proxy", dst.Transport.Proxy.URL)
 	} else {
-		log.Debugw("received proxy from fleet, applying it", "old proxy", dst.Transport.Proxy.URL, "new proxy", src.Transport.Proxy.URL)
+		log.Debugw("received proxy from fleet, applying it", "old_proxy", dst.Transport.Proxy.URL, "new_proxy", src.Transport.Proxy.URL)
 		// copy the proxy struct
 		dst.Transport.Proxy = src.Transport.Proxy
 
@@ -236,8 +236,7 @@ func updateFleetConfig(log *logger.Logger, src remote.Config, dst *remote.Config
 			dst.Transport.TLS = &tlsCopy
 		}
 
-		emptyCertificate := tlscommon.CertificateConfig{}
-		if src.Transport.TLS.Certificate == emptyCertificate {
+		if src.Transport.TLS.Certificate == emptyCertificateConfig() {
 			log.Debug("TLS certificates from fleet are empty or null, the TLS config will not be changed")
 		} else {
 			dst.Transport.TLS.Certificate = src.Transport.TLS.Certificate
@@ -254,12 +253,11 @@ func updateFleetConfig(log *logger.Logger, src remote.Config, dst *remote.Config
 	}
 }
 
-func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.Config) (err error) {
-	//cfg, err := configuration.NewFromConfig(c)
-	//if err != nil {
-	//	return errors.New(err, "could not parse the configuration from the policy", errors.TypeConfig)
-	//}
+func emptyCertificateConfig() tlscommon.CertificateConfig {
+	return tlscommon.CertificateConfig{}
+}
 
+func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.Config) (err error) {
 	var validationErr error
 
 	// validate Fleet connectivity with the new configuration

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
@@ -6,10 +6,16 @@ package handlers
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"testing"
@@ -19,7 +25,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/testing/certutil"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
+	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/actions"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
@@ -123,63 +131,121 @@ func TestPolicyChangeHandler_handlePolicyChange_FleetClientSettings(t *testing.T
 	fleetServerPort, err := strconv.Atoi(fleetServerURL.Port())
 	require.NoError(t, err)
 
-	t.Run("Rollback client changes when cannot create client",
-		func(t *testing.T) {
-			log, _ := logger.NewTesting("TestPolicyChangeHandler")
-			var setterCalledCount int
-			setter := testSetter{SetClientFn: func(c client.Sender) {
-				setterCalledCount++
-			}}
+	t.Run("policy with proxy config", func(t *testing.T) {
+		t.Run("rollback client changes when cannot create client",
+			func(t *testing.T) {
+				log, _ := logger.NewTesting("TestPolicyChangeHandler")
+				var setterCalledCount int
+				setter := testSetter{SetClientFn: func(c client.Sender) {
+					setterCalledCount++
+				}}
 
-			originalCfg := &configuration.Configuration{
-				Fleet: &configuration.FleetAgentConfig{
-					Server: &configuration.FleetServerConfig{
-						Host: fleetServerHost,
-						Port: uint16(fleetServerPort),
+				originalCfg := &configuration.Configuration{
+					Fleet: &configuration.FleetAgentConfig{
+						Server: &configuration.FleetServerConfig{
+							Host: fleetServerHost,
+							Port: uint16(fleetServerPort),
+						},
+						Client: remote.Config{
+							Host:  "http://example.co",
+							Hosts: []string{"http://hosts1.com", "http://hosts2.com"},
+							Transport: httpcommon.HTTPTransportSettings{
+								Proxy: httpcommon.HTTPClientProxySettings{
+									URL: &httpcommon.ProxyURI{
+										Host: "original.proxy",
+									},
+								}}},
 					},
-					Client: remote.Config{
-						Host:  "http://example.co",
-						Hosts: []string{"http://hosts1.com", "http://hosts2.com"},
-						Transport: httpcommon.HTTPTransportSettings{
-							Proxy: httpcommon.HTTPClientProxySettings{
-								URL: &httpcommon.ProxyURI{
-									Host: "original.proxy",
-								},
-							}}},
-				},
-				Settings: configuration.DefaultSettingsConfig()}
+					Settings: configuration.DefaultSettingsConfig()}
 
-			h := PolicyChangeHandler{
-				agentInfo: &info.AgentInfo{},
-				config:    originalCfg,
-				store:     &storage.NullStore{},
-				setters:   []actions.ClientSetter{&setter},
-				log:       log,
-			}
+				h := PolicyChangeHandler{
+					agentInfo:            &info.AgentInfo{},
+					config:               originalCfg,
+					store:                &storage.NullStore{},
+					setters:              []actions.ClientSetter{&setter},
+					log:                  log,
+					policyLogLevelSetter: mockhandlers.NewLogLevelSetter(t),
+				}
 
-			cfg := config.MustNewConfigFrom(
-				map[string]interface{}{
-					"fleet.host":      "http://some.url",
-					"fleet.proxy_url": "http://some.proxy",
-				})
+				cfg := config.MustNewConfigFrom(
+					map[string]interface{}{
+						"fleet.host":      "http://some.url",
+						"fleet.proxy_url": "http://some.proxy",
+					})
 
-			err := h.handlePolicyChange(context.Background(), cfg)
-			require.Error(t, err) // it needs to fail to rollback
+				err := h.handlePolicyChange(context.Background(), cfg)
+				require.Error(t, err) // it needs to fail to rollback
 
-			assert.Equal(t, 0, setterCalledCount)
-			assert.Equal(t,
-				originalCfg.Fleet.Client.Host,
-				h.config.Fleet.Client.Host)
-			assert.Equal(t,
-				originalCfg.Fleet.Client.Hosts,
-				h.config.Fleet.Client.Hosts)
-			assert.Equal(t,
-				originalCfg.Fleet.Client.Transport.Proxy.URL,
-				h.config.Fleet.Client.Transport.Proxy.URL)
-		})
+				assert.Equal(t, 0, setterCalledCount)
+				assert.Equal(t,
+					originalCfg.Fleet.Client.Host,
+					h.config.Fleet.Client.Host)
+				assert.Equal(t,
+					originalCfg.Fleet.Client.Hosts,
+					h.config.Fleet.Client.Hosts)
+				assert.Equal(t,
+					originalCfg.Fleet.Client.Transport.Proxy.URL,
+					h.config.Fleet.Client.Transport.Proxy.URL)
+			})
 
-	t.Run("Rollback client changes when cannot reach fleet-server",
-		func(t *testing.T) {
+		t.Run("rollback client changes when cannot reach fleet-server",
+			func(t *testing.T) {
+				log, _ := logger.NewTesting("TestPolicyChangeHandler")
+				var setterCalledCount int
+				setter := testSetter{SetClientFn: func(c client.Sender) {
+					setterCalledCount++
+				}}
+
+				originalCfg := &configuration.Configuration{
+					Fleet: &configuration.FleetAgentConfig{
+						Server: &configuration.FleetServerConfig{
+							Host: fleetServerHost,
+							Port: uint16(fleetServerPort),
+						},
+						AccessAPIKey: "ignore",
+						Client: remote.Config{
+							Host:  "http://example.co",
+							Hosts: []string{"http://hosts1.com", "http://hosts2.com"},
+							Transport: httpcommon.HTTPTransportSettings{
+								Proxy: httpcommon.HTTPClientProxySettings{
+									URL: &httpcommon.ProxyURI{
+										Host: "original.proxy",
+									},
+								}}},
+					},
+					Settings: configuration.DefaultSettingsConfig()}
+
+				h := PolicyChangeHandler{
+					agentInfo:            &info.AgentInfo{},
+					config:               originalCfg,
+					store:                &storage.NullStore{},
+					setters:              []actions.ClientSetter{&setter},
+					log:                  log,
+					policyLogLevelSetter: mockhandlers.NewLogLevelSetter(t),
+				}
+
+				cfg := config.MustNewConfigFrom(
+					map[string]interface{}{
+						"fleet.host":      "http://some.url",
+						"fleet.proxy_url": "http://some.proxy",
+					})
+
+				err := h.handlePolicyChange(context.Background(), cfg)
+				require.Error(t, err) // it needs to fail to rollback
+
+				assert.Equal(t, 0, setterCalledCount)
+				assert.Equal(t,
+					originalCfg.Fleet.Client.Host,
+					h.config.Fleet.Client.Host)
+				assert.Equal(t,
+					originalCfg.Fleet.Client.Hosts,
+					h.config.Fleet.Client.Hosts)
+				assert.Equal(t,
+					originalCfg.Fleet.Client.Transport.Proxy.URL,
+					h.config.Fleet.Client.Transport.Proxy.URL)
+			})
+
+		t.Run("a new Host and no proxy changes the Host", func(t *testing.T) {
 			log, _ := logger.NewTesting("TestPolicyChangeHandler")
 			var setterCalledCount int
 			setter := testSetter{SetClientFn: func(c client.Sender) {
@@ -194,17 +260,9 @@ func TestPolicyChangeHandler_handlePolicyChange_FleetClientSettings(t *testing.T
 					},
 					AccessAPIKey: "ignore",
 					Client: remote.Config{
-						Host:  "http://example.co",
-						Hosts: []string{"http://hosts1.com", "http://hosts2.com"},
-						Transport: httpcommon.HTTPTransportSettings{
-							Proxy: httpcommon.HTTPClientProxySettings{
-								URL: &httpcommon.ProxyURI{
-									Host: "original.proxy",
-								},
-							}}},
+						Host: "http://example.co"},
 				},
-				Settings: configuration.DefaultSettingsConfig(),
-			}
+				Settings: configuration.DefaultSettingsConfig()}
 
 			h := PolicyChangeHandler{
 				agentInfo:            &info.AgentInfo{},
@@ -212,175 +270,29 @@ func TestPolicyChangeHandler_handlePolicyChange_FleetClientSettings(t *testing.T
 				store:                &storage.NullStore{},
 				setters:              []actions.ClientSetter{&setter},
 				log:                  log,
-				policyLogLevelSetter: mockhandlers.NewLogLevelSetter(t),
+				policyLogLevelSetter: noLogLevelSet(t),
 			}
 
 			cfg := config.MustNewConfigFrom(
 				map[string]interface{}{
-					"fleet.host":      "http://some.url",
-					"fleet.proxy_url": "http://some.proxy",
-				})
+					"fleet.host": fleetServer.URL})
 
 			err := h.handlePolicyChange(context.Background(), cfg)
-			require.Error(t, err) // it needs to fail to rollback
+			require.NoError(t, err)
 
-			assert.Equal(t, 0, setterCalledCount)
-			assert.Equal(t,
-				originalCfg.Fleet.Client.Host,
-				h.config.Fleet.Client.Host)
-			assert.Equal(t,
-				originalCfg.Fleet.Client.Hosts,
-				h.config.Fleet.Client.Hosts)
-			assert.Equal(t,
-				originalCfg.Fleet.Client.Transport.Proxy.URL,
+			assert.Equal(t, 1, setterCalledCount)
+			assert.Equal(t, fleetServer.URL, h.config.Fleet.Client.Host)
+			assert.Empty(t,
 				h.config.Fleet.Client.Transport.Proxy.URL)
 		})
 
-	t.Run("A policy with a new Host and no proxy changes the Host", func(t *testing.T) {
-		log, _ := logger.NewTesting("TestPolicyChangeHandler")
-		var setterCalledCount int
-		setter := testSetter{SetClientFn: func(c client.Sender) {
-			setterCalledCount++
-		}}
-
-		originalCfg := &configuration.Configuration{
-			Fleet: &configuration.FleetAgentConfig{
-				Server: &configuration.FleetServerConfig{
-					Host: fleetServerHost,
-					Port: uint16(fleetServerPort),
-				},
-				AccessAPIKey: "ignore",
-				Client: remote.Config{
-					Host: "http://example.co"},
-			},
-			Settings: configuration.DefaultSettingsConfig()}
-
-		h := PolicyChangeHandler{
-			agentInfo:            &info.AgentInfo{},
-			config:               originalCfg,
-			store:                &storage.NullStore{},
-			setters:              []actions.ClientSetter{&setter},
-			log:                  log,
-			policyLogLevelSetter: noLogLevelSet(t),
-		}
-
-		cfg := config.MustNewConfigFrom(
-			map[string]interface{}{
-				"fleet.host": fleetServer.URL})
-
-		err := h.handlePolicyChange(context.Background(), cfg)
-		require.NoError(t, err)
-
-		assert.Equal(t, 1, setterCalledCount)
-		assert.Equal(t, fleetServer.URL, h.config.Fleet.Client.Host)
-		assert.Empty(t,
-			h.config.Fleet.Client.Transport.Proxy.URL)
-	})
-
-	t.Run("A policy with new Hosts and no proxy changes the Hosts", func(t *testing.T) {
-		log, _ := logger.NewTesting("TestPolicyChangeHandler")
-		var setterCalledCount int
-		setter := testSetter{SetClientFn: func(c client.Sender) {
-			setterCalledCount++
-		}}
-
-		originalCfg := &configuration.Configuration{
-			Fleet: &configuration.FleetAgentConfig{
-				Server: &configuration.FleetServerConfig{
-					Host: fleetServerHost,
-					Port: uint16(fleetServerPort),
-				},
-				AccessAPIKey: "ignore",
-				Client: remote.Config{
-					Host: "http://example.co"},
-			},
-			Settings: configuration.DefaultSettingsConfig()}
-
-		h := PolicyChangeHandler{
-			agentInfo:            &info.AgentInfo{},
-			config:               originalCfg,
-			store:                &storage.NullStore{},
-			setters:              []actions.ClientSetter{&setter},
-			log:                  log,
-			policyLogLevelSetter: noLogLevelSet(t),
-		}
-
-		wantHosts := []string{fleetServer.URL, fleetServer.URL}
-		cfg := config.MustNewConfigFrom(
-			map[string]interface{}{
-				"fleet.hosts": wantHosts})
-
-		err := h.handlePolicyChange(context.Background(), cfg)
-		require.NoError(t, err)
-
-		assert.Equal(t, 1, setterCalledCount)
-		assert.Equal(t, wantHosts, h.config.Fleet.Client.Hosts)
-		assert.Empty(t,
-			h.config.Fleet.Client.Transport.Proxy.URL)
-	})
-
-	t.Run("A policy with proxy changes the fleet client", func(t *testing.T) {
-		log, _ := logger.NewTesting("TestPolicyChangeHandler")
-		var setterCalledCount int
-		setter := testSetter{SetClientFn: func(c client.Sender) {
-			setterCalledCount++
-		}}
-
-		originalCfg := &configuration.Configuration{
-			Fleet: &configuration.FleetAgentConfig{
-				Server: &configuration.FleetServerConfig{
-					Host: fleetServerHost,
-					Port: uint16(fleetServerPort),
-				},
-				AccessAPIKey: "ignore",
-				Client: remote.Config{
-					Transport: httpcommon.HTTPTransportSettings{
-						Proxy: httpcommon.HTTPClientProxySettings{
-							URL: &httpcommon.ProxyURI{
-								Host: "original.proxy",
-							},
-						}}},
-			},
-			Settings: configuration.DefaultSettingsConfig()}
-
-		h := PolicyChangeHandler{
-			agentInfo:            &info.AgentInfo{},
-			config:               originalCfg,
-			store:                &storage.NullStore{},
-			setters:              []actions.ClientSetter{&setter},
-			log:                  log,
-			policyLogLevelSetter: noLogLevelSet(t),
-		}
-
-		cfg := config.MustNewConfigFrom(
-			map[string]interface{}{
-				"fleet.proxy_url": mockProxy.URL,
-				"fleet.host":      fleetServer.URL})
-
-		err := h.handlePolicyChange(context.Background(), cfg)
-		require.NoError(t, err)
-
-		assert.Equal(t, 1, setterCalledCount)
-		assert.Equal(t,
-			mockProxy.URL,
-			h.config.Fleet.Client.Transport.Proxy.URL.String())
-	})
-
-	t.Run("A policy with empty proxy don't change the fleet client",
-		func(t *testing.T) {
-			wantProxy := mockProxy.URL
-
+		t.Run("a proxy changes the fleet client", func(t *testing.T) {
 			log, _ := logger.NewTesting("TestPolicyChangeHandler")
 			var setterCalledCount int
 			setter := testSetter{SetClientFn: func(c client.Sender) {
 				setterCalledCount++
 			}}
 
-			mockProxyURL, err := url.Parse(mockProxy.URL)
-			require.NoError(t, err)
-
-			tmpMockProxyURI := httpcommon.ProxyURI(*mockProxyURL)
-			mockProxyURI := &tmpMockProxyURI
 			originalCfg := &configuration.Configuration{
 				Fleet: &configuration.FleetAgentConfig{
 					Server: &configuration.FleetServerConfig{
@@ -389,10 +301,11 @@ func TestPolicyChangeHandler_handlePolicyChange_FleetClientSettings(t *testing.T
 					},
 					AccessAPIKey: "ignore",
 					Client: remote.Config{
-						Host: fleetServerHost,
 						Transport: httpcommon.HTTPTransportSettings{
 							Proxy: httpcommon.HTTPClientProxySettings{
-								URL: mockProxyURI,
+								URL: &httpcommon.ProxyURI{
+									Host: "original.proxy",
+								},
 							}}},
 				},
 				Settings: configuration.DefaultSettingsConfig()}
@@ -408,17 +321,507 @@ func TestPolicyChangeHandler_handlePolicyChange_FleetClientSettings(t *testing.T
 
 			cfg := config.MustNewConfigFrom(
 				map[string]interface{}{
-					"fleet.proxy_url": "",
+					"fleet.proxy_url": mockProxy.URL,
 					"fleet.host":      fleetServer.URL})
 
-			err = h.handlePolicyChange(context.Background(), cfg)
+			err := h.handlePolicyChange(context.Background(), cfg)
 			require.NoError(t, err)
 
 			assert.Equal(t, 1, setterCalledCount)
 			assert.Equal(t,
-				wantProxy,
+				mockProxy.URL,
 				h.config.Fleet.Client.Transport.Proxy.URL.String())
 		})
+
+		t.Run("empty proxy don't change the fleet client",
+			func(t *testing.T) {
+				wantProxy := mockProxy.URL
+
+				log, _ := logger.NewTesting("TestPolicyChangeHandler")
+				var setterCalledCount int
+				setter := testSetter{SetClientFn: func(c client.Sender) {
+					setterCalledCount++
+				}}
+
+				mockProxyURL, err := url.Parse(mockProxy.URL)
+				require.NoError(t, err)
+
+				tmpMockProxyURI := httpcommon.ProxyURI(*mockProxyURL)
+				mockProxyURI := &tmpMockProxyURI
+				originalCfg := &configuration.Configuration{
+					Fleet: &configuration.FleetAgentConfig{
+						Server: &configuration.FleetServerConfig{
+							Host: fleetServerHost,
+							Port: uint16(fleetServerPort),
+						},
+						AccessAPIKey: "ignore",
+						Client: remote.Config{
+							Host: fleetServerHost,
+							Transport: httpcommon.HTTPTransportSettings{
+								Proxy: httpcommon.HTTPClientProxySettings{
+									URL: mockProxyURI,
+								}}},
+					},
+					Settings: configuration.DefaultSettingsConfig()}
+
+				h := PolicyChangeHandler{
+					agentInfo:            &info.AgentInfo{},
+					config:               originalCfg,
+					store:                &storage.NullStore{},
+					setters:              []actions.ClientSetter{&setter},
+					log:                  log,
+					policyLogLevelSetter: noLogLevelSet(t),
+				}
+
+				cfg := config.MustNewConfigFrom(
+					map[string]interface{}{
+						"fleet.proxy_url": "",
+						"fleet.host":      fleetServer.URL})
+
+				err = h.handlePolicyChange(context.Background(), cfg)
+				require.NoError(t, err)
+
+				assert.Equal(t, 1, setterCalledCount)
+				assert.Equal(t,
+					wantProxy,
+					h.config.Fleet.Client.Transport.Proxy.URL.String())
+			})
+	})
+
+	t.Run("policy with SSL config", func(t *testing.T) {
+		agentChildEncPassphrase := `reallySecurePassword`
+		passphrasePath := filepath.Join(t.TempDir(), "passphrase")
+		err = os.WriteFile(
+			passphrasePath,
+			[]byte(agentChildEncPassphrase),
+			0400)
+		require.NoError(t, err,
+			"could not write agent child certificate key passphrase to temp directory")
+
+		fleetRootPair, fleetChildPair, err := certutil.NewRootAndChildCerts()
+		require.NoError(t, err, "failed creating fleet root and child certs")
+
+		agentRootPair, agentChildPair, err := certutil.NewRootAndChildCerts()
+		require.NoError(t, err, "failed creating root and child certs")
+
+		agentChildDERKey, _ := pem.Decode(agentChildPair.Key)
+		require.NoError(t, err, "could not create tls.Certificates from child certificate")
+
+		encPem, err := x509.EncryptPEMBlock( //nolint:staticcheck // we need to drop support for this, but while we don't, it needs to be tested.
+			rand.Reader,
+			"EC PRIVATE KEY",
+			agentChildDERKey.Bytes,
+			[]byte(agentChildEncPassphrase),
+			x509.PEMCipherAES128)
+		require.NoError(t, err, "failed encrypting agent child certificate key block")
+		agentChildEncPair := certutil.Pair{
+			Cert: agentChildPair.Cert,
+			Key:  pem.EncodeToMemory(encPem),
+		}
+
+		wrongRootPair, wrongChildPair, err := certutil.NewRootAndChildCerts()
+		require.NoError(t, err, "failed creating root and child certs")
+
+		statusHandler := func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "api/status" {
+				w.WriteHeader(http.StatusNotFound)
+				_, err := w.Write(nil)
+				require.NoError(t, err)
+			}
+			_, err := w.Write(nil)
+			require.NoError(t, err)
+		}
+		fleetTLSServer := httptest.NewUnstartedServer(
+			http.HandlerFunc(statusHandler))
+
+		fleetNomTLSServer := httptest.NewUnstartedServer(
+			http.HandlerFunc(statusHandler))
+
+		fleetRootCertPool := x509.NewCertPool()
+		fleetRootCertPool.AppendCertsFromPEM(fleetRootPair.Cert)
+		cert, err := tls.X509KeyPair(fleetChildPair.Cert, fleetChildPair.Key)
+		require.NoError(t, err, "could not create tls.Certificates from child certificate")
+
+		agentRootCertPool := x509.NewCertPool()
+		agentRootCertPool.AppendCertsFromPEM(agentRootPair.Cert)
+
+		fleetTLSServer.TLS = &tls.Config{ //nolint:gosec // it's just a test
+			RootCAs:      fleetRootCertPool,
+			Certificates: []tls.Certificate{cert},
+			ClientCAs:    agentRootCertPool,
+			ClientAuth:   tls.RequireAndVerifyClientCert,
+		}
+
+		fleetNomTLSServer.TLS = &tls.Config{ //nolint:gosec // it's just a test
+			RootCAs:      fleetRootCertPool,
+			Certificates: []tls.Certificate{cert},
+		}
+
+		fleetTLSServer.StartTLS()
+		defer fleetTLSServer.Close()
+		fleetNomTLSServer.StartTLS()
+		defer fleetNomTLSServer.Close()
+
+		trueVar := true
+		tcs := []struct {
+			name                  string
+			originalCfg           *configuration.Configuration
+			newCfg                map[string]interface{}
+			setterCalledCount     int
+			wantCAs               []string
+			wantCertificateConfig tlscommon.CertificateConfig
+			assertErr             func(t *testing.T, err error)
+		}{
+			{
+				name: "certificate_authorities is applied when present",
+				originalCfg: &configuration.Configuration{
+					Fleet: &configuration.FleetAgentConfig{
+						Client: remote.Config{
+							Host: fleetNomTLSServer.URL,
+						},
+						AccessAPIKey: "ignore",
+					},
+					Settings: configuration.DefaultSettingsConfig(),
+				},
+				newCfg: map[string]interface{}{
+					"fleet.ssl.enabled":                 true,
+					"fleet.ssl.certificate_authorities": []string{string(fleetRootPair.Cert)},
+				},
+				setterCalledCount: 1,
+				wantCAs:           []string{string(fleetRootPair.Cert)},
+				assertErr: func(t *testing.T, err error) {
+					assert.NoError(t, err,
+						"unexpected error when applying fleet.ssl.certificate_authorities")
+				},
+			},
+			{
+				name: "certificate_authorities is ignored if empty",
+				originalCfg: &configuration.Configuration{
+					Fleet: &configuration.FleetAgentConfig{
+						Client: remote.Config{
+							Host: fleetTLSServer.URL,
+							Transport: httpcommon.HTTPTransportSettings{
+								TLS: &tlscommon.Config{CAs: []string{string(fleetRootPair.Cert)}},
+							},
+						},
+						AccessAPIKey: "ignore",
+					},
+					Settings: configuration.DefaultSettingsConfig(),
+				},
+				newCfg: map[string]interface{}{
+					// changing the URL for a server without TLS, so it'll
+					// work without the CA.
+					"fleet.host":                        fleetServer.URL,
+					"fleet.ssl.enabled":                 true,
+					"fleet.ssl.certificate_authorities": []string{},
+				},
+				setterCalledCount: 1,
+				wantCAs:           []string{string(fleetRootPair.Cert)},
+				assertErr: func(t *testing.T, err error) {
+					assert.NoError(t, err,
+						"unexpected error when applying fleet.ssl.certificate_authorities")
+				},
+			},
+			{
+				name: "certificate_authorities is ignored if absent",
+				originalCfg: &configuration.Configuration{
+					Fleet: &configuration.FleetAgentConfig{
+						Client: remote.Config{
+							Host: fleetNomTLSServer.URL,
+							Transport: httpcommon.HTTPTransportSettings{
+								TLS: &tlscommon.Config{CAs: []string{string(fleetRootPair.Cert)}},
+							},
+						},
+						AccessAPIKey: "ignore",
+					},
+					Settings: configuration.DefaultSettingsConfig(),
+				},
+				newCfg: map[string]interface{}{
+					"fleet.ssl.enabled": true,
+				},
+				setterCalledCount: 1, // it should not exit early
+				wantCAs:           []string{string(fleetRootPair.Cert)},
+				assertErr: func(t *testing.T, err error) {
+					assert.NoError(t, err,
+						"unexpected error when applying fleet.ssl.certificate_authorities")
+				},
+			},
+			{
+				name: "certificate_authorities isn't applied if wrong",
+				originalCfg: &configuration.Configuration{
+					Fleet: &configuration.FleetAgentConfig{
+						Client: remote.Config{
+							Host: fleetNomTLSServer.URL,
+							Transport: httpcommon.HTTPTransportSettings{
+								TLS: &tlscommon.Config{
+									Enabled: &trueVar,
+									CAs:     []string{string(fleetRootPair.Cert)}},
+							},
+						},
+						AccessAPIKey: "ignore",
+					},
+					Settings: configuration.DefaultSettingsConfig(),
+				},
+				newCfg: map[string]interface{}{
+					"fleet.ssl.enabled":                 true,
+					"fleet.ssl.certificate_authorities": []string{string(wrongRootPair.Cert)},
+				},
+				setterCalledCount: 0,
+				wantCAs:           []string{string(fleetRootPair.Cert)},
+				assertErr: func(t *testing.T, err error) {
+					assert.Error(t, err,
+						"bad fleet.ssl.certificate_authorities provided, it should have returned an error")
+				},
+			},
+			{
+				name: "certificate and key is applied when present",
+				originalCfg: &configuration.Configuration{
+					Fleet: &configuration.FleetAgentConfig{
+						Client: remote.Config{
+							Host: fleetTLSServer.URL,
+							Transport: httpcommon.HTTPTransportSettings{
+								TLS: &tlscommon.Config{
+									CAs: []string{string(fleetRootPair.Cert)},
+								},
+							},
+						},
+						AccessAPIKey: "ignore",
+					},
+					Settings: configuration.DefaultSettingsConfig(),
+				},
+				newCfg: map[string]interface{}{
+					"fleet.ssl.enabled":     true,
+					"fleet.ssl.certificate": string(agentChildPair.Cert),
+					"fleet.ssl.key":         string(agentChildPair.Key),
+				},
+				setterCalledCount: 1,
+				wantCAs:           []string{string(fleetRootPair.Cert)},
+				wantCertificateConfig: tlscommon.CertificateConfig{
+					Certificate: string(agentChildPair.Cert),
+					Key:         string(agentChildPair.Key),
+				},
+				assertErr: func(t *testing.T, err error) {
+					assert.NoError(t, err,
+						"unexpected error when applying fleet.ssl.certificate and key")
+				},
+			},
+			{
+				name: "certificate and key with passphrase is applied when present",
+				originalCfg: &configuration.Configuration{
+					Fleet: &configuration.FleetAgentConfig{
+						Client: remote.Config{
+							Host: fleetTLSServer.URL,
+							Transport: httpcommon.HTTPTransportSettings{
+								TLS: &tlscommon.Config{
+									CAs: []string{string(fleetRootPair.Cert)},
+								},
+							},
+						},
+						AccessAPIKey: "ignore",
+					},
+					Settings: configuration.DefaultSettingsConfig(),
+				},
+				newCfg: map[string]interface{}{
+					"fleet.ssl.enabled":        true,
+					"fleet.ssl.certificate":    string(agentChildEncPair.Cert),
+					"fleet.ssl.key":            string(agentChildEncPair.Key),
+					"fleet.ssl.key_passphrase": agentChildEncPassphrase,
+				},
+				setterCalledCount: 1,
+				wantCAs:           []string{string(fleetRootPair.Cert)},
+				wantCertificateConfig: tlscommon.CertificateConfig{
+					Certificate: string(agentChildEncPair.Cert),
+					Key:         string(agentChildEncPair.Key),
+					Passphrase:  agentChildEncPassphrase,
+				},
+				assertErr: func(t *testing.T, err error) {
+					assert.NoError(t, err,
+						"unexpected error when applying fleet.ssl.certificate and key")
+				},
+			},
+			{
+				name: "certificate and key with passphrase_path is applied when present",
+				originalCfg: &configuration.Configuration{
+					Fleet: &configuration.FleetAgentConfig{
+						Client: remote.Config{
+							Host: fleetTLSServer.URL,
+							Transport: httpcommon.HTTPTransportSettings{
+								TLS: &tlscommon.Config{
+									CAs: []string{string(fleetRootPair.Cert)},
+								},
+							},
+						},
+						AccessAPIKey: "ignore",
+					},
+					Settings: configuration.DefaultSettingsConfig(),
+				},
+				newCfg: map[string]interface{}{
+					"fleet.ssl.enabled":             true,
+					"fleet.ssl.certificate":         string(agentChildEncPair.Cert),
+					"fleet.ssl.key":                 string(agentChildEncPair.Key),
+					"fleet.ssl.key_passphrase_path": passphrasePath,
+				},
+				setterCalledCount: 1,
+				wantCAs:           []string{string(fleetRootPair.Cert)},
+				wantCertificateConfig: tlscommon.CertificateConfig{
+					Certificate:    string(agentChildEncPair.Cert),
+					Key:            string(agentChildEncPair.Key),
+					PassphrasePath: passphrasePath,
+				},
+				assertErr: func(t *testing.T, err error) {
+					assert.NoError(t, err,
+						"unexpected error when applying fleet.ssl.certificate and key")
+				},
+			},
+			{
+				name: "certificate and key is ignored if empty",
+				originalCfg: &configuration.Configuration{
+					Fleet: &configuration.FleetAgentConfig{
+						Client: remote.Config{
+							Host: fleetTLSServer.URL,
+							Transport: httpcommon.HTTPTransportSettings{
+								TLS: &tlscommon.Config{
+									CAs: []string{string(fleetRootPair.Cert)},
+									Certificate: tlscommon.CertificateConfig{
+										Certificate: string(agentChildPair.Cert),
+										Key:         string(agentChildPair.Key),
+									},
+								},
+							},
+						},
+						AccessAPIKey: "ignore",
+					},
+					Settings: configuration.DefaultSettingsConfig(),
+				},
+				newCfg: map[string]interface{}{
+					"fleet.ssl.enabled":     true,
+					"fleet.ssl.certificate": "",
+					"fleet.ssl.key":         "",
+				},
+				setterCalledCount: 1,
+				wantCAs:           []string{string(fleetRootPair.Cert)},
+				wantCertificateConfig: tlscommon.CertificateConfig{
+					Certificate: string(agentChildPair.Cert),
+					Key:         string(agentChildPair.Key),
+				},
+				assertErr: func(t *testing.T, err error) {
+					assert.NoError(t, err,
+						"unexpected error when applying fleet.ssl.certificate and key")
+				},
+			},
+			{
+				name: "certificate and key is ignored if absent",
+				originalCfg: &configuration.Configuration{
+					Fleet: &configuration.FleetAgentConfig{
+						Client: remote.Config{
+							Host: fleetTLSServer.URL,
+							Transport: httpcommon.HTTPTransportSettings{
+								TLS: &tlscommon.Config{
+									CAs: []string{string(fleetRootPair.Cert)},
+									Certificate: tlscommon.CertificateConfig{
+										Certificate: string(agentChildPair.Cert),
+										Key:         string(agentChildPair.Key),
+									},
+								},
+							},
+						},
+						AccessAPIKey: "ignore",
+					},
+					Settings: configuration.DefaultSettingsConfig(),
+				},
+				newCfg:            map[string]interface{}{},
+				setterCalledCount: 0,
+				wantCAs:           []string{string(fleetRootPair.Cert)},
+				wantCertificateConfig: tlscommon.CertificateConfig{
+					Certificate: string(agentChildPair.Cert),
+					Key:         string(agentChildPair.Key),
+				},
+				assertErr: func(t *testing.T, err error) {
+					assert.NoError(t, err,
+						"unexpected error when applying fleet.ssl.certificate and key")
+				},
+			},
+			{
+				name: "certificate and key isn't applied if wrong",
+				originalCfg: &configuration.Configuration{
+					Fleet: &configuration.FleetAgentConfig{
+						Client: remote.Config{
+							Host: fleetTLSServer.URL,
+							Transport: httpcommon.HTTPTransportSettings{
+								TLS: &tlscommon.Config{
+									CAs: []string{string(fleetRootPair.Cert)},
+									Certificate: tlscommon.CertificateConfig{
+										Certificate: string(agentChildPair.Cert),
+										Key:         string(agentChildPair.Key),
+									},
+								},
+							},
+						},
+						AccessAPIKey: "ignore",
+					},
+					Settings: configuration.DefaultSettingsConfig(),
+				},
+				newCfg: map[string]interface{}{
+					"fleet.ssl.enabled":     true,
+					"fleet.ssl.certificate": string(wrongChildPair.Cert),
+					"fleet.ssl.key":         string(wrongChildPair.Key),
+				},
+				setterCalledCount: 0,
+				wantCAs:           []string{string(fleetRootPair.Cert)},
+				wantCertificateConfig: tlscommon.CertificateConfig{
+					Certificate: string(agentChildPair.Cert),
+					Key:         string(agentChildPair.Key),
+				},
+				assertErr: func(t *testing.T, err error) {
+					assert.Error(t, err,
+						"wrong fleet.ssl.certificate and key should cause an error")
+				},
+			},
+		}
+
+		for _, tc := range tcs {
+			t.Run(tc.name, func(t *testing.T) {
+				log, logs := logger.NewTesting("")
+				defer func() {
+					if t.Failed() {
+						t.Log("test failed, see handler logs below:")
+						for _, l := range logs.TakeAll() {
+							t.Log(l)
+						}
+					}
+				}()
+
+				var setterCalledCount int
+				setter := testSetter{SetClientFn: func(c client.Sender) {
+					setterCalledCount++
+				}}
+				h := PolicyChangeHandler{
+					agentInfo:            &info.AgentInfo{},
+					config:               tc.originalCfg,
+					store:                &storage.NullStore{},
+					setters:              []actions.ClientSetter{&setter},
+					log:                  log,
+					policyLogLevelSetter: noLogLevelSet(t),
+				}
+
+				cfg := config.MustNewConfigFrom(tc.newCfg)
+
+				err := h.handlePolicyChange(context.Background(), cfg)
+				tc.assertErr(t, err)
+
+				assert.Equal(t, tc.setterCalledCount, setterCalledCount,
+					"setter was not called")
+				if assert.NotNil(t, h.config.Fleet.Client.Transport.TLS, "TLS settings in fleet client config should not be null") {
+					assert.Equal(t,
+						tc.wantCAs, h.config.Fleet.Client.Transport.TLS.CAs,
+						"unexpected CAs")
+					assert.Equal(t,
+						tc.wantCertificateConfig, h.config.Fleet.Client.Transport.TLS.Certificate,
+						"unexpected certificate/key pair")
+				}
+			})
+		}
+	})
 }
 
 type testAcker struct {

--- a/internal/pkg/agent/application/dispatcher/dispatcher.go
+++ b/internal/pkg/agent/application/dispatcher/dispatcher.go
@@ -156,7 +156,7 @@ func (ad *ActionDispatcher) Dispatch(ctx context.Context, detailsSetter details.
 				ad.scheduleRetry(ctx, rAction, acker)
 				continue
 			}
-			ad.log.Debugf("Failed to dispatch action '%+v', error: %+v", action, err)
+			ad.log.Errorf("Failed to dispatch action id %q of type %q, error: %+v", action.ID(), action.Type(), err)
 			reportedErr = err
 			continue
 		}

--- a/internal/pkg/remote/config.go
+++ b/internal/pkg/remote/config.go
@@ -34,8 +34,8 @@ const (
 
 // Unpack the protocol.
 func (p *Protocol) Unpack(from string) error {
-	if Protocol(from) != ProtocolHTTPS && Protocol(from) != ProtocolHTTP {
-		return fmt.Errorf("invalid protocol %s, accepted values are 'http' and 'https'", from)
+	if from != "" && Protocol(from) != ProtocolHTTPS && Protocol(from) != ProtocolHTTP {
+		return fmt.Errorf("invalid protocol %q, accepted values are 'http' and 'https'", from)
 	}
 
 	*p = Protocol(from)

--- a/pkg/testing/fixture_install.go
+++ b/pkg/testing/fixture_install.go
@@ -91,6 +91,11 @@ type InstallOpts struct {
 
 	Privileged bool // inverse of --unprivileged (as false is the default)
 
+	// SSL/TLS options
+	CertificateAuthorities []string
+	Certificate            string
+	Key                    string
+
 	EnrollOpts
 	FleetBootstrapOpts
 }
@@ -117,6 +122,18 @@ func (i InstallOpts) toCmdArgs(operatingSystem string) ([]string, error) {
 	}
 	if !i.Privileged {
 		args = append(args, "--unprivileged")
+	}
+
+	if len(i.CertificateAuthorities) > 0 {
+		args = append(args, "--certificate-authorities="+strings.Join(i.CertificateAuthorities, ","))
+	}
+
+	if i.Certificate != "" {
+		args = append(args, "--elastic-agent-cert="+i.Certificate)
+	}
+
+	if i.Key != "" {
+		args = append(args, "--elastic-agent-cert-key="+i.Key)
 	}
 
 	args = append(args, i.EnrollOpts.toCmdArgs()...)

--- a/pkg/testing/fixture_install.go
+++ b/pkg/testing/fixture_install.go
@@ -43,6 +43,11 @@ type CmdOpts interface {
 type EnrollOpts struct {
 	URL             string // --url
 	EnrollmentToken string // --enrollment-token
+
+	// SSL/TLS options
+	CertificateAuthorities []string // --certificate-authorities
+	Certificate            string   // --elastic-agent-cert
+	Key                    string   // --elastic-agent-cert-key
 }
 
 func (e EnrollOpts) toCmdArgs() []string {
@@ -52,6 +57,18 @@ func (e EnrollOpts) toCmdArgs() []string {
 	}
 	if e.EnrollmentToken != "" {
 		args = append(args, "--enrollment-token", e.EnrollmentToken)
+	}
+
+	if len(e.CertificateAuthorities) > 0 {
+		args = append(args, "--certificate-authorities="+strings.Join(e.CertificateAuthorities, ","))
+	}
+
+	if e.Certificate != "" {
+		args = append(args, "--elastic-agent-cert="+e.Certificate)
+	}
+
+	if e.Key != "" {
+		args = append(args, "--elastic-agent-cert-key="+e.Key)
 	}
 	return args
 }
@@ -91,11 +108,6 @@ type InstallOpts struct {
 
 	Privileged bool // inverse of --unprivileged (as false is the default)
 
-	// SSL/TLS options
-	CertificateAuthorities []string
-	Certificate            string
-	Key                    string
-
 	EnrollOpts
 	FleetBootstrapOpts
 }
@@ -122,18 +134,6 @@ func (i InstallOpts) toCmdArgs(operatingSystem string) ([]string, error) {
 	}
 	if !i.Privileged {
 		args = append(args, "--unprivileged")
-	}
-
-	if len(i.CertificateAuthorities) > 0 {
-		args = append(args, "--certificate-authorities="+strings.Join(i.CertificateAuthorities, ","))
-	}
-
-	if i.Certificate != "" {
-		args = append(args, "--elastic-agent-cert="+i.Certificate)
-	}
-
-	if i.Key != "" {
-		args = append(args, "--elastic-agent-cert-key="+i.Key)
 	}
 
 	args = append(args, i.EnrollOpts.toCmdArgs()...)

--- a/testing/fleetservertest/checkin.go
+++ b/testing/fleetservertest/checkin.go
@@ -179,7 +179,7 @@ const (
 			"ssl": {
 				"renegotiation": "{{ .SSL.Renegotiation }}",
 				"verification_mode": "{{ .SSL.VerificationMode }}",
-				"certificate_authorities": [{{ joinquoted .SSL.CertificateAuthorities "," }}],
+				"certificate_authorities": [{{ joinquoted .SSL.CertificateAuthorities ", " }}],
 				"certificate": "{{ .SSL.Certificate }}",
 				"key": "{{ .SSL.Key }}"
 			},
@@ -255,7 +255,7 @@ const (
 			"ssl": {
 				"renegotiation": "{{ .SSL.Renegotiation }}",
 				"verification_mode": "{{ .SSL.VerificationMode }}",
-				"certificate_authorities": ["{{ .SSL.CertificateAuthorities}}"],
+				"certificate_authorities": [{{ joinquoted .SSL.CertificateAuthorities ", " }}],
 				"certificate": "{{ .SSL.Certificate }}",
 				"key": "{{ .SSL.Key }}"
 			},

--- a/testing/fleetservertest/checkin.go
+++ b/testing/fleetservertest/checkin.go
@@ -25,9 +25,8 @@ type SSL struct {
 type TmplPolicy struct {
 	AgentID  string
 	PolicyID string
-	// FleetHosts should be a JSON array without the square brackets:
-	// - `"host1", "host2"`
-	// - `"host"`
+	// FleetHosts should be a regular string array containing fleet hosts
+	// []string{"host1", "host2"}
 	FleetHosts []string
 	// AddFleetProxyURL bool
 	FleetProxyURL *string
@@ -50,8 +49,8 @@ func NewCheckinResponse(ackToken string, actions ...string) string {
 
 // NewEmptyPolicy returns an policy without any input and monitoring disabled.
 func NewEmptyPolicy(data TmplPolicy) (string, error) {
-	t := template.Must(template.New("policyEmpryTmpl").Funcs(funcMap).
-		Parse(policyEmpryTmpl))
+	t := template.Must(template.New("policyEmptyTmpl").Funcs(funcMap).
+		Parse(policyEmptyTmpl))
 
 	buf := &strings.Builder{}
 	err := t.Execute(buf, data)
@@ -214,7 +213,7 @@ const (
         }
       }`
 
-	policyEmpryTmpl = `
+	policyEmptyTmpl = `
     {
         "policy": {
           "agent": {

--- a/testing/fleetservertest/checkin.go
+++ b/testing/fleetservertest/checkin.go
@@ -13,7 +13,7 @@ import (
 
 type SSL struct {
 	Renegotiation          string   `json:"renegotiation,omitempty"`
-	VerificationMode       string   `json:"verification_mode"`
+	VerificationMode       string   `json:"verification_mode,omitempty"`
 	CertificateAuthorities []string `json:"certificate_authorities,omitempty"`
 	Certificate            string   `json:"certificate,omitempty"`
 	Key                    string   `json:"key,omitempty"`

--- a/testing/fleetservertest/fleetserver_test.go
+++ b/testing/fleetservertest/fleetserver_test.go
@@ -252,8 +252,7 @@ func ExampleNewServer_checkin_fleetConnectionParams() {
 	//         "/path/to/CA2"
 	//       ],
 	//       "key": "/path/to/key",
-	//       "renegotiation": "never",
-	//       "verification_mode": ""
+	//       "renegotiation": "never"
 	//     }
 	//   },
 	//   "id": "",

--- a/testing/fleetservertest/fleetserver_test.go
+++ b/testing/fleetservertest/fleetserver_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -43,7 +44,7 @@ func TestRunFleetServer(t *testing.T) {
 	// address from it.
 	// If you want to predefine an address for the server to listen on, pass
 	// WithAddress(addr) to NewServer.
-	fleetHosts := "host1"
+	fleetHosts := []string{"host1"}
 	var actionsIdx int
 
 	tmpl := TmplPolicy{
@@ -55,7 +56,7 @@ func TestRunFleetServer(t *testing.T) {
 		// get the port the server is listening on. Therefore, the action generator
 		// captures the 'fleetHosts' variable, so it can read the real fleet-server
 		// address from it.
-		FleetHosts: `"host1", "host2"`,
+		FleetHosts: []string{"host1", "host2"},
 		SourceURI:  "http://source.uri",
 		CreatedAt:  "2023-05-31T11:37:50.607Z",
 		Output: struct {
@@ -104,7 +105,7 @@ func TestRunFleetServer(t *testing.T) {
 		WithRequestLog(t.Logf))
 	defer ts.Close()
 
-	fleetHosts = fmt.Sprintf(`"%s"`, ts.URL)
+	fleetHosts = []string{fmt.Sprintf(`"%s"`, ts.URL)}
 
 	fmt.Println("listening on:", fleetHosts)               //nolint:forbidigo // it's a test
 	fmt.Println("press CTRL + C or kill the test to stop") //nolint:forbidigo // it's a test
@@ -171,6 +172,129 @@ func ExampleNewServer_checkin() {
 	fmt.Println(got.Actions)
 	// Output:
 	// [action_id: anActionID, type: POLICY_CHANGE]
+}
+
+func ExampleNewServer_checkin_fleetConnectionParams() {
+	agentID := "agentID"
+	tmpl := TmplPolicy{
+		FleetHosts: []string{"https://fleet.somehost.somedomain"},
+		SSL: &SSL{
+			Renegotiation:          "never",
+			VerificationMode:       "",
+			CertificateAuthorities: []string{"/path/to/CA1", "/path/to/CA2"},
+			Certificate:            "/path/to/certificate",
+			Key:                    "/path/to/key",
+		},
+	}
+
+	actions, err := NewActionPolicyChangeWithFakeComponent("anActionID", tmpl)
+	if err != nil {
+		panic(fmt.Sprintf("failed to get new actions: %v", err))
+	}
+
+	// NewHandlerCheckin
+	ts := NewServer(&Handlers{
+		CheckinFn: NewHandlerCheckin(func() (CheckinAction, *HTTPError) {
+			return CheckinAction{Actions: []string{actions.data}}, nil
+		})},
+		WithAgentID(agentID))
+
+	cmd := fleetapi.NewCheckinCmd(
+		agentInfo(agentID), sender{url: ts.URL, path: NewPathCheckin(agentID)})
+
+	got, _, err := cmd.Execute(context.Background(), &fleetapi.CheckinRequest{})
+	if err != nil {
+		panic(fmt.Sprintf("ExampleNewServer_checkin_fleetConnectionParams failed executing checkin: %v", err))
+	}
+
+	fmt.Println(got.Actions)
+	if len(got.Actions) > 0 {
+		policy := got.Actions[0].(*fleetapi.ActionPolicyChange).Policy
+		b := new(strings.Builder)
+		encoder := json.NewEncoder(b)
+		encoder.SetIndent("", "  ")
+		err = encoder.Encode(policy)
+		if err != nil {
+			panic(fmt.Sprintf("Error marshaling received policy: %v", err))
+		}
+		fmt.Println(b.String())
+	}
+
+	// Output:
+	// [action_id: anActionID, type: POLICY_CHANGE]
+	// {
+	//   "agent": {
+	//     "download": {
+	//       "sourceURI": ""
+	//     },
+	//     "features": {},
+	//     "monitoring": {
+	//       "enabled": true,
+	//       "logs": true,
+	//       "metrics": true,
+	//       "namespace": "default",
+	//       "use_output": "default"
+	//     },
+	//     "protection": {
+	//       "enabled": false,
+	//       "signing_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQ9BPoHUCyLyElVpfwvKeFdUt6U9wBb+QlZNf4cy5eAwK9Xh4D8fClgciPeRs3j62i6IEeGyvOs9U3+fElyUigg==",
+	//       "uninstall_token_hash": "lORSaDIQq4nglUMJwWjKrwexj4IDRJA+FtoQeeqKH/I="
+	//     }
+	//   },
+	//   "fleet": {
+	//     "hosts": [
+	//       "https://fleet.somehost.somedomain"
+	//     ],
+	//     "ssl": {
+	//       "certificate": "/path/to/certificate",
+	//       "certificate_authorities": [
+	//         "/path/to/CA1",
+	//         "/path/to/CA2"
+	//       ],
+	//       "key": "/path/to/key",
+	//       "renegotiation": "never",
+	//       "verification_mode": ""
+	//     }
+	//   },
+	//   "id": "",
+	//   "inputs": [
+	//     {
+	//       "data_stream": {
+	//         "namespace": "default"
+	//       },
+	//       "id": "fake-input",
+	//       "meta": {
+	//         "package": {
+	//           "name": "fake-input",
+	//           "version": "0.0.1"
+	//         }
+	//       },
+	//       "name": "fake-input",
+	//       "package_policy_id": "",
+	//       "revision": 1,
+	//       "streams": [],
+	//       "type": "fake-input",
+	//       "use_output": "default"
+	//     }
+	//   ],
+	//   "output_permissions": {
+	//     "default": {}
+	//   },
+	//   "outputs": {
+	//     "default": {
+	//       "api_key": "",
+	//       "hosts": [],
+	//       "type": ""
+	//     }
+	//   },
+	//   "revision": 2,
+	//   "secret_references": [],
+	//   "signed": {
+	//     "data": "eyJpZCI6IjI0ZTRkMDMwLWZmYTctMTFlZC1iMDQwLTlkZWJhYTVmZWNiOCIsImFnZW50Ijp7InByb3RlY3Rpb24iOnsiZW5hYmxlZCI6ZmFsc2UsInVuaW5zdGFsbF90b2tlbl9oYXNoIjoibE9SU2FESVFxNG5nbFVNSndXaktyd2V4ajRJRFJKQStGdG9RZWVxS0gvST0iLCJzaWduaW5nX2tleSI6Ik1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRVE5QlBvSFVDeUx5RWxWcGZ3dktlRmRVdDZVOXdCYitRbFpOZjRjeTVlQXdLOVhoNEQ4ZkNsZ2NpUGVSczNqNjJpNklFZUd5dk9zOVUzK2ZFbHlVaWdnPT0ifX19",
+	//     "signature": "MEUCIQCfS6wPj/AvfFA79dwKATnvyFl/ZeyA8eKOLHg1XuA9NgIgNdhjIT+G/GZFqsVoWk5jThONhpqPhfiHLE5OkTdrwT0="
+	//   }
+	// }
+
 }
 
 func ExampleNewServer_ack() {
@@ -296,7 +420,7 @@ func ExampleNewServer_checkin_fakeComponent() {
 	tmpl := TmplPolicy{
 		AgentID:    "AgentID",
 		PolicyID:   policyID,
-		FleetHosts: `"host1", "host2"`,
+		FleetHosts: []string{"host1", "host2"},
 		SourceURI:  "http://source.uri",
 		CreatedAt:  "2023-05-31T11:37:50.607Z",
 		Output: struct {
@@ -365,7 +489,7 @@ func ExampleNewServer_checkin_withDelay() {
 	tmpl := TmplPolicy{
 		AgentID:    "AgentID",
 		PolicyID:   policyID,
-		FleetHosts: `"host1", "host2"`,
+		FleetHosts: []string{"host1", "host2"},
 		SourceURI:  "http://source.uri",
 		CreatedAt:  "2023-05-31T11:37:50.607Z",
 		Output: struct {
@@ -508,7 +632,7 @@ func ExampleNewServer_checkin_and_ackWithAcker() {
 	tmpl := TmplPolicy{
 		AgentID:    agentID,
 		PolicyID:   policyID,
-		FleetHosts: `"host1", "host2"`,
+		FleetHosts: []string{"host1", "host2"},
 		SourceURI:  "http://source.uri",
 		CreatedAt:  "2023-05-31T11:37:50.607Z",
 		Output: struct {

--- a/testing/integration/proxy_url_test.go
+++ b/testing/integration/proxy_url_test.go
@@ -8,7 +8,6 @@ package integration
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -432,7 +431,7 @@ func createBasicFleetPolicyData(t *testing.T, fleetHost string) (fleetservertest
 	policyData := fleetservertest.TmplPolicy{
 		AgentID:    agentID,
 		PolicyID:   t.Name() + policyID,
-		FleetHosts: fmt.Sprintf("%q", fleetHost),
+		FleetHosts: []string{fleetHost},
 		SourceURI:  "http://source.uri",
 		CreatedAt:  time.Now().Format(time.RFC3339),
 		Output: struct {

--- a/testing/integration/proxy_url_test.go
+++ b/testing/integration/proxy_url_test.go
@@ -711,6 +711,8 @@ func TestProxyURL(t *testing.T) {
 
 			privileged := false
 			if runtime.GOOS == "windows" {
+				// On windows installing in unprivileged mode leads to access denied error when updating fleet.enc.
+				// See https://github.com/elastic/elastic-agent/issues/4913
 				privileged = true
 			}
 

--- a/testing/integration/proxy_url_test.go
+++ b/testing/integration/proxy_url_test.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -369,7 +370,11 @@ func TestProxyURL(t *testing.T) {
 			setup: func(t *testing.T, mockFleet *mockFleetComponents) (proxies map[string]*proxytest.Proxy) {
 
 				// use os.MkdirTemp since we are installing agent unprivileged and t.TempDir() does not guarantee that the elastic-agent user has access
-				tmpDir, err := os.MkdirTemp("", "TLSProxyWithCAInThePolicy*")
+				baseDir := ""
+				if runtime.GOOS == "windows" {
+					baseDir = "C:\\"
+				}
+				tmpDir, err := os.MkdirTemp(baseDir, "TLSProxyWithCAInThePolicy*")
 				require.NoError(t, err, "error creating temp dir for TLS files")
 				t.Cleanup(func() {
 					cleanupErr := os.RemoveAll(tmpDir)
@@ -466,7 +471,11 @@ func TestProxyURL(t *testing.T) {
 			setup: func(t *testing.T, mockFleet *mockFleetComponents) (proxies map[string]*proxytest.Proxy) {
 
 				// use os.MkdirTemp since we are installing agent unprivileged and t.TempDir() does not guarantee that the elastic-agent user has access
-				tmpDir, err := os.MkdirTemp("", "mTLSProxyInThePolicy*")
+				baseDir := ""
+				if runtime.GOOS == "windows" {
+					baseDir = "C:\\"
+				}
+				tmpDir, err := os.MkdirTemp(baseDir, "mTLSProxyInThePolicy*")
 				require.NoError(t, err, "error creating temp dir for TLS files")
 
 				t.Cleanup(func() {

--- a/testing/integration/proxy_url_test.go
+++ b/testing/integration/proxy_url_test.go
@@ -523,7 +523,7 @@ func TestProxyURL(t *testing.T) {
 			name: "TLSEnrollProxy-mTLSProxyInThePolicy",
 			setup: func(t *testing.T, mockFleet *mockFleetComponents) (proxies map[string]*proxytest.Proxy, enrollArgs installArgs) {
 
-				t.Skip("Currently skipped due to https -> http proxy issues")
+				t.Skip("Currently skipped due to https proxy -> http fleet issues. See issues https://github.com/elastic/elastic-agent/issues/4896 and https://github.com/elastic/elastic-agent/issues/4903")
 
 				tmpDir := createTempDir(t)
 

--- a/testing/integration/proxy_url_test.go
+++ b/testing/integration/proxy_url_test.go
@@ -717,17 +717,17 @@ func TestProxyURL(t *testing.T) {
 			out, err := fixture.Install(
 				ctx,
 				&integrationtest.InstallOpts{
-					Force:                  true,
-					NonInteractive:         true,
-					Insecure:               args.insecure,
-					ProxyURL:               args.proxyURL,
-					CertificateAuthorities: args.certificateAuthorities,
-					Certificate:            args.certificate,
-					Key:                    args.key,
-					Privileged:             privileged,
+					Force:          true,
+					NonInteractive: true,
+					Insecure:       args.insecure,
+					ProxyURL:       args.proxyURL,
+					Privileged:     privileged,
 					EnrollOpts: integrationtest.EnrollOpts{
-						URL:             args.enrollmentURL,
-						EnrollmentToken: "anythingWillDO",
+						URL:                    args.enrollmentURL,
+						EnrollmentToken:        "anythingWillDO",
+						CertificateAuthorities: args.certificateAuthorities,
+						Certificate:            args.certificate,
+						Key:                    args.key,
 					}})
 			t.Logf("elastic-agent install output: \n%s\n", string(out))
 			if tt.wantErr(t, err, "elastic-agent install returned an unexpected error") {

--- a/testing/integration/proxy_url_test.go
+++ b/testing/integration/proxy_url_test.go
@@ -709,6 +709,11 @@ func TestProxyURL(t *testing.T) {
 			err = fixture.EnsurePrepared(ctx)
 			require.NoError(t, err, "SetupTest: fixture.Prepare failed")
 
+			privileged := false
+			if runtime.GOOS == "windows" {
+				privileged = true
+			}
+
 			out, err := fixture.Install(
 				ctx,
 				&integrationtest.InstallOpts{
@@ -719,6 +724,7 @@ func TestProxyURL(t *testing.T) {
 					CertificateAuthorities: args.certificateAuthorities,
 					Certificate:            args.certificate,
 					Key:                    args.key,
+					Privileged:             privileged,
 					EnrollOpts: integrationtest.EnrollOpts{
 						URL:             args.enrollmentURL,
 						EnrollmentToken: "anythingWillDO",

--- a/testing/proxytest/proxytest.go
+++ b/testing/proxytest/proxytest.go
@@ -26,7 +26,7 @@ type Proxy struct {
 	// Port is the port Server is listening on.
 	Port string
 
-	// LocalhostURL is the server URL as "http://localhost:PORT".
+	// LocalhostURL is the server URL as "http(s)://localhost:PORT".
 	LocalhostURL string
 
 	// proxiedRequests is a "request log" for every request the proxy receives.
@@ -176,7 +176,7 @@ func (p *Proxy) StartTLS() error {
 	}
 
 	p.Port = u.Port()
-	p.LocalhostURL = "http://localhost:" + p.Port
+	p.LocalhostURL = "https://localhost:" + p.Port
 
 	p.opts.logFn("running on %s -> %s", p.URL, p.LocalhostURL)
 	return nil


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This PR implements reading and applying TLS configuration for Fleet client  using CA, certificate and key included in Fleet policy.

This PR:
- includes unit tests ported from #4398, 
- reimplements the solution of #4398 to adapt it to the new structure of internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
- modifies mock fleet server to support SSL configuration
- Add integration tests for both TLS and mTLS usecases using custom CAs

~~Note to reviewers: refactor of ProxyURL integration tests has been moved to PR #4813 , so for initial review you can have a look at [this set of commits](https://github.com/elastic/elastic-agent/pull/4770/files/cae577b7aa3ff22a4d9fbaeaff57ba5b71c088e1..bd9fe64bd86252f39f7b07f2354164fe85fbf860) or wait till PR #4813 is merged and this PR rebased onto the new main~~ 
PR #4813 has been merged and this change has been rebase on top of the new `main`.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Configuring TLS via the policy allows agent to connect to Fleet (possibly via a proxy) using custom CAs or enabling mTLS (certificate verification of both the client and the server).
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

In order to test this PR we need:
- fleet server or proxy with TLS (or mTLS) configured using custom CAs and certificates signed by such CAs (left as exercise to the reader) 
- Make sure that the agent can connect to fleet for enrolling without custom CAs or certificates.
- enroll agent with a simple policy
- Add Custom CAs and or key + certificates for the agent to use along with a new URL (maybe a proxy) pointing to where TLS has been configured.
- Verify that the agent can connect correctly using CAs (and Certificate/Key in case of mTLS)

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Supersedes #4398
- Requires #4745
- Requires #4813 
- Closes #2247
- Closes #2248   

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 