### PR TITLE
[helm] add envFrom in agent preset

### DIFF
--- a/deploy/helm/elastic-agent/templates/agent/eck/_pod_template.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/eck/_pod_template.yaml
@@ -97,4 +97,8 @@ template:
           {{- end }}
           {{- end }}
           {{- end }}
+        {{- with ($presetVal).envFrom }}
+        envFrom:
+          {{- . | toYaml | nindent 10}}
+        {{- end }}
 {{- end }}

--- a/deploy/helm/elastic-agent/templates/agent/k8s/_pod_template.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/k8s/_pod_template.yaml
@@ -139,4 +139,8 @@ template:
           {{- end }}
           {{- end }}
           {{- end }}
+        {{- with ($presetVal).envFrom }}
+        envFrom:
+          {{- . | toYaml | nindent 10}}
+        {{- end }}
 {{- end }}

--- a/deploy/helm/elastic-agent/values.schema.json
+++ b/deploy/helm/elastic-agent/values.schema.json
@@ -1058,6 +1058,22 @@
                 "clusterRole": {
                     "$ref": "#/definitions/AgentPresetClusterRole"
                 },
+                "envFrom": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    },
+                    "description": "Environment variables for the deployment.",
+                    "examples": [
+                        [
+                            {
+                                "configMapRef": {
+                                    "name": "my-config"
+                                }
+                            }
+                        ]
+                    ]
+                },
                 "nodeSelector": {
                     "type": "object",
                     "additionalProperties": {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR adds support for specifying `envFrom` in the pod template of the Helm chart. By introducing this feature, users can configure environment variables from ConfigMaps or Secrets more flexibly and efficiently. The change modifies the pod template to include a new section that allows injecting `envFrom` values, providing an enhanced way to handle environment settings.


## Why is it important?

This enhancement is useful for users who need to manage environment variables dynamically through ConfigMaps or Secrets e.g. through ExternalSecrets.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

N/A
<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. create a k8s secret with the name `$secretName`
2. follow the [kubernetes example](https://github.com/elastic/elastic-agent/blob/main/deploy/helm/elastic-agent/examples/kubernetes-default/README.md) and add this param `--set 'agent.presets.perNode.envFrom[0].secretRef.name'=$secretName`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
N/A
