### PR TITLE
Redacted nested secrets path value

### DIFF
--- a/changelog/fragments/1738874791-Fix-secret_paths-redaction-along-complex-paths.yaml
+++ b/changelog/fragments/1738874791-Fix-secret_paths-redaction-along-complex-paths.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix secret_paths redaction along complex paths
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/6710
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -398,7 +398,8 @@ func redactKey(k string) bool {
 		strings.Contains(k, "passphrase") ||
 		strings.Contains(k, "password") ||
 		strings.Contains(k, "token") ||
-		strings.Contains(k, "key")
+		strings.Contains(k, "key") ||
+		strings.Contains(k, "secret")
 }
 
 func zipLogs(zw *zip.Writer, ts time.Time, topPath string, excludeEvents bool) error {
@@ -601,11 +602,13 @@ func RedactSecretPaths(mapStr map[string]any, errOut io.Writer) map[string]any {
 			continue
 		}
 
-		if ok, _ := cfg.Has(key, -1, ucfg.PathSep(".")); ok {
+		if ok, err := cfg.Has(key, -1, ucfg.PathSep(".")); ok {
 			err := cfg.SetString(key, -1, REDACTED, ucfg.PathSep("."))
 			if err != nil {
 				fmt.Fprintf(errOut, "No output redaction for %q: %v.\n", key, err)
 			}
+		} else {
+			fmt.Fprintf(errOut, "Unable to find secret path %q for redaction: %v.\n", key, err)
 		}
 	}
 	result, err := config.MustNewConfigFrom(cfg).ToMapStr()

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -602,13 +602,15 @@ func RedactSecretPaths(mapStr map[string]any, errOut io.Writer) map[string]any {
 			continue
 		}
 
-		if ok, err := cfg.Has(key, -1, ucfg.PathSep(".")); ok {
+		if ok, err := cfg.Has(key, -1, ucfg.PathSep(".")); err != nil {
+			fmt.Fprintf(errOut, "Error redacting secret path %q: %v.\n", key, err)
+		} else if ok {
 			err := cfg.SetString(key, -1, REDACTED, ucfg.PathSep("."))
 			if err != nil {
 				fmt.Fprintf(errOut, "No output redaction for %q: %v.\n", key, err)
 			}
 		} else {
-			fmt.Fprintf(errOut, "Unable to find secret path %q for redaction: %v.\n", key, err)
+			fmt.Fprintf(errOut, "Unable to find secret path %q for redaction.\n", key)
 		}
 	}
 	result, err := config.MustNewConfigFrom(cfg).ToMapStr()

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -594,7 +594,7 @@ func RedactSecretPaths(mapStr map[string]any, errOut io.Writer) map[string]any {
 		fmt.Fprintln(errOut, "No output redaction: secret_paths attribute is not a list.")
 		return mapStr
 	}
-	cfg := ucfg.MustNewFrom(mapStr)
+	cfg := ucfg.MustNewFrom(mapStr, ucfg.PathSep("."))
 	for _, v := range arr {
 		key, ok := v.(string)
 		if !ok {

--- a/internal/pkg/diagnostics/diagnostics_test.go
+++ b/internal/pkg/diagnostics/diagnostics_test.go
@@ -274,13 +274,14 @@ inputs:
         namespace: default
       streams:
         - config_version: "2"
-          request.transforms:
-            - set:
-                target: header.Authorization
-                value: <REDACTED>
-            - set:
-                target: url.params.limit
-                value: "1000"
+          request:
+            transforms:
+                - set:
+                    target: header.Authorization
+                    value: <REDACTED>
+                - set:
+                    target: url.params.limit
+                    value: "1000"
       type: httpjson
 secret_paths:
     - inputs.0.streams.0.request.transforms.0.set.value

--- a/internal/pkg/diagnostics/diagnostics_test.go
+++ b/internal/pkg/diagnostics/diagnostics_test.go
@@ -249,15 +249,53 @@ secret_paths:
     - inputs.1.missingKey
     - outputs.default.redactOtherKey
 `,
+	}, {
+		name: "path in nested list",
+		input: []byte(`id: test-policy
+inputs:
+    - type: httpjson
+      data_stream:
+        namespace: default
+      streams:
+        - config_version: "2"
+          request.transforms:
+            - set:
+                target: header.Authorization
+                value: SSWS this-should-be-redacted
+            - set:
+                target: url.params.limit
+                value: "1000"
+secret_paths:
+    - inputs.0.streams.0.request.transforms.0.set.value
+`),
+		expect: `id: test-policy
+inputs:
+    - data_stream:
+        namespace: default
+      streams:
+        - config_version: "2"
+          request.transforms:
+            - set:
+                target: header.Authorization
+                value: <REDACTED>
+            - set:
+                target: url.params.limit
+                value: "1000"
+      type: httpjson
+secret_paths:
+    - inputs.0.streams.0.request.transforms.0.set.value
+`,
 	}}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			file := client.DiagnosticFileResult{Content: tc.input, ContentType: "application/yaml"}
 			var out bytes.Buffer
-			err := writeRedacted(io.Discard, &out, "testPath", file)
+			var errOut bytes.Buffer
+			err := writeRedacted(&errOut, &out, "testPath", file)
 			require.NoError(t, err)
 
+			t.Logf("Error output: %s", errOut.String())
 			assert.Equal(t, tc.expect, out.String())
 		})
 	}


### PR DESCRIPTION
## What does this PR do?

Redact secrets within complex nested paths.

## Why is it important?

some secrets are getting skipped within diagnostics bundles

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None