### PR TITLE
Allow PR comments for failures from the elastic-agent pipeline

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -58,6 +58,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.* !8.* !9.*"
       env:
+        ELASTIC_PR_COMMENTS_ENABLED: 'true'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: "true"
         SLACK_NOTIFICATIONS_CHANNEL: "#ingest-notifications"
         SLACK_NOTIFICATIONS_ALL_BRANCHES: "false"


### PR DESCRIPTION
## What does this PR do?

This comment enables the native PR comment functionality from the Buildkite build bot which will allow comments in the PR about steps that failed even when they are flaky. It is enabled on the parent `elastic-agent` pipeline.

## Why is it important?

Improves visibility for PR authors and the team about test failures and flakiness.
Because the parent job triggers other pipelines e.g. [extended-testing](https://github.com/elastic/elastic-agent/blob/c1d42aef0869d194484d9113dcbac2a4d8fec0bf/.buildkite/pipeline.yml#L296) if any steps failed in the triggered pipeline, the comment will only mention the triggered pipeline. In a [follow up PR](https://github.com/elastic/elastic-agent/pull/6978/files), we are exploring whether it's possible to collapse triggered steps under the same pipeline.

## Disruptive User Impact

PR will now have an additional comment, like this one: https://github.com/elastic/logstash/pull/17137#issuecomment-2675185437 pinging the assignee about it as well (assignee is ensured via mergify).
