### PR TITLE
Add statePersistence value to helm chart presets

### DIFF
--- a/deploy/helm/elastic-agent/examples/eck/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/eck/rendered/manifest.yaml
@@ -1093,7 +1093,6 @@ spec:
             privileged: false
             runAsGroup: 1000
             runAsUser: 1000
-          volumeMounts: null
         dnsPolicy: ClusterFirstWithHostNet
         nodeSelector:
           kubernetes.io/os: linux

--- a/deploy/helm/elastic-agent/examples/eck/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/eck/rendered/manifest.yaml
@@ -1033,6 +1033,10 @@ spec:
         - hostPath:
             path: /var/log
           name: varlog
+        - hostPath:
+            path: /etc/elastic-agent/default/agent-pernode-example/state
+            type: DirectoryOrCreate
+          name: agent-data
 ---
 # Source: elastic-agent/templates/agent/eck/deployment.yaml
 apiVersion: agent.k8s.elastic.co/v1alpha1

--- a/deploy/helm/elastic-agent/examples/netflow-service/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/netflow-service/rendered/manifest.yaml
@@ -158,9 +158,7 @@ spec:
           subPath: agent.yml
       dnsPolicy: ClusterFirstWithHostNet
       volumes:
-      - hostPath:
-          path: /etc/elastic-agent/default/agent-netflow-example/state
-          type: DirectoryOrCreate
+      - emptyDir: {}
         name: agent-data
       - name: config
         secret:

--- a/deploy/helm/elastic-agent/examples/nginx-custom-integration/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/nginx-custom-integration/rendered/manifest.yaml
@@ -107,9 +107,7 @@ spec:
           subPath: agent.yml
       dnsPolicy: ClusterFirstWithHostNet
       volumes:
-      - hostPath:
-          path: /etc/elastic-agent/default/agent-nginx-example/state
-          type: DirectoryOrCreate
+      - emptyDir: {}
         name: agent-data
       - name: config
         secret:

--- a/deploy/helm/elastic-agent/examples/user-cluster-role/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/user-cluster-role/rendered/manifest.yaml
@@ -147,9 +147,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: agent-nginx-example
       volumes:
-      - hostPath:
-          path: /etc/elastic-agent/default/agent-nginx-example/state
-          type: DirectoryOrCreate
+      - emptyDir: {}
         name: agent-data
       - name: config
         secret:

--- a/deploy/helm/elastic-agent/templates/agent/eck/_pod_template.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/eck/_pod_template.yaml
@@ -2,6 +2,7 @@
 {{- $ := index . 0 -}}
 {{- $presetVal := index . 1 -}}
 {{- $agentName := index . 2 }}
+{{- $agentVolumes := (include "elasticagent.preset.render.volumes"  (list $ $presetVal $agentName) | fromYaml) -}}
 apiVersion: v1
 kind: PodTemplate
 template:
@@ -39,10 +40,10 @@ template:
     topologySpreadConstraints:
       {{- . | toYaml | nindent 6 }}
     {{- end }}
+    {{- with ($agentVolumes).volumes }}
     volumes:
-      {{- with ($presetVal).extraVolumes }}
       {{- . | toYaml | nindent 6 }}
-      {{- end }}
+    {{- end }}
     {{- with ($presetVal).initContainers }}
     initContainers:
       {{- . | toYaml | nindent 6 }}
@@ -90,10 +91,10 @@ template:
           {{- end }}
         {{- end }}
         {{- end }}
+        {{- with ($presetVal).extraVolumeMounts }}
         volumeMounts:
-          {{- with ($presetVal).extraVolumeMounts }}
           {{- . | toYaml | nindent 10 }}
-          {{- end }}
+        {{- end }}
         env:
           - name: NODE_NAME
             valueFrom:

--- a/deploy/helm/elastic-agent/templates/agent/k8s/_pod_template.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/k8s/_pod_template.yaml
@@ -2,6 +2,7 @@
 {{- $ := index . 0 -}}
 {{- $presetVal := index . 1 -}}
 {{- $agentName := index . 2 }}
+{{- $agentVolumes := (include "elasticagent.preset.render.volumes"  (list $ $presetVal $agentName) | fromYaml) -}}
 apiVersion: v1
 kind: PodTemplate
 template:
