### PR TITLE
Fix connection info socket path that affects DEB/RPM installs

### DIFF
--- a/pkg/component/runtime/service.go
+++ b/pkg/component/runtime/service.go
@@ -312,7 +312,8 @@ func getConnInfoServerAddress(os string, isLocal bool, port int, socket string) 
 		}
 
 		u.Scheme = "unix"
-		return u.JoinPath(paths.InstallPath(paths.DefaultBasePath), socket).String(), nil
+		// Use the path that is relative to path.top which corresponds to the agent binary directory in all installation types
+		return u.JoinPath(paths.Top(), socket).String(), nil
 	}
 
 	return fmt.Sprintf("127.0.0.1:%d", port), nil

--- a/pkg/component/runtime/service_test.go
+++ b/pkg/component/runtime/service_test.go
@@ -236,7 +236,7 @@ func TestGetConnInfoServerAddress(t *testing.T) {
 				u := url.URL{}
 				u.Path = "/"
 				u.Scheme = "unix"
-				return u.JoinPath(paths.InstallPath(paths.DefaultBasePath), "test.sock").String()
+				return u.JoinPath(paths.Top(), "test.sock").String()
 			}(),
 		},
 	}


### PR DESCRIPTION
## What does this PR do?

This is one liner change to how the connection info socket path is configured.
Changed it from the hardcoded install path to the "top" path that points to the agent binary directory.
Took longer to validate than to make the change. 
Let me know if there are any cases where this assumption might not work.

Addresses this issue where the connection info socket was created in ```/opt/Elastic/Agent/.eaci.sock``` 
for DEB/RPM install.
https://github.com/elastic/endpoint-dev/issues/14557

The DEB/RPM installs are using ```/var/lib/elastic-agent``` directory for the Agent install.

Endpoint is checking the following paths in that order:
1. /opt/Elastic/Agent/.eaci.sock
2. /var/lib/elastic-agent/.eaci.sock

During testing uncovered the Endpoint defect, that is fixed here:
https://github.com/elastic/endpoint-dev/pull/14645
So this PR depends on that fix for DEP/RPM install to work correctly with Endpoint.

## Why is it important?

Addresses:
https://github.com/elastic/endpoint-dev/issues/14557

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test


## How to test this PR locally

Run Agent with Endpoint on Linux, make sure it works for the regular install and DEP/RPM install, Endpoint is healthy and checkin-in with the Agent as expected.

## Related issues

- Closes https://github.com/elastic/endpoint-dev/issues/14557

