### PR TITLE
TestManager_StartStopComponent add test logs, alternate manager ready signal

### DIFF
--- a/pkg/component/runtime/manager.go
+++ b/pkg/component/runtime/manager.go
@@ -191,7 +191,7 @@ func NewManager(
 		errCh:          make(chan error),
 		monitor:        monitor,
 		grpcConfig:     grpcConfig,
-		serverReady:    make(chan struct{}, 1),
+		serverReady:    make(chan struct{}),
 		doneChan:       make(chan struct{}),
 		runAsOtel:      runAsOtel,
 	}
@@ -342,7 +342,7 @@ LOOP:
 }
 
 func (m *Manager) serverLoop(ctx context.Context, listener net.Listener, server *grpc.Server) {
-	m.serverReady <- struct{}{}
+	close(m.serverReady)
 	for ctx.Err() == nil {
 		err := server.Serve(listener)
 		if err != nil && ctx.Err() == nil {

--- a/pkg/component/runtime/manager_fake_input_test.go
+++ b/pkg/component/runtime/manager_fake_input_test.go
@@ -2703,6 +2703,7 @@ func (suite *FakeInputSuite) TestManager_StartStopComponent() {
 	default:
 	}
 
+	t.Log("Apply component config 1")
 	m.Update(component.Model{Components: components})
 	err = <-m.errCh
 	require.NoError(t, err, "expected no error from the manager when applying"+
@@ -2720,6 +2721,7 @@ func (suite *FakeInputSuite) TestManager_StartStopComponent() {
 		200*time.Millisecond,
 		"component %s did not start", comp0ID)
 
+	t.Log("Apply component config 2")
 	m.Update(component.Model{Components: components2})
 	err = <-m.errCh
 	require.NoError(t, err, "expected no error from the manager when applying"+
@@ -2740,6 +2742,7 @@ func (suite *FakeInputSuite) TestManager_StartStopComponent() {
 	// component 1 started, we can stop the manager
 	cancel()
 
+	t.Log("Verify behaviour")
 	comp0StartLogs := logs.FilterMessageSnippet(
 		fmt.Sprintf("Starting component %q", comp0ID)).TakeAll()
 	comp0StopLogs := logs.FilterMessageSnippet(
@@ -2761,7 +2764,7 @@ func (suite *FakeInputSuite) TestManager_StartStopComponent() {
 	assert.NoError(t, err, "Manager.Run returned and error")
 
 	if t.Failed() {
-		t.Logf("manager logs:")
+		t.Log("manager logs:")
 		for _, l := range logs.TakeAll() {
 			t.Log(l)
 		}

--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -164,14 +164,12 @@ func (*testMonitoringManager) Cleanup(string) error                             
 
 // waitForReady waits until the RPC server is ready to be used.
 func waitForReady(ctx context.Context, m *Manager) error {
-	for !m.serverReady.Load() {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(100 * time.Millisecond):
-		}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-m.serverReady:
+		return nil
 	}
-	return nil
 }
 
 // [gRPC:8.15] Uncomment this test only after Agent/Endpoint switches fully to local gRPC, post 8.14


### PR DESCRIPTION
## What does this PR do?

Add some output to make it easier to see wheree the flakey `TestManager_StartStopComponent` test is getting stuck.
Use a chan instead of an atomic bool to signal when the manager is ready for tests as it is more idiomatic.

## Related issues

- Relates #4502