### PR TITLE
Run DRA steps for *.x branches as well

### DIFF
--- a/.buildkite/pipeline.elastic-agent-binary-dra.yml
+++ b/.buildkite/pipeline.elastic-agent-binary-dra.yml
@@ -10,7 +10,7 @@ env:
 steps:
   - group: ":beats: DRA Elastic-Agent Core Snapshot :beats:"
     key: "dra-core-snapshot"
-    if: build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_SNAPSHOT") == "true"
+    if: build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/ || build.env("RUN_SNAPSHOT") == "true"
     steps:
     - label: ":package: Build Elastic-Agent Core Snapshot"
       commands:
@@ -43,7 +43,7 @@ steps:
 
   - group: ":beats: DRA Elastic-Agent Core Staging :beats:"
     key: "dra-core-staging"
-    if: build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_STAGING") == "true"
+    if: build.branch =~ /^[0-9]+\.[0-9x]+\$/ || build.env("RUN_STAGING") == "true"
     steps:
     - label: ":package: Build Elastic-Agent Core staging"
       commands:


### PR DESCRIPTION
This PR updates the DRA buildkite pipeline to run steps for _n_.x branches, e.g. `8.x`, in addition to the existing _n.m_ branches (where _n_ and _m_ are digits).