### PR TITLE
Avoid reporting empty version_info for components that just started

### DIFF
--- a/testing/integration/package_version_test.go
+++ b/testing/integration/package_version_test.go
@@ -102,16 +102,23 @@ func TestComponentBuildHashInDiagnostics(t *testing.T) {
 		}
 
 		for _, c := range status.Components {
+			bs, err := json.MarshalIndent(status, "", "  ")
+			if err != nil {
+				stateBuff.WriteString(fmt.Sprintf("%s not health, could not marshal status outptu: %v",
+					c.Name, err))
+				return false
+			}
+
 			state := client.State(c.State)
 			if state != client.Healthy {
-				bs, err := json.MarshalIndent(status, "", "  ")
-				if err != nil {
-					stateBuff.WriteString(fmt.Sprintf("%s not health, could not marshal status outptu: %v",
-						c.Name, err))
-					return false
-				}
 
 				stateBuff.WriteString(fmt.Sprintf("%s not health, agent status output: %s",
+					c.Name, bs))
+				return false
+			}
+
+			if c.VersionInfo.Meta.Commit == "" {
+				stateBuff.WriteString(fmt.Sprintf("%s health, but no versionInfo. agent status output: %s",
 					c.Name, bs))
 				return false
 			}


### PR DESCRIPTION

## What does this PR do?

The state diagnostics hook now re-fetches once the state when necessary, improving the accuracy of component status reporting.

## Why is it important?

Given a design choice, the coordinator's reported state might be stale, leading to healthy components lacking version_info immediately after they start.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using th~~e [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

Run the [`TestDiagnosticState`](https://github.com/AndersonQ/elastic-agent/blob/db1be7588b892df7d2ca902d5edd49727ae766d8/internal/pkg/agent/application/coordinator/diagnostics_test.go#L413) test

## Related issues


- Closes https://github.com/elastic/elastic-agent/issues/4215

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->