### PR TITLE
[k8s] fix hints stream missing ids

### DIFF
--- a/deploy/helm/elastic-agent/examples/kubernetes-hints-autodiscover/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/kubernetes-hints-autodiscover/rendered/manifest.yaml
@@ -564,6 +564,7 @@ stringData:
     providers:
       kubernetes:
         hints:
+          default_container_logs: false
           enabled: true
         node: ${NODE_NAME}
         scope: node
@@ -1081,7 +1082,7 @@ spec:
       labels:
         name: agent-pernode-example
       annotations:
-        checksum/config: 0df24cb5f7362916ba8cb10621b123918f22f52a7ce9f0b0514c5983de6d06f3
+        checksum/config: daca0d998edb3afa587d96e69b0833f6919ca6ba72f58f3a1f83b22d7e5ffaf6
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/examples/multiple-integrations/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/multiple-integrations/rendered/manifest.yaml
@@ -590,6 +590,7 @@ stringData:
     providers:
       kubernetes:
         hints:
+          default_container_logs: false
           enabled: true
         node: ${NODE_NAME}
         scope: node
@@ -1107,7 +1108,7 @@ spec:
       labels:
         name: agent-pernode-example
       annotations:
-        checksum/config: 0df24cb5f7362916ba8cb10621b123918f22f52a7ce9f0b0514c5983de6d06f3
+        checksum/config: daca0d998edb3afa587d96e69b0833f6919ca6ba72f58f3a1f83b22d7e5ffaf6
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_preset_pernode.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_preset_pernode.tpl
@@ -65,6 +65,11 @@ providers:
   kubernetes:
     hints:
       enabled: true
+{{- if (eq $.Values.kubernetes.containers.logs.enabled false) }}
+      default_container_logs: true
+{{- else }}
+      default_container_logs: false
+{{- end }}
 {{- end -}}
 
 {{- define "elasticagent.kubernetes.pernode.preset.tolerations" -}}

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/activemq.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/activemq.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.activemq.audit.enabled} == true or ${kubernetes.hints.activemq.enabled} == true
+          id: filestream-activemq-audit-${kubernetes.hints.container_id}
           data_stream:
             dataset: activemq.audit
             type: logs
@@ -27,6 +28,7 @@ inputs:
             - forwarded
             - activemq-audit
         - condition: ${kubernetes.hints.activemq.log.enabled} == true or ${kubernetes.hints.activemq.enabled} == true
+          id: filestream-activemq-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: activemq.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/apache.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/apache.yml
@@ -103,6 +103,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.apache.access.enabled} == true or ${kubernetes.hints.apache.enabled} == true
+          id: filestream-apache-access-${kubernetes.hints.container_id}
           data_stream:
             dataset: apache.access
             type: logs
@@ -124,6 +125,7 @@ inputs:
           tags:
             - apache-access
         - condition: ${kubernetes.hints.apache.error.enabled} == true or ${kubernetes.hints.apache.enabled} == true
+          id: filestream-apache-error-${kubernetes.hints.container_id}
           data_stream:
             dataset: apache.error
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/cassandra.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/cassandra.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.cassandra.log.enabled} == true or ${kubernetes.hints.cassandra.enabled} == true
+          id: filestream-cassandra-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: cassandra.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/cef.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/cef.yml
@@ -26,6 +26,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.cef.log.enabled} == true or ${kubernetes.hints.cef.enabled} == true
+          id: filestream-cef-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: cef.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/checkpoint.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/checkpoint.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.checkpoint.firewall.enabled} == true or ${kubernetes.hints.checkpoint.enabled} == true
+          id: filestream-checkpoint-firewall-${kubernetes.hints.container_id}
           data_stream:
             dataset: checkpoint.firewall
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/cockroachdb.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/cockroachdb.yml
@@ -28,6 +28,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.cockroachdb.container_logs.enabled} == true
+          id: filestream-cockroachdb-logs-${kubernetes.hints.container_id}
           data_stream:
             dataset: cockroachdb.container_logs
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/container_logs.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/container_logs.yml
@@ -5,6 +5,7 @@ inputs:
     use_output: default
     streams:
       - condition: ${kubernetes.hints.container_logs.enabled} == true
+        id: hints-filestream-container-logs-${kubernetes.hints.container_id}
         data_stream:
           dataset: kubernetes.container_logs
           type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/crowdstrike.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/crowdstrike.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.crowdstrike.falcon.enabled} == true or ${kubernetes.hints.crowdstrike.enabled} == true
