### PR TITLE
Make Wolfi a part of Docker packaging

### DIFF
--- a/changelog/fragments/1720208209-add-docker-wolfi.yaml
+++ b/changelog/fragments/1720208209-add-docker-wolfi.yaml
@@ -1,0 +1,3 @@
+kind: security
+summary: Add Wolfi docker image to packaging, the cloud image is now based on Wolfi
+component: "elastic-agent"

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -207,21 +207,58 @@ shared:
       'data/{{.BeatName}}-{{ commit_short }}/otelcol.ps1':
         source: '{{ repo.RootDir }}/dev-tools/packaging/files/windows/otelcol.ps1'
         mode: 0755
-      # windows not supported yet  
+      # windows not supported yet
       # 'otel_samples':
       #   source: '{{ repo.RootDir }}/internal/pkg/otel/samples/windows/'
       #   mode: 0755
 
+  # This image is used only for preparing the file tree before actually building the image
+  - &docker_builder_spec
+    extra_vars:
+      buildFrom: '--platform=linux/amd64 cgr.dev/chainguard/wolfi-base'
+
+  - &docker_builder_arm_spec
+    extra_vars:
+      buildFrom: '--platform=linux/arm64 cgr.dev/chainguard/wolfi-base'
+
+  - &docker_ubuntu_spec
+    extra_vars:
+      from: '--platform=linux/amd64 ubuntu:20.04'
+      image_name: '{{.BeatName}}'
+  - &docker_ubuntu_arm_spec
+    extra_vars:
+      from: '--platform=linux/arm64 ubuntu:20.04'
+      image_name: '{{.BeatName}}'
+
+  - &docker_ubi_spec
+    extra_vars:
+      from: '--platform=linux/amd64 docker.elastic.co/ubi9/ubi-minimal'
+      image_name: '{{.BeatName}}-ubi'
+  - &docker_ubi_arm_spec
+    extra_vars:
+      from: '--platform=linux/arm64 docker.elastic.co/ubi9/ubi-minimal'
+      image_name: '{{.BeatName}}-ubi'
+
+  - &docker_wolfi_spec
+    extra_vars:
+      from: '--platform=linux/amd64 cgr.dev/chainguard/wolfi-base'
+      image_name: '{{.BeatName}}-wolfi'
+  - &docker_wolfi_arm_spec
+    extra_vars:
+      from: '--platform=linux/arm64 cgr.dev/chainguard/wolfi-base'
+      image_name: '{{.BeatName}}-wolfi'
+
+  - &docker_elastic_spec
+    extra_vars:
+      repository: 'docker.elastic.co/beats'
+
   - &agent_docker_spec
     <<: *agent_binary_spec
     extra_vars:
-      from: 'ubuntu:20.04'
-      buildFrom: 'ubuntu:20.04'
       dockerfile: 'Dockerfile.elastic-agent.tmpl'
       docker_entrypoint: 'docker-entrypoint.elastic-agent.tmpl'
       user: '{{ .BeatName }}'
       linux_capabilities: ''
-      image_name: ''
       beats_install_path: "install"
     files:
       'elastic-agent.yml':
@@ -237,14 +274,7 @@ shared:
           {{ commit }}
         mode: 0644
 
-  - &agent_docker_arm_spec
-    <<: *agent_docker_spec
-    extra_vars:
-      from: 'arm64v8/ubuntu:20.04'
-      buildFrom: 'arm64v8/ubuntu:20.04'
-
   - &agent_docker_cloud_spec
-    <<: *agent_docker_spec
     extra_vars:
       image_name: '{{.BeatName}}-cloud'
       repository: 'docker.elastic.co/beats-ci'
@@ -259,6 +289,7 @@ shared:
         source: '{{.AgentDropPath}}/archives/{{.GOOS}}-{{.AgentArchName}}.tar.gz/agentbeat-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz'
         mode: 0755
 
+  # not different to the default image, kept for backwards-compatibility
   - &agent_docker_complete_spec
     <<: *agent_docker_spec
     extra_vars:
@@ -408,8 +439,6 @@ shared:
   - &docker_spec
     <<: *binary_spec
     extra_vars:
-      from: 'ubuntu:20.04'
-      buildFrom: 'ubuntu:20.04'
       user: '{{ .BeatName }}'
       linux_capabilities: ''
     files:
@@ -417,26 +446,6 @@ shared:
         source: '{{.BeatName}}.docker.yml'
         mode: 0600
         config: true
-
-  - &docker_arm_spec
-    <<: *docker_spec
-    extra_vars:
-      from: 'arm64v8/ubuntu:20.04'
-      buildFrom: 'arm64v8/ubuntu:20.04'
-
-  - &docker_ubi_spec
-    extra_vars:
-      image_name: '{{.BeatName}}-ubi'
-      from: 'docker.elastic.co/ubi9/ubi-minimal'
-
-  - &docker_arm_ubi_spec
-    extra_vars:
-      image_name: '{{.BeatName}}-ubi'
-      from: 'registry.access.redhat.com/ubi9/ubi-minimal:9.3'
-
-  - &elastic_docker_spec
-    extra_vars:
-      repository: 'docker.elastic.co/beats'
 
   #
   # License modifiers for Apache 2.0
@@ -514,6 +523,15 @@ specs:
       types: [docker]
       spec:
         <<: *docker_spec
+        <<: *docker_ubuntu_spec
+        <<: *docker_builder_spec
+
+    - os: linux
+      types: [docker]
+      spec:
+        <<: *docker_spec
+        <<: *docker_wolfi_spec
+        <<: *docker_builder_spec
 
     - os: aix
       types: [tgz]
@@ -555,7 +573,19 @@ specs:
       types: [docker]
       spec:
         <<: *docker_spec
