### PR TITLE
use production api key link instead of staging

### DIFF
--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -25,9 +25,7 @@ The Elastic Agent package that is used for integration tests packages Beats buil
 
 ### Configuration
 
-ESS (staging) API Key to create on https://staging.found.no/account/keys
-
-ESS (staging) API Key to create on <https://cloud.elastic.co/account/keys>
+ESS (production) API Key to create on <https://cloud.elastic.co/account/keys>
 Warning: if you never created a deployment on it, you won't have permission to get this key, so you will need to create one first.
 
 ## Running tests

--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -27,6 +27,7 @@ The Elastic Agent package that is used for integration tests packages Beats buil
 
 ESS (staging) API Key to create on https://staging.found.no/account/keys
 
+ESS (staging) API Key to create on <https://cloud.elastic.co/account/keys>
 Warning: if you never created a deployment on it, you won't have permission to get this key, so you will need to create one first.
 
 ## Running tests


### PR DESCRIPTION
- Docs

## What does this PR do?
Replaces the staging link with the production one to create api keys to be used in the integration test setup

## Why is it important?
Following the current documentation, a developer won't be able to setup the integration tests

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [X] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~

## Related issues
- Relates to #5320 


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->