### PR TITLE
Revert "refactor: replace x/exp usage with iterators"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 	go.opentelemetry.io/collector/receiver/nopreceiver v0.119.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.32.0
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/net v0.34.0
 	golang.org/x/sync v0.10.0
 	golang.org/x/sys v0.29.0
@@ -617,7 +618,6 @@ require (
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect

--- a/internal/pkg/agent/cmd/container_init_test.go
+++ b/internal/pkg/agent/cmd/container_init_test.go
@@ -8,14 +8,13 @@ package cmd
 
 import (
 	"errors"
-	"maps"
 	"os"
 	"path/filepath"
-	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"golang.org/x/exp/maps"
 	"kernel.org/pub/linux/libs/security/libcap/cap"
 )
 
@@ -193,8 +192,8 @@ func Test_raiseEffectiveCapabilities(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.ElementsMatch(t, tt.expectedCaps, slices.Collect(maps.Keys(tt.mockedProcCaps.effectiveCaps)))
-				require.ElementsMatch(t, tt.expectedCaps, slices.Collect(maps.Keys(tt.mockedProcCaps.inheritableCaps)))
+				require.ElementsMatch(t, tt.expectedCaps, maps.Keys(tt.mockedProcCaps.effectiveCaps))
+				require.ElementsMatch(t, tt.expectedCaps, maps.Keys(tt.mockedProcCaps.inheritableCaps))
 			}
 		})
 	}
@@ -292,7 +291,7 @@ func Test_raiseAmbientCapabilities(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.ElementsMatch(t, tt.expectedAmbientCaps, slices.Collect(maps.Keys(tt.mockedBoundCaps.ambientCaps)))
+				require.ElementsMatch(t, tt.expectedAmbientCaps, maps.Keys(tt.mockedBoundCaps.ambientCaps))
 			}
 		})
 	}


### PR DESCRIPTION
Reverting back to go 1.22 because goland crossbuild packaging fails on ARM with:

```
>> buildGoDaemon: Building for linux/arm64
Unable to find image 'docker.elastic.co/beats-dev/golang-crossbuild:1.23.6-arm' locally
1.23.6-arm: Pulling from beats-dev/golang-crossbuild
...
Status: Downloaded newer image for docker.elastic.co/beats-dev/golang-crossbuild:1.23.6-arm
exec /crossbuild: exec format error
```

Reverts elastic/elastic-agent#6933
