### PR TITLE
Add feature flags for running beats as OTel receivers

### DIFF
--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -186,3 +186,73 @@ agent:
 		})
 	}
 }
+
+func TestMonitoringWithOtelFlag(t *testing.T) {
+	tcs := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{
+			name: "flag missing",
+			yaml: `
+agent:
+  features:`,
+			want: false,
+		},
+		{
+			name: "flag empty",
+			yaml: `
+agent:
+  features:
+    monitoring_with_otel:`,
+			want: false,
+		},
+		{
+			name: "flag not specified",
+			yaml: `
+agent:
+  features:
+    monitoring_with_otel: {}`,
+			want: false,
+		},
+		{
+			name: "flag disabled",
+			yaml: `
+agent:
+  features:
+    monitoring_with_otel:
+      enabled: false`,
+			want: false,
+		},
+		{
+			name: "flag enabled",
+			yaml: `
+agent:
+  features:
+    monitoring_with_otel:
+      enabled: true`,
+			want: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+
+			c, err := config.NewConfigFrom(tc.yaml)
+			if err != nil {
+				t.Fatalf("could not parse config YAML: %v", err)
+			}
+
+			err = Apply(c)
+			if err != nil {
+				t.Fatalf("Apply failed: %v", err)
+			}
+
+			got := MonitoringWithOtel()
+			if got != tc.want {
+				t.Errorf("want: %t, got %t", tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -116,3 +116,73 @@ func TestFQDNCallbacks(t *testing.T) {
 	RemoveFQDNOnChangeCallback("cb2")
 	require.Len(t, current.fqdnCallbacks, 0)
 }
+
+func TestBeatsAsOtelReceiversFlag(t *testing.T) {
+	tcs := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{
+			name: "flag missing",
+			yaml: `
+agent:
+  features:`,
+			want: false,
+		},
+		{
+			name: "flag empty",
+			yaml: `
+agent:
+  features:
+    beats_as_otel_receivers:`,
+			want: false,
+		},
+		{
+			name: "flag not specified",
+			yaml: `
+agent:
+  features:
+    beats_as_otel_receivers: {}`,
+			want: false,
+		},
+		{
+			name: "flag disabled",
+			yaml: `
+agent:
+  features:
+    beats_as_otel_receivers:
+      enabled: false`,
+			want: false,
+		},
+		{
+			name: "flag enabled",
+			yaml: `
+agent:
+  features:
+    beats_as_otel_receivers:
+      enabled: true`,
+			want: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+
+			c, err := config.NewConfigFrom(tc.yaml)
+			if err != nil {
+				t.Fatalf("could not parse config YAML: %v", err)
+			}
+
+			err = Apply(c)
+			if err != nil {
+				t.Fatalf("Apply failed: %v", err)
+			}
+
+			got := BeatsAsOtelReceivers()
+			if got != tc.want {
+				t.Errorf("want: %t, got %t", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION

## What does this PR do?

Adds new Agent feature flag "beats_as_otel_receivers". This is for internal usage only. No documentation or changelog is added for this.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~