### PR TITLE
Don't run any agent service when running `otel` subcommand

### DIFF
--- a/internal/pkg/agent/application/application.go
+++ b/internal/pkg/agent/application/application.go
@@ -28,7 +28,6 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/capabilities"
 	"github.com/elastic/elastic-agent/internal/pkg/composable"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
-	"github.com/elastic/elastic-agent/internal/pkg/otel"
 	"github.com/elastic/elastic-agent/internal/pkg/release"
 	"github.com/elastic/elastic-agent/pkg/component"
 	"github.com/elastic/elastic-agent/pkg/component/runtime"
@@ -47,13 +46,11 @@ func New(
 	testingMode bool,
 	fleetInitTimeout time.Duration,
 	disableMonitoring bool,
-	runAsOtel bool,
 	modifiers ...component.PlatformModifier,
 ) (*coordinator.Coordinator, coordinator.ConfigManager, composable.Controller, error) {
 
 	err := version.InitVersionError()
-	if err != nil && !runAsOtel {
-		// ignore this error when running in otel mode
+	if err != nil {
 		// non-fatal error, log a warning and move on
 		log.With("error.message", err).Warnf("Error initializing version information: falling back to %s", release.Version())
 	}
@@ -92,13 +89,7 @@ func New(
 		log.Infof("Loading baseline config from %v", pathConfigFile)
 		rawConfig, err = config.LoadFile(pathConfigFile)
 		if err != nil {
-			if !runAsOtel {
-				return nil, nil, nil, fmt.Errorf("failed to load configuration: %w", err)
-			}
-
-			// initialize with empty config, configuration file is not necessary in otel mode,
-			// best effort is fine
-			rawConfig = config.New()
+			return nil, nil, nil, fmt.Errorf("failed to load configuration: %w", err)
 		}
 	}
 	if err := info.InjectAgentConfig(rawConfig); err != nil {
@@ -124,7 +115,6 @@ func New(
 		tracer,
 		monitor,
 		cfg.Settings.GRPC,
-		runAsOtel,
 	)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to initialize runtime manager: %w", err)
@@ -141,9 +131,6 @@ func New(
 
 		// testing mode uses a config manager that takes configuration from over the control protocol
 		configMgr = newTestingModeConfigManager(log)
-	} else if runAsOtel {
-		// ignoring configuration in elastic-agent.yml
-		configMgr = otel.NewOtelModeConfigManager()
 	} else if configuration.IsStandalone(cfg.Fleet) {
 		log.Info("Parsed configuration and determined agent is managed locally")
 
@@ -187,13 +174,10 @@ func New(
 		}
 	}
 
-	var varsManager composable.Controller
-	if !runAsOtel {
-		// no need for vars in otel mode
-		varsManager, err = composable.New(log, rawConfig, composableManaged)
-		if err != nil {
-			return nil, nil, nil, errors.New(err, "failed to initialize composable controller")
-		}
+	// no need for vars in otel mode
+	varsManager, err := composable.New(log, rawConfig, composableManaged)
+	if err != nil {
+		return nil, nil, nil, errors.New(err, "failed to initialize composable controller")
 	}
 
 	coord := coordinator.New(log, cfg, logLevel, agentInfo, specs, reexec, upgrader, runtime, configMgr, varsManager, caps, monitor, isManaged, compModifiers...)

--- a/internal/pkg/agent/application/application_test.go
+++ b/internal/pkg/agent/application/application_test.go
@@ -63,7 +63,6 @@ func TestLimitsLog(t *testing.T) {
 		true,              // testingMode
 		time.Millisecond,  // fleetInitTimeout
 		true,              // disable monitoring
-		false,             // not otel mode
 	)
 	require.NoError(t, err)
 

--- a/internal/pkg/agent/application/coordinator/coordinator_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_test.go
@@ -895,7 +895,7 @@ func createCoordinator(t *testing.T, ctx context.Context, opts ...CoordinatorOpt
 	monitoringMgr := newTestMonitoringMgr()
 	cfg := configuration.DefaultGRPCConfig()
 	cfg.Port = 0
-	rm, err := runtime.NewManager(l, l, ai, apmtest.DiscardTracer, monitoringMgr, cfg, false)
+	rm, err := runtime.NewManager(l, l, ai, apmtest.DiscardTracer, monitoringMgr, cfg)
 	require.NoError(t, err)
 
 	caps, err := capabilities.LoadFile(paths.AgentCapabilitiesPath(), l)

--- a/internal/pkg/agent/cmd/otel.go
+++ b/internal/pkg/agent/cmd/otel.go
@@ -8,6 +8,7 @@ package cmd
 
 import (
 	"context"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -397,9 +397,6 @@ LOOP:
 	}
 	cancel()
 	err = <-appErr
-	for _, a := range awaiters {
-		<-a // wait for awaiter to be done
-	}
 
 	if logShutdown {
 		l.Info("Shutting down completed.")

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -64,7 +64,6 @@ const (
 
 type (
 	cfgOverrider func(cfg *configuration.Configuration)
-	awaiters     []<-chan struct{}
 )
 
 func newRunCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {

--- a/pkg/component/runtime/manager_fake_input_test.go
+++ b/pkg/component/runtime/manager_fake_input_test.go
@@ -97,8 +97,7 @@ func (suite *FakeInputSuite) TestManager_Features() {
 		agentInfo,
 		apmtest.DiscardTracer,
 		newTestMonitoringMgr(),
-		testGrpcConfig(),
-		false)
+		testGrpcConfig())
 	require.NoError(t, err)
 
 	managerErrCh := make(chan error)
@@ -298,8 +297,7 @@ func (suite *FakeInputSuite) TestManager_APM() {
 		agentInfo,
 		apmtest.DiscardTracer,
 		newTestMonitoringMgr(),
-		testGrpcConfig(),
-		false)
+		testGrpcConfig())
 	require.NoError(t, err)
 
 	managerErrCh := make(chan error)
@@ -575,9 +573,7 @@ func (suite *FakeInputSuite) TestManager_Limits() {
 		agentInfo,
 		apmtest.DiscardTracer,
 		newTestMonitoringMgr(),
-		testGrpcConfig(),
-		false,
-	)
+		testGrpcConfig())
 	require.NoError(t, err)
 
 	managerErrCh := make(chan error)
@@ -733,8 +729,7 @@ func (suite *FakeInputSuite) TestManager_BadUnitToGood() {
 	defer cancel()
 
 	ai := &info.AgentInfo{}
-	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig(),
-		false)
+	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig())
 	require.NoError(t, err)
 	errCh := make(chan error)
 	go func() {
@@ -903,8 +898,7 @@ func (suite *FakeInputSuite) TestManager_GoodUnitToBad() {
 	defer cancel()
 
 	ai := &info.AgentInfo{}
-	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig(),
-		false)
+	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig())
 	require.NoError(t, err)
 	runResultChan := make(chan error, 1)
 	go func() {
@@ -1086,8 +1080,7 @@ func (suite *FakeInputSuite) TestManager_NoDeadlock() {
 
 	// Create the runtime manager
 	ai := &info.AgentInfo{}
-	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig(),
-		false)
+	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig())
 	require.NoError(t, err)
 
 	// Start the runtime manager in a goroutine, passing its termination state
@@ -1161,8 +1154,7 @@ func (suite *FakeInputSuite) TestManager_Configure() {
 	defer cancel()
 
 	ai := &info.AgentInfo{}
-	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig(),
-		false)
+	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig())
 	require.NoError(t, err)
 	errCh := make(chan error)
 	go func() {
@@ -1284,8 +1276,7 @@ func (suite *FakeInputSuite) TestManager_RemoveUnit() {
 	defer cancel()
 
 	ai := &info.AgentInfo{}
-	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig(),
-		false)
+	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig())
 	require.NoError(t, err)
 	errCh := make(chan error)
 	go func() {
@@ -1440,8 +1431,7 @@ func (suite *FakeInputSuite) TestManager_ActionState() {
 	defer cancel()
 
 	ai := &info.AgentInfo{}
-	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig(),
-		false)
+	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig())
 	require.NoError(t, err)
 	errCh := make(chan error)
 	go func() {
@@ -1566,8 +1556,7 @@ func (suite *FakeInputSuite) TestManager_Restarts() {
 	defer cancel()
 
 	ai := &info.AgentInfo{}
-	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig(),
-		false)
+	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig())
 	require.NoError(t, err)
 	errCh := make(chan error)
 	go func() {
@@ -1703,8 +1692,7 @@ func (suite *FakeInputSuite) TestManager_Restarts_ConfigKill() {
 	defer cancel()
 
 	ai := &info.AgentInfo{}
-	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig(),
-		false)
+	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig())
 	require.NoError(t, err)
 	errCh := make(chan error)
 	go func() {
@@ -1848,8 +1836,7 @@ func (suite *FakeInputSuite) TestManager_KeepsRestarting() {
 	defer cancel()
 
 	ai := &info.AgentInfo{}
-	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig(),
-		false)
+	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig())
 	require.NoError(t, err)
 	errCh := make(chan error)
 	go func() {
@@ -1993,8 +1980,7 @@ func (suite *FakeInputSuite) TestManager_RestartsOnMissedCheckins() {
 	defer cancel()
 
 	ai := &info.AgentInfo{}
-	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig(),
-		false)
+	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig())
 	require.NoError(t, err)
 	errCh := make(chan error)
 	go func() {
@@ -2113,8 +2099,7 @@ func (suite *FakeInputSuite) TestManager_InvalidAction() {
 	defer cancel()
 
 	ai := &info.AgentInfo{}
-	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig(),
-		false)
+	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), testGrpcConfig())
 	require.NoError(t, err)
 	errCh := make(chan error)
 	go func() {
@@ -2238,8 +2223,7 @@ func (suite *FakeInputSuite) TestManager_MultiComponent() {
 		agentInfo,
 		apmtest.DiscardTracer,
 		newTestMonitoringMgr(),
-		testGrpcConfig(),
-		false)
+		testGrpcConfig())
 	require.NoError(t, err)
 
 	errCh := make(chan error)
@@ -2452,8 +2436,7 @@ func (suite *FakeInputSuite) TestManager_LogLevel() {
 		ai,
 		apmtest.DiscardTracer,
 		newTestMonitoringMgr(),
-		testGrpcConfig(),
-		false)
+		testGrpcConfig())
 	require.NoError(t, err)
 
 	errCh := make(chan error)
@@ -2594,8 +2577,7 @@ func (suite *FakeInputSuite) TestManager_StartStopComponent() {
 		ai,
 		apmtest.DiscardTracer,
 		newTestMonitoringMgr(),
-		testGrpcConfig(),
-		false)
+		testGrpcConfig())
 	require.NoError(t, err, "could not crete new manager")
 
 	managerErrCh := make(chan error)
