### PR TITLE
Add go.mod full version support to updatecli

### DIFF
--- a/.ci/updatecli/updatecli-bump-golang.yml
+++ b/.ci/updatecli/updatecli-bump-golang.yml
@@ -57,18 +57,6 @@ sources:
         kind: regex
         pattern: go1\.{{ source "minor" }}\.(\d*)$
 
-  gomod:
-    dependson:
-      - latestGoVersion
-    name: Get version in go.mod format
-    kind: shell
-    transformers:
-      - findsubmatch:
-          pattern: '^(\d+.\d+).\d+'
-          captureindex: 1
-    spec:
-      command: echo {{ source "latestGoVersion" }}
-
 conditions:
   dockerTag:
     name: Is docker image golang:{{ source "latestGoVersion" }} published
@@ -124,21 +112,12 @@ targets:
         - Dockerfile
         - Dockerfile.skaffold
       matchpattern: 'ARG GO_VERSION=\d+.\d+.\d+'
-  update-gomod-minor-version:
-    name: "Update go.mod minor version"
-    sourceid: gomod
-    scmid: githubConfig
-    kind: file
-    spec:
-      content: 'go {{ source "gomod" }}'
-      file: go.mod
-      matchpattern: 'go \d+.\d+'
-  update-gomod-toolchain-version:
-    name: "Update go.mod toolchain version"
+  update-gomod-full-version:
+    name: "Update go.mod version"
     sourceid: latestGoVersion
     scmid: githubConfig
     kind: file
     spec:
-      content: 'toolchain go{{ source "latestGoVersion" }}'
+      content: 'go {{ source "latestGoVersion" }}'
       file: go.mod
-      matchpattern: 'toolchain go\d+.\d+.\d+'
+      matchpattern: 'go \d+.\d+.\d+'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/elastic-agent
 
