### PR TITLE
Add failureThreshold to elastic-agent self-monitoring config

### DIFF
--- a/internal/pkg/agent/application/coordinator/diagnostics_test.go
+++ b/internal/pkg/agent/application/coordinator/diagnostics_test.go
@@ -100,6 +100,7 @@ agent:
     metrics_period: ""
     namespace: ""
     pprof: null
+    failure_threshold: null
     traces: true
     apm:
       hosts:

--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -160,19 +160,18 @@ func (b *BeatsMonitor) MonitoringConfig(
 					}
 
 					if policyFailureThresholdRaw, found := monitoringMap[failureThresholdKey]; found {
-						switch policyFailureThresholdRaw.(type) {
+						switch policyValue := policyFailureThresholdRaw.(type) {
 						case uint:
-							policyValue := policyFailureThresholdRaw.(uint)
 							failureThreshold = &policyValue
 						case int:
-							policyValue := uint(policyFailureThresholdRaw.(int))
-							failureThreshold = &policyValue
+							unsignedValue := uint(policyValue)
+							failureThreshold = &unsignedValue
 						case string:
-							policyValue, err := strconv.Atoi(policyFailureThresholdRaw.(string))
+							parsedPolicyValue, err := strconv.Atoi(policyValue)
 							if err != nil {
 								return nil, fmt.Errorf("failed to convert policy failure threshold string to int: %w", err)
 							}
-							uintPolicyValue := uint(policyValue)
+							uintPolicyValue := uint(parsedPolicyValue)
 							failureThreshold = &uintPolicyValue
 						default:
 							return nil, fmt.Errorf("unsupported type for policy failure threshold: %T", policyFailureThresholdRaw)

--- a/internal/pkg/agent/application/monitoring/v1_monitor_test.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor_test.go
@@ -234,17 +234,20 @@ func TestMonitoringConfigMetricsInterval(t *testing.T) {
 					t.Logf("input %q", inputID)
 					// check the streams created for the input, should be a list of objects
 					if assert.Contains(t, input, "streams", "input %q does not contain any stream", inputID) &&
-						assert.IsTypef(t, []map[string]any{}, input["streams"], "streams for input %q are not a list of maps", inputID) {
+						assert.IsTypef(t, []any{}, input["streams"], "streams for input %q are not a list of objects", inputID) {
 						// loop over streams and access keys
-						for _, stream := range input["streams"].([]map[string]any) {
-							// check period and assert its value
-							streamID := stream["id"]
-							if assert.Containsf(t, stream, "period", "stream %q for input %q does not contain a period", streamID, inputID) &&
-								assert.IsType(t, "", stream["period"], "period for stream %q of input %q is not represented as a string", streamID, inputID) {
-								periodString := stream["period"].(string)
-								duration, err := time.ParseDuration(periodString)
-								if assert.NoErrorf(t, err, "Unparseable period duration %s for stream %q of input %q", periodString, streamID, inputID) {
-									assert.Equalf(t, duration, tc.expectedInterval, "unexpected duration for stream %q of input %q", streamID, inputID)
+						for _, rawStream := range input["streams"].([]any) {
+							if assert.IsTypef(t, map[string]any{}, rawStream, "stream %v for input %q is not a map", rawStream, inputID) {
+								stream := rawStream.(map[string]any)
+								// check period and assert its value
+								streamID := stream["id"]
+								if assert.Containsf(t, stream, "period", "stream %q for input %q does not contain a period", streamID, inputID) &&
+									assert.IsType(t, "", stream["period"], "period for stream %q of input %q is not represented as a string", streamID, inputID) {
+									periodString := stream["period"].(string)
+									duration, err := time.ParseDuration(periodString)
+									if assert.NoErrorf(t, err, "Unparseable period duration %s for stream %q of input %q", periodString, streamID, inputID) {
+										assert.Equalf(t, duration, tc.expectedInterval, "unexpected duration for stream %q of input %q", streamID, inputID)
+									}
 								}
 							}
 						}
@@ -437,15 +440,19 @@ func TestMonitoringConfigMetricsFailureThreshold(t *testing.T) {
 					t.Logf("input %q", inputID)
 					// check the streams created for the input, should be a list of objects
 					if assert.Contains(t, input, "streams", "input %q does not contain any stream", inputID) &&
-						assert.IsTypef(t, []map[string]any{}, input["streams"], "streams for input %q are not a list of objects", inputID) {
+						assert.IsTypef(t, []any{}, input["streams"], "streams for input %q are not a list of objects", inputID) {
+
 						// loop over streams and cast to map[string]any to access keys
-						for _, stream := range input["streams"].([]map[string]any) {
-							// check period and assert its value
-							streamID := stream["id"]
-							if assert.Containsf(t, stream, failureThresholdKey, "stream %q for input %q does not contain a failureThreshold", streamID, inputID) &&
-								assert.IsType(t, uint(0), stream[failureThresholdKey], "period for stream %q of input %q is not represented as a string", streamID, inputID) {
-								actualFailureThreshold := stream[failureThresholdKey].(uint)
-								assert.Equalf(t, actualFailureThreshold, tc.expectedThreshold, "unexpected failure threshold for stream %q of input %q", streamID, inputID)
+						for _, rawStream := range input["streams"].([]any) {
+							if assert.IsTypef(t, map[string]any{}, rawStream, "stream %v for input %q is not a map", rawStream, inputID) {
+								stream := rawStream.(map[string]any)
+								// check period and assert its value
+								streamID := stream["id"]
+								if assert.Containsf(t, stream, failureThresholdKey, "stream %q for input %q does not contain a failureThreshold", streamID, inputID) &&
+									assert.IsType(t, uint(0), stream[failureThresholdKey], "period for stream %q of input %q is not represented as a string", streamID, inputID) {
+									actualFailureThreshold := stream[failureThresholdKey].(uint)
+									assert.Equalf(t, actualFailureThreshold, tc.expectedThreshold, "unexpected failure threshold for stream %q of input %q", streamID, inputID)
+								}
 							}
 						}
 					}
@@ -513,9 +520,9 @@ func TestMonitoringConfigComponentFields(t *testing.T) {
 	inputsSlice := monitoringConfig["inputs"].([]any)
 	for _, input := range inputsSlice {
 		inpMap := input.(map[string]any)
-		for _, stream := range inpMap["streams"].([]map[string]any) {
-			streamID := stream["id"].(string)
-			processors := stream["processors"].([]any)
+		for _, rawStream := range inpMap["streams"].([]any) {
+			streamID := rawStream.(map[string]any)["id"].(string)
+			processors := rawStream.(map[string]any)["processors"].([]any)
 			for _, rawProcessor := range processors {
 				processor := rawProcessor.(map[string]any)
 				if _, exists := processor["add_fields"]; !exists {

--- a/internal/pkg/agent/application/monitoring/v1_monitor_test.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor_test.go
@@ -234,21 +234,218 @@ func TestMonitoringConfigMetricsInterval(t *testing.T) {
 					t.Logf("input %q", inputID)
 					// check the streams created for the input, should be a list of objects
 					if assert.Contains(t, input, "streams", "input %q does not contain any stream", inputID) &&
-						assert.IsTypef(t, []any{}, input["streams"], "streams for input %q are not a list of objects", inputID) {
-						// loop over streams and cast to map[string]any to access keys
-						for _, rawStream := range input["streams"].([]any) {
-							if assert.IsTypef(t, map[string]any{}, rawStream, "stream %v for input %q is not a map", rawStream, inputID) {
-								stream := rawStream.(map[string]any)
-								// check period and assert its value
-								streamID := stream["id"]
-								if assert.Containsf(t, stream, "period", "stream %q for input %q does not contain a period", streamID, inputID) &&
-									assert.IsType(t, "", stream["period"], "period for stream %q of input %q is not represented as a string", streamID, inputID) {
-									periodString := stream["period"].(string)
-									duration, err := time.ParseDuration(periodString)
-									if assert.NoErrorf(t, err, "Unparseable period duration %s for stream %q of input %q", periodString, streamID, inputID) {
-										assert.Equalf(t, duration, tc.expectedInterval, "unexpected duration for stream %q of input %q", streamID, inputID)
-									}
+						assert.IsTypef(t, []map[string]any{}, input["streams"], "streams for input %q are not a list of maps", inputID) {
+						// loop over streams and access keys
+						for _, stream := range input["streams"].([]map[string]any) {
+							// check period and assert its value
+							streamID := stream["id"]
+							if assert.Containsf(t, stream, "period", "stream %q for input %q does not contain a period", streamID, inputID) &&
+								assert.IsType(t, "", stream["period"], "period for stream %q of input %q is not represented as a string", streamID, inputID) {
+								periodString := stream["period"].(string)
+								duration, err := time.ParseDuration(periodString)
+								if assert.NoErrorf(t, err, "Unparseable period duration %s for stream %q of input %q", periodString, streamID, inputID) {
+									assert.Equalf(t, duration, tc.expectedInterval, "unexpected duration for stream %q of input %q", streamID, inputID)
 								}
+							}
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestMonitoringConfigMetricsFailureThreshold(t *testing.T) {
+
+	agentInfo, err := info.NewAgentInfo(context.Background(), false)
+	require.NoError(t, err, "Error creating agent info")
+
+	sampleFiveErrorsStreamThreshold := uint(5)
+	sampleTenErrorsStreamThreshold := uint(10)
+
+	tcs := []struct {
+		name              string
+		monitoringCfg     *monitoringConfig
+		policy            map[string]any
+		expectedThreshold uint
+	}{
+		{
+			name: "default failure threshold",
+			monitoringCfg: &monitoringConfig{
+				C: &monitoringcfg.MonitoringConfig{
+					Enabled:        true,
+					MonitorMetrics: true,
+					HTTP: &monitoringcfg.MonitoringHTTPConfig{
+						Enabled: false,
+					},
+				},
+			},
+			policy: map[string]any{
+				"agent": map[string]any{
+					"monitoring": map[string]any{
+						"metrics": true,
+						"http": map[string]any{
+							"enabled": false,
+						},
+					},
+				},
+				"outputs": map[string]any{
+					"default": map[string]any{},
+				},
+			},
+			expectedThreshold: defaultMetricsStreamFailureThreshold,
+		},
+		{
+			name: "agent config failure threshold",
+			monitoringCfg: &monitoringConfig{
+				C: &monitoringcfg.MonitoringConfig{
+					Enabled:        true,
+					MonitorMetrics: true,
+					HTTP: &monitoringcfg.MonitoringHTTPConfig{
+						Enabled: false,
+					},
+					FailureThreshold: &sampleFiveErrorsStreamThreshold,
+				},
+			},
+			policy: map[string]any{
+				"agent": map[string]any{
+					"monitoring": map[string]any{
+						"metrics": true,
+						"http": map[string]any{
+							"enabled": false,
+						},
+					},
+				},
+				"outputs": map[string]any{
+					"default": map[string]any{},
+				},
+			},
+			expectedThreshold: sampleFiveErrorsStreamThreshold,
+		},
+		{
+			name: "policy failure threshold uint",
+			monitoringCfg: &monitoringConfig{
+				C: &monitoringcfg.MonitoringConfig{
+					Enabled:        true,
+					MonitorMetrics: true,
+					HTTP: &monitoringcfg.MonitoringHTTPConfig{
+						Enabled: false,
+					},
+					FailureThreshold: &sampleFiveErrorsStreamThreshold,
+				},
+			},
+			policy: map[string]any{
+				"agent": map[string]any{
+					"monitoring": map[string]any{
+						"metrics": true,
+						"http": map[string]any{
+							"enabled": false,
+						},
+						failureThresholdKey: sampleTenErrorsStreamThreshold,
+					},
+				},
+				"outputs": map[string]any{
+					"default": map[string]any{},
+				},
+			},
+			expectedThreshold: sampleTenErrorsStreamThreshold,
+		},
+		{
+			name: "policy failure threshold int",
+			monitoringCfg: &monitoringConfig{
+				C: &monitoringcfg.MonitoringConfig{
+					Enabled:        true,
+					MonitorMetrics: true,
+					HTTP: &monitoringcfg.MonitoringHTTPConfig{
+						Enabled: false,
+					},
+					FailureThreshold: &sampleFiveErrorsStreamThreshold,
+				},
+			},
+			policy: map[string]any{
+				"agent": map[string]any{
+					"monitoring": map[string]any{
+						"metrics": true,
+						"http": map[string]any{
+							"enabled": false,
+						},
+						failureThresholdKey: 10,
+					},
+				},
+				"outputs": map[string]any{
+					"default": map[string]any{},
+				},
+			},
+			expectedThreshold: sampleTenErrorsStreamThreshold,
+		},
+		{
+			name: "policy failure threshold string",
+			monitoringCfg: &monitoringConfig{
+				C: &monitoringcfg.MonitoringConfig{
+					Enabled:        true,
+					MonitorMetrics: true,
+					HTTP: &monitoringcfg.MonitoringHTTPConfig{
+						Enabled: false,
+					},
+					FailureThreshold: &sampleFiveErrorsStreamThreshold,
+				},
+			},
+			policy: map[string]any{
+				"agent": map[string]any{
+					"monitoring": map[string]any{
+						"metrics": true,
+						"http": map[string]any{
+							"enabled": false,
+						},
+						failureThresholdKey: "10",
+					},
+				},
+				"outputs": map[string]any{
+					"default": map[string]any{},
+				},
+			},
+			expectedThreshold: sampleTenErrorsStreamThreshold,
+		},
+	}
+
+	for _, tc := range tcs {
+
+		t.Run(tc.name, func(t *testing.T) {
+			b := &BeatsMonitor{
+				enabled:         true,
+				config:          tc.monitoringCfg,
+				operatingSystem: runtime.GOOS,
+				agentInfo:       agentInfo,
+			}
+			got, err := b.MonitoringConfig(tc.policy, nil, map[string]string{"foobeat": "filebeat"}, map[string]uint64{}) // put a componentID/binary mapping to have something in the beats monitoring input
+			assert.NoError(t, err)
+
+			rawInputs, ok := got["inputs"]
+			require.True(t, ok, "monitoring config contains no input")
+			inputs, ok := rawInputs.([]any)
+			require.True(t, ok, "monitoring inputs are not a list")
+			marshaledInputs, err := yaml.Marshal(inputs)
+			if assert.NoError(t, err, "error marshaling monitoring inputs") {
+				t.Logf("marshaled monitoring inputs:\n%s\n", marshaledInputs)
+			}
+
+			// loop over the created inputs
+			for _, i := range inputs {
+				input, ok := i.(map[string]any)
+				if assert.Truef(t, ok, "input is not represented as a map: %v", i) {
+					inputID := input["id"]
+					t.Logf("input %q", inputID)
+					// check the streams created for the input, should be a list of objects
+					if assert.Contains(t, input, "streams", "input %q does not contain any stream", inputID) &&
+						assert.IsTypef(t, []map[string]any{}, input["streams"], "streams for input %q are not a list of objects", inputID) {
+						// loop over streams and cast to map[string]any to access keys
+						for _, stream := range input["streams"].([]map[string]any) {
+							// check period and assert its value
+							streamID := stream["id"]
+							if assert.Containsf(t, stream, failureThresholdKey, "stream %q for input %q does not contain a failureThreshold", streamID, inputID) &&
+								assert.IsType(t, uint(0), stream[failureThresholdKey], "period for stream %q of input %q is not represented as a string", streamID, inputID) {
+								actualFailureThreshold := stream[failureThresholdKey].(uint)
+								assert.Equalf(t, actualFailureThreshold, tc.expectedThreshold, "unexpected failure threshold for stream %q of input %q", streamID, inputID)
 							}
 						}
 					}
@@ -316,9 +513,9 @@ func TestMonitoringConfigComponentFields(t *testing.T) {
 	inputsSlice := monitoringConfig["inputs"].([]any)
 	for _, input := range inputsSlice {
 		inpMap := input.(map[string]any)
-		for _, rawStream := range inpMap["streams"].([]any) {
-			streamID := rawStream.(map[string]any)["id"].(string)
-			processors := rawStream.(map[string]any)["processors"].([]any)
+		for _, stream := range inpMap["streams"].([]map[string]any) {
+			streamID := stream["id"].(string)
+			processors := stream["processors"].([]any)
 			for _, rawProcessor := range processors {
 				processor := rawProcessor.(map[string]any)
 				if _, exists := processor["add_fields"]; !exists {

--- a/internal/pkg/core/monitoring/config/config.go
+++ b/internal/pkg/core/monitoring/config/config.go
@@ -21,17 +21,18 @@ const (
 
 // MonitoringConfig describes a configuration of a monitoring
 type MonitoringConfig struct {
-	Enabled        bool                  `yaml:"enabled" config:"enabled"`
-	MonitorLogs    bool                  `yaml:"logs" config:"logs"`
-	MonitorMetrics bool                  `yaml:"metrics" config:"metrics"`
-	MetricsPeriod  string                `yaml:"metrics_period" config:"metrics_period"`
-	LogMetrics     bool                  `yaml:"-" config:"-"`
-	HTTP           *MonitoringHTTPConfig `yaml:"http" config:"http"`
-	Namespace      string                `yaml:"namespace" config:"namespace"`
-	Pprof          *PprofConfig          `yaml:"pprof" config:"pprof"`
-	MonitorTraces  bool                  `yaml:"traces" config:"traces"`
-	APM            APMConfig             `yaml:"apm,omitempty" config:"apm,omitempty" json:"apm,omitempty"`
-	Diagnostics    Diagnostics           `yaml:"diagnostics,omitempty" json:"diagnostics,omitempty"`
+	Enabled          bool                  `yaml:"enabled" config:"enabled"`
+	MonitorLogs      bool                  `yaml:"logs" config:"logs"`
+	MonitorMetrics   bool                  `yaml:"metrics" config:"metrics"`
+	MetricsPeriod    string                `yaml:"metrics_period" config:"metrics_period"`
+	FailureThreshold *uint                 `yaml:"failure_threshold" config:"failure_threshold"`
+	LogMetrics       bool                  `yaml:"-" config:"-"`
+	HTTP             *MonitoringHTTPConfig `yaml:"http" config:"http"`
+	Namespace        string                `yaml:"namespace" config:"namespace"`
+	Pprof            *PprofConfig          `yaml:"pprof" config:"pprof"`
+	MonitorTraces    bool                  `yaml:"traces" config:"traces"`
+	APM              APMConfig             `yaml:"apm,omitempty" config:"apm,omitempty" json:"apm,omitempty"`
+	Diagnostics      Diagnostics           `yaml:"diagnostics,omitempty" json:"diagnostics,omitempty"`
 }
 
 // MonitoringHTTPConfig is a config defining HTTP endpoint published by agent


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Use `failure_threshold` introduced in https://github.com/elastic/beats/pull/41570 in self-monitoring configuration to avoid elastic-agent reporting DEGRADED if it fails to fetch metrics due to a component starting/stopping.
The default value for the failure threshold is set to 2 but it can be configured via config file or fleet policy.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
It is important to avoid a misrepresentation of agent status due to a single metrics fetch erroring out once.
See https://github.com/elastic/elastic-agent/issues/5332
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Requires https://github.com/elastic/beats/pull/41570
- Closes #5332

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->