### PR TITLE
Introduce filter by group and dry-run for integration tests

### DIFF
--- a/pkg/testing/define/define.go
+++ b/pkg/testing/define/define.go
@@ -150,7 +150,7 @@ func runOrSkip(t *testing.T, req Requirements, local bool, kubernetes bool) *Inf
 		return nil
 	}
 
-	if SudoFilter.HasBeenSet() && req.Sudo != SudoFilter.Value() {
+	if SudoFilter.IsSet() && req.Sudo != SudoFilter.Value() {
 		t.Skipf("sudo requirement %t not matching sudo filter %t. Skipping", req.Sudo, SudoFilter.Value())
 	}
 

--- a/pkg/testing/define/define.go
+++ b/pkg/testing/define/define.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -143,6 +144,12 @@ func runOrSkip(t *testing.T, req Requirements, local bool, kubernetes bool) *Inf
 	if err := req.Validate(); err != nil {
 		panic(fmt.Sprintf("test %s has invalid requirements: %s", t.Name(), err))
 	}
+
+	if len(Groups) > 0 && !slices.Contains(Groups, req.Group) {
+		t.Skip("group % not selected. Skipping")
+		return nil
+	}
+
 	if !req.Local && local {
 		t.Skip("running local only tests and this test doesn't support local")
 		return nil

--- a/pkg/testing/define/define.go
+++ b/pkg/testing/define/define.go
@@ -146,7 +146,7 @@ func runOrSkip(t *testing.T, req Requirements, local bool, kubernetes bool) *Inf
 	}
 
 	if len(Groups) > 0 && !slices.Contains(Groups, req.Group) {
-		t.Skip("group % not selected. Skipping")
+		t.Skipf("group %s not found in %s. Skipping", req.Group, Groups)
 		return nil
 	}
 
@@ -180,6 +180,11 @@ func runOrSkip(t *testing.T, req Requirements, local bool, kubernetes bool) *Inf
 		t.Skipf("platform: %s, architecture: %s, version: %s, and distro: %s combination is not supported by test.  required: %v", runtime.GOOS, runtime.GOARCH, osInfo.Version, osInfo.Platform, req.OS)
 		return nil
 	}
+
+	if DryRun {
+		return dryRun(t, req)
+	}
+
 	namespace, err := getNamespace(t, local)
 	if err != nil {
 		panic(err)

--- a/pkg/testing/define/define.go
+++ b/pkg/testing/define/define.go
@@ -145,9 +145,13 @@ func runOrSkip(t *testing.T, req Requirements, local bool, kubernetes bool) *Inf
 		panic(fmt.Sprintf("test %s has invalid requirements: %s", t.Name(), err))
 	}
 
