### PR TITLE
Remove unnecessary loop variable copies

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,7 +46,7 @@ linters:
     - asciicheck # simple linter to check that your code does not contain non-ASCII identifiers
     - bodyclose # checks whether HTTP response body is closed successfully
     - durationcheck # check for two durations multiplied together
-    - exportloopref # checks for pointers to enclosing loop variables
+    - copyloopvar # checks for unnecessary loop variable copies
     - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports
     - gosec # inspects source code for security problems
     - importas # enforces consistent import aliases

--- a/internal/pkg/agent/application/monitoring/processes_cloud_test.go
+++ b/internal/pkg/agent/application/monitoring/processes_cloud_test.go
@@ -90,7 +90,6 @@ func TestExpectedCloudProcessID(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc // make a copy to avoid implicit memory aliasing
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.id, expectedCloudProcessID(&tc.component))
 		})
@@ -143,7 +142,6 @@ func TestMatchesCloudProcessID(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc // make a copy to avoid implicit memory aliasing
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.matches, matchesCloudProcessID(&tc.component, tc.processID))
 		})

--- a/internal/pkg/eql/eql_test.go
+++ b/internal/pkg/eql/eql_test.go
@@ -380,7 +380,6 @@ func TestEql(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		test := test
 		var title string
 		if test.err {
 			title = fmt.Sprintf("%s failed parsing", test.expression)

--- a/internal/pkg/otel/configtranslate/otelconfig.go
+++ b/internal/pkg/otel/configtranslate/otelconfig.go
@@ -77,7 +77,6 @@ func getSupportedComponents(model *component.Model) []*component.Component {
 	var supportedComponents []*component.Component
 
 	for _, comp := range model.Components {
-		comp := comp
 		if IsComponentOtelSupported(&comp) {
 			supportedComponents = append(supportedComponents, &comp)
 		}

--- a/testing/fleetservertest/server.go
+++ b/testing/fleetservertest/server.go
@@ -110,7 +110,6 @@ func NewRouter(handlers *Handlers) *mux.Router {
 
 	router := mux.NewRouter().StrictSlash(true)
 	for _, route := range handlers.Routes() {
-		route := route // needed because it's been captured in the closure
 		router.
 			Methods(route.Method).
 			Path(route.Pattern).
@@ -514,7 +513,7 @@ func (s *statusResponseWriter) Header() http.Header {
 
 func (s *statusResponseWriter) Write(bs []byte) (int, error) {
 	n, err := s.w.Write(bs)
-	s.byteCount.Add(uint64(n))
+	s.byteCount.Add(uint64(n)) //nolint:gosec// output of Write is guaranteed to be non-negative
 	return n, err
 }
 


### PR DESCRIPTION
## What does this PR do?

Removes unnecessary loop variable copies. These are not necessary anymore as of Go 1.22. It also replaces the deprecated `exportloopref` linter which would find places where these copies are necessary, with the `copyloopvar` linter which instead flags the copies as unnecessary.

## Why is it important?

We shouldn't unnecessarily copy loop variables, it's confusing and was only necessary due to older Go behaviour.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
