### PR TITLE
Add support for running version updates on multiple branches

### DIFF
--- a/.github/workflows/bump-agent-versions.sh
+++ b/.github/workflows/bump-agent-versions.sh
@@ -8,28 +8,31 @@ if [ -z "$changes" ]
 then
     echo "The version files didn't change, skipping..."
 else
+		# because this script is running on the matrix, we need to fetch the current branch on every run
+		current_rf=$(git rev-parse --abbrev-ref HEAD)
     echo "The version file(s) changed"
     git diff -p
-    open=$(gh pr list --repo "$GITHUB_REPOSITORY" --label="update-versions" --limit 1 --state open --base "$GITHUB_REF_NAME")
+    open=$(gh pr list --repo "$GITHUB_REPOSITORY" --label="update-versions" --limit 1 --state open --base "$current_ref")
     if [ -n "$open" ]
     then
-        echo "Another PR for $GITHUB_REF_NAME is in review, skipping..."
+        echo "Another PR for $current_ref is in review, skipping..."
         exit 0
     fi
+		pr_branch="$current_ref-update-agent-versions-$GITHUB_RUN_ID"
     # the mage target above requires to be on a release branch
     # so, the new branch should not be created before the target is run
-    git checkout -b update-agent-versions-$GITHUB_RUN_ID
+    git checkout -b "$pr_branch"
     git add testing/integration/testdata/.upgrade-test-agent-versions.yml .package-version
 
     nl=$'\n' # otherwise the new line character is not recognized properly
     commit_desc="These files are used for picking the starting (pre-upgrade) or ending (post-upgrade) agent versions in upgrade integration tests.${nl}${nl}The content is based on responses from https://www.elastic.co/api/product_versions and https://snapshots.elastic.co${nl}${nl}The current update is generated based on the following requirements:${nl}${nl}Package version: ${package_version}${nl}${nl}\`\`\`json${nl}${version_requirements}${nl}\`\`\`"
 
-    git commit -m "[$GITHUB_REF_NAME][Automation] Update versions" -m "$commit_desc"
-    git push --set-upstream origin "update-agent-versions-$GITHUB_RUN_ID"
+    git commit -m "[$current_ref][Automation] Update versions" -m "$commit_desc"
+    git push --set-upstream origin "$pr_branch"
     pr=$(gh pr create \
-       --base "$GITHUB_REF_NAME" \
+       --base "$current_ref" \
        --fill-first \
-       --head "update-agent-versions-$GITHUB_RUN_ID" \
+       --head "$pr_branch" \
        --label 'Team:Elastic-Agent' \
        --label 'Team:Elastic-Agent-Control-Plane' \
        --label 'update-versions' \

--- a/.github/workflows/bump-agent-versions.sh
+++ b/.github/workflows/bump-agent-versions.sh
@@ -9,7 +9,7 @@ then
     echo "The version files didn't change, skipping..."
 else
 		# because this script is running on the matrix, we need to fetch the current branch on every run
-		current_rf=$(git rev-parse --abbrev-ref HEAD)
+		current_ref=$(git rev-parse --abbrev-ref HEAD)
     echo "The version file(s) changed"
     git diff -p
     open=$(gh pr list --repo "$GITHUB_REPOSITORY" --label="update-versions" --limit 1 --state open --base "$current_ref")


### PR DESCRIPTION
Now the script can be run on a matrix for multiple release branches.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Superseds https://github.com/elastic/elastic-agent/pull/6309

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->