### PR TITLE
Only run providers that are referenced in the policy

### DIFF
--- a/changelog/fragments/1732840106-Only-run-providers-referenced-in-the-policy.yaml
+++ b/changelog/fragments/1732840106-Only-run-providers-referenced-in-the-policy.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Only run providers referenced in the policy
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/6169
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/3609

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -284,15 +284,10 @@ func runElasticAgent(ctx context.Context, cancel context.CancelFunc, override cf
 		l.Info("APM instrumentation disabled")
 	}
 
-	coord, configMgr, composable, err := application.New(ctx, l, baseLogger, logLvl, agentInfo, rex, tracer, testingMode, fleetInitTimeout, configuration.IsFleetServerBootstrap(cfg.Fleet), modifiers...)
+	coord, configMgr, _, err := application.New(ctx, l, baseLogger, logLvl, agentInfo, rex, tracer, testingMode, fleetInitTimeout, configuration.IsFleetServerBootstrap(cfg.Fleet), modifiers...)
 	if err != nil {
 		return logReturn(l, err)
 	}
-	defer func() {
-		if composable != nil {
-			composable.Close()
-		}
-	}()
 
 	monitoringServer, err := setupMetrics(l, cfg.Settings.DownloadConfig.OS(), cfg.Settings.MonitoringConfig, tracer, coord)
 	if err != nil {

--- a/internal/pkg/agent/transpiler/ast_test.go
+++ b/internal/pkg/agent/transpiler/ast_test.go
@@ -1019,6 +1019,58 @@ func TestVars(t *testing.T) {
 	}
 }
 