-        <<: *elastic_docker_spec
+        <<: *docker_ubuntu_spec
+        <<: *docker_builder_spec
+        <<: *docker_elastic_spec
+        <<: *apache_license_for_binaries
+        name: '{{.BeatName}}-oss'
+
+    - os: linux
+      types: [docker]
+      spec:
+        <<: *docker_spec
+        <<: *docker_wolfi_spec
+        <<: *docker_builder_spec
+        <<: *docker_elastic_spec
         <<: *apache_license_for_binaries
         name: '{{.BeatName}}-oss'
 
@@ -600,7 +630,18 @@ specs:
       types: [docker]
       spec:
         <<: *docker_spec
-        <<: *elastic_docker_spec
+        <<: *docker_ubuntu_spec
+        <<: *docker_builder_spec
+        <<: *docker_elastic_spec
+        <<: *elastic_license_for_binaries
+    - os: linux
+      arch: arm64
+      types: [docker]
+      spec:
+        <<: *docker_spec
+        <<: *docker_ubuntu_arm_spec
+        <<: *docker_builder_arm_spec
+        <<: *docker_elastic_spec
         <<: *elastic_license_for_binaries
 
     - os: linux
@@ -609,24 +650,36 @@ specs:
       spec:
         <<: *docker_spec
         <<: *docker_ubi_spec
-        <<: *elastic_docker_spec
+        <<: *docker_builder_spec
+        <<: *docker_elastic_spec
         <<: *elastic_license_for_binaries
-
     - os: linux
       arch: arm64
       types: [docker]
       spec:
-        <<: *docker_arm_spec
-        <<: *elastic_docker_spec
+        <<: *docker_spec
+        <<: *docker_ubi_arm_spec
+        <<: *docker_builder_arm_spec
+        <<: *docker_elastic_spec
         <<: *elastic_license_for_binaries
 
+    - os: linux
+      arch: amd64
+      types: [docker]
+      spec:
+        <<: *docker_spec
+        <<: *docker_wolfi_spec
+        <<: *docker_builder_spec
+        <<: *docker_elastic_spec
+        <<: *elastic_license_for_binaries
     - os: linux
       arch: arm64
       types: [docker]
       spec:
-        <<: *docker_arm_spec
-        <<: *docker_arm_ubi_spec
-        <<: *elastic_docker_spec
+        <<: *docker_spec
+        <<: *docker_wolfi_arm_spec
+        <<: *docker_builder_arm_spec
+        <<: *docker_elastic_spec
         <<: *elastic_license_for_binaries
 
     - os: aix
@@ -710,7 +763,21 @@ specs:
       types: [docker]
       spec:
         <<: *docker_spec
-        <<: *elastic_docker_spec
+        <<: *docker_ubuntu_spec
+        <<: *docker_builder_spec
+        <<: *docker_elastic_spec
+        <<: *elastic_license_for_binaries
+        files:
+          '{{.BeatName}}{{.BinaryExt}}':
+            source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+    - os: linux
+      arch: arm64
+      types: [docker]
+      spec:
+        <<: *docker_spec
+        <<: *docker_ubuntu_arm_spec
+        <<: *docker_builder_arm_spec
+        <<: *docker_elastic_spec
         <<: *elastic_license_for_binaries
         files:
           '{{.BeatName}}{{.BinaryExt}}':
@@ -722,30 +789,45 @@ specs:
       spec:
         <<: *docker_spec
         <<: *docker_ubi_spec
-        <<: *elastic_docker_spec
+        <<: *docker_builder_spec
+        <<: *docker_elastic_spec
+        <<: *elastic_license_for_binaries
+        files:
+          '{{.BeatName}}{{.BinaryExt}}':
+            source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+    - os: linux
+      arch: arm64
+      types: [docker]
+      spec:
+        <<: *docker_spec
+        <<: *docker_ubi_arm_spec
+        <<: *docker_builder_arm_spec
+        <<: *docker_elastic_spec
         <<: *elastic_license_for_binaries
         files:
           '{{.BeatName}}{{.BinaryExt}}':
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
-      arch: arm64
+      arch: amd64
       types: [docker]
       spec:
-        <<: *docker_arm_spec
-        <<: *elastic_docker_spec
+        <<: *docker_spec
+        <<: *docker_wolfi_spec
+        <<: *docker_builder_spec
+        <<: *docker_elastic_spec
         <<: *elastic_license_for_binaries
         files:
           '{{.BeatName}}{{.BinaryExt}}':
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
     - os: linux
       arch: arm64
       types: [docker]
       spec:
-        <<: *docker_arm_spec
-        <<: *docker_arm_ubi_spec
-        <<: *elastic_docker_spec
+        <<: *docker_spec
+        <<: *docker_wolfi_arm_spec
+        <<: *docker_builder_arm_spec
+        <<: *docker_elastic_spec
         <<: *elastic_license_for_binaries
         files:
           '{{.BeatName}}{{.BinaryExt}}':
@@ -809,105 +891,136 @@ specs:
         <<: *deb_rpm_agent_spec
         <<: *elastic_license_for_deb_rpm
 
-    - os: linux
-      arch: amd64
-      types: [docker]
-      spec:
-        <<: *agent_docker_spec
-        <<: *elastic_docker_spec
-        <<: *elastic_license_for_binaries
-        files:
-          '{{.BeatName}}{{.BinaryExt}}':
-            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
+    ######## Docker images #########
+    #### Ubuntu-based images ####
     # Complete image gets a 'complete' variant for synthetics and other large
     # packages too big to fit in the main image
     - os: linux
       arch: amd64
       types: [docker]
       spec:
-        <<: *agent_docker_spec
+        <<: *docker_ubuntu_spec
+        <<: *docker_builder_spec
         <<: *agent_docker_complete_spec
-        <<: *elastic_docker_spec
+        <<: *docker_elastic_spec
         <<: *elastic_license_for_binaries
         files:
           '{{.BeatName}}{{.BinaryExt}}':
             source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
-    # Cloud specific docker image
     - os: linux
-      arch: amd64
+      arch: arm64
       types: [docker]
       spec:
