### PR TITLE
Collapse pipelines under elastic-agent

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -293,7 +293,8 @@ steps:
                 - .buildkite/hooks/
 
               config:
-                trigger: "elastic-agent-extended-testing"
+                label: ":pipeline: Upload extended testing Pipeline"
+                command: "buildkite-agent pipeline upload .buildkite/integration.pipeline.yml"
                 build:
                   commit: "${BUILDKITE_COMMIT}"
                   branch: "${BUILDKITE_BRANCH}"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -58,6 +58,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.* !8.* !9.*"
       env:
+        ELASTIC_PR_COMMENTS_ENABLED: 'true'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: "true"
         SLACK_NOTIFICATIONS_CHANNEL: "#ingest-notifications"
         SLACK_NOTIFICATIONS_ALL_BRANCHES: "false"


### PR DESCRIPTION
## What does this PR do?

In order for the Buildkite PR bot to be able to publish meaningful comments for failures, the pipelines need to be collapsed / uploaded rather than triggered, otherwise we lose the context and the ability to have the comment include specific failures for the failed steps in triggered pipelines.

This commit switches away from triggering to pipeline upload commands to enable this functionality.

## Why is it important?

Allows enabling `ELASTIC_PR_COMMENTS_ENABLED: 'true'` only on the parent job
