### PR TITLE
Remove `set -x` from Buildkite scripts

### DIFF
--- a/.buildkite/scripts/install-gh.sh
+++ b/.buildkite/scripts/install-gh.sh
@@ -2,7 +2,7 @@
 
 # Required environment variables:
 # - GH_VERSION - the version of gh to install
-set -exuo pipefail
+set -euo pipefail
 
 echo "--- Install gh cli"
 

--- a/.buildkite/scripts/steps/merge.sh
+++ b/.buildkite/scripts/steps/merge.sh
@@ -3,7 +3,7 @@
 # Downloads and merges coverage files from multiple steps into a single file (build/TEST-go-unit.cov).
 # Usage: merge.sh <step1> <step2> ... Where <step> is the id of the step that contains the coverage artifact.#  
 
-set -exuo pipefail
+set -euo pipefail
 
 COV_ARTIFACT="coverage.out"
 MERGED_COV_FILE="build/TEST-go-unit.cov"


### PR DESCRIPTION
## What does this PR do?

This PR removes the `set -x` options from two scripts run as part of ["K8s tests" group](https://github.com/elastic/elastic-agent/blob/ca726a219e7289ca1278653003c8dc299d302093/.buildkite/pipeline.yml#L180C13-L180C22) in the Elastic Agent buildkite pipeline.

## Why is it important?

To avoid printing out secrets.

