### PR TITLE
Do external package manager check only at startup

### DIFF
--- a/changelog/fragments/1733131399-vars-for-platform.yaml
+++ b/changelog/fragments/1733131399-vars-for-platform.yaml
@@ -8,7 +8,7 @@
 # - security: impacts on the security of a product or a user’s deployment.
 # - upgrade: important information for someone upgrading from a prior version
 # - other: does not fit into any of the other categories
-kind: feature
+kind: enhancement
 
 # Change summary; a 80ish characters long description of the change.
 summary: Do the external package manager check only at startup

--- a/changelog/fragments/1733131399-vars-for-platform.yaml
+++ b/changelog/fragments/1733131399-vars-for-platform.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Do the external package manager check only at startup
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -15,7 +15,6 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
-	"github.com/elastic/elastic-agent/internal/pkg/agent/install/pkgmgr"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/transpiler"
 	"github.com/elastic/elastic-agent/internal/pkg/core/monitoring/config"
 	"github.com/elastic/elastic-agent/internal/pkg/eql"
@@ -682,7 +681,7 @@ type outputI struct {
 func varsForPlatform(platform PlatformDetail) (*transpiler.Vars, error) {
 	return transpiler.NewVars("", map[string]interface{}{
 		"install": map[string]interface{}{
-			"in_default": paths.ArePathsEqual(paths.Top(), paths.InstallPath(paths.DefaultBasePath)) || pkgmgr.InstalledViaExternalPkgMgr(),
+			"in_default": paths.ArePathsEqual(paths.Top(), paths.InstallPath(paths.DefaultBasePath)) || platform.IsInstalledViaExternalPkgMgr,
 		},
 		"runtime": map[string]interface{}{
 			"platform":    platform.String(),

--- a/pkg/component/platforms.go
+++ b/pkg/component/platforms.go
@@ -9,6 +9,8 @@ import (
 	goruntime "runtime"
 	"strings"
 
+	"github.com/elastic/elastic-agent/internal/pkg/agent/install/pkgmgr"
+
 	"github.com/elastic/go-sysinfo"
 
 	"github.com/elastic/elastic-agent/pkg/utils"
@@ -114,7 +116,8 @@ type PlatformDetail struct {
 	Major      int
 	Minor      int
 
-	User UserDetail
+	IsInstalledViaExternalPkgMgr bool
+	User                         UserDetail
 }
 
 // PlatformModifier can modify the platform details before the runtime specifications are loaded.
@@ -155,6 +158,7 @@ func LoadPlatformDetail(modifiers ...PlatformModifier) (PlatformDetail, error) {
 		User: UserDetail{
 			Root: hasRoot,
 		},
+		IsInstalledViaExternalPkgMgr: pkgmgr.InstalledViaExternalPkgMgr(),
 	}
 	for _, modifier := range modifiers {
 		detail = modifier(detail)


### PR DESCRIPTION
## What does this PR do?

We were doing the check for external package manager use when validating vars for the platform, which happens on every configuration reload. I've made this an attribute of the platform instead, and it's now only checked on startup.

## Why is it important?

Reading a bunch of files every time configuration is reloaded is an unnecessary expense.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Related issues

- Relates #5835 #5991 

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->