### PR TITLE
Revert "Skip flaky integration test - TestAPMConfig"

### DIFF
--- a/testing/integration/apm_propagation_test.go
+++ b/testing/integration/apm_propagation_test.go
@@ -55,9 +55,6 @@ func TestAPMConfig(t *testing.T) {
 		Group: Default,
 		Stack: &define.Stack{},
 	})
-
-	t.Skip("https://github.com/elastic/elastic-agent/issues/5624; apm-server not working correctly")
-
 	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 


### PR DESCRIPTION
Now that the APM server issue on Integration server is resolved we can revert this change.
Reverts elastic/elastic-agent#5625

