### PR TITLE
Run integration tests on changes to K8s packaging

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -274,6 +274,7 @@ steps:
                 - internal/
                 - dev-tools/
                 - pkg/
+                - deploy/
                 - testing/
                 - version/
                 - specs/


### PR DESCRIPTION
## What does this PR do?

Run integration tests on changes to K8s packaging. Ideally we'd only run the k8s integration tests here, but all of them will do for now.

## Why is it important?

We shouldn't merge changes to K8s packaging without integration tests passing.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