+          id: filestream-crowdstrike-falcon-${kubernetes.hints.container_id}
           data_stream:
             dataset: crowdstrike.falcon
             type: logs
@@ -32,6 +33,7 @@ inputs:
             - forwarded
             - crowdstrike-falcon
         - condition: ${kubernetes.hints.crowdstrike.fdr.enabled} == true or ${kubernetes.hints.crowdstrike.enabled} == true
+          id: filestream-crowdstrike-fdr-${kubernetes.hints.container_id}
           data_stream:
             dataset: crowdstrike.fdr
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/cyberarkpas.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/cyberarkpas.yml
@@ -39,6 +39,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.cyberarkpas.audit.enabled} == true and ${kubernetes.hints.cyberarkpas.enabled} == true
+          id: filestream-cyberarkpas-audit-${kubernetes.hints.container_id}
           data_stream:
             dataset: cyberarkpas.audit
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/elasticsearch.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/elasticsearch.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.elasticsearch.audit.enabled} == true or ${kubernetes.hints.elasticsearch.enabled} == true
+          id: filestream-elasticsearch-audit-${kubernetes.hints.container_id}
           data_stream:
             dataset: elasticsearch.audit
             type: logs
@@ -49,6 +50,7 @@ inputs:
                     enabled: true
                 symlinks: true
         - condition: ${kubernetes.hints.elasticsearch.deprecation.enabled} == true or ${kubernetes.hints.elasticsearch.enabled} == true
+          id: filestream-elasticsearch-deprecation-${kubernetes.hints.container_id}
           data_stream:
             dataset: elasticsearch.deprecation
             type: logs
@@ -70,6 +72,7 @@ inputs:
                     enabled: true
                 symlinks: true
         - condition: ${kubernetes.hints.elasticsearch.gc.enabled} == true or ${kubernetes.hints.elasticsearch.enabled} == true
+          id: filestream-elasticsearch-gc-${kubernetes.hints.container_id}
           data_stream:
             dataset: elasticsearch.gc
             type: logs
@@ -103,6 +106,7 @@ inputs:
                     enabled: true
                 symlinks: true
         - condition: ${kubernetes.hints.elasticsearch.server.enabled} == true or ${kubernetes.hints.elasticsearch.enabled} == true
+          id: filestream-elasticsearch-server-${kubernetes.hints.container_id}
           data_stream:
             dataset: elasticsearch.server
             type: logs
@@ -125,6 +129,7 @@ inputs:
                     enabled: true
                 symlinks: true
         - condition: ${kubernetes.hints.elasticsearch.slowlog.enabled} == true or ${kubernetes.hints.elasticsearch.enabled} == true
+          id: filestream-elasticsearch-slowlog-${kubernetes.hints.container_id}
           data_stream:
             dataset: elasticsearch.slowlog
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/endpoint.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/endpoint.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.endpoint.container_logs.enabled} == true
+          id: filestream-endpoint-logs-${kubernetes.hints.container_id}
           data_stream:
             dataset: endpoint.container_logs
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/fireeye.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/fireeye.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.fireeye.nx.enabled} == true or ${kubernetes.hints.fireeye.enabled} == true
+          id: filestream-fireeye-nx-${kubernetes.hints.container_id}
           data_stream:
             dataset: fireeye.nx
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/haproxy.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/haproxy.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.haproxy.log.enabled} == true or ${kubernetes.hints.haproxy.enabled} == true
+          id: filestream-haproxy-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: haproxy.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/hashicorp_vault.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/hashicorp_vault.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.hashicorp_vault.audit.enabled} == true or ${kubernetes.hints.hashicorp_vault.enabled} == true
+          id: filestream-hashicorp_vault-audit-${kubernetes.hints.container_id}
           data_stream:
             dataset: hashicorp_vault.audit
             type: logs
@@ -26,6 +27,7 @@ inputs:
           tags:
             - hashicorp-vault-audit
         - condition: ${kubernetes.hints.hashicorp_vault.log.enabled} == true or ${kubernetes.hints.hashicorp_vault.enabled} == true
+          id: filestream-hashicorp_vault-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: hashicorp_vault.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/hid_bravura_monitor.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/hid_bravura_monitor.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.hid_bravura_monitor.log.enabled} == true or ${kubernetes.hints.hid_bravura_monitor.enabled} == true
+          id: filestream-hid_bravura_monitor-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: hid_bravura_monitor.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/iis.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/iis.yml
@@ -32,6 +32,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.iis.access.enabled} == true or ${kubernetes.hints.iis.enabled} == true
+          id: filestream-iis-access-${kubernetes.hints.container_id}
           data_stream:
             dataset: iis.access
             type: logs
