### PR TITLE
Wait on the watcher at startup instead of just releasing resources associated with it

### DIFF
--- a/changelog/fragments/1717185708-Stop-creating-a-zombie-process-on-each-restart.yaml
+++ b/changelog/fragments/1717185708-Stop-creating-a-zombie-process-on-each-restart.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Stop creating a zombie process on each restart.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/4834
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1717185708-Stop-creating-a-zombie-process-on-each-restart.yaml
+++ b/changelog/fragments/1717185708-Stop-creating-a-zombie-process-on-each-restart.yaml
@@ -8,7 +8,7 @@
 # - security: impacts on the security of a product or a user’s deployment.
 # - upgrade: important information for someone upgrading from a prior version
 # - other: does not fit into any of the other categories
-kind: feature
+kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
 summary: Stop creating a zombie process on each restart.


### PR DESCRIPTION
- Relates https://github.com/elastic/elastic-agent/issues/2190

Today every time the agent starts the watcher it results in a zombie process on Linux. This is because we never wait on it. There are two places where this happens:

1. As part of the upgrade process: https://github.com/elastic/elastic-agent/blob/7b81fea37ed79b26a641f9d2c28cfcd913cdb645/internal/pkg/agent/application/upgrade/upgrade.go#L302-L308
2. At startup in case we are starting as a result of an upgrade: https://github.com/elastic/elastic-agent/blob/7b81fea37ed79b26a641f9d2c28cfcd913cdb645/internal/pkg/agent/cmd/run.go#L243-L247

I don't believe the first case is addressed by this change. This is because the agent process re-execs itself before the `Wait` can complete. I still have to do some experimenting to see exactly what happens in this case.

In the second case, 99% of the time the watcher exits quickly because the restart is not after an upgrade, and so simply waiting will prevent the zombie. If we are rolled back we are in a similar situation to case 1, as we may reexec before the wait completes.

This PR made me read the implementation of [process.Release()](https://pkg.go.dev/os#Process.Release) which on Unix makes no system calls at all, it just cleans up resources:

https://cs.opensource.google/go/go/+/refs/tags/go1.22.3:src/os/exec_unix.go;l=85-91
```go
func (p *Process) release() error {
	// NOOP for unix.
	p.Pid = -1
	// no need for a finalizer anymore
	runtime.SetFinalizer(p, nil)
	return nil
}
```

On Windows it makes a system call to close the handle:

https://cs.opensource.google/go/go/+/refs/tags/go1.22.3:src/os/exec_windows.go;l=65-77
```go
func (p *Process) release() error {
	handle := atomic.SwapUintptr(&p.handle, uintptr(syscall.InvalidHandle))
	if handle == uintptr(syscall.InvalidHandle) {
		return syscall.EINVAL
	}
	e := syscall.CloseHandle(syscall.Handle(handle))
	if e != nil {
		return NewSyscallError("CloseHandle", e)
	}
	// no need for a finalizer anymore
	runtime.SetFinalizer(p, nil)
	return nil
}
```

The reason `release()` not making a system call is interesting is because this means that the watcher is still child of the agent process, meaning it dies when the agent dies. This cannot be changed without a system call happening on Unix. This means there is an opportunity where the agent is dead and the watcher is also dead, unable to roll back. I think we may need to use something like https://github.com/sevlyar/go-daemon?tab=readme-ov-file#how-it-works to fix this. I suspect our existing test for this case isn't precise enough. The watcher from the agent starting the upgrade would need to be killed, and the agent we upgraded to would have to exit before it launched the watcher. This is not how it works today. I don't think this PR makes anything any worse but it doesn't fix this problem.

https://github.com/elastic/elastic-agent/blob/7b81fea37ed79b26a641f9d2c28cfcd913cdb645/testing/integration/upgrade_rollback_test.go#L201-L231

On Windows child processes do not share the lifetime of their parent process unless they are manually assigned to the same Job group, which we manually do when launching component sub-processes but do not do here. This means this should work as intended under all circumstances on Windows.

https://github.com/elastic/elastic-agent/blob/7b81fea37ed79b26a641f9d2c28cfcd913cdb645/pkg/core/process/process.go#L169-L177

I am going to do some manual testing and open an issue if I can confirm there is a window where the watcher isn't running and the agent process can have exited. Fixing that requires more work.

