### PR TITLE
fix(6235): added config provider that wraps otel provider and removes  non-otel fields from config

### DIFF
--- a/changelog/fragments/1736918570-remove-non-otel-config-in-config-providers.yaml
+++ b/changelog/fragments/1736918570-remove-non-otel-config-in-config-providers.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Added a wrapper for otel config providers that removes non-otel config properties
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/6481
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/6235

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -17,6 +17,8 @@ import (
 	"github.com/elastic/go-ucfg/cfgutil"
 )
 
+var OTelConfKeys []string = []string{"connectors", "receivers", "processors", "exporters", "extensions", "service"}
+
 // options hold the specified options
 type options struct {
 	otelKeys []string
@@ -51,7 +53,7 @@ var DefaultOptions = []interface{}{
 	ucfg.VarExp,
 	VarSkipKeys("inputs"),
 	ucfg.IgnoreCommas,
-	OTelKeys("connectors", "receivers", "processors", "exporters", "extensions", "service"),
+	OTelKeys(OTelConfKeys...),
 }
 
 // Config custom type that can provide both an Agent configuration alongside of an optional OTel configuration.

--- a/internal/pkg/otel/configprovider/provider.go
+++ b/internal/pkg/otel/configprovider/provider.go
@@ -1,11 +1,16 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package configprovider
 
 import (
 	"context"
 	"fmt"
 
-	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"go.opentelemetry.io/collector/confmap"
+
+	"github.com/elastic/elastic-agent/internal/pkg/config"
 )
 
 type provider struct {

--- a/internal/pkg/otel/configprovider/provider.go
+++ b/internal/pkg/otel/configprovider/provider.go
@@ -1,0 +1,67 @@
+package configprovider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/elastic/elastic-agent/internal/pkg/config"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+type provider struct {
+	otelConfProvider confmap.Provider
+}
+
+func NewFactory(otelPF func() confmap.ProviderFactory) confmap.ProviderFactory {
+	providerFunc := func(set confmap.ProviderSettings) confmap.Provider {
+		otelFactory := otelPF()
+		return &provider{
+			otelConfProvider: otelFactory.Create(set),
+		}
+	}
+
+	return confmap.NewProviderFactory(providerFunc)
+}
+
+func removeElasticFields(conf any) (map[string]interface{}, error) {
+	otelOnlyConf := map[string]interface{}{}
+	mapRaw, ok := conf.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("provided hybrid configuration is of type %T, expected map[string]interface{}", conf)
+	}
+
+	for _, key := range config.OTelConfKeys {
+		v, ok := mapRaw[key]
+		if ok {
+			otelOnlyConf[key] = v
+		}
+	}
+	return otelOnlyConf, nil
+}
+
+func (p *provider) Retrieve(ctx context.Context, uri string, watcher confmap.WatcherFunc) (*confmap.Retrieved, error) {
+	ret, err := p.otelConfProvider.Retrieve(ctx, uri, watcher)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := ret.AsRaw()
+	if err != nil {
+		return nil, err
+	}
+
+	otelOnlyConf, err := removeElasticFields(raw)
+	if err != nil {
+		return nil, fmt.Errorf("error removing elastic fields: %w", err)
+	}
+
+	return confmap.NewRetrieved(otelOnlyConf)
+}
+
+func (p *provider) Scheme() string {
+	return p.otelConfProvider.Scheme()
+}
+
+func (p *provider) Shutdown(ctx context.Context) error {
+	return p.otelConfProvider.Shutdown(ctx)
+}

