### PR TITLE
cleanup(2489): removed path.install option from the paths command, removed any usage of this command

### DIFF
--- a/changelog/fragments/1735664420-remove-deprecated-path-install-cli-flag.yaml
+++ b/changelog/fragments/1735664420-remove-deprecated-path-install-cli-flag.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: breaking-change
+
+# Change summary; a 80ish characters long description of the change.
+summary: Removing --path.install option
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/2489

--- a/changelog/fragments/1735664420-remove-deprecated-path-install-cli-flag.yaml
+++ b/changelog/fragments/1735664420-remove-deprecated-path-install-cli-flag.yaml
@@ -24,8 +24,7 @@ component: "elastic-agent"
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
-
+pr: https://github.com/elastic/elastic-agent/pull/6461/files
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.
 issue: https://github.com/elastic/elastic-agent/issues/2489

--- a/internal/pkg/agent/application/paths/common.go
+++ b/internal/pkg/agent/application/paths/common.go
@@ -84,7 +84,6 @@ func init() {
 	fs.StringVar(&configFilePath, "config", DefaultConfigName, "Configuration file, relative to path.config")
 	fs.StringVar(&configFilePath, "c", DefaultConfigName, "Configuration file, relative to path.config")
 	fs.StringVar(&logsPath, "path.logs", logsPath, "Logs path contains Agent log output")
-	fs.StringVar(&installPath, "path.install", installPath, "DEPRECATED, setting this flag has no effect since v8.6.0")
 	fs.StringVar(&controlSocketPath, "path.socket", controlSocketPath, "Control protocol socket path for the Agent")
 
 	// enable user to download update artifacts to alternative place
@@ -158,7 +157,6 @@ func SetConfig(path string) {
 
 // ConfigFile returns the path to the configuration file.
 func ConfigFile() string {
-
 	return configFileWithDefaultOverride(DefaultConfigName)
 }
 

--- a/internal/pkg/agent/cmd/common.go
+++ b/internal/pkg/agent/cmd/common.go
@@ -67,7 +67,6 @@ func NewCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Command {
 	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("config"))
 	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.logs"))
 	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.downloads"))
-	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.install"))
 	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.socket"))
 
 	// logging flags

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -417,9 +417,6 @@ func buildEnrollArgs(cfg setupConfig, token string, policyID string) ([]string, 
 	if paths.Downloads() != "" {
 		args = append(args, "--path.downloads", paths.Downloads())
 	}
-	if paths.Install() != "" {
-		args = append(args, "--path.install", paths.Install())
-	}
 	if !paths.IsVersionHome() {
 		args = append(args, "--path.home.unversioned")
 	}

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -663,9 +663,6 @@ func (c *enrollCmd) startAgent(ctx context.Context) (<-chan *os.ProcessState, er
 	if paths.Downloads() != "" {
 		args = append(args, "--path.downloads", paths.Downloads())
 	}
-	if paths.Install() != "" {
-		args = append(args, "--path.install", paths.Install())
-	}
 	if !paths.IsVersionHome() {
 		args = append(args, "--path.home.unversioned")
 	}


### PR DESCRIPTION

- Breaking change

## What does this PR do?

Removes `--path.install` flag declaration from the paths command and removes its use from container and enroll commands

## Why is it important?

This command is currently ignored and deprecated

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

Any client using `--path.install` flag will fail

## How to test this PR locally

- Deploy ess
- Prepare necessary packages for testing
  - tar.gz
  - docker
- Try to install tar.gz with `path.install` and verify that the installation fails
- Install tar.gz without the flag and validate that the installation is successful
- Unenroll the agent on fleet ui, and then enroll the agent again and validate that enrollment is successful
- Run agent in docker and validate that it is successfully run

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #2489 

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
