### PR TITLE
mergify: support backport-active-8, backport-active-9 and backport-active-all 

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -370,3 +370,41 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to all active minor branches
+    conditions:
+      - merged
+      - label=backport-active-minors
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        # NOTE: this list needs to be changed when a new minor branch is created
+        #       or an existing minor branch reached EOL.
+        branches:
+          - "9.0"
+          - "8.18"
+          - "8.17"
+          - "8.16"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to all active branches
+    conditions:
+      - merged
+      - label=backport-active-branches
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        # NOTE: this list needs to be changed when a new minor branch is created
+        #       or an existing release branch reached EOL.
+        branches:
+          - "9.0"
+          - "8.18"
+          - "8.17"
+          - "8.16"
+          - "8.x"
+          - "7.17"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -122,9 +122,10 @@ pull_request_rules:
           This pull request does not have a backport label. Could you fix it @{{author}}? 🙏
           To fixup this pull request, you need to add the backport labels for the needed
           branches, such as:
-          * `backport-./d./d` is the label to automatically backport to the `8./d` branch. `/d` is the digit
-          * `backport-active-branches` is the label to automatically backport to all active branches
-          * `backport-active-minors` is the label to automatically backport to all active minor branches
+          * `backport-./d./d` is the label that automatically backports to the `8./d` branch. `/d` is the digit
+          * `backport-active-all` is the label that automatically backports to all active branches.
+          * `backport-active-8` is the label that automatically backports to all active minor branches for the 8 major.
+          * `backport-active-9` is the label that automatically backports to all active minor branches for the 9 major.
 
   - name: backport patches to 7.17 branch
     conditions:
@@ -373,10 +374,28 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to all active minor branches
+
+  - name: backport patches to all active minor branches for the 8 major.
     conditions:
       - merged
-      - label=backport-active-minors
+      - label=backport-active-8
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        # NOTE: this list needs to be changed when a new minor branch is created
+        #       or an existing minor branch reached EOL.
+        branches:
+          - "8.18"
+          - "8.17"
+          - "8.16"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to all active minor branches for the 9 major.
+    conditions:
+      - merged
+      - label=backport-active-9
     actions:
       backport:
         assignees:
@@ -385,16 +404,13 @@ pull_request_rules:
         #       or an existing minor branch reached EOL.
         branches:
           - "9.0"
-          - "8.18"
-          - "8.17"
-          - "8.16"
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to all active branches
     conditions:
       - merged
-      - label=backport-active-branches
+      - label=backport-active-all
     actions:
       backport:
         assignees:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -123,6 +123,9 @@ pull_request_rules:
           To fixup this pull request, you need to add the backport labels for the needed
           branches, such as:
           * `backport-./d./d` is the label to automatically backport to the `8./d` branch. `/d` is the digit
+          * `backport-active-branches` is the label to automatically backport to all active branches
+          * `backport-active-minors` is the label to automatically backport to all active minor branches
+
   - name: backport patches to 7.17 branch
     conditions:
       - merged


### PR DESCRIPTION

## What does this PR do?

Enable `backport-active-all`, `backport-active-8` and `backport-active-9` GitHub labels in Mergify to backport to a set of active branches in addition to the existing automation with the `backport-<major>.<minor>` labels. This can help with the current 6 active branches, which we have today.

See https://docs.mergify.com/workflow/actions/backport/#parameters


<img width="530" alt="image" src="https://github.com/user-attachments/assets/9a24a72b-2d9b-43ed-bab0-918087aa7273" />


I can find `regexes` too:

<img width="624" alt="image" src="https://github.com/user-attachments/assets/71ef6d2f-f98d-4e7b-a0a0-8e1d7b99b33d" />


But I'm not sure whether that can solve our current release model easily

## Why is it important?

> Maybe this is solved already, but is there a way we can get an automatically kept up to date “backport-active-minors” label that auto backports to the set of minor releases that are still supported? I’d want this in Beats, Elastic Agent, and Fleet Server if it already exists. I’ve noticed an increase in forgotten backports because there are more releases to keep track of. If we can abstract this it’d make life easier, I think Kibana does something like this


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
