### PR TITLE
[otel] docs: fix spaces in README

### DIFF
--- a/internal/pkg/otel/README.md
+++ b/internal/pkg/otel/README.md
@@ -4,15 +4,14 @@ This is an Elastic supported distribution of the [OpenTelemetry Collector](https
 
 ## Running the Elastic Distribution for OpenTelemetry Collector
 
-To run the Elastic Distribution for OpenTelemetry Collector you can use Elastic-Agent binary downloaded for your OS and architecture. 
-Running command 
+To run the Elastic Distribution for OpenTelemetry Collector you can use Elastic-Agent binary downloaded for your OS and architecture.
+Running command
 
 ```bash
 ./elastic-agent otel --config otel.yml
 ```
 
 from unpacked Elastic Agent package will run Elastic-Agent as an OpenTelemetry Collector. The `--config` flag needs to point to [OpenTelemetry Collector Configuration file](https://opentelemetry.io/docs/collector/configuration/). OTel mode is available only using `otel` subcommand. Elastic Agent will not do any autodetection of configuration file passed when used without `otel` subcommand and will try to run normally.
-
 
 To validate OTel configuration run `otel validate` subcommand:
 
@@ -26,63 +25,49 @@ To validate OTel configuration run `otel validate` subcommand:
 
 This section provides a summary of components included in the Elastic Distribution for OpenTelemetry Collector.
 
-
 ### Receivers
 
 | Component | Version |
 |---|---|
-| filelogreceiver | v0.104.0|
-| hostmetricsreceiver | v0.104.0|
-| httpcheckreceiver | v0.104.0|
-| k8sclusterreceiver | v0.104.0|
-| kubeletstatsreceiver | v0.104.0|
-| otlpreceiver | v0.104.0|
-
-
-
+| filelogreceiver | v0.104.0 |
+| hostmetricsreceiver | v0.104.0 |
+| httpcheckreceiver | v0.104.0 |
+| k8sclusterreceiver | v0.104.0 |
+| kubeletstatsreceiver | v0.104.0 |
+| otlpreceiver | v0.104.0 |
 
 ### Exporters
 
 | Component | Version |
 |---|---|
-| elasticsearchexporter | v0.104.0|
-| fileexporter | v0.104.0|
-| debugexporter | v0.104.0|
-| otlpexporter | v0.104.0|
-| otlphttpexporter | v0.104.0|
-
-
-
+| elasticsearchexporter | v0.104.0 |
+| fileexporter | v0.104.0 |
+| debugexporter | v0.104.0 |
+| otlpexporter | v0.104.0 |
+| otlphttpexporter | v0.104.0 |
 
 ### Processors
 
 | Component | Version |
 |---|---|
-| elasticinframetricsprocessor | v0.7.0|
-| attributesprocessor | v0.104.0|
-| filterprocessor | v0.104.0|
-| k8sattributesprocessor | v0.104.0|
-| resourcedetectionprocessor | v0.104.0|
-| resourceprocessor | v0.104.0|
-| transformprocessor | v0.104.0|
-| batchprocessor | v0.104.0|
-
-
-
+| elasticinframetricsprocessor | v0.7.0 |
+| attributesprocessor | v0.104.0 |
+| filterprocessor | v0.104.0 |
+| k8sattributesprocessor | v0.104.0 |
+| resourcedetectionprocessor | v0.104.0 |
+| resourceprocessor | v0.104.0 |
+| transformprocessor | v0.104.0 |
+| batchprocessor | v0.104.0 |
 
 ### Extensions
 
 | Component | Version |
 |---|---|
-| storage/filestorage | v0.104.0|
-| memorylimiterextension | v0.104.0|
-
-
-
+| storage/filestorage | v0.104.0 |
+| memorylimiterextension | v0.104.0 |
 
 ### Connectors
 
 | Component | Version |
 |---|---|
-| spanmetricsconnector | v0.104.0|
-
+| spanmetricsconnector | v0.104.0 |

--- a/internal/pkg/otel/templates/README.md.tmpl
+++ b/internal/pkg/otel/templates/README.md.tmpl
@@ -4,15 +4,14 @@ This is an Elastic supported distribution of the [OpenTelemetry Collector](https
 
 ## Running the Elastic Distribution for OpenTelemetry Collector
 
-To run the Elastic Distribution for OpenTelemetry Collector you can use Elastic-Agent binary downloaded for your OS and architecture. 
-Running command 
+To run the Elastic Distribution for OpenTelemetry Collector you can use Elastic-Agent binary downloaded for your OS and architecture.
+Running command
 
 ```bash
 ./elastic-agent otel --config otel.yml
 ```
 
 from unpacked Elastic Agent package will run Elastic-Agent as an OpenTelemetry Collector. The `--config` flag needs to point to [OpenTelemetry Collector Configuration file](https://opentelemetry.io/docs/collector/configuration/). OTel mode is available only using `otel` subcommand. Elastic Agent will not do any autodetection of configuration file passed when used without `otel` subcommand and will try to run normally.
-
 
 To validate OTel configuration run `otel validate` subcommand:
 
@@ -26,47 +25,52 @@ To validate OTel configuration run `otel validate` subcommand:
 
 This section provides a summary of components included in the Elastic Distribution for OpenTelemetry Collector.
 
-{{ if .Receivers }}
+{{ if .Receivers -}}
 ### Receivers
 
 | Component | Version |
 |---|---|
-{{ range .Receivers }}| {{ .Name }} | {{ .Version -}} |
-{{ end }}
-{{ end }}
+{{ range .Receivers -}}
+| {{ .Name }} | {{ .Version }} |
+{{ end -}}
+{{ end -}}
 
 {{ if .Exporters }}
 ### Exporters
 
 | Component | Version |
 |---|---|
-{{ range .Exporters }}| {{ .Name }} | {{ .Version -}} |
-{{ end }}
-{{ end }}
+{{ range .Exporters -}}
+| {{ .Name }} | {{ .Version }} |
+{{ end -}}
+{{ end -}}
 
 {{ if .Processors }}
 ### Processors
 
 | Component | Version |
 |---|---|
-{{ range .Processors }}| {{ .Name }} | {{ .Version -}} |
-{{ end }}
-{{ end }}
+{{ range .Processors -}}
+| {{ .Name }} | {{ .Version }} |
+{{ end -}}
+{{ end -}}
 
 {{ if .Extensions }}
 ### Extensions
 
 | Component | Version |
 |---|---|
-{{ range .Extensions }}| {{ .Name }} | {{ .Version -}} |
-{{ end }}
-{{ end }}
+{{ range .Extensions -}}
+| {{ .Name }} | {{ .Version }} |
+{{ end -}}
+{{ end -}}
 
 {{ if .Connectors }}
 ### Connectors
 
 | Component | Version |
 |---|---|
-{{ range .Connectors }}| {{ .Name }} | {{ .Version -}} |
-{{ end }}
-{{ end }}
+{{ range .Connectors -}}
+| {{ .Name }} | {{ .Version }} |
+{{ end -}}
+{{ end -}}


### PR DESCRIPTION
## What does this PR do?

Fixes formatting of the OTel README file by removing redundant whitespace.

## Why is it important?

Not that important really :stuck_out_tongue: but makes the formatter happy and makes the Markdown code cleaner.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~