### PR TITLE
[Integration Testing Framework][ESS] Stop using deprecated ESS resource IDs

### DIFF
--- a/pkg/testing/ess/create_deployment_csp_configuration.yaml
+++ b/pkg/testing/ess/create_deployment_csp_configuration.yaml
@@ -1,15 +1,15 @@
 gcp:
-  integrations_server_conf_id: "gcp.integrationsserver.n2.68x32x45.2"
+  integrations_server_conf_id: "gcp.integrationsserver.n2.68x32x45"
   elasticsearch_conf_id: "gcp.es.datahot.n2.68x10x45"
   elasticsearch_deployment_template_id: "gcp-storage-optimized"
   kibana_instance_configuration_id: "gcp.kibana.n2.68x32x45"
 azure:
-  integrations_server_conf_id: "azure.integrationsserver.fsv2.2"
+  integrations_server_conf_id: "azure.integrationsserver.fsv2"
   elasticsearch_conf_id: "azure.es.datahot.edsv4"
   elasticsearch_deployment_template_id: "azure-storage-optimized"
   kibana_instance_configuration_id: "azure.kibana.fsv2"
 aws:
-  integrations_server_conf_id: "aws.integrationsserver.c5d.2.1"
-  elasticsearch_conf_id: "aws.es.datahot.i3.1.1"
+  integrations_server_conf_id: "aws.integrationsserver.c5d"
+  elasticsearch_conf_id: "aws.es.datahot.i3"
   elasticsearch_deployment_template_id: "aws-storage-optimized"
-  kibana_instance_configuration_id: "aws.kibana.c5d.1.1"
+  kibana_instance_configuration_id: "aws.kibana.c5d"

--- a/pkg/testing/ess/create_deployment_csp_configuration.yaml
+++ b/pkg/testing/ess/create_deployment_csp_configuration.yaml
@@ -1,15 +1,15 @@
 gcp:
   integrations_server_conf_id: "gcp.integrationsserver.n2.68x32x45.2"
   elasticsearch_conf_id: "gcp.es.datahot.n2.68x10x45"
-  elasticsearch_deployment_template_id: "gcp-storage-optimized-v5"
+  elasticsearch_deployment_template_id: "gcp-storage-optimized"
   kibana_instance_configuration_id: "gcp.kibana.n2.68x32x45"
 azure:
   integrations_server_conf_id: "azure.integrationsserver.fsv2.2"
   elasticsearch_conf_id: "azure.es.datahot.edsv4"
-  elasticsearch_deployment_template_id: "azure-storage-optimized-v2"
+  elasticsearch_deployment_template_id: "azure-storage-optimized"
   kibana_instance_configuration_id: "azure.kibana.fsv2"
 aws:
   integrations_server_conf_id: "aws.integrationsserver.c5d.2.1"
   elasticsearch_conf_id: "aws.es.datahot.i3.1.1"
-  elasticsearch_deployment_template_id: "aws-storage-optimized-v5"
+  elasticsearch_deployment_template_id: "aws-storage-optimized"
   kibana_instance_configuration_id: "aws.kibana.c5d.1.1"


### PR DESCRIPTION
## What does this PR do?

This PR updates the deployment template IDs and instance configuration IDs used to spin up deployments in ESS for integration testing.  

## Why is it important?

The deployments template IDs and instance configuration IDs being used have been [deprecated](https://www.elastic.co/guide/en/cloud/current/ec-regions-templates-instances.html).  Continuing to use them causes errors like so when the integration testing framework attempts to create deployments in ESS:

```
failed to create ESS cloud for version 8.17.0-SNAPSHOT: failed to create: (deployments.elasticsearch_using_legacy_dt) The referenced deployment template in elasticsearch plan [gcp-storage-optimized-v5] is no longer available.
```

```
failed to create ESS cloud for version 9.0.0-SNAPSHOT: failed to create: (deployments.topology_element_using_legacy_ic) The referenced instance configuration [gcp.integrationsserver.n2.68x32x45.2] in topology element [<unknown>] is no longer available.
```