--- a/internal/pkg/otel/configprovider/provider_test.go
+++ b/internal/pkg/otel/configprovider/provider_test.go
@@ -1,0 +1,35 @@
+package configprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elastic/elastic-agent/internal/pkg/config"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
+)
+
+func TestOTelConfigProvider(t *testing.T) {
+	t.Run("file-provider", func(t *testing.T) {
+		pf := NewFactory(fileprovider.NewFactory)
+		prSet := confmap.ProviderSettings{}
+		provider := pf.Create(prSet)
+		ret, err := provider.Retrieve(context.Background(), "file:./test-otel-config.yml", nil)
+		require.NoError(t, err)
+
+		raw, err := ret.AsRaw()
+		require.NoError(t, err)
+
+		mapRaw, ok := raw.(map[string]interface{})
+		require.True(t, ok)
+
+		for _, key := range config.OTelConfKeys {
+			_, ok := mapRaw[key]
+			if ok {
+				delete(mapRaw, key)
+			}
+		}
+		require.Equal(t, 0, len(mapRaw))
+	})
+}

--- a/internal/pkg/otel/configprovider/provider_test.go
+++ b/internal/pkg/otel/configprovider/provider_test.go
@@ -1,13 +1,18 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package configprovider
 
 import (
 	"context"
 	"testing"
 
-	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
+
+	"github.com/elastic/elastic-agent/internal/pkg/config"
 )
 
 func TestOTelConfigProvider(t *testing.T) {

--- a/internal/pkg/otel/configprovider/test-otel-config.yml
+++ b/internal/pkg/otel/configprovider/test-otel-config.yml
@@ -1,0 +1,47 @@
+filebeat.inputs:
+  - type: filestream
+    id: filestream-filebeat
+    enabled: true
+    paths:
+      - /tmp/filebeat.log
+output.elasticsearch:
+  hosts:
+    - https://esendpoint
+  api_key: api-key
+  index: filebeat-index
+
+receivers:
+  filebeatreceiver:
+    filebeat:
+      inputs:
+        - type: filestream
+          id: filestream-fbreceiver
+          enabled: true
+          paths:
+            - /tmp/fbreceiver.log
+    output:
+      otelconsumer:
+    logging:
+      level: info
+      selectors:
+        - "*"
+    path.home: /tmp
+    queue.mem.flush.timeout: 0s
+exporters:
+  elasticsearch/log:
+    endpoints:
+      - https://esendpoint
+    api_key: api-key
+    logs_index: fbreceiver-index
+    batcher:
+      enabled: true
+      flush_timeout: 1s
+    mapping:
+      mode: bodymap
+service:
+  pipelines:
+    logs:
+      receivers:
+        - filebeatreceiver
+      exporters:
+        - elasticsearch/log

--- a/internal/pkg/otel/run.go
+++ b/internal/pkg/otel/run.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/provider/envprovider"
+
 	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
 	"go.opentelemetry.io/collector/confmap/provider/httpprovider"
 	"go.opentelemetry.io/collector/confmap/provider/httpsprovider"
@@ -20,6 +21,7 @@ import (
 
 	"go.opentelemetry.io/collector/otelcol"
 
+	"github.com/elastic/elastic-agent/internal/pkg/otel/configprovider"
 	"github.com/elastic/elastic-agent/internal/pkg/release"
 )
 
@@ -83,12 +85,13 @@ func NewSettings(version string, configPaths []string, opts ...SettingOpt) *otel
 	}
 
 	providerFactories := []confmap.ProviderFactory{
-		fileprovider.NewFactory(),
-		envprovider.NewFactory(),
-		yamlprovider.NewFactory(),
-		httpprovider.NewFactory(),
-		httpsprovider.NewFactory(),
+		configprovider.NewFactory(fileprovider.NewFactory),
+		configprovider.NewFactory(envprovider.NewFactory),
+		configprovider.NewFactory(yamlprovider.NewFactory),
+		configprovider.NewFactory(httpprovider.NewFactory),
+		configprovider.NewFactory(httpsprovider.NewFactory),
 	}
+
 	providerFactories = append(providerFactories, o.resolverConfigProviders...)
 	var converterFactories []confmap.ConverterFactory
 	converterFactories = append(converterFactories, o.resolverConverterFactories...)

