### PR TITLE
Update Elastic Agent Ironbank Docker image to use ubi 9.4

### DIFF
--- a/dev-tools/packaging/templates/ironbank/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/ironbank/Dockerfile.tmpl
@@ -4,7 +4,7 @@
 ################################################################################
 ARG BASE_REGISTRY=registry1.dsop.io
 ARG BASE_IMAGE=redhat/ubi/ubi9
-ARG BASE_TAG=9.3
+ARG BASE_TAG=9.4
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} as prep_files
 


### PR DESCRIPTION
Update Elastic Agent docker image to use ubi 9.4 within the Ironbank context

