### PR TITLE
Use newer multiarch support for DRA packaging in ARM

### DIFF
--- a/.buildkite/pipeline.elastic-agent-package.yml
+++ b/.buildkite/pipeline.elastic-agent-package.yml
@@ -79,11 +79,14 @@ steps:
         agents:
           provider: "aws"
           instanceType: "t4g.2xlarge"
-          imagePrefix: "core-ubuntu-2004-aarch64"
+          imagePrefix: "core-ubuntu-2204-aarch64"
         env:
           PLATFORMS: "linux/arm64"
           PACKAGES: "docker"
         command: |
+          echo "Add support for multiarch"
+          docker run --privileged --rm tonistiigi/binfmt:master --install all
+
           if [[ -z "$${MANIFEST_URL}" ]]; then
             export MANIFEST_URL=$(buildkite-agent meta-data get MANIFEST_URL --default "")
             if [[ -z "$${MANIFEST_URL}" ]]; then
@@ -110,10 +113,10 @@ steps:
       DRA_PROJECT_ARTIFACT_ID: "agent-package"
     command: |
       echo "+++ Restoring Artifacts"
-      buildkite-agent artifact download "build/**/*" . 
+      buildkite-agent artifact download "build/**/*" .
 
-      echo "+++ Changing permissions for the release manager"      
-      sudo chmod -R a+r build/distributions/ 
+      echo "+++ Changing permissions for the release manager"
+      sudo chmod -R a+r build/distributions/
       sudo chown -R :1000 build/distributions/
       ls -lahR build/
 


### PR DESCRIPTION
## What does this PR do?

- switch to ubuntu 22.04 ARM for the ARM part of the DRA packaging
- enable multi arch builds avoid the exec format errors when attempting to build arm64 inside arm64 workers

## Why is it important?

After the [recent upgrade to go 1.23.6](https://github.com/elastic/elastic-agent/pull/5309) we are noticing failures like

```
>> buildGoDaemon: Building for linux/arm64
Unable to find image 'docker.elastic.co/beats-dev/golang-crossbuild:1.23.6-arm' locally
1.23.6-arm: Pulling from beats-dev/golang-crossbuild
d8ccec8a513f: Pull complete
Digest: sha256:4e859ff74164fe8ebc675f93691083aecf7cd13b6fb4f78723a9e8ddad8b4692
Status: Downloaded newer image for docker.elastic.co/beats-dev/golang-crossbuild:1.23.6-arm
exec /crossbuild: exec format error
```

in the packaging ARM step


## How to test this PR locally

Tested via https://buildkite.com/elastic/elastic-agent-package/builds/4332#0195241f-2d2a-495c-99d1-4c45dd39ff72

## Related issues

Relates to https://github.com/elastic/golang-crossbuild/pull/507
