### PR TITLE
enhancement(5423): added logic to replaces scheduler with long-wait scheduler in case of exceeded unauth response limit

### DIFF
--- a/changelog/fragments/1738199968-update-scheduler-when-received-too-many-unathorized-responses.yaml
+++ b/changelog/fragments/1738199968-update-scheduler-when-received-too-many-unathorized-responses.yaml
@@ -1,0 +1,30 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Updated the fleet gateway so that when the number of unauthorized fleet responses exceeds the set limit, instead of unenrolling, the gateway starts checking in less frequently.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/6619
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/5428

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -127,6 +127,7 @@ func newFleetGatewayWithScheduler(
 		acker:        acker,
 		stateFetcher: stateFetcher,
 		stateStore:   stateStore,
+		isLongSched:  false,
 		errCh:        make(chan error),
 		actionCh:     make(chan []fleetapi.Action, 1),
 	}, nil

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -566,54 +566,6 @@ func TestAgentStateToString(t *testing.T) {
 	}
 }
 
-func TestTryReplaceScheduler(t *testing.T) {
-	t.Run("switch from long to short wait duration when isLongSched flag is false and the current scheduler is a long-wait scheduler", func(t *testing.T) {
-		gateway := &FleetGateway{
-			scheduler:   scheduler.NewPeriodic(defaultGatewaySettings.ErrDuration),
-			isLongSched: false,
-		}
-
-		gateway.tryReplaceScheduler()
-
-		_, ok := gateway.scheduler.(*scheduler.PeriodicJitter)
-		require.True(t, ok)
-	})
-
-	t.Run("switch from short to long wait duration when isLongSched flag is true and the current scheduler is a short-wait scheduler", func(t *testing.T) {
-		gateway := &FleetGateway{
-			scheduler:   scheduler.NewPeriodicJitter(defaultGatewaySettings.Duration, defaultGatewaySettings.Jitter),
-			isLongSched: true,
-		}
-
-		gateway.tryReplaceScheduler()
-
-		_, ok := gateway.scheduler.(*scheduler.Periodic)
-		require.True(t, ok)
-	})
-
-	t.Run("no change needed when scheduler type matches what's required", func(t *testing.T) {
-		initialScheduler := scheduler.NewPeriodic(defaultGatewaySettings.Duration)
-		gateway := &FleetGateway{
-			scheduler:   initialScheduler,
-			isLongSched: true,
-		}
-
-		gateway.tryReplaceScheduler()
-
-		assert.Same(t, initialScheduler, gateway.scheduler)
-
-		initialScheduler2 := scheduler.NewPeriodic(defaultGatewaySettings.Duration)
-		gateway2 := &FleetGateway{
-			scheduler:   initialScheduler2,
-			isLongSched: true,
-		}
-
-		gateway2.tryReplaceScheduler()
-
-		assert.Same(t, initialScheduler2, gateway2.scheduler)
-	})
-}
-
 func TestFleetGatewaySchedulerSwitch(t *testing.T) {
 	agentInfo := &testAgentInfo{}
 	settings := &fleetGatewaySettings{
@@ -651,7 +603,6 @@ func TestFleetGatewaySchedulerSwitch(t *testing.T) {
 
 		_, ok = g.scheduler.(*scheduler.Periodic)
 		require.True(t, ok)
-		require.True(t, g.isLongSched)
 	}))
 
 	t.Run("should switch back to short-wait scheduler if the a successful response is received", withGateway(agentInfo, settings, func(
@@ -683,6 +634,5 @@ func TestFleetGatewaySchedulerSwitch(t *testing.T) {
 
 		_, ok = g.scheduler.(*scheduler.PeriodicJitter)
 		require.True(t, ok)
-		require.False(t, g.isLongSched)
 	}))
 }

--- a/internal/pkg/scheduler/scheduler.go
+++ b/internal/pkg/scheduler/scheduler.go
@@ -14,6 +14,7 @@ import (
 type Scheduler interface {
 	WaitTick() <-chan time.Time
 	Stop()
+	SetDuration(time.Duration)
 }
 
 // Stepper is a scheduler where each Tick is manually triggered, this is useful in scenario
@@ -31,6 +32,9 @@ func (s *Stepper) Next() {
 func (s *Stepper) WaitTick() <-chan time.Time {
 	return s.C
 }
+
+// Sets the wait duration for the scheduler. Noop for stepper scheduler
+func (s *Stepper) SetDuration(_ time.Duration) {}
 
 // Stop is stopping the scheduler, in the case of the Stepper scheduler nothing is done.
 func (s *Stepper) Stop() {}
@@ -66,6 +70,10 @@ func (p *Periodic) WaitTick() <-chan time.Time {
 	p.ran = true
 
 	return rC
+}
+
+func (p *Periodic) SetDuration(d time.Duration) {
+	p.Ticker = time.NewTicker(d)
 }
 
 // Stop stops the internal Ticker.
@@ -121,6 +129,10 @@ func (p *PeriodicJitter) WaitTick() <-chan time.Time {
 	}
 
 	return p.C
+}
+
+func (p *PeriodicJitter) SetDuration(d time.Duration) {
+	p.d = d
 }
 
 // Stop stops the PeriodicJitter scheduler.


### PR DESCRIPTION
- Enhancement

## What does this PR do?

Removes the forced unenroll from fleet gateway. Adds logic in the fleet gateway to switch out the scheduler used for checkins. If the unauthorized response limit is exceeded, a the scheduler is replaced with one that has a long wait duration. When the gateway receives a successful response, it switches back to using the regular scheduler with the shorter wait duration.

## Why is it important?

Currently the agent unenrolls after 7 unauthorized error responses. This can causes problems in disaster recovery scenarios where users may have to manually intervene. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

None

## How to test this PR locally

- Create ESS deployment
- Build the agent locally
- Enroll the agent
- In dev tools find the access token and delete it
```
GET /.security-7/_search
{
  "query": {
    "bool": {
      "must": [
        {
          "term": {
            "name": "AGENT ID"
          }
        }
      ]
    }
  }
}
```
```
DELETE /_security/api_key
{
  "ids": ["KEY ID"]
}
```
- Follow the agent logs `sudo elastic-agent logs -f`
- After a while you will see `retrieved an invalid api key error '10' times. will use long scheduler` error message in the logs
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
 Due to the backoff algorithm used, this test can take a long time. In order to see immediate results comment out the following code block
```
			if !bo.Wait() {
				if ctx.Err() != nil {
					// if the context is cancelled, break out of the loop
					break
				}

				// This should not really happen, but just in-case this error is used to show that
				// something strange occurred and we want to log it and report it.
				err := errors.New(
					"checkin retry loop was stopped",
					errors.TypeNetwork,
					errors.M(errors.MetaKeyURI, f.client.URI()),
				)

				f.log.Error(err)
				f.errCh <- err
				return nil, err
			}
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #5428 
- Relates #6760
