### PR TITLE
Remove SonarQube badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Elastic Agent
 
 [![Build status](https://badge.buildkite.com/1d35bb40427cc6833979645b61ea214fc4b686a2ffe3a68bdf.svg)](https://buildkite.com/elastic/elastic-agent)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=elastic_elastic-agent&metric=coverage)](https://sonarcloud.io/summary/new_code?id=elastic_elastic-agent)
 
 ## Architecture and Internals
 


### PR DESCRIPTION
This PR removes the currently-broken SonarQube badge from the Elastic Agent README file.  

Elastic's SonarQube instance is private (hosted at sonar.elastic.dev instead of the public sonarcloud.io).  As such a security token is needed as part of the badge image URL.  Since the elastic-agent repository is public, it would not be a good idea to expose this token.  So we remove the badge instead of trying to replace it.