### PR TITLE
[integration tests] Keep work directory if test fails

### DIFF
--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -1205,7 +1205,6 @@ func createTempDir(t *testing.T) string {
 	tempDir, err := os.MkdirTemp("", strings.ReplaceAll(t.Name(), "/", "-"))
 	if err != nil {
 		t.Fatalf("failed to make temp directory: %s", err)
-		t.Logf("Created temp directory %q", tempDir)
 	}
 
 	cleanup := func() {

--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -1205,6 +1205,7 @@ func createTempDir(t *testing.T) string {
 	tempDir, err := os.MkdirTemp("", strings.ReplaceAll(t.Name(), "/", "-"))
 	if err != nil {
 		t.Fatalf("failed to make temp directory: %s", err)
+		t.Logf("Created temp directory %q", tempDir)
 	}
 
 	cleanup := func() {

--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -1214,7 +1214,7 @@ func createTempDir(t *testing.T) string {
 				t.Errorf("could not remove temp dir '%s': %s", tempDir, err)
 			}
 		} else {
-			t.Logf("Temporary directory saved: %s", tempDir)
+			t.Logf("Temporary directory %q preserved for investigation/debugging", tempDir)
 		}
 	}
 	t.Cleanup(cleanup)

--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -206,7 +206,7 @@ func (f *Fixture) Prepare(ctx context.Context, components ...UsableComponent) er
 	if err != nil {
 		return err
 	}
-	workDir := f.t.TempDir()
+	workDir := createTempDir(f.t)
 	finalDir := filepath.Join(workDir, name)
 	err = ExtractArtifact(f.t, src, workDir)
 	if err != nil {
@@ -1194,6 +1194,31 @@ func performConfigure(ctx context.Context, c client.Client, cfg string, timeout 
 		return fmt.Errorf("state management failed update configuration: %w", err)
 	}
 	return nil
+}
+
+// createTempDir creates a temporary directory that will be
+// removed after the tests passes. If the test fails, the
+// directory is kept for further investigation.
+//
+// If the test is run with -v and fails the temporary directory is logged
+func createTempDir(t *testing.T) string {
+	tempDir, err := os.MkdirTemp("", strings.ReplaceAll(t.Name(), "/", "-"))
+	if err != nil {
+		t.Fatalf("failed to make temp directory: %s", err)
+	}
+
+	cleanup := func() {
+		if !t.Failed() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Errorf("could not remove temp dir '%s': %s", tempDir, err)
+			}
+		} else {
+			t.Logf("Temporary directory saved: %s", tempDir)
+		}
+	}
+	t.Cleanup(cleanup)
+
+	return tempDir
 }
 
 type AgentStatusOutput struct {


### PR DESCRIPTION


## What does this PR do?

This commit enables the work directory used by the integration tests framework to be kept in the filesystem if the test fails. The full path of the test directory is printed when the test fails.

## Why is it important?

It helps debugging failing integration tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

There is no disruptive user impact because this PR changes our integration tests framework.

## How to test this PR locally

1. Add `t.FailNow()` at the end of any integration test
2. Run the integration test you modified with the `-v` flag
3. You will see a log entry like this:
```
fixture.go:242: Temporary directory saved: /tmp/TestEventLogOutputConfiguredViaFleet411647803
```

~~## Related issues~~

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->