--- a/testing/integration/otel_validate_config_test.go
+++ b/testing/integration/otel_validate_config_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 package integration
 
 import (

--- a/testing/integration/otel_validate_config_test.go
+++ b/testing/integration/otel_validate_config_test.go
@@ -1,4 +1,9 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 //go:build integration
+
 package integration
 
 import (
@@ -9,8 +14,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/pkg/testing/define"
 )
 
 func TestOtelConfigVerification(t *testing.T) {

--- a/testing/integration/otel_validate_config_test.go
+++ b/testing/integration/otel_validate_config_test.go
@@ -1,0 +1,71 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOtelConfigVerification(t *testing.T) {
+	define.Require(t, define.Requirements{
+		Group: Default,
+		Local: true,
+	})
+
+	t.Run("file-provider", func(t *testing.T) {
+		fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
+		require.NoError(t, err)
+
+		out, err := fixture.Exec(context.Background(), []string{"otel", "validate", "--config=./test-otel-config.yml"})
+		require.NoError(t, err, string(out))
+	})
+
+	t.Run("env-provider", func(t *testing.T) {
+		fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
+		require.NoError(t, err)
+
+		envVarName := "TEST_OTEL_CONFIG"
+		testConf, err := os.ReadFile("./test-otel-config.yml")
+		require.NoError(t, err)
+
+		err = os.Setenv(envVarName, string(testConf))
+		require.NoError(t, err)
+		defer func() {
+			err := os.Unsetenv(envVarName)
+			require.NoError(t, err)
+		}()
+
+		out, err := fixture.Exec(context.Background(), []string{"otel", "validate", fmt.Sprintf("--config=env:%s", envVarName)})
+		require.NoError(t, err, string(out))
+	})
+
+	t.Run("yaml-provider", func(t *testing.T) {
+		fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
+		require.NoError(t, err)
+
+		out, err := fixture.Exec(context.Background(), []string{"otel", "validate", "--config=./test-otel-config.yml", "--config=yaml:testing::test::t: 1"})
+		require.NoError(t, err, out)
+	})
+
+	t.Run("http-provider", func(t *testing.T) {
+		fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
+		require.NoError(t, err)
+
+		testConf, err := os.ReadFile("./test-otel-config.yml")
+		require.NoError(t, err)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write(testConf)
+		}))
+		defer server.Close()
+
+		out, err := fixture.Exec(context.Background(), []string{"otel", "validate", fmt.Sprintf("--config=%s", server.URL)})
+		require.NoError(t, err, string(out))
+	})
+}

--- a/testing/integration/test-otel-config.yml
+++ b/testing/integration/test-otel-config.yml
@@ -1,0 +1,47 @@
+filebeat.inputs:
+  - type: filestream
+    id: filestream-filebeat
+    enabled: true
+    paths:
+      - /tmp/filebeat.log
+output.elasticsearch:
+  hosts:
+    - https://esendpoint
+  api_key: api-key
+  index: filebeat-index
+
+receivers:
+  filebeatreceiver:
+    filebeat:
+      inputs:
+        - type: filestream
+          id: filestream-fbreceiver
+          enabled: true
+          paths:
+            - /tmp/fbreceiver.log
+    output:
+      otelconsumer:
+    logging:
+      level: info
+      selectors:
+        - "*"
+    path.home: /tmp
+    queue.mem.flush.timeout: 0s
+exporters:
+  elasticsearch/log:
+    endpoints:
+      - https://esendpoint
+    api_key: api-key
+    logs_index: fbreceiver-index
+    batcher:
+      enabled: true
+      flush_timeout: 1s
+    mapping:
+      mode: bodymap
+service:
+  pipelines:
+    logs:
+      receivers:
+        - filebeatreceiver
+      exporters:
+        - elasticsearch/log


### PR DESCRIPTION
- Bug

## What does this PR do?

This PR adds a wrapper for otel config providers that removes the non-otel fields from the config. 

## Why is it important?

If a user tries to validate an otel-agent hybrid config file, or tries to start an elastic-agent in otel mode, they will run into config validation errors as the config file provided to the otel components contains elastic specific entries.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

None

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #6235 


