### PR TITLE
Fix config used in Otel manager test

### DIFF
--- a/internal/pkg/otel/manager/manager_test.go
+++ b/internal/pkg/otel/manager/manager_test.go
@@ -24,38 +24,36 @@ import (
 var (
 	testConfig = map[string]interface{}{
 		"receivers": map[string]interface{}{
-			"otlp": map[string]interface{}{
-				"protocols": map[string]interface{}{
-					"grpc": map[string]interface{}{
-						"endpoint": "0.0.0.0:4317",
-					},
-				},
-			},
+			"nop": map[string]interface{}{},
 		},
 		"processors": map[string]interface{}{
 			"batch": map[string]interface{}{},
 		},
 		"exporters": map[string]interface{}{
-			"otlp": map[string]interface{}{
-				"endpoint": "otelcol:4317",
-			},
+			"debug": map[string]interface{}{},
 		},
 		"service": map[string]interface{}{
+			"telemetry": map[string]interface{}{
+				"metrics": map[string]interface{}{
+					"level":   "none",
+					"readers": []any{},
+				},
+			},
 			"pipelines": map[string]interface{}{
 				"traces": map[string]interface{}{
-					"receivers":  []string{"otlp"},
+					"receivers":  []string{"nop"},
 					"processors": []string{"batch"},
-					"exporters":  []string{"otlp"},
+					"exporters":  []string{"debug"},
 				},
 				"metrics": map[string]interface{}{
-					"receivers":  []string{"otlp"},
+					"receivers":  []string{"nop"},
 					"processors": []string{"batch"},
-					"exporters":  []string{"otlp"},
+					"exporters":  []string{"debug"},
 				},
 				"logs": map[string]interface{}{
-					"receivers":  []string{"otlp"},
+					"receivers":  []string{"nop"},
 					"processors": []string{"batch"},
-					"exporters":  []string{"otlp"},
+					"exporters":  []string{"debug"},
 				},
 			},
 		},
@@ -191,7 +189,7 @@ func TestOTelManager_ConfigError(t *testing.T) {
 
 	go func() {
 		err := m.Run(ctx)
-		require.ErrorIs(t, err, context.Canceled, "otel manager should be cancelled")
+		assert.ErrorIs(t, err, context.Canceled, "otel manager should be cancelled")
 	}()
 
 	// watch is synchronous, so we need to read from it to avoid blocking the manager


### PR DESCRIPTION
## What does this PR do?

Otel collector exposes metrics on port 8888 by default, which can cause conflicts with other applications in tests. Disable this.

Use the debugexporter and nopreceiver in the test instead of the otlpexporter and otlpreceiver. This is faster and doesn't require binding to any ports as well.

## Why is it important?

Tests should not be flaky.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project


## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/6965

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
