### PR TITLE
Change getPersistentConfig to handle all agent.* attributes

### DIFF
--- a/internal/pkg/agent/cmd/enroll_cmd_test.go
+++ b/internal/pkg/agent/cmd/enroll_cmd_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"sync/atomic"
@@ -669,4 +670,58 @@ func readConfig(raw []byte) (*configuration.FleetAgentConfig, error) {
 		return nil, err
 	}
 	return cfg.Fleet, nil
+}
+
+func TestGetPersistentAgentConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect map[string]interface{}
+	}{{
+		name:   "log level",
+		input:  `agent.logging.level: debug`,
+		expect: map[string]interface{}{"logging": map[string]interface{}{"level": "debug"}},
+	}, {
+		name: "http monitoring",
+		input: `agent.monitoring.http:
+  enabled: true`,
+		expect: map[string]interface{}{"monitoring": map[string]interface{}{"http": map[string]interface{}{"enabled": true}}},
+	}, {
+		name: "headers",
+		input: `agent.headers:
+  key1: val1
+  key2: val2`,
+		expect: map[string]interface{}{"headers": map[string]interface{}{"key1": "val1", "key2": "val2"}},
+	}, {
+		name: "nested keys",
+		input: `agent:
+  monitoring:
+    http:
+      enabled: true`,
+		expect: map[string]interface{}{"monitoring": map[string]interface{}{"http": map[string]interface{}{"enabled": true}}},
+	}, {
+		name: "apm config",
+		input: `agent.monitoring:
+  traces: true
+  apm:
+    hosts:
+      - example:8200
+    secret_key: secretVal`,
+		expect: map[string]interface{}{"monitoring": map[string]interface{}{"traces": true, "apm": map[string]interface{}{"hosts": []interface{}{"example:8200"}, "secret_key": "secretVal"}}},
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "input.yml")
+			f, err := os.Create(path)
+			require.NoError(t, err)
+			_, err = f.WriteString(tc.input)
+			require.NoError(t, err)
+			err = f.Close()
+			require.NoError(t, err)
+
+			mp, err := getPersistentAgentConfig(path)
+			require.NoError(t, err)
+			require.Equal(t, tc.expect, mp)
+		})
+	}
 }


### PR DESCRIPTION
## What does this PR do?

Change getPersistentConfig to handle all agent.* attributes by directly using ToMapStr and returning the value of the agent attribute if it's an object.

## Why is it important?

Currently only a limited number of `agent.*` attributes, such as `agent.logging.level` are able to be specified through the `elastic-agent.yml` file when an agent is enrolled into fleet before the file is replaced. This change will use all `agent.*` attributes.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes #5204 

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->