### PR TITLE
Use higher tier ARM VM for integration testing

### DIFF
--- a/pkg/testing/ogc/supported.go
+++ b/pkg/testing/ogc/supported.go
@@ -28,7 +28,7 @@ var ogcSupported = []LayoutOS{
 			Version: "22.04",
 		},
 		Provider:     Google,
-		InstanceSize: "e2-standard-2", // 2 amd64 cpus
+		InstanceSize: "e2-standard-2", // 2 amd64 cpus, 8 GB RAM
 		RunsOn:       "ubuntu-2204-lts",
 		Username:     "ubuntu",
 		RemotePath:   "/home/ubuntu/agent",
@@ -41,7 +41,7 @@ var ogcSupported = []LayoutOS{
 			Version: "20.04",
 		},
 		Provider:     Google,
-		InstanceSize: "e2-standard-2", // 2 amd64 cpus
+		InstanceSize: "e2-standard-2", // 2 amd64 cpus, 8 GB RAM
 		RunsOn:       "ubuntu-2004-lts",
 		Username:     "ubuntu",
 		RemotePath:   "/home/ubuntu/agent",
@@ -54,7 +54,7 @@ var ogcSupported = []LayoutOS{
 			Version: "22.04",
 		},
 		Provider:     Google,
-		InstanceSize: "t2a-standard-2", // 2 arm64 cpus
+		InstanceSize: "t2a-standard-4", // 4 arm64 cpus, 16 GB RAM
 		RunsOn:       "ubuntu-2204-lts-arm64",
 		Username:     "ubuntu",
 		RemotePath:   "/home/ubuntu/agent",
@@ -67,7 +67,7 @@ var ogcSupported = []LayoutOS{
 			Version: "20.04",
 		},
 		Provider:     Google,
-		InstanceSize: "t2a-standard-2", // 2 arm64 cpus
+		InstanceSize: "t2a-standard-4", // 4 arm64 cpus, 16 GB RAM
 		RunsOn:       "ubuntu-2004-lts-arm64",
 		Username:     "ubuntu",
 		RemotePath:   "/home/ubuntu/agent",
@@ -80,7 +80,7 @@ var ogcSupported = []LayoutOS{
 			Version: "8",
 		},
 		Provider:     Google,
-		InstanceSize: "e2-standard-2", // 2 amd64 cpus
+		InstanceSize: "e2-standard-2", // 2 amd64 cpus, 8 GB RAM
 		RunsOn:       "rhel-8",
 		Username:     "rhel",
 		RemotePath:   "/home/rhel/agent",
@@ -92,7 +92,7 @@ var ogcSupported = []LayoutOS{
 			Version: "2022",
 		},
 		Provider:     Google,
-		InstanceSize: "e2-standard-4", // 4 amd64 cpus
+		InstanceSize: "e2-standard-4", // 4 amd64 cpus, 16 GB RAM
 		RunsOn:       "windows-2022",
 		Username:     "windows",
 		RemotePath:   "C:\\Users\\windows\\agent",
@@ -104,7 +104,7 @@ var ogcSupported = []LayoutOS{
 			Version: "2022-core",
 		},
 		Provider:     Google,
-		InstanceSize: "e2-standard-4", // 4 amd64 cpus
+		InstanceSize: "e2-standard-4", // 4 amd64 cpus, 16 GB RAM
 		RunsOn:       "windows-2022-core",
 		Username:     "windows",
 		RemotePath:   "C:\\Users\\windows\\agent",
@@ -116,7 +116,7 @@ var ogcSupported = []LayoutOS{
 			Version: "2019",
 		},
 		Provider:     Google,
-		InstanceSize: "e2-standard-4", // 4 amd64 cpus
+		InstanceSize: "e2-standard-4", // 4 amd64 cpus, 16 GB RAM
 		RunsOn:       "windows-2019",
 		Username:     "windows",
 		RemotePath:   "C:\\Users\\windows\\agent",
@@ -128,7 +128,7 @@ var ogcSupported = []LayoutOS{
 			Version: "2019-core",
 		},
 		Provider:     Google,
-		InstanceSize: "e2-standard-4", // 4 amd64 cpus
+		InstanceSize: "e2-standard-4", // 4 amd64 cpus, 16 GB RAM
 		RunsOn:       "windows-2019-core",
 		Username:     "windows",
 		RemotePath:   "C:\\Users\\windows\\agent",
@@ -140,7 +140,7 @@ var ogcSupported = []LayoutOS{
 			Version: "2016",
 		},
 		Provider:     Google,
-		InstanceSize: "e2-standard-4", // 4 amd64 cpus
+		InstanceSize: "e2-standard-4", // 4 amd64 cpus, 16 GB RAM
 		RunsOn:       "windows-2016",
 		Username:     "windows",
 		RemotePath:   "C:\\Users\\windows\\agent",
@@ -152,7 +152,7 @@ var ogcSupported = []LayoutOS{
 			Version: "2016-core",
 		},
 		Provider:     Google,
-		InstanceSize: "e2-standard-4", // 4 amd64 cpus
+		InstanceSize: "e2-standard-4", // 4 amd64 cpus, 16 GB RAM
 		RunsOn:       "windows-2016-core",
 		Username:     "windows",
 		RemotePath:   "C:\\Users\\windows\\agent",


### PR DESCRIPTION
ARM cores are lower performance, to make it equal to our AMD64 VMs we should use higher tier instances.