### PR TITLE
Skip TestAPMConfig 

### DIFF
--- a/testing/integration/apm_propagation_test.go
+++ b/testing/integration/apm_propagation_test.go
@@ -55,6 +55,8 @@ func TestAPMConfig(t *testing.T) {
 		Group: Default,
 		Stack: &define.Stack{},
 	})
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/5890")
+
 	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR skips the `TestAPMConfig` test until we figure out root cause and fix it (see https://github.com/elastic/elastic-agent/issues/5890).

## Why is it important?

To get CI on `main` to green again.
