### PR TITLE
Fix how `updatecli` version is pinned

### DIFF
--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -22,7 +22,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@9a37c7e35598d7b37d8e7568b40ed9538112be01 # v0.76.1
+        uses: updatecli/updatecli-action@v2
+        with:
+          version: v0.76.1
 
       - name: Run Updatecli in Apply mode
         run: updatecli apply --config .github/updatecli-bump-golang.yml


### PR DESCRIPTION
## What does this PR do?

Changes how the version of `updatecli` tool is pinned in CI to be more explicit and safer. We should allow updates to the `updatecli-action` (to allow e.g. bug fixes or security updates). If we want to pin the version of the `updatecli` tool, let's use the option that the action exposes for it: https://github.com/updatecli/updatecli-action/blob/v2.58.0/README.md#usage.

## Why is it important?

Keeps us up to date on the action versions, preventing security vulnerabilities or bugs.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~