### PR TITLE
Fix the complete image for Wolfi

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -239,7 +239,7 @@ RUN for iter in {1..10}; do \
     (exit $exit_code)
 {{- end }}
 
-{{- if (and (eq .Variant "wolfi-complete") (contains .from "wolfi"))  }}
+{{- if (and (eq .Variant "complete-wolfi") (contains .from "wolfi"))  }}
 USER root
 # Install required dependencies from wolfi repository
 RUN for iter in {1..10}; do \


### PR DESCRIPTION
There was a missed rename in https://github.com/elastic/elastic-agent/pull/5557

Testing:

```
PLATFORMS=linux/arm64 PACKAGES=docker mage package
```

Then get shell and check the dependencies for Synthetics are there:

```
docker run -it --rm --entrypoint bash docker.elastic.co/beats/elastic-agent-complete-wolfi:9.0.0
ls -lah ~/.npm/bin
```