### PR TITLE
Update CODEOWNERS for Eng Prod ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,15 @@
 # Team responsible for Fleet Server
 * @elastic/elastic-agent-control-plane
 
+/.github/CODEOWNERS @elastic/ingest-tech-lead
+
 /deploy/kubernetes @elastic/obs-cloudnative-monitoring
 /dev-tools/kubernetes @elastic/obs-cloudnative-monitoring
 /internal/pkg/composable/providers/kubernetes @elastic/obs-cloudnative-monitoring
 /internal/pkg/agent/application/configuration_embed_changed_test.go @elastic/cloudbeat
+
+# Ownership of CI or related files by the Ingest Eng Prod team
+/.buildkite @elastic/ingest-eng-prod
+/.ci @elastic/ingest-eng-prod
+/.github @elastic/ingest-eng-prod
+/catalog-info.yaml @elastic/ingest-eng-prod


### PR DESCRIPTION
Update CODEOWNERS so the Eng Prod team is automatically added to reviews where CI is getting updated.