### PR TITLE
[helm] support using user-created serviceAccount and clusterRole

### DIFF
--- a/deploy/helm/elastic-agent/examples/eck/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/eck/rendered/manifest.yaml
@@ -11,6 +11,8 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    eck.k8s.elastic.co/license: basic
 ---
 # Source: elastic-agent/templates/agent/service-account.yaml
 apiVersion: v1
@@ -24,6 +26,8 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    eck.k8s.elastic.co/license: basic
 ---
 # Source: elastic-agent/templates/agent/service-account.yaml
 apiVersion: v1
@@ -37,6 +41,8 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    eck.k8s.elastic.co/license: basic
 ---
 # Source: elastic-agent/templates/agent/eck/secret.yaml
 apiVersion: v1
@@ -571,6 +577,8 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    eck.k8s.elastic.co/license: basic
 rules:
   - apiGroups: [ "" ] # "" indicates the core API group
     resources:
@@ -694,6 +702,8 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    eck.k8s.elastic.co/license: basic
 rules:
   - apiGroups: [ "" ] # "" indicates the core API group
     resources:
@@ -926,6 +936,8 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    eck.k8s.elastic.co/license: basic
 rules:
   - apiGroups: [ "" ] # "" indicates the core API group
     resources:
@@ -1007,6 +1019,8 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    eck.k8s.elastic.co/license: basic
 subjects:
   - kind: ServiceAccount
     name: agent-clusterwide-example
@@ -1027,6 +1041,8 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    eck.k8s.elastic.co/license: basic
 subjects:
   - kind: ServiceAccount
     name: agent-ksmsharded-example
@@ -1047,6 +1063,8 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    eck.k8s.elastic.co/license: basic
 subjects:
   - kind: ServiceAccount
     name: agent-pernode-example

--- a/deploy/helm/elastic-agent/examples/fleet-managed/fleet-values.yaml
+++ b/deploy/helm/elastic-agent/examples/fleet-managed/fleet-values.yaml
@@ -9,31 +9,35 @@ agent:
       mode: deployment
       securityContext:
         runAsUser: 0
-      rules:
-        # minimum cluster role ruleset required by agent
-        - apiGroups: [ "" ]
-          resources:
-            - nodes
-            - namespaces
-            - pods
-          verbs:
-            - get
-            - watch
-            - list
-        - apiGroups: [ "apps" ]
-          resources:
-            - replicasets
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups: [ "batch" ]
-          resources:
-            - jobs
-          verbs:
-            - get
-            - list
-            - watch
+      serviceAccount:
+        create: true
+      clusterRole:
+        create: true
+        rules:
+          # minimum cluster role ruleset required by agent
+          - apiGroups: [ "" ]
+            resources:
+              - nodes
+              - namespaces
+              - pods
+            verbs:
+              - get
+              - watch
+              - list
+          - apiGroups: [ "apps" ]
+            resources:
+              - replicasets
+            verbs:
+              - get
+              - list
+              - watch
+          - apiGroups: [ "batch" ]
+            resources:
+              - jobs
+            verbs:
+              - get
+              - list
+              - watch
       providers:
         kubernetes_leaderelection:
           enabled: false

