### PR TITLE
fix(6107): skipping escaping secrets in policy test because it is flaky

### DIFF
--- a/testing/integration/escaping_secrets_in_policy_test.go
+++ b/testing/integration/escaping_secrets_in_policy_test.go
@@ -30,7 +30,7 @@ func TestEscapingSecretsInPolicy(t *testing.T) {
 		Stack: &define.Stack{},
 		Sudo:  true,
 	})
-	t.Skip("flaky test")
+	t.Skip("flaky test: https://github.com/elastic/elastic-agent/issues/6107")
 	ctx := context.Background()
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)

--- a/testing/integration/escaping_secrets_in_policy_test.go
+++ b/testing/integration/escaping_secrets_in_policy_test.go
@@ -25,12 +25,12 @@ import (
 )
 
 func TestEscapingSecretsInPolicy(t *testing.T) {
-	t.Skip("flaky test")
 	info := define.Require(t, define.Requirements{
 		Group: Default,
 		Stack: &define.Stack{},
 		Sudo:  true,
 	})
+	t.Skip("flaky test")
 	ctx := context.Background()
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)

--- a/testing/integration/escaping_secrets_in_policy_test.go
+++ b/testing/integration/escaping_secrets_in_policy_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestEscapingSecretsInPolicy(t *testing.T) {
+	t.Skip("flaky test")
 	info := define.Require(t, define.Requirements{
 		Group: Default,
 		Stack: &define.Stack{},


### PR DESCRIPTION
- Bug

## What does this PR do?

Skips test that was added in #5987 

## Why is it important?

The test is flaky, will skip until it is fixed

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~


## Related issues
- Relates #6107 
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

