### PR TITLE
[helm] fleet mode fixes

### DIFF
--- a/deploy/helm/elastic-agent/README.md
+++ b/deploy/helm/elastic-agent/README.md
@@ -62,7 +62,7 @@ The chart built-in [kubernetes integration](https://docs.elastic.co/integrations
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| kubernetes.enabled | bool | `false` | enable Kubernetes integration. |
+| kubernetes.enabled | bool | `true` | enable Kubernetes integration. |
 | kubernetes.output | string | `"default"` | name of the output used in kubernetes integration. Note that this output needs to be defined in [outputs](#1-outputs) |
 | kubernetes.namespace | string | `"default"` | kubernetes namespace |
 | kubernetes.hints.enabled | bool | `false` | enable [elastic-agent autodiscovery](https://www.elastic.co/guide/en/fleet/current/elastic-agent-kubernetes-autodiscovery.html) feature |

--- a/deploy/helm/elastic-agent/examples/eck/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/eck/rendered/manifest.yaml
@@ -1141,6 +1141,7 @@ spec:
             name: var-lib
             readOnly: true
         dnsPolicy: ClusterFirstWithHostNet
+        hostNetwork: true
         nodeSelector:
           kubernetes.io/os: linux
         serviceAccountName: agent-pernode-example

--- a/deploy/helm/elastic-agent/examples/fleet-managed/README.md
+++ b/deploy/helm/elastic-agent/examples/fleet-managed/README.md
@@ -31,38 +31,5 @@ agent:
     enabled: true
     url: $FLEET_URL # replace with Fleet URL
     token: $FLEET_TOKEN # replace with Fleet Enrollment token
-    preset: nginx
-  presets:
-    nginx:
-      mode: deployment
-      securityContext:
-        runAsUser: 0
-      rules:
-        # minimum cluster role ruleset required by agent
-        - apiGroups: [ "" ]
-          resources:
-            - nodes
-            - namespaces
-            - pods
-          verbs:
-            - get
-            - watch
-            - list
-        - apiGroups: [ "apps" ]
-          resources:
-            - replicasets
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups: [ "batch" ]
-          resources:
-            - jobs
-          verbs:
-            - get
-            - list
-            - watch
-      providers:
-        kubernetes_leaderelection:
-          enabled: false
+    preset: perNode
 ```

--- a/deploy/helm/elastic-agent/examples/fleet-managed/fleet-values.yaml
+++ b/deploy/helm/elastic-agent/examples/fleet-managed/fleet-values.yaml
@@ -1,43 +1,10 @@
+kubernetes:
+  enabled: true
+system:
+  enabled: true
 agent:
   fleet:
     enabled: true
     url: http://localhost:8220
     token: fleetToken
-    preset: nginx
-  presets:
-    nginx:
-      mode: deployment
-      securityContext:
-        runAsUser: 0
-      serviceAccount:
-        create: true
-      clusterRole:
-        create: true
-        rules:
-          # minimum cluster role ruleset required by agent
-          - apiGroups: [ "" ]
-            resources:
-              - nodes
-              - namespaces
-              - pods
-            verbs:
-              - get
-              - watch
-              - list
-          - apiGroups: [ "apps" ]
-            resources:
-              - replicasets
-            verbs:
-              - get
-              - list
-              - watch
-          - apiGroups: [ "batch" ]
-            resources:
-              - jobs
-            verbs:
-              - get
-              - list
-              - watch
-      providers:
-        kubernetes_leaderelection:
-          enabled: false
+    preset: perNode

--- a/deploy/helm/elastic-agent/examples/fleet-managed/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/fleet-managed/rendered/manifest.yaml
@@ -32,7 +32,7 @@ stringData:
         node: ${NODE_NAME}
         scope: node
       kubernetes_leaderelection:
-        enabled: false
+        enabled: true
         leader_lease: example-pernode
 ---
 # Source: elastic-agent/templates/agent/cluster-role.yaml
@@ -154,7 +154,7 @@ spec:
       labels:
         name: agent-pernode-example
       annotations:
-        checksum/config: af3259ba23f68d99ef807759ff88472468ae32fe402c062fa164b19041d533c9
+        checksum/config: cd7c5c4f03cc8377d18ee22cf236428090959fc194ee647bd97a39b79f38c807
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/examples/fleet-managed/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/fleet-managed/rendered/manifest.yaml
@@ -220,6 +220,7 @@ spec:
           readOnly: true
           subPath: agent.yml
       dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: agent-pernode-example

--- a/deploy/helm/elastic-agent/examples/fleet-managed/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/fleet-managed/rendered/manifest.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: agent-nginx-example
+  name: agent-pernode-example
   namespace: "default"
   labels:
     helm.sh/chart: elastic-agent-9.0.0-beta
@@ -15,7 +15,7 @@ metadata:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: agent-nginx-example
+  name: agent-pernode-example
   namespace: "default"
   labels:
     helm.sh/chart: elastic-agent-9.0.0-beta
@@ -28,15 +28,18 @@ stringData:
     fleet:
       enabled: true
     providers:
+      kubernetes:
+        node: ${NODE_NAME}
+        scope: node
       kubernetes_leaderelection:
         enabled: false
-        leader_lease: example-nginx
+        leader_lease: example-pernode
 ---
 # Source: elastic-agent/templates/agent/cluster-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: agent-nginx-example-default
+  name: agent-perNode-example-default
   labels:
     helm.sh/chart: elastic-agent-9.0.0-beta
     app.kubernetes.io/name: elastic-agent
@@ -111,38 +114,12 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-    - nodes
-    - namespaces
-    - pods
-    verbs:
-    - get
-    - watch
-    - list
-  - apiGroups:
-    - apps
-    resources:
-    - replicasets
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - batch
-    resources:
-    - jobs
-    verbs:
-    - get
-    - list
-    - watch
 ---
 # Source: elastic-agent/templates/agent/cluster-role-binding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: agent-nginx-example-default
+  name: agent-perNode-example-default
   labels:
     helm.sh/chart: elastic-agent-9.0.0-beta
     app.kubernetes.io/name: elastic-agent
@@ -150,18 +127,18 @@ metadata:
     app.kubernetes.io/version: 9.0.0
 subjects:
   - kind: ServiceAccount
-    name: agent-nginx-example
+    name: agent-pernode-example
     namespace: "default"
 roleRef:
   kind: ClusterRole
-  name: agent-nginx-example-default
+  name: agent-perNode-example-default
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: elastic-agent/templates/agent/k8s/deployment.yaml
+# Source: elastic-agent/templates/agent/k8s/daemonset.yaml
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
-  name: agent-nginx-example
+  name: agent-pernode-example
   namespace: "default"
   labels:
     helm.sh/chart: elastic-agent-9.0.0-beta
@@ -171,13 +148,13 @@ metadata:
 spec:
   selector:
     matchLabels:
-      name: agent-nginx-example
+      name: agent-pernode-example
   template:
     metadata:
       labels:
-        name: agent-nginx-example
+        name: agent-pernode-example
       annotations:
-        checksum/config: 975ed05540e0d099fe1b28b15d6403aacee676d0776a69fb75eb8624e19ad2de
+        checksum/config: af3259ba23f68d99ef807759ff88472468ae32fe402c062fa164b19041d533c9
     spec:
       automountServiceAccountToken: true
       containers:
@@ -196,6 +173,8 @@ spec:
               fieldPath: metadata.name
         - name: STATE_PATH
           value: /usr/share/elastic-agent/state
+        - name: ELASTIC_NETINFO
+          value: "false"
         - name: FLEET_URL
           value: http://localhost:8220
         - name: FLEET_ENROLLMENT_TOKEN
@@ -207,9 +186,33 @@ spec:
         image: docker.elastic.co/beats/elastic-agent:9.0.0-SNAPSHOT
         imagePullPolicy: IfNotPresent
         name: agent
+        resources:
+          limits:
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 400Mi
         securityContext:
           runAsUser: 0
         volumeMounts:
+        - mountPath: /hostfs/proc
+          name: proc
+          readOnly: true
+        - mountPath: /hostfs/sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker/containers
+          name: varlibdockercontainers
+          readOnly: true
+        - mountPath: /var/log
+          name: varlog
+          readOnly: true
+        - mountPath: /hostfs/etc
+          name: etc-full
+          readOnly: true
+        - mountPath: /hostfs/var/lib
+          name: var-lib
+          readOnly: true
         - mountPath: /usr/share/elastic-agent/state
           name: agent-data
         - mountPath: /etc/elastic-agent/agent.yml
@@ -217,13 +220,33 @@ spec:
           readOnly: true
           subPath: agent.yml
       dnsPolicy: ClusterFirstWithHostNet
-      serviceAccountName: agent-nginx-example
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: agent-pernode-example
       volumes:
       - hostPath:
-          path: /etc/elastic-agent/default/agent-nginx-example-managed/state
+          path: /proc
+        name: proc
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: cgroup
+      - hostPath:
+          path: /var/lib/docker/containers
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/log
+        name: varlog
+      - hostPath:
+          path: /etc
+        name: etc-full
+      - hostPath:
+          path: /var/lib
+        name: var-lib
+      - hostPath:
+          path: /etc/elastic-agent/default/agent-pernode-example-managed/state
           type: DirectoryOrCreate
         name: agent-data
       - name: config
         secret:
           defaultMode: 292
-          secretName: agent-nginx-example
+          secretName: agent-pernode-example

--- a/deploy/helm/elastic-agent/examples/kubernetes-default/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/kubernetes-default/rendered/manifest.yaml
@@ -1147,6 +1147,7 @@ spec:
           readOnly: true
           subPath: agent.yml
       dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: agent-pernode-example

--- a/deploy/helm/elastic-agent/examples/kubernetes-hints-autodiscover/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/kubernetes-hints-autodiscover/rendered/manifest.yaml
@@ -1151,6 +1151,7 @@ spec:
           readOnly: true
           subPath: agent.yml
       dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
       initContainers:
       - args:
         - -c

--- a/deploy/helm/elastic-agent/examples/kubernetes-only-logs/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/kubernetes-only-logs/rendered/manifest.yaml
@@ -291,6 +291,7 @@ spec:
           readOnly: true
           subPath: agent.yml
       dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: agent-pernode-example

--- a/deploy/helm/elastic-agent/examples/multiple-integrations/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/multiple-integrations/rendered/manifest.yaml
@@ -1167,6 +1167,7 @@ spec:
           readOnly: true
           subPath: agent.yml
       dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
       initContainers:
       - args:
         - -c

--- a/deploy/helm/elastic-agent/examples/system-custom-auth-paths/agent-system-values.yaml
+++ b/deploy/helm/elastic-agent/examples/system-custom-auth-paths/agent-system-values.yaml
@@ -8,6 +8,7 @@ system:
     vars:
       paths:
         - /var/log/custom_syslog.log
-
+kubernetes:
+  enabled: false
 agent:
   unprivileged: true

--- a/deploy/helm/elastic-agent/examples/system-custom-auth-paths/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/system-custom-auth-paths/rendered/manifest.yaml
@@ -363,6 +363,7 @@ spec:
           readOnly: true
           subPath: agent.yml
       dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: agent-pernode-example

--- a/deploy/helm/elastic-agent/examples/user-service-account/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/user-service-account/rendered/manifest.yaml
@@ -1117,6 +1117,7 @@ spec:
           readOnly: true
           subPath: agent.yml
       dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: user-sa-perNode

--- a/deploy/helm/elastic-agent/templates/agent/_helpers.tpl
+++ b/deploy/helm/elastic-agent/templates/agent/_helpers.tpl
@@ -30,8 +30,8 @@ Entrypoint for chart initialisation
 {{- if not (hasKey $.Values.agent "initialised") -}}
 {{/* init order matters */}}
 {{- include (printf "elasticagent.engine.%s.init" $.Values.agent.engine) $ -}}
-{{- include "elasticagent.init.fleet" $ -}}
 {{- include "elasticagent.init.inputs" $ -}}
+{{- include "elasticagent.init.fleet" $ -}}
 {{- include "elasticagent.init.presets" $ -}}
 {{- $_ := set $.Values.agent "initialised" dict -}}
 {{- end -}}
@@ -62,10 +62,12 @@ Initialise input templates if we are not deploying as managed
 */}}
 {{- define "elasticagent.init.inputs" -}}
 {{- $ := . -}}
-{{- if eq $.Values.agent.fleet.enabled false -}}
-{{/* standalone agent so initialise inputs */}}
+{{/* initialise inputs of the built-in integrations, even if fleet is enabled,
+ as they change the k8s configuration of presets e.g. necessary volume mounts, etc. */}}
 {{- include "elasticagent.kubernetes.init" $ -}}
 {{- include "elasticagent.system.init" $ -}}
+{{/* initialise inputs the custom integrations only if fleet is disabled */}}
+{{- if eq $.Values.agent.fleet.enabled false -}}
 {{- range $customInputName, $customInputVal := $.Values.extraIntegrations -}}
 {{- $customInputPresetName := ($customInputVal).preset -}}
 {{- $presetVal := get $.Values.agent.presets $customInputPresetName -}}

--- a/deploy/helm/elastic-agent/templates/agent/_helpers.tpl
+++ b/deploy/helm/elastic-agent/templates/agent/_helpers.tpl
@@ -99,7 +99,6 @@ Validate and initialise the defined agent presets
 {{- end -}}
 {{- end -}}
 {{- end -}}
-{{/* by default we disable leader election but we also set the name of the leader lease in case it is explicitly enabled */}}
 {{- if empty ($presetVal).providers -}}
 {{- $_ := set $presetVal "providers" dict -}}
 {{- end -}}
@@ -108,7 +107,13 @@ Validate and initialise the defined agent presets
 {{- $_ := set $presetProviders "kubernetes_leaderelection" dict -}}
 {{- end -}}
 {{- $presetLeaderLeaseName := (printf "%s-%s" $.Release.Name $presetName) | lower  -}}
+{{/* by default we disable leader election but we also set the name of the leader lease in case it is explicitly enabled */}}
 {{- $defaultLeaderElection := dict "enabled" false "leader_lease" $presetLeaderLeaseName -}}
+{{- if eq $.Values.agent.fleet.enabled true -}}
+{{/* for fleet mode the leader election is enabled by default */}}
+{{- $_ := set $defaultLeaderElection "enabled" true -}}
+{{- end -}}
+{{/* merge the default leader election with the leader election from the preset giving priority to the one from the preset */}}
 {{- $presetLeaderElection := mergeOverwrite dict $defaultLeaderElection ($presetProviders).kubernetes_leaderelection -}}
 {{- $_ := set $presetProviders "kubernetes_leaderelection" $presetLeaderElection -}}
 {{- end -}}

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_preset_pernode.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_preset_pernode.tpl
@@ -2,7 +2,7 @@
 {{- include "elasticagent.preset.mutate.volumemounts" (list $ $.Values.agent.presets.perNode "elasticagent.kubernetes.pernode.preset.volumemounts") -}}
 {{- include "elasticagent.preset.mutate.volumes" (list $ $.Values.agent.presets.perNode "elasticagent.kubernetes.pernode.preset.volumes") -}}
 {{- include "elasticagent.preset.mutate.outputs.byname" (list $ $.Values.agent.presets.perNode $.Values.kubernetes.output)}}
-{{- if eq $.Values.kubernetes.hints.enabled true -}}
+{{- if and (eq $.Values.kubernetes.hints.enabled true) (eq $.Values.agent.fleet.enabled false) -}}
 {{- include "elasticagent.preset.mutate.initcontainers" (list $ $.Values.agent.presets.perNode "elasticagent.kubernetes.pernode.preset.initcontainers") -}}
 {{- include "elasticagent.preset.mutate.providers.kubernetes.hints" (list $ $.Values.agent.presets.perNode "elasticagent.kubernetes.pernode.preset.providers.kubernetes.hints") -}}
 {{- end -}}

--- a/deploy/helm/elastic-agent/values.yaml
+++ b/deploy/helm/elastic-agent/values.yaml
@@ -438,6 +438,7 @@ agent:
         create: true
       clusterRole:
         create: true
+      hostNetwork: true
       resources:
         limits:
           memory: 1000Mi

--- a/deploy/helm/elastic-agent/values.yaml
+++ b/deploy/helm/elastic-agent/values.yaml
@@ -333,7 +333,7 @@ agent:
     pullPolicy: IfNotPresent
     tag: "9.0.0-SNAPSHOT"
   # -- image pull secrets
-  # @section -- 3 - Elastic-Agent Configuration
+  # @section -- 6 - Elastic-Agent Configuration
   imagePullSecrets: []
   # -- generate kubernetes manifests or [ECK](https://github.com/elastic/cloud-on-k8s) CRDs
   # @section -- 6 - Elastic-Agent Configuration

--- a/deploy/helm/elastic-agent/values.yaml
+++ b/deploy/helm/elastic-agent/values.yaml
@@ -47,7 +47,7 @@ kubernetes:
   # -- enable Kubernetes integration.
   # @section -- 2 - Kubernetes integration
   # @sectionDescriptionTemplate -- Kubernetes
-  enabled: false
+  enabled: true
   # -- name of the output used in kubernetes integration. Note that this output needs to be defined in
   # [outputs](#1-outputs)
   # @section -- 2 - Kubernetes integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR introduces several fixes to the Elastic Agent Helm chart regarding Fleet Mode deployments:
   - Fleet mode now includes the necessary Kubernetes changes (e.g., volume mounts, resource requests) for enabled integrations.
   - Leader election is enabled by default for Fleet mode unless explicitly disabled by the user in the agent preset.
   - Kubernetes integration is now enabled by default.
   - Sets `hostNetwork=true` for `perNode` (`Daemonset`) agent preset, used by kubernetes and system integrations

## Why is it important?

These changes are critical as they address bugs 🙂 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

N/A

## How to test this PR locally

- You can see in the [./deploy/helm/examples/fleet-managed/rendered/manifest.yaml](https://github.com/pkoutsovasilis/elastic-agent/blob/ba5a48c8a2760bbca430a3069708ff6ad0a9235d/deploy/helm/elastic-agent/examples/fleet-managed/rendered/manifest.yaml) that now fleet-managed agent has the appropriate volume mounts and leader election enabled.
- Follow this [example](https://github.com/pkoutsovasilis/elastic-agent/blob/ba5a48c8a2760bbca430a3069708ff6ad0a9235d/deploy/helm/elastic-agent/examples/fleet-managed/README.md) and you should be able to see container logs correctly

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

-->

- Closes https://github.com/elastic/elastic-agent/issues/6284
- Closes https://github.com/elastic/elastic-agent/issues/6204
- Closes https://github.com/elastic/elastic-agent/issues/6324