@@ -56,6 +57,7 @@ inputs:
           tags:
             - iis-access
         - condition: ${kubernetes.hints.iis.error.enabled} == true or ${kubernetes.hints.iis.enabled} == true
+          id: filestream-iis-error-${kubernetes.hints.container_id}
           data_stream:
             dataset: iis.error
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/infoblox_nios.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/infoblox_nios.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.infoblox_nios.log.enabled} == true or ${kubernetes.hints.infoblox_nios.enabled} == true
+          id: filestream-infoblox_nios-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: infoblox_nios.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/iptables.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/iptables.yml
@@ -21,6 +21,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.iptables.log.enabled} == true and ${kubernetes.hints.iptables.enabled} == true
+          id: filestream-iptables-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: iptables.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/kafka.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/kafka.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.kafka.log.enabled} == true or ${kubernetes.hints.kafka.enabled} == true
+          id: filestream-kafka-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: kafka.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/keycloak.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/keycloak.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.keycloak.log.enabled} == true or ${kubernetes.hints.keycloak.enabled} == true
+          id: filestream-keycloak-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: keycloak.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/kibana.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/kibana.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.kibana.audit.enabled} == true or ${kubernetes.hints.kibana.enabled} == true
+          id: filestream-kibana-audit-${kubernetes.hints.container_id}
           data_stream:
             dataset: kibana.audit
             type: logs
@@ -24,6 +25,7 @@ inputs:
                     enabled: true
                 symlinks: true
         - condition: ${kubernetes.hints.kibana.log.enabled} == true or ${kubernetes.hints.kibana.enabled} == true
+          id: filestream-kibana-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: kibana.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/log.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/log.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.log.container_logs.enabled} == true
+          id: filestream-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: log.container_logs
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/logstash.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/logstash.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.logstash.log.enabled} == true or ${kubernetes.hints.logstash.enabled} == true
+          id: filestream-logstash-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: logstash.log
             type: logs
@@ -34,6 +35,7 @@ inputs:
                     enabled: true
                 symlinks: true
         - condition: ${kubernetes.hints.logstash.slowlog.enabled} == true or ${kubernetes.hints.logstash.enabled} == true
+          id: filestream-logstash-slowlog-${kubernetes.hints.container_id}
           data_stream:
             dataset: logstash.slowlog
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/mattermost.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/mattermost.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.mattermost.audit.enabled} == true or ${kubernetes.hints.mattermost.enabled} == true
+          id: filestream-mattermost-audit-${kubernetes.hints.container_id}
           data_stream:
             dataset: mattermost.audit
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/microsoft_sqlserver.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/microsoft_sqlserver.yml
@@ -18,6 +18,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.microsoft_sqlserver.log.enabled} == true or ${kubernetes.hints.microsoft_sqlserver.enabled} == true
+          id: filestream-microsoft_sqlserver-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: microsoft_sqlserver.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/mimecast.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/mimecast.yml
@@ -1073,6 +1073,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.mimecast.container_logs.enabled} == true
+          id: filestream-mimecast-logs-${kubernetes.hints.container_id}
           data_stream:
             dataset: mimecast.container_logs
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/modsecurity.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/modsecurity.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.modsecurity.auditlog.enabled} == true or ${kubernetes.hints.modsecurity.enabled} == true
+          id: filestream-modsecurity-auditlog-${kubernetes.hints.container_id}
           data_stream:
             dataset: modsecurity.auditlog
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/mongodb.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/mongodb.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.mongodb.log.enabled} == true or ${kubernetes.hints.mongodb.enabled} == true
+          id: filestream-mongodb-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: mongodb.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/mysql.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/mysql.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.mysql.error.enabled} == true or ${kubernetes.hints.mysql.enabled} == true
+          id: filestream-mysql-error-${kubernetes.hints.container_id}
           data_stream:
             dataset: mysql.error
             type: logs
@@ -30,6 +31,7 @@ inputs:
                     enabled: true
                 symlinks: true
         - condition: ${kubernetes.hints.mysql.slowlog.enabled} == true or ${kubernetes.hints.mysql.enabled} == true
