### PR TITLE
Prevent leaking secrets when logging component model

### DIFF
--- a/changelog/fragments/1734098868-prevent-leaking-secrets-when-logging-component-model.yaml
+++ b/changelog/fragments/1734098868-prevent-leaking-secrets-when-logging-component-model.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Prevent leaking secrets when logging the component model
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -1400,6 +1400,7 @@ func (c *Coordinator) refreshComponentModel(ctx context.Context) (err error) {
 	}
 
 	c.logger.Info("Updating running component model")
+	c.logger.With("components", model.Components).Debug("Updating running component model")
 	c.runtimeMgr.Update(model)
 	return nil
 }

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -5,6 +5,7 @@
 package component
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -171,6 +172,39 @@ func (c Component) MarshalYAML() (interface{}, error) {
 		c.ErrMsg = c.Err.Error()
 	}
 	return c, nil
+}
+
+func (c *Component) MarshalJSON() ([]byte, error) {
+	marshalableComponent := struct {
+		ID         string `json:"ID"`
+		InputType  string `json:"InputType"`
+		OutputType string `json:"OutputType"`
+		ErrMsg     string `json:"ErrMsg,omitempty"`
+		Units      []struct {
+			ID     string `json:"ID"`
+			ErrMsg string `json:"ErrMsg,omitempty"`
+		} `json:"Units"`
+	}{
+		ID:         c.ID,
+		InputType:  c.InputType,
+		OutputType: c.OutputType,
+	}
+	if c.Err != nil {
+		marshalableComponent.ErrMsg = c.Err.Error()
+	}
+	for i := range c.Units {
+		marshalableComponent.Units = append(marshalableComponent.Units, struct {
+			ID     string `json:"ID"`
+			ErrMsg string `json:"ErrMsg,omitempty"`
+		}{
+			ID: c.Units[i].ID,
+		})
+		if c.Units[i].Err != nil {
+			marshalableComponent.Units[i].ErrMsg = c.Units[i].Err.Error()
+		}
+	}
+
+	return json.Marshal(marshalableComponent)
 }
 
 // Type returns the type of the component.

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -59,6 +59,32 @@ func TestComponentMarshalError(t *testing.T) {
 	require.Contains(t, string(outData), "test error value")
 }
 
