### PR TITLE
[testing/integration] - Add test cases covering unprivileged mode for nginx.stubstatus metricset

### DIFF
--- a/testing/integration/nginx_integration_setup.json
+++ b/testing/integration/nginx_integration_setup.json
@@ -1,0 +1,50 @@
+{
+    "id": "9bf446fc-58d4-4767-b42d-3450815d5d3d",
+    "version": "WzYzMSwxXQ==",
+    "name": "nginx-1",
+    "namespace": "default",
+    "package": {
+      "name": "nginx",
+      "title": "Nginx",
+      "version": "1.23.0"
+    },
+    "enabled": true,
+    "policy_id": "0a4f6c12-446a-401a-b0eb-96afea6ca92d",
+    "inputs": [
+      {
+        "type": "nginx/metrics",
+        "policy_template": "nginx",
+        "enabled": true,
+        "streams": [
+          {
+            "enabled": true,
+            "data_stream": {
+              "type": "metrics",
+              "dataset": "nginx.stubstatus"
+            },
+            "vars": {
+              "period": {
+                "value": "1s",
+                "type": "text"
+              },
+              "server_status_path": {
+                "value": "/nginx_status",
+                "type": "text"
+              },
+              "tags": {
+                "value": ["nginx-stubstatus"],
+                "type": "text"
+              }
+            },
+            "id": "nginx/metrics-nginx.core-9bf446fc-58d4-4767-b42d-3450815d5d3d"
+          }
+        ],
+        "vars": {
+          "hosts": {
+            "value": ["http://127.0.0.1:81"],
+            "type": "text"
+          }
+        }
+      }
+    ]
+  }

