### PR TITLE
fix: rootless k8s integration tests

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -56,8 +56,7 @@ RUN true && \
     true
 
 # Keep this after any chown command, chown resets any applied capabilities
-RUN setcap =p {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/elastic-agent
-RUN setcap cap_net_raw,cap_setuid+p {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/components/agentbeat && \
+RUN setcap =p {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/elastic-agent && \
 {{- if .linux_capabilities }}
 # Since the beat is stored at the other end of a symlink we must follow the symlink first
 # For security reasons setcap does not support symlinks. This is smart in the general case

--- a/testing/integration/kubernetes_agent_standalone_test.go
+++ b/testing/integration/kubernetes_agent_standalone_test.go
@@ -30,6 +30,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -159,6 +160,10 @@ func TestKubernetesAgentStandalone(t *testing.T) {
 					// set ImagePullPolicy to "Never" to avoid pulling the image
 					// as the image is already loaded by the kubernetes provisioner
 					container.ImagePullPolicy = "Never"
+
+					container.Resources.Limits = corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("800Mi"),
+					}
 
 					if tc.capabilitiesDrop != nil || tc.capabilitiesAdd != nil || tc.runUser != nil || tc.runGroup != nil {
 						// set security context

--- a/testing/integration/kubernetes_agent_standalone_test.go
+++ b/testing/integration/kubernetes_agent_standalone_test.go
@@ -122,18 +122,18 @@ func TestKubernetesAgentStandalone(t *testing.T) {
 			int64Ptr(1000), // elastic-agent uid
 			nil,
 			[]corev1.Capability{"ALL"},
-			[]corev1.Capability{"CHOWN", "SETPCAP"},
+			[]corev1.Capability{"CHOWN", "SETPCAP", "DAC_READ_SEARCH", "SYS_PTRACE"},
 			true,
-			"https://github.com/elastic/elastic-agent/issues/5275",
+			"",
 		},
 		{
 			"drop ALL add CHOWN, SETPCAP capabilities - rootless agent random uid:gid",
 			int64Ptr(500),
 			int64Ptr(500),
 			[]corev1.Capability{"ALL"},
-			[]corev1.Capability{"CHOWN", "SETPCAP", "DAC_READ_SEARCH"},
+			[]corev1.Capability{"CHOWN", "SETPCAP", "DAC_READ_SEARCH", "SYS_PTRACE"},
 			true,
-			"https://github.com/elastic/elastic-agent/issues/5275",
+			"",
 		},
 	}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR addresses the failures of k8s integrations tests:

1. Fix degraded agent status for rootless agent running with elastic-agent uid (1000). The main reason behind this was the setcap on the `agentbeat` binary in conjunction with it getting copied from a "builder" image during the building of the elastic-agent container image. I am not sure why this is the case, but I have observed in the past that copying files with capabilities across different docker layers results in an Effective set with no capabilities of the file at hand, ignoring completely the Ambient set of the parent which is elastic-agent in our case. This quirk got highlighted when metricbeat implemented status reporting. Now fun fact, we weren't bumping into this scenario for rootless agent with random uid:gid as in this case, elastic-agent is chowing everything and when you chown a file to a different user the capabilities are getting reset and hence the Ambient set of elastic-agent was getting applied. The solution is to remove setcap from agentbeat completely as it is redundant, elastic-agent will raise and pass down all capabilities in Bounding set and thus the former doesn't need to specify anything special in terms of capabilities.
2. Add extra required capabilities for rootless agent. The extra capabilities required to read /proc/${pid}/io are `DAC_READ_SEARCH` and `SYS_PTRACE`
3. increase memory limits for elastic-agent container as I observed some failures due to OOM when fixing the above issues
4. increase the timeout to 90 seconds while waiting elastic-agent to report healthy. As of now we get a degraded agent status until kube-state-metrics is properly initialised. Thus I feel like 60 seconds when running three kind clusters on the same machine with parallel integration k8s tests is kinda tight


<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Because it fixes the k8s integration tests

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

N/A

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```shell
DEV=true SNAPSHOT=true EXTERNAL=true PLATFORMS=linux/arm64 PACKAGES=docker mage -v package
mage integration:auth
mage integration:kubernetes
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
Closes https://github.com/elastic/elastic-agent/issues/5275