### PR TITLE
[docker][agentbeat]: add cap_sys_ptrace and cap_dac_override in permitted set

### DIFF
--- a/changelog/fragments/1723149357-fix-insufficient-capabilities.yaml
+++ b/changelog/fragments/1723149357-fix-insufficient-capabilities.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Assign sys_ptrace and dac_override capabilities in permitted set to agentbeat binary.
+component: elastic-agent, metricbeat

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -57,7 +57,7 @@ RUN true && \
 
 # Keep this after any chown command, chown resets any applied capabilities
 RUN setcap =p {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/elastic-agent
-RUN setcap cap_net_raw,cap_setuid+p {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/components/agentbeat && \
+RUN setcap cap_net_raw,cap_setuid,cap_sys_ptrace,cap_dac_override+p {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/components/agentbeat && \
 {{- if .linux_capabilities }}
 # Since the beat is stored at the other end of a symlink we must follow the symlink first
 # For security reasons setcap does not support symlinks. This is smart in the general case

--- a/testing/integration/agent_long_running_leak_test.go
+++ b/testing/integration/agent_long_running_leak_test.go
@@ -151,7 +151,7 @@ func (runner *ExtendedRunner) TestHandleLeak() {
 	timer := time.NewTimer(testDuration)
 	defer timer.Stop()
 
-	ticker := time.NewTicker(time.Second * 10)
+	ticker := time.NewTicker(time.Second * 60)
 	defer ticker.Stop()
 
 	done := false

--- a/testing/integration/agent_long_test_base_system_integ.json
+++ b/testing/integration/agent_long_test_base_system_integ.json
@@ -531,7 +531,7 @@
             }
           },
           {
-            "enabled": true,
+            "enabled": false,
             "data_stream": {
               "type": "metrics",
               "dataset": "system.process"
@@ -596,7 +596,7 @@
             }
           },
           {
-            "enabled": true,
+            "enabled": false,
             "data_stream": {
               "type": "metrics",
               "dataset": "system.process.summary"

--- a/testing/integration/kubernetes_agent_standalone_test.go
+++ b/testing/integration/kubernetes_agent_standalone_test.go
@@ -118,7 +118,7 @@ func TestKubernetesAgentStandalone(t *testing.T) {
 			int64Ptr(1000), // elastic-agent uid
 			nil,
 			[]corev1.Capability{"ALL"},
-			[]corev1.Capability{"CHOWN", "SETPCAP"},
+			[]corev1.Capability{"CHOWN", "SETPCAP", "DAC_OVERRIDE", "SYS_PTRACE"},
 			true,
 		},
 		{
@@ -126,7 +126,7 @@ func TestKubernetesAgentStandalone(t *testing.T) {
 			int64Ptr(500),
 			int64Ptr(500),
 			[]corev1.Capability{"ALL"},
-			[]corev1.Capability{"CHOWN", "SETPCAP", "DAC_READ_SEARCH"},
+			[]corev1.Capability{"CHOWN", "SETPCAP", "DAC_OVERRIDE", "SYS_PTRACE"},
 			true,
 		},
 	}


### PR DESCRIPTION
## What does this PR do?

Grant cap_sys_ptrace and cap_dac_override to permitted set.
Required to operate in unprivileged mode.

This PR also updates k8s standalone tests and adds required permissions and disables the long running test case https://github.com/elastic/elastic-agent/issues/5279. 
I'm including all of these changes in the same PR because they are related to a same problem.

## Why is it important?

- Without these capabilities, agent will always remain in DEGRADED state inside the container

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## How to test this PR locally

- `PACKAGES=docker mage package` on this branch
```bash
docker run --entrypoint bash --user root --rm -it docker.elastic.co/beats/elastic-agent:8.16.0-SNAPSHOT
getcap data/elastic-agent-a1fd2c/components/agentbeat
data/elastic-agent-a1fd2c/components/agentbeat = cap_dac_override,cap_setuid,cap_net_raw,cap_sys_ptrace+p
``` 

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/5269
- Relates https://github.com/elastic/elastic-agent/issues/5279