-go 1.22.8
+go 1.22.9
 
 require (
 	github.com/Jeffail/gabs/v2 v2.6.0


### PR DESCRIPTION
So, we have the Go version in `go.mod` synced to the rest of the values.

## How to test this PR locally

I used a simplified updatecli configuration that includes these changes:

```yaml
# update-cli configuration for automated go updates
---
name: Bump golang-version to latest version

sources:
  latestGoVersion:
    name: Get minor version in .go-version
    kind: shell
    transformers:
      - findsubmatch:
          pattern: '^(\d+.\d+.\d+)$'
          captureindex: 1
    spec:
      command: cat test-version

conditions:
  goDefaultVersion-check:
    name: Check if defined golang version differs
    kind: shell
    sourceid: latestGoVersion
    spec:
      command: 'grep -v -q {{ source "latestGoVersion" }} .go-version #'

targets:
  update-go-version:
    name: 'Update .go-version'
    sourceid: latestGoVersion
    kind: file
    spec:
      content: '{{ source "latestGoVersion" }}'
      file: .go-version
      matchpattern: '\d+.\d+.\d+'
  update-golang.ci:
    name: 'Update .golangci.yml'
    sourceid: latestGoVersion
    kind: file
    spec:
      content: '{{ source "latestGoVersion" }}'
      file: .golangci.yml
      matchpattern: '\d+.\d+.\d+'
  update-version.asciidoc:
    name: 'Update version.asciidoc'
    sourceid: latestGoVersion
    kind: file
    spec:
      content: ':go-version: {{ source "latestGoVersion" }}'
      file: version/docs/version.asciidoc
      matchpattern: ':go-version: \d+.\d+.\d+'
  update-dockerfiles:
    name: 'Update from dockerfiles'
    sourceid: latestGoVersion
    kind: file
    spec:
      content: 'ARG GO_VERSION={{ source "latestGoVersion" }}'
      files:
        - Dockerfile
        - Dockerfile.skaffold
      matchpattern: 'ARG GO_VERSION=\d+.\d+.\d+'
  update-gomod-full-version:
    name: 'Update go.mod version'
    sourceid: latestGoVersion
    kind: file
    spec:
      content: 'go {{ source "latestGoVersion" }}'
      file: go.mod
      matchpattern: 'go \d+.\d+.\d+'
```

I ran `updatecli diff -c test.yaml` and got the following output:

<details>
<summary>Click to see</summary>

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline ".ci/updatecli/test.yml"

SCM repository retrieved: 0


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



#########################################
# BUMP GOLANG-VERSION TO LATEST VERSION #
#########################################

source: source#latestGoVersion
----------------------
The shell 🐚 command "/bin/sh /var/folders/xm/p75f2blx50q3b0l9k76w9lgh0000gn/T/updatecli/bin/24f1d4cee25aa14e8dc9d8289158cf81a7097ee4f17e2ad485ffac6c9c2f8f21.sh" ran successfully with the following output:
----
1.22.10
----
✔ shell command executed successfully
[transformers]
✔ Result correctly transformed from "1.22.10" to "1.22.10"

condition: condition#goDefaultVersion-check
--------------------------------
The shell 🐚 command "/bin/sh /var/folders/xm/p75f2blx50q3b0l9k76w9lgh0000gn/T/updatecli/bin/f3b4a0ce640274660f495845709f56ba777e8dc14c4eb4a7634f32f078ae3bdc.sh" ran successfully with the following output:
----
----
✔ shell condition of type "console/output", passing

target: target#update-golang.ci
-----------------------

**Dry Run enabled**

".golangci.yml" updated with [dry run] content "1.22.10"

--- .golangci.yml
+++ .golangci.yml
@@ -120,7 +120,7 @@
 
   gosimple:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.22.9"
+    go: "1.22.10"
 
   nolintlint:
     # Enable to ensure that nolint directives are all used. Default is true.
@@ -136,17 +136,17 @@
 
   staticcheck:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.22.9"
+    go: "1.22.10"
     checks: ["all"]
 
   stylecheck:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.22.9"
+    go: "1.22.10"
     checks: ["all"]
 
   unused:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.22.9"
+    go: "1.22.10"
 
   gosec:
     excludes:

⚠ - 1 file(s) updated with "1.22.10":
	* .golangci.yml

target: target#update-dockerfiles
-------------------------

**Dry Run enabled**

"Dockerfile" updated with [dry run] content "ARG GO_VERSION=1.22.10"

--- Dockerfile
+++ Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.22.9
+ARG GO_VERSION=1.22.10
 FROM circleci/golang:${GO_VERSION}
 
 


"Dockerfile.skaffold" updated with [dry run] content "ARG GO_VERSION=1.22.10"

--- Dockerfile.skaffold
+++ Dockerfile.skaffold
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.22.9
+ARG GO_VERSION=1.22.10
 ARG crossbuild_image="docker.elastic.co/beats-dev/golang-crossbuild"
 ARG AGENT_VERSION=8.9.0-SNAPSHOT
 ARG AGENT_IMAGE="docker.elastic.co/beats/elastic-agent"


⚠ - 2 file(s) updated with "ARG GO_VERSION=1.22.10":
	* Dockerfile
	* Dockerfile.skaffold

target: target#update-gomod-full-version
--------------------------------

**Dry Run enabled**

"go.mod" updated with [dry run] content "go 1.22.10"

--- go.mod
+++ go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/elastic-agent
 
-go 1.22.8
+go 1.22.10
 
 require (
 	github.com/Jeffail/gabs/v2 v2.6.0


⚠ - 1 file(s) updated with "go 1.22.10":
	* go.mod

target: target#update-version.asciidoc
------------------------------

**Dry Run enabled**

"version/docs/version.asciidoc" updated with [dry run] content ":go-version: 1.22.10"

--- version/docs/version.asciidoc
+++ version/docs/version.asciidoc
@@ -3,7 +3,7 @@
 // FIXME: once elastic.co docs have been switched over to use `main`, remove
 // the `doc-site-branch` line below as well as any references to it in the code.
 :doc-site-branch: master
-:go-version: 1.22.9
+:go-version: 1.22.10
 :release-state: unreleased
 :python: 3.7
 :docker: 1.12


⚠ - 1 file(s) updated with ":go-version: 1.22.10":
	* version/docs/version.asciidoc

target: target#update-go-version
------------------------

**Dry Run enabled**

".go-version" updated with [dry run] content "1.22.10"

--- .go-version
+++ .go-version
@@ -1 +1 @@
-1.22.9
+1.22.10

⚠ - 1 file(s) updated with "1.22.10":
	* .go-version


ACTIONS
========


=============================

SUMMARY:



⚠ Bump golang-version to latest version:
	Source:
		✔ [latestGoVersion] Get minor version in .go-version
	Condition:
		✔ [goDefaultVersion-check] Check if defined golang version differs
	Target:
		⚠ [update-dockerfiles] Update from dockerfiles
		⚠ [update-go-version] Update .go-version
		⚠ [update-golang.ci] Update .golangci.yml
		⚠ [update-gomod-full-version] Update go.mod version
		⚠ [update-version.asciidoc] Update version.asciidoc


Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	0
  * Total:	1
</details>
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->