### PR TITLE
Add batch aggregator before lsm interval processor

### DIFF
--- a/internal/pkg/otel/samples/darwin/logs_metrics_traces.yml
+++ b/internal/pkg/otel/samples/darwin/logs_metrics_traces.yml
@@ -340,6 +340,9 @@ processors:
           - set(resource.attributes["metricset.interval"], "60m")
           - set(attributes["data_stream.dataset"], Concat([attributes["metricset.name"], "60m"], "."))
           - set(attributes["processor.event"], "metric")
+  batch/aggs:
+    send_batch_size: 16384 # 2x the default
+    timeout: 10s
 
 exporters:
   elasticsearch/ecs:
@@ -386,7 +389,7 @@ service:
 
     metrics/aggregated-metrics:
       receivers: [signaltometrics]
-      processors: [lsminterval]
+      processors: [batch/aggs, lsminterval]
       exporters: [elasticsearch/otel]
 
     logs/fromsdk:

--- a/internal/pkg/otel/samples/linux/logs_metrics_traces.yml
+++ b/internal/pkg/otel/samples/linux/logs_metrics_traces.yml
@@ -347,6 +347,9 @@ processors:
           - set(resource.attributes["metricset.interval"], "60m")
           - set(attributes["data_stream.dataset"], Concat([attributes["metricset.name"], "60m"], "."))
           - set(attributes["processor.event"], "metric")
+  batch/aggs:
+    send_batch_size: 16384 # 2x the default
+    timeout: 10s
 
 exporters:
   elasticsearch/ecs:
@@ -393,7 +396,7 @@ service:
 
     metrics/aggregated-metrics:
       receivers: [signaltometrics]
-      processors: [lsminterval]
+      processors: [batch/aggs, lsminterval]
       exporters: [elasticsearch/otel]
 
     logs/fromsdk:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Adds batch processor before lsm interval processor. This reduces the merge operation that lsm interval processor needs to perform and improves performance.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

To improve performance of lsm interval processor. For more details checkout https://github.com/elastic/opentelemetry-collector-components/issues/211
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/opentelemetry-collector-components/issues/211

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
