### PR TITLE
use Stringer to get string values for eaclient Unit types

### DIFF
--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -231,31 +231,15 @@ func (f *FleetGateway) convertToCheckinComponents(components []runtime.Component
 		return nil
 	}
 	stateString := func(s eaclient.UnitState) string {
-		switch s {
-		case eaclient.UnitStateStarting:
-			return "STARTING"
-		case eaclient.UnitStateConfiguring:
-			return "CONFIGURING"
-		case eaclient.UnitStateHealthy:
-			return "HEALTHY"
-		case eaclient.UnitStateDegraded:
-			return fleetStateDegraded
-		case eaclient.UnitStateFailed:
-			return "FAILED"
-		case eaclient.UnitStateStopping:
-			return "STOPPING"
-		case eaclient.UnitStateStopped:
-			return "STOPPED"
+		if state := s.String(); state != "UNKNOWN" {
+			return state
 		}
 		return ""
 	}
 
 	unitTypeString := func(t eaclient.UnitType) string {
-		switch t {
-		case eaclient.UnitTypeInput:
-			return "input"
-		case eaclient.UnitTypeOutput:
-			return "output"
+		if typ := t.String(); typ != "unknown" {
+			return typ
 		}
 		return ""
 	}


### PR DESCRIPTION
## What does this PR do?

This PR simplifies getting string values for Unit type variants by using the fmt.Stringer impl provided by the elastic-agent-client.

Looking at the implementation in elastic-agent-client, it maps the exact same keys to the same strings, except for the 'unknown' variant, which we currently return as an empty string.

https://github.com/elastic/elastic-agent-client/blob/v7.15.0/pkg/client/unit.go#L91-L110
https://github.com/elastic/elastic-agent-client/blob/v7.15.0/pkg/client/unit.go#L27-L36

## Why is it important?

Just a cleanup. I'm not sure if it is better to map the values ourselves.