### PR TITLE
Fix log level value reported by Agent to Fleet

### DIFF
--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -333,8 +333,7 @@ func (f *FleetGateway) execute(ctx context.Context) (*fleetapi.CheckinResponse, 
 		// escMeta struct is incomplete: log a warning
 		f.log.Warnw("Agent ECSMetadata struct is missing/incomplete", "elastic_ecs_metadata", ecsMeta.Elastic)
 	} else {
-		// FIXME
-		f.log.Errorf("correcting agent loglevel from %s to %s using coordinator state", ecsMeta.Elastic.Agent.LogLevel, state.LogLevel.String())
+		f.log.Debugf("correcting agent loglevel from %s to %s using coordinator state", ecsMeta.Elastic.Agent.LogLevel, state.LogLevel.String())
 		// Fix loglevel with the current log level used by coordinator
 		ecsMeta.Elastic.Agent.LogLevel = state.LogLevel.String()
 	}

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -329,6 +329,16 @@ func (f *FleetGateway) execute(ctx context.Context) (*fleetapi.CheckinResponse, 
 	// convert components into checkin components structure
 	components := f.convertToCheckinComponents(state.Components)
 
+	if ecsMeta.Elastic == nil || ecsMeta.Elastic.Agent == nil {
+		// escMeta struct is incomplete: log a warning
+		f.log.Warnw("Agent ECSMetadata struct is missing/incomplete", "elastic_ecs_metadata", ecsMeta.Elastic)
+	} else {
+		// FIXME
+		f.log.Errorf("correcting agent loglevel from %s to %s using coordinator state", ecsMeta.Elastic.Agent.LogLevel, state.LogLevel.String())
+		// Fix loglevel with the current log level used by coordinator
+		ecsMeta.Elastic.Agent.LogLevel = state.LogLevel.String()
+	}
+
 	// checkin
 	cmd := fleetapi.NewCheckinCmd(f.agentInfo, f.client)
 	req := &fleetapi.CheckinRequest{

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -329,14 +329,9 @@ func (f *FleetGateway) execute(ctx context.Context) (*fleetapi.CheckinResponse, 
 	// convert components into checkin components structure
 	components := f.convertToCheckinComponents(state.Components)
 
-	if ecsMeta.Elastic == nil || ecsMeta.Elastic.Agent == nil {
-		// escMeta struct is incomplete: log a warning
-		f.log.Warnw("Agent ECSMetadata struct is missing/incomplete", "elastic_ecs_metadata", ecsMeta.Elastic)
-	} else {
-		f.log.Debugf("correcting agent loglevel from %s to %s using coordinator state", ecsMeta.Elastic.Agent.LogLevel, state.LogLevel.String())
-		// Fix loglevel with the current log level used by coordinator
-		ecsMeta.Elastic.Agent.LogLevel = state.LogLevel.String()
-	}
+	f.log.Debugf("correcting agent loglevel from %s to %s using coordinator state", ecsMeta.Elastic.Agent.LogLevel, state.LogLevel.String())
+	// Fix loglevel with the current log level used by coordinator
+	ecsMeta.Elastic.Agent.LogLevel = state.LogLevel.String()
 
 	// checkin
 	cmd := fleetapi.NewCheckinCmd(f.agentInfo, f.client)

--- a/internal/pkg/agent/application/info/agent_metadata_test.go
+++ b/internal/pkg/agent/application/info/agent_metadata_test.go
@@ -29,6 +29,10 @@ func TestECSMetadata(t *testing.T) {
 	metadata, err := agentInfo.ECSMetadata(l)
 	require.NoError(t, err)
 
+	if assert.NotNil(t, metadata.Elastic, "metadata.Elastic must not be nil") {
+		assert.NotNil(t, metadata.Elastic.Agent, "metadata.Elastic.Agent must not be nil")
+	}
+
 	sysInfo, err := sysinfo.Host()
 	require.NoError(t, err)
 

--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -665,6 +665,16 @@ func (f *Fixture) PrepareAgentCommand(ctx context.Context, args []string, opts .
 		return nil, fmt.Errorf("failed to prepare before exec: %w", err)
 	}
 
+	// prepare a client if it's not already set
+	if f.c == nil {
+		cAddr, err := control.AddressFromPath(f.operatingSystem, f.workDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get control protcol address: %w", err)
+		}
+		agentClient := client.New(client.WithAddress(cAddr))
+		f.setClient(agentClient)
+	}
+
 	// #nosec G204 -- Not so many ways to support variadic arguments to the elastic-agent command :(
 	cmd := exec.CommandContext(ctx, f.binaryPath(), args...)
 	for _, o := range opts {

--- a/testing/integration/log_level_test.go
+++ b/testing/integration/log_level_test.go
@@ -35,8 +35,9 @@ import (
 
 func TestSetLogLevelFleetManaged(t *testing.T) {
 	info := define.Require(t, define.Requirements{
-		Group: Default,
+		Group: Fleet,
 		Stack: &define.Stack{},
+		Sudo:  true,
 	})
 
 	deadline := time.Now().Add(10 * time.Minute)

--- a/testing/integration/log_level_test.go
+++ b/testing/integration/log_level_test.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httputil"
 	"strings"
 	"testing"
 	"text/template"
@@ -263,16 +262,18 @@ func updateAgentLogLevel(ctx context.Context, t *testing.T, kibanaClient *kibana
 
 	err = updateLogLevelTemplate.Execute(buf, templateData)
 	t.Logf("Updating agent-specific log level to %q", logLevel)
-	fleetResp, err := kibanaClient.SendWithContext(ctx, http.MethodPost, "/api/fleet/agents/"+agentID+"/actions", nil, nil, buf)
+	_, err = kibanaClient.SendWithContext(ctx, http.MethodPost, "/api/fleet/agents/"+agentID+"/actions", nil, nil, buf)
 	if err != nil {
 		return fmt.Errorf("error executing fleet request: %w", err)
 	}
-	respDump, err := httputil.DumpResponse(fleetResp, true)
-	if err != nil {
-		t.Logf("Error dumping Fleet response to updating agent-specific log level: %v", err)
-	} else {
-		t.Logf("Fleet response to updating agent-specific log level:\n----- BEGIN RESPONSE DUMP -----\n%s\n----- END RESPONSE DUMP -----\n", string(respDump))
-	}
+
+	// The log below is a bit spammy but it can be useful for debugging
+	//respDump, err := httputil.DumpResponse(fleetResp, true)
+	//if err != nil {
+	//	t.Logf("Error dumping Fleet response to updating agent-specific log level: %v", err)
+	//} else {
+	//	t.Logf("Fleet response to updating agent-specific log level:\n----- BEGIN RESPONSE DUMP -----\n%s\n----- END RESPONSE DUMP -----\n", string(respDump))
+	//}
 
 	return nil
 }
@@ -308,18 +309,19 @@ func updatePolicyLogLevel(ctx context.Context, t *testing.T, kibanaClient *kiban
 		return fmt.Errorf("error rendering policy update template: %w", err)
 	}
 
-	fleetResp, err := kibanaClient.SendWithContext(ctx, http.MethodPut, "/api/fleet/agent_policies/"+policy.ID, nil, nil, buf)
+	_, err = kibanaClient.SendWithContext(ctx, http.MethodPut, "/api/fleet/agent_policies/"+policy.ID, nil, nil, buf)
 
 	if err != nil {
 		return fmt.Errorf("error executing fleet request: %w", err)
 	}
 
-	respDump, err := httputil.DumpResponse(fleetResp, true)
-	if err != nil {
-		t.Logf("Error dumping Fleet response to updating policy log level: %v", err)
-	} else {
-		t.Logf("Fleet response to updating policy log level:\n----- BEGIN RESPONSE DUMP -----\n%s\n----- END RESPONSE DUMP -----\n", string(respDump))
-	}
+	// The log below is a bit spammy but it can be useful for debugging
+	//respDump, err := httputil.DumpResponse(fleetResp, true)
+	//if err != nil {
+	//	t.Logf("Error dumping Fleet response to updating policy log level: %v", err)
+	//} else {
+	//	t.Logf("Fleet response to updating policy log level:\n----- BEGIN RESPONSE DUMP -----\n%s\n----- END RESPONSE DUMP -----\n", string(respDump))
+	//}
 
 	return nil
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR fixes the log level reported by Agent when checking in with Fleet. 
Since merging #3090, a managed elastic-agent has now 2 sources of configuration for log level:
1. agent-specific log level setting saved in `fleet.enc`
2. log level setting in the Fleet policy itself (with lower priority than option 1.)

Before this change, the agent was sending only the information coming from 1. (with a default value equal to `info`), now we send back to Fleet the actual log level specified in coordinator state (which is the end result of evaluating the multiple settings with the correct priority)

There has also been a modification of the integration test related to the feature with additional assertions on log level received by Fleet.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

The log level is now correctly displayed in Fleet UI regardless for each agent, regardless of how it's been set (agent settings, policy or default value)

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Spin up a Stack deployment
2. Create a policy without any specific log level settings (check in `Advanced settings` under the Policy's `settings` Tab  
  ![image](https://github.com/elastic/elastic-agent/assets/96178987/1bcacadd-0beb-421a-a283-edb8ea48529d)
3. Install and enroll an agent and verify that the default log level reported is `info`
4. Set some log level in policy and check in the agent details that the change is reported correctly (Ignore the `offline` state in the image below, the screenshot was taken after the agent has been uninstalled)
  ![image](https://github.com/elastic/elastic-agent/assets/96178987/d2377fe9-9ff3-46cf-92ef-913f6b299d6e)
5. Set some specific (different!) log level in the agent settings tab and check that in a few seconds that change is also reflected in UI
6. Have fun! Try any combination of setting/unsetting the log level and verify that the agent log level is updated within a reasonable time in the agent details tab

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #4747

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...
