### PR TITLE
Improve watcher and TestWatcher_AgentErrorQuick logs

### DIFF
--- a/internal/pkg/agent/application/upgrade/watcher.go
+++ b/internal/pkg/agent/application/upgrade/watcher.go
@@ -93,14 +93,14 @@ func (ch *AgentWatcher) Run(ctx context.Context) {
 					if failedErr == nil {
 						flipFlopCount++
 						failedTimer.Reset(ch.checkInterval)
-						ch.log.Error("Agent reported failure (starting failed timer): %s", err)
+						ch.log.Errorf("Agent reported failure (starting failed timer): %s", err)
 					} else {
-						ch.log.Error("Agent reported failure (failed timer already started): %s", err)
+						ch.log.Errorf("Agent reported failure (failed timer already started): %s", err)
 					}
 				} else {
 					if failedErr != nil {
 						failedTimer.Stop()
-						ch.log.Error("Agent reported healthy (failed timer stopped): %s", err)
+						ch.log.Info("Agent reported healthy (failed timer stopped)")
 					}
 				}
 				failedErr = err
@@ -115,7 +115,8 @@ func (ch *AgentWatcher) Run(ctx context.Context) {
 					continue
 				}
 				// error lasted longer than the checkInterval, notify!
-				ch.notifyChan <- failedErr
+				ch.notifyChan <- fmt.Errorf("last error was not cleared before checkInterval (%s) elapsed: %w",
+					ch.checkInterval, failedErr)
 			}
 		}
 	}()
@@ -138,7 +139,7 @@ LOOP:
 			connectCancel()
 			if err != nil {
 				ch.connectCounter++
-				ch.log.Error("Failed connecting to running daemon: ", err)
+				ch.log.Errorf("Failed connecting to running daemon: %s", err)
 				if ch.checkFailures() {
 					return
 				}
@@ -152,7 +153,7 @@ LOOP:
 				// considered a connect error
 				stateCancel()
 				ch.agentClient.Disconnect()
-				ch.log.Error("Failed to start state watch: ", err)
+				ch.log.Errorf("Failed to start state watch: %s", err)
 				ch.connectCounter++
 				if ch.checkFailures() {
 					return
@@ -178,25 +179,30 @@ LOOP:
 			for {
 				state, err := watch.Recv()
 				if err != nil {
+					ch.log.Debugf("received state: error: %s",
+						err)
+
 					// agent has crashed or exited
 					stateCancel()
 					ch.agentClient.Disconnect()
-					ch.log.Error("Lost connection: failed reading next state: ", err)
+					ch.log.Errorf("Lost connection: failed reading next state: %s", err)
 					ch.lostCounter++
 					if ch.checkFailures() {
 						return
 					}
 					continue LOOP
 				}
+				ch.log.Debugf("received state: %s:%s",
+					state.State, state.Message)
 
 				// gRPC is good at hiding the fact that connection was lost
 				// to ensure that we don't miss a restart a changed PID means
 				// we are now talking to a different spawned Elastic Agent
 				if ch.lastPid == -1 {
 					ch.lastPid = state.Info.PID
-					ch.log.Info(fmt.Sprintf("Communicating with PID %d", ch.lastPid))
+					ch.log.Infof("Communicating with PID %d", ch.lastPid)
 				} else if ch.lastPid != state.Info.PID {
-					ch.log.Error(fmt.Sprintf("Communication with PID %d lost, now communicating with PID %d", ch.lastPid, state.Info.PID))
+					ch.log.Errorf("Communication with PID %d lost, now communicating with PID %d", ch.lastPid, state.Info.PID)
 					ch.lastPid = state.Info.PID
 					// count the PID change as a lost connection, but allow
 					// the communication to continue unless has become a failure


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

It improves the watcher logs and prints the logs if TestWatcher_AgentErrorQuick fails.
If the test would fail, the logs would be like the following:
```
❯ go test -run TestWatcher_AgentErrorQuick ./internal/pkg/agent/application/upgrade/
--- FAIL: TestWatcher_AgentErrorQuick (1.00s)
    watcher_test.go:287: [info] Agent watcher started
    watcher_test.go:287: [info] Trying to connect to agent
    watcher_test.go:287: [info] Connected to agent
    watcher_test.go:287: [debug] received state: FAILED:force failure
    watcher_test.go:287: [info] Communicating with PID 0
    watcher_test.go:287: [debug] received state: HEALTHY:healthy
    watcher_test.go:287: [error] Agent reported failure (starting failed timer): agent reported failed state: force failure
    watcher_test.go:287: [info] Agent reported healthy (failed timer stopped)
    watcher_test.go:287: [debug] received state: error: rpc error: code = DeadlineExceeded desc = context deadline exceeded
    watcher_test.go:287: [error] Lost connection: failed reading next state: rpc error: code = DeadlineExceeded desc = context deadline exceeded
FAIL
FAIL	github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade	1.351s
FAIL
```

## Why is it important?

`TestWatcher_AgentErrorQuick` was flaky before, but it hasn't happened again on CI. Even running it for 12 hours didn't reproduce the problem. 


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

None

## How to test this PR locally

make `TestWatcher_AgentErrorQuick` to fail by adding `t.Fail()` at the end of the test and then run the test.

```
❯ go test -count 43200 -run TestWatcher_AgentErrorQuick -timeout=0
PASS
ok      github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade 43320.474s
```

## Related issues


- Closes #3983

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->