### PR TITLE
chore: add linter that denies importing math/rand

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,8 @@ linters:
     - noctx # noctx finds sending http request without context.Context
     - unconvert # Remove unnecessary type conversions
     - wastedassign # wastedassign finds wasted assignment statements.
-    - gomodguard # check for blocked dependencies
+    - depguard # check for blocked imports from Go files
+    - gomodguard # check for blocked imports from go.mod
     - gomoddirectives
 
 # all available settings of specific linters
@@ -88,9 +89,9 @@ linters-settings:
   goimports:
     local-prefixes: github.com/elastic
 
+  # Check for blocked dependencies in go.mod.
   gomodguard:
     blocked:
-      # List of blocked modules.
       modules:
         # Blocked module.
         - github.com/pkg/errors:
@@ -104,6 +105,15 @@ linters-settings:
             recommendations:
               - github.com/gofrs/uuid/v5
             reason: "Use one uuid library consistently across the codebase"
+
+  # Check for blocked imports in Go files.
+  depguard:
+    rules:
+      main:
+        list-mode: lax
+        deny:
+          - pkg: "math/rand$"
+            desc: "superseded by math/rand/v2"
 
   gomoddirectives:
     # Forbid local `replace` directives


### PR DESCRIPTION
## What does this PR do?

We had previous PRs at https://github.com/elastic/elastic-agent/issues/5335 and https://github.com/elastic/beats/pull/42025 moving away from math/rand to the newer math/rand/v2 package. Currently there is nothing preventing contributors to commiting code using math/rand and regressing these changes.

Introduce a linter that catches math/rand imports in Go files.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Related issues

- https://github.com/elastic/elastic-agent/issues/5335
