### PR TITLE
Remove outdated comment on OTel v0.97.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,8 +85,6 @@ require (
 
 require (
 	// open telemetry dependencies
-	// pinned to v0.97.0 due to issue with ports binding which causes our tests to fail
-	// Do NOT upgrade the version beyond 0.97.0 until https://github.com/open-telemetry/opentelemetry-collector/issues/10031 is fixed!
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.100.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.100.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.100.0


### PR DESCRIPTION
## What does this PR do?

Removes an outdated code comment on not updating OTel Collector components beyond v0.97.0. The original blocking issue has been resolved and the components have already been updated to v0.100.0 before.

## Why is it important?

Keep the code tidy!

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

None.

## How to test this PR locally

No functional changes.