### PR TITLE
Support VERSION_QUALIFIER for elastic-agent-core DRA

### DIFF
--- a/.buildkite/pipeline.elastic-agent-binary-dra.yml
+++ b/.buildkite/pipeline.elastic-agent-binary-dra.yml
@@ -10,7 +10,8 @@ env:
 steps:
   - group: ":beats: DRA Elastic-Agent Core Snapshot :beats:"
     key: "dra-core-snapshot"
-    if: build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/ || build.env("RUN_SNAPSHOT") == "true"
+    # don't run snapshot builds with prereleases (non empty VERSION_QUALIFIER) unless forced (RUN_SNAPSHOT=true)
+    if: build.env("RUN_SNAPSHOT") == "true" || (build.env('VERSION_QUALIFIER') == null && (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/))
     steps:
     - label: ":package: Build Elastic-Agent Core Snapshot"
       commands:
@@ -43,7 +44,7 @@ steps:
 
   - group: ":beats: DRA Elastic-Agent Core Staging :beats:"
     key: "dra-core-staging"
-    if: build.branch =~ /^[0-9]+\.[0-9x]+\$/ || build.env("RUN_STAGING") == "true"
+    if: build.branch =~ /^[0-9]+\.[0-9x]+\$/ || build.env("RUN_STAGING") == "true" || build.env('VERSION_QUALIFIER') != null
     steps:
     - label: ":package: Build Elastic-Agent Core staging"
       commands:

--- a/.buildkite/scripts/steps/build-agent-core.sh
+++ b/.buildkite/scripts/steps/build-agent-core.sh
@@ -6,10 +6,16 @@ source .buildkite/scripts/common.sh
 
 echo "+++ Build Agent artifacts"
 SNAPSHOT=""
+VERSION_QUALIFIER="${VERSION_QUALIFIER:=""}"
 BEAT_VERSION_FULL=$BEAT_VERSION
+
 if [ "$DRA_WORKFLOW" == "snapshot" ]; then
     SNAPSHOT="true"
     BEAT_VERSION_FULL="${BEAT_VERSION}-SNAPSHOT"
+fi
+
+if [[ "$DRA_WORKFLOW" == "staging" ]] && [[ -n "$VERSION_QUALIFIER" ]]; then
+    BEAT_VERSION_FULL="${BEAT_VERSION_FULL}-${VERSION_QUALIFIER}"
 fi
 
 SNAPSHOT=$SNAPSHOT mage packageAgentCore

--- a/.buildkite/scripts/steps/dra-publish.sh
+++ b/.buildkite/scripts/steps/dra-publish.sh
@@ -7,6 +7,7 @@ WORKFLOW="${DRA_WORKFLOW:=""}"
 COMMIT="${DRA_COMMIT:="${BUILDKITE_COMMIT:=""}"}"
 BRANCH="${DRA_BRANCH:="${BUILDKITE_BRANCH:=""}"}"
 PACKAGE_VERSION="${DRA_VERSION:="${BEAT_VERSION:=""}"}"
+VERSION_QUALIFIER="${VERSION_QUALIFIER:=""}"
 
 # force main branch on PR's or it won't execute
 # because the PR branch does not have a project folder in release-manager
@@ -50,7 +51,8 @@ function run_release_manager_list() {
         --commit "${_commit}" \
         --workflow "${_workflow}" \
         --version "${_version}" \
-        --artifact-set "${_artifact_set}"
+        --artifact-set "${_artifact_set}" \
+        --qualifier "${VERSION_QUALIFIER}"
 }
 
 # Publish DRA artifacts
@@ -71,10 +73,11 @@ function run_release_manager_collect() {
         --workflow "${_workflow}" \
         --version "${_version}" \
         --artifact-set "${_artifact_set}" \
+        --qualifier "${VERSION_QUALIFIER}"
         ${_dry_run}
 }
 
-echo "+++ Release Manager ${WORKFLOW} / ${BRANCH} / ${COMMIT}";
+echo "+++ Release Manager Workflow: ${WORKFLOW} / Branch: ${BRANCH} / VERSION_QUALIFIER: ${VERSION_QUALIFIER} / Commit: ${COMMIT}"
 run_release_manager_list "${DRA_PROJECT_ID}" "${DRA_PROJECT_ARTIFACT_ID}" "${WORKFLOW}" "${COMMIT}" "${BRANCH}" "${PACKAGE_VERSION}"
 run_release_manager_collect "${DRA_PROJECT_ID}" "${DRA_PROJECT_ARTIFACT_ID}" "${WORKFLOW}" "${COMMIT}" "${BRANCH}" "${PACKAGE_VERSION}" "${DRY_RUN}"
 RM_EXIT_CODE=$?


### PR DESCRIPTION
## What does this PR do?

This commit adds support for the optional VERSION_QUALIFIER for the elastic-agent-core staging DRA builds.

## Why is it important?

Allow building prerelease artifacts

## How to test this PR locally

staging alpha1 artifact built from this PR -> https://buildkite.com/elastic/elastic-agent-binary-dra/builds/2013

snapshot build using `RUN_SNAPSHOT="true"` and `DRA_BRANCH="main"` -> https://buildkite.com/elastic/elastic-agent-binary-dra/builds/2014
 
## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/6543
