### PR TITLE
Fix issue with `--delay-enroll` and `--unprivileged` on Windows

### DIFF
--- a/changelog/fragments/1716227441-Fix-delay-enrollment-to-work-in-unprivileged-mode-on-Windows.yaml
+++ b/changelog/fragments/1716227441-Fix-delay-enrollment-to-work-in-unprivileged-mode-on-Windows.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix delay enrollment to work in unprivileged mode on Windows
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/4779
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/4678

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -255,7 +255,18 @@ func (c *enrollCmd) Execute(ctx context.Context, streams *cli.IOStreams) error {
 		if c.options.FleetServer.Host != "" {
 			return errors.New("--delay-enroll cannot be used with --fleet-server-es", errors.TypeConfig)
 		}
-		return c.writeDelayEnroll(streams)
+		err = c.writeDelayEnroll(streams)
+		if err != nil {
+			// context for error already provided in writeDelayEnroll
+			return err
+		}
+		if c.options.FixPermissions != nil {
+			err = perms.FixPermissions(paths.Top(), perms.WithOwnership(*c.options.FixPermissions))
+			if err != nil {
+				return errors.New(err, "failed to fix permissions")
+			}
+		}
+		return nil
 	}
 
 	err = c.enrollWithBackoff(ctx, persistentConfig)

--- a/testing/integration/delay_enroll_test.go
+++ b/testing/integration/delay_enroll_test.go
@@ -100,7 +100,7 @@ func TestDelayEnrollUnprivileged(t *testing.T) {
 
 	// 1. Create a policy in Fleet with monitoring enabled.
 	// To ensure there are no conflicts with previous test runs against
-	// the same ESS stack, we add the current time at the end of the policy
+	// the same ESS stack, we add a UUID at the end of the policy
 	// name. This policy does not contain any integration.
 	t.Log("Enrolling agent in Fleet with a test policy")
 	createPolicyReq := kibana.AgentPolicy{

--- a/testing/integration/delay_enroll_test.go
+++ b/testing/integration/delay_enroll_test.go
@@ -9,7 +9,6 @@ package integration
 import (
 	"context"
 	"fmt"
-	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
 	"testing"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/kibana"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"

--- a/testing/integration/delay_enroll_test.go
+++ b/testing/integration/delay_enroll_test.go
@@ -9,7 +9,7 @@ package integration
 import (
 	"context"
 	"fmt"
-	"os/exec"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
 	"testing"
 	"time"
 
@@ -30,7 +30,6 @@ func TestDelayEnroll(t *testing.T) {
 		Stack: &define.Stack{},
 		Local: false,
 		Sudo:  true,
-		OS:    []define.OS{{Type: define.Linux}},
 	})
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
@@ -64,6 +63,7 @@ func TestDelayEnroll(t *testing.T) {
 		NonInteractive: true,
 		Force:          true,
 		DelayEnroll:    true,
+		Privileged:     false,
 	}
 	// Install the Elastic-Agent with the policy that was just
 	// created.
@@ -77,11 +77,69 @@ func TestDelayEnroll(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start elastic-agent via service, this should do the enrollment
-	cmd := exec.Command("/usr/bin/systemctl", "start", "elastic-agent")
-	stdErrStdout, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "systemctl start elastic-agent output was %s", stdErrStdout)
+	err = install.StartService("") // topPath can be blank as this is only starting the service
+	require.NoErrorf(t, err, "failed to start service")
 
 	// check to make sure enroll worked
 	check.ConnectedToFleet(ctx, t, agentFixture, 5*time.Minute)
+}
 
+func TestDelayEnrollUnprivileged(t *testing.T) {
+	info := define.Require(t, define.Requirements{
+		Group: Fleet,
+		Stack: &define.Stack{},
+		Local: false,
+		Sudo:  true,
+	})
+
+	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	defer cancel()
+
+	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
+	require.NoError(t, err)
+
+	// 1. Create a policy in Fleet with monitoring enabled.
+	// To ensure there are no conflicts with previous test runs against
+	// the same ESS stack, we add the current time at the end of the policy
+	// name. This policy does not contain any integration.
+	t.Log("Enrolling agent in Fleet with a test policy")
+	createPolicyReq := kibana.AgentPolicy{
+		Name:        fmt.Sprintf("test-policy-enroll-%s", uuid.New().String()),
+		Namespace:   info.Namespace,
+		Description: "test policy for agent enrollment",
+		MonitoringEnabled: []kibana.MonitoringEnabledOption{
+			kibana.MonitoringEnabledLogs,
+			kibana.MonitoringEnabledMetrics,
+		},
+		AgentFeatures: []map[string]interface{}{
+			{
+				"name":    "test_enroll",
+				"enabled": true,
+			},
+		},
+	}
+
+	installOpts := atesting.InstallOpts{
+		NonInteractive: true,
+		Force:          true,
+		DelayEnroll:    true,
+		Privileged:     false,
+	}
+	// Install the Elastic-Agent with the policy that was just
+	// created.
+	_, err = tools.InstallAgentWithPolicy(
+		ctx,
+		t,
+		installOpts,
+		agentFixture,
+		info.KibanaClient,
+		createPolicyReq)
+	require.NoError(t, err)
+
+	// Start elastic-agent via service, this should do the enrollment
+	err = install.StartService("") // topPath can be blank as this is only starting the service
+	require.NoErrorf(t, err, "failed to start service")
+
+	// check to make sure enroll worked
+	check.ConnectedToFleet(ctx, t, agentFixture, 5*time.Minute)
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes an issue where `--delay-enroll` with `--unprivileged` on Windows didn't allow the Elastic Agent to start. This is because the `FixPermissions` work was being skipped with delayed enrollment.

This also adjusts the integration tests for delay enrollment to work both on Linux and on Windows. Adds specific tests for delay enrollment with privileged and unprivileged mode.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To allow `--delay-enroll` to work with `--unprivileged` on Windows.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (integration tests added)
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #4678 