-        <<: *elastic_docker_spec
-        <<: *agent_docker_spec
-        <<: *agent_docker_cloud_spec
+        <<: *docker_ubuntu_arm_spec
+        <<: *docker_builder_arm_spec
+        <<: *agent_docker_complete_spec
+        <<: *docker_elastic_spec
         <<: *elastic_license_for_binaries
         files:
           '{{.BeatName}}{{.BinaryExt}}':
             source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
     - os: linux
       arch: amd64
       types: [docker]
       spec:
+        <<: *docker_ubuntu_spec
+        <<: *docker_builder_spec
         <<: *agent_docker_spec
+        <<: *docker_elastic_spec
+        <<: *elastic_license_for_binaries
+        files:
+          '{{.BeatName}}{{.BinaryExt}}':
+            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+    - os: linux
+      arch: arm64
+      types: [docker]
+      spec:
+        <<: *docker_ubuntu_arm_spec
+        <<: *docker_builder_arm_spec
+        <<: *agent_docker_spec
+        <<: *docker_elastic_spec
+        <<: *elastic_license_for_binaries
+        files:
+          '{{.BeatName}}{{.BinaryExt}}':
+            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+    #### ubi-based ####
+    - os: linux
+      arch: amd64
+      types: [docker]
+      spec:
         <<: *docker_ubi_spec
-        <<: *elastic_docker_spec
+        <<: *docker_builder_spec
+        <<: *agent_docker_spec
+        <<: *docker_elastic_spec
         <<: *elastic_license_for_binaries
         files:
           '{{.BeatName}}{{.BinaryExt}}':
             source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
     - os: linux
       arch: arm64
       types: [docker]
       spec:
-        <<: *agent_docker_arm_spec
-        <<: *elastic_docker_spec
+        <<: *docker_ubi_arm_spec
+        <<: *docker_builder_arm_spec
+        <<: *agent_docker_spec
+        <<: *docker_elastic_spec
         <<: *elastic_license_for_binaries
         files:
           '{{.BeatName}}{{.BinaryExt}}':
             source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
-    # Complete image gets a 'complete' variant for synthetics and other large
-    # packages too big to fit in the main image
+    #### wolfi-based ####
+    #### Cloud specific docker images ####
     - os: linux
-      arch: arm64
+      arch: amd64
       types: [docker]
       spec:
-        <<: *agent_docker_arm_spec
-        <<: *agent_docker_complete_spec
-        <<: *elastic_docker_spec
-        <<: *elastic_license_for_binaries
-        files:
-          '{{.BeatName}}{{.BinaryExt}}':
-            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
-    # Cloud specific docker image
-    - os: linux
-      arch: arm64
-      types: [docker]
-      spec:
-        <<: *elastic_docker_spec
-        <<: *agent_docker_arm_spec
+        <<: *agent_docker_spec
+        # The cloud image is always based on Wolfi
+        <<: *docker_wolfi_spec
+        <<: *docker_builder_spec
         <<: *agent_docker_cloud_spec
         <<: *elastic_license_for_binaries
         files:
           '{{.BeatName}}{{.BinaryExt}}':
             source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
     - os: linux
       arch: arm64
       types: [docker]
       spec:
-        <<: *agent_docker_arm_spec
-        <<: *docker_arm_ubi_spec
-        <<: *elastic_docker_spec
+        <<: *agent_docker_spec
+        # The cloud image is always based on Wolfi
+        <<: *docker_wolfi_arm_spec
+        <<: *docker_builder_arm_spec
+        <<: *agent_docker_cloud_spec
         <<: *elastic_license_for_binaries
         files:
           '{{.BeatName}}{{.BinaryExt}}':
             source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+    - os: linux
+      arch: amd64
+      types: [docker]
+      spec:
+        <<: *docker_wolfi_spec
+        <<: *docker_builder_spec
+        <<: *agent_docker_spec
+        <<: *docker_elastic_spec
+        <<: *elastic_license_for_binaries
+        files:
+          '{{.BeatName}}{{.BinaryExt}}':
+            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+    - os: linux
+      arch: arm64
+      types: [docker]
+      spec:
+        <<: *docker_wolfi_arm_spec
+        <<: *docker_builder_arm_spec
+        <<: *agent_docker_spec
+        <<: *docker_elastic_spec
+        <<: *elastic_license_for_binaries
+        files:
+          '{{.BeatName}}{{.BinaryExt}}':
+            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+    ######## End Docker images ########
 
     - os: aix
       types: [tgz]
@@ -939,8 +1052,10 @@ specs:
     - os: linux
       types: [docker]
       spec:
+        <<: *docker_wolfi_spec
+        <<: *docker_builder_spec
         <<: *agent_docker_spec
-        <<: *elastic_docker_spec
+        <<: *docker_elastic_spec
         <<: *elastic_license_for_binaries
         files:
           '{{.BeatName}}{{.BinaryExt}}':

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -87,7 +87,7 @@ RUN for iter in {1..10}; do \
 {{- if contains .from "wolfi" }}
 RUN for iter in {1..10}; do \
         apk update && \
-        apk add --no-cache ca-certificates curl gawk shadow && \
+        apk add --no-cache ca-certificates curl gawk shadow bash && \
         exit_code=0 && break || exit_code=$? && echo "apk error: retry $iter in 10s" && sleep 10; \
     done; \
     (exit $exit_code)

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -6,13 +6,14 @@
 # the final image because of permission changes.
 FROM {{ .buildFrom }} AS home
 
+{{- if contains .buildFrom "wolfi" }}
 RUN for iter in {1..10}; do \
-        apt-get update -y && \
-        DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes libcap2-bin && \
-        apt-get clean all && \
-        exit_code=0 && break || exit_code=$? && echo "apt-get error: retry $iter in 10s" && sleep 10; \
+        apk update && \
+        apk add --no-cache shadow libcap-utils && \
+        exit_code=0 && break || exit_code=$? && echo "apk error: retry $iter in 10s" && sleep 10; \
     done; \
     (exit $exit_code)
