### PR TITLE
[helm] derive the lease name from the release and preset names

### DIFF
--- a/deploy/helm/elastic-agent/examples/eck/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/eck/rendered/manifest.yaml
@@ -76,6 +76,7 @@ stringData:
         scope: cluster
       kubernetes_leaderelection:
         enabled: true
+        leader_lease: example-clusterwide
     inputs:
       - data_stream:
           namespace: default
@@ -127,6 +128,7 @@ stringData:
         enabled: false
       kubernetes_leaderelection:
         enabled: false
+        leader_lease: example-ksmsharded
     inputs:
       - data_stream:
           namespace: default
@@ -417,6 +419,7 @@ stringData:
         scope: node
       kubernetes_leaderelection:
         enabled: false
+        leader_lease: example-pernode
     inputs:
       - data_stream:
           namespace: default

--- a/deploy/helm/elastic-agent/examples/fleet-managed/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/fleet-managed/rendered/manifest.yaml
@@ -32,6 +32,7 @@ stringData:
     providers:
       kubernetes_leaderelection:
         enabled: false
+        leader_lease: example-nginx
 ---
 # Source: elastic-agent/templates/agent/cluster-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -181,7 +182,7 @@ spec:
       labels:
         name: agent-nginx-example
       annotations:
-        checksum/config: ce25762427c9b6e207de5327b69be314f9d077db8138b7b241fd40f7b8a80aca
+        checksum/config: 975ed05540e0d099fe1b28b15d6403aacee676d0776a69fb75eb8624e19ad2de
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/examples/kubernetes-default/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/kubernetes-default/rendered/manifest.yaml
@@ -94,6 +94,7 @@ stringData:
         scope: cluster
       kubernetes_leaderelection:
         enabled: true
+        leader_lease: example-clusterwide
 ---
 # Source: elastic-agent/templates/agent/k8s/secret.yaml
 apiVersion: v1
@@ -388,6 +389,7 @@ stringData:
         enabled: false
       kubernetes_leaderelection:
         enabled: false
+        leader_lease: example-ksmsharded
 ---
 # Source: elastic-agent/templates/agent/k8s/secret.yaml
 apiVersion: v1
@@ -571,6 +573,7 @@ stringData:
         scope: node
       kubernetes_leaderelection:
         enabled: false
+        leader_lease: example-pernode
 ---
 # Source: elastic-agent/templates/agent/cluster-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1089,7 +1092,7 @@ spec:
       labels:
         name: agent-pernode-example
       annotations:
-        checksum/config: d361521be4fd034ea920a15f80ef519e05c00d801973175e3f165ea714931b52
+        checksum/config: 233affcd72143e637a130b5f099c30e194d90042eb00a26512f51c844c65a821
     spec:
       automountServiceAccountToken: true
       containers:
@@ -1209,7 +1212,7 @@ spec:
       labels:
         name: agent-clusterwide-example
       annotations:
-        checksum/config: 14177955837470abb34597058889ea1f1d34ded25b5271b0dbbfb0bc8f3161c9
+        checksum/config: 97e62ed0d731dea2ecadf31b0a7b4160db1b8a253589b7324f3a381af2519591
     spec:
       automountServiceAccountToken: true
       containers:
@@ -1291,7 +1294,7 @@ spec:
       labels:
         name: agent-ksmsharded-example
       annotations:
-        checksum/config: 58c52f37c9e2582e270e0c3b5c0150252db79a8a1be4e9b287da943a7c9e3bdf
+        checksum/config: 3b64edf7317419b11b0aef4cd10cad04037b7bc0b6866da25871b47b41c04490
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/examples/kubernetes-hints-autodiscover/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/kubernetes-hints-autodiscover/rendered/manifest.yaml
@@ -94,6 +94,7 @@ stringData:
         scope: cluster
       kubernetes_leaderelection:
         enabled: true
+        leader_lease: example-clusterwide
 ---
 # Source: elastic-agent/templates/agent/k8s/secret.yaml
 apiVersion: v1
@@ -388,6 +389,7 @@ stringData:
         enabled: false
       kubernetes_leaderelection:
         enabled: false
