### PR TITLE
Set capabilities in the builder Docker image instead of the final

### DIFF
--- a/changelog/fragments/1720209553-reduce-docker-size.yaml
+++ b/changelog/fragments/1720209553-reduce-docker-size.yaml
@@ -1,0 +1,3 @@
+kind: enhancement
+summary: Reduce Docker image size by performing more steps in the builder image
+component: "elastic-agent"

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -6,6 +6,14 @@
 # the final image because of permission changes.
 FROM {{ .buildFrom }} AS home
 
+RUN for iter in {1..10}; do \
+        apt-get update -y && \
+        DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes libcap2-bin && \
+        apt-get clean all && \
+        exit_code=0 && break || exit_code=$? && echo "apt-get error: retry $iter in 10s" && sleep 10; \
+    done; \
+    (exit $exit_code)
+
 COPY beat {{ $beatHome }}
 
 RUN true && \
@@ -44,6 +52,17 @@ RUN true && \
 {{- end }}
     true
 
+# Keep this after any chown command, chown resets any applied capabilities
+RUN setcap cap_net_raw,cap_setuid+p {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/components/agentbeat && \
+{{- if .linux_capabilities }}
+# Since the beat is stored at the other end of a symlink we must follow the symlink first
+# For security reasons setcap does not support symlinks. This is smart in the general case
+# but in our specific case since we're building a trusted image from trusted binaries this is
+# fine. Thus, we use readlink to follow the link and setcap on the actual binary
+   setcap {{ .linux_capabilities }}  $(readlink -f {{ $beatBinary }}) && \
+{{- end }}
+true
+
 FROM {{ .from }}
 
 ENV BEAT_SETUID_AS={{ .user }}
@@ -54,7 +73,7 @@ RUN for iter in {1..10}; do microdnf update -y && microdnf install -y tar gzip f
 
 RUN for iter in {1..10}; do \
         apt-get update -y && \
-        DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes ca-certificates curl gawk libcap2-bin xz-utils && \
+        DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes ca-certificates curl gawk xz-utils && \
         apt-get clean all && \
         exit_code=0 && break || exit_code=$? && echo "apt-get error: retry $iter in 10s" && sleep 10; \
     done; \
@@ -142,17 +161,6 @@ COPY --from=home /opt /opt
 RUN mkdir /app && \
     chown {{ .user }}:{{ .user }} /app
 {{- end }}
-
-# Keep this after any chown command, chown resets any applied capabilities
-RUN setcap cap_net_raw,cap_setuid+p {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/components/agentbeat && \
-{{- if .linux_capabilities }}
-# Since the beat is stored at the other end of a symlink we must follow the symlink first
-# For security reasons setcap does not support symlinks. This is smart in the general case
-# but in our specific case since we're building a trusted image from trusted binaries this is
-# fine. Thus, we use readlink to follow the link and setcap on the actual binary
-   setcap {{ .linux_capabilities }}  $(readlink -f {{ $beatBinary }}) && \
-{{- end }}
-true
 
 {{- if (and (contains .image_name "-complete") (not (contains .from "ubi-minimal")))  }}
 USER root


### PR DESCRIPTION
This significantly reduces the size of the image.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```sh
PLATFORMS=linux/arm64 PACKAGES=docker mage package
```

Before this change:

```
REPOSITORY                                       TAG          IMAGE ID       CREATED         SIZE
docker.elastic.co/beats/elastic-agent-complete   8.15.0       1452af5ad002   4 minutes ago   2.36GB
docker.elastic.co/beats-ci/elastic-agent-cloud   8.15.0       fa0bc74c04ce   6 minutes ago   1.2GB
docker.elastic.co/beats/elastic-agent            8.15.0       cb118fa60f56   6 minutes ago   852MB
docker.elastic.co/beats/elastic-agent-ubi        8.15.0       0f3615fb5329   6 minutes ago   916MB
docker.elastic.co/beats-dev/golang-crossbuild    1.22.5-arm   0805c9714ddf   27 hours ago    752MB
```

After this change:

```
REPOSITORY                                       TAG          IMAGE ID       CREATED         SIZE
docker.elastic.co/beats/elastic-agent-complete   8.15.0       168b8aff9ca3   2 minutes ago   2.09GB
docker.elastic.co/beats-ci/elastic-agent-cloud   8.15.0       d0c156eaa4b4   5 minutes ago   939MB
docker.elastic.co/beats/elastic-agent            8.15.0       534200a70c76   5 minutes ago   588MB
docker.elastic.co/beats/elastic-agent-ubi        8.15.0       165729671f4e   5 minutes ago   652MB
docker.elastic.co/beats-dev/golang-crossbuild    1.22.5-arm   0805c9714ddf   28 hours ago    752MB
```

```sh
docker run -u root -it --entrypoint /bin/bash docker.elastic.co/beats/elastic-agent:8.15.0
apt-get install libcap2-bin
getcap data/elastic-agent-ee237a/components/agentbeat
```

it should output:

```
data/elastic-agent-ee237a/components/agentbeat = cap_setuid,cap_net_raw+p
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Follow up to https://github.com/elastic/elastic-agent/pull/5070