+{{- end }}
 
 COPY beat {{ $beatHome }}
 
@@ -38,9 +39,11 @@ RUN true && \
     (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/pf-elastic-symbolizer || true) && \
     (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/pf-host-agent || true) && \
     find {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/components -name "*.yml*" -type f -exec chmod 0644 {} \; && \
+
 {{- range $i, $modulesd := .ModulesDirs }}
     chmod 0775 {{ $beatHome}}/{{ $modulesd }} && \
 {{- end }}
+
 {{- if contains .image_name "-cloud" }}
     mkdir -p /opt/agentbeat /opt/filebeat /opt/metricbeat && \
     cp -f {{ $beatHome }}/data/cloud_downloads/filebeat.sh /opt/filebeat/filebeat && \
@@ -69,13 +72,23 @@ ENV BEAT_SETUID_AS={{ .user }}
 
 {{- if contains .from "ubi-minimal" }}
 RUN for iter in {1..10}; do microdnf update -y && microdnf install -y tar gzip findutils shadow-utils && microdnf clean all && exit_code=0 && break || exit_code=$? && echo "microdnf error: retry $iter in 10s" && sleep 10; done; (exit $exit_code)
-{{- else }}
+{{- end }}
 
+{{- if contains .from "ubuntu" }}
 RUN for iter in {1..10}; do \
         apt-get update -y && \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes ca-certificates curl gawk xz-utils && \
         apt-get clean all && \
         exit_code=0 && break || exit_code=$? && echo "apt-get error: retry $iter in 10s" && sleep 10; \
+    done; \
+    (exit $exit_code)
+{{- end }}
+
+{{- if contains .from "wolfi" }}
+RUN for iter in {1..10}; do \
+        apk update && \
+        apk add --no-cache ca-certificates curl gawk shadow && \
+        exit_code=0 && break || exit_code=$? && echo "apk error: retry $iter in 10s" && sleep 10; \
     done; \
     (exit $exit_code)
 {{- end }}
@@ -134,8 +147,14 @@ RUN set -e ; \
   chmod +x /usr/bin/tini
 
 COPY docker-entrypoint /usr/local/bin/docker-entrypoint
+
+# We do not want to add the agent user to the root group and because of backwards compatibility we can do it only for the new Wolfi image
 RUN groupadd --gid 1000 {{ .BeatName }} && \
+{{- if contains .from "wolfi" }}
+    useradd -M --uid 1000 --gid 1000 {{ .user }} && \
+{{- else }}
     useradd -M --uid 1000 --gid 1000 --groups 0 {{ .user }} && \
+{{- end }}
     chmod 755 /usr/local/bin/docker-entrypoint && \
     true
 
@@ -154,15 +173,12 @@ COPY --from=home {{ $beatHome }}/NOTICE.txt /licenses
 
 {{- if contains .image_name "-cloud" }}
 COPY --from=home /opt /opt
-{{- end }}
-
-{{- if contains .image_name "-cloud" }}
 # Generate folder for a stub command that will be overwritten at runtime
 RUN mkdir /app && \
     chown {{ .user }}:{{ .user }} /app
 {{- end }}
 
-{{- if (and (contains .image_name "-complete") (not (contains .from "ubi-minimal")))  }}
+{{- if (and (contains .image_name "-complete") (contains .from "ubuntu"))  }}
 USER root
 ENV NODE_PATH={{ $beatHome }}/.node
 RUN echo \
@@ -222,8 +238,8 @@ RUN for iter in {1..10}; do \
     exit_code=0 && break || exit_code=$? && echo "apt-get error: retry $iter in 10s" && sleep 10; \
     done; \
     (exit $exit_code)
-
 {{- end }}
+
 USER {{ .user }}
 
 

--- a/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
@@ -1,4 +1,4 @@
-{{- if contains .from "wolfi" }}#!/bin/ash{{- else }}#!/bin/bash{{- end }}
+#!/bin/bash
 
 # Update umask to retain group write permissions on runtime directories: $root/tmp/default, $root/logs/default and $root/run/default
 umask 0007

--- a/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+{{- if contains .from "wolfi" }}#!/bin/ash{{- else }}#!/bin/bash{{- end }}
 
 # Update umask to retain group write permissions on runtime directories: $root/tmp/default, $root/logs/default and $root/run/default
 umask 0007


### PR DESCRIPTION
## What does this PR do?

* New images with `-wolfi` suffix are created
* The `-cloud` image is now based on Wolfi
* Refactored the packaging spec for better readability
* Fixed ignored architecture flags when building Docker images. Building ARM64 on AMD64 and AMD64 or ARM64 is now possible

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Wolfi is a security-focused Linux image for containers, see more here https://github.com/wolfi-dev/

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
~~- [ ] I have added an integration test or an E2E test~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
### Images

#### x86

```sh
SNAPSHOT=true PLATFORMS=linux/amd64 PACKAGES=docker mage package
```

Before this change:

```
REPOSITORY                                       TAG                   IMAGE ID       CREATED         SIZE
docker.elastic.co/beats-ci/elastic-agent-cloud   8.16.0-SNAPSHOT       c3521379c659   4 minutes ago   982MB
docker.elastic.co/beats/elastic-agent            8.16.0-SNAPSHOT       79526721a60b   4 minutes ago   610MB
docker.elastic.co/beats/elastic-agent-complete   8.16.0-SNAPSHOT       5958311a5565   3 minutes ago   2.11GB
docker.elastic.co/beats/elastic-agent-ubi        8.16.0-SNAPSHOT       30c624ba0e7a   4 minutes ago   607MB
```

After this change:

```
REPOSITORY                                       TAG                   IMAGE ID       CREATED         SIZE
docker.elastic.co/beats-ci/elastic-agent-cloud   8.16.0-SNAPSHOT       0badce97e1fd   5 minutes ago   897MB
docker.elastic.co/beats/elastic-agent            8.16.0-SNAPSHOT       18bab22a67ba   5 minutes ago   635MB
docker.elastic.co/beats/elastic-agent-complete   8.16.0-SNAPSHOT       a392ec2eb0bd   3 minutes ago   2.1GB
docker.elastic.co/beats/elastic-agent-ubi        8.16.0-SNAPSHOT       4ce09f39a9f6   5 minutes ago   603MB
docker.elastic.co/beats/elastic-agent-wolfi      8.16.0-SNAPSHOT       b1a78ff97f30   5 minutes ago   526MB
```

Run this command to verify the correct architecture and layers
```sh
for id in $(docker image ls --format json | jq .ID -r); do docker inspect $id | jq '{"id":.[].Id, "tags":.[].RepoTags, "arch":.[].Architecture, "layers":.[].RootFS.Layers}'; done;
```

<details>
<summary>Output for X86</summary>

```json
{
  "id": "sha256:a392ec2eb0bd34a2f28653fe0aa8c696da519d003f87d947c1706a4d52209366",
  "tags": [
    "docker.elastic.co/beats/elastic-agent-complete:8.16.0-SNAPSHOT"
  ],
  "arch": "amd64",
  "layers": [
    "sha256:3ec3ded77c0ce89e931f92aed086b2a2c774a6fbd51617853decc8afa4e1087a",
    "sha256:2bc7e199fd03b7fa1a5ccdd3b40620f4cad3c31cddd4ba35418b749aa4b56a7a",
    "sha256:034383ef36a09b960ecccdf6447f0ef91865b9c143b7cb813970c7cff6f2d486",
    "sha256:c7e981d93236a530ed1f85b1a6a48106ada33ecd5e00ccf441e73d276aed1e0e",
    "sha256:3a3aee489da2e892d6f9e249188a3b8005733cf40defab1d86b4750cd6ec2fd0",
    "sha256:3cc880076321c7a5e53323f71d491019f5dbc77c2cda1c9646bde6552b41a1bb",
    "sha256:60e644e5b4a2e40102ea8c08503a99f4186d709b5e21420fb126b6f79185e912",
    "sha256:a64e3cf3a0dea43af928d17c407ddce12a09422a7e28c09a521576feee8771fe",
    "sha256:b564db3600afe2361c0c0a652fb649798ac3e3cb09488a6e539910723a7eb044",
    "sha256:b181d57d8070fcd47a74c1236241b31503be7545d343929cf8fdafdf10bdc933",
    "sha256:aa5916b66195dbb492d4136e5cf4a7ab5a76f80297fbc0651e6cacb7749f07bc",
    "sha256:7c087c82778976e1c17e8a4690b93601e532a355b1b2861141e17ed038e6a0c2",
    "sha256:c516ba2122be517e0482d3a3176dece36783c07ad0320fefa0da571d7b2b3607",
    "sha256:f9b47742633802667f72abeb3e40d1302dded32b178db5a4fd3830cb3fd2fd35",
    "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
  ]
}
{
  "id": "sha256:0badce97e1fdc44b4fc1f8fd75da363cb186bc0177f5515917665c41129f53e3",
  "tags": [
    "docker.elastic.co/beats-ci/elastic-agent-cloud:8.16.0-SNAPSHOT"
  ],
  "arch": "amd64",
  "layers": [
    "sha256:2edb767fffebfc8a70f5707270f5149869375b068775e577392935da7b1479fb",
    "sha256:76569ac0371094c9e125284a0b0064714e35301769f61e6438a53005ba51c14f",
    "sha256:4a9b777b7899a0dede9acc199920cc79187340499c425a310efc5a3ed76b9a93",
    "sha256:de395ebe3180e995a0ce4042d7d57189db3cc073eecfb19f724536ec82a7ceda",
    "sha256:cacfb25128769999206886731660d153d65e179ca0cdbc48ed46343130d70d87",
    "sha256:145615672d99eee3c4141006aed32aced5026bf28138c4e4f1a08d702c37a9a5",
    "sha256:c26cc68bb5a38e9bb7de5867417e744e12f57809d0490703c69811c2f798fc43",
    "sha256:5a448e62d052daa6ea985cdde07958e08b03f16e2d183def1111fff16156e2b3",
    "sha256:4a14d733387aa41288ef0088344a64431a34dd7f61afb52746b6a3d0376b97c8",
    "sha256:cd5070c8fefb35da7128adb49880234939bdc4cbd9edd8e9ab151230b5d52c8b",
    "sha256:450c527682673789b9c452f14be8e27ab38a19a93328bf63e085f5d818be350c",
    "sha256:fba67135c63cd1ebf9d0306af475c16e5c73f34cd47c26b17ce612a688e30d19",
    "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
    "sha256:14292d6d4baaed40be5300e922ca9ede36eda50c6eb163c2c1036fa4bb67984d"
  ]
}
{
  "id": "sha256:4ce09f39a9f66b87db3894f5719c0fd3b1b870d9297565eb548b934dbd13f184",
  "tags": [
    "docker.elastic.co/beats/elastic-agent-ubi:8.16.0-SNAPSHOT"
  ],
  "arch": "amd64",
  "layers": [
    "sha256:53544948f51f66ab8080a28acc12474abac3103c6194ca36777aa60762ede49c",
    "sha256:08fac24b901a21e09cea780072d324d4f59b25c59df57dc751693fc45d2013c6",
    "sha256:03519818d277314069da56002bd7e9659b8d9e12bb344805046b0c79196d243c",
    "sha256:e9c2e4dffda76a83486323690097aae91b9157ea9d9ae52a4a50e742f232e5c5",
    "sha256:7d9a73ac223fbb81cf7d805e1186699955baae50f45f7755b6565218ec908d9a",
    "sha256:134ca32a71fc8779643553bec547fb3aebe7b38b7141ad423f63edfd8edd7e8f",
    "sha256:f83a9cb758884fcfb3b4fc22a5757e44cf4cbc2924d48baa568a99b2e742d602",
    "sha256:8734dc44c0afe9b751162681999e6a4ab7b7390d94f5a101a70caf067192345f",
    "sha256:1b1ecb12e774737dc5a3e9e5b8bf8e42f6eb52b18d47e4c8b26ec4816fdde4dc",
    "sha256:304cb5fd0b2055ac8478fac7d19f5c5f4d780ec40554be513bd8a47ff6a9b6c7",
    "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
  ]
}
{
  "id": "sha256:b1a78ff97f30a78f53e789d3255a27563b4b50b199d0a94a33ee00c2ea6cd525",
  "tags": [
    "docker.elastic.co/beats/elastic-agent-wolfi:8.16.0-SNAPSHOT"
  ],
  "arch": "amd64",
  "layers": [
    "sha256:2edb767fffebfc8a70f5707270f5149869375b068775e577392935da7b1479fb",
    "sha256:76569ac0371094c9e125284a0b0064714e35301769f61e6438a53005ba51c14f",
    "sha256:4a9b777b7899a0dede9acc199920cc79187340499c425a310efc5a3ed76b9a93",
    "sha256:de395ebe3180e995a0ce4042d7d57189db3cc073eecfb19f724536ec82a7ceda",
    "sha256:cacfb25128769999206886731660d153d65e179ca0cdbc48ed46343130d70d87",
    "sha256:145615672d99eee3c4141006aed32aced5026bf28138c4e4f1a08d702c37a9a5",
    "sha256:c26cc68bb5a38e9bb7de5867417e744e12f57809d0490703c69811c2f798fc43",
    "sha256:5a448e62d052daa6ea985cdde07958e08b03f16e2d183def1111fff16156e2b3",
    "sha256:1b1ecb12e774737dc5a3e9e5b8bf8e42f6eb52b18d47e4c8b26ec4816fdde4dc",
    "sha256:304cb5fd0b2055ac8478fac7d19f5c5f4d780ec40554be513bd8a47ff6a9b6c7",
    "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
  ]
}
{
  "id": "sha256:18bab22a67babed8fdc70cc0a18546b2536ac99f20732f2db941d96a7f27a1c6",
  "tags": [
    "docker.elastic.co/beats/elastic-agent:8.16.0-SNAPSHOT"
  ],
  "arch": "amd64",
  "layers": [
    "sha256:3ec3ded77c0ce89e931f92aed086b2a2c774a6fbd51617853decc8afa4e1087a",
    "sha256:2bc7e199fd03b7fa1a5ccdd3b40620f4cad3c31cddd4ba35418b749aa4b56a7a",
    "sha256:034383ef36a09b960ecccdf6447f0ef91865b9c143b7cb813970c7cff6f2d486",
    "sha256:c7e981d93236a530ed1f85b1a6a48106ada33ecd5e00ccf441e73d276aed1e0e",
    "sha256:3a3aee489da2e892d6f9e249188a3b8005733cf40defab1d86b4750cd6ec2fd0",
    "sha256:3cc880076321c7a5e53323f71d491019f5dbc77c2cda1c9646bde6552b41a1bb",
    "sha256:60e644e5b4a2e40102ea8c08503a99f4186d709b5e21420fb126b6f79185e912",
    "sha256:a64e3cf3a0dea43af928d17c407ddce12a09422a7e28c09a521576feee8771fe",
    "sha256:b564db3600afe2361c0c0a652fb649798ac3e3cb09488a6e539910723a7eb044",
    "sha256:b181d57d8070fcd47a74c1236241b31503be7545d343929cf8fdafdf10bdc933",
    "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
  ]
}
```

Note: the base layer is always different except `elastic-agent-cloud:8.16.0` and `elastic-agent-wolfi:8.16.0` which share the same base image – Wolfi.

</details>

#### ARM64

```sh
SNAPSHOT=true PLATFORMS=linux/arm64 PACKAGES=docker mage package
```

Before this change:

```
REPOSITORY                                       TAG               IMAGE ID       CREATED         SIZE
docker.elastic.co/beats-ci/elastic-agent-cloud   8.16.0-SNAPSHOT   700d4fa3c833   4 minutes ago   939MB
docker.elastic.co/beats/elastic-agent            8.16.0-SNAPSHOT   d35803d66a50   4 minutes ago   587MB
docker.elastic.co/beats/elastic-agent-complete   8.16.0-SNAPSHOT   8579bbe2702f   3 minutes ago   2.09GB
docker.elastic.co/beats/elastic-agent-ubi        8.16.0-SNAPSHOT   3b420a665959   4 minutes ago   651MB
```

After this change:

```
REPOSITORY                                       TAG               IMAGE ID       CREATED         SIZE
docker.elastic.co/beats-ci/elastic-agent-cloud   8.16.0-SNAPSHOT   dd883460e711   5 minutes ago   857MB
docker.elastic.co/beats/elastic-agent            8.16.0-SNAPSHOT   388643bca650   5 minutes ago   587MB
docker.elastic.co/beats/elastic-agent-complete   8.16.0-SNAPSHOT   c121e9f0b3fe   3 minutes ago   2.09GB
docker.elastic.co/beats/elastic-agent-ubi        8.16.0-SNAPSHOT   c76846bb58a6   5 minutes ago   584MB
docker.elastic.co/beats/elastic-agent-wolfi      8.16.0-SNAPSHOT   8b6e0408b6a9   5 minutes ago   506MB
```

Run this command to verify the correct architecture and layers
```sh
for id in $(docker image ls --format json | jq .ID -r); do docker inspect $id | jq '{"id":.[].Id, "tags":.[].RepoTags, "arch":.[].Architecture, "layers":.[].RootFS.Layers}'; done;
```

<details>
<summary>Output for ARM64</summary>

```json
{
  "id": "sha256:c121e9f0b3fea483adda5584871a6c31fb7c4a59fa3d2ab98255dd4f99c44d27",
  "tags": [
    "docker.elastic.co/beats/elastic-agent-complete:8.16.0-SNAPSHOT"
  ],
  "arch": "arm64",
  "layers": [
    "sha256:a8c68591d421fc2d4bdda704f67a796edf5ff880c59358d75107eb5261821650",
    "sha256:21229740e72f63b67049ff375ff86856df76851a41b961ccc0258b657ffebda2",
    "sha256:6840669b7d1a9f2f9c3df0543a9e4631bbba4ba142bfb8f761004a291b63beba",
    "sha256:b5cd85927d89525d1b54f53ab9258e1ea8b30ed34f5da82dcb0b18cc201b8fcb",
    "sha256:b4a623370ab35d201645f15379c4f1b92f124f66e466b2603b068a05db16d3d9",
    "sha256:dc936f5e71f48a6e8e57a4328afaf8e37eb41ffdfb5516423281d0869f5df5b1",
    "sha256:71c4a2ae2df81aa3dc4cd6d6bfa92540effe2393baa42db484601d33b1bf047d",
    "sha256:d5bb4fe5276cdf6557706692c76b6051b14946b426eeb2be1b21b89f849146bf",
    "sha256:e6b6f0f2a25ab40dd864b67516870f3a766178e30abbef3ece8bc23cb833981d",
    "sha256:a21254dc1a33f8724f4e6142b4c41712c5582494a81b9d7321f6ab98756e967f",
    "sha256:5fa9d5af66ec9f9a7bf5afc9982f75ec4fb10b42cc1d05564ca9c4bfda905e8d",
    "sha256:ad755fd23e96c489fef28eb0d75f46edcc0c078594f2c97404775e40484af575",
    "sha256:bdb359ba5f4e2d70d51bf50873f382c52cc973bc6b2a704c863e8c9d2f94751e",
    "sha256:edb11face2b4381516f07e35d7a9b707d4b2052dc6d717972165290321752381",
    "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
  ]
}
{
  "id": "sha256:dd883460e7114da32e9f5493dca264160375fb927cb95cf551d64a365fb59608",
  "tags": [
    "docker.elastic.co/beats-ci/elastic-agent-cloud:8.16.0-SNAPSHOT"
  ],
  "arch": "arm64",
  "layers": [
    "sha256:5dac778dd0e9fee84eb001bdee474ff61de7bb829bba016e245b9f5ca872c316",
    "sha256:403f8fb20960b5233268fb9a88804a7309c408108ea375732eb6446271a2fcf2",
    "sha256:21aea1db0998d0e4b32065cddc24250b110343cdb1e0fc26dc392fad1f749656",
    "sha256:d63995dd206cb5a32e74ba032b1d63c83095b8c990690bd6d5f305757d150865",
    "sha256:ae5e6fff71558c5d0e39ab3597d75efb36c3c992e65dd7988aa3e3017ae824c4",
    "sha256:56b8e2d5440ac7f14e2e3cd98f43e42b176fc8cef83503f9902fe4c7027b3338",
    "sha256:823f5659f29b456726d7583c75d3bdf6ed3c86e5e962ac94b8c905052dad14ff",
    "sha256:95e4de2bd43f201fb5783dccf2d50529c6459db00762abba4d2257c90bb5df72",
    "sha256:68c9b420458c7ed43377cde1f3d6198c5febb0e2ddc295e06620c4fb1b3cbfe2",
    "sha256:1c1100d00f0a9c3da1831f65ba11cfa18395608efc39805819c89f0396c51dfb",
    "sha256:26e65983188b6cea86e04051db52bb905f48a1253d164c2a6854b3350d934c27",
    "sha256:578c74ee9711a36c7e5187eb1a47a32472b253239b41f7d0914b1b4f1e798b10",
    "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
    "sha256:fd64f6588c4d61caffed04eefd78a04e0aa0caabfa567e65fde6d615d1f6760b"
  ]
}
{
  "id": "sha256:c76846bb58a6f9d832f649e6ddd263d72ae63b7bbc1fc27d1fe9370d122ac8b3",
  "tags": [
    "docker.elastic.co/beats/elastic-agent-ubi:8.16.0-SNAPSHOT"
  ],
  "arch": "arm64",
  "layers": [
    "sha256:53ce7ccd46624c30c3cd21bfbd9589c37e2ce99e7c724595ca4a17e65f1da763",
    "sha256:0902763b71b13c7e5013246515ddfdd761ddf4f2ade8d020d74a1864391cb5ca",
    "sha256:4384f36086948324e63d5e96f3787395d5ee8adc2c6bd81e5f8812bcfe0ef656",
    "sha256:60820fe03ecc3ca16269c97403c77db81d6234799dcba06c6a108e624f1d9f77",
    "sha256:e58b83c62f02b792127741abce7c3b811e0468d409c103e81df43ae6e7670b2f",
    "sha256:c22267259a1f8412cca21e46d14001b3feeefd4578596868277565aca388ad86",
    "sha256:fe0ca0592c517007820d50131070b37ea385a829284bd9e7e4243d6f6b2059be",
    "sha256:d5bb4fe5276cdf6557706692c76b6051b14946b426eeb2be1b21b89f849146bf",
    "sha256:0c7cfd329bf2561dffe3ce26f21e444d614556112bf490781f5fedd4b50afc4c",
    "sha256:8338344e41f8a66c2f0f84728e2dc8d358d23300dba919ba412c9727daadc56c",
    "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
  ]
}
{
  "id": "sha256:388643bca650d38118b00ab21ab5fc4f1ee80333d97065de16ff2e2d7736915d",
  "tags": [
    "docker.elastic.co/beats/elastic-agent:8.16.0-SNAPSHOT"
  ],
  "arch": "arm64",
  "layers": [
    "sha256:a8c68591d421fc2d4bdda704f67a796edf5ff880c59358d75107eb5261821650",
    "sha256:21229740e72f63b67049ff375ff86856df76851a41b961ccc0258b657ffebda2",
    "sha256:6840669b7d1a9f2f9c3df0543a9e4631bbba4ba142bfb8f761004a291b63beba",
    "sha256:b5cd85927d89525d1b54f53ab9258e1ea8b30ed34f5da82dcb0b18cc201b8fcb",
    "sha256:b4a623370ab35d201645f15379c4f1b92f124f66e466b2603b068a05db16d3d9",
    "sha256:dc936f5e71f48a6e8e57a4328afaf8e37eb41ffdfb5516423281d0869f5df5b1",
    "sha256:71c4a2ae2df81aa3dc4cd6d6bfa92540effe2393baa42db484601d33b1bf047d",
    "sha256:d5bb4fe5276cdf6557706692c76b6051b14946b426eeb2be1b21b89f849146bf",
    "sha256:e6b6f0f2a25ab40dd864b67516870f3a766178e30abbef3ece8bc23cb833981d",
    "sha256:a21254dc1a33f8724f4e6142b4c41712c5582494a81b9d7321f6ab98756e967f",
    "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
  ]
}
{
  "id": "sha256:8b6e0408b6a9904f44fef9ebb655218c2151e8930e2359310313058da51ccd71",
  "tags": [
    "docker.elastic.co/beats/elastic-agent-wolfi:8.16.0-SNAPSHOT"
  ],
  "arch": "arm64",
  "layers": [
    "sha256:5dac778dd0e9fee84eb001bdee474ff61de7bb829bba016e245b9f5ca872c316",
    "sha256:403f8fb20960b5233268fb9a88804a7309c408108ea375732eb6446271a2fcf2",
    "sha256:21aea1db0998d0e4b32065cddc24250b110343cdb1e0fc26dc392fad1f749656",
    "sha256:d63995dd206cb5a32e74ba032b1d63c83095b8c990690bd6d5f305757d150865",
    "sha256:ae5e6fff71558c5d0e39ab3597d75efb36c3c992e65dd7988aa3e3017ae824c4",
    "sha256:0bf79c41e96eadd70505f9bb0b3946573fd445242dd7e2de3f887e2cd6570d41",
    "sha256:9aa24d8e0a2fe6e1ac1b0ab22a0c7710c7cfb12993fca5ce137f97d3777b68c1",
    "sha256:3ce01354e678c9d44bba2eb95b512d724e2dc376eff30314f99ebb45867bcf0d",
    "sha256:0c7cfd329bf2561dffe3ce26f21e444d614556112bf490781f5fedd4b50afc4c",
    "sha256:8338344e41f8a66c2f0f84728e2dc8d358d23300dba919ba412c9727daadc56c",
    "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
  ]
}
```

Note: the base layer is always different except `elastic-agent-cloud:8.16.0` and `elastic-agent-wolfi:8.16.0` which share the same base image – Wolfi.

</details>

#### Size change

The different size of the x86 `docker.elastic.co/beats/elastic-agent` image between main and this branch is due to the fixed bug (ignored architecture flag). Before this change, one could not build an amd64 image on an arm64 machine. Now, the architecture is correct and the size of the base layer is different.

### Elastic Agent functionality in Wolfi

1. I created a 8.16.0-SNAPSHOT stack in the cloud
2. Enrolled the agent using this command:

```sh
docker run -ti \
-e FLEET_ENROLL='1' \
-e FLEET_INSECURE='false' \
-e FLEET_URL='https://<host>.fleet.us-west2.gcp.elastic-cloud.com:443' \
-e FLEET_ENROLLMENT_TOKEN='<token>' \
-e KIBANA_HOST='http://kibana:5601' \
-e KIBANA_FLEET_USERNAME='elastic' \
-e KIBANA_FLEET_PASSWORD='changeme' \
-e ELASTIC_NETINFO='false' \
docker.elastic.co/beats/elastic-agent:8.16.0-SNAPSHOT
```

note: fill the `<host>` and `<value>` placeholders

3. Saw successful enrollment and data in Discover

<img width="802" alt="Screenshot 2024-07-10 at 14 28 12" src="https://github.com/elastic/elastic-agent/assets/887952/af4ceb77-ce8f-44fc-b2d7-7035e33498f0">
<img width="1404" alt="Screenshot 2024-07-10 at 14 31 15" src="https://github.com/elastic/elastic-agent/assets/887952/d40f464e-bc11-415e-a266-4cb10d2a5512">

4. I repeated the steps for `docker.elastic.co/beats/elastic-agent:8.16.0-SNAPSHOT` and `docker.elastic.co/beats-ci/elastic-agent-cloud:8.16.0-SNAPSHOT` images to check for regressions. Both of them enrolled and sent data successfully.

5. I also double-checked that the capabilities is still there:

```sh
docker run -u root -it --entrypoint /bin/ash docker.elastic.co/beats/elastic-agent-wolfi:8.16.0-SNAPSHOT
apk add libcap-utils
getcap data/elastic-agent-68eb65/components/agentbeat
```

The output was:

```
data/elastic-agent-68eb65/components/agentbeat cap_setuid,cap_net_raw=p
```

### Kubernetes integration

1. Created a deployment
2. Created a policy with the Kubernetes integration
3. Applied the generated manifest using the custom `-wolfi` image
4. Made sure of its successful enrollment and incoming data

<img width="804" alt="Screenshot 2024-07-16 at 16 57 31" src="https://github.com/user-attachments/assets/23f3d707-ac9c-4e4b-b244-e14f86435ca8">
<img width="1617" alt="Screenshot 2024-07-16 at 16 58 18" src="https://github.com/user-attachments/assets/394eaf73-1d38-46f6-a30f-70271d5a5207">

### Elastic Cloud

I followed this guide to test the new Wolfi-based cloud image https://github.com/elastic/elastic-agent?tab=readme-ov-file#testing-on-elastic-cloud
