### PR TITLE
Increase removal timeout when uninstall

### DIFF
--- a/changelog/fragments/1718268915-increase-remove-timeout.yaml
+++ b/changelog/fragments/1718268915-increase-remove-timeout.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Increase removal timeout when uninstall
+component: "elastic-agent"

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -168,7 +168,7 @@ func checkForUnprivilegedVault(ctx context.Context, opts ...vault.OptionFunc) (b
 // to an ERROR_SHARING_VIOLATION. RemovePath will retry up to 2
 // seconds if it keeps getting that error.
 func RemovePath(path string) error {
-	const arbitraryTimeout = 30 * time.Second
+	const arbitraryTimeout = 60 * time.Second
 	start := time.Now()
 	var lastErr error
 	for time.Since(start) <= arbitraryTimeout {


### PR DESCRIPTION
## What does this PR do?

On particularly slow machines 30 seconds might be still not enough to release the agent binary, so we're able to remove it on uninstall. This change doubles the timeout to 60 seconds.

- Closes https://github.com/elastic/elastic-agent/issues/4164