### PR TITLE
Use xxhash instead of sha256 for hashing AST nodes

### DIFF
--- a/changelog/fragments/1733238171-use-xxhash-for-ast-hashing.yaml
+++ b/changelog/fragments/1733238171-use-xxhash-for-ast-hashing.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Use xxHash for hashing AST nodes
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2
 	github.com/cavaliergopher/rpm v1.2.0
 	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/docker/docker v27.3.1+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/dolmen-go/contextio v0.0.0-20200217195037-68fc5150bcd5
@@ -222,7 +223,6 @@ require (
 	github.com/aws/smithy-go v1.20.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.7.1 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/cloudfoundry-community/go-cfclient v0.0.0-20190808214049-35bcce23fc5f // indirect
 	github.com/cloudfoundry/noaa v2.1.0+incompatible // indirect

--- a/internal/pkg/agent/transpiler/ast.go
+++ b/internal/pkg/agent/transpiler/ast.go
@@ -5,7 +5,6 @@
 package transpiler
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
@@ -13,6 +12,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/cespare/xxhash/v2"
 
 	"github.com/elastic/elastic-agent/internal/pkg/eql"
 )
@@ -57,6 +58,9 @@ type Node interface {
 
 	// Hash compute a sha256 hash of the current node and recursively call any children.
 	Hash() []byte
+
+	// Hash64With recursively computes the given hash for the Node and its children
+	Hash64With(h *xxhash.Digest) error
 
 	// Vars adds to the array with the variables identified in the node. Returns the array in-case
 	// the capacity of the array had to be changed.
@@ -164,6 +168,16 @@ func (d *Dict) Hash() []byte {
 		h.Write(v.Hash())
 	}
 	return h.Sum(nil)
+}
+
+// Hash64With recursively computes the given hash for the Node and its children
+func (d *Dict) Hash64With(h *xxhash.Digest) error {
+	for _, v := range d.value {
+		if err := v.Hash64With(h); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Vars returns a list of all variables referenced in the dictionary.
@@ -290,6 +304,17 @@ func (k *Key) Hash() []byte {
 	return h.Sum(nil)
 }
 
+// Hash64With recursively computes the given hash for the Node and its children
+func (k *Key) Hash64With(h *xxhash.Digest) error {
+	if _, err := h.WriteString(k.name); err != nil {
+		return err
+	}
+	if k.value != nil {
+		return k.value.Hash64With(h)
+	}
+	return nil
+}
+
 // Vars returns a list of all variables referenced in the value.
 func (k *Key) Vars(vars []string) []string {
 	if k.value == nil {
@@ -371,6 +396,16 @@ func (l *List) Hash() []byte {
 	}
 
 	return h.Sum(nil)
+}
+
+// Hash64With recursively computes the given hash for the Node and its children
+func (l *List) Hash64With(h *xxhash.Digest) error {
+	for _, v := range l.value {
+		if err := v.Hash64With(h); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Find takes an index and return the values at that index.
@@ -501,6 +536,12 @@ func (s *StrVal) Hash() []byte {
 	return []byte(s.value)
 }
 
+// Hash64With recursively computes the given hash for the Node and its children
+func (s *StrVal) Hash64With(h *xxhash.Digest) error {
+	_, err := h.WriteString(s.value)
+	return err
+}
+
 // Vars returns a list of all variables referenced in the string.
 func (s *StrVal) Vars(vars []string) []string {
 	// errors are ignored (if there is an error determine the vars it will also error computing the policy)
@@ -577,6 +618,12 @@ func (s *IntVal) Hash() []byte {
 	return []byte(s.String())
 }
 
+// Hash64With recursively computes the given hash for the Node and its children
+func (s *IntVal) Hash64With(h *xxhash.Digest) error {
+	_, err := h.WriteString(s.String())
+	return err
+}
+
 // Processors returns any linked processors that are now connected because of Apply.
 func (s *IntVal) Processors() Processors {
 	return s.processors
@@ -626,6 +673,12 @@ func (s *UIntVal) ShallowClone() Node {
 // Hash we convert the value into a string and return the byte slice.
 func (s *UIntVal) Hash() []byte {
 	return []byte(s.String())
+}
+
+// Hash64With recursively computes the given hash for the Node and its children
+func (s *UIntVal) Hash64With(h *xxhash.Digest) error {
+	_, err := h.WriteString(s.String())
+	return err
 }
 
 // Vars does nothing. Cannot have variable in an UIntVal.
@@ -687,7 +740,18 @@ func (s *FloatVal) ShallowClone() Node {
 
 // Hash return a string representation of the value, we try to return the minimal precision we can.
 func (s *FloatVal) Hash() []byte {
-	return []byte(strconv.FormatFloat(s.value, 'f', -1, 64))
+	return []byte(s.hashString())
+}
+
+// Hash64With recursively computes the given hash for the Node and its children
+func (s *FloatVal) Hash64With(h *xxhash.Digest) error {
+	_, err := h.WriteString(s.hashString())
+	return err
+}
+
+// hashString returns a string representation of s suitable for hashing.
+func (s *FloatVal) hashString() string {
+	return strconv.FormatFloat(s.value, 'f', -1, 64)
 }
 
 // Vars does nothing. Cannot have variable in an FloatVal.
@@ -755,6 +819,18 @@ func (s *BoolVal) Hash() []byte {
 		return trueVal
 	}
 	return falseVal
+}
+
+// Hash64With recursively computes the given hash for the Node and its children
+func (s *BoolVal) Hash64With(h *xxhash.Digest) error {
+	var encodedBool []byte
+	if s.value {
+		encodedBool = trueVal
+	} else {
+		encodedBool = falseVal
+	}
+	_, err := h.Write(encodedBool)
+	return err
 }
 
 // Vars does nothing. Cannot have variable in an BoolVal.
@@ -877,6 +953,11 @@ func (a *AST) Hash() []byte {
 	return a.root.Hash()
 }
 
+// Hash64With recursively computes the given hash for the Node and its children
+func (a *AST) Hash64With(h *xxhash.Digest) error {
+	return a.root.Hash64With(h)
+}
+
 // HashStr return the calculated hash as a base64 url encoded string.
 func (a *AST) HashStr() string {
 	return base64.URLEncoding.EncodeToString(a.root.Hash())
@@ -887,7 +968,13 @@ func (a *AST) Equal(other *AST) bool {
 	if a.root == nil || other.root == nil {
 		return a.root == other.root
 	}
-	return bytes.Equal(a.Hash(), other.Hash())
+	hasher := xxhash.New()
+	_ = a.Hash64With(hasher)
+	thisHash := hasher.Sum64()
+	hasher.Reset()
+	_ = other.Hash64With(hasher)
+	otherHash := hasher.Sum64()
+	return thisHash == otherHash
 }
 
 // Lookup looks for a value from the AST.

--- a/internal/pkg/agent/transpiler/utils.go
+++ b/internal/pkg/agent/transpiler/utils.go
@@ -7,6 +7,8 @@ package transpiler
 import (
 	"errors"
 	"fmt"
+
+	"github.com/cespare/xxhash/v2"
 )
 
 const (
@@ -23,7 +25,8 @@ func RenderInputs(inputs Node, varsArray []*Vars) (Node, error) {
 		return nil, fmt.Errorf("inputs must be an array")
 	}
 	var nodes []varIDMap
-	nodesMap := map[string]*Dict{}
+	nodesMap := map[uint64]*Dict{}
+	hasher := xxhash.New()
 	for _, vars := range varsArray {
 		for _, node := range l.Value().([]Node) {
 			dict, ok := node.Clone().(*Dict)
@@ -55,7 +58,9 @@ func RenderInputs(inputs Node, varsArray []*Vars) (Node, error) {
 					continue
 				}
 			}
-			hash := string(dict.Hash())
+			hasher.Reset()
+			_ = dict.Hash64With(hasher)
+			hash := hasher.Sum64()
 			_, exists := nodesMap[hash]
 			if !exists {
 				nodesMap[hash] = dict


### PR DESCRIPTION
## What does this PR do?

We currently use sha256 for hashing AST nodes when generating configuration. This is used both for checking equality between AST instances and for avoiding recomputing inputs unnecessarily. This PR changes this to xxHash, which is much faster. It also changes the interface, letting the caller supply their own hasher instance, and avoiding needing to allocate one for each Node in the tree.

Of note is that I'm using the `xxhash.Digest` struct as an argument instead of the generic `hash.Hash64` interface from the standard library. The reason is that the former has an optimized `WriteString` method, which avoid needing to cast the string to a byte slice. I also don't expect to need to actually supply different hash implementations to this method.

Note also that there's already fairly exhaustive tests for this, some unexpected behaviour included.

## Why is it important?

It's a pretty significant performance improvement. See the benchstat results using the benchmark from #6180:

```
goos: linux
goarch: amd64
pkg: github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator
cpu: 13th Gen Intel(R) Core(TM) i7-13700H
                                      │ bench_main.txt │           bench_hash.txt            │
                                      │     sec/op     │    sec/op     vs base               │
Coordinator_generateComponentModel-20     37.99m ± 24%   34.29m ± 14%  -9.73% (p=0.009 n=10)

                                      │ bench_main.txt │           bench_hash.txt            │
                                      │      B/op      │     B/op      vs base               │
Coordinator_generateComponentModel-20     34.22Mi ± 0%   31.53Mi ± 0%  -7.88% (p=0.000 n=10)

                                      │ bench_main.txt │           bench_hash.txt            │
                                      │   allocs/op    │  allocs/op   vs base                │
Coordinator_generateComponentModel-20      810.7k ± 0%   713.0k ± 0%  -12.05% (p=0.000 n=10)
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Related issues

- Relates #5835 
- Related #5991 

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->