--- a/deploy/helm/elastic-agent/examples/user-cluster-role/README.md
+++ b/deploy/helm/elastic-agent/examples/user-cluster-role/README.md
@@ -1,0 +1,37 @@
+# Example: Kubernetes Integration with User-created cluster role
+
+In this example we define a `nginx` custom integration alongside a custom agent preset defined in [agent-nginx-values.yaml](agent-nginx-values.yaml) including the use of a user-created cluster role. Note that the user is responsible for assigning the correct permissions to the cluster role.
+
+## Prerequisites:
+1. A k8s secret that contains the connection details to an Elasticsearch cluster such as the URL and the API key ([Kibana - Creating API Keys](https://www.elastic.co/guide/en/kibana/current/api-keys.html)):
+    ```console
+    kubectl create secret generic es-api-secret \
+       --from-literal=api_key=... \
+       --from-literal=url=...
+    ```
+
+2. `nginx` integration assets are installed through Kibana
+
+3. Create a cluster role.
+
+    ```console
+    kubectl create clusterrole user-cr --verb=get,list,watch --resource=pods,namespaces,nodes,replicasets,jobs
+    ```
+
+## Run:
+1. Install Helm chart
+    ```console
+    helm install elastic-agent ../../ \
+         -f ./agent-nginx-values.yaml \
+         --set outputs.default.type=ESSecretAuthAPI \
+         --set outputs.default.secretName=es-api-secret
+    ```
+
+2. Install the nginx deployment
+    ```console
+   kubectl apply -f ./nginx.yaml
+    ```
+
+## Validate:
+
+1. The Kibana `nginx`-related dashboards should start showing nginx related data.

--- a/deploy/helm/elastic-agent/examples/user-cluster-role/agent-nginx-values.yaml
+++ b/deploy/helm/elastic-agent/examples/user-cluster-role/agent-nginx-values.yaml
@@ -33,11 +33,15 @@ extraIntegrations:
 agent:
   presets:
     nginx:
+      annotations:
+        elastic-agent.k8s.elastic.co/preset: nginx
       mode: deployment
       securityContext:
         runAsUser: 0
       serviceAccount:
         create: true
+        annotations:
+          elastic-agent.k8s.elastic.co/sa: nginx
       clusterRole:
         create: false
         name: user-cr

--- a/deploy/helm/elastic-agent/examples/user-cluster-role/agent-nginx-values.yaml
+++ b/deploy/helm/elastic-agent/examples/user-cluster-role/agent-nginx-values.yaml
@@ -39,32 +39,8 @@ agent:
       serviceAccount:
         create: true
       clusterRole:
-        create: true
-        rules:
-          # minimum cluster role ruleset required by agent
-          - apiGroups: [ "" ]
-            resources:
-              - nodes
-              - namespaces
-              - pods
-            verbs:
-              - get
-              - watch
-              - list
-          - apiGroups: [ "apps" ]
-            resources:
-              - replicasets
-            verbs:
-              - get
-              - list
-              - watch
-          - apiGroups: [ "batch" ]
-            resources:
-              - jobs
-            verbs:
-              - get
-              - list
-              - watch
+        create: false
+        name: user-cr
       providers:
         kubernetes_leaderelection:
           enabled: false

--- a/deploy/helm/elastic-agent/examples/user-cluster-role/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/user-cluster-role/rendered/manifest.yaml
@@ -1,0 +1,153 @@
+---
+# Source: elastic-agent/templates/agent/service-account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-nginx-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-0.0.1
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.0.0
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: elastic-agent/templates/agent/k8s/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agent-nginx-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-0.0.1
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.0.0
+    app.kubernetes.io/managed-by: Helm
+stringData:
+
+  agent.yml: |-
+    id: agent-nginx-example
+    outputs:
+      default:
+        hosts:
+        - http://elasticsearch:9200
+        password: changeme
+        type: elasticsearch
+        username: elastic
+    secret_references: []
+    inputs:
+      - data_stream:
+          namespace: default
+        id: nginx/metrics-nginx-69240207-6fcc-4d19-aee3-dbf716e3bb0f
+        meta:
+          package:
+            name: nginx
+            version: 1.19.1
+        name: nginx-1
+        package_policy_id: 69240207-6fcc-4d19-aee3-dbf716e3bb0f
+        preset: nginx
+        revision: 1
+        streams:
+        - data_stream:
+            dataset: nginx.stubstatus
+            type: metrics
+          hosts:
+          - http://nginx.default.svc.cluster.local:80
+          id: nginx/metrics-nginx.stubstatus-69240207-6fcc-4d19-aee3-dbf716e3bb0f
+          metricsets:
+          - stubstatus
+          period: 10s
+          server_status_path: /nginx_status
+          tags:
+          - nginx-stubstatus
+        type: nginx/metrics
+        use_output: default
+    providers:
+      kubernetes_leaderelection:
+        enabled: false
+        leader_lease: example-nginx
+---
+# Source: elastic-agent/templates/agent/cluster-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-nginx-example-default
+  labels:
+    helm.sh/chart: elastic-agent-0.0.1
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.0.0
+    app.kubernetes.io/managed-by: Helm
+subjects:
+  - kind: ServiceAccount
+    name: agent-nginx-example
+    namespace: "default"
+roleRef:
+  kind: ClusterRole
+  name: user-cr
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: elastic-agent/templates/agent/k8s/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-nginx-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-0.0.1
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.0.0
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      name: agent-nginx-example
+  template:
+    metadata:
+      labels:
+        name: agent-nginx-example
+      annotations:
+        checksum/config: 99eaac30ab163ab5f4cedbdbf3e6936d34c2b0e2c22dee59947487bab88fcc26
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - -c
+        - /etc/elastic-agent/agent.yml
+        - -e
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: STATE_PATH
+          value: /usr/share/elastic-agent/state
+        image: docker.elastic.co/beats/elastic-agent:9.0.0-SNAPSHOT
+        imagePullPolicy: IfNotPresent
+        name: agent
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /usr/share/elastic-agent/state
+          name: agent-data
+        - mountPath: /etc/elastic-agent/agent.yml
+          name: config
+          readOnly: true
+          subPath: agent.yml
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: agent-nginx-example
+      volumes:
+      - hostPath:
+          path: /etc/elastic-agent/default/agent-nginx-example/state
+          type: DirectoryOrCreate
+        name: agent-data
+      - name: config
+        secret:
+          defaultMode: 292
+          secretName: agent-nginx-example

--- a/deploy/helm/elastic-agent/examples/user-cluster-role/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/user-cluster-role/rendered/manifest.yaml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    elastic-agent.k8s.elastic.co/preset: nginx
+    elastic-agent.k8s.elastic.co/sa: nginx
 ---
 # Source: elastic-agent/templates/agent/k8s/secret.yaml
 apiVersion: v1
@@ -24,6 +27,8 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    elastic-agent.k8s.elastic.co/preset: nginx
 stringData:
 
   agent.yml: |-
@@ -79,6 +84,8 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    elastic-agent.k8s.elastic.co/preset: nginx
 subjects:
   - kind: ServiceAccount
     name: agent-nginx-example
@@ -110,6 +117,7 @@ spec:
         name: agent-nginx-example
       annotations:
         checksum/config: 99eaac30ab163ab5f4cedbdbf3e6936d34c2b0e2c22dee59947487bab88fcc26
+        elastic-agent.k8s.elastic.co/preset: nginx
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/examples/user-service-account/README.md
+++ b/deploy/helm/elastic-agent/examples/user-service-account/README.md
@@ -1,0 +1,30 @@
+# Example: Kubernetes Integration with User-created service account
+
+In this example we install the built-in `kubernetes` integration with the default built-in values, including the use of a user-created service account.
+
+## Prerequisites:
+1. A k8s secret that contains the connection details to an Elasticsearch cluster such as the URL and the API key ([Kibana - Creating API Keys](https://www.elastic.co/guide/en/kibana/current/api-keys.html)):
+    ```console
+    kubectl create secret generic es-api-secret \
+       --from-literal=api_key=... \
+       --from-literal=url=...
+    ```
+
+2. `kubernetes` integration assets installed through Kibana ([Kibana - Install and uninstall Elastic Agent integration assets](https://www.elastic.co/guide/en/fleet/current/install-uninstall-integration-assets.html))
+
+3. A k8s service account
+    ```console
+    kubectl create serviceaccount user-sa
+    ```
+
+## Run:
+```console
+helm install elastic-agent ../../ \
+     -f ./agent-kubernetes-values.yaml \
+     --set outputs.default.type=ESSecretAuthAPI \
+     --set outputs.default.secretName=es-api-secret
+```
+
+## Validate:
+
+1. The Kibana `kubernetes`-related dashboards should start showing up the respective info.

--- a/deploy/helm/elastic-agent/examples/user-service-account/agent-kubernetes-values.yaml
+++ b/deploy/helm/elastic-agent/examples/user-service-account/agent-kubernetes-values.yaml
@@ -8,11 +8,20 @@ agent:
       serviceAccount:
         create: false
         name: user-sa-perNode
+      clusterRole:
+        annotations:
+          elastic-agent.k8s.elastic.co/cr: nginx
     clusterWide:
       serviceAccount:
         create: false
         name: user-sa-clusterWide
+      clusterRole:
+        annotations:
+          elastic-agent.k8s.elastic.co/cr: nginx
     ksmSharded:
       serviceAccount:
         create: false
         name: user-sa-ksmSharded
+      clusterRole:
+        annotations:
+          elastic-agent.k8s.elastic.co/cr: nginx

--- a/deploy/helm/elastic-agent/examples/user-service-account/agent-kubernetes-values.yaml
+++ b/deploy/helm/elastic-agent/examples/user-service-account/agent-kubernetes-values.yaml
@@ -1,0 +1,18 @@
+kubernetes:
+  enabled: true
+
+agent:
+  unprivileged: true
+  presets:
+    perNode:
+      serviceAccount:
+        create: false
+        name: user-sa-perNode
+    clusterWide:
+      serviceAccount:
+        create: false
+        name: user-sa-clusterWide
+    ksmSharded:
+      serviceAccount:
+        create: false
+        name: user-sa-ksmSharded

--- a/deploy/helm/elastic-agent/examples/user-service-account/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/user-service-account/rendered/manifest.yaml
@@ -1,44 +1,5 @@
 ---
-# Source: elastic-agent/templates/agent/service-account.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: agent-clusterwide-example
-  namespace: "default"
-  labels:
-    helm.sh/chart: elastic-agent-0.0.1
-    app.kubernetes.io/name: elastic-agent
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: 9.0.0
-    app.kubernetes.io/managed-by: Helm
----
-# Source: elastic-agent/templates/agent/service-account.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: agent-ksmsharded-example
-  namespace: "default"
-  labels:
-    helm.sh/chart: elastic-agent-0.0.1
-    app.kubernetes.io/name: elastic-agent
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: 9.0.0
-    app.kubernetes.io/managed-by: Helm
----
-# Source: elastic-agent/templates/agent/service-account.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: agent-pernode-example
-  namespace: "default"
-  labels:
-    helm.sh/chart: elastic-agent-0.0.1
-    app.kubernetes.io/name: elastic-agent
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: 9.0.0
-    app.kubernetes.io/managed-by: Helm
----
-# Source: elastic-agent/templates/agent/eck/secret.yaml
+# Source: elastic-agent/templates/agent/k8s/secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -50,12 +11,17 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    eck.k8s.elastic.co/license: basic
 stringData:
+
   agent.yml: |-
     id: agent-clusterwide-example
     outputs:
+      default:
+        hosts:
+        - http://elasticsearch:9200
+        password: changeme
+        type: elasticsearch
+        username: elastic
     secret_references: []
     agent:
       monitoring:
@@ -64,13 +30,6 @@ stringData:
         metrics: true
         namespace: default
         use_output: default
-    providers:
-      kubernetes:
-        node: ${NODE_NAME}
-        scope: cluster
-      kubernetes_leaderelection:
-        enabled: true
-        leader_lease: example-clusterwide
     inputs:
       - data_stream:
           namespace: default
@@ -90,8 +49,15 @@ stringData:
           - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         type: kubernetes/metrics
         use_output: default
+    providers:
+      kubernetes:
+        node: ${NODE_NAME}
+        scope: cluster
+      kubernetes_leaderelection:
+        enabled: true
+        leader_lease: example-clusterwide
 ---
-# Source: elastic-agent/templates/agent/eck/secret.yaml
+# Source: elastic-agent/templates/agent/k8s/secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -103,12 +69,17 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    eck.k8s.elastic.co/license: basic
 stringData:
+
   agent.yml: |-
     id: agent-ksmsharded-example
     outputs:
+      default:
+        hosts:
+        - http://elasticsearch:9200
+        password: changeme
+        type: elasticsearch
+        username: elastic
     secret_references: []
     agent:
       monitoring:
@@ -117,12 +88,6 @@ stringData:
         metrics: true
         namespace: default
         use_output: default
-    providers:
-      kubernetes:
-        enabled: false
-      kubernetes_leaderelection:
-        enabled: false
-        leader_lease: example-ksmsharded
     inputs:
       - data_stream:
           namespace: default
@@ -380,8 +345,14 @@ stringData:
           period: 10s
         type: kubernetes/metrics
         use_output: default
+    providers:
+      kubernetes:
+        enabled: false
+      kubernetes_leaderelection:
+        enabled: false
+        leader_lease: example-ksmsharded
 ---
-# Source: elastic-agent/templates/agent/eck/secret.yaml
+# Source: elastic-agent/templates/agent/k8s/secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -393,12 +364,17 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    eck.k8s.elastic.co/license: basic
 stringData:
+
   agent.yml: |-
     id: agent-pernode-example
     outputs:
+      default:
+        hosts:
+        - http://elasticsearch:9200
+        password: changeme
+        type: elasticsearch
+        username: elastic
     secret_references: []
     agent:
       monitoring:
@@ -407,13 +383,6 @@ stringData:
         metrics: true
         namespace: default
         use_output: default
-    providers:
-      kubernetes:
-        node: ${NODE_NAME}
-        scope: node
-      kubernetes_leaderelection:
-        enabled: false
-        leader_lease: example-pernode
     inputs:
       - data_stream:
           namespace: default
@@ -559,6 +528,13 @@ stringData:
           ssl.verification_mode: none
         type: kubernetes/metrics
         use_output: default
+    providers:
+      kubernetes:
+        node: ${NODE_NAME}
+        scope: node
+      kubernetes_leaderelection:
+        enabled: false
+        leader_lease: example-pernode
 ---
 # Source: elastic-agent/templates/agent/cluster-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1009,7 +985,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount
-    name: agent-clusterwide-example
+    name: user-sa-clusterWide
     namespace: "default"
 roleRef:
   kind: ClusterRole
@@ -1029,7 +1005,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount
-    name: agent-ksmsharded-example
+    name: user-sa-ksmSharded
     namespace: "default"
 roleRef:
   kind: ClusterRole
@@ -1049,16 +1025,16 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount
-    name: agent-pernode-example
+    name: user-sa-perNode
     namespace: "default"
 roleRef:
   kind: ClusterRole
   name: agent-perNode-example-default
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: elastic-agent/templates/agent/eck/daemonset.yaml
-apiVersion: agent.k8s.elastic.co/v1alpha1
-kind: Agent
+# Source: elastic-agent/templates/agent/k8s/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
 metadata:
   name: agent-pernode-example
   namespace: "default"
@@ -1068,100 +1044,117 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    eck.k8s.elastic.co/license: basic
 spec:
-  version: 9.0.0
-  configRef:
-    secretName: agent-pernode-example
-  elasticsearchRefs:
-    - name: elasticsearch-sample
-      namespace: elastic-system
-  daemonSet:
-    podTemplate:
-      spec:
-        automountServiceAccountToken: true
-        containers:
-        - env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: STATE_PATH
-            value: /usr/share/elastic-agent/state
-          - name: ELASTIC_NETINFO
-            value: "false"
-          image: docker.elastic.co/beats/elastic-agent:9.0.0-SNAPSHOT
-          imagePullPolicy: IfNotPresent
-          name: agent
-          resources:
-            limits:
-              memory: 1000Mi
-            requests:
-              cpu: 100m
-              memory: 400Mi
-          securityContext:
-            capabilities:
-              add:
-              - DAC_READ_SEARCH
-              - CHOWN
-              - SETPCAP
-              - SYS_PTRACE
-              drop:
-              - ALL
-            privileged: false
-            runAsGroup: 1000
-            runAsUser: 1000
-          volumeMounts:
-          - mountPath: /hostfs/proc
-            name: proc
-            readOnly: true
-          - mountPath: /hostfs/sys/fs/cgroup
-            name: cgroup
-            readOnly: true
-          - mountPath: /var/lib/docker/containers
-            name: varlibdockercontainers
-            readOnly: true
-          - mountPath: /var/log
-            name: varlog
-            readOnly: true
-          - mountPath: /hostfs/etc
-            name: etc-full
-            readOnly: true
-          - mountPath: /hostfs/var/lib
-            name: var-lib
-            readOnly: true
-        dnsPolicy: ClusterFirstWithHostNet
-        nodeSelector:
-          kubernetes.io/os: linux
-        serviceAccountName: agent-pernode-example
-        volumes:
-        - hostPath:
-            path: /proc
+  selector:
+    matchLabels:
+      name: agent-pernode-example
+  template:
+    metadata:
+      labels:
+        name: agent-pernode-example
+      annotations:
+        checksum/config: 233affcd72143e637a130b5f099c30e194d90042eb00a26512f51c844c65a821
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - -c
+        - /etc/elastic-agent/agent.yml
+        - -e
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: STATE_PATH
+          value: /usr/share/elastic-agent/state
+        - name: ELASTIC_NETINFO
+          value: "false"
+        image: docker.elastic.co/beats/elastic-agent:9.0.0-SNAPSHOT
+        imagePullPolicy: IfNotPresent
+        name: agent
+        resources:
+          limits:
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 400Mi
+        securityContext:
+          capabilities:
+            add:
+            - DAC_READ_SEARCH
+            - CHOWN
+            - SETPCAP
+            - SYS_PTRACE
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 1000
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /hostfs/proc
           name: proc
-        - hostPath:
-            path: /sys/fs/cgroup
+          readOnly: true
+        - mountPath: /hostfs/sys/fs/cgroup
           name: cgroup
-        - hostPath:
-            path: /var/lib/docker/containers
+          readOnly: true
+        - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
-        - hostPath:
-            path: /var/log
+          readOnly: true
+        - mountPath: /var/log
           name: varlog
-        - hostPath:
-            path: /etc
+          readOnly: true
+        - mountPath: /hostfs/etc
           name: etc-full
-        - hostPath:
-            path: /var/lib
+          readOnly: true
+        - mountPath: /hostfs/var/lib
           name: var-lib
+          readOnly: true
+        - mountPath: /usr/share/elastic-agent/state
+          name: agent-data
+        - mountPath: /etc/elastic-agent/agent.yml
+          name: config
+          readOnly: true
+          subPath: agent.yml
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: user-sa-perNode
+      volumes:
+      - hostPath:
+          path: /proc
+        name: proc
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: cgroup
+      - hostPath:
+          path: /var/lib/docker/containers
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/log
+        name: varlog
+      - hostPath:
+          path: /etc
+        name: etc-full
+      - hostPath:
+          path: /var/lib
+        name: var-lib
+      - hostPath:
+          path: /etc/elastic-agent/default/agent-pernode-example/state
+          type: DirectoryOrCreate
+        name: agent-data
+      - name: config
+        secret:
+          defaultMode: 292
+          secretName: agent-pernode-example
 ---
-# Source: elastic-agent/templates/agent/eck/deployment.yaml
-apiVersion: agent.k8s.elastic.co/v1alpha1
-kind: Agent
+# Source: elastic-agent/templates/agent/k8s/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: agent-clusterwide-example
   namespace: "default"
@@ -1171,66 +1164,79 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    eck.k8s.elastic.co/license: basic
 spec:
-  version: 9.0.0
-  configRef:
-    secretName: agent-clusterwide-example
-  elasticsearchRefs:
-    - name: elasticsearch-sample
-      namespace: elastic-system
-  deployment:
-    podTemplate:
-      spec:
-        automountServiceAccountToken: true
-        containers:
-        - env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: STATE_PATH
-            value: /usr/share/elastic-agent/state
-          - name: ELASTIC_NETINFO
-            value: "false"
-          image: docker.elastic.co/beats/elastic-agent:9.0.0-SNAPSHOT
-          imagePullPolicy: IfNotPresent
-          name: agent
-          resources:
-            limits:
-              memory: 800Mi
-            requests:
-              cpu: 100m
-              memory: 400Mi
-          securityContext:
-            capabilities:
-              add:
-              - CHOWN
-              - SETPCAP
-              - DAC_READ_SEARCH
-              - SYS_PTRACE
-              drop:
-              - ALL
-            privileged: false
-            runAsGroup: 1000
-            runAsUser: 1000
-          volumeMounts: null
-        dnsPolicy: ClusterFirstWithHostNet
-        nodeSelector:
-          kubernetes.io/os: linux
-        serviceAccountName: agent-clusterwide-example
-        volumes:
-        - emptyDir: {}
+  selector:
+    matchLabels:
+      name: agent-clusterwide-example
+  template:
+    metadata:
+      labels:
+        name: agent-clusterwide-example
+      annotations:
+        checksum/config: 97e62ed0d731dea2ecadf31b0a7b4160db1b8a253589b7324f3a381af2519591
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - -c
+        - /etc/elastic-agent/agent.yml
+        - -e
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: STATE_PATH
+          value: /usr/share/elastic-agent/state
+        - name: ELASTIC_NETINFO
+          value: "false"
+        image: docker.elastic.co/beats/elastic-agent:9.0.0-SNAPSHOT
+        imagePullPolicy: IfNotPresent
+        name: agent
+        resources:
+          limits:
+            memory: 800Mi
+          requests:
+            cpu: 100m
+            memory: 400Mi
+        securityContext:
+          capabilities:
+            add:
+            - CHOWN
+            - SETPCAP
+            - DAC_READ_SEARCH
+            - SYS_PTRACE
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 1000
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /usr/share/elastic-agent/state
           name: agent-data
+        - mountPath: /etc/elastic-agent/agent.yml
+          name: config
+          readOnly: true
+          subPath: agent.yml
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: user-sa-clusterWide
+      volumes:
+      - emptyDir: {}
+        name: agent-data
+      - name: config
+        secret:
+          defaultMode: 292
+          secretName: agent-clusterwide-example
 ---
-# Source: elastic-agent/templates/agent/eck/statefulset.yaml
-apiVersion: agent.k8s.elastic.co/v1alpha1
-kind: Agent
+# Source: elastic-agent/templates/agent/k8s/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
   name: agent-ksmsharded-example
   namespace: "default"
@@ -1240,100 +1246,113 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    eck.k8s.elastic.co/license: basic
 spec:
-  version: 9.0.0
-  configRef:
-    secretName: agent-ksmsharded-example
-  elasticsearchRefs:
-    - name: elasticsearch-sample
-      namespace: elastic-system
-  statefulSet:
-    podTemplate:
-      spec:
-        automountServiceAccountToken: true
-        containers:
-        - args:
-          - --pod=$(POD_NAME)
-          - --pod-namespace=$(POD_NAMESPACE)
-          env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
-            initialDelaySeconds: 5
-            timeoutSeconds: 5
-          name: kube-state-metrics
-          ports:
-          - containerPort: 8080
-            name: http-metrics
-          - containerPort: 8081
-            name: telemetry
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 8081
-            initialDelaySeconds: 5
-            timeoutSeconds: 5
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 65534
-            seccompProfile:
-              type: RuntimeDefault
-        - env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: STATE_PATH
-            value: /usr/share/elastic-agent/state
-          - name: ELASTIC_NETINFO
-            value: "false"
-          image: docker.elastic.co/beats/elastic-agent:9.0.0-SNAPSHOT
-          imagePullPolicy: IfNotPresent
-          name: agent
-          resources:
-            limits:
-              memory: 800Mi
-            requests:
-              cpu: 100m
-              memory: 400Mi
-          securityContext:
-            capabilities:
-              add:
-              - CHOWN
-              - SETPCAP
-              - DAC_READ_SEARCH
-              - SYS_PTRACE
-              drop:
-              - ALL
-            privileged: false
-            runAsGroup: 1000
-            runAsUser: 1000
-          volumeMounts: null
-        dnsPolicy: ClusterFirstWithHostNet
-        nodeSelector:
-          kubernetes.io/os: linux
-        serviceAccountName: agent-ksmsharded-example
-        volumes:
-        - emptyDir: {}
+  selector:
+    matchLabels:
+      name: agent-ksmsharded-example
+  template:
+    metadata:
+      labels:
+        name: agent-ksmsharded-example
+      annotations:
+        checksum/config: 3b64edf7317419b11b0aef4cd10cad04037b7bc0b6866da25871b47b41c04490
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - --pod=$(POD_NAME)
+        - --pod-namespace=$(POD_NAMESPACE)
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        name: kube-state-metrics
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 8081
+          name: telemetry
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8081
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
+      - args:
+        - -c
+        - /etc/elastic-agent/agent.yml
+        - -e
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: STATE_PATH
+          value: /usr/share/elastic-agent/state
+        - name: ELASTIC_NETINFO
+          value: "false"
+        image: docker.elastic.co/beats/elastic-agent:9.0.0-SNAPSHOT
+        imagePullPolicy: IfNotPresent
+        name: agent
+        resources:
+          limits:
+            memory: 800Mi
+          requests:
+            cpu: 100m
+            memory: 400Mi
+        securityContext:
+          capabilities:
+            add:
+            - CHOWN
+            - SETPCAP
+            - DAC_READ_SEARCH
+            - SYS_PTRACE
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 1000
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /usr/share/elastic-agent/state
           name: agent-data
+        - mountPath: /etc/elastic-agent/agent.yml
+          name: config
+          readOnly: true
+          subPath: agent.yml
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: user-sa-ksmSharded
+      volumes:
+      - emptyDir: {}
+        name: agent-data
+      - name: config
+        secret:
+          defaultMode: 292
+          secretName: agent-ksmsharded-example

--- a/deploy/helm/elastic-agent/examples/user-service-account/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/user-service-account/rendered/manifest.yaml
@@ -547,6 +547,8 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    elastic-agent.k8s.elastic.co/cr: nginx
 rules:
   - apiGroups: [ "" ] # "" indicates the core API group
     resources:
@@ -670,6 +672,8 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    elastic-agent.k8s.elastic.co/cr: nginx
 rules:
   - apiGroups: [ "" ] # "" indicates the core API group
     resources:
@@ -902,6 +906,8 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: 9.0.0
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    elastic-agent.k8s.elastic.co/cr: nginx
 rules:
   - apiGroups: [ "" ] # "" indicates the core API group
     resources:

--- a/deploy/helm/elastic-agent/templates/agent/_helpers.tpl
+++ b/deploy/helm/elastic-agent/templates/agent/_helpers.tpl
@@ -284,10 +284,12 @@ app.kubernetes.io/version: {{ .Values.agent.version}}
 {{- $ := index . 0 -}}
 {{- $preset := index . 1 -}}
 {{- $templateName := index . 2 -}}
-{{- $presetRules := dig "rules" (list) $preset -}}
+{{- if eq ($preset).clusterRole.create true -}}
+{{- $presetClusterRoleRules := dig "rules" (list) ($preset).clusterRole -}}
 {{- $rulesToAdd := get (include $templateName $ | fromYaml) "rules" -}}
-{{- $presetRules = uniq (concat $presetRules $rulesToAdd) -}}
-{{- $_ := set $preset "rules" $presetRules -}}
+{{- $presetClusterRoleRules = uniq (concat $presetClusterRoleRules $rulesToAdd) -}}
+{{- $_ := set ($preset).clusterRole "rules" $presetClusterRoleRules -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "elasticagent.preset.mutate.annotations" -}}

--- a/deploy/helm/elastic-agent/templates/agent/cluster-role-binding.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/cluster-role-binding.yaml
@@ -1,6 +1,6 @@
 {{- include "elasticagent.init" $ -}}
 {{- range $presetName, $presetVal := $.Values.agent.presets -}}
-{{- $serviceAccountName := include "elasticagent.preset.fullname" (list $ $presetName)  -}}
+{{- if or (eq $presetVal.clusterRole.create true) (eq $presetVal.serviceAccount.create true) -}}
 {{/* cluster role binding is not namespace bound so let's try to give it a unique enough name */}}
 {{- $clusterRoleName := printf "agent-%s-%s-%s" $presetName $.Release.Name $.Release.Namespace -}}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12,17 +12,22 @@ metadata:
     {{- with ($presetVal).labels -}}
     {{ toYaml . | nindent 4 }}
     {{- end }}
-  {{- with ($presetVal).annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 subjects:
   - kind: ServiceAccount
-    name: {{ $serviceAccountName }}
+    {{-  if eq $presetVal.serviceAccount.create true }}
+    name: {{ include "elasticagent.preset.fullname" (list $ $presetName) }}
+    {{- else }}
+    name: {{ $presetVal.serviceAccount.name }}
+    {{- end }}
     namespace: {{ $.Release.Namespace | quote }}
 roleRef:
   kind: ClusterRole
+  {{- if eq $presetVal.clusterRole.create true }}
   name: {{ $clusterRoleName }}
+  {{- else }}
+  name: {{ $presetVal.clusterRole.name }}
+  {{- end }}
   apiGroup: rbac.authorization.k8s.io
 ---
+{{- end }}
 {{- end }}

--- a/deploy/helm/elastic-agent/templates/agent/cluster-role-binding.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/cluster-role-binding.yaml
@@ -12,6 +12,10 @@ metadata:
     {{- with ($presetVal).labels -}}
     {{ toYaml . | nindent 4 }}
     {{- end }}
+  {{- with ($presetVal).annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     {{-  if eq $presetVal.serviceAccount.create true }}

--- a/deploy/helm/elastic-agent/templates/agent/cluster-role.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/cluster-role.yaml
@@ -1,5 +1,6 @@
 {{- include "elasticagent.init" $ -}}
 {{- range $presetName, $presetVal := $.Values.agent.presets -}}
+{{- if eq $presetVal.clusterRole.create true -}}
 {{/* cluster role binding is not namespace bound so let's try to give it a unique enough name */}}
 {{- $clusterRoleName := printf "agent-%s-%s-%s" $presetName $.Release.Name $.Release.Namespace -}}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -11,9 +12,9 @@ metadata:
     {{- with ($presetVal).labels -}}
     {{ toYaml . | nindent 4 }}
     {{- end }}
-  {{- with ($presetVal).annotations }}
+  {{- with ($presetVal).clusterRole.annotations -}}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{ toYaml . | nindent 4 }}
   {{- end }}
 rules:
   - apiGroups: [ "" ] # "" indicates the core API group
@@ -84,8 +85,9 @@ rules:
       - get
       - list
       - watch
-  {{- with ($presetVal).rules }}
+  {{- with ($presetVal).clusterRole.rules }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/deploy/helm/elastic-agent/templates/agent/cluster-role.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/cluster-role.yaml
@@ -12,9 +12,11 @@ metadata:
     {{- with ($presetVal).labels -}}
     {{ toYaml . | nindent 4 }}
     {{- end }}
-  {{- with ($presetVal).clusterRole.annotations -}}
+  {{- $presetValAnnotations := ($presetVal).annotations | default dict }}
+  {{- $clusterRoleAnnotations := ($presetVal).clusterRole.annotations | default dict }}
+  {{- with (merge dict $presetValAnnotations $clusterRoleAnnotations) }}
   annotations:
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 rules:
   - apiGroups: [ "" ] # "" indicates the core API group

--- a/deploy/helm/elastic-agent/templates/agent/eck/_pod_template.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/eck/_pod_template.yaml
@@ -13,7 +13,11 @@ template:
     {{- with ($presetVal).hostPID }}
     hostPID: {{ . }}
     {{- end }}
+    {{- if eq (dig "automountServiceAccountToken" true $presetVal) true }}
     automountServiceAccountToken: true
+    {{- else }}
+    automountServiceAccountToken: false
+    {{- end }}
     {{- with ($presetVal).nodeSelector }}
     nodeSelector:
       {{- . | toYaml | nindent 6 }}

--- a/deploy/helm/elastic-agent/templates/agent/eck/_pod_template.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/eck/_pod_template.yaml
@@ -18,7 +18,11 @@ template:
     nodeSelector:
       {{- . | toYaml | nindent 6 }}
     {{- end }}
+    {{- if eq ($presetVal).serviceAccount.create true }}
     serviceAccountName: {{ $agentName }}
+    {{- else }}
+    serviceAccountName: {{ ($presetVal).serviceAccount.name }}
+    {{- end }}
     {{- with ($presetVal).affinity }}
     affinity:
       {{- . | toYaml | nindent 6 }}

--- a/deploy/helm/elastic-agent/templates/agent/k8s/_pod_template.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/k8s/_pod_template.yaml
@@ -13,7 +13,11 @@ template:
     {{- with ($presetVal).hostPID }}
     hostPID: {{ . }}
     {{- end }}
+    {{- if eq (dig "automountServiceAccountToken" true $presetVal) true }}
     automountServiceAccountToken: true
+    {{- else }}
+    automountServiceAccountToken: false
+    {{- end }}
     {{- with ($presetVal).nodeSelector }}
     nodeSelector:
       {{- . | toYaml | nindent 6 }}

--- a/deploy/helm/elastic-agent/templates/agent/k8s/_pod_template.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/k8s/_pod_template.yaml
@@ -18,7 +18,11 @@ template:
     nodeSelector:
       {{- . | toYaml | nindent 6 }}
     {{- end }}
+    {{- if eq ($presetVal).serviceAccount.create true }}
     serviceAccountName: {{ $agentName }}
+    {{- else }}
+    serviceAccountName: {{ ($presetVal).serviceAccount.name }}
+    {{- end }}
     {{- with ($presetVal).affinity }}
     affinity:
       {{- . | toYaml | nindent 6 }}

--- a/deploy/helm/elastic-agent/templates/agent/service-account.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/service-account.yaml
@@ -1,5 +1,6 @@
 {{- include "elasticagent.init" $ -}}
 {{- range $presetName, $presetVal := $.Values.agent.presets -}}
+{{- if eq $presetVal.serviceAccount.create true -}}
 {{- $agentName := include "elasticagent.preset.fullname" (list $ $presetName)  -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -11,9 +12,10 @@ metadata:
     {{- with ($presetVal).labels -}}
     {{ toYaml . | nindent 4 }}
     {{- end }}
-  {{- with ($presetVal).annotations }}
+  {{- with ($presetVal).serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/deploy/helm/elastic-agent/templates/agent/service-account.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/service-account.yaml
@@ -12,7 +12,9 @@ metadata:
     {{- with ($presetVal).labels -}}
     {{ toYaml . | nindent 4 }}
     {{- end }}
-  {{- with ($presetVal).serviceAccount.annotations }}
+  {{- $presetValAnnotations := ($presetVal).annotations | default dict }}
+  {{- $serviceAccountAnnotations := ($presetVal).serviceAccount.annotations | default dict }}
+  {{- with merge dict $presetValAnnotations $serviceAccountAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/deploy/helm/elastic-agent/values.schema.json
+++ b/deploy/helm/elastic-agent/values.schema.json
@@ -1044,29 +1044,11 @@
                         }
                     ]
                 },
-                "rules": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    },
-                    "description": "Rules for the deployment.",
-                    "examples": [
-                        [
-                            {
-                                "apiGroups": [
-                                    ""
-                                ],
-                                "resources": [
-                                    "pods"
-                                ],
-                                "verbs": [
-                                    "get",
-                                    "watch",
-                                    "list"
-                                ]
-                            }
-                        ]
-                    ]
+                "serviceAccount": {
+                    "$ref": "#/definitions/AgentPresetServiceAccount"
+                },
+                "clusterRole": {
+                    "$ref": "#/definitions/AgentPresetClusterRole"
                 },
                 "nodeSelector": {
                     "type": "object",
@@ -1247,7 +1229,173 @@
                 }
             },
             "required": [
-                "mode"
+                "mode",
+                "serviceAccount",
+                "clusterRole"
+            ]
+        },
+        "AgentPresetClusterRole": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Create the cluster role.",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the cluster role to use if create is set to false."
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for the cluster role if create is set to true."
+                },
+                "rules": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    },
+                    "description": "Rules for the cluster role to create if create is set to true.",
+                    "examples": [
+                        [
+                            {
+                                "apiGroups": [
+                                    ""
+                                ],
+                                "resources": [
+                                    "pods"
+                                ],
+                                "verbs": [
+                                    "get",
+                                    "watch",
+                                    "list"
+                                ]
+                            }
+                        ]
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "create": true,
+                    "name": ""
+                }
+            ],
+            "required": [
+                "create"
+            ],
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "create": {
+                                "const": false
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "minLength": 1
+                            }
+                        },
+                        "required": [
+                            "create",
+                            "name"
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "create": {
+                                "const": true
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        },
+                        "required": [
+                            "create"
+                        ]
+                    }
+                }
+            ]
+        },
+        "AgentPresetServiceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Create the service account.",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the service account to use if create is set to false."
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for the service account if create is set to true."
+                }
+            },
+            "examples": [
+                {
+                    "create": true,
+                    "name": ""
+                }
+            ],
+            "required": [
+                "create"
+            ],
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "create": {
+                                "const": false
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "minLength": 1
+                            }
+                        },
+                        "required": [
+                            "create",
+                            "name"
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "create": {
+                                "const": true
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        },
+                        "required": [
+                            "create"
+                        ]
+                    }
+                }
             ]
         },
         "SystemLogsStreamVars": {

--- a/deploy/helm/elastic-agent/values.schema.json
+++ b/deploy/helm/elastic-agent/values.schema.json
@@ -1003,6 +1003,14 @@
                         ]
                     ]
                 },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the deployment.",
