### PR TITLE
Make enroll command backoff more conservative

### DIFF
--- a/changelog/fragments/1740399399-fleet-backoff.yaml
+++ b/changelog/fragments/1740399399-fleet-backoff.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Make enroll command backoff consistent with other requests to Fleet
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/6761

--- a/changelog/fragments/1740399399-fleet-backoff.yaml
+++ b/changelog/fragments/1740399399-fleet-backoff.yaml
@@ -11,12 +11,14 @@
 kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
-summary: Make enroll command backoff consistent with other requests to Fleet
+summary: Make enroll command backoff more conservative
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
 # NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
-#description:
+description: |
+  The plain enroll command now has an initial delay of 5s and a maximum of 10 minutes. It also has a jitter.
+  Delayed enroll now uses the same backoff behaviour as other requests to Fleet Server.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component: elastic-agent

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -37,21 +37,24 @@ const (
 	fleetStateStarting = "starting"
 )
 
+// Default backoff settings for connecting to Fleet
+var defaultFleetBackoffSettings = backoffSettings{
+	Init: 60 * time.Second,
+	Max:  10 * time.Minute,
+}
+
 // Default Configuration for the Fleet Gateway.
 var defaultGatewaySettings = &fleetGatewaySettings{
 	Duration:                     1 * time.Second,        // time between successful calls
 	Jitter:                       500 * time.Millisecond, // used as a jitter for duration
 	ErrConsecutiveUnauthDuration: 1 * time.Hour,          // time between calls when the agent exceeds unauthorized response limit
-	Backoff: backoffSettings{ // time after a failed call
-		Init: 60 * time.Second,
-		Max:  10 * time.Minute,
-	},
+	Backoff:                      &defaultFleetBackoffSettings,
 }
 
 type fleetGatewaySettings struct {
-	Duration                     time.Duration   `config:"checkin_frequency"`
-	Jitter                       time.Duration   `config:"jitter"`
-	Backoff                      backoffSettings `config:"backoff"`
+	Duration                     time.Duration    `config:"checkin_frequency"`
+	Jitter                       time.Duration    `config:"jitter"`
+	Backoff                      *backoffSettings `config:"backoff"`
 	ErrConsecutiveUnauthDuration time.Duration
 }
 
