### PR TITLE
Temporary skip TestEventLogOutputConfiguredViaFleet

### DIFF
--- a/testing/integration/event_logging_test.go
+++ b/testing/integration/event_logging_test.go
@@ -163,6 +163,7 @@ func TestEventLogOutputConfiguredViaFleet(t *testing.T) {
 		},
 		Group: "container",
 	})
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/5159")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()


### PR DESCRIPTION
The test is flaky https://github.com/elastic/elastic-agent/issues/5159