### PR TITLE
Avoid unnecessary copies during config generation

### DIFF
--- a/changelog/fragments/1733158776-avoid-copies-config-gen.yaml
+++ b/changelog/fragments/1733158776-avoid-copies-config-gen.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Avoid unnecessary copies when generating component configurations
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -1414,7 +1414,7 @@ func (c *Coordinator) generateComponentModel() (err error) {
 		c.setComponentGenError(err)
 	}()
 
-	ast := c.ast.Clone()
+	ast := c.ast.ShallowClone()
 	inputs, ok := transpiler.Lookup(ast, "inputs")
 	if ok {
 		renderedInputs, err := transpiler.RenderInputs(inputs, c.vars)

--- a/internal/pkg/agent/transpiler/ast.go
+++ b/internal/pkg/agent/transpiler/ast.go
@@ -151,7 +151,8 @@ func (d *Dict) ShallowClone() Node {
 		if i == nil {
 			continue
 		}
-		nodes = append(nodes, i)
+		// Dict nodes are key-value pairs, and we do want to make a copy of the key here
+		nodes = append(nodes, i.ShallowClone())
 
 	}
 	return &Dict{value: nodes}

--- a/internal/pkg/agent/transpiler/ast.go
+++ b/internal/pkg/agent/transpiler/ast.go
@@ -62,7 +62,7 @@ type Node interface {
 	// the capacity of the array had to be changed.
 	Vars([]string) []string
 
-	// Apply apply the current vars, returning the new value for the node.
+	// Apply apply the current vars, returning the new value for the node. This does not modify the original Node.
 	Apply(*Vars) (Node, error)
 
 	// Processors returns any attached processors, because of variable substitution.
@@ -176,7 +176,7 @@ func (d *Dict) Vars(vars []string) []string {
 	return vars
 }
 
-// Apply applies the vars to all the nodes in the dictionary.
+// Apply applies the vars to all the nodes in the dictionary. This does not modify the original dictionary.
 func (d *Dict) Apply(vars *Vars) (Node, error) {
 	nodes := make([]Node, 0, len(d.value))
 	for _, v := range d.value {
@@ -299,7 +299,7 @@ func (k *Key) Vars(vars []string) []string {
 	return k.value.Vars(vars)
 }
 
-// Apply applies the vars to the value.
+// Apply applies the vars to the value. This does not modify the original node.
 func (k *Key) Apply(vars *Vars) (Node, error) {
 	if k.value == nil {
 		return k, nil
@@ -427,7 +427,7 @@ func (l *List) Vars(vars []string) []string {
 	return vars
 }
 
-// Apply applies the vars to all nodes in the list.
+// Apply applies the vars to all nodes in the list. This does not modify the original list.
 func (l *List) Apply(vars *Vars) (Node, error) {
 	nodes := make([]Node, 0, len(l.value))
 	for _, v := range l.value {
@@ -512,7 +512,7 @@ func (s *StrVal) Vars(vars []string) []string {
 	return vars
 }
 
-// Apply applies the vars to the string value.
+// Apply applies the vars to the string value. This does not modify the original string.
 func (s *StrVal) Apply(vars *Vars) (Node, error) {
 	return vars.Replace(s.value)
 }

--- a/internal/pkg/agent/transpiler/ast_test.go
+++ b/internal/pkg/agent/transpiler/ast_test.go
@@ -909,7 +909,7 @@ func TestShallowClone(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			cloned := test.input.ShallowClone()
 			assert.Equal(t, test.input, cloned)
-			err := test.input.Insert(&AST{root: &BoolVal{value: true}}, "key")
+			err := test.input.Insert(&AST{root: &Key{name: "integer", value: &IntVal{value: 7}}}, "integer")
 			if err == nil {
 				assert.NotEqual(t, test.input, cloned)
 			} else if list, ok := test.input.root.(*List); ok {

--- a/internal/pkg/agent/transpiler/utils.go
+++ b/internal/pkg/agent/transpiler/utils.go
@@ -26,7 +26,7 @@ func RenderInputs(inputs Node, varsArray []*Vars) (Node, error) {
 	nodesMap := map[string]*Dict{}
 	for _, vars := range varsArray {
 		for _, node := range l.Value().([]Node) {
-			dict, ok := node.Clone().(*Dict)
+			dict, ok := node.(*Dict)
 			if !ok {
 				continue
 			}
@@ -34,6 +34,7 @@ func RenderInputs(inputs Node, varsArray []*Vars) (Node, error) {
 			if streams := getStreams(dict); streams != nil {
 				hadStreams = true
 			}
+			// Apply creates a new Node with a deep copy of all the values
 			n, err := dict.Apply(vars)
 			if errors.Is(err, ErrNoMatch) {
 				// has a variable that didn't exist, so we ignore it


### PR DESCRIPTION
## What does this PR do?

Remove some unnecessary copies when generating component configuration.

The first copy avoided is done because we want to replace the `inputs` key with the rendered inputs. A shallow copy is sufficient for this. I did find and fix a bug in Dict shallow copies while at it.

The rest of the copies have to do with applying vars to each AST node. We currently make a copy of each Node we do this for, but that's not necessary, as `Apply` creates a new Node with all the data recursively copied anyway. I've added a test to verify that `Apply` actually works this way.

Benchstat result vs `main`, using the benchmark from #6180:

```
goos: linux
goarch: amd64
pkg: github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator
cpu: 13th Gen Intel(R) Core(TM) i7-13700H
                                      │ bench_main.txt │          bench_noclone.txt          │
                                      │     sec/op     │   sec/op     vs base                │
Coordinator_generateComponentModel-20     37.99m ± 24%   32.36m ± 4%  -14.82% (p=0.000 n=10)

                                      │ bench_main.txt │          bench_noclone.txt           │
                                      │      B/op      │     B/op      vs base                │
Coordinator_generateComponentModel-20     34.22Mi ± 0%   25.38Mi ± 0%  -25.84% (p=0.000 n=10)

                                      │ bench_main.txt │          bench_noclone.txt          │
                                      │   allocs/op    │  allocs/op   vs base                │
Coordinator_generateComponentModel-20      810.7k ± 0%   580.4k ± 0%  -28.40% (p=0.000 n=10)
```

## Why is it important?

More performance is good! More broadly, this is an attempt to incrementally improve the problem from #5991.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Related issues

- Related #5991
- Relates #5835

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->