### PR TITLE
Exclude the coverage files from the annotate step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,7 +158,7 @@ steps:
   - label: ":junit: Junit annotate"
     plugins:
       - junit-annotate#v2.5.0:
-          artifacts: "*/TEST-*.xml"
+          artifacts: "**TEST-*.xml"
           always-annotate: true
     agents:
       provider: "gcp"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,7 +158,7 @@ steps:
   - label: ":junit: Junit annotate"
     plugins:
       - junit-annotate#v2.5.0:
-          artifacts: "build/*.xml;build\\\\*.xml"
+          artifacts: "build/*.xml;build\*.xml"
           always-annotate: true
     agents:
       provider: "gcp"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,7 +158,7 @@ steps:
   - label: ":junit: Junit annotate"
     plugins:
       - junit-annotate#v2.5.0:
-          artifacts: "build/TEST-!(*cov).xml"
+          artifacts: "build/*.xml"
           always-annotate: true
     agents:
       provider: "gcp"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,7 +158,7 @@ steps:
   - label: ":junit: Junit annotate"
     plugins:
       - junit-annotate#v2.5.0:
-          artifacts: "build/*.xml;build\*.xml"
+          artifacts: "*/TEST-*.xml"
           always-annotate: true
     agents:
       provider: "gcp"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,7 +158,7 @@ steps:
   - label: ":junit: Junit annotate"
     plugins:
       - junit-annotate#v2.5.0:
-          artifacts: "build/*.xml"
+          artifacts: "build/TEST-!(*cov).xml"
           always-annotate: true
     agents:
       provider: "gcp"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,7 +158,7 @@ steps:
   - label: ":junit: Junit annotate"
     plugins:
       - junit-annotate#v2.5.0:
-          artifacts: "build/*.xml"
+          artifacts: "build/*.xml;build\\*.xml"
           always-annotate: true
     agents:
       provider: "gcp"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,7 +158,7 @@ steps:
   - label: ":junit: Junit annotate"
     plugins:
       - junit-annotate#v2.5.0:
-          artifacts: "build/*.xml;build\\*.xml"
+          artifacts: "build/*.xml;build\\\\*.xml"
           always-annotate: true
     agents:
       provider: "gcp"

--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -5,7 +5,6 @@
 package mage
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -339,42 +338,6 @@ func GoTest(ctx context.Context, params GoTestArgs) error {
 		if err = coverToHTML(); err != nil {
 			return fmt.Errorf("failed to write HTML code coverage report: %w", err)
 		}
-	}
-
-	// Generate an XML code coverage report.
-	var codecovReport string
-	if params.CoverageProfileFile != "" {
-		fmt.Println(">> go run gocover-cobertura:", params.CoverageProfileFile, "Started")
-
-		// execute gocover-cobertura in order to create cobertura report
-		// install pre-requisites
-		installCobertura := sh.RunCmd("go", "install", "github.com/boumenot/gocover-cobertura@latest")
-		if err = installCobertura(); err != nil {
-			return fmt.Errorf("failed to install gocover-cobertura: %w", err)
-		}
-
-		codecovReport = strings.TrimSuffix(params.CoverageProfileFile,
-			filepath.Ext(params.CoverageProfileFile)) + "-cov.xml"
-
-		coverage, err := os.ReadFile(params.CoverageProfileFile)
-		if err != nil {
-			return fmt.Errorf("failed to read code coverage report: %w", err)
-		}
-
-		coberturaFile, err := os.Create(codecovReport)
-		if err != nil {
-			return err
-		}
-		defer coberturaFile.Close()
-
-		coverToXML := exec.Command("gocover-cobertura")
-		coverToXML.Stdout = coberturaFile
-		coverToXML.Stderr = os.Stderr
-		coverToXML.Stdin = bytes.NewReader(coverage)
-		if err = coverToXML.Run(); err != nil {
-			return fmt.Errorf("failed to write XML code coverage report: %w", err)
-		}
-		fmt.Println(">> go run gocover-cobertura:", params.CoverageProfileFile, "Created")
 	}
 
 	// Return an error indicating that testing failed.


### PR DESCRIPTION
## What does this PR do?

We noticed that the JUnit annotate step needed to take more time. This PR addresses that issue by not requiring it to parse the coverage files.

The generated coverage XML file was meant to be used in Jenkins to show the coverage report stats. The generated XML files were large, resulting in a problem with BK's JUnit annotate plugin. 

Given that we don't operate any Jenkins instance, this PR removes the code that generated the XML coverage reports.
Now, coverage is reported only to Sonar.

## Why is it important?

Reduce the time of CI step
