### PR TITLE
switch to monotonic clocks for component check-in

### DIFF
--- a/changelog/fragments/1723477450-use-monotonic-clock-for-check-in.yaml
+++ b/changelog/fragments/1723477450-use-monotonic-clock-for-check-in.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: use monotonic clock for component check-in
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/5284
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/5277

--- a/pkg/component/runtime/command.go
+++ b/pkg/component/runtime/command.go
@@ -195,7 +195,7 @@ func (c *commandRuntime) Run(ctx context.Context, comm Communicator) error {
 				// first check-in
 				sendExpected = true
 			}
-			c.lastCheckin = time.Now().UTC()
+			c.lastCheckin = time.Now()
 			if c.state.syncCheckin(checkin) {
 				changed = true
 			}
@@ -222,7 +222,7 @@ func (c *commandRuntime) Run(ctx context.Context, comm Communicator) error {
 					}
 				} else {
 					// running and should be running
-					now := time.Now().UTC()
+					now := time.Now()
 					if now.Sub(c.lastCheckin) <= checkinPeriod {
 						c.missedCheckins = 0
 					} else {

--- a/pkg/component/runtime/command.go
+++ b/pkg/component/runtime/command.go
@@ -195,6 +195,11 @@ func (c *commandRuntime) Run(ctx context.Context, comm Communicator) error {
 				// first check-in
 				sendExpected = true
 			}
+			// Warning lastCheckin must contain a
+			// monotonic clock.  Functions like Local(),
+			// UTC(), Round(), AddDate(), etc. remove the
+			// monotonic clock.  See
+			// https://pkg.go.dev/time
 			c.lastCheckin = time.Now()
 			if c.state.syncCheckin(checkin) {
 				changed = true
@@ -222,6 +227,12 @@ func (c *commandRuntime) Run(ctx context.Context, comm Communicator) error {
 					}
 				} else {
 					// running and should be running
+					//
+					// Warning now must contain a
+					// monotonic clock.  Functions like Local(),
+					// UTC(), Round(), AddDate(), etc. remove the
+					// monotonic clock.  See
+					// https://pkg.go.dev/time
 					now := time.Now()
 					if now.Sub(c.lastCheckin) <= checkinPeriod {
 						c.missedCheckins = 0

--- a/pkg/component/runtime/service.go
+++ b/pkg/component/runtime/service.go
@@ -478,7 +478,7 @@ func (s *serviceRuntime) processCheckin(checkin *proto.CheckinObserved, comm Com
 		// first check-in
 		sendExpected = true
 	}
-	*lastCheckin = time.Now().UTC()
+	*lastCheckin = time.Now()
 	if s.state.syncCheckin(checkin) {
 		changed = true
 	}
@@ -505,7 +505,7 @@ func (s *serviceRuntime) isRunning() bool {
 // checkStatus checks check-ins state, called on timer
 func (s *serviceRuntime) checkStatus(checkinPeriod time.Duration, lastCheckin *time.Time, missedCheckins *int) {
 	if s.isRunning() {
-		now := time.Now().UTC()
+		now := time.Now()
 		if lastCheckin.IsZero() {
 			// never checked-in
 			*missedCheckins++

--- a/pkg/component/runtime/service.go
+++ b/pkg/component/runtime/service.go
@@ -478,6 +478,10 @@ func (s *serviceRuntime) processCheckin(checkin *proto.CheckinObserved, comm Com
 		// first check-in
 		sendExpected = true
 	}
+	// Warning lastCheckin must contain a monotonic clock.
+	// Functions like Local(), UTC(), Round(), AddDate(),
+	// etc. remove the monotonic clock.  See
+	// https://pkg.go.dev/time
 	*lastCheckin = time.Now()
 	if s.state.syncCheckin(checkin) {
 		changed = true
@@ -505,6 +509,10 @@ func (s *serviceRuntime) isRunning() bool {
 // checkStatus checks check-ins state, called on timer
 func (s *serviceRuntime) checkStatus(checkinPeriod time.Duration, lastCheckin *time.Time, missedCheckins *int) {
 	if s.isRunning() {
+		// Warning now must contain a monotonic clock.
+		// Functions like Local(), UTC(), Round(), AddDate(),
+		// etc. remove the monotonic clock.  See
+		// https://pkg.go.dev/time
 		now := time.Now()
 		if lastCheckin.IsZero() {
 			// never checked-in


### PR DESCRIPTION
## What does this PR do?

Switch to montonic clocks for component check-in calculation.
Previously the wall clock was used and this caused components to
appear degraded if they "missed" check-ins because the time change
made it appear they hadn't checked in within the necessary time
window.

## Why is it important?

Necessary to prevent unnecessary restarting of components when the
wall time of the host changes significantly.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

1. Install `elastic-agent` on a machine
2. continuously advance the clock
3. without patch observe that components go into degraded state due to failed check-in, and eventually are restarted
4. with patch observer that components stay healthy and are not restarted.  No missed check-ins are reported

## Related issues

- Closes #5277

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->