@@ -2782,7 +2764,7 @@ func (suite *FakeInputSuite) TestManager_Chunk() {
 	grpcConfig.MaxMsgSize = grpcDefaultSize * 2 // set to double the default size
 
 	ai := &info.AgentInfo{}
-	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), grpcConfig, false)
+	m, err := NewManager(newDebugLogger(t), newDebugLogger(t), ai, apmtest.DiscardTracer, newTestMonitoringMgr(), grpcConfig)
 	require.NoError(t, err)
 	errCh := make(chan error)
 	go func() {

--- a/pkg/component/runtime/manager_test.go
+++ b/pkg/component/runtime/manager_test.go
@@ -32,9 +32,7 @@ func TestManager_SimpleComponentErr(t *testing.T) {
 		ai,
 		apmtest.DiscardTracer,
 		newTestMonitoringMgr(),
-		testGrpcConfig(),
-		false,
-	)
+		testGrpcConfig())
 	require.NoError(t, err)
 
 	errCh := make(chan error)

--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -477,8 +477,8 @@ func RunProcess(t *testing.T,
 // when `Run` is called.
 //
 // if shouldWatchState is set to false, communicating state does not happen.
-func (f *Fixture) RunOtelWithClient(ctx context.Context, shouldWatchState bool, enableTestingMode bool, states ...State) error {
-	return f.executeWithClient(ctx, "otel", false, shouldWatchState, enableTestingMode, states...)
+func (f *Fixture) RunOtelWithClient(ctx context.Context, states ...State) error {
+	return f.executeWithClient(ctx, "otel", false, false, false, states...)
 }
 
 func (f *Fixture) executeWithClient(ctx context.Context, command string, disableEncryptedStore bool, shouldWatchState bool, enableTestingMode bool, states ...State) error {

--- a/testing/integration/kubernetes_agent_service_test.go
+++ b/testing/integration/kubernetes_agent_service_test.go
@@ -123,7 +123,7 @@ func TestKubernetesAgentService(t *testing.T) {
 
 	ctx := context.Background()
 
-	deployK8SAgent(t, ctx, client, k8sObjects, testNamespace, false, testLogsBasePath, map[string]bool{
+	deployK8SAgent(t, ctx, client, k8sObjects, testNamespace, false, testLogsBasePath, true, map[string]bool{
 		"connectors-py": true,
 	})
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Previously the control protocol was started when the subcommand `otel` was ran. This should not be done as the subcommand `otel` should operate it in a pure OTel mode.

This is a cleanup that comes out of working on Hybrid mode.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Cleanup to make the code cleaner and less messy as the control protocol should not really be running when running the otel subcommand.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

Can no longer call `elastic-agent status` when a `elastic-agent otel` is running.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run `elastic-agent otel`, then try to run `elastic-agent status` and see that it doesn't connect.
