### PR TITLE
Add the full set of ECS metadata sent to Fleet to Diagnostics

### DIFF
--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -791,20 +791,21 @@ func (c *Coordinator) DiagnosticHooks() diagnostics.Hooks {
 			Description: "current state of the agent information of the running Elastic Agent",
 			ContentType: "application/yaml",
 			Hook: func(_ context.Context) []byte {
+				meta, err := c.agentInfo.ECSMetadata(c.logger)
+				if err != nil {
+					c.logger.Errorw("Error getting ECS metadata", "error.message", err)
+				}
+
 				output := struct {
-					AgentID      string            `yaml:"agent_id"`
-					Headers      map[string]string `yaml:"headers"`
-					LogLevel     string            `yaml:"log_level"`
-					Snapshot     bool              `yaml:"snapshot"`
-					Version      string            `yaml:"version"`
-					Unprivileged bool              `yaml:"unprivileged"`
+					Headers     map[string]string `yaml:"headers"`
+					LogLevel    string            `yaml:"log_level"`
+					RawLogLevel string            `yaml:"log_level_raw"`
+					Metadata    *info.ECSMeta     `yaml:"metadata"`
 				}{
-					AgentID:      c.agentInfo.AgentID(),
-					Headers:      c.agentInfo.Headers(),
-					LogLevel:     c.agentInfo.LogLevel(),
-					Snapshot:     c.agentInfo.Snapshot(),
-					Version:      c.agentInfo.Version(),
-					Unprivileged: c.agentInfo.Unprivileged(),
+					Headers:     c.agentInfo.Headers(),
+					LogLevel:    c.agentInfo.LogLevel(),
+					RawLogLevel: c.agentInfo.RawLogLevel(),
+					Metadata:    meta,
 				}
 				o, err := yaml.Marshal(output)
 				if err != nil {

--- a/internal/pkg/agent/application/info/agent_info.go
+++ b/internal/pkg/agent/application/info/agent_info.go
@@ -43,6 +43,9 @@ type Agent interface {
 
 	// IsStandalone returns true is the agent is running in standalone mode, i.e, without fleet
 	IsStandalone() bool
+
+	// ECSMetadata returns the ECS metadata that is attached as part of every Fleet checkin.
+	ECSMetadata(*logger.Logger) (*ECSMeta, error)
 }
 
 // AgentInfo is a collection of information about agent.


### PR DESCRIPTION
## What does this PR do?

Adds the full set of ECS metadata that is sent to Fleet when the agent checks in to diagnostics. If you don't know what that is, it's this:

https://github.com/elastic/elastic-agent/blob/d2047ac48df2f4536ca69a86ad4922b3e264501a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go#L327-L330

https://github.com/elastic/elastic-agent/blob/d2047ac48df2f4536ca69a86ad4922b3e264501a/internal/pkg/agent/application/info/agent_metadata.go#L25-L31

## Why is it important?

When all providers were enabled by default, you were able to get the information about the host from the host provider (hostname, OS version, etc) in the variables.yaml file. Now that providers are only enabled when referenced explicitly in the policy, the content of the variables.yaml file is by default:

```yaml
variables:
    - {}
```

This makes sure that detailed information about the host is available in diagnostics all the time separately from providers. This is useful if you are say, debugging why you can't find agent by the hostname you think it should have in Fleet. The format of the agent-info.yaml file now looks like:

```yaml
headers: {}
log_level: info
log_level_raw: info
metadata:
    elastic:
        agent:
            buildoriginal: '9.1.0-SNAPSHOT (build: d2047ac48df2f4536ca69a86ad4922b3e264501a at 2025-02-25 21:52:49 +0000 UTC)'
            complete: false
            id: 9ba45d59-e33f-42c7-a47d-50a9a37705ef
            loglevel: info
            snapshot: true
            unprivileged: false
            upgradeable: true
            version: 9.1.0
    host:
        arch: arm64
        hostname: Craigs-Macbook-Pro.local
        id: 48DA13D6-B83B-5C71-A4F3-494E674F9F37
        ip:
            - 127.0.0.1/8
            - ...
        mac:
            - ...
        name: craigs-macbook-pro.local
    os:
        family: darwin
        fullname: macOS(14.7.3)
        kernel: 23.6.0
        name: macOS
        platform: darwin
        version: 14.7.3

```

## Disruptive User Impact

I removed some of the duplicated keys from the top level of agent-info.yaml. I am assuming nobody was relying on this in a critical way. 

## How to test this PR locally

`elastic-development-agent diagnostics` and then read the agent-info.yaml file.
