### PR TITLE
Add Journald to the examples and default configuration

### DIFF
--- a/_meta/config/common.p2.yml.tmpl
+++ b/_meta/config/common.p2.yml.tmpl
@@ -52,6 +52,16 @@ inputs:
 #         paths:
 #           - /var/log/*.log
 
+#   # Collecting journald logs, including coredumps.
+#   - type: journald
+#     # Input ID allowing Elastic Agent to track the state of this input. Must be unique.
+#     id: your-journald-input-id
+#     streams:
+#       # Stream ID for this data stream allowing Filebeat to track the state of the ingested data. Must be unique.
+#       # Each journald data stream creates a separate instance of the Filebeat journald input.
+#       - id: your-journald-stream-id
+#         data_stream:
+#           dataset: generic
 
 # agent.monitoring:
 #   # enabled turns on monitoring of running processes

--- a/_meta/config/common.reference.p2.yml.tmpl
+++ b/_meta/config/common.reference.p2.yml.tmpl
@@ -50,6 +50,17 @@ inputs:
 #         paths:
 #           - /var/log/*.log
 
+#   # Collecting journald logs, including coredumps.
+#   - type: journald
+#     # Input ID allowing Elastic Agent to track the state of this input. Must be unique.
+#     id: your-journald-input-id
+#     streams:
+#       # Stream ID for this data stream allowing Filebeat to track the state of the ingested data. Must be unique.
+#       # Each journald data stream creates a separate instance of the Filebeat journald input.
+#       - id: your-journald-stream-id
+#         data_stream:
+#           dataset: generic
+
 # management:
 #   # Mode of management, the Elastic Agent support two modes of operation:
 #   #

--- a/elastic-agent.reference.yml
+++ b/elastic-agent.reference.yml
@@ -56,6 +56,17 @@ inputs:
 #         paths:
 #           - /var/log/*.log
 
+#   # Collecting journald logs, including coredumps.
+#   - type: journald
+#     # Input ID allowing Elastic Agent to track the state of this input. Must be unique.
+#     id: your-journald-input-id
+#     streams:
+#       # Stream ID for this data stream allowing Filebeat to track the state of the ingested data. Must be unique.
+#       # Each journald data stream creates a separate instance of the Filebeat journald input.
+#       - id: your-journald-stream-id
+#         data_stream:
+#           dataset: generic
+
 # management:
 #   # Mode of management, the Elastic Agent support two modes of operation:
 #   #

--- a/elastic-agent.yml
+++ b/elastic-agent.yml
@@ -58,6 +58,16 @@ inputs:
 #         paths:
 #           - /var/log/*.log
 
+#   # Collecting journald logs, including coredumps.
+#   - type: journald
+#     # Input ID allowing Elastic Agent to track the state of this input. Must be unique.
+#     id: your-journald-input-id
+#     streams:
+#       # Stream ID for this data stream allowing Filebeat to track the state of the ingested data. Must be unique.
+#       # Each journald data stream creates a separate instance of the Filebeat journald input.
+#       - id: your-journald-stream-id
+#         data_stream:
+#           dataset: generic
 
 # agent.monitoring:
 #   # enabled turns on monitoring of running processes


### PR DESCRIPTION
## What does this PR do?

Add Journald to the examples and default configuration

## Why is it important?

Linux distributions like Debian 12 are migrating away from traditional log files in favour of journald to system logs, we need good examples of how to ingest those logs.

## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~

~~## Disruptive User Impact~~
~~## How to test this PR locally~~
~~## Related issues~~

- It's part of https://github.com/elastic/beats/issues/37877

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->