### PR TITLE
Add notification for when the packaging pipeline fails

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -171,6 +171,11 @@ spec:
     spec:
       repository: elastic/elastic-agent
       pipeline_file: ".buildkite/pipeline.elastic-agent-package.yml"
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_CHANNEL: "#ingest-notifications"
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+        SLACK_NOTIFICATIONS_ALL_BRANCHES: "true"
       provider_settings:
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot


### PR DESCRIPTION

## What does this PR do?

This PR adds a notification for the packaging pipeline when it fails.
The notification is for all the branches this pipeline runs and only on failures.
The notification is sent to the team on their Slack channel.

## Why is it important?

Yes, this is related to https://github.com/elastic/ingest-dev/issues/3625