### PR TITLE
Fix TestEventLogFile, TestContainerCMDEventToStderr and TestEventLogOutputConfiguredViaFleet

### DIFF
--- a/testing/integration/container_cmd_test.go
+++ b/testing/integration/container_cmd_test.go
@@ -378,7 +378,7 @@ func TestContainerCMDEventToStderr(t *testing.T) {
 		agentOutputStr := agentOutput.String()
 		scanner := bufio.NewScanner(strings.NewReader(agentOutputStr))
 		for scanner.Scan() {
-			if strings.Contains(scanner.Text(), "Cannot index event publisher.Event") {
+			if strings.Contains(scanner.Text(), "Cannot index event") {
 				return true
 			}
 		}

--- a/testing/integration/event_logging_test.go
+++ b/testing/integration/event_logging_test.go
@@ -76,8 +76,6 @@ func TestEventLogFile(t *testing.T) {
 		Sudo:  false,
 	})
 
-	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/5337")
-
 	ctx, cancel := testcontext.WithDeadline(
 		t,
 		context.Background(),
@@ -343,7 +341,7 @@ func requireEventLogFileExistsWithData(t *testing.T, agentFixture *atesting.Fixt
 	}
 
 	logEntry := string(logEntryBytes)
-	expectedStr := "Cannot index event publisher.Event"
+	expectedStr := "Cannot index event"
 	if !strings.Contains(logEntry, expectedStr) {
 		t.Errorf(
 			"did not find the expected log entry ('%s') in the events log file",

--- a/testing/integration/event_logging_test.go
+++ b/testing/integration/event_logging_test.go
@@ -163,7 +163,6 @@ func TestEventLogOutputConfiguredViaFleet(t *testing.T) {
 		},
 		Group: "container",
 	})
-	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/5159")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
@@ -255,7 +254,7 @@ func TestEventLogOutputConfiguredViaFleet(t *testing.T) {
 		agentOutputStr := agentOutput.String()
 		scanner := bufio.NewScanner(strings.NewReader(agentOutputStr))
 		for scanner.Scan() {
-			if strings.Contains(scanner.Text(), "Cannot index event publisher.Event") {
+			if strings.Contains(scanner.Text(), "Cannot index event") {
 				return true
 			}
 		}


### PR DESCRIPTION
## What does this PR do?

Fix TestEventLogFile, TestContainerCMDEventToStderr and TestEventLogOutputConfiguredViaFleet by updating the string that needs to be searched in the logs.

## Why is it important?

It fixes some test that were breaking CI

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

There is no disruptive user impact because this PR is fixing a broken test

## How to test this PR locally
Package the Elastic-Agent from this PR:
```
DEV=true SNAPSHOT=true EXTERNAL=true PACKAGES="deb,rpm,tar.gz" PLATFORMS=linux/amd64 mage -v package
```
Then run one of the  integration test that were failing: `TestEventLogFile`, `TestContainerCMDEventToStderr` or `TestEventLogOutputConfiguredViaFleet`
```
SNAPSHOT=true TEST_PLATFORMS="linux/amd64" mage -v integration:single  TestEventLogFile
```
## Related issues
- Closes https://github.com/elastic/elastic-agent/issues/5337

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->