+        leader_lease: example-ksmsharded
 ---
 # Source: elastic-agent/templates/agent/k8s/secret.yaml
 apiVersion: v1
@@ -573,6 +575,7 @@ stringData:
         scope: node
       kubernetes_leaderelection:
         enabled: false
+        leader_lease: example-pernode
 ---
 # Source: elastic-agent/templates/agent/cluster-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1091,7 +1094,7 @@ spec:
       labels:
         name: agent-pernode-example
       annotations:
-        checksum/config: c9823ca6e0ab0a28164ee0111de74d3225480f5c5e81057159d3276ad3208f46
+        checksum/config: 0df24cb5f7362916ba8cb10621b123918f22f52a7ce9f0b0514c5983de6d06f3
     spec:
       automountServiceAccountToken: true
       containers:
@@ -1236,7 +1239,7 @@ spec:
       labels:
         name: agent-clusterwide-example
       annotations:
-        checksum/config: 14177955837470abb34597058889ea1f1d34ded25b5271b0dbbfb0bc8f3161c9
+        checksum/config: 97e62ed0d731dea2ecadf31b0a7b4160db1b8a253589b7324f3a381af2519591
     spec:
       automountServiceAccountToken: true
       containers:
@@ -1318,7 +1321,7 @@ spec:
       labels:
         name: agent-ksmsharded-example
       annotations:
-        checksum/config: 58c52f37c9e2582e270e0c3b5c0150252db79a8a1be4e9b287da943a7c9e3bdf
+        checksum/config: 3b64edf7317419b11b0aef4cd10cad04037b7bc0b6866da25871b47b41c04490
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/examples/kubernetes-only-logs/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/kubernetes-only-logs/rendered/manifest.yaml
@@ -104,6 +104,7 @@ stringData:
         scope: node
       kubernetes_leaderelection:
         enabled: false
+        leader_lease: example-pernode
 ---
 # Source: elastic-agent/templates/agent/cluster-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -227,7 +228,7 @@ spec:
       labels:
         name: agent-pernode-example
       annotations:
-        checksum/config: 10cb3f4c3996f9ccaee8461e274a694fbbb03df6437e46d293cc515296b00cc0
+        checksum/config: 0840dcdf026f64cefb7aa69f420bc923d7e2d7d6e9a239e107fd2684e309d8ae
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/examples/multiple-integrations/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/multiple-integrations/rendered/manifest.yaml
@@ -120,6 +120,7 @@ stringData:
         scope: cluster
       kubernetes_leaderelection:
         enabled: true
+        leader_lease: example-clusterwide
 ---
 # Source: elastic-agent/templates/agent/k8s/secret.yaml
 apiVersion: v1
@@ -414,6 +415,7 @@ stringData:
         enabled: false
       kubernetes_leaderelection:
         enabled: false
+        leader_lease: example-ksmsharded
 ---
 # Source: elastic-agent/templates/agent/k8s/secret.yaml
 apiVersion: v1
@@ -599,6 +601,7 @@ stringData:
         scope: node
       kubernetes_leaderelection:
         enabled: false
+        leader_lease: example-pernode
 ---
 # Source: elastic-agent/templates/agent/cluster-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1117,7 +1120,7 @@ spec:
       labels:
         name: agent-pernode-example
       annotations:
-        checksum/config: c9823ca6e0ab0a28164ee0111de74d3225480f5c5e81057159d3276ad3208f46
+        checksum/config: 0df24cb5f7362916ba8cb10621b123918f22f52a7ce9f0b0514c5983de6d06f3
     spec:
       automountServiceAccountToken: true
       containers:
@@ -1252,7 +1255,7 @@ spec:
       labels:
         name: agent-clusterwide-example
       annotations:
-        checksum/config: 7cd88cef1c964a3660d069d4525c2efc0eed06607e0011c2af83a37648fcaacc
+        checksum/config: 4425148664b320184754e6ab2438144cdda5ec331ba76501a4264ddcab801623
     spec:
       automountServiceAccountToken: true
       containers:
@@ -1324,7 +1327,7 @@ spec:
       labels:
         name: agent-ksmsharded-example
       annotations:
