### PR TITLE
Change the default gRPC port to 0 when in a container

### DIFF
--- a/changelog/fragments/1737657890-Use-a-random-free-port-for-sub-process-communication-in-containers.yaml
+++ b/changelog/fragments/1737657890-Use-a-random-free-port-for-sub-process-communication-in-containers.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Use a random free port for sub-process communication in containers by default. Avoids port collisions when using host networking in Kubernetes.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/6585
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/application_test.go
+++ b/internal/pkg/agent/application/application_test.go
@@ -63,6 +63,7 @@ func TestLimitsLog(t *testing.T) {
 		true,              // testingMode
 		time.Millisecond,  // fleetInitTimeout
 		true,              // disable monitoring
+		nil,               // no configuration overrides
 	)
 	require.NoError(t, err)
 

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -783,19 +783,7 @@ func containerCfgOverrides(cfg *configuration.Configuration) {
 		cfg.Settings.EventLoggingConfig.ToStderr = true
 	}
 
-	// Default the container gRPC port to 0 in containers. This allows multiple agent pods to run on the same
-	// node when host networking is used (or when some other pod uses the same port). The ELASTIC_AGENT_GRPC_PORT
-	// variable is intentionally undocumented, nobody should need to use it but it's available in case of the unexpected.
-	defaultContainerGRPCPort := 0
-	grpcPortEnv := envWithDefault(strconv.Itoa(defaultContainerGRPCPort), "ELASTIC_AGENT_GRPC_PORT")
-	grpcPort, err := strconv.Atoi(grpcPortEnv)
-	if err != nil {
-		grpcPort = defaultContainerGRPCPort
-		logp.Warn("cannot parse ELASTIC_AGENT_GRPC_PORT='%s' as integer, using default %d'", grpcPortEnv, grpcPort)
-	}
-
-	cfg.Settings.GRPC.Port = uint16(grpcPort)
-	logp.Warn("Overrode default gRPC port with %d", cfg.Settings.GRPC.Port)
+	configuration.OverrideDefaultContainerGRPCPort(cfg.Settings.GRPC)
 }
 
 func setPaths(statePath, configPath, logsPath, socketPath string, writePaths bool) error {

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -77,7 +77,6 @@ The following actions are possible and grouped based on the actions.
   ELASTIC_AGENT_CERT - path to certificate to use for connecting to fleet-server.
   ELASTIC_AGENT_CERT_KEY - path to private key use for connecting to fleet-server.
 
-
   The following vars are need in the scenario that Elastic Agent should automatically fetch its own token.
 
   KIBANA_FLEET_HOST - Kibana host to enable create enrollment token on [$KIBANA_HOST]
@@ -282,7 +281,7 @@ func runContainerCmd(streams *cli.IOStreams, cfg setupConfig) error {
 	_, err = os.Stat(paths.AgentConfigFile())
 	if !os.IsNotExist(err) && !cfg.Fleet.Force {
 		// already enrolled, just run the standard run
-		return run(logToStderr, false, initTimeout, isContainer)
+		return run(containerCfgOverrides, false, initTimeout, isContainer)
 	}
 
 	if cfg.FleetServer.Enable {
@@ -336,7 +335,7 @@ func runContainerCmd(streams *cli.IOStreams, cfg setupConfig) error {
 		}
 	}
 
-	return run(logToStderr, false, initTimeout, isContainer)
+	return run(containerCfgOverrides, false, initTimeout, isContainer)
 }
 
 // TokenResp is used to decode a response for generating a service token
@@ -766,7 +765,7 @@ func runLegacyAPMServer(streams *cli.IOStreams) (*process.Info, error) {
 	return process.Start(spec.BinaryPath, options...)
 }
 
-func logToStderr(cfg *configuration.Configuration) {
+func containerCfgOverrides(cfg *configuration.Configuration) {
 	logsPath := envWithDefault("", "LOGS_PATH")
 	if logsPath == "" {
 		// when no LOGS_PATH defined the container should log to stderr
@@ -783,6 +782,20 @@ func logToStderr(cfg *configuration.Configuration) {
 		cfg.Settings.EventLoggingConfig.ToFiles = false
 		cfg.Settings.EventLoggingConfig.ToStderr = true
 	}
+
+	// Default the container gRPC port to 0 in containers. This allows multiple agent pods to run on the same
+	// node when host networking is used (or when some other pod uses the same port). The ELASTIC_AGENT_GRPC_PORT
+	// variable is intentionally undocumented, nobody should need to use it but it's available in case of the unexpected.
+	defaultContainerGRPCPort := 0
+	grpcPortEnv := envWithDefault(strconv.Itoa(defaultContainerGRPCPort), "ELASTIC_AGENT_GRPC_PORT")
+	grpcPort, err := strconv.Atoi(grpcPortEnv)
+	if err != nil {
+		grpcPort = defaultContainerGRPCPort
+		logp.Warn("cannot parse ELASTIC_AGENT_GRPC_PORT='%s' as integer, using default %d'", grpcPortEnv, grpcPort)
+	}
+
+	cfg.Settings.GRPC.Port = uint16(grpcPort)
+	logp.Warn("Overrode default gRPC port with %d", cfg.Settings.GRPC.Port)
 }
 
 func setPaths(statePath, configPath, logsPath, socketPath string, writePaths bool) error {

--- a/internal/pkg/agent/configuration/grpc.go
+++ b/internal/pkg/agent/configuration/grpc.go
@@ -64,7 +64,7 @@ func OverrideDefaultContainerGRPCPort(cfg *GRPCConfig) {
 	if ok {
 		port, err := strconv.Atoi(grpcPortEnv)
 		if err == nil {
-			cfg.Port = uint16(port)
+			cfg.Port = uint16(port) //nolint:gosec // integer size truncation is fine here.
 		}
 	}
 }

--- a/internal/pkg/agent/configuration/grpc.go
+++ b/internal/pkg/agent/configuration/grpc.go
@@ -6,8 +6,28 @@ package configuration
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+)
+
+const (
+	// DefaultGRPCPort is the default non-zero port in most situations. Ideally we'd always bind to
+	// port 0 to avoid collisions with other Elastic Agents or applications, but this would be a
+	// breaking change for users that have to manually whitelist the gRPC port in local firewall rules.
+	DefaultGRPCPort = uint16(6789)
+
+	// DefaultGRPCPortInInstallNamespace is the port used when explicitly installed in an installation
+	// namespace to allow multiple Elastic Agents on the same machine. Must be zero to avoid collisions.
+	DefaultGRPCPortInInstallNamespace = uint16(0)
+
+	// DefaultGPRCPortInContainer is the port used in a container. Defaults to zero to allow use of
+	// host networking (hostNetwork: true) in Kubernetes without port collisions between pods.
+	DefaultGPRCPortInContainer = uint16(0)
+
+	// grpcPortContainerEnvVar is the environment variable allowing containers to specify a fixed port.
+	grpcPortContainerEnvVar = "ELASTIC_AGENT_GRPC_PORT"
 )
 
 // GRPCConfig is a configuration of GRPC server.
@@ -20,17 +40,9 @@ type GRPCConfig struct {
 
 // DefaultGRPCConfig creates a default server configuration.
 func DefaultGRPCConfig() *GRPCConfig {
-	// When in an installation namespace, bind to port zero to select a random free port to avoid
-	// collisions with any already installed Elastic Agent. Ideally we'd always bind to port zero,
-	// but this would be breaking for users that had to manually whitelist the gRPC port in local
-	// firewall rules.
-	//
-	// Note: this uses local TCP by default. A port of -1 switches to unix domain sockets / named
-	// pipes. Using domain sockets by default is preferable but is currently blocked because the
-	// gRPC library endpoint security uses does not support Windows named pipes.
-	defaultPort := uint16(6789)
+	defaultPort := DefaultGRPCPort
 	if paths.InInstallNamespace() {
-		defaultPort = 0
+		defaultPort = DefaultGRPCPortInInstallNamespace
 	}
 
 	return &GRPCConfig{
@@ -38,6 +50,22 @@ func DefaultGRPCConfig() *GRPCConfig {
 		Port:                    defaultPort,
 		MaxMsgSize:              1024 * 1024 * 100, // grpc default 4MB is unsufficient for diagnostics
 		CheckinChunkingDisabled: false,             // on by default
+	}
+}
+
+// OverrideDefaultContainerGRPCPort is the configuration override used by the container command
+// to switch to a more convenient default port.
+func OverrideDefaultContainerGRPCPort(cfg *GRPCConfig) {
+	cfg.Port = DefaultGPRCPortInContainer
+
+	// Allow manually specifying the port via an undocumented environment variable in case
+	// the change from the original DefaultGRPCPort causes unexpected problems.
+	grpcPortEnv, ok := os.LookupEnv(grpcPortContainerEnvVar)
+	if ok {
+		port, err := strconv.Atoi(grpcPortEnv)
+		if err == nil {
+			cfg.Port = uint16(port)
+		}
 	}
 }
 

--- a/internal/pkg/agent/configuration/grpc_test.go
+++ b/internal/pkg/agent/configuration/grpc_test.go
@@ -1,0 +1,44 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package configuration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOverrideDefaultGRPCPort(t *testing.T) {
+	testcases := []struct {
+		name     string
+		env      string
+		expected uint16
+	}{{
+		name:     "no env var",
+		env:      "",
+		expected: DefaultGPRCPortInContainer,
+	}, {
+		name:     "valid env var",
+		env:      "1234",
+		expected: 1234,
+	}, {
+		name:     "invalid env var",
+		env:      "not a number",
+		expected: DefaultGPRCPortInContainer,
+	}}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := GRPCConfig{}
+			if tc.env != "" {
+				os.Setenv(grpcPortContainerEnvVar, tc.env)
+				defer os.Unsetenv(grpcPortContainerEnvVar)
+			}
+			OverrideDefaultContainerGRPCPort(&cfg)
+			assert.Equal(t, tc.expected, cfg.Port)
+		})
+	}
+}

--- a/testing/integration/kubernetes_agent_standalone_test.go
+++ b/testing/integration/kubernetes_agent_standalone_test.go
@@ -266,7 +266,10 @@ func TestKubernetesAgentHelm(t *testing.T) {
 		steps      []k8sTestStep
 	}{
 		{
-			name: "helm standalone agent default kubernetes privileged",
+			// Configure the perNode and clusterWide agents to both use host networking. On the node that
+			// runs the clusterWide agent, this tests that two agents do not try to bind to the same
+			// gRPC control protocol port by default preventing one from starting.
+			name: "helm standalone agent default kubernetes privileged without host network port collision",
 			steps: []k8sTestStep{
 				k8sStepCreateNamespace(),
 				k8sStepHelmDeploy(agentK8SHelm, "helm-agent", map[string]any{
@@ -279,6 +282,14 @@ func TestKubernetesAgentHelm(t *testing.T) {
 							"repository": kCtx.agentImageRepo,
 							"tag":        kCtx.agentImageTag,
 							"pullPolicy": "Never",
+						},
+						"presets": map[string]any{
+							"clusterWide": map[string]any{
+								"hostNetwork": true,
+							},
+							"perNode": map[string]any{
+								"hostNetwork": true,
+							},
 						},
 					},
 					"outputs": map[string]any{


### PR DESCRIPTION
## What does this PR do?

Changes the default port used when agent runs in a container to port 0. There is at least one user whose rollout of Elastic Agent is experiencing collisions with another application on the same port (nobody else could ever pick 6789 as a default port surely...) and I thought this would be straight forward to fix quickly. I was wrong. I expected ~2 hours and spent 3 days:

1. It looked like we already have a separate default config file for Docker containers I could just update: https://github.com/elastic/elastic-agent/blob/9b8a25f8feb5919965f1e5480d26e0324dd88736/_meta/config/elastic-agent.docker.yml.tmpl#L88-L89
2. This didn't work because the Helm chart defines its own configuration separately. I also didn't want to define this more than once because we'll probably change it again later (see **note** below): https://github.com/elastic/elastic-agent/blob/9b8a25f8feb5919965f1e5480d26e0324dd88736/deploy/helm/elastic-agent/templates/agent/k8s/_secret.tpl#L5
3. The `run()` function that is the entrypoint of the agent already has a hook for overriding configuration https://github.com/elastic/elastic-agent/blob/4199196174f1361e14c3ed6e6315b97bf98c3b81/internal/pkg/agent/cmd/run.go#L426-L428 that is already used in the container command to override the logging configuration https://github.com/elastic/elastic-agent/blob/4199196174f1361e14c3ed6e6315b97bf98c3b81/internal/pkg/agent/cmd/container.go#L769 but of course updating this to change the gRPC port also didn't work.
4. It turns out we load the configuration from disk at least twice at startup, once in https://github.com/elastic/elastic-agent/blob/9b8a25f8feb5919965f1e5480d26e0324dd88736/internal/pkg/agent/cmd/run.go#L415 and again in https://github.com/elastic/elastic-agent/blob/4199196174f1361e14c3ed6e6315b97bf98c3b81/internal/pkg/agent/application/application.go#L99 The second use didn't apply the overrides, the overrides only applied for the first case because that's when we created our logger and the only current overrides are for logging 🤦. Probably we could tidy this up but I've already spent enough time on this one.

**note** We should eventually stop using local TCP at all for the control protocol between sub-processes, and switch to unix sockets / named pipes. The capability for this was added in https://github.com/elastic/elastic-agent/pull/4249, but it was left disabled because endpoint-security doesn't support it yet (because the upstream gRPC C++ client doesn't support it on Windows). We have now removed endpoint-security from our containers which would allow us to switch to unix sockets there, but this change required an elastic-agent-client package update and we need to test that every client we have has it first. This was more testing effort than I wanted to take on now, but I will create a follow up issue to do this.

## Why is it important?

This automatically avoids port collisions between Elastic Agents using `hostNetwork: true` on Kubernetes as our DaemonSet does by default and other applications (or other Elastic Agents). 

## Disruptive User Impact

None, but in case I'm wrong about this I made it possible to choose a specific port with an environment variable.

## How to test this PR locally

```
INSTANCE_PROVISIONER=kind SNAPSHOT=true GOTEST_FLAGS="-test.run TestKubernetesAgentHelm" TEST_PLATFORMS="kubernetes/arm64/1.31.0/basic" mage -v integration:kubernetes
```