### PR TITLE
Fix migration log messages

### DIFF
--- a/internal/pkg/agent/migration/migrate_config.go
+++ b/internal/pkg/agent/migration/migrate_config.go
@@ -42,7 +42,7 @@ func MigrateToEncryptedConfig(ctx context.Context, l *logp.Logger, unencryptedCo
 		return nil
 	}
 
-	l.Info("Initiating migration of %q to %q", unencryptedConfigPath, encryptedConfigPath)
+	l.Info(fmt.Sprintf("Initiating migration of %q to %q", unencryptedConfigPath, encryptedConfigPath))
 	legacyStore, err := storage.NewDiskStore(unencryptedConfigPath)
 	if err != nil {
 		return fmt.Errorf("error instantiating disk store: %w", err)
@@ -65,7 +65,7 @@ func MigrateToEncryptedConfig(ctx context.Context, l *logp.Logger, unencryptedCo
 	if err != nil {
 		return errors.New(err, fmt.Sprintf("error writing encrypted config from file %q to file %q", unencryptedConfigPath, encryptedConfigPath))
 	}
-	l.Info("Migration of %q to %q complete", unencryptedConfigPath, encryptedConfigPath)
+	l.Info(fmt.Sprintf("Migration of %q to %q complete", unencryptedConfigPath, encryptedConfigPath))
 
 	return nil
 }


### PR DESCRIPTION
Fix some log messages that included bare `%q` in the text (the log library doesn't support %q directly, that requires wrapping in a `fmt.Sprintf`).

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~
