### PR TITLE
Run agent test version bump on all active branches

### DIFF
--- a/.github/workflows/bump-agent-versions.yml
+++ b/.github/workflows/bump-agent-versions.yml
@@ -7,16 +7,31 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
+  filter:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      matrix: ${{ steps.generator.outputs.matrix }}
+    steps:
+      - id: generator
+        uses: elastic/oblt-actions/elastic/active-branches@v1
+        with:
+          exclude-branches: "7.17"
+
   update_versions:
     runs-on: ubuntu-latest
+    needs: [filter]
     permissions:
       contents: write
       pull-requests: write
+    strategy:
+      matrix: ${{ fromJson(needs.filter.outputs.matrix) }}
     steps:
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: "${{ matrix.branch }}"
+
           # no depth limit
           # so, we can generate snapshot versions based on release branches
           fetch-depth: 0


### PR DESCRIPTION
Before we had to manually trigger the update version automation for all branches other than `main`.

Was tested by triggering the job manually, see https://github.com/elastic/elastic-agent/actions/runs/12303810957/

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/5897

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->