### PR TITLE
chore: update kind version to v0.24.0

### DIFF
--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -107,7 +107,7 @@ steps:
     key: "k8s-integration-tests"
     env:
       K8S_VERSION: "v1.31.0"
-      KIND_VERSION: "v0.20.0"
+      KIND_VERSION: "v0.24.0"
     command: ".buildkite/scripts/steps/k8s-extended-tests.sh"
     artifact_paths:
       - "build/k8s-logs*/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -183,7 +183,7 @@ steps:
       - label: "K8s tests: {{matrix.k8s_version}}"
         env:
           K8S_VERSION: "v{{matrix.k8s_version}}"
-          KIND_VERSION: "v0.20.0"
+          KIND_VERSION: "v0.24.0"
         command: ".buildkite/scripts/steps/k8s-tests.sh"
         agents:
           provider: "gcp"


### PR DESCRIPTION
## What does this PR do?

Upgrades the version of [kind](https://kind.sigs.k8s.io/) to the [latest](https://github.com/kubernetes-sigs/kind/releases) (v0.24.0)


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## How to test this PR locally

## Related issues

- Related to https://github.com/elastic/observability-dev/issues/3718