### PR TITLE
Add support of the new branch setup to the version update automation

### DIFF
--- a/pkg/testing/tools/git/git.go
+++ b/pkg/testing/tools/git/git.go
@@ -30,7 +30,7 @@ type outputReader func(io.Reader) error
 // current repository ordered descending by creation date.
 // e.g. 8.13, 8.12, etc.
 func GetReleaseBranches(ctx context.Context) ([]string, error) {
-	c := exec.CommandContext(ctx, "git", "for-each-ref", "refs/heads/[0-9]*.*[0-9x]", "--format=%(refname:short)")
+	c := exec.CommandContext(ctx, "git", "for-each-ref", "refs/remotes/origin/[0-9]*.*[0-9x]", "--format=%(refname:short)")
 
 	branchList := []string{}
 	err := runCommand(c, releaseBranchReader(&branchList))
@@ -102,7 +102,7 @@ func releaseBranchReader(out *[]string) outputReader {
 		var seen = map[string]struct{}{}
 		scanner := bufio.NewScanner(r)
 		for scanner.Scan() {
-			branch := scanner.Text()
+			branch := strings.TrimPrefix(scanner.Text(), "origin/")
 			_, exists := seen[branch]
 			if exists {
 				continue

--- a/pkg/testing/tools/git/git.go
+++ b/pkg/testing/tools/git/git.go
@@ -43,8 +43,6 @@ func GetReleaseBranches(ctx context.Context) ([]string, error) {
 	return branchList, nil
 }
 
-const majorBranchSuffix = ".x"
-
 // we use this to emulate the maximum possible version value aliased by `.x`
 var maxIntString = strconv.Itoa(math.MaxInt)
 

--- a/pkg/testing/tools/git/git.go
+++ b/pkg/testing/tools/git/git.go
@@ -11,13 +11,17 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os/exec"
-	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/elastic/elastic-agent/pkg/version"
 )
 
 var (
 	ErrNotReleaseBranch = errors.New("this is not a release branch")
-	releaseBranchRegexp = regexp.MustCompile(`.*(\d+\.(\d+|x))$`)
 )
 
 type outputReader func(io.Reader) error
@@ -26,7 +30,7 @@ type outputReader func(io.Reader) error
 // current repository ordered descending by creation date.
 // e.g. 8.13, 8.12, etc.
 func GetReleaseBranches(ctx context.Context) ([]string, error) {
-	c := exec.CommandContext(ctx, "git", "branch", "-r", "--list", "*/[0-9]*.*[0-9x]", "--sort=-creatordate")
+	c := exec.CommandContext(ctx, "git", "for-each-ref", "refs/heads/[0-9]*.*[0-9x]", "--format=%(refname:short)")
 
 	branchList := []string{}
 	err := runCommand(c, releaseBranchReader(&branchList))
@@ -34,7 +38,36 @@ func GetReleaseBranches(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
+	sort.Slice(branchList, less(branchList))
+
 	return branchList, nil
+}
+
+const majorBranchSuffix = ".x"
+
+// we use this to emulate the maximum possible version value aliased by `.x`
+var maxIntString = strconv.Itoa(math.MaxInt)
+
+// less makes sure we have our release branches in the right order
+func less(branches []string) func(i, j int) bool {
+	return func(i, j int) bool {
+		// we complete the versions, so we can parse semver and compare
+		var (
+			v1 = strings.ReplaceAll(branches[i], "x", maxIntString) + ".0"
+			v2 = strings.ReplaceAll(branches[j], "x", maxIntString) + ".0"
+		)
+
+		parsed1, err1 := version.ParseVersion(v1)
+		parsed2, err2 := version.ParseVersion(v2)
+		if err1 != nil {
+			return false
+		}
+		if err2 != nil {
+			return true
+		}
+		// descending order
+		return !parsed1.Less(*parsed2)
+	}
 }
 
 // GetCurrentReleaseBranch returns the current branch of the repository
@@ -52,7 +85,7 @@ func GetCurrentReleaseBranch(ctx context.Context) (string, error) {
 		return "master", nil
 	}
 
-	return extractReleaseBranch(branch)
+	return branch, nil
 }
 
 func fullOutputReader(out *string) outputReader {
@@ -72,10 +105,6 @@ func releaseBranchReader(out *[]string) outputReader {
 		scanner := bufio.NewScanner(r)
 		for scanner.Scan() {
 			branch := scanner.Text()
-			branch, err := extractReleaseBranch(branch)
-			if err != nil {
-				continue
-			}
 			_, exists := seen[branch]
 			if exists {
 				continue
@@ -91,18 +120,6 @@ func releaseBranchReader(out *[]string) outputReader {
 
 		return nil
 	}
-}
-
-func extractReleaseBranch(branch string) (string, error) {
-	if !releaseBranchRegexp.MatchString(branch) {
-		return "", fmt.Errorf("failed to process branch %q: %w", branch, ErrNotReleaseBranch)
-	}
-
-	matches := releaseBranchRegexp.FindStringSubmatch(branch)
-	if len(matches) != 3 {
-		return "", fmt.Errorf("failed to process branch %q: expected 3 matches, got %d", branch, len(matches))
-	}
-	return matches[1], nil
 }
 
 func runCommand(c *exec.Cmd, or outputReader) error {

--- a/pkg/testing/tools/git/git_test.go
+++ b/pkg/testing/tools/git/git_test.go
@@ -6,12 +6,16 @@ package git
 
 import (
 	"context"
+	"regexp"
+	"sort"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var releaseBranchRegexp = regexp.MustCompile(`.*(\d+\.(\d+|x))$`)
 
 func TestGetReleaseBranches(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
@@ -23,4 +27,30 @@ func TestGetReleaseBranches(t *testing.T) {
 	for _, b := range branches {
 		assert.Regexp(t, releaseBranchRegexp, b)
 	}
+}
+
+func TestLess(t *testing.T) {
+	branchList := []string{
+		"8.16",
+		"9.1",
+		"8.x",
+		"wrong",
+		"9.0",
+		"9.x",
+		"8.15",
+	}
+
+	expected := []string{
+		"9.x",
+		"9.1",
+		"9.0",
+		"8.x",
+		"8.16",
+		"8.15",
+		"wrong",
+	}
+
+	sort.Slice(branchList, less(branchList))
+
+	require.Equal(t, expected, branchList)
 }

--- a/pkg/testing/tools/git/git_test.go
+++ b/pkg/testing/tools/git/git_test.go
@@ -6,7 +6,6 @@ package git
 
 import (
 	"context"
-	"regexp"
 	"sort"
 	"testing"
 	"time"
@@ -14,8 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-var releaseBranchRegexp = regexp.MustCompile(`.*(\d+\.(\d+|x))$`)
 
 func TestGetReleaseBranches(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)


### PR DESCRIPTION
## What does this PR do?

So, we can support the new 9.0 release, 8.x branch and the rest of the release branches.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

It's fixing wrong automation behavior, for example like here https://github.com/elastic/elastic-agent/pull/5953 and here https://github.com/elastic/elastic-agent/pull/5948

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
~- [ ] I have added an integration test or an E2E test~