### PR TITLE
Fixing the hints autodiscovery configuration path in Elastic Agent Manifests

### DIFF
--- a/deploy/kubernetes/creator_k8s_manifest.sh
+++ b/deploy/kubernetes/creator_k8s_manifest.sh
@@ -52,6 +52,7 @@ echo "" >> $OUTPUT_FILE
 
 #Replacing all occurencies of elastic-agent-standalone
 sed -i -e 's/elastic-agent-standalone/elastic-agent/g' $OUTPUT_FILE
+sed -i -e 's/elastic-agent\/templates.d/elastic-agent-standalone\/templates.d/g' $OUTPUT_FILE
 
 #Remove ES_HOST entry from file
 sed -i -e '/# The Elasticsearch host to communicate with/d' $OUTPUT_FILE

--- a/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-daemonset-configmap.yaml
@@ -28,7 +28,7 @@ data:
     providers.kubernetes:
       node: ${NODE_NAME}
       scope: node
-      #Uncomment to enable hints' support https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
+      #Uncomment to enable hints' support - https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
       #hints.enabled: true
       #hints.default_container_logs: true
     inputs:

--- a/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-daemonset-configmap.yaml
@@ -28,8 +28,9 @@ data:
     providers.kubernetes:
       node: ${NODE_NAME}
       scope: node
-      #Uncomment to enable hints' support
+      #Uncomment to enable hints' support https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
       #hints.enabled: true
+      #hints.default_container_logs: true
     inputs:
       - id: kubernetes-cluster-metrics
         condition: ${kubernetes_leaderelection.leader} == true

--- a/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-ksm-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-ksm-daemonset-configmap.yaml
@@ -26,8 +26,9 @@ data:
     providers.kubernetes:
       node: ${NODE_NAME}
       scope: node
-      #Uncomment to enable hints' support
+      #Uncomment to enable hints' support https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
       #hints.enabled: true
+      #hints.default_container_logs: true
     inputs:
       - id: kubernetes-cluster-metrics
         condition: ${kubernetes_leaderelection.leader} == true

--- a/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-ksm-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-ksm-daemonset-configmap.yaml
@@ -26,7 +26,7 @@ data:
     providers.kubernetes:
       node: ${NODE_NAME}
       scope: node
-      #Uncomment to enable hints' support https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
+      #Uncomment to enable hints' support - https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
       #hints.enabled: true
       #hints.default_container_logs: true
     inputs:

--- a/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/base/elastic-agent-standalone-ksm-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/base/elastic-agent-standalone-ksm-daemonset-configmap.yaml
@@ -26,8 +26,9 @@ data:
     providers.kubernetes:
       node: ${NODE_NAME}
       scope: node
-      #Uncomment to enable hints' support
+      #Uncomment to enable hints' support https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
       #hints.enabled: true
+      #hints.default_container_logs: true
     inputs:
       - id: kubernetes-cluster-metrics
         condition: ${kubernetes_leaderelection.leader} == true

--- a/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/base/elastic-agent-standalone-ksm-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/base/elastic-agent-standalone-ksm-daemonset-configmap.yaml
@@ -26,7 +26,7 @@ data:
     providers.kubernetes:
       node: ${NODE_NAME}
       scope: node
-      #Uncomment to enable hints' support https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
+      #Uncomment to enable hints' support - https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
       #hints.enabled: true
       #hints.default_container_logs: true
     inputs:

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -28,7 +28,7 @@ data:
     providers.kubernetes:
       node: ${NODE_NAME}
       scope: node
-      #Uncomment to enable hints' support https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
+      #Uncomment to enable hints' support - https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
       #hints.enabled: true
       #hints.default_container_logs: true
     inputs:

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -28,8 +28,9 @@ data:
     providers.kubernetes:
       node: ${NODE_NAME}
       scope: node
-      #Uncomment to enable hints' support
+      #Uncomment to enable hints' support https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
       #hints.enabled: true
+      #hints.default_container_logs: true
     inputs:
       - id: kubernetes-cluster-metrics
         condition: ${kubernetes_leaderelection.leader} == true

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
@@ -28,7 +28,7 @@ data:
     providers.kubernetes:
       node: ${NODE_NAME}
       scope: node
-      #Uncomment to enable hints' support https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
+      #Uncomment to enable hints' support - https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
       #hints.enabled: true
       #hints.default_container_logs: true
     inputs:

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
@@ -28,8 +28,9 @@ data:
     providers.kubernetes:
       node: ${NODE_NAME}
       scope: node
-      #Uncomment to enable hints' support
+      #Uncomment to enable hints' support https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
       #hints.enabled: true
+      #hints.default_container_logs: true
     inputs:
       - id: kubernetes-cluster-metrics
         condition: ${kubernetes_leaderelection.leader} == true

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-ksm-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-ksm-daemonset-configmap.yaml
@@ -26,8 +26,9 @@ data:
     providers.kubernetes:
       node: ${NODE_NAME}
       scope: node
-      #Uncomment to enable hints' support
+      #Uncomment to enable hints' support https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
       #hints.enabled: true
+      #hints.default_container_logs: true
     inputs:
       - id: kubernetes-cluster-metrics
         condition: ${kubernetes_leaderelection.leader} == true

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-ksm-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-ksm-daemonset-configmap.yaml
@@ -26,7 +26,7 @@ data:
     providers.kubernetes:
       node: ${NODE_NAME}
       scope: node
-      #Uncomment to enable hints' support https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
+      #Uncomment to enable hints' support - https://www.elastic.co/guide/en/fleet/current/hints-annotations-autodiscovery.html
       #hints.enabled: true
       #hints.default_container_logs: true
     inputs:


### PR DESCRIPTION
- Bug


## What does this PR do?

WHAT: Fixes the path that is being used in hints autodiscovery of elastic-agent
WHY: The path for hint configuration was not correct when users where extracting the manifest from Kibana page

Note: We have added `hints.default_container_logs: true` also in the standalone configmap

## Why is it important?

Improves the UX for elastic agent users that want to use kibana to create their manifests

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test


## How to test this PR locally

1. Download this nranch
2. Navigate to `deploy/kubernetes`
3. Run: 
```bash
WITHOUTCONFIG=true make generate-k8s
 ./creator_k8s_manifest.sh .
``
4. Check the new `elastic_agent_manifest.ts` that is being created should include `elastic-agent-standalone/templates.d` line
```yaml
      #        curl -sL https://github.com/elastic/elastic-agent/archive/8.16.tar.gz | tar xz -C /usr/share/elastic-agent/state/inputs.d --strip=5 "elastic-agent-8.16/deploy/kubernetes/elastic-agent-standalone/templates.d"

```

