### PR TITLE
Add all Docker images to K8s integration tests

### DIFF
--- a/testing/integration/kubernetes_agent_standalone_test.go
+++ b/testing/integration/kubernetes_agent_standalone_test.go
@@ -66,9 +66,12 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 		Local: false,
 		Sudo:  false,
 		OS: []define.OS{
-			// only test the basic and the wolfi container with otel
+			// test all produced images
 			{Type: define.Kubernetes, DockerVariant: "basic"},
 			{Type: define.Kubernetes, DockerVariant: "wolfi"},
+			{Type: define.Kubernetes, DockerVariant: "ubi"},
+			{Type: define.Kubernetes, DockerVariant: "complete"},
+			{Type: define.Kubernetes, DockerVariant: "complete-wolfi"},
 		},
 		Group: define.Kubernetes,
 	})


### PR DESCRIPTION
So, we validate all produced images.

Test runtime:
* before this PR – [~57 minutes](https://buildkite.com/elastic/elastic-agent-extended-testing/builds/3760#019290b0-a3b7-4600-b3a3-673bc796005b)
* after this PR – [~1h 37 minutes](https://buildkite.com/elastic/elastic-agent-extended-testing/builds/3756#0192908e-d36e-4588-ba19-262921ad51ca)

Let me know if the runtime increase is sensible.