### PR TITLE
Fail fast dra publish on errors

### DIFF
--- a/.buildkite/scripts/steps/dra-publish.sh
+++ b/.buildkite/scripts/steps/dra-publish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -uo pipefail
+set -euo pipefail
 
 DRY_RUN="${DRA_DRY_RUN:=""}"
 WORKFLOW="${DRA_WORKFLOW:=""}"


### PR DESCRIPTION
## What does this PR do?

This commit ensures that the DRA publish BK steps fails fast when there is an error.

## Why is it important?

Ensures that failing DRA builds are silently failing: https://buildkite.com/elastic/elastic-agent-package/builds/3861#019483f1-cb95-4515-aa84-a67de114bf16/281-355

## Related issues

- Relates: #6523 