-	if len(Groups) > 0 && !slices.Contains(Groups, req.Group) {
-		t.Skipf("group %s not found in %s. Skipping", req.Group, Groups)
+	if len(GroupsFilter) > 0 && !slices.Contains(GroupsFilter, req.Group) {
+		t.Skipf("group %s not found in groups filter %s. Skipping", req.Group, GroupsFilter)
 		return nil
+	}
+
+	if SudoFilter.HasBeenSet() && req.Sudo != SudoFilter.Value() {
+		t.Skipf("sudo requirement %t not matching sudo filter %t. Skipping", req.Sudo, SudoFilter.Value())
 	}
 
 	if !req.Local && local {

--- a/pkg/testing/define/define.go
+++ b/pkg/testing/define/define.go
@@ -151,8 +151,8 @@ func runOrSkip(t *testing.T, req Requirements, local bool, kubernetes bool) *Inf
 		return nil
 	}
 
-	if SudoFilter.IsSet() && req.Sudo != SudoFilter.Value() {
-		t.Skipf("sudo requirement %t not matching sudo filter %t. Skipping", req.Sudo, SudoFilter.Value())
+	if SudoFilter.value != nil && req.Sudo != *SudoFilter.value {
+		t.Skipf("sudo requirement %t not matching sudo filter %t. Skipping", req.Sudo, *SudoFilter.value)
 	}
 
 	if !req.Local && local {

--- a/pkg/testing/define/define.go
+++ b/pkg/testing/define/define.go
@@ -145,8 +145,9 @@ func runOrSkip(t *testing.T, req Requirements, local bool, kubernetes bool) *Inf
 		panic(fmt.Sprintf("test %s has invalid requirements: %s", t.Name(), err))
 	}
 
-	if len(GroupsFilter) > 0 && !slices.Contains(GroupsFilter, req.Group) {
-		t.Skipf("group %s not found in groups filter %s. Skipping", req.Group, GroupsFilter)
+	filteredGroups := GroupsFilter.values
+	if len(filteredGroups) > 0 && !slices.Contains(filteredGroups, req.Group) {
+		t.Skipf("group %s not found in groups filter %s. Skipping", req.Group, filteredGroups)
 		return nil
 	}
 

--- a/pkg/testing/define/define_flags.go
+++ b/pkg/testing/define/define_flags.go
@@ -25,15 +25,11 @@ func (o *optionalBoolFlag) String() string {
 
 func (o *optionalBoolFlag) Set(s string) error {
 	o.set = true
-	if s == "" || s == "true" {
-		o.value = true
-		return nil
-	}
-	o.value = false
+	o.value = s == "" || s == "true"
 	return nil
 }
 
-func (o *optionalBoolFlag) HasBeenSet() bool {
+func (o *optionalBoolFlag) IsSet() bool {
 	return o.set
 }
 

--- a/pkg/testing/define/define_flags.go
+++ b/pkg/testing/define/define_flags.go
@@ -1,0 +1,17 @@
+package define
+
+import (
+	"github.com/spf13/pflag"
+)
+
+var (
+	DryRun    bool
+	Groups    []string
+	Platforms []string
+)
+
+func RegisterFlags(prefix string, set *pflag.FlagSet) {
+	set.BoolVar(&DryRun, prefix+"dry-run", false, "Forces test in dry-run mode: drops platform/group/sudo requirements")
+	set.StringArrayVar(&Groups, prefix+"groups", nil, "test groups")
+	set.StringArrayVar(&Platforms, prefix+"plarforms", nil, "test platforms")
+}

--- a/pkg/testing/define/define_flags.go
+++ b/pkg/testing/define/define_flags.go
@@ -1,17 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package define
 
 import (
-	"github.com/spf13/pflag"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
 )
 
 var (
 	DryRun    bool
 	Groups    []string
 	Platforms []string
+
+	groupStringFlag    string
+	platformStringFlag string
 )
 
-func RegisterFlags(prefix string, set *pflag.FlagSet) {
+func RegisterFlags(prefix string, set *flag.FlagSet) {
 	set.BoolVar(&DryRun, prefix+"dry-run", false, "Forces test in dry-run mode: drops platform/group/sudo requirements")
-	set.StringArrayVar(&Groups, prefix+"groups", nil, "test groups")
-	set.StringArrayVar(&Platforms, prefix+"plarforms", nil, "test platforms")
+	set.StringVar(&groupStringFlag, prefix+"groups", "", "test groups, comma-separated")
+	set.StringVar(&platformStringFlag, prefix+"platforms", "", "test platforms, comma-separated")
+}
+
+func ParseFlags() {
+	Groups = splitStringToArray(groupStringFlag)
+	Platforms = splitStringToArray(platformStringFlag)
+}
+
+func splitStringToArray(stringFlag string) []string {
+	if stringFlag == "" {
+		return nil
+	}
+	fmt.Fprintf(os.Stderr, "Splitting %q...", stringFlag)
+	return strings.Split(stringFlag, ",")
+}
+
+func dryRun(t *testing.T, req Requirements) *Info {
+	// always validate requirement is valid
+	if err := req.Validate(); err != nil {
+		t.Logf("test %s has invalid requirements: %s", t.Name(), err)
+		t.FailNow()
+		return nil
+	}
+	// skip the test as we are in dry run
+	t.Skip(fmt.Sprintf("Skipped because dry-run mode has been specified."))
+	return nil
 }

--- a/pkg/testing/define/define_flags.go
+++ b/pkg/testing/define/define_flags.go
@@ -13,29 +13,20 @@ import (
 )
 
 type optionalBoolFlag struct {
-	set   bool
-	value bool
+	value *bool
 }
 
 func (o *optionalBoolFlag) String() string {
-	if !o.set {
-		return "<not set>"
+	if o.value == nil {
+		return "nil"
 	}
-	return strconv.FormatBool(o.value)
+	return strconv.FormatBool(*o.value)
 }
 
 func (o *optionalBoolFlag) Set(s string) error {
-	o.set = true
-	o.value = s == "" || s == "true"
+	bValue := s == "" || s == "true"
+	o.value = &bValue
 	return nil
-}
-
-func (o *optionalBoolFlag) IsSet() bool {
-	return o.set
-}
-
-func (o *optionalBoolFlag) Value() bool {
-	return o.value
 }
 
 type stringArrayFlag struct {

--- a/pkg/testing/define/define_flags.go
+++ b/pkg/testing/define/define_flags.go
@@ -6,6 +6,7 @@ package define
 
 import (
 	"flag"
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -37,33 +38,34 @@ func (o *optionalBoolFlag) Value() bool {
 	return o.value
 }
 
+type stringArrayFlag struct {
+	values []string
+}
+
+func (s *stringArrayFlag) String() string {
+	return fmt.Sprintf("%s", s.values)
+}
+
+func (s *stringArrayFlag) Set(stringValue string) error {
+	if stringValue == "" {
+		return nil
+	}
+	s.values = strings.Split(stringValue, ",")
+	return nil
+}
+
 var (
 	DryRun          bool
-	GroupsFilter    []string
-	PlatformsFilter []string
+	GroupsFilter    stringArrayFlag
+	PlatformsFilter stringArrayFlag
 	SudoFilter      optionalBoolFlag
-
-	groupStringFlag    string
-	platformStringFlag string
 )
 
 func RegisterFlags(prefix string, set *flag.FlagSet) {
 	set.BoolVar(&DryRun, prefix+"dry-run", false, "Forces test in dry-run mode: skips the main test and puts a successful placeholder <TestName>/dry-run if the test would have run")
-	set.StringVar(&groupStringFlag, prefix+"groups", "", "test groups, comma-separated")
-	set.StringVar(&platformStringFlag, prefix+"platforms", "", "test platforms, comma-separated")
+	set.Var(&GroupsFilter, prefix+"groups", "test groups, comma-separated")
+	set.Var(&PlatformsFilter, prefix+"platforms", "test platforms, comma-separated")
 	set.Var(&SudoFilter, prefix+"sudo", "Filter tests by sudo requirements")
-}
-
-func ParseFlags() {
-	GroupsFilter = splitStringToArray(groupStringFlag)
-	PlatformsFilter = splitStringToArray(platformStringFlag)
-}
-
-func splitStringToArray(stringFlag string) []string {
-	if stringFlag == "" {
-		return nil
-	}
-	return strings.Split(stringFlag, ",")
 }
 
 func dryRun(t *testing.T, req Requirements) *Info {

--- a/pkg/testing/define/define_flags.go
+++ b/pkg/testing/define/define_flags.go
@@ -84,6 +84,6 @@ func dryRun(t *testing.T, req Requirements) *Info {
 	t.Run("dry-run", func(t *testing.T) {
 		t.Log("Test dry-run successful")
 	})
-	t.Skip(fmt.Sprintf("Skipped because dry-run mode has been specified."))
+	t.Skip("Skipped because dry-run mode has been specified.")
 	return nil
 }

--- a/pkg/testing/define/define_flags.go
+++ b/pkg/testing/define/define_flags.go
@@ -48,6 +48,9 @@ func dryRun(t *testing.T, req Requirements) *Info {
 		return nil
 	}
 	// skip the test as we are in dry run
+	t.Run("dry-run", func(t *testing.T) {
+		t.Log("Test dry-run successful")
+	})
 	t.Skip(fmt.Sprintf("Skipped because dry-run mode has been specified."))
 	return nil
 }

--- a/pkg/testing/define/define_flags.go
+++ b/pkg/testing/define/define_flags.go
@@ -6,8 +6,6 @@ package define
 
 import (
 	"flag"
-	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -69,7 +67,6 @@ func splitStringToArray(stringFlag string) []string {
 	if stringFlag == "" {
 		return nil
 	}
-	fmt.Fprintf(os.Stderr, "Splitting %q...", stringFlag)
 	return strings.Split(stringFlag, ",")
 }
 

--- a/pkg/testing/define/parser.go
+++ b/pkg/testing/define/parser.go
@@ -26,7 +26,7 @@ func ValidateDir(dir string) error {
 		for _, file := range pkg.Files {
 			for _, d := range file.Decls {
 				fn, ok := d.(*ast.FuncDecl)
-				if ok && "TestMain" != fn.Name.Name && strings.HasPrefix(fn.Name.Name, "Test") && fn.Recv == nil {
+				if ok && fn.Name.Name != "TestMain" && strings.HasPrefix(fn.Name.Name, "Test") && fn.Recv == nil {
 					if !validateRequireFromFunc(fn) {
 						return fmt.Errorf("test %s first statement must be a function call to define.Require", fn.Name.Name)
 					}

--- a/pkg/testing/define/parser.go
+++ b/pkg/testing/define/parser.go
@@ -26,7 +26,7 @@ func ValidateDir(dir string) error {
 		for _, file := range pkg.Files {
 			for _, d := range file.Decls {
 				fn, ok := d.(*ast.FuncDecl)
-				if ok && strings.HasPrefix(fn.Name.Name, "Test") && fn.Recv == nil {
+				if ok && "TestMain" != fn.Name.Name && strings.HasPrefix(fn.Name.Name, "Test") && fn.Recv == nil {
 					if !validateRequireFromFunc(fn) {
 						return fmt.Errorf("test %s first statement must be a function call to define.Require", fn.Name.Name)
 					}

--- a/testing/integration/main_test.go
+++ b/testing/integration/main_test.go
@@ -21,7 +21,6 @@ func init() {
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-	define.ParseFlags()
 	runExitCode := m.Run()
 
 	if define.DryRun {

--- a/testing/integration/main_test.go
+++ b/testing/integration/main_test.go
@@ -1,0 +1,28 @@
+package integration
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+	"github.com/spf13/pflag"
+)
+
+var flagSet = pflag.CommandLine
+
+func init() {
+	define.RegisterFlags("integration.", flagSet)
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	runExitCode := m.Run()
+
+	if define.DryRun {
+		// TODO add parsing of requirements and dump them
+	}
+
+	os.Exit(runExitCode)
+}

--- a/testing/integration/main_test.go
+++ b/testing/integration/main_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package integration
 
 import (
@@ -6,10 +10,9 @@ import (
 	"testing"
 
 	"github.com/elastic/elastic-agent/pkg/testing/define"
-	"github.com/spf13/pflag"
 )
 
-var flagSet = pflag.CommandLine
+var flagSet = flag.CommandLine
 
 func init() {
 	define.RegisterFlags("integration.", flagSet)
@@ -17,7 +20,7 @@ func init() {
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-
+	define.ParseFlags()
 	runExitCode := m.Run()
 
 	if define.DryRun {

--- a/testing/integration/main_test.go
+++ b/testing/integration/main_test.go
@@ -6,6 +6,7 @@ package integration
 
 import (
 	"flag"
+	"log"
 	"os"
 	"testing"
 
@@ -25,6 +26,7 @@ func TestMain(m *testing.M) {
 
 	if define.DryRun {
 		// TODO add parsing of requirements and dump them
+		log.Print("Dry-run mode specified...")
 	}
 
 	os.Exit(runExitCode)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR adds a `TestMain()` to the `testing/integration` package to allow passing some command-line arguments when running integration tests using `go test`:
- `-integration.groups` allows to specify a comma-separated list of groups to filter on
- `-integration.dry-run` will validate define constraints but will skip the real tests that contain `define` directives and add a placeholder `<Test name>/dry-run` which will pass if all the `define` checks pass

The `groups` flag allows for a simple way of selecting a subset of tests (for either real running or dry-runs)
The `sudo` flag allows to filter tests based on their sudo requirements (if those need to run as root/administrator or not)
The `dry-run` argument allows for quick execution when experimenting with group filtering (making sure that what would be executed matches expectations)

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Running by groups should simplify initial implementation of running Integration tests on CI

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

```shell
go test -tags integration github.com/elastic/elastic-agent/testing/integration -v -args -integration.groups="fleet,default" -integration.dry-run=true
```
(since it's a dry-run it won't actually run the tests)
```shell
=== RUN   TestLongRunningAgentForLeaks
    define.go:170: not running as root and test requires root
--- SKIP: TestLongRunningAgentForLeaks (0.00s)
=== RUN   TestAPMConfig
=== RUN   TestAPMConfig/dry-run
    define_flags.go:52: Test dry-run successful
=== NAME  TestAPMConfig
    define_flags.go:54: Skipped because dry-run mode has been specified.
--- SKIP: TestAPMConfig (0.00s)
    --- PASS: TestAPMConfig/dry-run (0.00s)
=== RUN   TestBeatsServerless
    define.go:170: not running as root and test requires root
--- SKIP: TestBeatsServerless (0.00s)
=== RUN   TestContainerCMD
    define.go:149: group container not found in [fleet default]. Skipping
--- SKIP: TestContainerCMD (0.00s)
=== RUN   TestContainerCMDWithAVeryLongStatePath
    define.go:149: group container not found in [fleet default]. Skipping
--- SKIP: TestContainerCMDWithAVeryLongStatePath (0.00s)

... a long list of tests is omitted here ...

=== RUN   TestStandaloneUpgradeFailsWhenUpgradeIsInProgress
    define.go:149: group upgrade not found in [fleet default]. Skipping
--- SKIP: TestStandaloneUpgradeFailsWhenUpgradeIsInProgress (0.00s)
=== RUN   TestStandaloneUpgradeRetryDownload
    define.go:149: group upgrade not found in [fleet default]. Skipping
--- SKIP: TestStandaloneUpgradeRetryDownload (0.00s)
=== RUN   TestStandaloneUpgradeSameCommit
    define.go:149: group upgrade not found in [fleet default]. Skipping
--- SKIP: TestStandaloneUpgradeSameCommit (0.00s)
=== RUN   TestStandaloneUpgrade
    define.go:149: group upgrade not found in [fleet default]. Skipping
--- SKIP: TestStandaloneUpgrade (0.00s)
=== RUN   TestStandaloneUpgradeUninstallKillWatcher
    define.go:149: group upgrade not found in [fleet default]. Skipping
--- SKIP: TestStandaloneUpgradeUninstallKillWatcher (0.00s)
PASS
ok      github.com/elastic/elastic-agent/testing/integration    1.123s

```

Adding a sudo filter for running only test that do not require sudo:
```shell
sudo go test -tags integration github.com/elastic/elastic-agent/testing/integration -v -args -integration.groups="fleet,default" -integration.dry-run=true -integration.sudo=true

=== RUN   TestLongRunningAgentForLeaks
=== RUN   TestLongRunningAgentForLeaks/dry-run
    define_flags.go:85: Test dry-run successful
=== NAME  TestLongRunningAgentForLeaks
    define_flags.go:87: Skipped because dry-run mode has been specified.
--- SKIP: TestLongRunningAgentForLeaks (0.00s)
    --- PASS: TestLongRunningAgentForLeaks/dry-run (0.00s)
=== RUN   TestAPMConfig
    define.go:154: sudo requirement false not matching sudo filter true. Skipping
--- SKIP: TestAPMConfig (0.00s)
=== RUN   TestBeatsServerless
=== RUN   TestBeatsServerless/dry-run
    define_flags.go:85: Test dry-run successful
=== NAME  TestBeatsServerless
    define_flags.go:87: Skipped because dry-run mode has been specified.
--- SKIP: TestBeatsServerless (0.00s)
    --- PASS: TestBeatsServerless/dry-run (0.00s)
=== RUN   TestContainerCMD
    define.go:149: group container not found in groups filter [fleet default]. Skipping
--- SKIP: TestContainerCMD (0.00s)
... a long list of tests is omitted here ...
=== RUN   TestOtelFileProcessing
    define.go:154: sudo requirement false not matching sudo filter true. Skipping
--- SKIP: TestOtelFileProcessing (0.00s)
=== RUN   TestOtelLogsIngestion
    define.go:154: sudo requirement false not matching sudo filter true. Skipping
--- SKIP: TestOtelLogsIngestion (0.00s)
=== RUN   TestOtelAPMIngestion
    define.go:154: sudo requirement false not matching sudo filter true. Skipping
--- SKIP: TestOtelAPMIngestion (0.00s)
=== RUN   TestFileBeatReceiver
    define.go:154: sudo requirement false not matching sudo filter true. Skipping
--- SKIP: TestFileBeatReceiver (0.00s)
=== RUN   TestPackageVersion
    define.go:154: sudo requirement false not matching sudo filter true. Skipping
--- SKIP: TestPackageVersion (0.00s)
=== RUN   TestComponentBuildHashInDiagnostics
=== RUN   TestComponentBuildHashInDiagnostics/dry-run
    define_flags.go:85: Test dry-run successful
=== NAME  TestComponentBuildHashInDiagnostics
    define_flags.go:87: Skipped because dry-run mode has been specified.
--- SKIP: TestComponentBuildHashInDiagnostics (0.00s)
    --- PASS: TestComponentBuildHashInDiagnostics/dry-run (0.00s)
=== RUN   TestProxyURL
=== RUN   TestProxyURL/dry-run
    define_flags.go:85: Test dry-run successful
=== NAME  TestProxyURL
    define_flags.go:87: Skipped because dry-run mode has been specified.
--- SKIP: TestProxyURL (0.00s)
    --- PASS: TestProxyURL/dry-run (0.00s)
    ... a long list of tests is omitted here ...
PASS
ok      github.com/elastic/elastic-agent/testing/integration    1.094s


```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->