@@ -136,11 +139,18 @@ func (f *FleetGateway) Actions() <-chan []fleetapi.Action {
 }
 
 func (f *FleetGateway) Run(ctx context.Context) error {
-	backoff := backoff.NewEqualJitterBackoff(
-		ctx.Done(),
-		f.settings.Backoff.Init,
-		f.settings.Backoff.Max,
-	)
+	var requestBackoff backoff.Backoff
+	if f.settings.Backoff == nil {
+		requestBackoff = RequestBackoff(ctx.Done())
+	} else {
+		// this is only used in tests
+		requestBackoff = backoff.NewEqualJitterBackoff(
+			ctx.Done(),
+			f.settings.Backoff.Init,
+			f.settings.Backoff.Max,
+		)
+	}
+
 	f.log.Info("Fleet gateway started")
 	for {
 		select {
@@ -154,7 +164,7 @@ func (f *FleetGateway) Run(ctx context.Context) error {
 			// Execute the checkin call and for any errors returned by the fleet-server API
 			// the function will retry to communicate with fleet-server with an exponential delay and some
 			// jitter to help better distribute the load from a fleet of agents.
-			resp, err := f.doExecute(ctx, backoff)
+			resp, err := f.doExecute(ctx, requestBackoff)
 			if err != nil {
 				continue
 			}
@@ -427,4 +437,12 @@ func agentStateToString(state agentclient.State) string {
 	}
 	// Unknown states map to degraded.
 	return fleetStateDegraded
+}
+
+func RequestBackoff(done <-chan struct{}) backoff.Backoff {
+	return backoff.NewEqualJitterBackoff(
+		done,
+		defaultFleetBackoffSettings.Init,
+		defaultFleetBackoffSettings.Max,
+	)
 }

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -124,7 +124,7 @@ func TestFleetGateway(t *testing.T) {
 	agentInfo := &testAgentInfo{}
 	settings := &fleetGatewaySettings{
 		Duration: 5 * time.Second,
-		Backoff:  backoffSettings{Init: 1 * time.Second, Max: 5 * time.Second},
+		Backoff:  &backoffSettings{Init: 1 * time.Second, Max: 5 * time.Second},
 	}
 
 	t.Run("send no event and receive no action", withGateway(agentInfo, settings, func(
@@ -274,7 +274,7 @@ func TestFleetGateway(t *testing.T) {
 			log,
 			&fleetGatewaySettings{
 				Duration: d,
-				Backoff:  backoffSettings{Init: 1 * time.Second, Max: 30 * time.Second},
+				Backoff:  &backoffSettings{Init: 1 * time.Second, Max: 30 * time.Second},
 			},
 			agentInfo,
 			client,
@@ -383,7 +383,7 @@ func TestRetriesOnFailures(t *testing.T) {
 	agentInfo := &testAgentInfo{}
 	settings := &fleetGatewaySettings{
 		Duration: 5 * time.Second,
-		Backoff:  backoffSettings{Init: 100 * time.Millisecond, Max: 5 * time.Second},
+		Backoff:  &backoffSettings{Init: 100 * time.Millisecond, Max: 5 * time.Second},
 	}
 
 	t.Run("When the gateway fails to communicate with the checkin API we will retry",
@@ -434,7 +434,7 @@ func TestRetriesOnFailures(t *testing.T) {
 	t.Run("The retry loop is interruptible",
 		withGateway(agentInfo, &fleetGatewaySettings{
 			Duration: 0 * time.Second,
-			Backoff:  backoffSettings{Init: 10 * time.Minute, Max: 20 * time.Minute},
+			Backoff:  &backoffSettings{Init: 10 * time.Minute, Max: 20 * time.Minute},
 		}, func(
 			t *testing.T,
 			gateway coordinator.FleetGateway,
@@ -587,7 +587,7 @@ func TestFleetGatewaySchedulerSwitch(t *testing.T) {
 	agentInfo := &testAgentInfo{}
 	settings := &fleetGatewaySettings{
 		Duration: 1 * time.Second,
-		Backoff:  backoffSettings{Init: 1 * time.Millisecond, Max: 2 * time.Millisecond},
+		Backoff:  &backoffSettings{Init: 1 * time.Millisecond, Max: 2 * time.Millisecond},
 	}
 
 	tempSet := *defaultGatewaySettings

--- a/internal/pkg/agent/cmd/enroll.go
+++ b/internal/pkg/agent/cmd/enroll.go
@@ -559,6 +559,7 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command) error {
 		&options,
 		pathConfigFile,
 		store,
+		nil,
 	)
 	if err != nil {
 		return err

--- a/internal/pkg/agent/cmd/enroll_cmd_test.go
+++ b/internal/pkg/agent/cmd/enroll_cmd_test.go
@@ -496,10 +496,14 @@ func TestEnroll(t *testing.T) {
 			require.NoError(t, err)
 
 			streams, _, _, _ := cli.NewTestingIOStreams()
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			backoffInit := time.Minute
+			ctx, cancel := context.WithTimeout(context.Background(), 2*backoffInit)
 			defer cancel()
+			now := time.Now()
 			err = cmd.Execute(ctx, streams)
+			elapsed := time.Since(now)
 			require.NoError(t, err, "enroll command should return no error")
+			assert.LessOrEqual(t, backoffInit/2, elapsed, "enroll should wait at least half of the backoff init")
 
 			assert.True(t, store.Called, "the store should have been called")
 			config, err := readConfig(store.Content)

--- a/internal/pkg/agent/cmd/enroll_cmd_test.go
+++ b/internal/pkg/agent/cmd/enroll_cmd_test.go
@@ -110,6 +110,7 @@ func TestEnroll(t *testing.T) {
 				},
 				"",
 				store,
+				nil,
 			)
 			require.NoError(t, err)
 
@@ -181,6 +182,7 @@ func TestEnroll(t *testing.T) {
 			&enrollOptions,
 			"",
 			store,
+			nil,
 		)
 		require.NoError(t, err, "could not create enroll command")
 
@@ -254,6 +256,7 @@ func TestEnroll(t *testing.T) {
 				},
 				"",
 				store,
+				nil,
 			)
 			require.NoError(t, err)
 
@@ -316,6 +319,7 @@ func TestEnroll(t *testing.T) {
 				},
 				"",
 				store,
+				nil,
 			)
 			require.NoError(t, err)
 
@@ -380,6 +384,7 @@ func TestEnroll(t *testing.T) {
 				},
 				"",
 				store,
+				nil,
 			)
 			require.NoError(t, err)
 
@@ -424,6 +429,7 @@ func TestEnroll(t *testing.T) {
 				},
 				"",
 				store,
+				nil,
 			)
 			require.NoError(t, err)
 
@@ -492,18 +498,15 @@ func TestEnroll(t *testing.T) {
 				},
 				"",
 				store,
+				nil,
 			)
 			require.NoError(t, err)
 
 			streams, _, _, _ := cli.NewTestingIOStreams()
-			backoffInit := time.Minute
-			ctx, cancel := context.WithTimeout(context.Background(), 2*backoffInit)
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 			defer cancel()
-			now := time.Now()
 			err = cmd.Execute(ctx, streams)
-			elapsed := time.Since(now)
 			require.NoError(t, err, "enroll command should return no error")
-			assert.LessOrEqual(t, backoffInit/2, elapsed, "enroll should wait at least half of the backoff init")
 
 			assert.True(t, store.Called, "the store should have been called")
 			config, err := readConfig(store.Content)

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -547,7 +547,7 @@ func tryDelayEnroll(ctx context.Context, logger *logger.Logger, cfg *configurati
 		&options,
 		paths.ConfigFile(),
 		store,
-		fleetgateway.RequestBackoff, // for delayed enroll, we want to use m
+		fleetgateway.RequestBackoff, // for delayed enroll, we want to use the same backoff settings as fleet checkins
 	)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -16,6 +16,8 @@ import (
 	"syscall"
 	"time"
 
+	fleetgateway "github.com/elastic/elastic-agent/internal/pkg/agent/application/gateway/fleet"
+
 	"go.elastic.co/apm/v2"
 	apmtransport "go.elastic.co/apm/v2/transport"
 	"gopkg.in/yaml.v2"
@@ -545,6 +547,7 @@ func tryDelayEnroll(ctx context.Context, logger *logger.Logger, cfg *configurati
 		&options,
 		paths.ConfigFile(),
 		store,
+		fleetgateway.RequestBackoff, // for delayed enroll, we want to use m
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What does this PR do?

We make two changes to the backoff behaviour of the enroll command:

* Plain enroll now has an initial delay of 5s, a max delay of 10m, and uses jitter.
* Delayed enroll now has the same backoff behaviour as other requests to Fleet. This means an initial delay of 1m, a max delay of 10m, and jitter equal to half the delay time.

## Why is it important?

We've had a report where a lot of agents trying to enroll before Fleet was ready resulted in a DDOS with the previous backoff settings. Any situation where we can retry forever should use very conservative settings to avoid these kinds of situations.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## How to test this PR locally

There's a unit test for this behaviour. Testing the actual binary e2e is annoying, because we need to induce fleet server to return 503s.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/6761

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
