### PR TITLE
Upgrade mage from 1.14.0 to 1.15.0

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -7,7 +7,7 @@ if [[ -z "${WORKSPACE-""}" ]]; then
     export WORKSPACE
 fi
 if [[ -z "${SETUP_MAGE_VERSION-""}" ]]; then
-    SETUP_MAGE_VERSION="1.14.0"
+    SETUP_MAGE_VERSION="1.15.0"
 fi
 if [[ -z "${SETUP_GVM_VERSION-""}" ]]; then
     SETUP_GVM_VERSION="v0.5.0" # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COVERAGE_DIR=$(BUILD_DIR)/coverage
 BEATS?=elastic-agent
 PROJECTS= $(BEATS)
 PYTHON_ENV?=$(BUILD_DIR)/python-env
-MAGE_VERSION     ?= v1.14.0
+MAGE_VERSION     ?= v1.15.0
 MAGE_PRESENT     := $(shell mage --version 2> /dev/null | grep $(MAGE_VERSION))
 MAGE_IMPORT_PATH ?= github.com/magefile/mage
 export MAGE_IMPORT_PATH


### PR DESCRIPTION
## What does this PR do?

Updates the [Mage](https://github.com/magefile/mage) version used from 1.14.0 to 1.15.0 (currently latest version).

## Why is it important?

We should be using latest version to be on top of any bug/security fixes.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

```
make mage
```

Note that with the way mage is currently installed using `go install`, the `mage --version` command does not return actual version. Perhaps we should rather switch to downloading released binaries from https://github.com/magefile/mage/releases - they report the version correctly.

```console
$ make mage                      
Installing mage v1.15.0.
/home/andrzej/.magefile cleaned
$ mage --version
Mage Build Tool <not set>
Build Date: <not set>
Commit: <not set>
built with: go1.22.5

$ tar zxvf mage_1.15.0_Linux-64bit.tar.gz       
LICENSE
mage
$ ./mage --version
Mage Build Tool 1.15.0
Build Date: 2023-05-11T15:39:32Z
Commit: 9e91a03eaa438d0d077aca5654c7757141536a60
built with: go1.20
```