### PR TITLE
Fix minor issues with the test framework guide

### DIFF
--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -38,6 +38,11 @@ version without SNAPSHOT.
 One-time setup is required to run any integration and E2E tests. Run
 `mage integration:auth` to perform this setup.
 
+You'll also need to separately authenticate to [Elastic's docker registry][elastic_docker_registry].
+Go to https://docker-auth.elastic.co/ and authenticate with Okta to receive your credentials.
+
+[elastic_docker_registry]: docker.elastic.co
+
 ### Running the tests
 
 The test are run with mage using the `integration` namespace:
@@ -242,7 +247,7 @@ VM you will have shell connected to it.
 
 ### Credentials for cloud stack/projects
 All cloud deployments and projects can be listed with `mage
-integration:listStacks`, they can be used to manually connect to
+integration:stacks`, they can be used to manually connect to
 Kibana and Elasticsearch.
 
 If you need to manually run tests against any deployments, `mage


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

In the integration test framework guide, mention that authenticating with Elastic's docker registry is necessary to run integration tests. Change `integration:listStacks` to `integration:stacks`.

## Related issues

- https://github.com/elastic/ingest-dev/issues/3759
