### PR TITLE
fix(6235): added long description for the validate command

### DIFF
--- a/internal/pkg/agent/cmd/validate.go
+++ b/internal/pkg/agent/cmd/validate.go
@@ -17,6 +17,7 @@ func newValidateCommandWithArgs(_ []string, _ *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "validate",
 		Short:         "Validates the OpenTelemetry collector configuration without running the collector",
+		Long:          "Validates the OpenTelemetry collector configuration without running the collector. Validation will fail for otel-elastic hybrid configuration files. This command will return true for valid otel configurations only.",
 		SilenceUsage:  true, // do not display usage on error
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {


### PR DESCRIPTION
- Enhancement

## What does this PR do?
Adds help message explaining what exactly the otel validation command validates

## Why is it important?
Otel validation fails for otel-elastic hybrid config files. This is the intended behaviour. This PR adds command help message that explains this.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

None

## How to test this PR locally

Run `elastic-agent validate --help`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #6235 
