### PR TITLE
mage: run mage update steps in parallel

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -651,7 +651,7 @@ func commitID() string {
 
 // Update is an alias for executing control protocol, configs, and specs.
 func Update() {
-	mg.SerialDeps(Config, BuildPGP, BuildFleetCfg, Otel.Readme)
+	mg.Deps(Config, BuildPGP, BuildFleetCfg, Otel.Readme)
 }
 
 func EnsureCrossBuildOutputDir() error {


### PR DESCRIPTION
## What does this PR do?

From the looks of it, none of the update steps interact with each other, so I don't see a reason to run them serially.

As an example, making a single line change in the otel components file results in the following timings:

	parallel mage update  9.19s user 1.92s system 366% cpu 3.027 total
	serial mage update  20.20s user 2.93s system 181% cpu 12.748 total

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

## How to test this PR locally

```bash
mage update
```
