### PR TITLE
[k8s]: restructure kubernetes integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	helm.sh/helm/v3 v3.15.4
 	k8s.io/api v0.31.3
 	k8s.io/apimachinery v0.31.3
+	k8s.io/cli-runtime v0.30.3
 	k8s.io/client-go v0.31.3
 	kernel.org/pub/linux/libs/security/libcap/cap v1.2.70
 	sigs.k8s.io/e2e-framework v0.4.0
@@ -592,7 +593,6 @@ require (
 	howett.net/plist v1.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.30.3 // indirect
 	k8s.io/apiserver v0.31.3 // indirect
-	k8s.io/cli-runtime v0.30.3 // indirect
 	k8s.io/component-base v0.31.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/kubectl v0.30.3 // indirect


### PR DESCRIPTION
## What does this PR do?

This PR lays the groundwork for Kubernetes hints integration tests. The related commits of the former will be included in a follow-up PR (https://github.com/elastic/elastic-agent/commit/6fa8ffb27756ed1dacb4543045aed4c6e7749e02, https://github.com/elastic/elastic-agent/commit/9a48d023c3e4feae03dfd5fb62cee99bbed4abc3) as I want to keep this PR around [500 lines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md?plain=1#L47) (excluding go.mod and NOTICE files). These changes address the need to avoid duplicating code logic, as hints tests require deploying plain Kubernetes YAML files and checking the agent status independently. Key updates include:

- **Centralized Context**: Introduced `k8sContext` to standardize Kubernetes test setup.
- **Refactored Helpers**: Streamlined functions for Kubernetes operations (e.g., `k8sCreateObjects`, `k8sDeleteObjects`, `k8sWaitForReady`) with better error handling.
- **Agent Health Validation**: Enhanced agent status checks with `k8sCheckAgentStatus`.
- **Readiness Checker**: Leveraged Helm's `ReadyChecker` to validate readiness of Kubernetes objects (e.g., pods, deployments, daemonSets, statefulSets, etc.).

These updates improve code readability, modularity, and reusability, reducing the need for duplicate logic in k8s tests.

## Why is it important?

- **Avoiding Duplication**: Eliminates the need for repeated logic in k8s tests.
- **Improved Modularity**: Encapsulates reusable functionality for easier maintenance and test extension.
- **Readiness Assurance**: Ensures Kubernetes objects are fully ready before test execution, reducing test flakiness.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- ~~[ ] I have made corresponding changes to the documentation.~~
- ~~[ ] I have made corresponding changes to the default configuration files.~~
- [x] I have added tests that prove my fix is effective or that my feature works.
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog).~~
- [x] I have added an integration test or an E2E test.

## Disruptive User Impact

No disruptive changes. Enhancements are internal to Kubernetes integration tests.

## How to test this PR locally

```
mage integration:auth
PLATFORMS=linux/arm64 EXTERNAL=true SNAPSHOT=true PACKAGES=docker mage -v package 
INSTANCE_PROVISIONER=kind STACK_PROVISIONER=stateful K8S_VERSION=v1.31.1 SNAPSHOT=true mage integration:kubernetes
```

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/5660