### PR TITLE
Return nil error instead of syscall.Errno(0) on windows

### DIFF
--- a/changelog/fragments/1724103107-Check-windows-permissions-for-false-positive-return.yaml
+++ b/changelog/fragments/1724103107-Check-windows-permissions-for-false-positive-return.yaml
@@ -1,0 +1,33 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Check windows permissions for false-positive return
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Check the errors returned when handling the ACL on windows systems to stop emmitting an error that states "The operation completed successfully".
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/5317
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/4496

--- a/internal/pkg/agent/perms/windows.go
+++ b/internal/pkg/agent/perms/windows.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"syscall"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/hectane/go-acl"
@@ -91,6 +92,11 @@ func FixPermissions(topPath string, opts ...OptFunc) error {
 
 					err = acl.Apply(name, true, inherit, grants...)
 					if err != nil {
+						// Check for Errno = 0 which indicates success
+						// https://pkg.go.dev/golang.org/x/sys/windows#Errno
+						if errors.Is(err, syscall.Errno(0)) {
+							return nil
+						}
 						return err
 					}
 					if userSID != nil && groupSID != nil {
@@ -112,7 +118,13 @@ func FixPermissions(topPath string, opts ...OptFunc) error {
 			if topPath == name {
 				inherit = false
 			}
-			return acl.Apply(name, true, inherit, grants...)
+			err = acl.Apply(name, true, inherit, grants...)
+			// Check for Errno = 0 which indicates success
+			// https://pkg.go.dev/golang.org/x/sys/windows#Errno
+			if errors.Is(err, syscall.Errno(0)) {
+				return nil
+			}
+			return err
 		} else if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}


### PR DESCRIPTION
## What does this PR do?

Return a nil error instead of syscall.Errno(0) which indicates a successful operation on windows.

## Why is it important?

Installation may fail with the error: `Error: failed to fix permissions: The operation completed successfully.`. This is caused by `golang.org/x/sys/windows` [using Errno(0)](https://cs.opensource.google/go/x/sys/+/master:windows/zerrors_windows.go;drc=134d130e1a049f4194ae9920ac9f96455cde360d;l=151) to indicate a success in some cases as described by the [Windows API](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

N/A


## Related issues

- Closes #4496 
