### PR TITLE
Switch crossbuilding to Debian 11

### DIFF
--- a/changelog/fragments/1729750939-crossbuild-debian11.yaml
+++ b/changelog/fragments/1729750939-crossbuild-debian11.yaml
@@ -1,0 +1,4 @@
+kind: breaking-change
+summary: crossbuild-debian11
+description: We're dropping support for Debian 10, so no need to crossbuild using the outdated image anymore. This also updates the statically linked glibc from 2.19 to 2.31.
+component: elastic-agent

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -225,9 +225,9 @@ func CrossBuildImage(platform string) (string, error) {
 
 	switch {
 	case platform == "darwin/amd64":
-		tagSuffix = "darwin-debian10"
+		tagSuffix = "darwin-debian11"
 	case platform == "darwin/arm64" || platform == "darwin/universal":
-		tagSuffix = "darwin-arm64-debian10"
+		tagSuffix = "darwin-arm64-debian11"
 	case platform == "linux/arm64":
 		tagSuffix = "arm"
 	case platform == "linux/armv5" || platform == "linux/armv6":
@@ -235,15 +235,13 @@ func CrossBuildImage(platform string) (string, error) {
 	case platform == "linux/armv7":
 		tagSuffix = "armhf"
 	case strings.HasPrefix(platform, "linux/mips"):
-		tagSuffix = "mips-debian10"
+		tagSuffix = "mips-debian11"
 	case strings.HasPrefix(platform, "linux/ppc"):
-		tagSuffix = "ppc-debian10"
+		tagSuffix = "ppc-debian11"
 	case platform == "linux/s390x":
-		tagSuffix = "s390x-debian10"
+		tagSuffix = "s390x-debian11"
 	case strings.HasPrefix(platform, "linux"):
-		// Use an older version of libc to gain greater OS compatibility.
-		// Debian 8 uses glibc 2.19.
-		tagSuffix = "main-debian8"
+		tagSuffix = "main-debian11"
 	}
 
 	goVersion, err := GoVersion()


### PR DESCRIPTION
We're dropping support for Debian 10,
so no need to crossbuild using the outdated image anymore.

This also updates the statically linked glibc from 2.19 to 2.31.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
```sh
PLATFORMS=linux/arm64 PACKAGES=docker mage package
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/beats/pull/41402