### PR TITLE
Add asset inventory as input to cloudbeat

### DIFF
--- a/changelog/fragments/1716543533-add-cloudbeat-asset-inventory-aws.yaml
+++ b/changelog/fragments/1716543533-add-cloudbeat-asset-inventory-aws.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add cloudbeat asset inventory aws
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: cloudbeat
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/specs/cloudbeat.spec.yml
+++ b/specs/cloudbeat.spec.yml
@@ -80,7 +80,7 @@ inputs:
     shippers: *shippers
     command: *command
     isolate_units: true
-    - name: cloudbeat/asset_inventory
+  - name: cloudbeat/asset_inventory_aws
     description: "AWS Asset Inventory Discovery"
     platforms: *platforms
     outputs: *outputs

--- a/specs/cloudbeat.spec.yml
+++ b/specs/cloudbeat.spec.yml
@@ -80,3 +80,10 @@ inputs:
     shippers: *shippers
     command: *command
     isolate_units: true
+    - name: cloudbeat/asset_inventory
+    description: "AWS Asset Inventory Discovery"
+    platforms: *platforms
+    outputs: *outputs
+    shippers: *shippers
+    command: *command
+    isolate_units: true


### PR DESCRIPTION
## What does this PR do?

Adds AWS Asset Inventory input to cloudbeat

## Why is it important?

Cloud Security Posture team is focusing on the CDR Vision, which means we need to build an Asset Inventory. 

The Asset Inventory fetching will reside inside cloudbeat (this decision can be changed in the future). We decided to build an isolated integration for beta testing and avoid unintended side effects to existing cloudbeat inputs. Therefore we are adding a new input.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

No disruptions expected.

## How to test this PR locally
--

## Related issues

- Part of https://github.com/elastic/security-team/issues/9067
