### PR TITLE
[testing/integration] make sure all unit are healthy for `agent_long_running_leak_test`

### DIFF
--- a/testing/integration/agent_long_running_leak_test.go
+++ b/testing/integration/agent_long_running_leak_test.go
@@ -151,7 +151,7 @@ func (runner *ExtendedRunner) TestHandleLeak() {
 	timer := time.NewTimer(testDuration)
 	defer timer.Stop()
 
-	ticker := time.NewTicker(time.Second * 60)
+	ticker := time.NewTicker(time.Second * 10)
 	defer ticker.Stop()
 
 	done := false
@@ -230,6 +230,10 @@ func (runner *ExtendedRunner) CheckHealthAtStartup(ctx context.Context) {
 				}
 				if !foundSystem && strings.Contains(v.UnitID, systemMatch) {
 					foundSystem = true
+				}
+				runner.T().Logf("unit state: %s", v.Message)
+				if v.State != int(cproto.State_HEALTHY) {
+					allHealthy = false
 				}
 			}
 			runner.T().Logf("component state: %s", comp.Message)


### PR DESCRIPTION
- Enhancement

## What does this PR do?

>  I opted for a 60s interval to be cautious and ensure the system has enough time to stabilize. But I think `30s` wait would be sufficient. Let me know what do you think
> 
> If we need for the status to stabilize I would have extended the period where we wait for everything to be healthy during the setup but after that I would have kept the check every few seconds instead of waiting a full minute for the status checks (basically checking that once we get the HEALTHY state we keep being healthy for the duration of the test).
> 
> As a first fix I guess we can leave 60s interval between ticks, maybe we can improve this in following iterations...
> 

_Originally posted by @pchila in https://github.com/elastic/elastic-agent/issues/5359#issuecomment-2310453791_

In long running tests, we only check components' (not unit's) health. 
As per current implementation, a component's health is determined by checkins/missed checkins.
https://github.com/elastic/elastic-agent/blob/fd477ec3aa00afc77ae86e7fa9a4ce978a6958b6/pkg/component/runtime/command.go#L185-L192
    -  _I believe this shouldn't be the case anymore with the introduction of degraded mode. It's a potential enhancement. I'll open an issue for it_.

 ## Why is it important?

This PR updates the test case to consider the unit's health.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test
