### PR TITLE
Fix warning on emitting diagnostics for otel hybrid mode

### DIFF
--- a/internal/pkg/diagnostics/diagnostics_test.go
+++ b/internal/pkg/diagnostics/diagnostics_test.go
@@ -117,6 +117,19 @@ i4EFZLWrFRsAAAARYWxleGtAZ3JlbWluLm5lc3QBAg==
 	require.NotContains(t, outWriter.String(), privKey)
 }
 
+func TestRedactPlainString(t *testing.T) {
+	errOut := strings.Builder{}
+	outWriter := strings.Builder{}
+	inputString := "Just a string"
+	res := client.DiagnosticFileResult{Content: []byte(inputString), ContentType: "application/yaml"}
+
+	err := writeRedacted(&errOut, &outWriter, "test/path", res)
+	require.NoError(t, err)
+
+	require.Empty(t, errOut.String())
+	require.Equal(t, outWriter.String(), inputString)
+}
+
 func TestRedactComplexKeys(t *testing.T) {
 	// taken directly from the yaml spec: https://yaml.org/spec/1.1/#c-mapping-key
 	// This test mostly serves to document that part of the YAML library doesn't work properly


### PR DESCRIPTION
## What does this PR do?

If an Otel hybrid mode configuration doesn't exist, we emit a plain text message into the config file generated by diagnostics. When we try to redact secrets from it, we fail to unmarshal it into a map and log a warning about it.

Instead, only run the redaction after confirming the value is actually a map.

## Why is it important?

We shouldn't emit spurious warnings.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

Build the agent locally, start it, and get diagnostics. You shouldn't see a warning message mentioned in https://github.com/elastic/elastic-agent/issues/6783.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/6783

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