@@ -40,28 +41,8 @@ template:
       {{- . | toYaml | nindent 6 }}
     {{- end }}
     volumes:
-      {{- $definedAgentStateVolume := false -}}
-      {{- with ($presetVal).extraVolumes }}
+      {{- with ($agentVolumes).volumes }}
       {{- . | toYaml | nindent 6 }}
-      {{- range $idx, $volume := . -}}
-      {{- if eq $definedAgentStateVolume false -}}
-      {{- if eq ($volume).name "agent-data" -}}
-      {{- $definedAgentStateVolume = true}}
-      {{- end -}}
-      {{- end -}}
-      {{- end -}}
-      {{- end }}
-      {{- if eq $definedAgentStateVolume false }}
-      - name: agent-data
-        hostPath:
-          {{- if eq $.Values.agent.fleet.enabled true }}
-          {{/* different state hostPath for managed agents */}}
-          path: /etc/elastic-agent/{{$.Release.Namespace}}/{{$agentName}}-managed/state
-          {{- else }}
-          {{/* different state hostPath for standalone agents */}}
-          path: /etc/elastic-agent/{{$.Release.Namespace}}/{{$agentName}}/state
-          {{- end }}
-          type: DirectoryOrCreate
       {{- end }}
       {{/* standalone mode so config is static */}}
       - name: config
@@ -117,20 +98,8 @@ template:
         {{- end }}
         {{- end }}
         volumeMounts:
-          {{- $definedAgentStateVolumeMount := false -}}
-          {{- with ($presetVal).extraVolumeMounts }}
-          {{- . | toYaml | nindent 10}}
-          {{- range $idx, $volumeMount := . -}}
-          {{- if eq $definedAgentStateVolumeMount false -}}
-          {{- if eq ($volumeMount).name "agent-data" -}}
-          {{- $definedAgentStateVolumeMount = true}}
-          {{- end -}}
-          {{- end -}}
-          {{- end -}}
-          {{- end }}
-          {{- if eq $definedAgentStateVolumeMount false }}
-          - name: agent-data
-            mountPath: /usr/share/elastic-agent/state
+          {{- with ($agentVolumes).volumeMounts }}
+          {{- . | toYaml | nindent 10 }}
           {{- end }}
           - name: config
             mountPath: /etc/elastic-agent/agent.yml

--- a/deploy/helm/elastic-agent/values.schema.json
+++ b/deploy/helm/elastic-agent/values.schema.json
@@ -1356,6 +1356,15 @@
                         ]
                     ]
                 },
+                "statePersistence": {
+                    "type": "string",
+                    "enum": [
+                        "HostPath",
+                        "EmptyDir",
+                        "None"
+                    ],
+                    "description": "Volume type used for Agent state persistence."
+                },
                 "extraVolumes": {
                     "type": "array",
                     "items": {

--- a/deploy/helm/elastic-agent/values.yaml
+++ b/deploy/helm/elastic-agent/values.yaml
@@ -396,6 +396,7 @@ agent:
     #    tolerations: []
     #    topologySpreadConstraints: []
     #    extraEnv: []
+    #    statePersistence: [HostPath, EmptyDir, None]
     #    extraVolumes: []
     #    extraVolumeMounts: []
     #    https://github.com/elastic/elastic-agent/blob/main/_meta/elastic-agent.yml
@@ -418,10 +419,8 @@ agent:
           memory: 400Mi
       nodeSelector:
         kubernetes.io/os: linux
-      extraVolumes:
-        # override the default agent-data volume and make it an emptyDir
-        - name: agent-data
-          emptyDir: {}
+      statePersistence: EmptyDir
+      extraVolumes: []
       extraEnvs:
         - name: ELASTIC_NETINFO
           value: "false"
@@ -454,6 +453,7 @@ agent:
           memory: 400Mi
       nodeSelector:
         kubernetes.io/os: linux
+      statePersistence: HostPath
       extraEnvs:
         - name: ELASTIC_NETINFO
           value: "false"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This PR adds a `statePersistence` value in Elastic Agent helm chart to allow configuring which type of volume is defined for Agent pods.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
The new value `statePersistence` simplify the process of defining storage for Elastic Agent state by providing sensible defaults while allowing flexibility for custom configurations.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #6026 

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
