### PR TITLE
[CI] Correct Go version when running the coverage report

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -171,7 +171,7 @@ steps:
     artifact_paths:
       - "build/TEST-go-unit.cov"
     agents:
-      image: "golang:1.20.10"
+      image: "golang:1.22.6"
     depends_on:
       - unit-tests
       - extended-windows


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Updates the coverage report step to use the proper Golang version

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

I am not sure if this is related, but recent builds show that the `golang.org/x/tools/cover` suddenly fails when pulling.

We should ensure the version is pulled from the right place `.go-version` or similar.  This is not in scope in this PR, this is to help unblock main.
