### PR TITLE
Remove unneeded `Infof` line in runtime

### DIFF
--- a/pkg/component/runtime/runtime_comm.go
+++ b/pkg/component/runtime/runtime_comm.go
@@ -295,7 +295,6 @@ func (c *runtimeComm) checkin(server proto.ElasticAgent_CheckinV2Server, init *p
 				close(recvDone)
 				return
 			}
-			c.logger.Infof("got checkin with pid %d", checkin.Pid)
 			c.checkinObserved <- checkin
 		}
 	}()


### PR DESCRIPTION

## What does this PR do?

closes https://github.com/elastic/elastic-agent/issues/4974

Once again forgot to remove one of me debug lines before I merged something. This removes a superfluous `Infof()` call.
