### PR TITLE
[proxytest] Wait all requests to finish before closing the server

### DIFF
--- a/testing/proxytest/proxytest.go
+++ b/testing/proxytest/proxytest.go
@@ -251,9 +251,11 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *Proxy) Close() {
-	p.requestsWG.Wait()
-
 	p.Server.Close()
+
+	// it's necessary as sometimes the request log happens after the test
+	// finishes. See https://github.com/elastic/elastic-agent/issues/5869
+	p.requestsWG.Wait()
 }
 
 func (p *Proxy) serveHTTP(w http.ResponseWriter, r *http.Request) {

--- a/testing/proxytest/proxytest.go
+++ b/testing/proxytest/proxytest.go
@@ -251,11 +251,11 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *Proxy) Close() {
-	p.Server.Close()
-
 	// it's necessary as sometimes the request log happens after the test
 	// finishes. See https://github.com/elastic/elastic-agent/issues/5869
 	p.requestsWG.Wait()
+
+	p.Server.Close()
 }
 
 func (p *Proxy) serveHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Makes the proxytest to wait all requests to finish before closing the underlying HTTP server

## Why is it important?

The request log sometimes happens after the tests has finished, what causes the test to panic

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

```
go test -count 15000 -timeout 0 -run TestHTTPSProxy ./testing/proxytest/
```

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/5869

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->