### PR TITLE
fix go vet errors with Go 1.24

### DIFF
--- a/internal/pkg/agent/application/monitoring/handler.go
+++ b/internal/pkg/agent/application/monitoring/handler.go
@@ -48,7 +48,7 @@ func (h *apiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		}
 
-		writeResponse(w, unexpectedErrorWithReason(err.Error()))
+		writeResponse(w, unexpectedErrorWithReason("%s", err.Error()))
 	}
 }
 

--- a/internal/pkg/agent/vault/aesgcm/aesgcm_test.go
+++ b/internal/pkg/agent/vault/aesgcm/aesgcm_test.go
@@ -173,12 +173,12 @@ func TestEncryptDecryptHex(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			enc, err := EncryptHex(tc.key, tc.data)
 			if !errors.Is(tc.err, err) {
-				t.Fatalf(cmp.Diff(tc.err, err))
+				t.Fatal(cmp.Diff(tc.err, err))
 			}
 
 			dec, err := DecryptHex(tc.key, enc)
 			if !errors.Is(tc.err, err) {
-				t.Fatalf(cmp.Diff(tc.err, err))
+				t.Fatal(cmp.Diff(tc.err, err))
 			}
 
 			if len(tc.data) == 0 {

--- a/internal/pkg/cli/confirm.go
+++ b/internal/pkg/cli/confirm.go
@@ -22,14 +22,14 @@ func Confirm(prompt string, def bool) (bool, error) {
 }
 
 func confirm(r io.Reader, out io.Writer, prompt string, def bool) (bool, error) {
-	options := " [Y/n]"
+	options := "[Y/n]"
 	if !def {
-		options = " [y/N]"
+		options = "[y/N]"
 	}
 
 	reader := bufio.NewScanner(r)
 	for {
-		fmt.Fprintf(out, prompt+options+":")
+		fmt.Fprintf(out, "%s %s:", prompt, options)
 
 		if !reader.Scan() {
 			break

--- a/internal/pkg/cli/input.go
+++ b/internal/pkg/cli/input.go
@@ -20,7 +20,7 @@ func ReadInput(prompt string) (string, error) {
 
 func input(r io.Reader, out io.Writer, prompt string) (string, error) {
 	reader := bufio.NewScanner(r)
-	fmt.Fprintf(out, prompt+" ")
+	fmt.Fprintf(out, "%s ", prompt)
 
 	if !reader.Scan() {
 		return "", errors.New("error reading user input")

--- a/pkg/control/v1/client/client.go
+++ b/pkg/control/v1/client/client.go
@@ -7,7 +7,7 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"sync"
 	"time"
 
@@ -165,7 +165,7 @@ func (c *client) Restart(ctx context.Context) error {
 		return err
 	}
 	if res.Status == proto.ActionStatus_V1_FAILURE {
-		return fmt.Errorf(res.Error)
+		return errors.New(res.Error)
 	}
 	return nil
 }
@@ -180,7 +180,7 @@ func (c *client) Upgrade(ctx context.Context, version string, sourceURI string) 
 		return "", err
 	}
 	if res.Status == proto.ActionStatus_V1_FAILURE {
-		return "", fmt.Errorf(res.Error)
+		return "", errors.New(res.Error)
 	}
 	return res.Version, nil
 }

--- a/pkg/control/v2/client/client.go
+++ b/pkg/control/v2/client/client.go
@@ -295,7 +295,7 @@ func (c *client) Restart(ctx context.Context) error {
 		return err
 	}
 	if res.Status == cproto.ActionStatus_FAILURE {
-		return fmt.Errorf(res.Error)
+		return errors.New(res.Error)
 	}
 	return nil
 }
@@ -313,7 +313,7 @@ func (c *client) Upgrade(ctx context.Context, version string, sourceURI string, 
 		return "", err
 	}
 	if res.Status == cproto.ActionStatus_FAILURE {
-		return "", fmt.Errorf(res.Error)
+		return "", errors.New(res.Error)
 	}
 	return res.Version, nil
 }

--- a/pkg/testing/multipass/provisioner.go
+++ b/pkg/testing/multipass/provisioner.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -208,7 +209,7 @@ func (p *provisioner) ensureInstanceNotExist(ctx context.Context, batch common.O
 		p.logger.Logf(msg)
 		p.logger.Logf("output: %s", output.String())
 		p.logger.Logf("stderr: %s", stdErr.String())
-		return fmt.Errorf(msg)
+		return errors.New(msg)
 	}
 	list := struct {
 		List []struct {
@@ -248,7 +249,7 @@ func (p *provisioner) ensureInstanceNotExist(ctx context.Context, batch common.O
 				p.logger.Logf(msg)
 				p.logger.Logf("output: %s", output.String())
 				p.logger.Logf("stderr: %s", stdErr.String())
-				return fmt.Errorf(msg)
+				return errors.New(msg)
 			}
 
 			break


### PR DESCRIPTION
## What does this PR do?

The cmd/vet in Go 1.24 reports printf calls with non-const format and no args, causing failures.

## How to test this PR locally

```
$ go install golang.org/dl/gotip@latest
$ gotip download
$ gotip vet ./...
```

## Related issues

- Related to https://github.com/elastic/elastic-agent-libs/pull/233