### PR TITLE
Allow reading apm config from file in ESS deployments

### DIFF
--- a/internal/pkg/agent/application/application.go
+++ b/internal/pkg/agent/application/application.go
@@ -145,6 +145,7 @@ func New(
 		}
 	} else {
 		isManaged = true
+		apmConfigPatcher := PatchAPMConfig(log, rawConfig)
 		var store storage.Store
 		store, cfg, err = mergeFleetConfig(ctx, rawConfig)
 		if err != nil {
@@ -152,9 +153,8 @@ func New(
 		}
 		if configuration.IsFleetServerBootstrap(cfg.Fleet) {
 			log.Info("Parsed configuration and determined agent is in Fleet Server bootstrap mode")
-
 			compModifiers = append(compModifiers, FleetServerComponentModifier(cfg.Fleet.Server))
-			configMgr = coordinator.NewConfigPatchManager(newFleetServerBootstrapManager(log), PatchAPMConfig(log, rawConfig))
+			configMgr = coordinator.NewConfigPatchManager(newFleetServerBootstrapManager(log), apmConfigPatcher)
 		} else {
 			log.Info("Parsed configuration and determined agent is managed by Fleet")
 
@@ -172,7 +172,7 @@ func New(
 			if err != nil {
 				return nil, nil, nil, err
 			}
-			configMgr = coordinator.NewConfigPatchManager(managed, PatchAPMConfig(log, rawConfig))
+			configMgr = coordinator.NewConfigPatchManager(managed, apmConfigPatcher)
 		}
 	}
 

--- a/internal/pkg/agent/cmd/enroll.go
+++ b/internal/pkg/agent/cmd/enroll.go
@@ -512,12 +512,19 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command) error {
 	if err != nil {
 		return fmt.Errorf("failed to create encrypted disk store: %w", err)
 	}
-	store := storage.NewReplaceOnSuccessStore(
-		pathConfigFile,
-		application.DefaultAgentFleetConfig,
-		encStore,
-		storeOpts...,
-	)
+
+	var store saver
+
+	if cfg.Fleet != nil && cfg.Fleet.Enabled {
+		store = encStore
+	} else {
+		store = storage.NewReplaceOnSuccessStore(
+			pathConfigFile,
+			application.DefaultAgentFleetConfig,
+			encStore,
+			storeOpts...,
+		)
+	}
 
 	c, err := newEnrollCmd(
 		logger,

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -352,7 +352,11 @@ func (c *enrollCmd) fleetServerBootstrap(ctx context.Context, persistentConfig m
 		return "", err
 	}
 
+	c.log.Infof("creating agent config for Fleet bootstrap from %v", persistentConfig)
+
 	agentConfig := c.createAgentConfig("", persistentConfig, c.options.FleetServer.Headers)
+
+	c.log.Infof("created agent config for Fleet bootstrap: %v", agentConfig)
 
 	//nolint:dupl // duplicate because same params are passed
 	fleetConfig, err := createFleetServerBootstrapConfig(
@@ -1069,9 +1073,10 @@ func getPersistentConfig(pathConfigFile string) (map[string]interface{}, error) 
 	}
 
 	pc := &struct {
-		Headers        map[string]string                      `json:"agent.headers,omitempty" yaml:"agent.headers,omitempty" config:"agent.headers,omitempty"`
-		LogLevel       string                                 `json:"agent.logging.level,omitempty" yaml:"agent.logging.level,omitempty" config:"agent.logging.level,omitempty"`
-		MonitoringHTTP *monitoringConfig.MonitoringHTTPConfig `json:"agent.monitoring.http,omitempty" yaml:"agent.monitoring.http,omitempty" config:"agent.monitoring.http,omitempty"`
+		Headers             map[string]string                      `json:"agent.headers,omitempty" yaml:"agent.headers,omitempty" config:"agent.headers,omitempty"`
+		LogLevel            string                                 `json:"agent.logging.level,omitempty" yaml:"agent.logging.level,omitempty" config:"agent.logging.level,omitempty"`
+		MonitoringHTTP      *monitoringConfig.MonitoringHTTPConfig `json:"agent.monitoring.http,omitempty" yaml:"agent.monitoring.http,omitempty" config:"agent.monitoring.http,omitempty"`
+		MonitoringAPMConfig *monitoringConfig.APMConfig            `json:"agent.monitoring.apm,omitempty" yaml:"agent.monitoring.apm,omitempty" config:"agent.monitoring.apm,omitempty"`
 	}{
 		MonitoringHTTP: monitoringConfig.DefaultConfig().HTTP,
 	}
@@ -1088,6 +1093,9 @@ func getPersistentConfig(pathConfigFile string) (map[string]interface{}, error) 
 		persistentMap["monitoring.http"] = pc.MonitoringHTTP
 	}
 
+	if pc.MonitoringAPMConfig != nil {
+		persistentMap["monitoring.apm"] = pc.MonitoringAPMConfig
+	}
 	return persistentMap, nil
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This PR preserves the `agent.monitoring.apm.*` settings when the agent is managed and in fleet bootstrap mode (as it is in an ESS deployment)
- `PatchAPMConfig` is initialized *before* fleet config is merged onto the file config.
- `MonitoringAPMConfig` is preserved when loading the persistent configuration
- `elastic-agent.yml` is not rotated if it already contains `fleet.enabled=true` (similar to what has been done in #4166, although I didn't manage to make it work on the `8.16` branch where I tested spinning up ESS deployments with custom agent images) so I implemented a simpler solution here
- There's a bunch of logs that need to print only in `debug` or removed altogether (to figure out what was going on I had to dump part of the configuration in multiple places)

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Allow elastic-agent running fleet-server and apm-server in ESS integration server to propagate APM settings coming from `elastic-agent.yml` without the need of replicating such configuration in Fleet Cloud policy.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->