### PR TITLE
Update config to reflect `degrade_on_partial` 

### DIFF
--- a/_meta/config/common.p2.yml.tmpl
+++ b/_meta/config/common.p2.yml.tmpl
@@ -38,6 +38,20 @@ inputs:
       - metricsets:
         - filesystem
         data_stream.dataset: system.filesystem
+#     - metricsets:
+#       - process
+#       data_stream.dataset: system.process
+#       # While running in unprivileged mode, process/process_summary metricsets can emit
+#       # partial metrics. Some metrics that require privileged access can be missing.
+#       # On Windows, non-administrator users may not be able to access protected processes, leading 
+#       # to missing details like command line and arguments. On Unix, non-root users can't access 
+#       # procfs without the right permissions. 
+#       # Errors like ERROR_ACCESS_DENIED, EPERM, and EACCESS may result in partial metrics. 
+#       # Enabling the config below will mark the metricset as degraded when this occurs.
+#       # You may want to enable it to identify potential permission-related issues.
+#       # If you're unable to provide the necessary access, you can disable this config to keep
+#       # metricsets healthy.
+#       #degrade_on_partial: false
 
 #   # Collecting log files
 #   - type: filestream

--- a/_meta/config/common.reference.p2.yml.tmpl
+++ b/_meta/config/common.reference.p2.yml.tmpl
@@ -36,6 +36,20 @@ inputs:
       - metricsets:
         - filesystem
         data_stream.dataset: system.filesystem
+#     - metricsets:
+#       - process
+#       data_stream.dataset: system.process
+#       # While running in unprivileged mode, process/process_summary metricsets can emit
+#       # partial metrics. Some metrics that require privileged access can be missing.
+#       # On Windows, non-administrator users may not be able to access protected processes, leading 
+#       # to missing details like command line and arguments. On Unix, non-root users can't access 
+#       # procfs without the right permissions. 
+#       # Errors like ERROR_ACCESS_DENIED, EPERM, and EACCESS may result in partial metrics. 
+#       # Enabling the config below will mark the metricset as degraded when this occurs.
+#       # You may want to enable it to identify potential permission-related issues.
+#       # If you're unable to provide the necessary access, you can disable this config to keep
+#       # metricsets healthy.
+#       #degrade_on_partial: false
 
 #   # Collecting log files
 #   - type: filestream

--- a/_meta/elastic-agent.yml
+++ b/_meta/elastic-agent.yml
@@ -30,6 +30,20 @@ inputs:
       - metricsets: 
         - filesystem
         data_stream.dataset: system.filesystem
+#     - metricsets:
+#       - process
+#       data_stream.dataset: system.process
+#       # While running in unprivileged mode, process/process_summary metricsets can emit
+#       # partial metrics. Some metrics that require privileged access can be missing.
+#       # On Windows, non-administrator users may not be able to access protected processes, leading 
+#       # to missing details like command line and arguments. On Unix, non-root users can't access 
+#       # procfs without the right permissions. 
+#       # Errors like ERROR_ACCESS_DENIED, EPERM, and EACCESS may result in partial metrics. 
+#       # Enabling the config below will mark the metricset as degraded when this occurs.
+#       # You may want to enable it to identify potential permission-related issues.
+#       # If you're unable to provide the necessary access, you can disable this config to keep
+#       # metricsets healthy.
+#       #degrade_on_partial: false
 
 # management:
 #   # Mode of management, the Elastic Agent support two modes of operation:

--- a/elastic-agent.reference.yml
+++ b/elastic-agent.reference.yml
@@ -42,6 +42,20 @@ inputs:
       - metricsets:
         - filesystem
         data_stream.dataset: system.filesystem
+#     - metricsets:
+#       - process
+#       data_stream.dataset: system.process
+#       # While running in unprivileged mode, process/process_summary metricsets can emit
+#       # partial metrics. Some metrics that require privileged access can be missing.
+#       # On Windows, non-administrator users may not be able to access protected processes, leading 
+#       # to missing details like command line and arguments. On Unix, non-root users can't access 
+#       # procfs without the right permissions. 
+#       # Errors like ERROR_ACCESS_DENIED, EPERM, and EACCESS may result in partial metrics. 
+#       # Enabling the config below will mark the metricset as degraded when this occurs.
+#       # You may want to enable it to identify potential permission-related issues.
+#       # If you're unable to provide the necessary access, you can disable this config to keep
+#       # metricsets healthy.
+#       #degrade_on_partial: false
 
 #   # Collecting log files
 #   - type: filestream

--- a/elastic-agent.yml
+++ b/elastic-agent.yml
@@ -44,6 +44,20 @@ inputs:
       - metricsets:
         - filesystem
         data_stream.dataset: system.filesystem
+#     - metricsets:
+#       - process
+#       data_stream.dataset: system.process
+#       # While running in unprivileged mode, process/process_summary metricsets can emit
+#       # partial metrics. Some metrics that require privileged access can be missing.
+#       # On Windows, non-administrator users may not be able to access protected processes, leading 
+#       # to missing details like command line and arguments. On Unix, non-root users can't access 
+#       # procfs without the right permissions. 
+#       # Errors like ERROR_ACCESS_DENIED, EPERM, and EACCESS may result in partial metrics. 
+#       # Enabling the config below will mark the metricset as degraded when this occurs.
+#       # You may want to enable it to identify potential permission-related issues.
+#       # If you're unable to provide the necessary access, you can disable this config to keep
+#       # metricsets healthy.
+#       #degrade_on_partial: false
 
 #   # Collecting log files
 #   - type: filestream


### PR DESCRIPTION
https://github.com/elastic/beats/pull/42160 added the ability to mark metricset as degraded when partial metrics are encountered. As per [this discussion](https://github.com/elastic/beats/pull/42160#discussion_r1918772579), it didn't really make sense to document this behaviour on beats repo, as this option is only usable while running elastic-agent.

Until now, we weren't marking metricsets as degraded due to various hidden bugs encountered and CI failures on agent. 
The plan is to enable this in agent integration test cases in elastic-agent. Once we're confident enough, we will enable this feature by default in beats and eventually, remove the flag.

This PR updates the reference file with the necessary information about the config.

Simultaneously, I've opened a [PR to update system integration](https://github.com/elastic/integrations/pull/12533) to reflect the changes on UI.