### PR TITLE
Add support for CLI flag for mTLS client certificate key passphrase

### DIFF
--- a/changelog/fragments/1726040648-Add-support-for-passphrase-protected-mTLS-client-certificate-key.yaml
+++ b/changelog/fragments/1726040648-Add-support-for-passphrase-protected-mTLS-client-certificate-key.yaml
@@ -1,0 +1,35 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add support for passphrase protected mTLS client certificate key during install/enroll
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Adds `--elastic-agent-cert-key-passphrase` command line flag for the `install`
+  and `enroll` commands. The new flag accepts a absolute path for a file containing
+  a passphrase to be used to decrypt the mTLS client certificate key.
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -111,6 +111,7 @@ type enrollCmdOption struct {
 	CASha256             []string                   `yaml:"ca_sha256,omitempty"`
 	Certificate          string                     `yaml:"certificate,omitempty"`
 	Key                  string                     `yaml:"key,omitempty"`
+	KeyPassphrasePath    string                     `yaml:"key_passphrase_path,omitempty"`
 	Insecure             bool                       `yaml:"insecure,omitempty"`
 	EnrollAPIKey         string                     `yaml:"enrollment_key,omitempty"`
 	Staging              string                     `yaml:"staging,omitempty"`
@@ -149,8 +150,9 @@ func (e *enrollCmdOption) remoteConfig() (remote.Config, error) {
 	}
 	if e.Certificate != "" || e.Key != "" {
 		tlsCfg.Certificate = tlscommon.CertificateConfig{
-			Certificate: e.Certificate,
-			Key:         e.Key,
+			Certificate:    e.Certificate,
+			Key:            e.Key,
+			PassphrasePath: e.KeyPassphrasePath,
 		}
 	}
 

--- a/internal/pkg/agent/cmd/enroll_cmd_test.go
+++ b/internal/pkg/agent/cmd/enroll_cmd_test.go
@@ -7,12 +7,17 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"sync/atomic"
@@ -22,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/elastic-agent-libs/testing/certutil"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
@@ -113,6 +119,95 @@ func TestEnroll(t *testing.T) {
 		},
 	))
 
