### PR TITLE
Rename elastic-agent-wolfi-complete->elastic-agent-complete-wolfi

### DIFF
--- a/dev-tools/mage/dockervariants.go
+++ b/dev-tools/mage/dockervariants.go
@@ -15,7 +15,7 @@ const (
 	ubi           = "ubi"
 	wolfi         = "wolfi"
 	complete      = "complete"
-	wolfiComplete = "wolfi-complete"
+	completeWolfi = "complete-wolfi"
 	cloud         = "cloud"
 )
 
@@ -45,7 +45,7 @@ func (typ DockerVariant) String() string {
 	case Wolfi:
 		return wolfi
 	case WolfiComplete:
-		return wolfiComplete
+		return completeWolfi
 	case Complete:
 		return complete
 	case Cloud:
@@ -71,7 +71,7 @@ func (typ *DockerVariant) UnmarshalText(text []byte) error {
 		*typ = UBI
 	case wolfi:
 		*typ = Wolfi
-	case wolfiComplete:
+	case completeWolfi:
 		*typ = WolfiComplete
 	case complete:
 		*typ = Complete

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -298,7 +298,7 @@ shared:
 
   - &agent_docker_wolfi_complete_spec
     <<: *agent_docker_spec
-    docker_variant: 'wolfi-complete'
+    docker_variant: 'complete-wolfi'
 
   # Deb/RPM spec for community beats.
   - &deb_rpm_spec


### PR DESCRIPTION
To follow the release process convention.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```sh
PLATFORMS=linux/arm64 PACKAGES=docker mage package
```

yields

```
REPOSITORY                                             TAG          IMAGE ID       CREATED         SIZE
docker.elastic.co/beats-ci/elastic-agent-cloud         9.0.0        f0570e7deecb   9 minutes ago   966MB
docker.elastic.co/beats-dev/golang-crossbuild          1.22.6-arm   eae46a040730   2 weeks ago     752MB
docker.elastic.co/beats/elastic-agent                  9.0.0        e5ed4f7a9877   9 minutes ago   660MB
docker.elastic.co/beats/elastic-agent-complete         9.0.0        5dd0cbf7908f   8 minutes ago   2.17GB
docker.elastic.co/beats/elastic-agent-complete-wolfi   9.0.0        01a2d61e4a3b   9 minutes ago   587MB
docker.elastic.co/beats/elastic-agent-ubi              9.0.0        c1043238e8d3   9 minutes ago   657MB
docker.elastic.co/beats/elastic-agent-wolfi            9.0.0        01a2d61e4a3b   9 minutes ago   587MB
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates to https://github.com/elastic/elastic-agent/pull/5475