### PR TITLE
Disable integration tests on ARM due to instability

### DIFF
--- a/pkg/testing/ogc/supported.go
+++ b/pkg/testing/ogc/supported.go
@@ -46,32 +46,35 @@ var ogcSupported = []LayoutOS{
 		Username:     "ubuntu",
 		RemotePath:   "/home/ubuntu/agent",
 	},
-	{
-		OS: define.OS{
-			Type:    define.Linux,
-			Arch:    define.ARM64,
-			Distro:  runner.Ubuntu,
-			Version: "22.04",
-		},
-		Provider:     Google,
-		InstanceSize: "t2a-standard-4", // 4 arm64 cpus, 16 GB RAM
-		RunsOn:       "ubuntu-2204-lts-arm64",
-		Username:     "ubuntu",
-		RemotePath:   "/home/ubuntu/agent",
-	},
-	{
-		OS: define.OS{
-			Type:    define.Linux,
-			Arch:    define.ARM64,
-			Distro:  runner.Ubuntu,
-			Version: "20.04",
-		},
-		Provider:     Google,
-		InstanceSize: "t2a-standard-4", // 4 arm64 cpus, 16 GB RAM
-		RunsOn:       "ubuntu-2004-lts-arm64",
-		Username:     "ubuntu",
-		RemotePath:   "/home/ubuntu/agent",
-	},
+	// These instance types are experimental on Google Cloud and very unstable
+	// We will wait until Google introduces new ARM instance types
+	// https://cloud.google.com/blog/products/compute/introducing-googles-new-arm-based-cpu
+	// {
+	// 	OS: define.OS{
+	// 		Type:    define.Linux,
+	// 		Arch:    define.ARM64,
+	// 		Distro:  runner.Ubuntu,
+	// 		Version: "22.04",
+	// 	},
+	// 	Provider:     Google,
+	// 	InstanceSize: "t2a-standard-4", // 4 arm64 cpus, 16 GB RAM
+	// 	RunsOn:       "ubuntu-2204-lts-arm64",
+	// 	Username:     "ubuntu",
+	// 	RemotePath:   "/home/ubuntu/agent",
+	// },
+	// {
+	// 	OS: define.OS{
+	// 		Type:    define.Linux,
+	// 		Arch:    define.ARM64,
+	// 		Distro:  runner.Ubuntu,
+	// 		Version: "20.04",
+	// 	},
+	// 	Provider:     Google,
+	// 	InstanceSize: "t2a-standard-4", // 4 arm64 cpus, 16 GB RAM
+	// 	RunsOn:       "ubuntu-2004-lts-arm64",
+	// 	Username:     "ubuntu",
+	// 	RemotePath:   "/home/ubuntu/agent",
+	// },
 	{
 		OS: define.OS{
 			Type:    define.Linux,


### PR DESCRIPTION
The current ARM hardware is experimental and very unstable, we should wait until a new stable instance type is introduced.