+func TestLookup(t *testing.T) {
+	tests := map[string]struct {
+		ast      *AST
+		selector Selector
+		node     Node
+		ok       bool
+	}{
+		"nil": {
+			ast:      nil,
+			selector: "",
+			node:     nil,
+			ok:       false,
+		},
+		"noroot": {
+			ast:      &AST{},
+			selector: "",
+			node:     nil,
+			ok:       false,
+		},
+		"notfound": {
+			ast: &AST{
+				root: NewDict([]Node{NewKey("entry", NewDict([]Node{
+					NewKey("var1", NewStrVal("value1")),
+					NewKey("var2", NewStrVal("value2")),
+				}))}),
+			},
+			selector: "entry.var3",
+			node:     nil,
+			ok:       false,
+		},
+		"found": {
+			ast: &AST{
+				root: NewDict([]Node{NewKey("entry", NewDict([]Node{
+					NewKey("var1", NewStrVal("value1")),
+					NewKey("var2", NewStrVal("value2")),
+				}))}),
+			},
+			selector: "entry.var2",
+			node:     NewKey("var2", NewStrVal("value2")),
+			ok:       true,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			node, ok := Lookup(test.ast, test.selector)
+			if assert.Equal(t, test.ok, ok) {
+				assert.Equal(t, test.node, node)
+			}
+		})
+	}
+}
+
 func mustMakeVars(mapping map[string]interface{}) *Vars {
 	v, err := NewVars("", mapping, nil)
 	if err != nil {

--- a/internal/pkg/agent/transpiler/ast_test.go
+++ b/internal/pkg/agent/transpiler/ast_test.go
@@ -920,6 +920,105 @@ func TestShallowClone(t *testing.T) {
 	}
 }
 
+func TestVars(t *testing.T) {
+	tests := map[string]struct {
+		input  map[string]interface{}
+		result []string
+	}{
+		"empty": {
+			input:  map[string]interface{}{},
+			result: nil,
+		},
+		"badbracket": {
+			input: map[string]interface{}{
+				"badbracket": "${missing.end",
+			},
+			result: nil,
+		},
+		"allconstant": {
+			input: map[string]interface{}{
+				"constant": "${'constant'}",
+			},
+			result: nil,
+		},
+		"escaped": {
+			input: map[string]interface{}{
+				"constant": "$${var1}",
+			},
+			result: nil,
+		},
+		"nested": {
+			input: map[string]interface{}{
+				"novars": map[string]interface{}{
+					"list1": []interface{}{
+						map[string]interface{}{
+							"int":   1,
+							"float": 1.1234,
+							"bool":  true,
+							"str":   "value1",
+						},
+					},
+					"list2": []interface{}{
+						map[string]interface{}{
+							"int":   2,
+							"float": 2.3456,
+							"bool":  false,
+							"str":   "value2",
+						},
+					},
+				},
+				"vars1": map[string]interface{}{
+					"list1": []interface{}{
+						map[string]interface{}{
+							"int":   1,
+							"float": 1.1234,
+							"bool":  true,
+							"str":   "${var1|var2|'constant'}",
+						},
+					},
+					"list2": []interface{}{
+						map[string]interface{}{
+							"int":   2,
+							"float": 2.3456,
+							"bool":  false,
+							"str":   "${var3|var1|'constant'}",
+						},
+					},
+				},
+				"vars2": map[string]interface{}{
+					"list1": []interface{}{
+						map[string]interface{}{
+							"int":   1,
+							"float": 1.1234,
+							"bool":  true,
+							"str":   "${var5|var6|'constant'}",
+						},
+					},
+					"list2": []interface{}{
+						map[string]interface{}{
+							"int":   2,
+							"float": 2.3456,
+							"bool":  false,
+							"str":   "${var1}",
+						},
+					},
+				},
+			},
+			result: []string{"var1", "var2", "var3", "var1", "var5", "var6", "var1"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ast, err := NewAST(test.input)
+			require.NoError(t, err)
+			var vars []string
+			vars = ast.root.Vars(vars)
+			assert.Equal(t, test.result, vars)
+		})
+	}
+}
+
 func mustMakeVars(mapping map[string]interface{}) *Vars {
 	v, err := NewVars("", mapping, nil)
 	if err != nil {

--- a/internal/pkg/agent/vars/vars.go
+++ b/internal/pkg/agent/vars/vars.go
@@ -26,7 +26,6 @@ func WaitForVariables(ctx context.Context, l *logger.Logger, cfg *config.Config,
 	if err != nil {
 		return nil, fmt.Errorf("failed to create composable controller: %w", err)
 	}
-	defer composable.Close()
 
 	hasTimeout := false
 	if wait > time.Duration(0) {

--- a/internal/pkg/composable/benchmark_test.go
+++ b/internal/pkg/composable/benchmark_test.go
@@ -28,9 +28,9 @@ func BenchmarkGenerateVars100Pods(b *testing.B) {
 	log, err := logger.New("", false)
 	require.NoError(b, err)
 	c := controller{
-		contextProviders: make(map[string]*contextProviderState),
-		dynamicProviders: make(map[string]*dynamicProviderState),
-		logger:           log,
+		contextProviderStates: make(map[string]*contextProviderState),
+		dynamicProviderStates: make(map[string]*dynamicProviderState),
+		logger:                log,
 	}
 	podCount := 100
 
@@ -63,14 +63,14 @@ func BenchmarkGenerateVars100Pods(b *testing.B) {
 				}
 				providerState.mappings[string(podUID)] = podMapping
 			}
-			c.dynamicProviders[providerName] = providerState
+			c.dynamicProviderStates[providerName] = providerState
 		} else {
 			providerAst, err := transpiler.NewAST(providerData[providerName])
 			require.NoError(b, err)
 			providerState := &contextProviderState{
 				mapping: providerAst,
 			}
-			c.contextProviders[providerName] = providerState
+			c.contextProviderStates[providerName] = providerState
 		}
 	}
 

--- a/internal/pkg/composable/config.go
+++ b/internal/pkg/composable/config.go
@@ -4,10 +4,15 @@
 
 package composable
 
-import "github.com/elastic/elastic-agent/internal/pkg/config"
+import (
+	"time"
+
+	"github.com/elastic/elastic-agent/internal/pkg/config"
+)
 
 // Config is config for multiple providers.
 type Config struct {
-	Providers               map[string]*config.Config `config:"providers"`
-	ProvidersInitialDefault *bool                     `config:"agent.providers.initial_default"`
+	Providers                map[string]*config.Config `config:"providers"`
+	ProvidersInitialDefault  *bool                     `config:"agent.providers.initial_default"`
+	ProvidersRestartInterval *time.Duration            `config:"agent.providers.restart_interval"`
 }

--- a/internal/pkg/composable/controller.go
+++ b/internal/pkg/composable/controller.go
@@ -22,6 +22,10 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
+const (
+	defaultRetryInterval = 30 * time.Second
+)
+
 // Controller manages the state of the providers current context.
 type Controller interface {
 	// Run runs the controller.
@@ -73,7 +77,7 @@ func New(log *logger.Logger, c *config.Config, managed bool) (Controller, error)
 		providersInitialDefault = *providersCfg.ProvidersInitialDefault
 	}
 
-	restartInterval := 5 * time.Second
+	restartInterval := defaultRetryInterval
 	if providersCfg.ProvidersRestartInterval != nil {
 		restartInterval = *providersCfg.ProvidersRestartInterval
 	}

--- a/internal/pkg/composable/controller_test.go
+++ b/internal/pkg/composable/controller_test.go
@@ -11,16 +11,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/elastic-agent/pkg/core/logger"
-
-	"github.com/elastic/elastic-agent/internal/pkg/agent/transpiler"
-
 	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/elastic-agent/internal/pkg/agent/transpiler"
 	"github.com/elastic/elastic-agent/internal/pkg/composable"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
 
 	_ "github.com/elastic/elastic-agent/internal/pkg/composable/providers/env"
 	_ "github.com/elastic/elastic-agent/internal/pkg/composable/providers/host"
@@ -82,21 +79,28 @@ func TestController(t *testing.T) {
 	c, err := composable.New(log, cfg, false)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 1*time.Second)
-	defer timeoutCancel()
-
-	var setVars []*transpiler.Vars
+	var setVars1 []*transpiler.Vars
+	var setVars2 []*transpiler.Vars
+	var setVars3 []*transpiler.Vars
 	go func() {
-		defer cancel()
 		for {
 			select {
-			case <-timeoutCtx.Done():
+			case <-ctx.Done():
 				return
 			case vars := <-c.Watch():
-				setVars = vars
+				if setVars1 == nil {
+					setVars1 = vars
+					c.Observe([]string{"local.vars.key1", "local_dynamic.vars.key1"}) // observed local and local_dynamic
+				} else if setVars2 == nil {
+					setVars2 = vars
+					c.Observe(nil) // no observed (will turn off those providers)
+				} else {
+					setVars3 = vars
+					cancel()
+				}
 			}
 		}
 	}()
@@ -111,52 +115,67 @@ func TestController(t *testing.T) {
 	}
 	require.NoError(t, err)
 
-	assert.Len(t, setVars, 3)
+	assert.Len(t, setVars1, 1)
+	assert.Len(t, setVars2, 3)
+	assert.Len(t, setVars3, 1)
 
-	_, hostExists := setVars[0].Lookup("host")
-	assert.True(t, hostExists)
-	_, envExists := setVars[0].Lookup("env")
-	assert.False(t, envExists)
-	local, _ := setVars[0].Lookup("local")
+	vars1map, err := setVars1[0].Map()
+	require.NoError(t, err)
+	assert.Len(t, vars1map, 0) // should be empty on initial
+
+	_, hostExists := setVars2[0].Lookup("host")
+	assert.False(t, hostExists) // should not exist, not referenced
+	_, envExists := setVars2[0].Lookup("env")
+	assert.False(t, envExists) // should not exist, not referenced
+	local, _ := setVars2[0].Lookup("local")
 	localMap, ok := local.(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "value1", localMap["key1"])
 
-	local, _ = setVars[1].Lookup("local_dynamic")
+	local, _ = setVars2[1].Lookup("local_dynamic")
 	localMap, ok = local.(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "value1", localMap["key1"])
 
-	local, _ = setVars[2].Lookup("local_dynamic")
+	local, _ = setVars2[2].Lookup("local_dynamic")
 	localMap, ok = local.(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "value2", localMap["key1"])
+
+	vars3map, err := setVars3[0].Map()
+	require.NoError(t, err)
+	assert.Len(t, vars3map, 0) // should be empty after empty Observe
 }
 
 func TestProvidersDefaultDisabled(t *testing.T) {
 	tests := []struct {
-		name string
-		cfg  map[string]interface{}
-		want int
+		name     string
+		cfg      map[string]interface{}
+		observed []string
+		context  []string
+		dynamic  []string
 	}{
 		{
 			name: "default disabled",
 			cfg: map[string]interface{}{
 				"agent.providers.initial_default": "false",
 			},
-			want: 0,
+			observed: []string{"env.var1", "host.name"}, // has observed but explicitly disabled
+			context:  nil,                               // should have none
 		},
 		{
 			name: "default enabled",
 			cfg: map[string]interface{}{
 				"agent.providers.initial_default": "true",
 			},
-			want: 1,
+			observed: []string{"env.var1", "host.name"},
+			context:  []string{"env", "host"},
 		},
 		{
-			name: "default enabled - no config",
-			cfg:  map[string]interface{}{},
-			want: 1,
+			name:     "default enabled - no config",
+			cfg:      map[string]interface{}{},
+			observed: nil, // none observed
+			context:  nil, // should have none
 		},
 		{
 			name: "default enabled - explicit config",
@@ -206,7 +225,9 @@ func TestProvidersDefaultDisabled(t *testing.T) {
 					},
 				},
 			},
-			want: 3,
+			observed: []string{"local.vars.key1", "local_dynamic.vars.key1"},
+			context:  []string{"local"},
+			dynamic:  []string{"local_dynamic", "local_dynamic"},
 		},
 	}
 
@@ -219,6 +240,8 @@ func TestProvidersDefaultDisabled(t *testing.T) {
 			require.NoError(t, err)
 			c, err := composable.New(log, cfg, false)
 			require.NoError(t, err)
+
+			c.Observe(tt.observed)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -249,7 +272,26 @@ func TestProvidersDefaultDisabled(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			assert.Len(t, setVars, tt.want)
+			if len(tt.context) > 0 {
+				for _, name := range tt.context {
+					_, ok := setVars[0].Lookup(name)
+					assert.Truef(t, ok, "context vars group missing %s", name)
+				}
+			} else {
+				m, err := setVars[0].Map()
+				if assert.NoErrorf(t, err, "failed to convert context vars to map") {
+					assert.Len(t, m, 0) // should be empty
+				}
+			}
+			if len(tt.dynamic) > 0 {
+				for i, name := range tt.dynamic {
+					_, ok := setVars[i+1].Lookup(name)
+					assert.Truef(t, ok, "dynamic vars group %d missing %s", i+1, name)
+				}
+			} else {
+				// should not have any dynamic vars
+				assert.Len(t, setVars, 1)
+			}
 		})
 	}
 }
