### PR TITLE
Skip flaky test: `TestEventLogFile`

### DIFF
--- a/testing/integration/event_logging_test.go
+++ b/testing/integration/event_logging_test.go
@@ -76,6 +76,8 @@ func TestEventLogFile(t *testing.T) {
 		Sudo:  false,
 	})
 
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/5337")
+
 	ctx, cancel := testcontext.WithDeadline(
 		t,
 		context.Background(),


### PR DESCRIPTION
This PR skips the `TestEventLogFile` flaky test to unblock builds while we figure out and fix the root cause for the failure.

This PR should be reverted once https://github.com/elastic/elastic-agent/issues/5337 is resolved.