### PR TITLE
Create a version update branch after the mage target is run

### DIFF
--- a/.github/workflows/bump-agent-versions.sh
+++ b/.github/workflows/bump-agent-versions.sh
@@ -16,6 +16,9 @@ else
         echo "Another PR for $GITHUB_REF_NAME is in review, skipping..."
         exit 0
     fi
+    # the mage target above requires to be on a release branch
+    # so, the new branch should not be created before the target is run
+    git checkout -b update-agent-versions-$GITHUB_RUN_ID
     git add .agent-versions.json .package-version
 
     nl=$'\n' # otherwise the new line character is not recognized properly

--- a/.github/workflows/bump-agent-versions.yml
+++ b/.github/workflows/bump-agent-versions.yml
@@ -31,9 +31,6 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
-      - name: Set up branch
-        run: git checkout -b update-agent-versions-$GITHUB_RUN_ID
-
       - name: Install mage
         uses: magefile/mage-action@v3
         with:
@@ -88,4 +85,3 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_MESSAGE: "Update for Elastic Agent versions has been created: ${{ steps.update.outputs.pr }}"
-


### PR DESCRIPTION
The mage target now requires to be run on a release branch.