### PR TITLE
add kubernetes v1.31 to test matrix

### DIFF
--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -106,7 +106,7 @@ steps:
   - label: "Kubernetes Integration tests"
     key: "k8s-integration-tests"
     env:
-      K8S_VERSION: "v1.30.2"
+      K8S_VERSION: "v1.31.0"
       KIND_VERSION: "v0.20.0"
     command: ".buildkite/scripts/steps/k8s-extended-tests.sh"
     artifact_paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -191,10 +191,10 @@ steps:
         matrix:
           setup:
             k8s_version:
+              - "1.31.0"
               - "1.30.0"
               - "1.29.4"
               - "1.28.9"
-              - "1.27.13"
         retry:
           manual:
             allowed: true

--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -77,7 +77,7 @@ between, and it can be very specific or not very specific.
 - `TEST_PLATFORMS="linux/amd64/ubuntu/20.04 mage integration:test` to execute tests only on Ubuntu 20.04 ARM64.
 - `TEST_PLATFORMS="windows/amd64/2022 mage integration:test` to execute tests only on Windows Server 2022.
 - `TEST_PLATFORMS="linux/amd64 windows/amd64/2022 mage integration:test` to execute tests on Linux AMD64 and Windows Server 2022.
-- `TEST_PLATFORMS="kubernetes/arm64/1.30.2/wolfi" mage integration:kubernetes` to execute kubernetes tests on Kubernetes version 1.30.2 with wolfi docker variant.
+- `TEST_PLATFORMS="kubernetes/arm64/1.31.0/wolfi" mage integration:kubernetes` to execute kubernetes tests on Kubernetes version 1.31.0 with wolfi docker variant.
 
 > **_NOTE:_**  This only filters down the tests based on the platform. It will not execute a tests on a platform unless
 > the test defines as supporting it.

--- a/pkg/testing/kubernetes/supported.go
+++ b/pkg/testing/kubernetes/supported.go
@@ -18,6 +18,11 @@ var arches = []string{define.AMD64, define.ARM64}
 
 // versions defines the list of supported version of Kubernetes.
 var versions = []define.OS{
+	// Kubernetes 1.31
+	{
+		Type:    define.Kubernetes,
+		Version: "1.31.0",
+	},
 	// Kubernetes 1.30
 	{
 		Type:    define.Kubernetes,


### PR DESCRIPTION
## What does this PR do?

Adds test coverage for kubernetes v1.31.0, released Aug 13 2024.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Related issues

- Relates https://github.com/elastic/observability-dev/issues/3718