### PR TITLE
Handle BUILDKITE_MESSAGE length in pre-command.ps1

### DIFF
--- a/.buildkite/hooks/pre-command.ps1
+++ b/.buildkite/hooks/pre-command.ps1
@@ -1,3 +1,6 @@
+# Shorten BUILDKITE_MESSAGE if needed to avoid filling the Windows env var buffer
+$env:BUILDKITE_MESSAGE = $env:BUILDKITE_MESSAGE.Substring(0, [System.Math]::Min(2048, $env:BUILDKITE_MESSAGE.Length))
+
 # Install gcc TODO: Move to the VM image
 choco install mingw
 Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1


### PR DESCRIPTION
Description of problem:
Windows unit test pre-command steps were failing in CI when the BUILDKITE_MESSAGE param was too long, which would occur when commits had very long descriptions. This sometimes happens from automated processes, such as dependency updates. The BUILDKITE_MESSAGE would be very long, which would fill the Windows env var buffer, preventing further pre-command steps from adding directories to the PATH.
Problem report: https://elastic.slack.com/archives/C0522G6FBNE/p1727193548224399

Fix:
Trim the BUILDKITE_MESSAGE param to the INTERNET_MAX_URL_LENGTH of 2048. 
This was tested in draft PR https://github.com/elastic/elastic-agent/pull/5609 with very long and short commit messages. I confirmed that the Windows unit test steps got past the pre-command phase.

References:
- https://devblogs.microsoft.com/oldnewthing/20100203-00/?p=15083
- https://devblogs.microsoft.com/oldnewthing/20031210-00/?p=41553
- Example of path shortening in shell APIs: https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-pathcreatefromurlw