### PR TITLE
Add a test for empty local provider

### DIFF
--- a/internal/pkg/composable/controller_test.go
+++ b/internal/pkg/composable/controller_test.go
@@ -159,6 +159,15 @@ func TestProvidersDefaultDisabled(t *testing.T) {
 			context:  nil,                               // should have none
 		},
 		{
+			name: "default disabled, local provider without data",
+			cfg: map[string]interface{}{
+				"agent.providers.initial_default": "false",
+				"providers": map[string]any{
+					"local": map[string]any{},
+				},
+			},
+		},
+		{
 			name: "default enabled",
 			cfg: map[string]interface{}{
 				"agent.providers.initial_default": "true",


### PR DESCRIPTION
## What does this PR do?

Adds a test verifying that the composable provider will correctly emit variables if only an empty local provider is present. https://github.com/elastic/elastic-agent/pull/6598 fixed a bug related to this in 8.17 and 8.16. The bug doesn't exist in newer versions due to https://github.com/elastic/elastic-agent/pull/6169.

## Why is it important?

Before https://github.com/elastic/elastic-agent/pull/6169 allowed providers to not run if there weren't any references to them in the policy, adding an empty local provider was how users would intentionally disable providers. This test case verifies that newer versions of agent don't break this setup.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
