### PR TITLE
Build only cloud image variant when it's requested

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -84,6 +84,7 @@ const (
 	externalArtifacts = "EXTERNAL"
 	platformsEnv      = "PLATFORMS"
 	packagesEnv       = "PACKAGES"
+	dockerVariants    = "DOCKER_VARIANTS"
 	configFile        = "elastic-agent.yml"
 	agentDropPath     = "AGENT_DROP_PATH"
 	checksumFilename  = "checksum.yml"
@@ -782,9 +783,13 @@ func (Cloud) Image(ctx context.Context) {
 	dev := os.Getenv(devEnv)
 	defer os.Setenv(devEnv, dev)
 
+	variant := os.Getenv(dockerVariants)
+	defer os.Setenv(dockerVariants, variant)
+
 	os.Setenv(platformsEnv, "linux/amd64")
 	os.Setenv(packagesEnv, "docker")
 	os.Setenv(devEnv, "true")
+	os.Setenv(dockerVariants, "cloud")
 
 	if s, err := strconv.ParseBool(snapshot); err == nil && !s {
 		// only disable SNAPSHOT build when explicitely defined
@@ -798,6 +803,7 @@ func (Cloud) Image(ctx context.Context) {
 	devtools.DevBuild = true
 	devtools.Platforms = devtools.Platforms.Filter("linux/amd64")
 	devtools.SelectedPackageTypes = []devtools.PackageType{devtools.Docker}
+	devtools.SelectedDockerVariants = []devtools.DockerVariant{devtools.Cloud}
 
 	if _, hasExternal := os.LookupEnv(externalArtifacts); !hasExternal {
 		devtools.ExternalBuild = true


### PR DESCRIPTION
Before this change we were building all possible Docker images to produce the cloud image. Which is unnecessary and takes a long time.

Now only the `cloud` variant is built. 

**On my machine this reduces this build time from 27 to 20 minutes.**

For testing:

```sh
mage cloud:image
```

Or follow this guide https://github.com/elastic/elastic-agent?tab=readme-ov-file#testing-on-elastic-cloud