### PR TITLE
Switch k8s input paths to /var/log/pods/* to ingest rotated container logs

### DIFF
--- a/deploy/helm/elastic-agent/examples/eck/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/eck/rendered/manifest.yaml
@@ -321,13 +321,13 @@ stringData:
         - data_stream:
             dataset: kubernetes.container_logs
             type: logs
-          id: kubernetes-container-logs-${kubernetes.pod.name}-${kubernetes.container.id}
+          id: kubernetes-container-logs-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
           parsers:
           - container:
               format: auto
               stream: all
           paths:
-          - /var/log/containers/*${kubernetes.container.id}.log
+          - /var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log
           processors:
           - add_fields:
               fields:

--- a/deploy/helm/elastic-agent/examples/kubernetes-default/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/kubernetes-default/rendered/manifest.yaml
@@ -320,13 +320,13 @@ stringData:
         - data_stream:
             dataset: kubernetes.container_logs
             type: logs
-          id: kubernetes-container-logs-${kubernetes.pod.name}-${kubernetes.container.id}
+          id: kubernetes-container-logs-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
           parsers:
           - container:
               format: auto
               stream: all
           paths:
-          - /var/log/containers/*${kubernetes.container.id}.log
+          - /var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log
           processors:
           - add_fields:
               fields:
@@ -888,7 +888,7 @@ spec:
       labels:
         name: agent-pernode-example
       annotations:
-        checksum/config: 233affcd72143e637a130b5f099c30e194d90042eb00a26512f51c844c65a821
+        checksum/config: 0a02c8b3783f5e072f6eb62d87c3fefb2df9cdaf8efb7dbda9bcc11050246c3d
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/examples/kubernetes-hints-autodiscover/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/kubernetes-hints-autodiscover/rendered/manifest.yaml
@@ -320,13 +320,13 @@ stringData:
         - data_stream:
             dataset: kubernetes.container_logs
             type: logs
-          id: kubernetes-container-logs-${kubernetes.pod.name}-${kubernetes.container.id}
+          id: kubernetes-container-logs-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
           parsers:
           - container:
               format: auto
               stream: all
           paths:
-          - /var/log/containers/*${kubernetes.container.id}.log
+          - /var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log
           processors:
           - add_fields:
               fields:
@@ -891,7 +891,7 @@ spec:
       labels:
         name: agent-pernode-example
       annotations:
-        checksum/config: daca0d998edb3afa587d96e69b0833f6919ca6ba72f58f3a1f83b22d7e5ffaf6
+        checksum/config: 440922798e9423e250298ce729018751f6a9d3343a03f3e54f93380e932acdfe
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/examples/kubernetes-ksm-sharding/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/kubernetes-ksm-sharding/rendered/manifest.yaml
@@ -132,13 +132,13 @@ stringData:
         - data_stream:
             dataset: kubernetes.container_logs
             type: logs
-          id: kubernetes-container-logs-${kubernetes.pod.name}-${kubernetes.container.id}
+          id: kubernetes-container-logs-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
           parsers:
           - container:
               format: auto
               stream: all
           paths:
-          - /var/log/containers/*${kubernetes.container.id}.log
+          - /var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log
           processors:
           - add_fields:
               fields:
@@ -949,7 +949,7 @@ spec:
       labels:
         name: agent-pernode-example
       annotations:
-        checksum/config: 05797fdfdd3cdeefb99e39e0f4756a6b812465509b31195ff57ae3925aa5e087
+        checksum/config: 916336da56b9ea407c8b613a721335c42af4fb6df724f54d0f301e6c193b8e4e
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/examples/kubernetes-only-logs/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/kubernetes-only-logs/rendered/manifest.yaml
@@ -49,13 +49,13 @@ stringData:
         - data_stream:
             dataset: kubernetes.container_logs
             type: logs
-          id: kubernetes-container-logs-${kubernetes.pod.name}-${kubernetes.container.id}
+          id: kubernetes-container-logs-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
           parsers:
           - container:
               format: auto
               stream: all
           paths:
-          - /var/log/containers/*${kubernetes.container.id}.log
+          - /var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log
           processors:
           - add_fields:
               fields:
@@ -223,7 +223,7 @@ spec:
       labels:
         name: agent-pernode-example
       annotations:
-        checksum/config: 0840dcdf026f64cefb7aa69f420bc923d7e2d7d6e9a239e107fd2684e309d8ae
+        checksum/config: 7c35f814b93d366f98c472a618bd968083df7c07072b6e510cbb71ad26b0b6ab
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/examples/multiple-integrations/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/multiple-integrations/rendered/manifest.yaml
@@ -346,13 +346,13 @@ stringData:
         - data_stream:
             dataset: kubernetes.container_logs
             type: logs
-          id: kubernetes-container-logs-${kubernetes.pod.name}-${kubernetes.container.id}
+          id: kubernetes-container-logs-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
           parsers:
           - container:
               format: auto
               stream: all
           paths:
-          - /var/log/containers/*${kubernetes.container.id}.log
+          - /var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log
           processors:
           - add_fields:
               fields:
@@ -917,7 +917,7 @@ spec:
       labels:
         name: agent-pernode-example
       annotations:
-        checksum/config: daca0d998edb3afa587d96e69b0833f6919ca6ba72f58f3a1f83b22d7e5ffaf6
+        checksum/config: 440922798e9423e250298ce729018751f6a9d3343a03f3e54f93380e932acdfe
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/examples/user-service-account/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/user-service-account/rendered/manifest.yaml
@@ -296,13 +296,13 @@ stringData:
         - data_stream:
             dataset: kubernetes.container_logs
             type: logs
-          id: kubernetes-container-logs-${kubernetes.pod.name}-${kubernetes.container.id}
+          id: kubernetes-container-logs-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
           parsers:
           - container:
               format: auto
               stream: all
           paths:
-          - /var/log/containers/*${kubernetes.container.id}.log
+          - /var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log
           processors:
           - add_fields:
               fields:
@@ -868,7 +868,7 @@ spec:
       labels:
         name: agent-pernode-example
       annotations:
-        checksum/config: 233affcd72143e637a130b5f099c30e194d90042eb00a26512f51c844c65a821
+        checksum/config: 0a02c8b3783f5e072f6eb62d87c3fefb2df9cdaf8efb7dbda9bcc11050246c3d
     spec:
       automountServiceAccountToken: true
       containers:

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_logs_containers.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_logs_containers.tpl
@@ -16,12 +16,12 @@ Config input for container logs
     namespace: {{ .Values.kubernetes.namespace }}
   use_output: {{ .Values.kubernetes.output }}
   streams:
-  - id: kubernetes-container-logs-${kubernetes.pod.name}-${kubernetes.container.id}
+  - id: kubernetes-container-logs-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
     data_stream:
       dataset: kubernetes.container_logs
       type: logs
     paths:
-      - '/var/log/containers/*${kubernetes.container.id}.log'
+      - '/var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log'
     prospector.scanner.symlinks: {{ dig "vars" "symlinks" true .Values.kubernetes.containers.logs }}
     parsers:
       - container:

--- a/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-daemonset-configmap.yaml
@@ -354,7 +354,7 @@ data:
             condition: '${host.platform} == ''windows'''
             ignore_older: 72h
       # Input ID allowing Elastic Agent to track the state of this input. Must be unique.
-      - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.id}
+      - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
         type: filestream
         use_output: default
         meta:
@@ -366,7 +366,7 @@ data:
         streams:
           # Stream ID for this data stream allowing Filebeat to track the state of the ingested files. Must be unique.
           # Each filestream data stream creates a separate instance of the Filebeat filestream input.
-          - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.id}
+          - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
             data_stream:
               dataset: kubernetes.container_logs
               type: logs

--- a/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-daemonset-configmap.yaml
@@ -354,7 +354,7 @@ data:
             condition: '${host.platform} == ''windows'''
             ignore_older: 72h
       # Input ID allowing Elastic Agent to track the state of this input. Must be unique.
-      - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
+      - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.id}
         type: filestream
         use_output: default
         meta:
@@ -366,7 +366,7 @@ data:
         streams:
           # Stream ID for this data stream allowing Filebeat to track the state of the ingested files. Must be unique.
           # Each filestream data stream creates a separate instance of the Filebeat filestream input.
-          - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
+          - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.id}
             data_stream:
               dataset: kubernetes.container_logs
               type: logs
@@ -381,7 +381,7 @@ data:
               #     negate: true
               #     match: after
             paths:
-              - /var/log/containers/*${kubernetes.container.id}.log
+              - /var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log
       - id: audit-log
         type: filestream
         use_output: default

--- a/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-ksm-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-ksm-daemonset-configmap.yaml
@@ -122,7 +122,7 @@ data:
               dataset: system.system
             condition: '${host.platform} == ''windows'''
             ignore_older: 72h
-      - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
+      - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
         type: filestream
         use_output: default
         meta:
@@ -146,7 +146,7 @@ data:
               #     negate: true
               #     match: after
             paths:
-              - /var/log/containers/*${kubernetes.container.id}.log
+              - /var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log
       - id: audit-log
         type: filestream
         use_output: default

--- a/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/base/elastic-agent-standalone-ksm-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/base/elastic-agent-standalone-ksm-daemonset-configmap.yaml
@@ -122,7 +122,7 @@ data:
               dataset: system.system
             condition: '${host.platform} == ''windows'''
             ignore_older: 72h
-      - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
+      - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
         type: filestream
         use_output: default
         meta:
@@ -146,7 +146,7 @@ data:
               #     negate: true
               #     match: after
             paths:
-              - /var/log/containers/*${kubernetes.container.id}.log
+              - /var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log
       - id: audit-log
         type: filestream
         use_output: default

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -363,7 +363,7 @@ data:
         streams:
           # Stream ID for this data stream allowing Filebeat to track the state of the ingested files. Must be unique.
           # Each filestream data stream creates a separate instance of the Filebeat filestream input.
-          - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
+          - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.id}
             data_stream:
               dataset: kubernetes.container_logs
               type: logs
@@ -378,7 +378,7 @@ data:
               #     negate: true
               #     match: after
             paths:
-              - /var/log/containers/*${kubernetes.container.id}.log
+              - /var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log
       - id: audit-log
         type: filestream
         use_output: default

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -351,7 +351,7 @@ data:
             condition: '${host.platform} == ''windows'''
             ignore_older: 72h
       # Input ID allowing Elastic Agent to track the state of this input. Must be unique.
-      - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
+      - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
         type: filestream
         use_output: default
         meta:
@@ -363,7 +363,7 @@ data:
         streams:
           # Stream ID for this data stream allowing Filebeat to track the state of the ingested files. Must be unique.
           # Each filestream data stream creates a separate instance of the Filebeat filestream input.
-          - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.id}
+          - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
             data_stream:
               dataset: kubernetes.container_logs
               type: logs

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
@@ -351,7 +351,7 @@ data:
             condition: '${host.platform} == ''windows'''
             ignore_older: 72h
       # Input ID allowing Elastic Agent to track the state of this input. Must be unique.
-      - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
+      - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
         type: filestream
         use_output: default
         meta:
@@ -363,7 +363,7 @@ data:
         streams:
           # Stream ID for this data stream allowing Filebeat to track the state of the ingested files. Must be unique.
           # Each filestream data stream creates a separate instance of the Filebeat filestream input.
-          - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
+          - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
             data_stream:
               dataset: kubernetes.container_logs
               type: logs
@@ -378,7 +378,7 @@ data:
               #     negate: true
               #     match: after
             paths:
-              - /var/log/containers/*${kubernetes.container.id}.log
+              - /var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log
       - id: audit-log
         type: filestream
         use_output: default

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-ksm-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-ksm-daemonset-configmap.yaml
@@ -122,7 +122,7 @@ data:
               dataset: system.system
             condition: '${host.platform} == ''windows'''
             ignore_older: 72h
-      - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
+      - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
         type: filestream
         use_output: default
         meta:
@@ -146,7 +146,7 @@ data:
               #     negate: true
               #     match: after
             paths:
-              - /var/log/containers/*${kubernetes.container.id}.log
+              - /var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log
       - id: audit-log
         type: filestream
         use_output: default

--- a/dev-tools/kubernetes/base/elastic-agent-standalone/config-map.yaml
+++ b/dev-tools/kubernetes/base/elastic-agent-standalone/config-map.yaml
@@ -330,7 +330,7 @@ data:
               dataset: system.system
             condition: '${host.platform} == ''windows'''
             ignore_older: 72h
-      - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
+      - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
         type: filestream
         use_output: default
         meta:
@@ -354,7 +354,7 @@ data:
               #     negate: true
               #     match: after
             paths:
-              - /var/log/containers/*${kubernetes.container.id}.log
+              - /var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log
       - id: audit-log
         type: filestream
         use_output: default

--- a/internal/pkg/agent/application/coordinator/testdata/config.yaml
+++ b/internal/pkg/agent/application/coordinator/testdata/config.yaml
@@ -243,7 +243,7 @@ inputs:
           dataset: system.system
         condition: '${host.platform} == ''windows'''
         ignore_older: 72h
-  - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
+  - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
     type: filestream
     use_output: default
     meta:
@@ -253,7 +253,7 @@ inputs:
     data_stream:
       namespace: default
     streams:
-      - id: container-log-${kubernetes.pod.name}-${kubernetes.container.id}
+      - id: container-log-${kubernetes.namespace}-${kubernetes.pod.name}-${kubernetes.container.name}
         data_stream:
           dataset: kubernetes.container_logs
           type: logs
@@ -261,7 +261,7 @@ inputs:
         parsers:
           - container: ~
         paths:
-          - /var/log/containers/*${kubernetes.container.id}.log
+          - /var/log/pods/${kubernetes.namespace}_${kubernetes.pod.name}_${kubernetes.pod.uid}/${kubernetes.container.name}/*.log
   - id: audit-log
     type: filestream
     use_output: default


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR changes the input definition for ingesting k8s container logs from `/var/log/containers/*` to `/var/log/pods/*` which contains all available logs (including rotated ones) for pods running on the k8s node. 

Before this change elastic-agent would configure the input using the currently running container id and locating the corresponding log file under `/var/log/containers/*` which would point to the current log file, ignoring previously rotated log files for the container.

This change only impacts standalone agents. To have the same behaviour for managed agents a separate PR must be opened for the kubernetes integration in https://github.com/elastic/integrations/tree/main/packages/kubernetes

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
This allow ingesting logs also for containers that rotate logs quickly (for example containers that are crashing very early in their execution) instad of trying to ingest only the last log file for the container.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally



<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #5164 

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
