### PR TITLE
remove DEV=true from CI build steps

### DIFF
--- a/.buildkite/scripts/steps/integration-package.sh
+++ b/.buildkite/scripts/steps/integration-package.sh
@@ -3,4 +3,4 @@ set -euo pipefail
 
 source .buildkite/scripts/common.sh
 
-AGENT_PACKAGE_VERSION=8.16.0 PACKAGES=tar.gz,zip,rpm,deb PLATFORMS=linux/amd64,linux/arm64,windows/amd64  SNAPSHOT=true EXTERNAL=true  DEV=true mage package
+AGENT_PACKAGE_VERSION=8.16.0 PACKAGES=tar.gz,zip,rpm,deb PLATFORMS=linux/amd64,linux/arm64,windows/amd64  SNAPSHOT=true EXTERNAL=true  mage package

--- a/.buildkite/scripts/steps/k8s-extended-tests.sh
+++ b/.buildkite/scripts/steps/k8s-extended-tests.sh
@@ -25,7 +25,7 @@ else
   exit 10
 fi
 
-AGENT_PACKAGE_VERSION="8.16.0" DEV=true SNAPSHOT=true EXTERNAL=true PACKAGES=docker mage -v package
+AGENT_PACKAGE_VERSION="8.16.0" SNAPSHOT=true EXTERNAL=true PACKAGES=docker mage -v package
 AGENT_VERSION="8.16.0-SNAPSHOT" TEST_INTEG_CLEAN_ON_EXIT=true INSTANCE_PROVISIONER=kind STACK_PROVISIONER=stateful SNAPSHOT=true mage integration:kubernetesMatrix
 TESTS_EXIT_STATUS=$?
 set -e


### PR DESCRIPTION
In CI we see failures like elastic/beats#41270

Removing `DEV=true` from CI builds should fix.