### PR TITLE
feat(otel): add integrations components

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/elastic/go-ucfg v0.8.8
 	github.com/elastic/mock-es v0.0.0-20240712014503-e5b47ece0015
 	github.com/elastic/opentelemetry-collector-components/extension/configintegrationextension v0.0.0
+	github.com/elastic/opentelemetry-collector-components/extension/fileintegrationextension v0.0.0
 	github.com/elastic/opentelemetry-collector-components/processor/elasticinframetricsprocessor v0.11.0
 	github.com/fatih/color v1.16.0
 	github.com/fsnotify/fsnotify v1.7.0
@@ -458,6 +459,7 @@ replace (
 	github.com/dop251/goja => github.com/andrewkroh/goja v0.0.0-20190128172624-dd2ac4456e20
 	github.com/dop251/goja_nodejs => github.com/dop251/goja_nodejs v0.0.0-20171011081505-adff31b136e6
 	github.com/elastic/opentelemetry-collector-components/extension/configintegrationextension => ../../../opentelemetry-collector-components/extension/configintegrationextension
+	github.com/elastic/opentelemetry-collector-components/extension/fileintegrationextension => ../../../opentelemetry-collector-components/extension/fileintegrationextension
 	github.com/elastic/opentelemetry-collector-components/internal/integrations => ../../../opentelemetry-collector-components/internal/integrations
 	// openshift removed all tags from their repo, use the pseudoversion from the release-3.9 branch HEAD
 	// See https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/12d41f40b0d408b0167633d8095160d3343d46ac/go.mod#L38

--- a/go.mod
+++ b/go.mod
@@ -460,11 +460,11 @@ replace (
 	github.com/Shopify/sarama => github.com/elastic/sarama v1.19.1-0.20220310193331-ebc2b0d8eef3
 	github.com/dop251/goja => github.com/andrewkroh/goja v0.0.0-20190128172624-dd2ac4456e20
 	github.com/dop251/goja_nodejs => github.com/dop251/goja_nodejs v0.0.0-20171011081505-adff31b136e6
-	github.com/elastic/opentelemetry-collector-components/extension/configintegrationextension => github.com/jsoriano/opentelemetry-collector-components/extension/configintegrationextension templates
-	github.com/elastic/opentelemetry-collector-components/extension/fileintegrationextension => github.com/jsoriano/opentelemetry-collector-components/extension/fileintegrationextension templates
-	github.com/elastic/opentelemetry-collector-components/internal/integrations => github.com/jsoriano/opentelemetry-collector-components/internal/integrations templates
-	github.com/elastic/opentelemetry-collector-components/processor/integrationprocessor => github.com/jsoriano/opentelemetry-collector-components/processor/integrationprocessor templates
-	github.com/elastic/opentelemetry-collector-components/receiver/integrationreceiver => github.com/jsoriano/opentelemetry-collector-components/receiver/integrationreceiver templates
+	github.com/elastic/opentelemetry-collector-components/extension/configintegrationextension => github.com/jsoriano/opentelemetry-collector-components/extension/configintegrationextension v0.0.0-20240924085621-781f96f74764
+	github.com/elastic/opentelemetry-collector-components/extension/fileintegrationextension => github.com/jsoriano/opentelemetry-collector-components/extension/fileintegrationextension v0.0.0-20240924085621-781f96f74764
+	github.com/elastic/opentelemetry-collector-components/internal/integrations => github.com/jsoriano/opentelemetry-collector-components/internal/integrations v0.0.0-20240924085621-781f96f74764
+	github.com/elastic/opentelemetry-collector-components/processor/integrationprocessor => github.com/jsoriano/opentelemetry-collector-components/processor/integrationprocessor v0.0.0-20240924085621-781f96f74764
+	github.com/elastic/opentelemetry-collector-components/receiver/integrationreceiver => github.com/jsoriano/opentelemetry-collector-components/receiver/integrationreceiver v0.0.0-20240924085621-781f96f74764
 	// openshift removed all tags from their repo, use the pseudoversion from the release-3.9 branch HEAD
 	// See https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/12d41f40b0d408b0167633d8095160d3343d46ac/go.mod#L38
 	github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api v0.0.0-20180801171038-322a19404e37

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/elastic/go-sysinfo v1.14.1
 	github.com/elastic/go-ucfg v0.8.8
 	github.com/elastic/mock-es v0.0.0-20240712014503-e5b47ece0015
+	github.com/elastic/opentelemetry-collector-components/extension/configintegrationextension v0.0.0
 	github.com/elastic/opentelemetry-collector-components/processor/elasticinframetricsprocessor v0.11.0
 	github.com/fatih/color v1.16.0
 	github.com/fsnotify/fsnotify v1.7.0
@@ -182,6 +183,7 @@ require (
 	github.com/elastic/go-windows v1.0.2 // indirect
 	github.com/elastic/gosigar v0.14.3 // indirect
 	github.com/elastic/lunes v0.1.0 // indirect
+	github.com/elastic/opentelemetry-collector-components/internal/integrations v0.0.0 // indirect
 	github.com/elastic/opentelemetry-lib v0.9.0 // indirect
 	github.com/elastic/pkcs8 v1.0.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
@@ -455,6 +457,8 @@ replace (
 	github.com/Shopify/sarama => github.com/elastic/sarama v1.19.1-0.20220310193331-ebc2b0d8eef3
 	github.com/dop251/goja => github.com/andrewkroh/goja v0.0.0-20190128172624-dd2ac4456e20
 	github.com/dop251/goja_nodejs => github.com/dop251/goja_nodejs v0.0.0-20171011081505-adff31b136e6
+	github.com/elastic/opentelemetry-collector-components/extension/configintegrationextension => ../../../opentelemetry-collector-components/extension/configintegrationextension
+	github.com/elastic/opentelemetry-collector-components/internal/integrations => ../../../opentelemetry-collector-components/internal/integrations
 	// openshift removed all tags from their repo, use the pseudoversion from the release-3.9 branch HEAD
 	// See https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/12d41f40b0d408b0167633d8095160d3343d46ac/go.mod#L38
 	github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api v0.0.0-20180801171038-322a19404e37

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/elastic/opentelemetry-collector-components/extension/configintegrationextension v0.0.0
 	github.com/elastic/opentelemetry-collector-components/extension/fileintegrationextension v0.0.0
 	github.com/elastic/opentelemetry-collector-components/processor/elasticinframetricsprocessor v0.11.0
+	github.com/elastic/opentelemetry-collector-components/processor/integrationprocessor v0.0.0
 	github.com/elastic/opentelemetry-collector-components/receiver/integrationreceiver v0.0.0
 	github.com/fatih/color v1.16.0
 	github.com/fsnotify/fsnotify v1.7.0
@@ -462,6 +463,7 @@ replace (
 	github.com/elastic/opentelemetry-collector-components/extension/configintegrationextension => ../../../opentelemetry-collector-components/extension/configintegrationextension
 	github.com/elastic/opentelemetry-collector-components/extension/fileintegrationextension => ../../../opentelemetry-collector-components/extension/fileintegrationextension
 	github.com/elastic/opentelemetry-collector-components/internal/integrations => ../../../opentelemetry-collector-components/internal/integrations
+	github.com/elastic/opentelemetry-collector-components/processor/integrationprocessor => ../../../opentelemetry-collector-components/processor/integrationprocessor
 	github.com/elastic/opentelemetry-collector-components/receiver/integrationreceiver => ../../../opentelemetry-collector-components/receiver/integrationreceiver
 	// openshift removed all tags from their repo, use the pseudoversion from the release-3.9 branch HEAD
 	// See https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/12d41f40b0d408b0167633d8095160d3343d46ac/go.mod#L38

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/elastic/opentelemetry-collector-components/extension/configintegrationextension v0.0.0
 	github.com/elastic/opentelemetry-collector-components/extension/fileintegrationextension v0.0.0
 	github.com/elastic/opentelemetry-collector-components/processor/elasticinframetricsprocessor v0.11.0
+	github.com/elastic/opentelemetry-collector-components/receiver/integrationreceiver v0.0.0
 	github.com/fatih/color v1.16.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-viper/mapstructure/v2 v2.1.0
@@ -461,6 +462,7 @@ replace (
 	github.com/elastic/opentelemetry-collector-components/extension/configintegrationextension => ../../../opentelemetry-collector-components/extension/configintegrationextension
 	github.com/elastic/opentelemetry-collector-components/extension/fileintegrationextension => ../../../opentelemetry-collector-components/extension/fileintegrationextension
 	github.com/elastic/opentelemetry-collector-components/internal/integrations => ../../../opentelemetry-collector-components/internal/integrations
+	github.com/elastic/opentelemetry-collector-components/receiver/integrationreceiver => ../../../opentelemetry-collector-components/receiver/integrationreceiver
 	// openshift removed all tags from their repo, use the pseudoversion from the release-3.9 branch HEAD
 	// See https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/12d41f40b0d408b0167633d8095160d3343d46ac/go.mod#L38
 	github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api v0.0.0-20180801171038-322a19404e37

--- a/go.mod
+++ b/go.mod
@@ -460,11 +460,11 @@ replace (
 	github.com/Shopify/sarama => github.com/elastic/sarama v1.19.1-0.20220310193331-ebc2b0d8eef3
 	github.com/dop251/goja => github.com/andrewkroh/goja v0.0.0-20190128172624-dd2ac4456e20
 	github.com/dop251/goja_nodejs => github.com/dop251/goja_nodejs v0.0.0-20171011081505-adff31b136e6
-	github.com/elastic/opentelemetry-collector-components/extension/configintegrationextension => ../../../opentelemetry-collector-components/extension/configintegrationextension
-	github.com/elastic/opentelemetry-collector-components/extension/fileintegrationextension => ../../../opentelemetry-collector-components/extension/fileintegrationextension
-	github.com/elastic/opentelemetry-collector-components/internal/integrations => ../../../opentelemetry-collector-components/internal/integrations
-	github.com/elastic/opentelemetry-collector-components/processor/integrationprocessor => ../../../opentelemetry-collector-components/processor/integrationprocessor
-	github.com/elastic/opentelemetry-collector-components/receiver/integrationreceiver => ../../../opentelemetry-collector-components/receiver/integrationreceiver
+	github.com/elastic/opentelemetry-collector-components/extension/configintegrationextension => github.com/jsoriano/opentelemetry-collector-components/extension/configintegrationextension templates
+	github.com/elastic/opentelemetry-collector-components/extension/fileintegrationextension => github.com/jsoriano/opentelemetry-collector-components/extension/fileintegrationextension templates
+	github.com/elastic/opentelemetry-collector-components/internal/integrations => github.com/jsoriano/opentelemetry-collector-components/internal/integrations templates
+	github.com/elastic/opentelemetry-collector-components/processor/integrationprocessor => github.com/jsoriano/opentelemetry-collector-components/processor/integrationprocessor templates
+	github.com/elastic/opentelemetry-collector-components/receiver/integrationreceiver => github.com/jsoriano/opentelemetry-collector-components/receiver/integrationreceiver templates
 	// openshift removed all tags from their repo, use the pseudoversion from the release-3.9 branch HEAD
 	// See https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/12d41f40b0d408b0167633d8095160d3343d46ac/go.mod#L38
 	github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api v0.0.0-20180801171038-322a19404e37

--- a/go.sum
+++ b/go.sum
@@ -624,6 +624,16 @@ github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/jsoriano/opentelemetry-collector-components/extension/configintegrationextension v0.0.0-20240924085621-781f96f74764 h1:Q7tI/8Jcf6dpRLalyJ4MgIte/VI20CFcb16WiKwoXps=
+github.com/jsoriano/opentelemetry-collector-components/extension/configintegrationextension v0.0.0-20240924085621-781f96f74764/go.mod h1:SROaTDvX0LohbvGvt4m7Iwj48tOgZ06mhYUOKlhoLHs=
+github.com/jsoriano/opentelemetry-collector-components/extension/fileintegrationextension v0.0.0-20240924085621-781f96f74764 h1:/4sNs8Lli3UxwdHa19lEHSSF4Uy4e/pKmBJQWhQZIK0=
+github.com/jsoriano/opentelemetry-collector-components/extension/fileintegrationextension v0.0.0-20240924085621-781f96f74764/go.mod h1:BJqkIlUI80X91A5ByYzFno9CuH2tG/AdvmF5sKIkMuM=
+github.com/jsoriano/opentelemetry-collector-components/internal/integrations v0.0.0-20240924085621-781f96f74764 h1:Y/x3h2O2MscazdZxBs0aFlPa+kXfBoAJseqXIqAMsiU=
+github.com/jsoriano/opentelemetry-collector-components/internal/integrations v0.0.0-20240924085621-781f96f74764/go.mod h1:MuHMRusvNxwy6QxRkoFbqwahR0pMj62125mThAX1JT0=
+github.com/jsoriano/opentelemetry-collector-components/processor/integrationprocessor v0.0.0-20240924085621-781f96f74764 h1:/AiWKmhQnbo+EWQgkrYyJQ05nOzbfundngdO30HxsF8=
+github.com/jsoriano/opentelemetry-collector-components/processor/integrationprocessor v0.0.0-20240924085621-781f96f74764/go.mod h1:pmUnpSrMZSLwu9EnvPStSL2jAnD1gkmlFKiFymOwEF8=
+github.com/jsoriano/opentelemetry-collector-components/receiver/integrationreceiver v0.0.0-20240924085621-781f96f74764 h1:XQ02Q3slbbruAoRY/P/ULM3H1Wmiv3K0y3eVtoFTfLI=
+github.com/jsoriano/opentelemetry-collector-components/receiver/integrationreceiver v0.0.0-20240924085621-781f96f74764/go.mod h1:QKv/oumN1ZIDJtUjBnWXPvhq/VqqSOuNkNMewv0MiUQ=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/internal/pkg/otel/README.md
+++ b/internal/pkg/otel/README.md
@@ -68,10 +68,12 @@ This section provides a summary of components included in the Elastic Distributi
 
 | Component | Version |
 |---|---|
+| [configintegrationextension](https://github.com/elastic/opentelemetry-collector-components/blob/extension/configintegrationextension/v0.0.0/extension/configintegrationextension/README.md) | v0.0.0 |
 | [healthcheckextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/extension/healthcheckextension/v0.109.0/extension/healthcheckextension/README.md) | v0.109.0 |
 | [pprofextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/extension/pprofextension/v0.109.0/extension/pprofextension/README.md) | v0.109.0 |
 | [filestorage](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/extension/storage/filestorage/v0.109.0/extension/storage/filestorage/README.md) | v0.109.0 |
 | [memorylimiterextension](https://github.com/open-telemetry/opentelemetry-collector/blob/extension/memorylimiterextension/v0.109.0/extension/memorylimiterextension/README.md) | v0.109.0 |
+| [configintegrationextension](https://github.com/elastic/opentelemetry-collector-components/blob/extension/configintegrationextension/=&gt; ../../../opentelemetry-collector-components/extension/configintegrationextension/extension/configintegrationextension/README.md) | =&gt; ../../../opentelemetry-collector-components/extension/configintegrationextension |
 
 ### Connectors
 

--- a/internal/pkg/otel/components.go
+++ b/internal/pkg/otel/components.go
@@ -46,6 +46,7 @@ import (
 	otlphttpexporter "go.opentelemetry.io/collector/exporter/otlphttpexporter"
 
 	// Extensions
+	"github.com/elastic/opentelemetry-collector-components/extension/configintegrationextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension"
 	pprofextension "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension"
 	filestorage "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"
@@ -116,6 +117,7 @@ func components() (otelcol.Factories, error) {
 		filestorage.NewFactory(),
 		healthcheckextension.NewFactory(),
 		pprofextension.NewFactory(),
+		configintegrationextension.NewFactory(),
 	)
 	if err != nil {
 		return otelcol.Factories{}, err

--- a/internal/pkg/otel/components.go
+++ b/internal/pkg/otel/components.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 
 	// Receivers:
+	"github.com/elastic/opentelemetry-collector-components/receiver/integrationreceiver"
 	filelogreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver" // for collecting log files
 	hostmetricsreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver"
 	httpcheckreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver"
@@ -69,6 +70,7 @@ func components() (otelcol.Factories, error) {
 		k8sclusterreceiver.NewFactory(),
 		hostmetricsreceiver.NewFactory(),
 		httpcheckreceiver.NewFactory(),
+		integrationreceiver.NewFactory(),
 		k8sobjectsreceiver.NewFactory(),
 		prometheusreceiver.NewFactory(),
 		jaegerreceiver.NewFactory(),

--- a/internal/pkg/otel/components.go
+++ b/internal/pkg/otel/components.go
@@ -28,6 +28,7 @@ import (
 	otlpreceiver "go.opentelemetry.io/collector/receiver/otlpreceiver"
 
 	// Processors:
+	"github.com/elastic/opentelemetry-collector-components/processor/integrationprocessor"
 	attributesprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor" // for modifying signal attributes
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"
 	k8sattributesprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor" // for adding k8s metadata
@@ -88,6 +89,7 @@ func components() (otelcol.Factories, error) {
 		transformprocessor.NewFactory(),
 		filterprocessor.NewFactory(),
 		k8sattributesprocessor.NewFactory(),
+		integrationprocessor.NewFactory(),
 		elasticinframetricsprocessor.NewFactory(),
 		resourcedetectionprocessor.NewFactory(),
 		memorylimiterprocessor.NewFactory(),

--- a/internal/pkg/otel/components.go
+++ b/internal/pkg/otel/components.go
@@ -47,6 +47,7 @@ import (
 
 	// Extensions
 	"github.com/elastic/opentelemetry-collector-components/extension/configintegrationextension"
+	"github.com/elastic/opentelemetry-collector-components/extension/fileintegrationextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension"
 	pprofextension "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension"
 	filestorage "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"
@@ -118,6 +119,7 @@ func components() (otelcol.Factories, error) {
 		healthcheckextension.NewFactory(),
 		pprofextension.NewFactory(),
 		configintegrationextension.NewFactory(),
+		fileintegrationextension.NewFactory(),
 	)
 	if err != nil {
 		return otelcol.Factories{}, err


### PR DESCRIPTION
This is a "proof of concept" draft pull request, not to be merged.

It adds the following OTel Collector components, as implemented in https://github.com/elastic/opentelemetry-collector-components/pull/96:

- `config_integrations` extension
- `file_integrations` extension
- `integration` receiver
- `integration` processor

I was able to build the agent binary using the command:

```console
go build .
```

After that, I ran the agent in OTel mode with the following command:

```console
./elastic-agent otel --config config.yaml
```

with the following `config.yaml` file:

```yaml
exporters:
  debug:

extensions:
  config_integrations:
  file_integrations:
    path: .

processors:
  integration:
    name: integ2

receivers:
  integration:
    name: integ1

service:
  extensions:
    - config_integrations
    - file_integrations
  pipelines:
    logs:
      exporters:
        - debug
      processors:
        - integration
      receivers:
        - integration
```