### PR TITLE
[k8s]: transition integration tests to adapter pattern

### DIFF
--- a/testing/integration/kubernetes_agent_service_test.go
+++ b/testing/integration/kubernetes_agent_service_test.go
@@ -7,17 +7,13 @@
 package integration
 
 import (
-	"bufio"
-	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 
 	"github.com/elastic/elastic-agent/pkg/testing/define"
@@ -35,73 +31,41 @@ func TestKubernetesAgentService(t *testing.T) {
 		Group: define.Kubernetes,
 	})
 
+	// read the service agent config
+	serviceAgentYAML, err := os.ReadFile(filepath.Join("testdata", "connectors.agent.yml"))
+	require.NoError(t, err, "failed to read service agent config")
+
 	ctx := context.Background()
 	kCtx := k8sGetContext(t, info)
-	testNamespace := kCtx.getNamespace(t)
 
-	renderedManifest, err := renderKustomize(agentK8SKustomize)
-	require.NoError(t, err, "failed to render kustomize")
-
-	k8sObjects, err := k8sYAMLToObjects(bufio.NewReader(bytes.NewReader(renderedManifest)))
-	require.NoError(t, err, "failed to convert yaml to k8s objects")
-
-	// add the testNamespace in the k8sObjects
-	k8sObjects = append([]k8s.Object{&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}}, k8sObjects...)
-
-	t.Cleanup(func() {
-		err = k8sDeleteObjects(ctx, kCtx.client, k8sDeleteOpts{wait: true}, k8sObjects...)
-		require.NoError(t, err, "failed to delete k8s namespace")
-	})
-
-	k8sKustomizeAdjustObjects(k8sObjects, testNamespace, "elastic-agent-standalone",
-		func(container *corev1.Container) {
-			// set agent image
-			container.Image = kCtx.agentImage
-			// set ImagePullPolicy to "Never" to avoid pulling the image
-			// as the image is already loaded by the kubernetes provisioner
-			container.ImagePullPolicy = "Never"
-
-			// set Elasticsearch host and API key
-			for idx, env := range container.Env {
-				if env.Name == "ES_HOST" {
-					container.Env[idx].Value = kCtx.esHost
-					container.Env[idx].ValueFrom = nil
-				}
-				if env.Name == "API_KEY" {
-					container.Env[idx].Value = kCtx.esAPIKey
-					container.Env[idx].ValueFrom = nil
-				}
-			}
-		},
-		func(pod *corev1.PodSpec) {
-			for volumeIdx, volume := range pod.Volumes {
-				// need to update the volume path of the state directory
-				// to match the test namespace
-				if volume.Name == "elastic-agent-state" {
-					hostPathType := corev1.HostPathDirectoryOrCreate
-					pod.Volumes[volumeIdx].VolumeSource.HostPath = &corev1.HostPathVolumeSource{
-						Type: &hostPathType,
-						Path: fmt.Sprintf("/var/lib/elastic-agent-standalone/%s/state", testNamespace),
-					}
-				}
-			}
-		})
-
-	// update the configmap to only run the connectors input
-	serviceAgentYAML, err := os.ReadFile(filepath.Join("testdata", "connectors.agent.yml"))
+	nodeList := corev1.NodeList{}
+	err = kCtx.client.Resources().List(ctx, &nodeList)
 	require.NoError(t, err)