+          id: filestream-mysql-slowlog-${kubernetes.hints.container_id}
           data_stream:
             dataset: mysql.slowlog
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/mysql_enterprise.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/mysql_enterprise.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.mysql_enterprise.audit.enabled} == true or ${kubernetes.hints.mysql_enterprise.enabled} == true
+          id: filestream-mysql_enterprise-audit-${kubernetes.hints.container_id}
           data_stream:
             dataset: mysql_enterprise.audit
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/nats.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/nats.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.nats.log.enabled} == true or ${kubernetes.hints.nats.enabled} == true
+          id: filestream-nats-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: nats.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/netflow.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/netflow.yml
@@ -32,6 +32,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.netflow.container_logs.enabled} == true
+          id: filestream-netflow-logs-${kubernetes.hints.container_id}
           data_stream:
             dataset: netflow.container_logs
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/nginx.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/nginx.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.nginx.access.enabled} == true or ${kubernetes.hints.nginx.enabled} == true
+          id: filestream-nginx-access-${kubernetes.hints.container_id}
           data_stream:
             dataset: nginx.access
             type: logs
@@ -29,6 +30,7 @@ inputs:
           tags:
             - nginx-access
         - condition: ${kubernetes.hints.nginx.error.enabled} == true or ${kubernetes.hints.nginx.enabled} == true
+          id: filestream-nginx-error-${kubernetes.hints.container_id}
           data_stream:
             dataset: nginx.error
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/nginx_ingress_controller.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/nginx_ingress_controller.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.nginx_ingress_controller.access.enabled} == true or ${kubernetes.hints.nginx_ingress_controller.enabled} == true
+          id: filestream-nginx_ingress_controller-access-${kubernetes.hints.container_id}
           data_stream:
             dataset: nginx_ingress_controller.access
             type: logs
@@ -22,6 +23,7 @@ inputs:
           tags:
             - nginx-ingress-controller-access
         - condition: ${kubernetes.hints.nginx_ingress_controller.error.enabled} == true or ${kubernetes.hints.nginx_ingress_controller.enabled} == true