@@ -312,7 +354,6 @@ func TestCancellation(t *testing.T) {
 		t.Run(fmt.Sprintf("test run %d", i), func(t *testing.T) {
 			c, err := composable.New(log, cfg, false)
 			require.NoError(t, err)
-			defer c.Close()
 
 			ctx, cancelFn := context.WithTimeout(context.Background(), timeout)
 			defer cancelFn()
@@ -328,7 +369,6 @@ func TestCancellation(t *testing.T) {
 	t.Run("immediate cancellation", func(t *testing.T) {
 		c, err := composable.New(log, cfg, false)
 		require.NoError(t, err)
-		defer c.Close()
 
 		ctx, cancelFn := context.WithTimeout(context.Background(), 0)
 		cancelFn()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This updates the Elastic Agent to only run composable providers if they are referenced in the policy.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This change provides the following benefits:

- Reduces the memory and load of the Elastic Agent, by only running the providers it references.
- No longer requires access to the kubernetes API or resources just to run an Elastic Agent (as long as its not using any ${kubernetes*` references in the policy).
- Fixes an issue where if no providers are running that a set of empty variables is passed to the coordinator.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~ (covered by unit tests)

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None. As it still runs all those that are referenced from the user.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run the elastic-agent container with just the system integration and notice that it doesn't require access to the Kubernetes API any more.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #3609 
- Closes #4648 
