### PR TITLE
[flaky] temporarily skip TestBeatsServerless

### DIFF
--- a/testing/integration/beats_serverless_test.go
+++ b/testing/integration/beats_serverless_test.go
@@ -49,6 +49,8 @@ type BeatRunner struct {
 }
 
 func TestBeatsServerless(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/6431")
+
 	info := define.Require(t, define.Requirements{
 		Group: Default,
 		OS: []define.OS{

--- a/testing/integration/beats_serverless_test.go
+++ b/testing/integration/beats_serverless_test.go
@@ -49,8 +49,6 @@ type BeatRunner struct {
 }
 
 func TestBeatsServerless(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/6431")
-
 	info := define.Require(t, define.Requirements{
 		Group: Default,
 		OS: []define.OS{
@@ -60,6 +58,7 @@ func TestBeatsServerless(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/6431")
 
 	suite.Run(t, &BeatRunner{requirementsInfo: info})
 }


### PR DESCRIPTION
Relates https://github.com/elastic/elastic-agent/issues/6431

temporarily skip TestBeatsServerless to unblock other PRs on main. I'm currently working on a permanent fix.