### PR TITLE
soft_fail on integration tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -272,7 +272,7 @@ steps:
                     - BUILDKITE_PULL_REQUEST=${BUILDKITE_PULL_REQUEST}
                     - BUILDKITE_PULL_REQUEST_BASE_BRANCH=${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
                     - GITHUB_PR_LABELS=${GITHUB_PR_LABELS}
-    soft_fail: true # https://github.com/elastic/ingest-dev/issues/4082
+                soft_fail: true # https://github.com/elastic/ingest-dev/issues/4082
 
   # Trigger for branches
   - label: "Triggering Integration tests for branches"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -272,6 +272,7 @@ steps:
                     - BUILDKITE_PULL_REQUEST=${BUILDKITE_PULL_REQUEST}
                     - BUILDKITE_PULL_REQUEST_BASE_BRANCH=${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
                     - GITHUB_PR_LABELS=${GITHUB_PR_LABELS}
+    soft_fail: true # https://github.com/elastic/ingest-dev/issues/4082
 
   # Trigger for branches
   - label: "Triggering Integration tests for branches"
@@ -280,3 +281,4 @@ steps:
     build:
       commit: "${BUILDKITE_COMMIT}"
       branch: "${BUILDKITE_BRANCH}"
+    soft_fail: true # https://github.com/elastic/ingest-dev/issues/4082


### PR DESCRIPTION
Enable soft_fail on the integration test pipeline steps to temporarily work around the issue in https://elastic.slack.com/archives/C047NDNGUMU/p1727087616173239

Rel: https://github.com/elastic/ingest-dev/issues/4082