+	t.Run("successfully enroll with mTLS and save fleet config in the store", func(t *testing.T) {
+		agentCertPassphrase := "a really secure passphrase"
+		passphrasePath := filepath.Join(t.TempDir(), "passphrase")
+		err := os.WriteFile(
+			passphrasePath,
+			[]byte(agentCertPassphrase),
+			0666)
+		require.NoError(t, err,
+			"could not write agent child certificate key passphrase to temp directory")
+
+		tlsCfg, _, agentCertPathPair, fleetRootPathPair, _ :=
+			mTLSServer(t, agentCertPassphrase)
+
+		mockHandlerCalled := false
+		mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mockHandlerCalled = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`
+{
+    "action": "created",
+    "item": {
+       "id": "a9328860-ec54-11e9-93c4-d72ab8a69391",
+        "active": true,
+        "policy_id": "69f3f5a0-ec52-11e9-93c4-d72ab8a69391",
+        "type": "PERMANENT",
+        "enrolled_at": "2019-10-11T18:26:37.158Z",
+        "user_provided_metadata": {
+						"custom": "customize"
+				},
+        "local_metadata": {
+            "platform": "linux",
+            "version": "8.0.0"
+        },
+        "actions": [],
+        "access_api_key": "my-access-api-key"
+    }
+}`))
+		})
+
+		s := httptest.NewUnstartedServer(mockHandler)
+		s.TLS = tlsCfg
+		s.StartTLS()
+		defer s.Close()
+
+		store := &mockStore{}
+		enrollOptions := enrollCmdOption{
+			CAs:               []string{string(fleetRootPathPair.Cert)},
+			Certificate:       string(agentCertPathPair.Cert),
+			Key:               string(agentCertPathPair.Key),
+			KeyPassphrasePath: passphrasePath,
+
+			URL:                  s.URL,
+			EnrollAPIKey:         "my-enrollment-api-key",
+			UserProvidedMetadata: map[string]interface{}{"custom": "customize"},
+			SkipCreateSecret:     skipCreateSecret,
+			SkipDaemonRestart:    true,
+		}
+		cmd, err := newEnrollCmd(
+			log,
+			&enrollOptions,
+			"",
+			store,
+		)
+		require.NoError(t, err, "could not create enroll command")
+
+		streams, _, _, _ := cli.NewTestingIOStreams()
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		defer cancel()
+
+		err = cmd.Execute(ctx, streams)
+		require.NoError(t, err, "enroll command returned and unexpected error")
+
+		fleetCfg, err := readConfig(store.Content)
+		require.NoError(t, err, "could not read fleet config from store")
+
+		assert.True(t, mockHandlerCalled, "mock handler should have been called")
+		fleetTLS := fleetCfg.Client.Transport.TLS
+
+		require.NotNil(t, fleetTLS, `fleet client TLS config should have been set`)
+		assert.Equal(t, s.URL, fmt.Sprintf("%s://%s",
+			fleetCfg.Client.Protocol, fleetCfg.Client.Host))
+		assert.Equal(t, enrollOptions.CAs, fleetTLS.CAs)
+		assert.Equal(t,
+			enrollOptions.Certificate, fleetTLS.Certificate.Certificate)
+		assert.Equal(t, enrollOptions.Key, fleetTLS.Certificate.Key)
+		assert.Equal(t,
+			enrollOptions.KeyPassphrasePath, fleetTLS.Certificate.PassphrasePath)
+	})
+
 	t.Run("successfully enroll with TLS and save access api key in the store", withTLSServer(
 		func(t *testing.T) *http.ServeMux {
 			mux := http.NewServeMux()
@@ -167,7 +262,7 @@ func TestEnroll(t *testing.T) {
 			defer cancel()
 
 			if err := cmd.Execute(ctx, streams); err != nil {
-				t.Fatalf("enrrol coms returned and unexpected error: %v", err)
+				t.Fatalf("enroll command returned and unexpected error: %v", err)
 			}
 
 			config, err := readConfig(store.Content)
@@ -229,7 +324,7 @@ func TestEnroll(t *testing.T) {
 			defer cancel()
 
 			if err := cmd.Execute(ctx, streams); err != nil {
-				t.Fatalf("enrrol coms returned and unexpected error: %v", err)
+				t.Fatalf("enroll command returned and unexpected error: %v", err)
 			}
 
 			assert.True(t, store.Called)
@@ -522,21 +617,55 @@ func TestValidateEnrollFlags(t *testing.T) {
 	t.Run("no flags", func(t *testing.T) {
 		cmd := newEnrollCommandWithArgs([]string{}, streams)
 		err := validateEnrollFlags(cmd)
-		require.NoError(t, err)
+
+		assert.NoError(t, err)
 	})
 
 	t.Run("service_token and a service_token_path are mutually exclusive", func(t *testing.T) {
+		absPath, err := filepath.Abs("/path/to/token")
+		require.NoError(t, err, "could not get absolute absPath")
+
 		cmd := newEnrollCommandWithArgs([]string{}, streams)
-		err := cmd.Flags().Set("fleet-server-service-token-path", "/path/to/token")
+		err = cmd.Flags().Set("fleet-server-service-token-path", absPath)
 		require.NoError(t, err)
 		err = cmd.Flags().Set("fleet-server-service-token", "token-value")
 		require.NoError(t, err)
+
 		err = validateEnrollFlags(cmd)
-		require.Error(t, err)
+		assert.Error(t, err)
 
 		var agentErr errors.Error
-		require.ErrorAs(t, err, &agentErr)
-		require.Equal(t, errors.TypeConfig, agentErr.Type())
+		assert.ErrorAs(t, err, &agentErr)
+		assert.Equal(t, errors.TypeConfig, agentErr.Type())
+	})
+
+	t.Run("elastic-agent-cert-key does not require key-passphrase", func(t *testing.T) {
+		absPath, err := filepath.Abs("/path/to/elastic-agent-cert-key")
+		require.NoError(t, err, "could not get absolute absPath")
+
+		cmd := newEnrollCommandWithArgs([]string{}, streams)
+		err = cmd.Flags().Set("elastic-agent-cert-key", absPath)
+		require.NoError(t, err, "could not set flag 'elastic-agent-cert-key'")
+
+		err = validateEnrollFlags(cmd)
+
+		assert.NoError(t, err, "validateEnrollFlags should have succeeded")
+	})
+
+	t.Run("elastic-agent-cert-key-passphrase requires certificate and key", func(t *testing.T) {
+		absPath, err := filepath.Abs("/path/to/elastic-agent-cert-key-passphrase")
+		require.NoError(t, err, "could not get absolute absPath")
+
+		cmd := newEnrollCommandWithArgs([]string{}, streams)
+		err = cmd.Flags().Set("elastic-agent-cert-key-passphrase", absPath)
+		require.NoError(t, err, "could not set flag 'elastic-agent-cert-key-passphrase'")
+
+		err = validateEnrollFlags(cmd)
+
+		assert.Error(t, err, "validateEnrollFlags should not accept only --elastic-agent-cert-key-passphrase")
+		var agentErr errors.Error
+		assert.ErrorAs(t, err, &agentErr)
+		assert.Equal(t, errors.TypeConfig, agentErr.Type())
 	})
 }
 
@@ -642,6 +771,81 @@ func withTLSServer(
 		go s.ServeTLS(listener, "", "") //nolint:errcheck // not required
 
 		test(t, ca.Crt(), "localhost:"+strconv.Itoa(port))
+	}
+}
+
+// mTLSServer generates the necessary certificates and tls.Config for a mTLS
+// server. If agentPassphrase is given, it'll encrypt the agent's client
+// certificate key.
+// It returns the *tls.Config to be used with httptest.NewUnstartedServer,
+// the agentRootPair, agentChildPair, fleetRootPathPair, fleetCertPathPair.
+// Theirs Cert and Key values are the path to the respective certificate and
+// certificate key in PEM format.
+func mTLSServer(t *testing.T, agentPassphrase string) (
+	*tls.Config, certutil.Pair, certutil.Pair, certutil.Pair, certutil.Pair) {
+
+	dir := t.TempDir()
+
+	// generate certificates
+	agentRootPair, agentCertPair, err := certutil.NewRootAndChildCerts()
+	require.NoError(t, err, "could not create agent's root CA and child certificate")
+
+	// encrypt keys if needed
+	if agentPassphrase != "" {
+		agentChildDERKey, _ := pem.Decode(agentCertPair.Key)
+		require.NoError(t, err, "could not create tls.Certificates from child certificate")
+
+		encPem, err := x509.EncryptPEMBlock( //nolint:staticcheck // we need to drop support for this, but while we don't, it needs to be tested.
+			rand.Reader,
+			"EC PRIVATE KEY",
+			agentChildDERKey.Bytes,
+			[]byte(agentPassphrase),
+			x509.PEMCipherAES128)
+		require.NoError(t, err, "failed encrypting agent child certificate key block")
+
+		agentCertPair.Key = pem.EncodeToMemory(encPem)
+	}
+
+	agentRootPathPair := savePair(t, dir, "agent_ca", agentRootPair)
+	agentCertPathPair := savePair(t, dir, "agent_cert", agentCertPair)
+
+	fleetRootPair, fleetChildPair, err := certutil.NewRootAndChildCerts()
+	require.NoError(t, err, "could not create fleet-server's root CA and child certificate")
+	fleetRootPathPair := savePair(t, dir, "fleet_ca", fleetRootPair)
+	fleetCertPathPair := savePair(t, dir, "fleet_cert", fleetChildPair)
+
+	// configure server's TLS
+	fleetRootCertPool := x509.NewCertPool()
+	fleetRootCertPool.AppendCertsFromPEM(fleetRootPair.Cert)
+	cert, err := tls.X509KeyPair(fleetRootPair.Cert, fleetRootPair.Key)
+	require.NoError(t, err, "could not create tls.Certificates from child certificate")
+
+	agentRootCertPool := x509.NewCertPool()
+	agentRootCertPool.AppendCertsFromPEM(agentRootPair.Cert)
+
+	cfg := &tls.Config{ //nolint:gosec // it's just a test
+		RootCAs:      fleetRootCertPool,
+		Certificates: []tls.Certificate{cert},
+		ClientCAs:    agentRootCertPool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+	}
+
+	return cfg, agentRootPathPair, agentCertPathPair, fleetRootPathPair, fleetCertPathPair
+}
+
+// savePair saves the key pair on {dest}/{name}.pem and {dest}/{name}_key.pem
+func savePair(t *testing.T, dest string, name string, pair certutil.Pair) certutil.Pair {
+	certPath := filepath.Join(dest, name+".pem")
+	err := os.WriteFile(certPath, pair.Cert, 0o600)
+	require.NoErrorf(t, err, "could not save %s certificate", name)
+
+	keyPath := filepath.Join(dest, name+"_key.pem")
+	err = os.WriteFile(keyPath, pair.Key, 0o600)
+	require.NoErrorf(t, err, "could not save %s certificate key", name)
+
+	return certutil.Pair{
+		Cert: []byte(certPath),
+		Key:  []byte(keyPath),
 	}
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

It adds support for encrypted client certificate key during install/enroll, which done by the cli flag `--elastic-agent-cert-key-passphrase`.

## Why is it important?

It enables Elastic Agent to be configured with passphrase-protected private keys for client mTLS certificates.
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~


## Author's checklist

**Tests**

- [x] Ensure `--elastic-agent-cert-key-passphrase` adheres to the same requirements as `--fleet-server-cert-key-passphrase`.
- [x] Verify that both `--elastic-agent-cert-key` and `--elastic-agent-cert` are provided when `--elastic-agent-cert-key-passphrase` is present.
- [x] Confirm that `*enrollCmdOption.remoteConfig()` accurately incorporates the passphrase into `tlscommon.CertificateConfig`.
- [x] Validate that `fleetclient.NewWithConfig` generates a valid client capable of establishing an mTLS connection to a mock server.
- [x] Ensure the policy TLS client settings take precedence over the CLI. Extend [`policy with SSL config`](https://github.com/elastic/elastic-agent/blob/8c43ad333837380f1646c3b007ff6339b1593a94/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go#L485) to ensure the client certificate key passphrase from the cli is not left in the config when the policy's client client certificate key is not passphrase-protected.

## Disruptive User Impact

 - None

## How to test this PR locally

 - Build Elastic Agent with the changes from this PR.
 - Enroll/Install the Elastic Agent using passphrase-protected private key for the client mTLS certificate.
 - Start Elastic Agent and observe successful enrollment/installation with mTLS enabled.

## Related issues

- Closes #5489

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->