### PR TITLE
Skipping flaky unit test: `TestUpgradeHandlerSameVersion`

### DIFF
--- a/internal/pkg/agent/application/actions/handlers/handler_action_upgrade_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_upgrade_test.go
@@ -130,6 +130,7 @@ func TestUpgradeHandler(t *testing.T) {
 }
 
 func TestUpgradeHandlerSameVersion(t *testing.T) {
+	t.Skip("flaky test: https://github.com/elastic/elastic-agent/issues/5938")
 	// Create a cancellable context that will shut down the coordinator after
 	// the test.
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
What it says on the tin.

This skip should be reverted when the flaky test failure is investigated and fixed, as part of https://github.com/elastic/elastic-agent/issues/5938.