### PR TITLE
Call tlscommon.SetInsecureDefaults

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -13,9 +13,14 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 	"gopkg.in/yaml.v2"
 
+	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 	"github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/cfgutil"
 )
+
+func init() {
+	tlscommon.SetInsecureDefaults()
+}
 
 // options hold the specified options
 type options struct {

--- a/internal/pkg/config/test/tls_version_test.go
+++ b/internal/pkg/config/test/tls_version_test.go
@@ -1,0 +1,56 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package main
+
+import (
+	"crypto/tls"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
+	"github.com/elastic/elastic-agent/internal/pkg/config"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+)
+
+func TestTLSVersionsDefault(t *testing.T) {
+	l := newLoader(t, filepath.Join("..", "testdata"))
+	c, err := l.Load([]string{filepath.Join("..", "testdata", "tls.yml")})
+	require.NoError(t, err)
+
+	agentCfg, err := configuration.NewFromConfig(c)
+	require.NoError(t, err)
+
+	common, err := tlscommon.LoadTLSConfig(agentCfg.Fleet.Client.Transport.TLS)
+	require.NoError(t, err)
+	cfg := common.ToConfig()
+	assert.Equal(t, uint16(tls.VersionTLS11), cfg.MinVersion)
+	assert.Equal(t, uint16(tls.VersionTLS13), cfg.MaxVersion)
+}
+
+func TestTLSVersions10(t *testing.T) {
+	l := newLoader(t, filepath.Join("..", "testdata"))
+	c, err := l.Load([]string{filepath.Join("..", "testdata", "tls10.yml")})
+	require.NoError(t, err)
+
+	agentCfg, err := configuration.NewFromConfig(c)
+	require.NoError(t, err)
+
+	common, err := tlscommon.LoadTLSConfig(agentCfg.Fleet.Client.Transport.TLS)
+	require.NoError(t, err)
+	cfg := common.ToConfig()
+	assert.Equal(t, uint16(tls.VersionTLS10), cfg.MinVersion)
+	assert.Equal(t, uint16(tls.VersionTLS10), cfg.MaxVersion)
+}
+
+func newLoader(t *testing.T, folder string) *config.Loader {
+	t.Helper()
+	log, err := logger.New("config_test", true)
+	require.NoError(t, err)
+	return config.NewLoader(log, folder)
+}

--- a/internal/pkg/config/testdata/tls.yml
+++ b/internal/pkg/config/testdata/tls.yml
@@ -1,0 +1,4 @@
+fleet:
+    hosts: [127.0.0.1:9201]
+    ssl:
+      enabled: true

--- a/internal/pkg/config/testdata/tls10.yml
+++ b/internal/pkg/config/testdata/tls10.yml
@@ -1,0 +1,6 @@
+fleet:
+    hosts: [127.0.0.1:9201]
+    ssl:
+      enabled: true
+      supported_protocols:
+        - TLSv1.0


### PR DESCRIPTION
## What does this PR do?

Call `tlscommon.SetInsecureDefaults` from within an init func in the config package.

## Why is it important?

Avoid a planned breaking change for tlscommon versions

## Checklist

- ~~My code follows the style guidelines of this project~~
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

N/A

## Related Issues

- Relates https://github.com/elastic/elastic-agent/issues/5996