### PR TITLE
ci: remove Dependabot config for OTel components

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,18 +9,9 @@ updates:
       - automation
       - skip-changelog
       - Team:Elastic-Agent-Control-Plane
-    groups:
-        otel-dependencies:
-            exclude-patterns:
-             - "github.com/elastic/*"
-            update-types:
-             - "minor"
-             - "patch"
     allow:
       # Only update internal dependencies for now while we evaluate this workflow.
       - dependency-name: "github.com/elastic/*"
-      - dependency-name: "go.opentelemetry.io/collector/*"
-      - dependency-name: "github.com/open-telemetry/opentelemetry-collector-contrib/*"
       - dependency-name: "github.com/elastic/opentelemetry-collector-components/*"
     ignore:
       - dependency-name: "github.com/elastic/beats/*"


### PR DESCRIPTION
## What does this PR do?

Removes the Dependabot config for OTel component updates.

## Why is it important?

The pull requests to update OTel components created by Dependabot have been unreliable and unfit for merging. Examples:
- https://github.com/elastic/elastic-agent/pull/6709/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R46
- https://github.com/elastic/elastic-agent/pull/6377/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R50

They also don't include a changelog entry, which we want to be included with OTel updates.

We have been relying on manual updates of OTel components for the last couple versions, with the intention to move to a different automation in the future that satisfies all requirements (see https://github.com/elastic/elastic-agent/issues/6132).

At this point, the Dependabot PRs are just noise, so let's remove this automation to get rid of the noise.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Part of https://github.com/elastic/elastic-agent/issues/6132