### PR TITLE
Emit Pod data only for running Pods in the Kubernetes provider

### DIFF
--- a/changelog/fragments/1731500837-pod-status-updates.yaml
+++ b/changelog/fragments/1731500837-pod-status-updates.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Emit Pod data only for running Pods in the Kubernetes provider
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/composable/providers/kubernetes/pod.go
+++ b/internal/pkg/composable/providers/kubernetes/pod.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
@@ -224,7 +226,9 @@ func (p *pod) Stop() {
 }
 
 func (p *pod) emitRunning(pod *kubernetes.Pod) {
-
+	if pod.Status.Phase == v1.PodPending || pod.Status.Phase == v1.PodUnknown {
+		return
+	}
 	namespaceAnnotations := kubernetes.PodNamespaceAnnotations(pod, p.namespaceWatcher)
 
 	data := generatePodData(pod, p.metagen, namespaceAnnotations)

--- a/internal/pkg/composable/providers/kubernetes/pod_test.go
+++ b/internal/pkg/composable/providers/kubernetes/pod_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -513,6 +514,63 @@ func TestPodEventer_Namespace_Node_Watcher(t *testing.T) {
 				assert.NotEqualf(t, nil, nodeWatcher, "Node "+test.msg)
 			}
 		})
+	}
+}
+
+func TestPodEventer_OnlyRunningPods(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+
+	log, err := logger.New("service-eventer-test", true)
+	assert.NoError(t, err)
+
+	providerDataChan := make(chan providerData, 1)
+
+	comm := MockDynamicComm{
+		context.TODO(),
+		providerDataChan,
+	}
+
+	var cfg Config
+	cfg.InitDefaults()
+
+	eventer, err := NewPodEventer(&comm, &cfg, log, client, "cluster", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pod := &kubernetes.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testpod",
+			UID:       types.UID(uid),
+			Namespace: "testns",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		Spec: kubernetes.PodSpec{
+			NodeName: "testnode",
+		},
+		Status: kubernetes.PodStatus{
+			PodIP: "127.0.0.5",
+			Phase: v1.PodPending,
+		},
+	}
+
+	eventer.OnUpdate(pod)
+	select {
+	case <-providerDataChan:
+		assert.Fail(t, "should not receive update for Pending Pod")
+	default:
+	}
+
+	// set status to Running, we should get an update now
+	pod.Status.Phase = v1.PodRunning
+	eventer.OnUpdate(pod)
+	select {
+	case <-providerDataChan:
+	case <-time.After(time.Second * 5):
+		assert.Fail(t, "should receive update for Pending Pod")
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

The kubernetes provider emits data each time a Pod gets updated, even if the Pod is not yet running. As a result, every time a new Pod is spawned, we get multiple updates as it is created, scheduled, containers are created, and so on. Instead, emit the data only if the Pod is actually running.

## Why is it important?

Configuration reloading can be quite expensive when there are a lot of Pods on the Node. We should avoid doing so unnecessarily. This change should help #5835 and #5991.

Note that in principle this exposes us to a new failure mode. It's possible for the Pod to successfully finish running and be removed before we push the new configuration to beats. This was much less likely when we included the Pod when it was scheduled, but still possible with our 100ms debounce timer in the coordinator. I think the tradeoff is worth it, considering the issues with config reloading on large Nodes.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## How to test this PR locally

Deploy the agent in a local kind cluster using either the default manifests or the Helm Chart.

## Related issues

- Relates #5835
- Relates #5991 

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->