### PR TITLE
Fix elastic-agent-service Docker container entrypoint

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -42,7 +42,7 @@ RUN true && \
     chmod 0775 {{ $beatHome}}/{{ $modulesd }} && \
 {{- end }}
 
-{{- if or (eq .Variant "cloud") (eq .Variant "service") }}
+{{- if or (eq .Variant "cloud") }}
     mkdir -p /opt/agentbeat /opt/filebeat /opt/metricbeat && \
     cp -f {{ $beatHome }}/data/cloud_downloads/filebeat.sh /opt/filebeat/filebeat && \
     chmod +x /opt/filebeat/filebeat && \
@@ -172,7 +172,7 @@ RUN mkdir /licenses
 COPY --from=home {{ $beatHome }}/LICENSE.txt /licenses
 COPY --from=home {{ $beatHome }}/NOTICE.txt /licenses
 
-{{- if or (eq .Variant "cloud") (eq .Variant "service") }}
+{{- if or (eq .Variant "cloud") }}
 COPY --from=home /opt /opt
 # Generate folder for a stub command that will be overwritten at runtime
 RUN mkdir /app && \
@@ -294,7 +294,7 @@ ENV LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVERRIDE=/
 
 WORKDIR {{ $beatHome }}
 
-{{- if or (eq .Variant "cloud") (eq .Variant "service") }}
+{{- if or (eq .Variant "cloud") }}
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/app/apm.sh"]
 # Generate a stub command that will be overwritten at runtime

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -42,7 +42,7 @@ RUN true && \
     chmod 0775 {{ $beatHome}}/{{ $modulesd }} && \
 {{- end }}
 
-{{- if or (eq .Variant "cloud") }}
+{{- if eq .Variant "cloud" }}
     mkdir -p /opt/agentbeat /opt/filebeat /opt/metricbeat && \
     cp -f {{ $beatHome }}/data/cloud_downloads/filebeat.sh /opt/filebeat/filebeat && \
     chmod +x /opt/filebeat/filebeat && \
@@ -172,7 +172,7 @@ RUN mkdir /licenses
 COPY --from=home {{ $beatHome }}/LICENSE.txt /licenses
 COPY --from=home {{ $beatHome }}/NOTICE.txt /licenses
 
-{{- if or (eq .Variant "cloud") }}
+{{- if eq .Variant "cloud" }}
 COPY --from=home /opt /opt
 # Generate folder for a stub command that will be overwritten at runtime
 RUN mkdir /app && \
@@ -294,7 +294,7 @@ ENV LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVERRIDE=/
 
 WORKDIR {{ $beatHome }}
 
-{{- if or (eq .Variant "cloud") }}
+{{- if eq .Variant "cloud" }}
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/app/apm.sh"]
 # Generate a stub command that will be overwritten at runtime

--- a/testing/integration/kubernetes_agent_service_test.go
+++ b/testing/integration/kubernetes_agent_service_test.go
@@ -88,11 +88,6 @@ func TestKubernetesAgentService(t *testing.T) {
 					container.Env[idx].ValueFrom = nil
 				}
 			}
-
-			// has a unique entrypoint and command because its ran in the cloud
-			// adjust the spec to run it correctly
-			container.Command = []string{"elastic-agent"}
-			container.Args = []string{"-c", "/etc/elastic-agent/agent.yml", "-e"}
 		},
 		func(pod *corev1.PodSpec) {
 			for volumeIdx, volume := range pod.Volumes {


### PR DESCRIPTION
The `elastic-agent-service` container followed the template for the `elastic-agent-cloud` container. This isn't quite correct, because while the service container will run exclusively in cloud it is otherwise meant to be used as a standard Elastic Agent docker container with the standard entrypoint.

- Closes https://github.com/elastic/ingest-dev/issues/4363#issuecomment-2447236159