--- a/testing/integration/nginx_unprivileged_test.go
+++ b/testing/integration/nginx_unprivileged_test.go
@@ -67,7 +67,7 @@ func TestNginxUnprivileged(t *testing.T) {
 		Group: "fleet",
 		Stack: &define.Stack{},
 		OS: []define.OS{
-			{Type: define.Linux},
+			{Type: define.Linux, Distro: "ubuntu"},
 		},
 		Local: false, // requires Agent installation
 		Sudo:  true,  // requires Agent installation

--- a/testing/integration/nginx_unprivileged_test.go
+++ b/testing/integration/nginx_unprivileged_test.go
@@ -66,6 +66,9 @@ func TestNginxUnprivileged(t *testing.T) {
 	info := define.Require(t, define.Requirements{
 		Group: "fleet",
 		Stack: &define.Stack{},
+		OS: []define.OS{
+			{Type: define.Linux},
+		},
 		Local: false, // requires Agent installation
 		Sudo:  true,  // requires Agent installation
 	})

--- a/testing/integration/nginx_unprivileged_test.go
+++ b/testing/integration/nginx_unprivileged_test.go
@@ -2,8 +2,6 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build integration
-
 package integration
 
 import (
@@ -90,6 +88,8 @@ func (runner *NginxUnprivilegedRunner) SetupSuite() {
 	cmd := exec.CommandContext(ctx, "apt-get", "install", "-v", "nginx-full")
 	out, err := cmd.CombinedOutput()
 	require.NoError(runner.T(), err, "error while installing nginx: %s", string(out))
+
+	require.NoError(runner.T(), os.MkdirAll("/etc/nginx/conf.d/", 0750))
 
 	err = os.WriteFile("/etc/nginx/conf.d/status.conf", []byte(nginxStatusModule), 0750)
 	require.NoError(runner.T(), err)

--- a/testing/integration/nginx_unprivileged_test.go
+++ b/testing/integration/nginx_unprivileged_test.go
@@ -11,14 +11,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/elastic/elastic-agent-libs/kibana"
 	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
-	"github.com/gofrs/uuid/v5"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 var nginxStatusModule string = `

--- a/testing/integration/nginx_unprivileged_test.go
+++ b/testing/integration/nginx_unprivileged_test.go
@@ -13,14 +13,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/elastic/elastic-agent-libs/kibana"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
 	"github.com/elastic/elastic-agent/pkg/testing/tools/estools"
-	"github.com/gofrs/uuid/v5"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 var nginxStatusModule string = `

--- a/testing/integration/unprivileged_test.go
+++ b/testing/integration/unprivileged_test.go
@@ -1,0 +1,142 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/kibana"
+	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
+	atesting "github.com/elastic/elastic-agent/pkg/testing"
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+	"github.com/elastic/elastic-agent/pkg/testing/tools"
+	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+var defaultTextCfgUnprivileged = `
+outputs:
+  default:
+    type: elasticsearch
+    hosts: [127.0.0.1:9200]
+    api_key: "example-key"
+    preset: balanced
+    allow_older_versions: true
+
+inputs:
+  - type: nginx/metrics
+    id: unique-system-metrics-input
+    data_stream.namespace: default
+    use_output: default
+    streams:
+      - metricsets:
+        - stubstatus
+        data_stream:
+			dataset: nginx.stubstatus
+			type: metrics
+
+agent.logging.level: debug
+agent.logging.to_stderr: true
+`
+
+// ExtendedRunner is the main test runner
+type UnprivilegedRunner struct {
+	suite.Suite
+	info                   *define.Info
+	agentFixture           *atesting.Fixture
+	policyID               string
+	policyName             string
+	healthCheckTime        time.Duration
+	healthCheckRefreshTime time.Duration
+}
+
+func TestNginxUnprivileged(t *testing.T) {
+	info := define.Require(t, define.Requirements{
+		Group: "fleet",
+		Stack: &define.Stack{},
+		Local: false, // requires Agent installation
+		Sudo:  true,  // requires Agent installation
+	})
+
+	runner := &UnprivilegedRunner{
+		info:                   info,
+		healthCheckTime:        time.Minute * 5,
+		healthCheckRefreshTime: time.Second * 5,
+	}
+
+	suite.Run(t, runner)
+}
+
+func (runner *UnprivilegedRunner) SetupSuite() {
+	fixture, err := define.NewFixtureFromLocalBuild(runner.T(), define.Version())
+	require.NoError(runner.T(), err)
+	runner.agentFixture = fixture
+
+	policyUUID := uuid.Must(uuid.NewV4()).String()
+	basePolicy := kibana.AgentPolicy{
+		Name:        "test-policy-" + policyUUID,
+		Namespace:   "default",
+		Description: "Test policy " + policyUUID,
+		MonitoringEnabled: []kibana.MonitoringEnabledOption{
+			kibana.MonitoringEnabledLogs,
+			kibana.MonitoringEnabledMetrics,
+		},
+	}
+
+	installOpts := atesting.InstallOpts{
+		NonInteractive: true,
+		Force:          true,
+		Privileged:     true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	// write a default config file that enables monitoring
+	err = runner.agentFixture.WriteFileToWorkDir(ctx, defaultTextCfgUnprivileged, "elastic-agent.yml")
+	require.NoError(runner.T(), err)
+
+	policyResp, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
+	require.NoError(runner.T(), err)
+
+	runner.policyID = policyResp.ID
+	runner.policyName = basePolicy.Name
+
+	_, err = tools.InstallPackageFromDefaultFile(ctx, runner.info.KibanaClient, "system", "1.53.1", "system_integration_setup.json", uuid.Must(uuid.NewV4()).String(), policyResp.ID)
+	require.NoError(runner.T(), err)
+}
+
+func (runner *UnprivilegedRunner) TestComponentHealth() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
+	defer cancel()
+
+	runner.AllComponentsHealthy(ctx)
+
+}
+
+// AllComponentsHealthy ensures all the beats and agent are healthy and working before we continue
+func (runner *UnprivilegedRunner) AllComponentsHealthy(ctx context.Context) {
+	compDebugName := ""
+	require.Eventually(runner.T(), func() bool {
+		allHealthy := true
+		status, err := runner.agentFixture.ExecStatus(ctx)
+		if err != nil {
+			runner.T().Logf("agent status returned an error: %v", err)
+			return false
+		}
+
+		for _, comp := range status.Components {
+			runner.T().Logf("component state: %s", comp.Message)
+			if comp.State != int(cproto.State_HEALTHY) {
+				compDebugName = comp.Name
+				allHealthy = false
+			}
+		}
+		return allHealthy
+	}, runner.healthCheckTime, runner.healthCheckRefreshTime, "install never became healthy: components did not return a healthy state: %s", compDebugName)
+}

--- a/testing/integration/unprivileged_test.go
+++ b/testing/integration/unprivileged_test.go
@@ -6,6 +6,8 @@ package integration
 
 import (
 	"context"
+	"os"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -19,29 +21,57 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-var defaultTextCfgUnprivileged = `
-outputs:
-  default:
-    type: elasticsearch
-    hosts: [127.0.0.1:9200]
-    api_key: "example-key"
-    preset: balanced
-    allow_older_versions: true
+// var defaultTextCfgUnprivileged = `
+// outputs:
+//   default:
+//     type: elasticsearch
+//     hosts: [127.0.0.1:9200]
+//     api_key: "example-key"
+//     preset: balanced
+//     allow_older_versions: true
 
-inputs:
-  - type: nginx/metrics
-    id: unique-system-metrics-input
-    data_stream.namespace: default
-    use_output: default
-    streams:
-      - metricsets:
-        - stubstatus
-        data_stream:
-			dataset: nginx.stubstatus
-			type: metrics
+// inputs:
+//   - type: nginx/metrics
+//     id: unique-system-metrics-input
+//     data_stream.namespace: default
+//     use_output: default
+//     streams:
+//       - metricsets:
+//         - stubstatus
+//         data_stream.dataset: nginx.stubstatus
+//         data_stream.type: metrics
 
-agent.logging.level: debug
-agent.logging.to_stderr: true
+// agent.logging.level: debug
+// agent.logging.to_stderr: true
+// `
+
+var nginxStatusModule string = `
+
+server {
+  listen 81;
+  server_name localhost;
+
+  access_log off;
+  allow 127.0.0.1;
+  # deny all;
+
+  location /nginx_status {
+    # Choose your status module
+
+    # freely available with open source NGINX
+    stub_status;
+
+    # for open source NGINX < version 1.7.5
+    # stub_status on;
+
+    # available only with NGINX Plus
+    # status;
+
+    # ensures the version information can be retrieved
+    server_tokens on;
+  }
+}
+
 `
 
 // ExtendedRunner is the main test runner
@@ -73,6 +103,19 @@ func TestNginxUnprivileged(t *testing.T) {
 }
 
 func (runner *UnprivilegedRunner) SetupSuite() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "apt-get", "install", "-v", "nginx-full")
+	out, err := cmd.CombinedOutput()
+	require.NoError(runner.T(), err, "error while installing nginx: %s", string(out))
+
+	err = os.WriteFile("/etc/nginx/conf.d/status.conf", []byte(nginxStatusModule), 0750)
+	require.NoError(runner.T(), err)
+
+	cmd = exec.CommandContext(ctx, "nginx", "-s", "reload")
+	out, err = cmd.CombinedOutput()
+	require.NoError(runner.T(), err, "error while reloading nginx: %s", string(out))
+
 	fixture, err := define.NewFixtureFromLocalBuild(runner.T(), define.Version())
 	require.NoError(runner.T(), err)
 	runner.agentFixture = fixture
@@ -94,12 +137,9 @@ func (runner *UnprivilegedRunner) SetupSuite() {
 		Privileged:     true,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-	defer cancel()
-
-	// write a default config file that enables monitoring
-	err = runner.agentFixture.WriteFileToWorkDir(ctx, defaultTextCfgUnprivileged, "elastic-agent.yml")
-	require.NoError(runner.T(), err)
+	// // write a default config file that enables monitoring
+	// err = runner.agentFixture.WriteFileToWorkDir(ctx, defaultTextCfgUnprivileged, "elastic-agent.yml")
+	// require.NoError(runner.T(), err)
 
 	policyResp, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
@@ -107,7 +147,7 @@ func (runner *UnprivilegedRunner) SetupSuite() {
 	runner.policyID = policyResp.ID
 	runner.policyName = basePolicy.Name
 
-	_, err = tools.InstallPackageFromDefaultFile(ctx, runner.info.KibanaClient, "system", "1.53.1", "system_integration_setup.json", uuid.Must(uuid.NewV4()).String(), policyResp.ID)
+	_, err = tools.InstallPackageFromDefaultFile(ctx, runner.info.KibanaClient, "nginx", "1.23.0", "nginx_integration_setup.json", uuid.Must(uuid.NewV4()).String(), policyResp.ID)
 	require.NoError(runner.T(), err)
 }
 
@@ -131,10 +171,16 @@ func (runner *UnprivilegedRunner) AllComponentsHealthy(ctx context.Context) {
 		}
 
 		for _, comp := range status.Components {
-			runner.T().Logf("component state: %s", comp.Message)
+			runner.T().Logf("%s: component state: %s", comp.Name, comp.Message)
 			if comp.State != int(cproto.State_HEALTHY) {
 				compDebugName = comp.Name
 				allHealthy = false
+			}
+			for _, unit := range comp.Units {
+				runner.T().Logf("%s: unit state: %s", unit.UnitID, unit.Message)
+				if unit.State != int(cproto.State_HEALTHY) {
+					allHealthy = false
+				}
 			}
 		}
 		return allHealthy


### PR DESCRIPTION
- Enhancement

## What does this PR do?

- This PR adds test cases covering `unprivileged` mode for nginx metrics integration

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/4818

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->