### PR TITLE
[8.x] restore cloud defend as an expected binary

### DIFF
--- a/changelog/fragments/1735833843-Restore-cloud-defend..yaml
+++ b/changelog/fragments/1735833843-Restore-cloud-defend..yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Restore the cloud-defend binary which was accidentally removed in 8.17.0.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/6470
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/6469

--- a/dev-tools/mage/manifest/manifest.go
+++ b/dev-tools/mage/manifest/manifest.go
@@ -101,6 +101,7 @@ var ExpectedBinaries = []BinarySpec{
 	{BinaryName: "agentbeat", ProjectName: "beats", Platforms: AllPlatforms, PackageTypes: pkgcommon.AllPackageTypes},
 	{BinaryName: "apm-server", ProjectName: "apm-server", Platforms: []Platform{{"linux", "x86_64"}, {"linux", "arm64"}, {"windows", "x86_64"}, {"darwin", "x86_64"}}, PackageTypes: pkgcommon.AllPackageTypes},
 	{BinaryName: "cloudbeat", ProjectName: "cloudbeat", Platforms: []Platform{{"linux", "x86_64"}, {"linux", "arm64"}}, PackageTypes: pkgcommon.AllPackageTypes},
+	{BinaryName: "cloud-defend", ProjectName: "cloud-defend", Platforms: []Platform{{"linux", "x86_64"}, {"linux", "arm64"}}, PackageTypes: []pkgcommon.PackageType{pkgcommon.Docker}},
 	{BinaryName: "connectors", ProjectName: "connectors", Platforms: []Platform{{"linux", "x86_64"}, {"linux", "arm64"}}, PythonWheel: true, PackageTypes: pkgcommon.AllPackageTypes},
 	{BinaryName: "endpoint-security", ProjectName: "endpoint-dev", Platforms: AllPlatforms, PackageTypes: []pkgcommon.PackageType{pkgcommon.RPM, pkgcommon.Deb, pkgcommon.Zip, pkgcommon.TarGz}},
 	{BinaryName: "fleet-server", ProjectName: "fleet-server", Platforms: AllPlatforms, PackageTypes: pkgcommon.AllPackageTypes},


### PR DESCRIPTION
The cloud-defend binary was accidentally removed from 8.x starting with 8.17.0 in the backport for https://github.com/elastic/elastic-agent/pull/6042/files, likely as part of merge conflict resolution.

## What does this PR do?

Includes the cloud-defend binary in the agent docker container again.

## Why is it important?

Defend for containers which is implemented by cloud-defend is still a supported product in 8.x.

## How to test this PR locally

```sh
DOCKER_VARIANTS=basic EXTERNAL=true SNAPSHOT=true PACKAGES=docker PLATFORMS=linux/arm64 mage package

docker run -it --entrypoint /bin/bash docker.elastic.co/beats/elastic-agent:8.18.0-SNAPSHOT
elastic-agent@240c9b878938:~$ ls data/elastic-agent-1f89c7/
components  elastic-agent  logs  otelcol  package.version
elastic-agent@240c9b878938:~$ ls data/elastic-agent-1f89c7/components/
LICENSE.txt                       bundle.tar.gz          lenses
NOTICE.pf-elastic-collector.txt   certs                  module
NOTICE.pf-elastic-symbolizer.txt  checksum.yml           osquery-extension.ext
NOTICE.pf-host-agent.txt          cloud-defend           osqueryd
NOTICE.txt                        cloud-defend.spec.yml  pf-elastic-collector
```

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/6469