### PR TITLE
Fix flaky test TestUpgradeHandlerSameVersion

### DIFF
--- a/internal/pkg/agent/application/actions/handlers/handler_action_upgrade_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_upgrade_test.go
@@ -123,14 +123,13 @@ func TestUpgradeHandler(t *testing.T) {
 
 	// Make sure this test does not dead lock or wait for too long
 	select {
-	case <-time.Tick(50 * time.Millisecond):
+	case <-time.Tick(1 * time.Second):
 		t.Fatal("mockUpgradeManager.Upgrade was not called")
 	case <-upgradeCalledChan:
 	}
 }
 
 func TestUpgradeHandlerSameVersion(t *testing.T) {
-	t.Skip("flaky test: https://github.com/elastic/elastic-agent/issues/5938")
 	// Create a cancellable context that will shut down the coordinator after
 	// the test.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -185,7 +184,7 @@ func TestUpgradeHandlerSameVersion(t *testing.T) {
 
 	// Make sure this test does not dead lock or wait for too long
 	select {
-	case <-time.Tick(50 * time.Millisecond):
+	case <-time.Tick(1 * time.Second):
 		t.Fatal("mockUpgradeManager.Upgrade was not called")
 	case <-upgradeCalledChan:
 	}


### PR DESCRIPTION
## What does this PR do?

Fix flaky test TestUpgradeHandlerSameVersion by increasing the maximum timeout to a generous 1 second. This does not extend the normal test execution time, so no reason to make this timeout too restrictive.

## Why is it important?

We don't want flaky tests.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/5938