### PR TITLE
Store AST directly in provider mappings

### DIFF
--- a/internal/pkg/agent/transpiler/ast.go
+++ b/internal/pkg/agent/transpiler/ast.go
@@ -825,6 +825,9 @@ func (a *AST) HashStr() string {
 
 // Equal check if two AST are equals by using the computed hash.
 func (a *AST) Equal(other *AST) bool {
+	if a.root == nil || other.root == nil {
+		return a.root == other.root
+	}
 	return bytes.Equal(a.Hash(), other.Hash())
 }
 

--- a/internal/pkg/composable/benchmark_test.go
+++ b/internal/pkg/composable/benchmark_test.go
@@ -5,7 +5,7 @@
 package composable
 
 import (
-	"maps"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/transpiler"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,7 +54,8 @@ func BenchmarkGenerateVars100Pods(b *testing.B) {
 				mappings: make(map[string]dynamicProviderMapping),
 			}
 			for i := 0; i < podCount; i++ {
-				podData := maps.Clone(providerMapping)
+				podData, err := transpiler.NewAST(providerMapping)
+				require.NoError(b, err)
 				podUID := uuid.NewUUID()
 				podMapping := dynamicProviderMapping{
 					mapping: podData,

--- a/internal/pkg/composable/benchmark_test.go
+++ b/internal/pkg/composable/benchmark_test.go
@@ -5,11 +5,12 @@
 package composable
 
 import (
-	"github.com/elastic/elastic-agent/internal/pkg/agent/transpiler"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/transpiler"
 
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -64,8 +65,10 @@ func BenchmarkGenerateVars100Pods(b *testing.B) {
 			}
 			c.dynamicProviders[providerName] = providerState
 		} else {
+			providerAst, err := transpiler.NewAST(providerData[providerName])
+			require.NoError(b, err)
 			providerState := &contextProviderState{
-				mapping: providerData[providerName],
+				mapping: providerAst,
 			}
 			c.contextProviders[providerName] = providerState
 		}

--- a/internal/pkg/composable/controller.go
+++ b/internal/pkg/composable/controller.go
@@ -79,10 +79,12 @@ func New(log *logger.Logger, c *config.Config, managed bool) (Controller, error)
 		if err != nil {
 			return nil, errors.New(err, fmt.Sprintf("failed to build provider '%s'", name), errors.TypeConfig, errors.M("provider", name))
 		}
+		emptyMapping, _ := transpiler.NewAST(nil)
 		contextProviders[name] = &contextProviderState{
 			// Safe for Context to be nil here because it will be filled in
 			// by (*controller).Run before the provider is started.
 			provider: provider,
+			mapping:  emptyMapping,
 		}
 	}
 
@@ -275,18 +277,16 @@ func (c *controller) Close() {
 func (c *controller) generateVars(fetchContextProviders mapstr.M) []*transpiler.Vars {
 	// build the vars list of mappings
 	vars := make([]*transpiler.Vars, 1)
-	mapping := map[string]interface{}{}
+	mapping, _ := transpiler.NewAST(map[string]any{})
 	for name, state := range c.contextProviders {
-		mapping[name] = state.Current()
+		_ = mapping.Insert(state.Current(), name)
 	}
-	// this is ensured not to error, by how the mappings states are verified
-	mappingAst, _ := transpiler.NewAST(mapping)
-	vars[0] = transpiler.NewVarsFromAst("", mappingAst, fetchContextProviders)
+	vars[0] = transpiler.NewVarsFromAst("", mapping, fetchContextProviders)
 
 	// add to the vars list for each dynamic providers mappings
 	for name, state := range c.dynamicProviders {
 		for _, mappings := range state.Mappings() {
-			local := mappingAst.ShallowClone()
+			local := mapping.ShallowClone()
 			_ = local.Insert(mappings.mapping, name)
 			id := fmt.Sprintf("%s-%s", name, mappings.id)
 			v := transpiler.NewVarsWithProcessorsFromAst(id, local, name, mappings.processors, fetchContextProviders)
@@ -301,7 +301,7 @@ type contextProviderState struct {
 
 	provider corecomp.ContextProvider
 	lock     sync.RWMutex
-	mapping  map[string]interface{}
+	mapping  *transpiler.AST
 	signal   chan bool
 }
 
@@ -323,12 +323,7 @@ func (c *contextProviderState) Signal() {
 // Set sets the current mapping.
 func (c *contextProviderState) Set(mapping map[string]interface{}) error {
 	var err error
-	mapping, err = cloneMap(mapping)
-	if err != nil {
-		return err
-	}
-	// ensure creating vars will not error
-	_, err = transpiler.NewVars("", mapping, nil)
+	ast, err := transpiler.NewAST(mapping)
 	if err != nil {
 		return err
 	}
@@ -336,17 +331,17 @@ func (c *contextProviderState) Set(mapping map[string]interface{}) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if reflect.DeepEqual(c.mapping, mapping) {
+	if c.mapping != nil && c.mapping.Equal(ast) {
 		// same mapping; no need to update and signal
 		return nil
 	}
-	c.mapping = mapping
+	c.mapping = ast
 	c.Signal()
 	return nil
 }
 
 // Current returns the current mapping.
-func (c *contextProviderState) Current() map[string]interface{} {
+func (c *contextProviderState) Current() *transpiler.AST {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.mapping
@@ -449,22 +444,6 @@ func (c *dynamicProviderState) Mappings() []dynamicProviderMapping {
 		}
 	}
 	return mappings
-}
-
-func cloneMap(source map[string]interface{}) (map[string]interface{}, error) {
-	if source == nil {
-		return nil, nil
-	}
-	bytes, err := json.Marshal(source)
-	if err != nil {
-		return nil, fmt.Errorf("failed to clone: %w", err)
-	}
-	var dest map[string]interface{}
-	err = json.Unmarshal(bytes, &dest)
-	if err != nil {
-		return nil, fmt.Errorf("failed to clone: %w", err)
-	}
-	return dest, nil
 }
 
 func cloneMapArray(source []map[string]interface{}) ([]map[string]interface{}, error) {


### PR DESCRIPTION
## What does this PR do?

For all variable provider types, we store mappings as untyped dictionaries and only convert them to AST when we're about to generate actual vars. This means we have to recompute all of it every time there's a change to any of the provider data, even if all the other data is unaffected. For example, if a Kubernetes Pod gains a new label, we need to regenerate vars for all Pods.

Instead, we can store mappings as AST to begin with. Then the only cost of emitting new vars after a change is updating a bunch of references.

## Why is it important?

This unnecessary recomputation can be quite expensive when there's a lot of mappings from the dynamic provider. See the benchstat report below:

```
goos: linux
goarch: amd64
pkg: github.com/elastic/elastic-agent/internal/pkg/composable
cpu: 13th Gen Intel(R) Core(TM) i7-13700H
                       │ bench_main.txt │          bench_dynamic.txt          │
                       │     sec/op     │   sec/op     vs base                │
GenerateVars100Pods-20     755.49µ ± 3%   76.87µ ± 2%  -89.82% (p=0.000 n=10)

                       │ bench_main.txt │          bench_dynamic.txt           │
                       │      B/op      │     B/op      vs base                │
GenerateVars100Pods-20    735.00Ki ± 0%   98.69Ki ± 0%  -86.57% (p=0.000 n=10)

                       │ bench_main.txt │          bench_dynamic.txt          │
                       │   allocs/op    │  allocs/op   vs base                │
GenerateVars100Pods-20     21.335k ± 0%   1.364k ± 0%  -93.61% (p=0.000 n=10)
```


<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/5835
- Relates https://github.com/elastic/elastic-agent/issues/5991

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->