### PR TITLE
Add retry to DownloadPackage

### DIFF
--- a/pkg/testing/fetcher_artifact.go
+++ b/pkg/testing/fetcher_artifact.go
@@ -195,6 +195,21 @@ func findLatestSnapshot(ctx context.Context, doer httpDoer, version string) (bui
 }
 
 func DownloadPackage(ctx context.Context, l Logger, doer httpDoer, downloadPath string, packageFile string) error {
+	for i := 0; i < 3; i++ {
+		err := func() error {
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+			defer cancel()
+			return downloadPackage(ctx, l, doer, downloadPath, packageFile)
+		}
+		if err == nil {
+			return nil
+		}
+		l.Logf("Download artifact from %s failed: %s", downloadPath, err)
+	}
+	return fmt.Errorf("downloading package failed after 3 retries")
+}
+
+func downloadPackage(ctx context.Context, l Logger, doer httpDoer, downloadPath string, packageFile string) error {
 	l.Logf("Downloading artifact from %s", downloadPath)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", downloadPath, nil)

--- a/pkg/testing/fetcher_artifact.go
+++ b/pkg/testing/fetcher_artifact.go
@@ -200,7 +200,7 @@ func DownloadPackage(ctx context.Context, l Logger, doer httpDoer, downloadPath 
 			ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 			defer cancel()
 			return downloadPackage(ctx, l, doer, downloadPath, packageFile)
-		}
+		}()
 		if err == nil {
 			return nil
 		}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds retry logic to the `DownloadPackage` function that is used in the integration testing framework.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Reduce test failures due to failure to download an artifact.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #5009 