### PR TITLE
Add pprof endpoints to the monitoring server if enabled

### DIFF
--- a/changelog/fragments/1726740792-pprof-endpoint.yaml
+++ b/changelog/fragments/1726740792-pprof-endpoint.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add pprof endpoints to the monitoring server if enabled
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/monitoring/server_test.go
+++ b/internal/pkg/agent/application/monitoring/server_test.go
@@ -98,18 +98,18 @@ func TestHTTPReloadEnableBehavior(t *testing.T) {
 			t.Logf("starting server...")
 			serverReloader.Start()
 			if testCase.httpOnAtInit {
-				waitOnReturnCode(t, http.StatusOK, "?failon=failed", serverReloader)
+				waitOnReturnCode(t, http.StatusOK, "liveness", "?failon=failed", serverReloader)
 			} else {
-				waitOnReturnCode(t, http.StatusNotFound, "?failon=failed", serverReloader)
+				waitOnReturnCode(t, http.StatusNotFound, "liveness", "?failon=failed", serverReloader)
 			}
 
 			err = serverReloader.Reload(testCase.secondConfig)
 			require.NoError(t, err)
 
 			if testCase.httpOnAfterReload {
-				waitOnReturnCode(t, http.StatusOK, "?failon=failed", serverReloader)
+				waitOnReturnCode(t, http.StatusOK, "liveness", "?failon=failed", serverReloader)
 			} else {
-				waitOnReturnCode(t, http.StatusNotFound, "?failon=failed", serverReloader)
+				waitOnReturnCode(t, http.StatusNotFound, "liveness", "?failon=failed", serverReloader)
 			}
 
 		})
@@ -132,9 +132,9 @@ func TestBasicLivenessConfig(t *testing.T) {
 	t.Logf("starting server...")
 	serverReloader.Start()
 
-	waitOnReturnCode(t, http.StatusInternalServerError, "?failon=degraded", serverReloader)
+	waitOnReturnCode(t, http.StatusInternalServerError, "liveness", "?failon=degraded", serverReloader)
 
-	waitOnReturnCode(t, http.StatusOK, "?failon=failed", serverReloader)
+	waitOnReturnCode(t, http.StatusOK, "liveness", "?failon=failed", serverReloader)
 
 	t.Logf("stopping server...")
 	err = serverReloader.Stop()
@@ -142,14 +142,41 @@ func TestBasicLivenessConfig(t *testing.T) {
 
 }
 
-func waitOnReturnCode(t *testing.T, expectedReturnCode int, formValue string, rel *reload.ServerReloader) {
+func TestPprofEnabled(t *testing.T) {
+	_ = logp.DevelopmentSetup()
+	testAPIConfig := api.Config{}
+	testConfig := config.MonitoringConfig{
+		Enabled: true,
+		HTTP: &config.MonitoringHTTPConfig{
+			Enabled: true,
+			Port:    0,
+		},
+		Pprof: &config.PprofConfig{
+			Enabled: true,
+		},
+	}
+	serverReloader, err := NewServer(logp.L(), testAPIConfig, nil, nil, fakeCoordCfg, "linux", &testConfig)
+	require.NoError(t, err)
+
+	t.Logf("starting server...")
+	serverReloader.Start()
+
+	waitOnReturnCode(t, http.StatusOK, "debug/pprof/", "", serverReloader)
+
+	t.Logf("stopping server...")
+	err = serverReloader.Stop()
+	require.NoError(t, err)
+
+}
+
+func waitOnReturnCode(t *testing.T, expectedReturnCode int, path string, formValue string, rel *reload.ServerReloader) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 	client := &http.Client{}
 	fastEventually(t, func() bool {
-		path := fmt.Sprintf("http://%s/liveness%s", rel.Addr().String(), formValue)
-		t.Logf("checking %s", path)
-		req, err := http.NewRequestWithContext(ctx, "GET", path, nil)
+		url := fmt.Sprintf("http://%s/%s%s", rel.Addr().String(), path, formValue)
+		t.Logf("checking %s", url)
+		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 		require.NoError(t, err)
 
 		resp, err := client.Do(req)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Adds pprof endpoints to the monitoring server if they're enabled in the config.

## Why is it important?

The [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-monitoring-configuration.html) claims this should work, and it not working is a bug. And in general, these endpoints are quite useful and provide functionality diagnostics don't.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
~~- [ ] I have added an integration test or an E2E test~~

## How to test this PR locally

I added a simple unit test. You can also just start the agent with pprof enabled and verify the endpoints exist at `/debug/pprof/`.


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->