### PR TITLE
Add Ubuntu 24.04 to integration testing.

### DIFF
--- a/pkg/testing/multipass/provisioner.go
+++ b/pkg/testing/multipass/provisioner.go
@@ -54,7 +54,7 @@ func (p *provisioner) Supported(os define.OS) bool {
 	if os.Distro != Ubuntu {
 		return false
 	}
-	if os.Version != "20.04" && os.Version != "22.04" {
+	if os.Version != "20.04" && os.Version != "22.04" && os.Version != "24.04" {
 		return false
 	}
 	// multipass only supports the same architecture of the host

--- a/pkg/testing/ogc/supported.go
+++ b/pkg/testing/ogc/supported.go
@@ -25,6 +25,19 @@ var ogcSupported = []LayoutOS{
 			Type:    define.Linux,
 			Arch:    define.AMD64,
 			Distro:  runner.Ubuntu,
+			Version: "24.04",
+		},
+		Provider:     Google,
+		InstanceSize: "e2-standard-2", // 2 amd64 cpus, 8 GB RAM
+		RunsOn:       "ubuntu-2404-lts",
+		Username:     "ubuntu",
+		RemotePath:   "/home/ubuntu/agent",
+	},
+	{
+		OS: define.OS{
+			Type:    define.Linux,
+			Arch:    define.AMD64,
+			Distro:  runner.Ubuntu,
 			Version: "22.04",
 		},
 		Provider:     Google,
@@ -49,6 +62,19 @@ var ogcSupported = []LayoutOS{
 	// These instance types are experimental on Google Cloud and very unstable
 	// We will wait until Google introduces new ARM instance types
 	// https://cloud.google.com/blog/products/compute/introducing-googles-new-arm-based-cpu
+	// {
+	// 	OS: define.OS{
+	// 		Type:    define.Linux,
+	// 		Arch:    define.ARM64,
+	// 		Distro:  runner.Ubuntu,
+	// 		Version: "24.04",
+	// 	},
+	// 	Provider:     Google,
+	// 	InstanceSize: "t2a-standard-4", // 4 arm64 cpus, 16 GB RAM
+	// 	RunsOn:       "ubuntu-2404-lts-arm64",
+	// 	Username:     "ubuntu",
+	// 	RemotePath:   "/home/ubuntu/agent",
+	// },
 	// {
 	// 	OS: define.OS{
 	// 		Type:    define.Linux,

--- a/pkg/testing/ogc/supported.go
+++ b/pkg/testing/ogc/supported.go
@@ -29,7 +29,7 @@ var ogcSupported = []LayoutOS{
 		},
 		Provider:     Google,
 		InstanceSize: "e2-standard-2", // 2 amd64 cpus, 8 GB RAM
-		RunsOn:       "ubuntu-2404-lts",
+		RunsOn:       "ubuntu-2404-lts-amd64",
 		Username:     "ubuntu",
 		RemotePath:   "/home/ubuntu/agent",
 	},

--- a/pkg/testing/runner/supported.go
+++ b/pkg/testing/runner/supported.go
@@ -31,6 +31,16 @@ type SupportedOS struct {
 }
 
 var (
+	// UbuntuAMD64_2404 - Ubuntu (amd64) 24.04
+	UbuntuAMD64_2404 = SupportedOS{
+		OS: define.OS{
+			Type:    define.Linux,
+			Arch:    define.AMD64,
+			Distro:  Ubuntu,
+			Version: "24.04",
+		},
+		Runner: DebianRunner{},
+	}
 	// UbuntuAMD64_2204 - Ubuntu (amd64) 22.04
 	UbuntuAMD64_2204 = SupportedOS{
 		OS: define.OS{
@@ -48,6 +58,16 @@ var (
 			Arch:    define.AMD64,
 			Distro:  Ubuntu,
 			Version: "20.04",
+		},
+		Runner: DebianRunner{},
+	}
+	// UbuntuARM64_2404 - Ubuntu (arm64) 24.04
+	UbuntuARM64_2404 = SupportedOS{
+		OS: define.OS{
+			Type:    define.Linux,
+			Arch:    define.ARM64,
+			Distro:  Ubuntu,
+			Version: "24.04",
 		},
 		Runner: DebianRunner{},
 	}
@@ -146,8 +166,10 @@ var (
 // one in this list will be picked. So it's best to place the one that we want the
 // most testing at the top.
 var supported = []SupportedOS{
+	UbuntuAMD64_2404,
 	UbuntuAMD64_2204,
 	UbuntuAMD64_2004,
+	UbuntuARM64_2404,
 	UbuntuARM64_2204,
 	UbuntuARM64_2004,
 	RhelAMD64_8,

--- a/pkg/testing/runner/supported_test.go
+++ b/pkg/testing/runner/supported_test.go
@@ -37,6 +37,7 @@ func TestGetSupported(t *testing.T) {
 				Distro: Ubuntu,
 			},
 			Results: []SupportedOS{
+				UbuntuAMD64_2404,
 				UbuntuAMD64_2204,
 				UbuntuAMD64_2004,
 			},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds the latest Ubuntu LTS release `24.04` to the integration testing framework.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Ensures that the Elastic Agent stays working on the latest release of Ubuntu.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

`mage integration:test` will now use Ubuntu 24.04 as the default

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #4830