+          id: filestream-nginx_ingress_controller-error-${kubernetes.hints.container_id}
           data_stream:
             dataset: nginx_ingress_controller.error
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/oracle.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/oracle.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.oracle.database_audit.enabled} == true or ${kubernetes.hints.oracle.enabled} == true
+          id: filestream-oracle-audit-${kubernetes.hints.container_id}
           data_stream:
             dataset: oracle.database_audit
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/panw.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/panw.yml
@@ -78,6 +78,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.panw.panos.enabled} == true or ${kubernetes.hints.panw.enabled} == true
+          id: filestream-panw-panos-${kubernetes.hints.container_id}
           data_stream:
             dataset: panw.panos
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/panw_cortex_xdr.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/panw_cortex_xdr.yml
@@ -74,6 +74,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.panw_cortex_xdr.container_logs.enabled} == true
+          id: filestream-panw_cortex_xdr-logs-${kubernetes.hints.container_id}
           data_stream:
             dataset: panw_cortex_xdr.container_logs
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/pfsense.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/pfsense.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.pfsense.container_logs.enabled} == true
+          id: filestream-pfsense-logs-${kubernetes.hints.container_id}
           data_stream:
             dataset: pfsense.container_logs
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/postgresql.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/postgresql.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.postgresql.log.enabled} == true or ${kubernetes.hints.postgresql.enabled} == true
+          id: filestream-postgresql-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: postgresql.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/prometheus.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/prometheus.yml
@@ -72,6 +72,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.prometheus.container_logs.enabled} == true
+          id: filestream-prometheus-logs-${kubernetes.hints.container_id}
           data_stream:
             dataset: prometheus.container_logs
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/qnap_nas.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/qnap_nas.yml
@@ -45,6 +45,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.qnap_nas.container_logs.enabled} == true
+          id: filestream-qnap_nas-logs-${kubernetes.hints.container_id}
           data_stream:
             dataset: qnap_nas.container_logs
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/rabbitmq.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/rabbitmq.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.rabbitmq.log.enabled} == true or ${kubernetes.hints.rabbitmq.enabled} == true
+          id: filestream-rabbitmq-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: rabbitmq.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/redis.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/redis.yml
@@ -66,6 +66,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.redis.log.enabled} == true or ${kubernetes.hints.redis.enabled} == true
+          id: filestream-redis-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: redis.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/santa.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/santa.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.santa.log.enabled} == true or ${kubernetes.hints.santa.enabled} == true
+          id: filestream-santa-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: santa.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/security_detection_engine.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/security_detection_engine.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.security_detection_engine.container_logs.enabled} == true
+          id: filestream-security_detection_engine-logs-${kubernetes.hints.container_id}
           data_stream:
             dataset: security_detection_engine.container_logs
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/sentinel_one.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/sentinel_one.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.sentinel_one.container_logs.enabled} == true
+          id: filestream-sentinel_one-logs-${kubernetes.hints.container_id}
           data_stream:
             dataset: sentinel_one.container_logs
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/snort.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/snort.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.snort.log.enabled} == true or ${kubernetes.hints.snort.enabled} == true
+          id: filestream-snort-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: snort.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/snyk.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/snyk.yml
@@ -123,6 +123,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.snyk.container_logs.enabled} == true
+          id: filestream-snyk-logs-${kubernetes.hints.container_id}
           data_stream:
             dataset: snyk.container_logs
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/stan.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/stan.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.stan.log.enabled} == true or ${kubernetes.hints.stan.enabled} == true
+          id: filestream-stan-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: stan.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/suricata.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/suricata.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.suricata.eve.enabled} == true or ${kubernetes.hints.suricata.enabled} == true
+          id: filestream-suricata-eve-${kubernetes.hints.container_id}
           data_stream:
             dataset: suricata.eve
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/symantec_endpoint.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/symantec_endpoint.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.symantec_endpoint.log.enabled} == true and ${kubernetes.hints.symantec_endpoint.enabled} == true
+          id: filestream-symantec_endpoint-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: symantec_endpoint.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/synthetics.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/synthetics.yml
@@ -117,6 +117,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.synthetics.container_logs.enabled} == true
+          id: filestream-synthetics-logs-${kubernetes.hints.container_id}
           data_stream:
             dataset: synthetics.container_logs
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/tcp.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/tcp.yml
@@ -17,6 +17,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.tcp.container_logs.enabled} == true
+          id: filestream-tcp-${kubernetes.hints.container_id}
           data_stream:
             dataset: tcp.container_logs
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/tomcat.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/tomcat.yml
@@ -5531,6 +5531,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.tomcat.log.enabled} == true and ${kubernetes.hints.tomcat.enabled} == true
+          id: filestream-tomcat-log-${kubernetes.hints.container_id}
           data_stream:
             dataset: tomcat.log
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/traefik.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/traefik.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.traefik.access.enabled} == true or ${kubernetes.hints.traefik.enabled} == true
+          id: filestream-traefik-access-${kubernetes.hints.container_id}
           data_stream:
             dataset: traefik.access
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/udp.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/udp.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.udp.container_logs.enabled} == true
+          id: filestream-udp-logs-${kubernetes.hints.container_id}
           data_stream:
             dataset: udp.container_logs
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/zeek.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/zeek.yml
@@ -5,6 +5,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.zeek.capture_loss.enabled} == true or ${kubernetes.hints.zeek.enabled} == true
+          id: filestream-zeek-loss-${kubernetes.hints.container_id}
           data_stream:
             dataset: zeek.capture_loss
             type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/templates.d/zookeeper.yml
+++ b/deploy/kubernetes/elastic-agent-standalone/templates.d/zookeeper.yml
@@ -38,6 +38,7 @@ inputs:
       use_output: default
       streams:
         - condition: ${kubernetes.hints.zookeeper.container_logs.enabled} == true
+          id: filestream-zookeeper-logs-${kubernetes.hints.container_id}
           data_stream:
             dataset: zookeeper.container_logs
             type: logs


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

After [this PR](https://github.com/elastic/beats/pull/41954) got merged our k8s [CI test started failing](https://buildkite.com/elastic/elastic-agent-extended-testing/builds/5958#01943e1b-bb24-43f8-8da0-2da5f265e1ab/60-358). After investigating I realised that all the hint-based inputs are lacking streams IDs in the respective filestream inputs resulting in all of them registering with an empty ID and thus colliding. Also, during this investigation, I realised that by default when hints are enabled are capturing the logs of containers that do not feature a hints-related annotation. Thus I updated the Helm chart to explicitly disable the former when both the contailer logs of kubernetes integration and hints are enabled. 

A fix should also happen in the actual job that fabricates and introduces these templates

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Because it fixes an actual bug and it brings the CI back to green 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->
None

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
mage integration:auth
PLATFORMS=linux/arm64 EXTERNAL=true SNAPSHOT=true PACKAGES=docker mage -v package 
INSTANCE_PROVISIONER=kind STACK_PROVISIONER=stateful K8S_VERSION=v1.31.1 SNAPSHOT=true mage integration:kubernetes
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
N/A
