### PR TITLE
[Flaky Test] TestComponentBuildHashInDiagnostics improve agent state check

### DIFF
--- a/testing/integration/package_version_test.go
+++ b/testing/integration/package_version_test.go
@@ -117,6 +117,10 @@ func TestComponentBuildHashInDiagnostics(t *testing.T) {
 			return false
 		}
 
+		// the agent might be healthy but waiting its first configuration,
+		// in that case, there would be no components yet. Therefore, ensure
+		// the agent received the policy with components before proceeding with
+		// the test.
 		for _, c := range status.Components {
 			bs, err := json.MarshalIndent(status, "", "  ")
 			if err != nil {
@@ -134,6 +138,11 @@ func TestComponentBuildHashInDiagnostics(t *testing.T) {
 				return false
 			}
 
+			// there is a rare a race condition unlike to happen on a
+			// production scenario where the component is healthy but the
+			// version info delays to update. As the Status command and the
+			// diagnostics fetch this information in the same way, it guarantees
+			// the version info is up-to-date before proceeding with the test.
 			if c.VersionInfo.Meta.Commit == "" {
 				stateBuff.WriteString(fmt.Sprintf(
 					"%s health, but no versionInfo. agent status output: %s",

--- a/testing/integration/package_version_test.go
+++ b/testing/integration/package_version_test.go
@@ -112,7 +112,7 @@ func TestComponentBuildHashInDiagnostics(t *testing.T) {
 
 		if len(status.Components) == 0 {
 			stateBuff.WriteString(fmt.Sprintf(
-				"healty but without components: agent status: %s-%s",
+				"healthy but without components: agent status: %s-%s",
 				client.State(status.State), status.Message))
 			return false
 		}
@@ -121,7 +121,7 @@ func TestComponentBuildHashInDiagnostics(t *testing.T) {
 			bs, err := json.MarshalIndent(status, "", "  ")
 			if err != nil {
 				stateBuff.WriteString(fmt.Sprintf(
-					"%s not health, could not marshal status outptu: %v",
+					"%s not healthy, could not marshal status outptu: %v",
 					c.Name, err))
 				return false
 			}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Improves the agent status check on TestComponentBuildHashInDiagnostics to ensure the agent is healthy and has components.

## Why is it important?

The test is flaky because the test did not account for the absence of components 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

- N/A

## How to test this PR locally

 - run the test with `TEST_RUN_UNTIL_FAILURE` until you're satisfied or it fails again

## Related issues

- Closes #5333

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->