### PR TITLE
otel: add kafkaexporter and kafkareceiver to EDOT collector

### DIFF
--- a/changelog/fragments/1737717648-add-kafkaexporter-otel-collector.yaml
+++ b/changelog/fragments/1737717648-add-kafkaexporter-otel-collector.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: add kafkaexporter and kafkareceiver to EDOT collector
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/6562

--- a/go.mod
+++ b/go.mod
@@ -44,12 +44,14 @@ require (
 	github.com/magefile/mage v1.15.0
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.117.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.117.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.117.0
@@ -180,6 +182,7 @@ require (
 	github.com/Code-Hex/go-generics-cache v1.5.1 // indirect
 	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0 // indirect
+	github.com/IBM/sarama v1.44.0 // indirect
 	github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
@@ -204,6 +207,7 @@ require (
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
+	github.com/aws/aws-msk-iam-sasl-signer-go v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.5 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.32.7 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.4 // indirect
@@ -439,16 +443,19 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics v0.117.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.117.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.117.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka v0.117.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/kubelet v0.117.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders v0.117.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/pdatautil v0.117.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.117.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.117.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.117.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic v0.117.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.117.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.117.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.117.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.117.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azure v0.117.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.117.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.117.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.117.0 // indirect
@@ -473,6 +480,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/prometheus/prometheus v0.54.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
+	github.com/relvacode/iso8601 v1.6.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/rs/cors v1.11.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0/go.mod h1:obipzmGjfSjam60XLwGfqUkJsfiheAl+TUjG+4yzyPM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
-github.com/IBM/sarama v1.43.3 h1:Yj6L2IaNvb2mRBop39N7mmJAHBVY3dTPncr3qGVkxPA=
-github.com/IBM/sarama v1.43.3/go.mod h1:FVIRaLrhK3Cla/9FfRF5X9Zua2KpS3SYIXxhac1H+FQ=
+github.com/IBM/sarama v1.44.0 h1:puNKqcScjSAgVLramjsuovZrS0nJZFVsrvuUymkWqhE=
+github.com/IBM/sarama v1.44.0/go.mod h1:MxQ9SvGfvKIorbk077Ff6DUnBlGpidiQOtU2vuBaxVw=
 github.com/Jeffail/gabs/v2 v2.6.0 h1:WdCnGaDhNa4LSRTMwhLZzJ7SRDXjABNP13SOKvCpL5w=
 github.com/Jeffail/gabs/v2 v2.6.0/go.mod h1:xCn81vdHKxFUuWWAaD5jCTQDNPBMh5pPs9IJ+NcziBI=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c h1:RGWPOewvKIROun94nF7v2cua9qP+thov/7M50KEoeSU=
@@ -234,6 +234,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/aws/aws-msk-iam-sasl-signer-go v1.0.0 h1:UyjtGmO0Uwl/K+zpzPwLoXzMhcN9xmnR2nrqJoBrg3c=
+github.com/aws/aws-msk-iam-sasl-signer-go v1.0.0/go.mod h1:TJAXuFs2HcMib3sN5L0gUC+Q01Qvy3DemvA55WuC+iA=
 github.com/aws/aws-sdk-go v1.38.35/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
 github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
@@ -1124,6 +1126,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearch
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.117.0/go.mod h1:xuraEUKd+a7jBtibet2xRnymQaJwY2TrO50fH+yP+cA=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.117.0 h1:l0HJg47QeTC977GfAqG7TIaRd275Q88SPwimbAU+hi8=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.117.0/go.mod h1:q5Ey16FbSdkSWVmbnWx2D6YfEDqD8s3X34ox9tfL2iA=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.117.0 h1:/rYuHD/ub5AGXbJmXisS22/Ru+MyN6Ev/FjQwp8qu2Q=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.117.0/go.mod h1:0xsGslwZOCYDvdOSefuja+He48ad7FLODp8Vqi+8754=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.117.0 h1:GQr5+q2OLPWMYaIJUQVj0iqzCOOa9+Ka0xInfMaPKGc=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.117.0/go.mod h1:s87Obi1jQsGoh4KBdy2K3N9yAdjQ3XdiJgr745dHSDM=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.117.0 h1:5SVrY+xan8gF/dFTrr1ZDNqpiLaKeObQESnLFS0hiWo=
@@ -1158,6 +1162,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.117.0/go.mod h1:GhC+Pk3PbAIq52vmYr+d6PN4Hnxyp4lGQMbomI7Bom8=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8stest v0.117.0 h1:yb5OzYhTUCEmdApRSRl3I+dFTIsMYeacGrJMnyh2RIw=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8stest v0.117.0/go.mod h1:EOJXILTPFRep4PfIM+G3kZ89xmGo2a49hNlP2Tn6CJ0=
+github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka v0.117.0 h1:xkAn7xjemB3pzfH9auCsmuJu39tmgnFEv3txiYq51Ys=
+github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka v0.117.0/go.mod h1:2BXMWdK7P3acUSH+tdpF6JmUzfbwZeKA7ygc2XrN6mU=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/kubelet v0.117.0 h1:oHibC0+/wLFAMb0SdehyYiMemzBUQ1efljzGX+S3NJw=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/kubelet v0.117.0/go.mod h1:gleMPWlFG0O77Thi95Ylg7NLIlWezDB3gAPkZ98Nr4w=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders v0.117.0 h1:NcKa3IoJeWcJhgR8PeON/WrVXvJEtwJk0JjOramOB2Y=
@@ -1172,6 +1178,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetric
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.117.0/go.mod h1:SMhpc9NNFHzzq75fmvcZa9f9KDZnIsum6Wfj4bG4/LQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.117.0 h1:tOJFUIZaAU4zm5CilqZN1/AuKQa7diTrcEhgQIYly6k=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.117.0/go.mod h1:PJ2FGCS+Hw+tlHUNNWVHNo3IXtEsb9RKgl/ssSi3Z98=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic v0.117.0 h1:+KEb5xtnKkJh5mxXau34ibLthXhMeRQOyTMiI2AbHaY=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic v0.117.0/go.mod h1:1q/L2R/28emNCz0EHfxEw853I6lPxTcHTqS+UrMea0k=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.117.0 h1:HnkgGMpQKEW9z2bJaIyK1HQ7nETyOvTYYXEDLA1GR8E=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.117.0/go.mod h1:/xsh6bL6X7OcPwdWWApGJH3j4tMchr0e0NL8t1qgAXs=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.117.0 h1:/wMNk8w1UEHKpKoNk1jA2aifHgfGZE+WelGNrCf0CJ0=
@@ -1186,6 +1194,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.117.0 h1
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.117.0/go.mod h1:iQ+EGeIfuiG4RMECbxrSEDAZ9xxOOWWh+bptaxGtlnM=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status v0.117.0 h1:nf3xfBvVhvlby7D4YT82+1bTuHTKdZO8614ykSnjwhk=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status v0.117.0/go.mod h1:3lPvq3mRHg8foQO4wB/cHKxRCOJNCDZqzCoBDTuVazo=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azure v0.117.0 h1:jwucV3KAIxEk52ESHnDvcUJ0BwNbu7T+cBB4sCFLEuA=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azure v0.117.0/go.mod h1:FXdXb4aJbrAzFPpWFckbZUKj86jZIBRzF3PEQXJNeVM=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.117.0 h1:6Ly4tQ502qTYyBYdvhPukffytHgXIn5F1469S1L+j+w=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.117.0/go.mod h1:AUUbtJw5om0NxjOPWFjZPzTSJHf6Fa42agazRmxYFoQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.117.0 h1:IgaGH6HLxv3UgrGKXzm/gJPta1Qnxa87WTcMlFp4gHc=
@@ -1218,6 +1228,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterrec
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.117.0/go.mod h1:JScN+Jg5i3ATKT5KeB4URvwv1SGbw6AF3Q10NLaGztQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.117.0 h1:fus4xS+nveMqai6SFEQQ91BRBrvPqGY+y3Y6JeeWvSA=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.117.0/go.mod h1:+1rfCYfsnM8TCX/3R5vfCapW0m7tVLGMuSXjLygj/LY=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.117.0 h1:0TtGso35PcqS8dqTI48MN8ehj3tyovOgwFgFc7ywvdA=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.117.0/go.mod h1:2bLb8fdBoH7Tpq76JVkZhLDOVv+D1q8Qvmp3OII8nXA=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.117.0 h1:FZGlGZvgOZCWjGtrUpqpqqvknJDtsuwdX9Q4SBUIRtE=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.117.0/go.mod h1:1ELm4C0E0On6u7hwVqVJymwmfx8NhfgAwZNb/g/IN00=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.117.0 h1:ZukmPvZSJnDPvUH0ECDliYxyRgSMs6mWXnX70uGnhvk=
@@ -1320,6 +1332,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5X
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rednafi/link-patrol v0.0.0-20240826150821-057643e74d4d h1:pflUVm462wgbblymtVaGR8vAoV5o3wHDwg60fzoflBo=
 github.com/rednafi/link-patrol v0.0.0-20240826150821-057643e74d4d/go.mod h1:wAGfe4fPMwk3UX7Tx2RfHAo6FvS6ZUp2U8ZcCoP8hqs=
+github.com/relvacode/iso8601 v1.6.0 h1:eFXUhMJN3Gz8Rcq82f9DTMW0svjtAVuIEULglM7QHTU=
+github.com/relvacode/iso8601 v1.6.0/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH2h3sZCn0I=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/internal/pkg/otel/README.md
+++ b/internal/pkg/otel/README.md
@@ -30,6 +30,7 @@ This section provides a summary of components included in the Elastic Distributi
 | Component | Version |
 |---|---|
 | [jaegerreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/receiver/jaegerreceiver/v0.117.0/receiver/jaegerreceiver/README.md) | v0.117.0 |
+| [kafkareceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/receiver/kafkareceiver/v0.117.0/receiver/kafkareceiver/README.md) | v0.117.0 |
 | [prometheusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/receiver/prometheusreceiver/v0.117.0/receiver/prometheusreceiver/README.md) | v0.117.0 |
 | [receivercreator](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/receiver/receivercreator/v0.117.0/receiver/receivercreator/README.md) | v0.117.0 |
 | [zipkinreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/receiver/zipkinreceiver/v0.117.0/receiver/zipkinreceiver/README.md) | v0.117.0 |
@@ -45,6 +46,7 @@ This section provides a summary of components included in the Elastic Distributi
 
 | Component | Version |
 |---|---|
+| [kafkaexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/exporter/kafkaexporter/v0.117.0/exporter/kafkaexporter/README.md) | v0.117.0 |
 | [loadbalancingexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/exporter/loadbalancingexporter/v0.117.0/exporter/loadbalancingexporter/README.md) | v0.117.0 |
 | [elasticsearchexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/exporter/elasticsearchexporter/v0.117.0/exporter/elasticsearchexporter/README.md) | v0.117.0 |
 | [fileexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/exporter/fileexporter/v0.117.0/exporter/fileexporter/README.md) | v0.117.0 |

--- a/internal/pkg/otel/components.go
+++ b/internal/pkg/otel/components.go
@@ -19,6 +19,7 @@ import (
 	jaegerreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver"
 	k8sclusterreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver"
 	k8sobjectsreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver"
+	kafkareceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
 	kubeletstatsreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver"
 	prometheusreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
 	receivercreator "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator"
@@ -46,6 +47,7 @@ import (
 	// Exporters:
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter"
 	fileexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter" // for e2e tests
+	kafkaexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
 	debugexporter "go.opentelemetry.io/collector/exporter/debugexporter" // for dev
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
@@ -85,6 +87,7 @@ func components(extensionFactories ...extension.Factory) func() (otelcol.Factori
 			zipkinreceiver.NewFactory(),
 			fbreceiver.NewFactory(),
 			mbreceiver.NewFactory(),
+			kafkareceiver.NewFactory(),
 		)
 		if err != nil {
 			return otelcol.Factories{}, err
@@ -116,6 +119,7 @@ func components(extensionFactories ...extension.Factory) func() (otelcol.Factori
 			elasticsearchexporter.NewFactory(),
 			loadbalancingexporter.NewFactory(),
 			otlphttpexporter.NewFactory(),
+			kafkaexporter.NewFactory(),
 		)
 		if err != nil {
 			return otelcol.Factories{}, err


### PR DESCRIPTION
## What does this PR do?

Add kafkaexporter and kafkareceiver to the list of components in the EDOT collector. Beats/Agent has a Kafka output, and this is the first step towards offering parity of outputs in the EDOT collector.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/6562
- Closes https://github.com/elastic/opentelemetry-dev/issues/613