### PR TITLE
Emit vars even if provider data is empty from the start

### DIFF
--- a/changelog/fragments/1737735780-fix-empty-provider-data.yaml
+++ b/changelog/fragments/1737735780-fix-empty-provider-data.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Emit vars even if provider data is empty from the start
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/composable/controller_test.go
+++ b/internal/pkg/composable/controller_test.go
@@ -147,6 +147,16 @@ func TestProvidersDefaultDisabled(t *testing.T) {
 			want: 0,
 		},
 		{
+			name: "default disabled, local provider without data",
+			cfg: map[string]interface{}{
+				"agent.providers.initial_default": "false",
+				"providers": map[string]any{
+					"local": map[string]any{},
+				},
+			},
+			want: 1,
+		},
+		{
 			name: "default enabled",
 			cfg: map[string]interface{}{
 				"agent.providers.initial_default": "true",


### PR DESCRIPTION
## What does this PR do?

We only signal from providers if the emitted data is different from the current state. This caused a bug where the data wasn't ever emitted if it was empty. The provider controller now distinguishes between no data (yet) and empty data. As a result, it's again possible to effectively disable all providers by using a local provider with no data.

This is a regression caused by https://github.com/elastic/elastic-agent/pull/6114. It doesn't apply to the main and 8.x branches due to https://github.com/elastic/elastic-agent/pull/6169 refactoring provider initialization in those.

## Why is it important?

Fixes a regression where agent wouldn't generate any configuration if the only enabled context providers only emitted empty data. This is something users do if they want to effectively disable providers.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Related issues



<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