+                    "examples": [
+                        true
+                    ],
+                    "default": true
+                },
                 "hostNetwork": {
                     "type": "boolean",
                     "description": "Enable host networking for the deployment.",

--- a/deploy/helm/elastic-agent/values.yaml
+++ b/deploy/helm/elastic-agent/values.yaml
@@ -385,7 +385,6 @@ agent:
     #    extraContainers: []
     #    resources: {}
     #    securityContext: {}
-    #    rules: []
     #    nodeSelector: {}
     #    tolerations: []
     #    topologySpreadConstraints: []
@@ -400,6 +399,10 @@ agent:
     # clusterWide preset is required by the built-in kubernetes integration
     clusterWide:
       mode: deployment
+      serviceAccount:
+        create: true
+      clusterRole:
+        create: true
       resources:
         limits:
           memory: 800Mi
@@ -431,6 +434,10 @@ agent:
     perNode:
       ## required by the built-in kubernetes integration
       mode: daemonset
+      serviceAccount:
+        create: true
+      clusterRole:
+        create: true
       resources:
         limits:
           memory: 1000Mi
@@ -456,6 +463,10 @@ agent:
     ksmSharded:
       ## required by the built-in kubernetes integration
       mode: statefulset
+      serviceAccount:
+        create: true
+      clusterRole:
+        create: true
       resources:
         limits:
           memory: 800Mi


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR introduces the capability for users to bind agent presets with custom service accounts and cluster roles, rather than relying solely on auto-generated or default configurations. This allows greater control over security and permissions for agent interactions. Additionally, it provides support for adding annotations to these bindings, allowing for custom metadata that can be leveraged by observability and monitoring tools to enhance tracking, auditing, and configuration management.

## Why is it important?

This added flexibility ensures that the Helm chart can be better aligned with organizational policies and infrastructure requirements of users.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

N/A
<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

```
mage helm:renderExamples
mage integration:kubernetesMatrix
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/5558 as this PR exposes `automountServiceAccountToken` for each preset which by setting it to false a user can effectively disable kubernetes provider completely 