### PR TITLE
test: increase passwd length in crypto io tests

### DIFF
--- a/internal/pkg/crypto/io_test.go
+++ b/internal/pkg/crypto/io_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestIO(t *testing.T) {
 	t.Run("encode and decode with the right password", func(t *testing.T) {
-		passwd := []byte("hello")
+		passwd := bytes.Repeat([]byte("hello"), 10)
 		msg := []byte("bonjour la famille")
 		dest := new(bytes.Buffer)
 
@@ -40,7 +40,7 @@ func TestIO(t *testing.T) {
 	})
 
 	t.Run("Large single write", func(t *testing.T) {
-		passwd := []byte("hello")
+		passwd := bytes.Repeat([]byte("hello"), 10)
 		msg, err := randomBytes(1327)
 
 		require.NoError(t, err)
@@ -67,7 +67,7 @@ func TestIO(t *testing.T) {
 	})
 
 	t.Run("try to decode with the wrong password", func(t *testing.T) {
-		passwd := []byte("hello")
+		passwd := bytes.Repeat([]byte("hello"), 10)
 		msg := []byte("bonjour la famille")
 		dest := new(bytes.Buffer)
 
@@ -90,7 +90,7 @@ func TestIO(t *testing.T) {
 	})
 
 	t.Run("Make sure that buffered IO works with the encoder", func(t *testing.T) {
-		passwd := []byte("hello")
+		passwd := bytes.Repeat([]byte("hello"), 10)
 		msg, err := randomBytes(2048)
 		require.NoError(t, err)
 		dest := new(bytes.Buffer)
@@ -121,7 +121,7 @@ func TestIO(t *testing.T) {
 	})
 
 	t.Run("Make sure that buffered IO works with the decoder", func(t *testing.T) {
-		passwd := []byte("hello")
+		passwd := bytes.Repeat([]byte("hello"), 10)
 		msg, err := randomBytes(2048)
 		require.NoError(t, err)
 		dest := new(bytes.Buffer)
@@ -163,7 +163,7 @@ func TestIO(t *testing.T) {
 	})
 
 	t.Run("works with multiple writes", func(t *testing.T) {
-		passwd := []byte("hello")
+		passwd := bytes.Repeat([]byte("hello"), 10)
 
 		expected := []byte("hello world bonjour la famille")
 


### PR DESCRIPTION
## What does this PR do?

the password is used to derive a key using pbkdf2 and hmac.

Update the test to use longer passwords.

## Why is it important?

In fips only mode use of keys shorter than 112 bits is not allowed for hmac.

The program will panic with the following error:

`panic: crypto/hmac: use of keys shorter than 112 bits is not allowed in FIPS 140-only mode`

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->