### PR TITLE
Cache conditions when applying variables to config

### DIFF
--- a/changelog/fragments/1733411331-cache-conditions-in-config.yaml
+++ b/changelog/fragments/1733411331-cache-conditions-in-config.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Cache conditions when applying variables to config
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/transpiler/ast.go
+++ b/internal/pkg/agent/transpiler/ast.go
@@ -238,13 +238,14 @@ func (d *Dict) sort() {
 
 // Key represents a Key / value pair in the dictionary.
 type Key struct {
-	name  string
-	value Node
+	name      string
+	value     Node
+	condition *eql.Expression
 }
 
 // NewKey creates a new key with provided name node pair.
 func NewKey(name string, val Node) *Key {
-	return &Key{name, val}
+	return &Key{name: name, value: val}
 }
 
 func (k *Key) String() string {
@@ -334,11 +335,18 @@ func (k *Key) Apply(vars *Vars) (Node, error) {
 		case *BoolVal:
 			return k, nil
 		case *StrVal:
-			cond, err := eql.Eval(v.value, vars, true)
+			var err error
+			if k.condition == nil {
+				k.condition, err = eql.New(v.value)
+				if err != nil {
+					return nil, fmt.Errorf(`invalid condition "%s": %w`, v.value, err)
+				}
+			}
+			cond, err := k.condition.Eval(vars, true)
 			if err != nil {
 				return nil, fmt.Errorf(`condition "%s" evaluation failed: %w`, v.value, err)
 			}
-			return &Key{k.name, NewBoolVal(cond)}, nil
+			return &Key{name: k.name, value: NewBoolVal(cond)}, nil
 		}
 		return nil, fmt.Errorf("condition key's value must be a string; received %T", k.value)
 	}
@@ -349,7 +357,7 @@ func (k *Key) Apply(vars *Vars) (Node, error) {
 	if v == nil {
 		return nil, nil
 	}
-	return &Key{k.name, v}, nil
+	return &Key{name: k.name, value: v}, nil
 }
 
 // Processors returns any attached processors, because of variable substitution.

--- a/internal/pkg/agent/transpiler/ast_test.go
+++ b/internal/pkg/agent/transpiler/ast_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/mapstr"
 
+	"github.com/elastic/elastic-agent/internal/pkg/eql"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1106,6 +1108,29 @@ func TestLookup(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCondition(t *testing.T) {
+	vars := mustMakeVars(map[string]interface{}{
+		"other": map[string]interface{}{
+			"data": "info",
+		}})
+
+	input := NewKey("condition", NewStrVal("${other.data} == 'info'"))
+	expected := NewKey("condition", NewBoolVal(true))
+
+	// the condition string hasn't been parsed yet
+	assert.Nil(t, input.condition)
+
+	output, err := input.Apply(vars)
+	require.NoError(t, err)
+	assert.Equal(t, expected, output)
+
+	// check if the condition was parsed and cached
+	assert.NotNil(t, input.condition)
+	condition, err := eql.New(input.value.Value().(string))
+	require.NoError(t, err)
+	assert.Equal(t, condition, input.condition)
 }
 
 func mustMakeVars(mapping map[string]interface{}) *Vars {

--- a/internal/pkg/agent/transpiler/ast_test.go
+++ b/internal/pkg/agent/transpiler/ast_test.go
@@ -1131,6 +1131,18 @@ func TestCondition(t *testing.T) {
 	condition, err := eql.New(input.value.Value().(string))
 	require.NoError(t, err)
 	assert.Equal(t, condition, input.condition)
+
+	// create a dict with the key
+	dict := NewDict([]Node{input})
+	ast := &AST{root: NewKey("key", dict)}
+	// the cached condition remains
+	assert.Equal(t, condition, input.condition)
+
+	// replace the key with a new one, without a cached condition
+	input2 := NewKey("condition", NewStrVal("${other.data} == 'info'"))
+	err = Insert(ast, input2, "")
+	require.NoError(t, err)
+	assert.Nil(t, input2.condition)
 }
 
 func mustMakeVars(mapping map[string]interface{}) *Vars {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Our configurations can have conditional sections. The conditions are expressed in an EQL-like syntax, and we parse the expressions lazily on evaluation. However, we don't cache the parsed expression, and parse it every time it's evaluated. This change instead only parses the condition expression once, and it's then cached in the AST node.

## Why is it important?

When there are a lot of variables from dynamic providers - notably in Kubernetes, on a Node with a lot of Pods - we end up spending significant resources on re-parsing the condition expressions for every var entry.

See benchstat showing the effect of this change on the benchmark from #6180 (not that this includes #6184, as otherwise we just make a copy before applying and never actually use the cache):

```
goos: linux
goarch: amd64
pkg: github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator
cpu: 13th Gen Intel(R) Core(TM) i7-13700H
                                      │ bench_noclone.txt │            bench_eql.txt            │
                                      │      sec/op       │   sec/op     vs base                │
Coordinator_generateComponentModel-20         32.36m ± 4%   27.45m ± 2%  -15.17% (p=0.000 n=10)

                                      │ bench_noclone.txt │            bench_eql.txt             │
                                      │       B/op        │     B/op      vs base                │
Coordinator_generateComponentModel-20        25.38Mi ± 0%   20.51Mi ± 0%  -19.17% (p=0.000 n=10)

                                      │ bench_noclone.txt │            bench_eql.txt            │
                                      │     allocs/op     │  allocs/op   vs base                │
Coordinator_generateComponentModel-20         580.4k ± 0%   490.1k ± 0%  -15.57% (p=0.000 n=10)
```



## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## How to test this PR locally

Unit tests are sufficient, the benchmark in #6180 helps as well.

## Related issues

- Relates #5835
- Relates #5991

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->