-        checksum/config: 58c52f37c9e2582e270e0c3b5c0150252db79a8a1be4e9b287da943a7c9e3bdf
+        checksum/config: 3b64edf7317419b11b0aef4cd10cad04037b7bc0b6866da25871b47b41c04490
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/examples/nginx-custom-integration/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/nginx-custom-integration/rendered/manifest.yaml
@@ -66,6 +66,7 @@ stringData:
     providers:
       kubernetes_leaderelection:
         enabled: false
+        leader_lease: example-nginx
 ---
 # Source: elastic-agent/templates/agent/cluster-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -215,7 +216,7 @@ spec:
       labels:
         name: agent-nginx-example
       annotations:
-        checksum/config: 627f26ad8791a17274403b380c484441f4b4667f49d72057b17921707be49b0c
+        checksum/config: 99eaac30ab163ab5f4cedbdbf3e6936d34c2b0e2c22dee59947487bab88fcc26
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/examples/system-custom-auth-paths/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/system-custom-auth-paths/rendered/manifest.yaml
@@ -176,6 +176,7 @@ stringData:
         scope: node
       kubernetes_leaderelection:
         enabled: false
+        leader_lease: example-pernode
 ---
 # Source: elastic-agent/templates/agent/cluster-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -299,7 +300,7 @@ spec:
       labels:
         name: agent-pernode-example
       annotations:
-        checksum/config: 2c282d47af61943389605343bda01a73669627e940b9c563e4a678dfcbaa0c73
+        checksum/config: 535875b1a8f244fc529158f3467dec1983ca2ef19d365518da249fd46e22d0ef
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/templates/agent/_helpers.tpl
+++ b/deploy/helm/elastic-agent/templates/agent/_helpers.tpl
@@ -97,6 +97,18 @@ Validate and initialise the defined agent presets
 {{- end -}}
 {{- end -}}
 {{- end -}}
+{{/* by default we disable leader election but we also set the name of the leader lease in case it is explicitly enabled */}}
+{{- if empty ($presetVal).providers -}}
+{{- $_ := set $presetVal "providers" dict -}}
+{{- end -}}
+{{- $presetProviders := get $presetVal "providers" -}}
+{{- if empty ($presetProviders).kubernetes_leaderelection -}}
+{{- $_ := set $presetProviders "kubernetes_leaderelection" dict -}}
+{{- end -}}
+{{- $presetLeaderLeaseName := (printf "%s-%s" $.Release.Name $presetName) | lower  -}}
+{{- $defaultLeaderElection := dict "enabled" false "leader_lease" $presetLeaderLeaseName -}}
+{{- $presetLeaderElection := mergeOverwrite dict $defaultLeaderElection ($presetProviders).kubernetes_leaderelection -}}
+{{- $_ := set $presetProviders "kubernetes_leaderelection" $presetLeaderElection -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/elastic-agent/values.yaml
+++ b/deploy/helm/elastic-agent/values.yaml
@@ -450,8 +450,6 @@ agent:
           logs: true
           metrics: true
       providers:
-        kubernetes_leaderelection:
-          enabled: false
         kubernetes:
           node: ${NODE_NAME}
           scope: node
@@ -481,7 +479,5 @@ agent:
           logs: true
           metrics: true
       providers:
-        kubernetes_leaderelection:
-          enabled: false
         kubernetes:
           enabled: false


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR disables by default the kubernetes leader election unless a user explicitly marks it as enabled. More importantly this PR sets the lease name from the Helm release and the agent preset names and thus different agent deployments won't utilise the same lease now.

## Why is it important?

Because it guarantees correct lease isolation across different agent deployments in the same namespace

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

N/A

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

follow [the kubernetes example](https://github.com/elastic/elastic-agent/tree/main/deploy/helm/elastic-agent/examples/kubernetes-default) and do two installations of the Helm chart with a different release name and under the same namespace (leases are namespace-scoped). With this PR you will see that two leases are created for the `clusterWide` preset where before there would be only one

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/ingest-dev/issues/3633 as the user facing issues with the lease name is mentioned there