### PR TITLE
Add daily cron for elastic-agent

### DIFF
--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -95,7 +95,6 @@ steps:
     command: |
       buildkite-agent artifact download build/distributions/** . --step 'package-it'
       .buildkite/scripts/steps/beats_tests.sh
-    # if: "build.env('CRON') == 'yes'"
     agents:
       provider: "gcp"
       machineType: "n1-standard-8"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -47,6 +47,11 @@ spec:
         filter_enabled: true
         filter_condition: >-
           build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
+      schedules:
+        Daily main:
+          branch: main
+          cronline: "0 0 * * 1-5"
+          message: Mon-Fri daily build
       cancel_intermediate_builds: true
       cancel_intermediate_builds_branch_filter: "!main !7.* !8.* !9.*"
       skip_intermediate_builds: true


### PR DESCRIPTION
Adds the [daily cron that was manually configured](https://buildkite.com/elastic/elastic-agent/settings/schedules/621c1260-ba0a-4ab1-874e-0fe8b2a2797b) to the yml config.
