### PR TITLE
Fix flaky test Test_runDispatcher/gateway_actions_passed

### DIFF
--- a/internal/pkg/agent/application/managed_mode_test.go
+++ b/internal/pkg/agent/application/managed_mode_test.go
@@ -104,7 +104,7 @@ func Test_runDispatcher(t *testing.T) {
 			return dispatcher
 		},
 		flushInterval:  time.Second,
-		contextTimeout: time.Millisecond * 100,
+		contextTimeout: time.Millisecond * 200,
 	}, {
 		name: "no gateway actions, dispatcher is flushed",
 		mockGateway: func(ch chan []fleetapi.Action) *mockGateway {

--- a/internal/pkg/agent/application/managed_mode_test.go
+++ b/internal/pkg/agent/application/managed_mode_test.go
@@ -74,7 +74,8 @@ func Test_runDispatcher(t *testing.T) {
 		name                string
 		mockGateway         func(chan []fleetapi.Action) *mockGateway
 		mockDispatcher      func() *mockDispatcher
-		interval            time.Duration
+		flushInterval       time.Duration
+		contextTimeout      time.Duration
 		skipOnWindowsReason string
 	}{{
 		name: "dispatcher not called",
@@ -87,7 +88,8 @@ func Test_runDispatcher(t *testing.T) {
 			dispatcher := &mockDispatcher{}
 			return dispatcher
 		},
-		interval: time.Second,
+		flushInterval:  time.Second,
+		contextTimeout: time.Millisecond * 100,
 	}, {
 		name: "gateway actions passed",
 		mockGateway: func(ch chan []fleetapi.Action) *mockGateway {
@@ -101,7 +103,8 @@ func Test_runDispatcher(t *testing.T) {
 			dispatcher.On("Dispatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once()
 			return dispatcher
 		},
-		interval: time.Second,
+		flushInterval:  time.Second,
+		contextTimeout: time.Millisecond * 100,
 	}, {
 		name: "no gateway actions, dispatcher is flushed",
 		mockGateway: func(ch chan []fleetapi.Action) *mockGateway {
@@ -115,7 +118,8 @@ func Test_runDispatcher(t *testing.T) {
 			dispatcher.On("Dispatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe() // allow a second call in case there are timing issues in the CI pipeline
 			return dispatcher
 		},
-		interval: time.Millisecond * 60,
+		flushInterval:  time.Millisecond * 60,
+		contextTimeout: time.Millisecond * 100,
 	}}
 
 	for _, tc := range tests {
@@ -130,9 +134,9 @@ func Test_runDispatcher(t *testing.T) {
 			detailsSetter := func(upgradeDetails *details.Details) {}
 			acker := &mockAcker{}
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+			ctx, cancel := context.WithTimeout(context.Background(), tc.contextTimeout)
 			defer cancel()
-			runDispatcher(ctx, dispatcher, gateway, detailsSetter, acker, tc.interval)
+			runDispatcher(ctx, dispatcher, gateway, detailsSetter, acker, tc.flushInterval)
 			assert.Empty(t, ch)
 
 			gateway.AssertExpectations(t)


### PR DESCRIPTION
## What does this PR do?

Fixes flaky test `Test_runDispatcher/gateway_actions_passed` by increasing the timeout from 100ms to 200ms.

The flakiness is a result of a 100 miliseconds not always being enough time to  dispatch the action in the test environment.

The correct way to fix this issue is to run the assertions in an `assert.Eventually` with a longer timeout. Unfortunately, a deficiency in the `testify` testing framework makes it impossible to put the `AssertExpectations` methods in an `assert.Eventually` or `assert.EventuallyWithT` function: https://github.com/stretchr/testify/issues/1414.

The workaround is to increase the context timeout for the `gateway actions passed` test case. I'm increasing it from 100ms to 200ms.

## Why is it important?

Flaky tests are evil!

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

```console
$ go test -v ./internal/pkg/agent/application/ -run Test_runDispatcher
```

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/4777
