### PR TITLE
Add breakdown of tests output for integration testing framework

### DIFF
--- a/pkg/testing/buildkite/buildkite.go
+++ b/pkg/testing/buildkite/buildkite.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/elastic/elastic-agent/pkg/testing/common"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
-	"github.com/elastic/elastic-agent/pkg/testing/supported"
 )
 
 const (
@@ -201,23 +200,13 @@ func shouldSkip(os common.SupportedOS) bool {
 }
 
 // GenerateSteps returns a computed set of steps to run the integration tests on buildkite.
-func GenerateSteps(cfg common.Config, batches ...define.Batch) (string, error) {
+func GenerateSteps(cfg common.Config, batches ...common.OSBatch) (string, error) {
 	stackSteps := map[string]Step{}
 	stackTeardown := map[string][]string{}
 	var steps []Step
 
-	// create the supported batches first
-	platforms, err := cfg.GetPlatforms()
-	if err != nil {
-		return "", err
-	}
-	osBatches, err := supported.CreateBatches(batches, platforms, cfg.Groups, cfg.Matrix, cfg.SingleTest)
-	if err != nil {
-		return "", err
-	}
-
 	// create the stack steps first
-	for _, lb := range osBatches {
+	for _, lb := range batches {
 		if !lb.Skip && lb.Batch.Stack != nil {
 			if lb.Batch.Stack.Version == "" {
 				// no version defined on the stack; set it to the defined stack version
@@ -241,7 +230,7 @@ func GenerateSteps(cfg common.Config, batches ...define.Batch) (string, error) {
 	}
 
 	// generate the steps for the tests
-	for _, lb := range osBatches {
+	for _, lb := range batches {
 		if lb.Skip {
 			continue
 		}

--- a/pkg/testing/common/batch.go
+++ b/pkg/testing/common/batch.go
@@ -11,11 +11,11 @@ import (
 // OSBatch defines the mapping between a SupportedOS and a define.Batch.
 type OSBatch struct {
 	// ID is the unique ID for the batch.
-	ID string
+	ID string `yaml:"id"`
 	// LayoutOS provides all the OS information to create an instance.
-	OS SupportedOS
+	OS SupportedOS `yaml:"os"`
 	// Batch defines the batch of tests to run on this layout.
-	Batch define.Batch
+	Batch define.Batch `yaml:"batch"`
 	// Skip defines if this batch will be skipped because no supported layout exists yet.
-	Skip bool
+	Skip bool `yaml:"skip,omitempty"`
 }

--- a/pkg/testing/common/supported.go
+++ b/pkg/testing/common/supported.go
@@ -8,8 +8,8 @@ import "github.com/elastic/elastic-agent/pkg/testing/define"
 
 // SupportedOS maps a OS definition to a OSRunner.
 type SupportedOS struct {
-	define.OS
+	define.OS `yaml:",inline"`
 
 	// Runner is the runner to use for the OS.
-	Runner OSRunner
+	Runner OSRunner `yaml:"-"`
 }

--- a/pkg/testing/define/batch.go
+++ b/pkg/testing/define/batch.go
@@ -43,37 +43,37 @@ var defaultOS = []OS{
 type Batch struct {
 	// Group must be set on each test to define which group the tests belongs.
 	// Tests that are in the same group are executed on the same runner.
-	Group string `json:"group"`
+	Group string `json:"group" yaml:"group"`
 
 	// OS defines the operating systems this test batch needs.
-	OS OS `json:"os"`
+	OS OS `json:"os,omitempty" yaml:"os,omitempty"`
 
 	// Stack defines the stack required for this batch.
-	Stack *Stack `json:"stack,omitempty"`
+	Stack *Stack `json:"stack,omitempty" yaml:"stack,omitempty"`
 
 	// Tests define the set of packages and tests that do not require sudo
 	// privileges to be performed.
-	Tests []BatchPackageTests `json:"tests"`
+	Tests []BatchPackageTests `json:"tests,omitempty" yaml:"tests,omitempty"`
 
 	// SudoTests define the set of packages and tests that do require sudo
 	// privileges to be performed.
-	SudoTests []BatchPackageTests `json:"sudo_tests"`
+	SudoTests []BatchPackageTests `json:"sudo_tests,omitempty" yaml:"sudo_tests,omitempty"`
 }
 
 // BatchPackageTests is a package and its tests that belong to a batch.
 type BatchPackageTests struct {
 	// Name is the package name.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 	// Tests is the set of tests in the package.
-	Tests []BatchPackageTest `json:"tests"`
+	Tests []BatchPackageTest `json:"tests" yaml:"tests"`
 }
 
 // BatchPackageTest is a specific test in a package.
 type BatchPackageTest struct {
 	// Name of the test.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 	// Stack needed for test.
-	Stack bool `json:"stack"`
+	Stack bool `json:"stack" yaml:"stack"`
 }
 
 // DetermineBatches parses the package directory with the possible extra build

--- a/pkg/testing/define/requirements.go
+++ b/pkg/testing/define/requirements.go
@@ -40,24 +40,24 @@ type OS struct {
 	//
 	// This is always required to be defined on the OS structure.
 	// If it is not defined the test runner will error.
-	Type string `json:"type"`
+	Type string `json:"type,omitempty" yaml:"type,omitempty"`
 	// Arch is the architecture type (amd64 or arm64).
 	//
 	// In the case that it's not provided the test will run on every
 	// architecture that is supported.
-	Arch string `json:"arch"`
+	Arch string `json:"arch,omitempty" yaml:"arch,omitempty"`
 	// Version is a specific version of the OS type to run this test on
 	//
 	// When defined the test runs on this specific version only. When not
 	// defined the test is run on a selected version for this operating system.
-	Version string `json:"version"`
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 	// Distro allows in the Linux case for a specific distribution to be
 	// selected for running on. Example would be "ubuntu". In the Kubernetes case
 	// for a specific distribution of kubernetes. Example would be "kind".
-	Distro string `json:"distro"`
+	Distro string `json:"distro,omitempty" yaml:"distro,omitempty"`
 	// DockerVariant allows in the Kubernetes case for a specific variant to
 	// be selected for running with. Example would be "wolfi".
-	DockerVariant string `json:"docker_variant"`
+	DockerVariant string `json:"docker_variant,omitempty" yaml:"docker_variant,omitempty"`
 }
 
 // Validate returns an error if not valid.
@@ -91,7 +91,7 @@ type Stack struct {
 	//
 	// In the case that no version is provided the same version being used for
 	// the current test execution is used.
-	Version string `json:"version"`
+	Version string `json:"version" yaml:"version"`
 }
 
 // Requirements defines the testing requirements for the test to run.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds a `mage integration:breakdown` and `mage integration:breakdownMatrix` targets that write an intermediate output of the list of operating systems and which tests need to run on each version of those operating systems.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Allows an easy way to see which tests run on which os/arch/distro/version combinations, along with if a stack is required and if the test needs the stack or not.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

`mage integration:breakdown`

or

`mage integration:breakdownMatrix`

## Enable output

```
- name: fqdn-sudo
  os:
    - type: linux
      arch: amd64
      version: "24.04"
      distro: ubuntu
    - type: linux
      arch: arm64
      version: "24.04"
      distro: ubuntu
  require_sudo: true
  tests:
    - TestFQDN
- name: kubernetes
  os:
    - type: kubernetes
      arch: amd64
      version: 1.31.0
      docker_variant: service
    - type: kubernetes
      arch: arm64
      version: 1.31.0
      docker_variant: service
    - type: kubernetes
      arch: amd64
      version: 1.31.0
      docker_variant: basic
    - type: kubernetes
      arch: arm64
      version: 1.31.0
      docker_variant: basic
    - type: kubernetes
      arch: amd64
      version: 1.31.0
      docker_variant: wolfi
    - type: kubernetes
      arch: arm64
      version: 1.31.0
      docker_variant: wolfi
    - type: kubernetes
      arch: amd64
      version: 1.31.0
      docker_variant: ubi
    - type: kubernetes
      arch: arm64
      version: 1.31.0
      docker_variant: ubi
    - type: kubernetes
      arch: amd64
      version: 1.31.0
      docker_variant: complete
    - type: kubernetes
      arch: arm64
      version: 1.31.0
      docker_variant: complete
    - type: kubernetes
      arch: amd64
      version: 1.31.0
      docker_variant: complete-wolfi
    - type: kubernetes
      arch: arm64
      version: 1.31.0
      docker_variant: complete-wolfi
  require_sudo: false
  tests: []
- name: deb-sudo
  os:
    - type: linux
      arch: amd64
      version: "24.04"
      distro: ubuntu
    - type: linux
      arch: arm64
      version: "24.04"
      distro: ubuntu
  require_sudo: true
  tests:
    - TestDebLogIngestFleetManaged
    - TestDebFleetUpgrade
- name: rpm-sudo
  os:
    - type: linux
      arch: amd64
      version: "8"
      distro: rhel
    - type: linux
      arch: arm64
      version: unknown
      distro: rhel
  require_sudo: true
  tests:
    - TestRpmLogIngestFleetManaged
    - TestRpmFleetUpgrade
- name: fleet-sudo
  os:
    - type: linux
      arch: amd64
      version: "24.04"
      distro: ubuntu
    - type: linux
      arch: arm64
      version: "24.04"
      distro: ubuntu
    - type: windows
      arch: amd64
      version: "2022"
    - type: darwin
      arch: amd64
      version: unknown
      distro: unknown
    - type: darwin
      arch: arm64
      version: unknown
      distro: unknown
  require_sudo: true
  tests:
    - TestLongRunningAgentForLeaks
    - TestDelayEnroll
    - TestDelayEnrollUnprivileged
    - TestRedactFleetSecretPathsDiagnostics
    - TestInstallAndCLIUninstallWithEndpointSecurity
    - TestInstallAndUnenrollWithEndpointSecurity
    - TestInstallWithEndpointSecurityAndRemoveEndpointIntegration
    - TestEndpointSecurityNonDefaultBasePath
    - TestEndpointSecurityUnprivileged
    - TestEndpointSecurityCannotSwitchToUnprivileged
    - TestEndpointLogsAreCollectedInDiagnostics
    - TestForceInstallOverProtectedPolicy
    - TestInspect
    - TestSetLogLevelFleetManaged
    - TestLogIngestionFleetManaged
    - TestMetricsMonitoringCorrectBinaries
    - TestEndpointAgentServiceMonitoring
    - TestMonitoringPreserveTextConfig
    - TestMonitoringLivenessReloadable
    - TestComponentBuildHashInDiagnostics
    - TestProxyURL
    - TestFleetManagedUpgradeUnprivileged
- name: default
  os:
    - type: darwin
      arch: amd64
      version: unknown
      distro: unknown
    - type: darwin
      arch: arm64
      version: unknown
      distro: unknown
    - type: linux
      arch: amd64
      version: "24.04"
      distro: ubuntu
    - type: linux
      arch: arm64
      version: "24.04"
      distro: ubuntu
    - type: windows
      arch: amd64
      version: "2022"
  require_sudo: false
  tests:
    - TestInstallWithoutBasePath
    - TestInstallWithBasePath
    - TestInstallPrivilegedWithoutBasePath
    - TestInstallPrivilegedWithBasePath
    - TestInstallUninstallAudit
    - TestRepeatedInstallUninstall
    - TestSwitchPrivilegedWithoutBasePath
    - TestSwitchPrivilegedWithBasePath
    - TestSwitchUnprivilegedWithoutBasePath
    - TestSwitchUnprivilegedWithBasePath
    - TestBeatsServerless
- name: container-sudo
  os:
    - type: linux
      arch: amd64
      version: "24.04"
      distro: ubuntu
    - type: linux
      arch: arm64
      version: "24.04"
      distro: ubuntu
  require_sudo: true
  tests:
    - TestContainerCMD
    - TestContainerCMDWithAVeryLongStatePath
    - TestContainerCMDEventToStderr
    - TestEventLogOutputConfiguredViaFleet
- name: fleet-privileged-sudo
  os:
    - type: darwin
      arch: amd64
      version: unknown
      distro: unknown
    - type: darwin
      arch: arm64
      version: unknown
      distro: unknown
    - type: linux
      arch: amd64
      version: "24.04"
      distro: ubuntu
    - type: linux
      arch: arm64
      version: "24.04"
      distro: ubuntu
    - type: windows
      arch: amd64
      version: "2022"
  require_sudo: true
  tests:
    - TestInstallFleetServerBootstrap
    - TestFleetManagedUpgradePrivileged
- name: upgrade-sudo
  os:
    - type: darwin
      arch: amd64
      version: unknown
      distro: unknown
    - type: darwin
      arch: arm64
      version: unknown
      distro: unknown
    - type: linux
      arch: amd64
      version: "24.04"
      distro: ubuntu
    - type: linux
      arch: arm64
      version: "24.04"
      distro: ubuntu
    - type: windows
      arch: amd64
      version: "2022"
  require_sudo: true
  tests:
    - TestUpgradeBrokenPackageVersion
    - TestStandaloneUpgradeWithGPGFallback
    - TestStandaloneUpgradeWithGPGFallbackOneRemoteFailing
    - TestStandaloneUpgradeRollback
    - TestStandaloneUpgradeRollbackOnRestarts
    - TestStandaloneUpgradeFailsWhenUpgradeIsInProgress
    - TestStandaloneUpgradeRetryDownload
    - TestStandaloneUpgradeSameCommit
    - TestStandaloneUpgrade
    - TestStandaloneUpgradeUninstallKillWatcher
- name: fleet-airgapped-sudo
  os:
    - type: linux
      arch: amd64
      version: "24.04"
      distro: ubuntu
    - type: linux
      arch: arm64
      version: "24.04"
      distro: ubuntu
  require_sudo: true
  tests:
    - TestFleetAirGappedUpgradeUnprivileged
- name: fleet-airgapped-privileged-sudo
  os:
    - type: linux
      arch: amd64
      version: "24.04"
      distro: ubuntu
    - type: linux
      arch: arm64
      version: "24.04"
      distro: ubuntu
  require_sudo: true
  tests:
    - TestFleetAirGappedUpgradePrivileged
- name: fleet-upgrade-to-pr-build-sudo
  os:
    - type: linux
      arch: amd64
      version: "24.04"
      distro: ubuntu
    - type: linux
      arch: arm64
      version: "24.04"
      distro: ubuntu
  require_sudo: true
  tests:
    - TestFleetUpgradeToPRBuild
- name: default-sudo
  os:
    - type: darwin
      arch: amd64
      version: unknown
      distro: unknown
    - type: darwin
      arch: arm64
      version: unknown
      distro: unknown
    - type: linux
      arch: amd64
      version: "24.04"
      distro: ubuntu
    - type: linux
      arch: arm64
      version: "24.04"
      distro: ubuntu
    - type: windows
      arch: amd64
      version: "2022"
  require_sudo: true
  tests:
    - TestInstallWithoutBasePath
    - TestInstallWithBasePath
    - TestInstallPrivilegedWithoutBasePath
    - TestInstallPrivilegedWithBasePath
    - TestInstallUninstallAudit
    - TestRepeatedInstallUninstall
    - TestSwitchPrivilegedWithoutBasePath
    - TestSwitchPrivilegedWithBasePath
    - TestSwitchUnprivilegedWithoutBasePath
    - TestSwitchUnprivilegedWithBasePath
    - TestBeatsServerless
```