### PR TITLE
Update the regex used to identify release branches to include 8.x

### DIFF
--- a/pkg/testing/tools/git/git.go
+++ b/pkg/testing/tools/git/git.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	ErrNotReleaseBranch = errors.New("this is not a release branch")
-	releaseBranchRegexp = regexp.MustCompile(`.*(\d+\.\d+)$`)
+	releaseBranchRegexp = regexp.MustCompile(`.*(\d+\.(\d+|x))$`)
 )
 
 type outputReader func(io.Reader) error
@@ -26,7 +26,7 @@ type outputReader func(io.Reader) error
 // current repository ordered descending by creation date.
 // e.g. 8.13, 8.12, etc.
 func GetReleaseBranches(ctx context.Context) ([]string, error) {
-	c := exec.CommandContext(ctx, "git", "branch", "-r", "--list", "*/[0-9]*.*[0-9]", "--sort=-creatordate")
+	c := exec.CommandContext(ctx, "git", "branch", "-r", "--list", "*/[0-9]*.*[0-9x]", "--sort=-creatordate")
 
 	branchList := []string{}
 	err := runCommand(c, releaseBranchReader(&branchList))
@@ -99,8 +99,8 @@ func extractReleaseBranch(branch string) (string, error) {
 	}
 
 	matches := releaseBranchRegexp.FindStringSubmatch(branch)
-	if len(matches) != 2 {
-		return "", fmt.Errorf("failed to process branch %q: expected 2 matches, got %d", branch, len(matches))
+	if len(matches) != 3 {
+		return "", fmt.Errorf("failed to process branch %q: expected 3 matches, got %d", branch, len(matches))
 	}
 	return matches[1], nil
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Update the regex used to identify release branches

## Why is it important?

Now we have `8.x` which isn't matched by the current regex

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

None

## How to test this PR locally

 - run the unit tests
```sh
go test -v -run TestGetReleaseBranches ./pkg/testing/tools/git
```


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- N/A

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->