### PR TITLE
Move back merged coverage report to build folder

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -188,7 +188,7 @@ steps:
     command: |
       .buildkite/scripts/steps/merge.sh
     artifact_paths:
-      - "TEST-go-unit.cov"
+      - "build/TEST-go-unit.cov"
     agents:
       image: "golang:1.22.6"
     depends_on:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -225,7 +225,7 @@ steps:
     agents:
       image: "docker.elastic.co/cloud-ci/sonarqube/buildkite-scanner:latest"
     command:
-      - "buildkite-agent artifact download --step merge-coverage TEST-go-unit.cov ."
+      - "buildkite-agent artifact download --step merge-coverage build/TEST-go-unit.cov ."
       - "/scan-source-code.sh"
     depends_on:
       - "merge-coverage"

--- a/.buildkite/scripts/steps/merge.sh
+++ b/.buildkite/scripts/steps/merge.sh
@@ -5,7 +5,8 @@
 set -euo pipefail
 set -x # for debugging
 
-MERGED_COV_FILE="TEST-go-unit.cov"
+mkdir -p build
+MERGED_COV_FILE="build/TEST-go-unit.cov"
 
 go install github.com/wadey/gocovmerge@latest
 


### PR DESCRIPTION

## What does this PR do?

Restore the file location of the coverage report file back to `/build` folder.

## Why is it important?

A recent commit change the generate coverage report file location and moved it from the `/build` to the root of the repo. This had a side effect on the Sonar scanning step that expected the file to be on the `/build` folder

Closes: https://github.com/elastic/ingest-dev/issues/4258