-	for _, obj := range k8sObjects {
-		switch objWithType := obj.(type) {
-		case *corev1.ConfigMap:
-			_, ok := objWithType.Data["agent.yml"]
-			if ok {
-				objWithType.Data["agent.yml"] = string(serviceAgentYAML)
+
+	totalK8SNodes := len(nodeList.Items)
+	require.NotZero(t, totalK8SNodes, "No Kubernetes nodes found")
+
+	testSteps := []k8sTestStep{
+		k8sStepCreateNamespace(),
+		k8sStepDeployKustomize(agentK8SKustomize, "elastic-agent-standalone", k8sKustomizeOverrides{
+			agentContainerMemoryLimit: "800Mi",
+		}, func(obj k8s.Object) {
+			// update the configmap to only run the connectors input
+			switch objWithType := obj.(type) {
+			case *corev1.ConfigMap:
+				_, ok := objWithType.Data["agent.yml"]
+				if ok {
+					objWithType.Data["agent.yml"] = string(serviceAgentYAML)
+				}
 			}
-		}
+		}),
+		k8sStepCheckAgentStatus("app=elastic-agent-standalone", totalK8SNodes, "elastic-agent-standalone", map[string]bool{
+			"connectors-py": true,
+		}),
 	}
 
-	k8sKustomizeDeployAgent(t, ctx, kCtx.client, k8sObjects, testNamespace, false, kCtx.logsBasePath,
-		true, map[string]bool{
-			"connectors-py": true,
-		})
+	testNamespace := kCtx.getNamespace(t)
+	for _, step := range testSteps {
+		step(t, ctx, kCtx, testNamespace)
+	}
 }

--- a/testing/integration/kubernetes_agent_service_test.go
+++ b/testing/integration/kubernetes_agent_service_test.go
@@ -38,12 +38,9 @@ func TestKubernetesAgentService(t *testing.T) {
 	ctx := context.Background()
 	kCtx := k8sGetContext(t, info)
 
-	nodeList := corev1.NodeList{}
-	err = kCtx.client.Resources().List(ctx, &nodeList)
-	require.NoError(t, err)
-
-	totalK8SNodes := len(nodeList.Items)
-	require.NotZero(t, totalK8SNodes, "No Kubernetes nodes found")
+	schedulableNodeCount, err := k8sSchedulableNodeCount(ctx, kCtx)
+	require.NoError(t, err, "error at getting schedulable node count")
+	require.NotZero(t, schedulableNodeCount, "no schedulable Kubernetes nodes found")
 
 	testSteps := []k8sTestStep{
 		k8sStepCreateNamespace(),
@@ -59,7 +56,7 @@ func TestKubernetesAgentService(t *testing.T) {
 				}
 			}
 		}),
-		k8sStepCheckAgentStatus("app=elastic-agent-standalone", totalK8SNodes, "elastic-agent-standalone", map[string]bool{
+		k8sStepCheckAgentStatus("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone", map[string]bool{
 			"connectors-py": true,
 		}),
 	}


### PR DESCRIPTION
## What does this PR do?

This PR continues the groundwork for Kubernetes hints integration tests. The next and last episode of this PR-series can be seen here https://github.com/elastic/elastic-agent/commit/2ea1f2ff2cdf57442ea29c1e5c269b907971c312. Again these were split up because I want to keep each PR around [500 lines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md?plain=1#L47). 

Key changes in this PR:
1. **Transition Kubernetes integration tests to an "adapter" pattern**:
   - Refactors Kubernetes integration tests to follow a more modular and reusable adapter pattern.
   - Introduces `k8sTestStep` functions that encapsulate individual test steps for clarity and flexibility.
   - Simplifies the test flow by eliminating repetitive code and leveraging reusable functions like `k8sStepCreateNamespace`, `k8sStepDeployKustomize`, and `k8sStepRunInnerTests`.
   - Improves readability and maintainability.

2. **Align all kubernetes integration tests**:
   - All kubernetes integration tests got an empty for now `skipReason`.
   - All kubernetes integration tests check for schedulable k8s nodes and got more deterministic in the number of agent pods expected to be running.

## Why is it important?

The adapter pattern for Kubernetes integration tests enhances readability, maintainability, making it easier to add or modify test cases.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding changes to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

- None expected. The changes affect only the internal kubernetes integration tests without altering user-facing configurations or behaviours.

## How to test this PR locally

```
mage integration:auth
PLATFORMS=linux/arm64 EXTERNAL=true SNAPSHOT=true PACKAGES=docker mage -v package 
INSTANCE_PROVISIONER=kind STACK_PROVISIONER=stateful K8S_VERSION=v1.31.1 SNAPSHOT=true mage integration:kubernetes
```

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/5660