### PR TITLE
Shorten allowlist for `replace`able dependencies

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -112,13 +112,8 @@ linters-settings:
     # Forbid any `replace` directives that are intended temporarily only during
     # development. The modules listed below are intended to be replaced permanently.
     replace-allow-list:
-      - github.com/Microsoft/go-winio
       - github.com/Shopify/sarama
-      - github.com/dop251/goja
-      - github.com/dop251/goja_nodejs
-      - github.com/fsnotify/fsnotify
       - github.com/openshift/api
-      - github.com/tonistiigi/fifo
 
   gosimple:
     # Select the Go version to target. The default is '1.13'.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,6 +113,9 @@ linters-settings:
     # development. The modules listed below are intended to be replaced permanently.
     replace-allow-list:
       - github.com/Shopify/sarama
+      - github.com/dop251/goja
+      - github.com/dop251/goja_nodejs
+      - github.com/fsnotify/fsnotify
       - github.com/openshift/api
 
   gosimple:


### PR DESCRIPTION
## What does this PR do?

This PR cleans up the list for allowed dependencies in the `go.mod` `replace` directive.  It removes dependencies from the allowlist that are no longer being `replace`d in `go.mod`.

## Why is it important?

To help minimize the number of dependencies we `replace` with forks.