### PR TITLE
Removed aged out snapshot version

### DIFF
--- a/.agent-versions.json
+++ b/.agent-versions.json
@@ -2,7 +2,6 @@
   "testVersions": [
     "8.15.1-SNAPSHOT",
     "8.15.0",
-    "8.14.4-SNAPSHOT",
     "8.14.3",
     "7.17.24-SNAPSHOT"
   ]


### PR DESCRIPTION
There doesn't exist an `8.14.4-SNAPSHOT` any more.  Consequently, upgrade integration tests have been failing like so:

```
Failed
=== RUN   TestStandaloneUpgrade/Upgrade_8.14.4-SNAPSHOT_to_8.16.0-SNAPSHOT_(unprivileged)
    upgrade_standalone_test.go:68: 
        	Error Trace:	C:/Users/windows/agent/testing/integration/upgrade_standalone_test.go:68
        	            				C:/Users/windows/agent/testing/integration/upgrade_standalone_test.go:47
        	Error:      	Received unexpected error:
        	            	failed to prepare before exec: failed to find artifact URI for version 8.14.4-SNAPSHOT: failed to find snapshot information for version "8.14.4-SNAPSHOT": snapshot for version "8.14.4" not found
        	Test:       	TestStandaloneUpgrade/Upgrade_8.14.4-SNAPSHOT_to_8.16.0-SNAPSHOT_(unprivileged)
--- FAIL: TestStandaloneUpgrade/Upgrade_8.14.4-SNAPSHOT_to_8.16.0-SNAPSHOT_(unprivileged) (0.20s)
```

This PR fixes the problem by removing this version from the list of starting versions used in upgrade integration tests.