### PR TITLE
[k8s] add kubernetes hints integration tests

### DIFF
--- a/testing/integration/testdata/k8s.hints.redis.yaml
+++ b/testing/integration/testdata/k8s.hints.redis.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redis # don't change this as integration tests depend on it
+  annotations:
+    co.elastic.hints/package: redis
+    co.elastic.hints/data_streams: info
+    co.elastic.hints/host: '${kubernetes.pod.ip}:6379'
+    co.elastic.hints/info.period: 5s
+  labels:
+    k8s-app: redis
+    app: redis
+spec:
+  containers:
+    - name: redis
+      image: redis:5.0.4
+      command:
+        - redis-server
+        - "/redis-master/redis.conf"
+      env:
+        - name: MASTER
+          value: "true"
+      ports:
+        - containerPort: 6379
+      resources:
+        limits:
+          cpu: "0.1"
+      volumeMounts:
+        - mountPath: /redis-master-data
+          name: data
+        - mountPath: /redis-master
+          name: config
+  volumes:
+    - name: data
+      emptyDir: {}
+    - name: config
+      configMap:
+        name: example-redis-config
+        items:
+          - key: redis-config
+            path: redis.conf
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-redis-config
+data:
+  redis-config: |
+    maxmemory 2mb
+    maxmemory-policy allkeys-lru
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: 6379
+      name: client
+  selector:
+    app: redis


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This is the last part (I promise) of the PR series to add support for Kubernetes hints and integration tests for Redis. It introduces:
- Additional test cases to validate agent Kubernetes hints functionality using Redis as the hints-enabled workload:
  - When hints-enabled workloads pre-exist the agent deployment.
  - When hints-enabled workloads are deployed after the agent is already running.


## Why is it important?

This PR completes the Kubernetes hints-based testing and it ensures that that Kubernetes hints functionality is thoroughly tested.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

There is no expected disruption for users as this PR only extends k8s integration tests.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
mage integration:auth
PLATFORMS=linux/arm64 EXTERNAL=true SNAPSHOT=true PACKAGES=docker mage -v package 
INSTANCE_PROVISIONER=kind STACK_PROVISIONER=stateful K8S_VERSION=v1.31.1 SNAPSHOT=true mage integration:kubernetes
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/5660
