### PR TITLE
Fix logic to detect if `NOTICE.txt` has changed

### DIFF
--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: check for modified NOTICE.txt
         id: notice-check
-        run: echo "modified=$(if git diff-index --quiet HEAD -- NOTICE.txt; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
+        run: echo "modified=$(if git diff -s --exit-code NOTICE.txt; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
 
       - name: commit NOTICE.txt
         if: steps.notice-check.outputs.modified == 'true'


### PR DESCRIPTION
## What does this PR do?

This PR fixes the logic used to detect if `NOTICE.txt` has changed after dependabot runs `make notice`.

## Why is it important?

The results of this check decide if the next step, to commit the `NOTICE.txt` file, needs to be executed.  Without the fix in this PR, the check was incorrectly returning `modified=true` even when the `NOTICE.txt` file was unchanged, causing the next step to be needlessly executed, and that step then returning a non-zero exit code, failing the build, e.g. https://github.com/elastic/elastic-agent/actions/runs/10462610242/job/28973151909

## How to test this PR manually

1. Make sure there are no changes to `NOTICE.txt`.
   ```
   $ git diff NOTICE.txt | wc -l
       0
   ```
2. Run the new logic.  Ensure that it outputs `modified=false`.
   ```
   $ echo modified=$(if git diff -s --exit-code NOTICE.txt; then echo "false"; else echo "true"; fi)
   modified=false
   ``` 
3. Make changes to `NOTICE.txt`
   ```
   echo "foo bar" >> NOTICE.txt
   ```
4. Run the new logic again.  Ensure that it outputs `modified=true`.
   ```
   $ echo modified=$(if git diff -s --exit-code NOTICE.txt; then echo "false"; else echo "true"; fi)
   modified=false
   ``` 
