### PR TITLE
[CI] Soft fail merge coverage reports step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -176,7 +176,7 @@ steps:
       - unit-tests
       - extended-windows
     allow_dependency_failure: true
-    soft_fail: true # See https://github.com/elastic/ingest-dev/issues/4042"
+    soft_fail: true # Until https://github.com/elastic/ingest-dev/issues/4042 is resolved
 
   - group: "K8s tests"
     key: "k8s-tests"
@@ -213,6 +213,7 @@ steps:
     retry:
       manual:
         allowed: true
+    soft_fail: true # Until https://github.com/elastic/ingest-dev/issues/4042 is resolved
 
   # Triggers a dynamic step: Sync K8s
   # Runs only on main and if k8s files are changed

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -176,6 +176,7 @@ steps:
       - unit-tests
       - extended-windows
     allow_dependency_failure: true
+    skip: "See https://github.com/elastic/ingest-dev/issues/4042"
 
   - group: "K8s tests"
     key: "k8s-tests"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -176,7 +176,7 @@ steps:
       - unit-tests
       - extended-windows
     allow_dependency_failure: true
-    skip: "See https://github.com/elastic/ingest-dev/issues/4042"
+    soft_fail: true # See https://github.com/elastic/ingest-dev/issues/4042"
 
   - group: "K8s tests"
     key: "k8s-tests"

--- a/.buildkite/scripts/steps/merge.sh
+++ b/.buildkite/scripts/steps/merge.sh
@@ -4,6 +4,7 @@
 # Usage: merge.sh <step1> <step2> ... Where <step> is the id of the step that contains the coverage artifact.#  
 
 set -euo pipefail
+set -x # for debugging
 
 COV_ARTIFACT="coverage.out"
 MERGED_COV_FILE="build/TEST-go-unit.cov"


### PR DESCRIPTION
## What does this PR do?

This PR makes it so that if the "Merge coverage reports" step (`key: merge-coverage`) in CI fails, we don't fail the build.  Since the SonarQube step depends on the `merge-coverage` step, we similarly don't fail the build if that step fails too, which is expected to happen if the `merge-coverage` step doesn't succeed.

## Why is it important?

We've observed that in some Agent PRs ([example](https://github.com/elastic/elastic-agent/pull/5547/)), if the "Merge coverage reports" step is retried, it fails like so:

```
$  .buildkite/scripts/steps/merge.sh unit-tests-2204 unit-tests-2204-arm64 unit-tests-win2016 unit-tests-win2022 unit-tests-macos-13 unit-tests-win10 unit-tests-win11
--
  | go: downloading github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
  | go: finding module for package golang.org/x/tools/cover
  | go: downloading golang.org/x/tools v0.25.0
  | go: found golang.org/x/tools/cover in golang.org/x/tools v0.25.0
  | 2024-09-20 15:54:06 INFO   Searching for artifacts: "coverage.out" within step: "unit-tests-2204"
  | 2024-09-20 15:54:06 INFO   Found 1 artifacts. Starting to download to: /buildkite/builds/bk-agent-prod-k8s-1726847620841271029/elastic/elastic-agent/unit-tests-2204
  | 2024-09-20 15:54:06 INFO   Successfully downloaded "coverage.out" 7.6 MiB
  | 2024-09-20 15:54:06 INFO   Searching for artifacts: "coverage.out" within step: "unit-tests-2204-arm64"
  | 2024-09-20 15:54:07 INFO   Found 1 artifacts. Starting to download to: /buildkite/builds/bk-agent-prod-k8s-1726847620841271029/elastic/elastic-agent/unit-tests-2204-arm64
  | 2024-09-20 15:54:07 INFO   Successfully downloaded "coverage.out" 7.6 MiB
  | 2024-09-20 15:54:07 INFO   Searching for artifacts: "coverage.out" within step: "unit-tests-win2016"
  | 2024-09-20 15:54:07 INFO   Found 1 artifacts. Starting to download to: /buildkite/builds/bk-agent-prod-k8s-1726847620841271029/elastic/elastic-agent/unit-tests-win2016
  | 2024-09-20 15:54:08 INFO   Successfully downloaded "coverage.out" 7.6 MiB
  | 2024-09-20 15:54:08 INFO   Searching for artifacts: "coverage.out" within step: "unit-tests-win2022"
  | 2024-09-20 15:54:08 INFO   Found 1 artifacts. Starting to download to: /buildkite/builds/bk-agent-prod-k8s-1726847620841271029/elastic/elastic-agent/unit-tests-win2022
  | 2024-09-20 15:54:09 INFO   Successfully downloaded "coverage.out" 7.6 MiB
  | 2024-09-20 15:54:09 INFO   Searching for artifacts: "coverage.out" within step: "unit-tests-macos-13"
  | 2024-09-20 15:54:09 INFO   Found 1 artifacts. Starting to download to: /buildkite/builds/bk-agent-prod-k8s-1726847620841271029/elastic/elastic-agent/unit-tests-macos-13
  | 2024-09-20 15:54:09 INFO   Successfully downloaded "coverage.out" 7.6 MiB
  | 2024-09-20 15:54:09 INFO   Searching for artifacts: "coverage.out" within step: "unit-tests-win10"
  | 2024-09-20 15:54:09 INFO   Found 1 artifacts. Starting to download to: /buildkite/builds/bk-agent-prod-k8s-1726847620841271029/elastic/elastic-agent/unit-tests-win10
  | 2024-09-20 15:54:10 INFO   Successfully downloaded "coverage.out" 7.6 MiB
  | 2024-09-20 15:54:10 INFO   Searching for artifacts: "coverage.out" within step: "unit-tests-win11"
  | 2024-09-20 15:54:10 INFO   Found 1 artifacts. Starting to download to: /buildkite/builds/bk-agent-prod-k8s-1726847620841271029/elastic/elastic-agent/unit-tests-win11
  | 2024-09-20 15:54:11 INFO   Successfully downloaded "coverage.out" 7.6 MiB
  | 2024/09/20 15:54:11 OVERLAP BEFORE: github.com/elastic/elastic-agent/internal/pkg/agent/cmd/run.go {132 40 134 3 1 0} {133 2 133 40 1 0}
  | 🚨 Error: The command exited with status 1
  | user command error: exit status 1
```

For now, we're temporarily going to skip this step while we investigate the root cause and failure separately.
