### PR TITLE
fix(5595): added logic to use development binary path for uninstall

### DIFF
--- a/changelog/fragments/1730662136-fix-development-agent-installation-with-force-flag.yaml
+++ b/changelog/fragments/1730662136-fix-development-agent-installation-with-force-flag.yaml
@@ -1,0 +1,30 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fixes how the force flag behaves when installing an agent in development mode. Using the force flag will correctly replace the development agent as opposed to the production agent.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: Currently using the force flag while installing an agent in development mode disregards the development flag and replaces the production agent. With this fix, the command correctly replaces the development agent with a new one.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/5877
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/paths/paths_darwin.go
+++ b/internal/pkg/agent/application/paths/paths_darwin.go
@@ -10,6 +10,10 @@ const (
 	// BinaryName is the name of the installed binary.
 	BinaryName = "elastic-agent"
 
+	// DevelopmentBinaryName is the name of the installed binary when --develop
+	// flag is used
+	DevelopmentBinaryName = "elastic-development-agent"
+
 	// DefaultBasePath is the base path used by the install command
 	// for installing Elastic Agent's files.
 	DefaultBasePath = "/Library"

--- a/internal/pkg/agent/application/paths/paths_linux.go
+++ b/internal/pkg/agent/application/paths/paths_linux.go
@@ -10,6 +10,10 @@ const (
 	// BinaryName is the name of the installed binary.
 	BinaryName = "elastic-agent"
 
+	// DevelopmentBinaryName is the name of the installed binary when --develop
+	// flag is used
+	DevelopmentBinaryName = "elastic-development-agent"
+
 	// DefaultBasePath is the base path used by the install command
 	// for installing Elastic Agent's files.
 	DefaultBasePath = "/opt"

--- a/internal/pkg/agent/application/paths/paths_windows.go
+++ b/internal/pkg/agent/application/paths/paths_windows.go
@@ -16,6 +16,10 @@ const (
 	// BinaryName is the name of the installed binary.
 	BinaryName = "elastic-agent.exe"
 
+	// DevelopmentBinaryName is the name of the installed binary when --develop
+	// flag is used
+	DevelopmentBinaryName = "elastic-development-agent.exe"
+
 	// DefaultBasePath is the base path used by the install command
 	// for installing Elastic Agent's files.
 	DefaultBasePath = `C:\Program Files`

--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -234,7 +234,8 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		// Uninstall the agent
 		progBar.Describe("Uninstalling current Elastic Agent")
 		if !runUninstallBinary {
-			err := execUninstall(streams)
+			bn := getBinaryName(isDevelopmentMode)
+			err := execUninstall(bn, streams)
 			if err != nil {
 				progBar.Describe("Uninstall failed")
 				return err
@@ -328,13 +329,20 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 	return nil
 }
 
+func getBinaryName(isDev bool) string {
+	if isDev {
+		return paths.DevelopmentBinaryName
+	}
+	return paths.BinaryName
+}
+
 // execUninstall execs "elastic-agent uninstall --force" from the elastic agent installed on the system (found in PATH)
-func execUninstall(streams *cli.IOStreams) error {
+func execUninstall(binaryName string, streams *cli.IOStreams) error {
 	args := []string{
 		"uninstall",
 		"--force",
 	}
-	execPath, err := exec.LookPath(paths.BinaryName)
+	execPath, err := exec.LookPath(binaryName)
 	if err != nil {
 		return fmt.Errorf("unable to find %s on path: %w", paths.BinaryName, err)
 	}

--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -344,7 +344,7 @@ func execUninstall(binaryName string, streams *cli.IOStreams) error {
 	}
 	execPath, err := exec.LookPath(binaryName)
 	if err != nil {
-		return fmt.Errorf("unable to find %s on path: %w", paths.BinaryName, err)
+		return fmt.Errorf("unable to find %s on path: %w", binaryName, err)
 	}
 	uninstall := exec.Command(execPath, args...)
 	uninstall.Stdout = streams.Out

--- a/testing/integration/install_test.go
+++ b/testing/integration/install_test.go
@@ -474,4 +474,3 @@ func randStr(length int) string {
 
 	return string(runes)
 }
-

--- a/testing/integration/install_test.go
+++ b/testing/integration/install_test.go
@@ -378,7 +378,6 @@ func TestRepeatedInstallUninstall(t *testing.T) {
 	iterations := 100
 	for i := 0; i < iterations; i++ {
 		t.Run(fmt.Sprintf("%s-%d", t.Name(), i), func(t *testing.T) {
-
 			// Get path to Elastic Agent executable
 			fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 			require.NoError(t, err)
@@ -443,7 +442,7 @@ func TestForceInstallDevelopment(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Confirm that the first development isntallation is successful
+	// Confirm that the first development installation is successful
 	require.True(t, devFix.IsInstalled())
 
 	devTopPath := installtest.NamespaceTopPath(devInstOpt.Namespace)

--- a/testing/integration/install_test.go
+++ b/testing/integration/install_test.go
@@ -452,7 +452,8 @@ func TestForceInstallDevelopment(t *testing.T) {
 	require.NoError(t, err)
 	err = devFix2.Prepare(ctx)
 	require.NoError(t, err)
-	devOut2, err := devFix2.Install(ctx, &devInstOpt)
+	devInstOpt2 := atesting.InstallOpts{Force: true, Privileged: false, Develop: true}
+	devOut2, err := devFix2.Install(ctx, &devInstOpt2)
 	if err != nil {
 		t.Logf("install output: %s", devOut2)
 		require.NoError(t, err)


### PR DESCRIPTION
- Bug


## What does this PR do?

Updates how the `upgrade` command works when used with the `--force` and `--develop` flags. Currently if a development agent is already installed, and if a user wants to force install a new development agent, the command uninstalls the production agent, if it exists, and tries to install the development agent again. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## How to test this PR locally

- Install and enroll production agent 
- Install and enroll development agent
- Run the development installation command with `--force` flag and confirm that at the end of the operation both `elastic-agent` and `elastic-development-agent` binaries are installed and that both agents are healthy 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #5595 
