### PR TITLE
Fix indefinite memory and CPU consumption when waiting fleet to be ready

### DIFF
--- a/changelog/fragments/1719934992-Fix-indefinite-memory-and-CPU-consumption-when-waiting-fleet-to-be-ready.yaml
+++ b/changelog/fragments/1719934992-Fix-indefinite-memory-and-CPU-consumption-when-waiting-fleet-to-be-ready.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix indefinite memory and CPU consumption when waiting fleet to be ready
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1719934992-Fix-indefinite-memory-and-CPU-consumption-when-waiting-fleet-to-be-ready.yaml
+++ b/changelog/fragments/1719934992-Fix-indefinite-memory-and-CPU-consumption-when-waiting-fleet-to-be-ready.yaml
@@ -8,7 +8,7 @@
 # - security: impacts on the security of a product or a user’s deployment.
 # - upgrade: important information for someone upgrading from a prior version
 # - other: does not fit into any of the other categories
-kind: feature
+kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
 summary: Fix indefinite memory and CPU consumption when waiting fleet to be ready
@@ -25,8 +25,8 @@ component:
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/elastic-agent/pull/5034
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.
-#issue: https://github.com/owner/repo/1234
+issue: https://github.com/elastic/elastic-agent/issues/5033

--- a/internal/pkg/core/backoff/exponential.go
+++ b/internal/pkg/core/backoff/exponential.go
@@ -45,7 +45,10 @@ func (b *ExpBackoff) NextWait() time.Duration {
 	return nextWait
 }
 
-// Wait block until either the timer is completed or channel is done.
+// Wait blocks until either the exponential backoff timer is completed or the
+// done channel is closed.
+// Wait returns true until done is closed. When done is closed, wait returns
+// immediately, therefore callers should always check the return value.
 func (b *ExpBackoff) Wait() bool {
 	b.duration = b.NextWait()
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fixes the wait for Fleet Server to be ready 

## Why is it important?

When waiting for Fleet Server to start, the Elastic Agent does not account for the timeout when waiting for Fleet Server to be ready.

Currently, when the timeout is reached, the operation isn't interrupted and the goroutine waiting for Fleet Server to be ready gets stuck in an infinite loop without any delay between iterations. It continually prints a log like:

`{"log.level":"info","@timestamp":"2024-07-02T13:18:59.354Z","log.origin":{"file.name":"cmd/enroll_cmd.go","file.line":812},"message":"Waiting for Elastic Agent to start: rpc error: code = Canceled desc = context canceled","ecs.version":"1.6.0"}
`.

This causes a spike in memory and CPU consumption until the agent is killed by the OS, potentially jeopardising the normal operation of the host.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

Try to reproduce https://github.com/elastic/elastic-agent/issues/5033, the issue should not be reproducible with this fix.

## Related issues


- Closes https://github.com/elastic/elastic-agent/issues/5033

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->