### PR TITLE
Update K8s version to 1.30

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -191,10 +191,10 @@ steps:
         matrix:
           setup:
             k8s_version:
-              - "1.29.0"
-              - "1.28.0"
-              - "1.27.3"
-              - "1.26.6"
+              - "1.30.0"
+              - "1.29.4"
+              - "1.28.9"
+              - "1.27.13"
         retry:
           manual:
             allowed: true


### PR DESCRIPTION
## What does this PR do

Updates the K8s version being used by elastic package.

## Related issues

Relates to https://github.com/elastic/observability-dev/issues/3068