+func TestMarshalJSON(t *testing.T) {
+	testComponent := Component{
+		ID:  "test-device",
+		Err: testErr{data: "test error value"},
+		Units: []Unit{
+			{
+				ID: "test-unit",
+				Config: &proto.UnitExpectedConfig{
+					Source: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"api_key": structpb.NewStringValue("test-api-key"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	marshaledBytes, err := testComponent.MarshalJSON()
+	require.NoError(t, err)
+	marshaledJsonString := string(marshaledBytes)
+	assert.Contains(t, marshaledJsonString, "test error value")
+	assert.Contains(t, marshaledJsonString, "test-unit")
+	assert.NotContains(t, marshaledJsonString, "test-api-key")
+}
+
 func TestToComponents(t *testing.T) {
 	linuxAMD64Platform := PlatformDetail{
 		Platform: Platform{


### PR DESCRIPTION
## What does this PR do?

Implements `MarshalJSON` method on the `component.Component` struct, so that when the component model is logged, the output does not contain any secrets that might be part of the component model (e.g. API keys to HTTP endpoints etc.).

This change also restores the debug log dumping the component model that was removed in https://github.com/elastic/elastic-agent/pull/5201/.

## Why is it important?

This is part of the effort to prevent leaking secrets in logs as much as possible.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

- Build the agent binary (`go build .`)
- Change `agent.logging.level` to `debug` in `elastic-agent.yml` file
- Run the built agent (`sudo ./elastic-agent`)
- Look for "Updating running components" debug log in the output.

The output I'm seeing is:


{"log.level":"debug","@timestamp":"2024-12-13T13:40:20.271Z","log.origin":{"function":"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator.(*Coordinator).refreshComponentModel","file.name":"coordinator/coordinator.go","file.line":1403},"message":"Updating running component model","log":{"source":"elastic-agent"},"components":[{"ID":"system/metrics-default","InputType":"system/metrics","OutputType":"elasticsearch","ErrMsg":"input not supported","Units":[{"ID":"system/metrics-default-unique-system-metrics-input"},{"ID":"system/metrics-default"}]},{"ID":"filestream-monitoring","InputType":"filestream","OutputType":"elasticsearch","ErrMsg":"input not supported","Units":[{"ID":"filestream-monitoring-filestream-monitoring-agent"},{"ID":"filestream-monitoring"}]},{"ID":"beat/metrics-monitoring","InputType":"beat/metrics","OutputType":"elasticsearch","ErrMsg":"input not supported","Units":[{"ID":"beat/metrics-monitoring-metrics-monitoring-beats"},{"ID":"beat/metrics-monitoring"}]},{"ID":"http/metrics-monitoring","InputType":"http/metrics","OutputType":"elasticsearch","ErrMsg":"input not supported","Units":[{"ID":"http/metrics-monitoring-metrics-monitoring-agent"},{"ID":"http/metrics-monitoring"}]}],"ecs.version":"1.6.0"}

Here's the formatted and JSON-sorted version of this debug log:

<details><summary>logged component model - after change</summary>

```json
{
    "@timestamp": "2024-12-13T13:40:20.271Z",
    "components": [
        {
            "ErrMsg": "input not supported",
            "ID": "system/metrics-default",
            "InputType": "system/metrics",
            "OutputType": "elasticsearch",
            "Units": [
                {
                    "ID": "system/metrics-default-unique-system-metrics-input"
                },
                {
                    "ID": "system/metrics-default"
                }
            ]
        },
        {
            "ErrMsg": "input not supported",
            "ID": "filestream-monitoring",
            "InputType": "filestream",
            "OutputType": "elasticsearch",
            "Units": [
                {
                    "ID": "filestream-monitoring-filestream-monitoring-agent"
                },
                {
                    "ID": "filestream-monitoring"
                }
            ]
        },
        {
            "ErrMsg": "input not supported",
            "ID": "beat/metrics-monitoring",
            "InputType": "beat/metrics",
            "OutputType": "elasticsearch",
            "Units": [
                {
                    "ID": "beat/metrics-monitoring-metrics-monitoring-beats"
                },
                {
                    "ID": "beat/metrics-monitoring"
                }
            ]
        },
        {
            "ErrMsg": "input not supported",
            "ID": "http/metrics-monitoring",
            "InputType": "http/metrics",
            "OutputType": "elasticsearch",
            "Units": [
                {
                    "ID": "http/metrics-monitoring-metrics-monitoring-agent"
                },
                {
                    "ID": "http/metrics-monitoring"
                }
            ]
        }
    ],
    "ecs.version": "1.6.0",
    "log": {
        "source": "elastic-agent"
    },
    "log.level": "debug",
    "log.origin": {
        "file.line": 1403,
        "file.name": "coordinator/coordinator.go",
        "function": "github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator.(*Coordinator).refreshComponentModel"
    },
    "message": "Updating running component model"
}
```

</details>

Here's the same debug log before MarshalJSON was implemented - note that it includes details like `"api_key": "example-key"`, which is not present in the modified output.

<details><summary>logged component model - before change</summary>

```json
{
    "@timestamp": "2024-12-10T13:36:42.542Z",
    "components": [
        {
            "Component": {
                "limits": {
                    "source": {
                        "go_max_procs": 0
                    }
                }
            },
            "Err": {
                "Reason": "input not supported"
            },
            "ErrMsg": "",
            "Features": {
                "fqdn": {},
                "source": {
                    "agent": {
                        "features": {
                            "fqdn": {
                                "enabled": false
                            }
                        }
                    }
                }
            },
            "ID": "system/metrics-default",
            "InputSpec": {
                "BinaryName": "",
                "BinaryPath": "",
                "InputType": "",
                "Spec": {
                    "Aliases": null,
                    "Command": null,
                    "Description": "",
                    "IsolateUnits": false,
                    "Name": "",
                    "Outputs": null,
                    "Platforms": null,
                    "ProxiedActions": null,
                    "Runtime": {
                        "Preventions": null
                    },
                    "Service": null
                }
            },
            "InputType": "system/metrics",
            "OutputType": "elasticsearch",
            "Units": [
                {
                    "Config": {
                        "data_stream": {
                            "namespace": "default"
                        },
                        "id": "unique-system-metrics-input",
                        "source": {
                            "data_stream.namespace": "default",
                            "id": "unique-system-metrics-input",
                            "streams": [
                                {
                                    "data_stream.dataset": "system.cpu",
                                    "metricsets": [
                                        "cpu"
                                    ]
                                },
                                {
                                    "data_stream.dataset": "system.memory",
                                    "metricsets": [
                                        "memory"
                                    ]
                                },
                                {
                                    "data_stream.dataset": "system.network",
                                    "metricsets": [
                                        "network"
                                    ]
                                },
                                {
                                    "data_stream.dataset": "system.filesystem",
                                    "metricsets": [
                                        "filesystem"
                                    ]
                                }
                            ],
                            "type": "system/metrics"
                        },
                        "streams": [
                            {
                                "data_stream": {
                                    "dataset": "system.cpu"
                                },
                                "source": {
                                    "data_stream.dataset": "system.cpu",
                                    "metricsets": [
                                        "cpu"
                                    ]
                                }
                            },
                            {
                                "data_stream": {
                                    "dataset": "system.memory"
                                },
                                "source": {
                                    "data_stream.dataset": "system.memory",
                                    "metricsets": [
                                        "memory"
                                    ]
                                }
                            },
                            {
                                "data_stream": {
                                    "dataset": "system.network"
                                },
                                "source": {
                                    "data_stream.dataset": "system.network",
                                    "metricsets": [
                                        "network"
                                    ]
                                }
                            },
                            {
                                "data_stream": {
                                    "dataset": "system.filesystem"
                                },
                                "source": {
                                    "data_stream.dataset": "system.filesystem",
                                    "metricsets": [
                                        "filesystem"
                                    ]
                                }
                            }
                        ],
                        "type": "system/metrics"
                    },
                    "Err": null,
                    "ID": "system/metrics-default-unique-system-metrics-input",
                    "LogLevel": 3,
                    "Type": 0
                },
                {
                    "Config": {
                        "data_stream": {},
                        "source": {
                            "api_key": "example-key",
                            "hosts": [
                                "127.0.0.1:9200"
                            ],
                            "preset": "balanced",
                            "type": "elasticsearch"
                        },
                        "type": "elasticsearch"
                    },
                    "Err": null,
                    "ID": "system/metrics-default",
                    "LogLevel": 3,
                    "Type": 1
                }
            ]
        },
        {
            "Component": {
                "limits": {
                    "source": {
                        "go_max_procs": 0
                    }
                }
            },
            "Err": {
                "Reason": "input not supported"
            },
            "ErrMsg": "",
            "Features": {
                "fqdn": {},
                "source": {
                    "agent": {
                        "features": {
                            "fqdn": {
                                "enabled": false
                            }
                        }
                    }
                }
            },
            "ID": "beat/metrics-monitoring",
            "InputSpec": {
                "BinaryName": "",
                "BinaryPath": "",
                "InputType": "",
                "Spec": {
                    "Aliases": null,
                    "Command": null,
                    "Description": "",
                    "IsolateUnits": false,
                    "Name": "",
                    "Outputs": null,
                    "Platforms": null,
                    "ProxiedActions": null,
                    "Runtime": {
                        "Preventions": null
                    },
                    "Service": null
                }
            },
            "InputType": "beat/metrics",
            "OutputType": "elasticsearch",
            "Units": [
                {
                    "Config": {
                        "data_stream": {
                            "namespace": "default",
                            "source": {
                                "namespace": "default"
                            }
                        },
                        "id": "metrics-monitoring-beats",
                        "name": "metrics-monitoring-beats",
                        "source": {
                            "data_stream": {
                                "namespace": "default"
                            },
                            "id": "metrics-monitoring-beats",
                            "name": "metrics-monitoring-beats",
                            "streams": [
                                {
                                    "data_stream": {
                                        "dataset": "elastic_agent.metricbeat",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "failure_threshold": 5,
                                    "hosts": [
                                        "http+unix:///vagrant/data/tmp/Hk6rvk9TDibMPcDvpl0jkLE-qDsHWVYL.sock"
                                    ],
                                    "id": "metrics-monitoring-metricbeat",
                                    "index": "metrics-elastic_agent.metricbeat-default",
                                    "metricsets": [
                                        "stats"
                                    ],
                                    "period": "1m0s",
                                    "processors": [
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.metricbeat",
                                                    "namespace": "default",
                                                    "type": "metrics"
                                                },
                                                "target": "data_stream"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.metricbeat"
                                                },
                                                "target": "event"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891",
                                                    "process": "metricbeat",
                                                    "snapshot": false,
                                                    "version": "9.0.0"
                                                },
                                                "target": "elastic_agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891"
                                                },
                                                "target": "agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "binary": "metricbeat",
                                                    "id": "beat/metrics-monitoring"
                                                },
                                                "target": "component"
                                            }
                                        }
                                    ]
                                },
                                {
                                    "data_stream": {
                                        "dataset": "elastic_agent.metricbeat",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "failure_threshold": 5,
                                    "hosts": [
                                        "http+unix:///vagrant/data/tmp/akSPbdqgaHaTY0_J01-dsfYK6JpMz2zn.sock"
                                    ],
                                    "id": "metrics-monitoring-metricbeat",
                                    "index": "metrics-elastic_agent.metricbeat-default",
                                    "metricsets": [
                                        "stats"
                                    ],
                                    "period": "1m0s",
                                    "processors": [
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.metricbeat",
                                                    "namespace": "default",
                                                    "type": "metrics"
                                                },
                                                "target": "data_stream"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.metricbeat"
                                                },
                                                "target": "event"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891",
                                                    "process": "metricbeat",
                                                    "snapshot": false,
                                                    "version": "9.0.0"
                                                },
                                                "target": "elastic_agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891"
                                                },
                                                "target": "agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "binary": "metricbeat",
                                                    "id": "http/metrics-monitoring"
                                                },
                                                "target": "component"
                                            }
                                        }
                                    ]
                                },
                                {
                                    "data_stream": {
                                        "dataset": "elastic_agent.filebeat",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "failure_threshold": 5,
                                    "hosts": [
                                        "http+unix:///vagrant/data/tmp/xTEtpJ7117ppc6OYvJCaYHbDW8mLjXGe.sock"
                                    ],
                                    "id": "metrics-monitoring-filebeat",
                                    "index": "metrics-elastic_agent.filebeat-default",
                                    "metricsets": [
                                        "stats"
                                    ],
                                    "period": "1m0s",
                                    "processors": [
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.filebeat",
                                                    "namespace": "default",
                                                    "type": "metrics"
                                                },
                                                "target": "data_stream"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.filebeat"
                                                },
                                                "target": "event"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891",
                                                    "process": "filebeat",
                                                    "snapshot": false,
                                                    "version": "9.0.0"
                                                },
                                                "target": "elastic_agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891"
                                                },
                                                "target": "agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "binary": "filebeat",
                                                    "id": "filestream-monitoring"
                                                },
                                                "target": "component"
                                            }
                                        }
                                    ]
                                }
                            ],
                            "type": "beat/metrics"
                        },
                        "streams": [
                            {
                                "data_stream": {
                                    "dataset": "elastic_agent.metricbeat",
                                    "namespace": "default",
                                    "source": {
                                        "dataset": "elastic_agent.metricbeat",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "type": "metrics"
                                },
                                "id": "metrics-monitoring-metricbeat",
                                "source": {
                                    "data_stream": {
                                        "dataset": "elastic_agent.metricbeat",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "failure_threshold": 5,
                                    "hosts": [
                                        "http+unix:///vagrant/data/tmp/Hk6rvk9TDibMPcDvpl0jkLE-qDsHWVYL.sock"
                                    ],
                                    "id": "metrics-monitoring-metricbeat",
                                    "index": "metrics-elastic_agent.metricbeat-default",
                                    "metricsets": [
                                        "stats"
                                    ],
                                    "period": "1m0s",
                                    "processors": [
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.metricbeat",
                                                    "namespace": "default",
                                                    "type": "metrics"
                                                },
                                                "target": "data_stream"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.metricbeat"
                                                },
                                                "target": "event"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891",
                                                    "process": "metricbeat",
                                                    "snapshot": false,
                                                    "version": "9.0.0"
                                                },
                                                "target": "elastic_agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891"
                                                },
                                                "target": "agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "binary": "metricbeat",
                                                    "id": "beat/metrics-monitoring"
                                                },
                                                "target": "component"
                                            }
                                        }
                                    ]
                                }
                            },
                            {
                                "data_stream": {
                                    "dataset": "elastic_agent.metricbeat",
                                    "namespace": "default",
                                    "source": {
                                        "dataset": "elastic_agent.metricbeat",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "type": "metrics"
                                },
                                "id": "metrics-monitoring-metricbeat",
                                "source": {
                                    "data_stream": {
                                        "dataset": "elastic_agent.metricbeat",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "failure_threshold": 5,
                                    "hosts": [
                                        "http+unix:///vagrant/data/tmp/akSPbdqgaHaTY0_J01-dsfYK6JpMz2zn.sock"
                                    ],
                                    "id": "metrics-monitoring-metricbeat",
                                    "index": "metrics-elastic_agent.metricbeat-default",
                                    "metricsets": [
                                        "stats"
                                    ],
                                    "period": "1m0s",
                                    "processors": [
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.metricbeat",
                                                    "namespace": "default",
                                                    "type": "metrics"
                                                },
                                                "target": "data_stream"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.metricbeat"
                                                },
                                                "target": "event"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891",
                                                    "process": "metricbeat",
                                                    "snapshot": false,
                                                    "version": "9.0.0"
                                                },
                                                "target": "elastic_agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891"
                                                },
                                                "target": "agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "binary": "metricbeat",
                                                    "id": "http/metrics-monitoring"
                                                },
                                                "target": "component"
                                            }
                                        }
                                    ]
                                }
                            },
                            {
                                "data_stream": {
                                    "dataset": "elastic_agent.filebeat",
                                    "namespace": "default",
                                    "source": {
                                        "dataset": "elastic_agent.filebeat",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "type": "metrics"
                                },
                                "id": "metrics-monitoring-filebeat",
                                "source": {
                                    "data_stream": {
                                        "dataset": "elastic_agent.filebeat",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "failure_threshold": 5,
                                    "hosts": [
                                        "http+unix:///vagrant/data/tmp/xTEtpJ7117ppc6OYvJCaYHbDW8mLjXGe.sock"
                                    ],
                                    "id": "metrics-monitoring-filebeat",
                                    "index": "metrics-elastic_agent.filebeat-default",
                                    "metricsets": [
                                        "stats"
                                    ],
                                    "period": "1m0s",
                                    "processors": [
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.filebeat",
                                                    "namespace": "default",
                                                    "type": "metrics"
                                                },
                                                "target": "data_stream"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.filebeat"
                                                },
                                                "target": "event"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891",
                                                    "process": "filebeat",
                                                    "snapshot": false,
                                                    "version": "9.0.0"
                                                },
                                                "target": "elastic_agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891"
                                                },
                                                "target": "agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "binary": "filebeat",
                                                    "id": "filestream-monitoring"
                                                },
                                                "target": "component"
                                            }
                                        }
                                    ]
                                }
                            }
                        ],
                        "type": "beat/metrics"
                    },
                    "Err": null,
                    "ID": "beat/metrics-monitoring-metrics-monitoring-beats",
                    "LogLevel": 3,
                    "Type": 0
                },
                {
                    "Config": {
                        "data_stream": {},
                        "source": {
                            "api_key": "example-key",
                            "hosts": [
                                "127.0.0.1:9200"
                            ],
                            "preset": "balanced",
                            "type": "elasticsearch"
                        },
                        "type": "elasticsearch"
                    },
                    "Err": null,
                    "ID": "beat/metrics-monitoring",
                    "LogLevel": 3,
                    "Type": 1
                }
            ]
        },
        {
            "Component": {
                "limits": {
                    "source": {
                        "go_max_procs": 0
                    }
                }
            },
            "Err": {
                "Reason": "input not supported"
            },
            "ErrMsg": "",
            "Features": {
                "fqdn": {},
                "source": {
                    "agent": {
                        "features": {
                            "fqdn": {
                                "enabled": false
                            }
                        }
                    }
                }
            },
            "ID": "http/metrics-monitoring",
            "InputSpec": {
                "BinaryName": "",
                "BinaryPath": "",
                "InputType": "",
                "Spec": {
                    "Aliases": null,
                    "Command": null,
                    "Description": "",
                    "IsolateUnits": false,
                    "Name": "",
                    "Outputs": null,
                    "Platforms": null,
                    "ProxiedActions": null,
                    "Runtime": {
                        "Preventions": null
                    },
                    "Service": null
                }
            },
            "InputType": "http/metrics",
            "OutputType": "elasticsearch",
            "Units": [
                {
                    "Config": {
                        "data_stream": {
                            "namespace": "default",
                            "source": {
                                "namespace": "default"
                            }
                        },
                        "id": "metrics-monitoring-agent",
                        "name": "metrics-monitoring-agent",
                        "source": {
                            "data_stream": {
                                "namespace": "default"
                            },
                            "id": "metrics-monitoring-agent",
                            "name": "metrics-monitoring-agent",
                            "streams": [
                                {
                                    "data_stream": {
                                        "dataset": "elastic_agent.elastic_agent",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "failure_threshold": 5,
                                    "hosts": [
                                        "http://localhost:6791"
                                    ],
                                    "id": "metrics-monitoring-agent",
                                    "index": "metrics-elastic_agent.elastic_agent-default",
                                    "metricsets": [
                                        "json"
                                    ],
                                    "namespace": "agent",
                                    "path": "/stats",
                                    "period": "1m0s",
                                    "processors": [
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.elastic_agent",
                                                    "namespace": "default",
                                                    "type": "metrics"
                                                },
                                                "target": "data_stream"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.elastic_agent"
                                                },
                                                "target": "event"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891",
                                                    "process": "elastic-agent",
                                                    "snapshot": false,
                                                    "version": "9.0.0"
                                                },
                                                "target": "elastic_agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891"
                                                },
                                                "target": "agent"
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fail_on_error": false,
                                                "fields": [
                                                    {
                                                        "from": "http.agent.beat.cpu",
                                                        "to": "system.process.cpu"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.memstats.memory_sys",
                                                        "to": "system.process.memory.size"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.handles",
                                                        "to": "system.process.fd"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.cgroup",
                                                        "to": "system.process.cgroup"
                                                    },
                                                    {
                                                        "from": "http.agent.apm-server",
                                                        "to": "apm-server"
                                                    },
                                                    {
                                                        "from": "http.filebeat_input",
                                                        "to": "filebeat_input"
                                                    }
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "drop_fields": {
                                                "fields": [
                                                    "http"
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "binary": "elastic-agent",
                                                    "id": "elastic-agent"
                                                },
                                                "target": "component"
                                            }
                                        }
                                    ]
                                },
                                {
                                    "data_stream": {
                                        "dataset": "elastic_agent.elastic_agent",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "failure_threshold": 5,
                                    "hosts": [
                                        "http+unix:///vagrant/data/tmp/Hk6rvk9TDibMPcDvpl0jkLE-qDsHWVYL.sock"
                                    ],
                                    "id": "metrics-monitoring-metricbeat-1",
                                    "index": "metrics-elastic_agent.elastic_agent-default",
                                    "metricsets": [
                                        "json"
                                    ],
                                    "namespace": "agent",
                                    "path": "/stats",
                                    "period": "1m0s",
                                    "processors": [
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.elastic_agent"
                                                },
                                                "target": "event"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891",
                                                    "process": "metricbeat",
                                                    "snapshot": false,
                                                    "version": "9.0.0"
                                                },
                                                "target": "elastic_agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891"
                                                },
                                                "target": "agent"
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fail_on_error": false,
                                                "fields": [
                                                    {
                                                        "from": "http.agent.beat.cpu",
                                                        "to": "system.process.cpu"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.memstats.memory_sys",
                                                        "to": "system.process.memory.size"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.handles",
                                                        "to": "system.process.fd"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.cgroup",
                                                        "to": "system.process.cgroup"
                                                    },
                                                    {
                                                        "from": "http.agent.apm-server",
                                                        "to": "apm-server"
                                                    },
                                                    {
                                                        "from": "http.filebeat_input",
                                                        "to": "filebeat_input"
                                                    }
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "drop_fields": {
                                                "fields": [
                                                    "http"
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "binary": "metricbeat",
                                                    "id": "beat/metrics-monitoring"
                                                },
                                                "target": "component"
                                            }
                                        }
                                    ]
                                },
                                {
                                    "data_stream": {
                                        "dataset": "elastic_agent.elastic_agent",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "failure_threshold": 5,
                                    "hosts": [
                                        "http+unix:///vagrant/data/tmp/akSPbdqgaHaTY0_J01-dsfYK6JpMz2zn.sock"
                                    ],
                                    "id": "metrics-monitoring-metricbeat-1",
                                    "index": "metrics-elastic_agent.elastic_agent-default",
                                    "metricsets": [
                                        "json"
                                    ],
                                    "namespace": "agent",
                                    "path": "/stats",
                                    "period": "1m0s",
                                    "processors": [
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.elastic_agent"
                                                },
                                                "target": "event"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891",
                                                    "process": "metricbeat",
                                                    "snapshot": false,
                                                    "version": "9.0.0"
                                                },
                                                "target": "elastic_agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891"
                                                },
                                                "target": "agent"
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fail_on_error": false,
                                                "fields": [
                                                    {
                                                        "from": "http.agent.beat.cpu",
                                                        "to": "system.process.cpu"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.memstats.memory_sys",
                                                        "to": "system.process.memory.size"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.handles",
                                                        "to": "system.process.fd"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.cgroup",
                                                        "to": "system.process.cgroup"
                                                    },
                                                    {
                                                        "from": "http.agent.apm-server",
                                                        "to": "apm-server"
                                                    },
                                                    {
                                                        "from": "http.filebeat_input",
                                                        "to": "filebeat_input"
                                                    }
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "drop_fields": {
                                                "fields": [
                                                    "http"
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "binary": "metricbeat",
                                                    "id": "http/metrics-monitoring"
                                                },
                                                "target": "component"
                                            }
                                        }
                                    ]
                                },
                                {
                                    "data_stream": {
                                        "dataset": "elastic_agent.elastic_agent",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "failure_threshold": 5,
                                    "hosts": [
                                        "http+unix:///vagrant/data/tmp/xTEtpJ7117ppc6OYvJCaYHbDW8mLjXGe.sock"
                                    ],
                                    "id": "metrics-monitoring-filebeat-1",
                                    "index": "metrics-elastic_agent.elastic_agent-default",
                                    "metricsets": [
                                        "json"
                                    ],
                                    "namespace": "agent",
                                    "path": "/stats",
                                    "period": "1m0s",
                                    "processors": [
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.elastic_agent"
                                                },
                                                "target": "event"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891",
                                                    "process": "filebeat",
                                                    "snapshot": false,
                                                    "version": "9.0.0"
                                                },
                                                "target": "elastic_agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891"
                                                },
                                                "target": "agent"
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fail_on_error": false,
                                                "fields": [
                                                    {
                                                        "from": "http.agent.beat.cpu",
                                                        "to": "system.process.cpu"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.memstats.memory_sys",
                                                        "to": "system.process.memory.size"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.handles",
                                                        "to": "system.process.fd"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.cgroup",
                                                        "to": "system.process.cgroup"
                                                    },
                                                    {
                                                        "from": "http.agent.apm-server",
                                                        "to": "apm-server"
                                                    },
                                                    {
                                                        "from": "http.filebeat_input",
                                                        "to": "filebeat_input"
                                                    }
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "drop_fields": {
                                                "fields": [
                                                    "http"
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "binary": "filebeat",
                                                    "id": "filestream-monitoring"
                                                },
                                                "target": "component"
                                            }
                                        }
                                    ]
                                },
                                {
                                    "data_stream": {
                                        "dataset": "elastic_agent.filebeat_input",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "failure_threshold": 5,
                                    "hosts": [
                                        "http+unix:///vagrant/data/tmp/xTEtpJ7117ppc6OYvJCaYHbDW8mLjXGe.sock"
                                    ],
                                    "id": "metrics-monitoring-filebeat-1",
                                    "index": "metrics-elastic_agent.filebeat_input-default",
                                    "json.is_array": true,
                                    "metricsets": [
                                        "json"
                                    ],
                                    "namespace": "filebeat_input",
                                    "path": "/inputs/",
                                    "period": "1m0s",
                                    "processors": [
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.filebeat_input"
                                                },
                                                "target": "event"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891",
                                                    "process": "filebeat",
                                                    "snapshot": false,
                                                    "version": "9.0.0"
                                                },
                                                "target": "elastic_agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891"
                                                },
                                                "target": "agent"
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fail_on_error": false,
                                                "fields": [
                                                    {
                                                        "from": "http.agent.beat.cpu",
                                                        "to": "system.process.cpu"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.memstats.memory_sys",
                                                        "to": "system.process.memory.size"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.handles",
                                                        "to": "system.process.fd"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.cgroup",
                                                        "to": "system.process.cgroup"
                                                    },
                                                    {
                                                        "from": "http.agent.apm-server",
                                                        "to": "apm-server"
                                                    },
                                                    {
                                                        "from": "http.filebeat_input",
                                                        "to": "filebeat_input"
                                                    }
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "drop_fields": {
                                                "fields": [
                                                    "http"
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "binary": "filebeat",
                                                    "id": "filestream-monitoring"
                                                },
                                                "target": "component"
                                            }
                                        }
                                    ]
                                }
                            ],
                            "type": "http/metrics"
                        },
                        "streams": [
                            {
                                "data_stream": {
                                    "dataset": "elastic_agent.elastic_agent",
                                    "namespace": "default",
                                    "source": {
                                        "dataset": "elastic_agent.elastic_agent",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "type": "metrics"
                                },
                                "id": "metrics-monitoring-agent",
                                "source": {
                                    "data_stream": {
                                        "dataset": "elastic_agent.elastic_agent",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "failure_threshold": 5,
                                    "hosts": [
                                        "http://localhost:6791"
                                    ],
                                    "id": "metrics-monitoring-agent",
                                    "index": "metrics-elastic_agent.elastic_agent-default",
                                    "metricsets": [
                                        "json"
                                    ],
                                    "namespace": "agent",
                                    "path": "/stats",
                                    "period": "1m0s",
                                    "processors": [
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.elastic_agent",
                                                    "namespace": "default",
                                                    "type": "metrics"
                                                },
                                                "target": "data_stream"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.elastic_agent"
                                                },
                                                "target": "event"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891",
                                                    "process": "elastic-agent",
                                                    "snapshot": false,
                                                    "version": "9.0.0"
                                                },
                                                "target": "elastic_agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891"
                                                },
                                                "target": "agent"
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fail_on_error": false,
                                                "fields": [
                                                    {
                                                        "from": "http.agent.beat.cpu",
                                                        "to": "system.process.cpu"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.memstats.memory_sys",
                                                        "to": "system.process.memory.size"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.handles",
                                                        "to": "system.process.fd"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.cgroup",
                                                        "to": "system.process.cgroup"
                                                    },
                                                    {
                                                        "from": "http.agent.apm-server",
                                                        "to": "apm-server"
                                                    },
                                                    {
                                                        "from": "http.filebeat_input",
                                                        "to": "filebeat_input"
                                                    }
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "drop_fields": {
                                                "fields": [
                                                    "http"
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "binary": "elastic-agent",
                                                    "id": "elastic-agent"
                                                },
                                                "target": "component"
                                            }
                                        }
                                    ]
                                }
                            },
                            {
                                "data_stream": {
                                    "dataset": "elastic_agent.elastic_agent",
                                    "namespace": "default",
                                    "source": {
                                        "dataset": "elastic_agent.elastic_agent",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "type": "metrics"
                                },
                                "id": "metrics-monitoring-metricbeat-1",
                                "source": {
                                    "data_stream": {
                                        "dataset": "elastic_agent.elastic_agent",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "failure_threshold": 5,
                                    "hosts": [
                                        "http+unix:///vagrant/data/tmp/Hk6rvk9TDibMPcDvpl0jkLE-qDsHWVYL.sock"
                                    ],
                                    "id": "metrics-monitoring-metricbeat-1",
                                    "index": "metrics-elastic_agent.elastic_agent-default",
                                    "metricsets": [
                                        "json"
                                    ],
                                    "namespace": "agent",
                                    "path": "/stats",
                                    "period": "1m0s",
                                    "processors": [
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.elastic_agent"
                                                },
                                                "target": "event"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891",
                                                    "process": "metricbeat",
                                                    "snapshot": false,
                                                    "version": "9.0.0"
                                                },
                                                "target": "elastic_agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891"
                                                },
                                                "target": "agent"
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fail_on_error": false,
                                                "fields": [
                                                    {
                                                        "from": "http.agent.beat.cpu",
                                                        "to": "system.process.cpu"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.memstats.memory_sys",
                                                        "to": "system.process.memory.size"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.handles",
                                                        "to": "system.process.fd"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.cgroup",
                                                        "to": "system.process.cgroup"
                                                    },
                                                    {
                                                        "from": "http.agent.apm-server",
                                                        "to": "apm-server"
                                                    },
                                                    {
                                                        "from": "http.filebeat_input",
                                                        "to": "filebeat_input"
                                                    }
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "drop_fields": {
                                                "fields": [
                                                    "http"
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "binary": "metricbeat",
                                                    "id": "beat/metrics-monitoring"
                                                },
                                                "target": "component"
                                            }
                                        }
                                    ]
                                }
                            },
                            {
                                "data_stream": {
                                    "dataset": "elastic_agent.elastic_agent",
                                    "namespace": "default",
                                    "source": {
                                        "dataset": "elastic_agent.elastic_agent",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "type": "metrics"
                                },
                                "id": "metrics-monitoring-metricbeat-1",
                                "source": {
                                    "data_stream": {
                                        "dataset": "elastic_agent.elastic_agent",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "failure_threshold": 5,
                                    "hosts": [
                                        "http+unix:///vagrant/data/tmp/akSPbdqgaHaTY0_J01-dsfYK6JpMz2zn.sock"
                                    ],
                                    "id": "metrics-monitoring-metricbeat-1",
                                    "index": "metrics-elastic_agent.elastic_agent-default",
                                    "metricsets": [
                                        "json"
                                    ],
                                    "namespace": "agent",
                                    "path": "/stats",
                                    "period": "1m0s",
                                    "processors": [
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.elastic_agent"
                                                },
                                                "target": "event"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891",
                                                    "process": "metricbeat",
                                                    "snapshot": false,
                                                    "version": "9.0.0"
                                                },
                                                "target": "elastic_agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891"
                                                },
                                                "target": "agent"
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fail_on_error": false,
                                                "fields": [
                                                    {
                                                        "from": "http.agent.beat.cpu",
                                                        "to": "system.process.cpu"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.memstats.memory_sys",
                                                        "to": "system.process.memory.size"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.handles",
                                                        "to": "system.process.fd"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.cgroup",
                                                        "to": "system.process.cgroup"
                                                    },
                                                    {
                                                        "from": "http.agent.apm-server",
                                                        "to": "apm-server"
                                                    },
                                                    {
                                                        "from": "http.filebeat_input",
                                                        "to": "filebeat_input"
                                                    }
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "drop_fields": {
                                                "fields": [
                                                    "http"
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "binary": "metricbeat",
                                                    "id": "http/metrics-monitoring"
                                                },
                                                "target": "component"
                                            }
                                        }
                                    ]
                                }
                            },
                            {
                                "data_stream": {
                                    "dataset": "elastic_agent.elastic_agent",
                                    "namespace": "default",
                                    "source": {
                                        "dataset": "elastic_agent.elastic_agent",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "type": "metrics"
                                },
                                "id": "metrics-monitoring-filebeat-1",
                                "source": {
                                    "data_stream": {
                                        "dataset": "elastic_agent.elastic_agent",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "failure_threshold": 5,
                                    "hosts": [
                                        "http+unix:///vagrant/data/tmp/xTEtpJ7117ppc6OYvJCaYHbDW8mLjXGe.sock"
                                    ],
                                    "id": "metrics-monitoring-filebeat-1",
                                    "index": "metrics-elastic_agent.elastic_agent-default",
                                    "metricsets": [
                                        "json"
                                    ],
                                    "namespace": "agent",
                                    "path": "/stats",
                                    "period": "1m0s",
                                    "processors": [
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.elastic_agent"
                                                },
                                                "target": "event"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891",
                                                    "process": "filebeat",
                                                    "snapshot": false,
                                                    "version": "9.0.0"
                                                },
                                                "target": "elastic_agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891"
                                                },
                                                "target": "agent"
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fail_on_error": false,
                                                "fields": [
                                                    {
                                                        "from": "http.agent.beat.cpu",
                                                        "to": "system.process.cpu"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.memstats.memory_sys",
                                                        "to": "system.process.memory.size"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.handles",
                                                        "to": "system.process.fd"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.cgroup",
                                                        "to": "system.process.cgroup"
                                                    },
                                                    {
                                                        "from": "http.agent.apm-server",
                                                        "to": "apm-server"
                                                    },
                                                    {
                                                        "from": "http.filebeat_input",
                                                        "to": "filebeat_input"
                                                    }
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "drop_fields": {
                                                "fields": [
                                                    "http"
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "binary": "filebeat",
                                                    "id": "filestream-monitoring"
                                                },
                                                "target": "component"
                                            }
                                        }
                                    ]
                                }
                            },
                            {
                                "data_stream": {
                                    "dataset": "elastic_agent.filebeat_input",
                                    "namespace": "default",
                                    "source": {
                                        "dataset": "elastic_agent.filebeat_input",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "type": "metrics"
                                },
                                "id": "metrics-monitoring-filebeat-1",
                                "source": {
                                    "data_stream": {
                                        "dataset": "elastic_agent.filebeat_input",
                                        "namespace": "default",
                                        "type": "metrics"
                                    },
                                    "failure_threshold": 5,
                                    "hosts": [
                                        "http+unix:///vagrant/data/tmp/xTEtpJ7117ppc6OYvJCaYHbDW8mLjXGe.sock"
                                    ],
                                    "id": "metrics-monitoring-filebeat-1",
                                    "index": "metrics-elastic_agent.filebeat_input-default",
                                    "json.is_array": true,
                                    "metricsets": [
                                        "json"
                                    ],
                                    "namespace": "filebeat_input",
                                    "path": "/inputs/",
                                    "period": "1m0s",
                                    "processors": [
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "dataset": "elastic_agent.filebeat_input"
                                                },
                                                "target": "event"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891",
                                                    "process": "filebeat",
                                                    "snapshot": false,
                                                    "version": "9.0.0"
                                                },
                                                "target": "elastic_agent"
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "id": "7f563b50-11f1-4e7c-8361-31458142a891"
                                                },
                                                "target": "agent"
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fail_on_error": false,
                                                "fields": [
                                                    {
                                                        "from": "http.agent.beat.cpu",
                                                        "to": "system.process.cpu"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.memstats.memory_sys",
                                                        "to": "system.process.memory.size"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.handles",
                                                        "to": "system.process.fd"
                                                    },
                                                    {
                                                        "from": "http.agent.beat.cgroup",
                                                        "to": "system.process.cgroup"
                                                    },
                                                    {
                                                        "from": "http.agent.apm-server",
                                                        "to": "apm-server"
                                                    },
                                                    {
                                                        "from": "http.filebeat_input",
                                                        "to": "filebeat_input"
                                                    }
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "drop_fields": {
                                                "fields": [
                                                    "http"
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "add_fields": {
                                                "fields": {
                                                    "binary": "filebeat",
                                                    "id": "filestream-monitoring"
                                                },
                                                "target": "component"
                                            }
                                        }
                                    ]
                                }
                            }
                        ],
                        "type": "http/metrics"
                    },
                    "Err": null,
                    "ID": "http/metrics-monitoring-metrics-monitoring-agent",
                    "LogLevel": 3,
                    "Type": 0
                },
                {
                    "Config": {
                        "data_stream": {},
                        "source": {
                            "api_key": "example-key",
                            "hosts": [
                                "127.0.0.1:9200"
                            ],
                            "preset": "balanced",
                            "type": "elasticsearch"
                        },
                        "type": "elasticsearch"
                    },
                    "Err": null,
                    "ID": "http/metrics-monitoring",
                    "LogLevel": 3,
                    "Type": 1
                }
            ]
        },
        {
            "Component": {
                "limits": {
                    "source": {
                        "go_max_procs": 0
                    }
                }
            },
            "Err": {
                "Reason": "input not supported"
            },
            "ErrMsg": "",
            "Features": {
                "fqdn": {},
                "source": {
                    "agent": {
                        "features": {
                            "fqdn": {
                                "enabled": false
                            }
                        }
                    }
                }
            },
            "ID": "filestream-monitoring",
            "InputSpec": {
                "BinaryName": "",
                "BinaryPath": "",
                "InputType": "",
                "Spec": {
                    "Aliases": null,
                    "Command": null,
                    "Description": "",
                    "IsolateUnits": false,
                    "Name": "",
                    "Outputs": null,
                    "Platforms": null,
                    "ProxiedActions": null,
                    "Runtime": {
                        "Preventions": null
                    },
                    "Service": null
                }
            },
            "InputType": "filestream",
            "OutputType": "elasticsearch",
            "Units": [
                {
                    "Config": {
                        "data_stream": {},
                        "id": "filestream-monitoring-agent",
                        "name": "filestream-monitoring-agent",
                        "source": {
                            "id": "filestream-monitoring-agent",
                            "name": "filestream-monitoring-agent",
                            "streams": [
                                {
                                    "close": {
                                        "on_state_change": {
                                            "inactive": "5m"
                                        }
                                    },
                                    "data_stream": {
                                        "dataset": "elastic_agent",
                                        "namespace": "default",
                                        "type": "logs"
                                    },
                                    "id": "filestream-monitoring-agent",
                                    "parsers": [
                                        {
                                            "ndjson": {
                                                "add_error_key": true,
                                                "message_key": "message",
                                                "overwrite_keys": true,
                                                "target": ""
                                            }
                                        }
                                    ],
                                    "paths": [
                                        "/vagrant/data/elastic-agent-unknow/logs/elastic-agent-*.ndjson",
                                        "/vagrant/data/elastic-agent-unknow/logs/elastic-agent-watcher-*.ndjson"
                                    ],
                                    "processors": [
                                        {
                                            "drop_event": {
                                                "when": {
                                                    "regexp": {
                                                        "component.id": ".*-monitoring$"
                                                    }
                                                }
                                            }
                                        },
                                        {
                                            "drop_event": {
                                                "when": {
                                                    "regexp": {
                                                        "message": "^Non-zero metrics in the last"
                                                    }
                                                }
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fields": [
                                                    {
                                                        "from": "data_stream.dataset",
                                                        "to": "data_stream.dataset_original"
                                                    }
                                                ]
                                            }
                                        },
                                        {
                                            "drop_fields": {
                                                "fields": [
                                                    "data_stream.dataset"
                                                ]
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fail_on_error": false,
                                                "fields": [
                                                    {
                                                        "from": "component.dataset",
                                                        "to": "data_stream.dataset"
                                                    }
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fail_on_error": false,
                                                "fields": [
                                                    {
                                                        "from": "data_stream.dataset_original",
                                                        "to": "data_stream.dataset"
                                                    }
                                                ]
                                            }
                                        },
                                        {
                                            "drop_fields": {
                                                "fields": [
                                                    "data_stream.dataset_original",
                                                    "event.dataset"
                                                ]
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fields": [
                                                    {
                                                        "from": "data_stream.dataset",
                                                        "to": "event.dataset"
                                                    }
                                                ]
                                            }
                                        },
                                        {
                                            "drop_fields": {
                                                "fields": [
                                                    "ecs.version"
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "add_formatted_index": {
                                                "index": "%{[data_stream.type]}-%{[data_stream.dataset]}-%{[data_stream.namespace]}"
                                            }
                                        }
                                    ],
                                    "type": "filestream"
                                }
                            ],
                            "type": "filestream"
                        },
                        "streams": [
                            {
                                "data_stream": {
                                    "dataset": "elastic_agent",
                                    "namespace": "default",
                                    "source": {
                                        "dataset": "elastic_agent",
                                        "namespace": "default",
                                        "type": "logs"
                                    },
                                    "type": "logs"
                                },
                                "id": "filestream-monitoring-agent",
                                "source": {
                                    "close": {
                                        "on_state_change": {
                                            "inactive": "5m"
                                        }
                                    },
                                    "data_stream": {
                                        "dataset": "elastic_agent",
                                        "namespace": "default",
                                        "type": "logs"
                                    },
                                    "id": "filestream-monitoring-agent",
                                    "parsers": [
                                        {
                                            "ndjson": {
                                                "add_error_key": true,
                                                "message_key": "message",
                                                "overwrite_keys": true,
                                                "target": ""
                                            }
                                        }
                                    ],
                                    "paths": [
                                        "/vagrant/data/elastic-agent-unknow/logs/elastic-agent-*.ndjson",
                                        "/vagrant/data/elastic-agent-unknow/logs/elastic-agent-watcher-*.ndjson"
                                    ],
                                    "processors": [
                                        {
                                            "drop_event": {
                                                "when": {
                                                    "regexp": {
                                                        "component.id": ".*-monitoring$"
                                                    }
                                                }
                                            }
                                        },
                                        {
                                            "drop_event": {
                                                "when": {
                                                    "regexp": {
                                                        "message": "^Non-zero metrics in the last"
                                                    }
                                                }
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fields": [
                                                    {
                                                        "from": "data_stream.dataset",
                                                        "to": "data_stream.dataset_original"
                                                    }
                                                ]
                                            }
                                        },
                                        {
                                            "drop_fields": {
                                                "fields": [
                                                    "data_stream.dataset"
                                                ]
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fail_on_error": false,
                                                "fields": [
                                                    {
                                                        "from": "component.dataset",
                                                        "to": "data_stream.dataset"
                                                    }
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fail_on_error": false,
                                                "fields": [
                                                    {
                                                        "from": "data_stream.dataset_original",
                                                        "to": "data_stream.dataset"
                                                    }
                                                ]
                                            }
                                        },
                                        {
                                            "drop_fields": {
                                                "fields": [
                                                    "data_stream.dataset_original",
                                                    "event.dataset"
                                                ]
                                            }
                                        },
                                        {
                                            "copy_fields": {
                                                "fields": [
                                                    {
                                                        "from": "data_stream.dataset",
                                                        "to": "event.dataset"
                                                    }
                                                ]
                                            }
                                        },
                                        {
                                            "drop_fields": {
                                                "fields": [
                                                    "ecs.version"
                                                ],
                                                "ignore_missing": true
                                            }
                                        },
                                        {
                                            "add_formatted_index": {
                                                "index": "%{[data_stream.type]}-%{[data_stream.dataset]}-%{[data_stream.namespace]}"
                                            }
                                        }
                                    ],
                                    "type": "filestream"
                                }
                            }
                        ],
                        "type": "filestream"
                    },
                    "Err": null,
                    "ID": "filestream-monitoring-filestream-monitoring-agent",
                    "LogLevel": 3,
                    "Type": 0
                },
                {
                    "Config": {
                        "data_stream": {},
                        "source": {
                            "api_key": "example-key",
                            "hosts": [
                                "127.0.0.1:9200"
                            ],
                            "preset": "balanced",
                            "type": "elasticsearch"
                        },
                        "type": "elasticsearch"
                    },
                    "Err": null,
                    "ID": "filestream-monitoring",
                    "LogLevel": 3,
                    "Type": 1
                }
            ]
        }
    ],
    "ecs.version": "1.6.0",
    "log": {
        "source": "elastic-agent"
    },
    "log.level": "debug",
    "log.origin": {
        "file.line": 1403,
        "file.name": "coordinator/coordinator.go",
        "function": "github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator.(*Coordinator).refreshComponentModel"
    },
    "message": "Updating running component model"
}
```

</details>


## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/5675