### PR TITLE
[flakiness] kubernetes_secrets provider unit tests

### DIFF
--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
@@ -151,8 +151,9 @@ func (p *contextProviderK8SSecrets) Fetch(key string) (string, bool) {
 
 	if p.config.DisableCache {
 		// cache disabled - fetch secret from the API
-		val, _, ok := p.fetchFromAPI(ctx, secretName, secretNamespace, secretKey)
-		return val, ok
+		apiSecretValue, apiSecretResourceVersion, ok := p.fetchFromAPI(ctx, secretName, secretNamespace, secretKey)
+		p.logger.Debugf(`Fetch: %q fetched. Resource Version of secret: %q`, key, apiSecretResourceVersion)
+		return apiSecretValue, ok
 	}
 
 	// cache enabled

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
@@ -967,7 +967,7 @@ func Test_FetchFromAPI(t *testing.T) {
 			secretKey:       "secret_key_not_found",
 		},
 		{
-			name: "key in secret not found",
+			name: "key in secret found",
 			k8sClient: k8sfake.NewClientset(
 				buildK8SSecretWithResourceVersion("secret_namespace", "secret_name", "secret_key", "secret_value", "100000"),
 			),

--- a/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
+++ b/internal/pkg/composable/providers/kubernetessecrets/kubernetes_secrets_test.go
@@ -692,7 +692,7 @@ func Test_Run(t *testing.T) {
 			providerCfg: Config{
 				RefreshInterval: 100 * time.Millisecond,
 				RequestTimeout:  100 * time.Millisecond,
-				TTLDelete:       2 * time.Second,
+				TTLDelete:       10 * time.Second,
 				DisableCache:    false,
 			},
 			expectedSignal: true,
@@ -714,7 +714,7 @@ func Test_Run(t *testing.T) {
 			providerCfg: Config{
 				RefreshInterval: 100 * time.Millisecond,
 				RequestTimeout:  100 * time.Millisecond,
-				TTLDelete:       2 * time.Second,
+				TTLDelete:       10 * time.Second,
 				DisableCache:    false,
 			},
 			expectedSignal: false,
@@ -740,7 +740,7 @@ func Test_Run(t *testing.T) {
 				DisableCache:    false,
 			},
 			expectedSignal: true,
-			waitForSignal:  time.Second,
+			waitForSignal:  2 * time.Second,
 			k8sClient: k8sfake.NewClientset(
 				testDataBuilder.buildK8SSecret("secret_value"),
 			),
@@ -756,7 +756,7 @@ func Test_Run(t *testing.T) {
 			providerCfg: Config{
 				RefreshInterval: 100 * time.Millisecond,
 				RequestTimeout:  100 * time.Millisecond,
-				TTLDelete:       2 * time.Second,
+				TTLDelete:       10 * time.Second,
 				DisableCache:    false,
 			},
 			expectedSignal: false,
@@ -777,7 +777,7 @@ func Test_Run(t *testing.T) {
 			providerCfg: Config{
 				RefreshInterval: 100 * time.Millisecond,
 				RequestTimeout:  100 * time.Millisecond,
-				TTLDelete:       2 * time.Second,
+				TTLDelete:       10 * time.Second,
 				DisableCache:    false,
 			},
 			k8sClient:    nil,
@@ -846,13 +846,11 @@ func Test_Run(t *testing.T) {
 				receivedSignal = true
 			case <-time.After(tc.waitForSignal):
 			}
+			list := p.store.List()
 			cancel()
-
 			wg.Wait()
 
 			require.Equal(t, tc.expectedSignal, receivedSignal)
-
-			list := p.store.List()
 			require.Equal(t, len(tc.postCacheState), len(list))
 
 			cacheMap := make(map[string]secret)
@@ -862,12 +860,12 @@ func Test_Run(t *testing.T) {
 			for k, v := range tc.postCacheState {
 				inCache, exists := cacheMap[k]
 				require.True(t, exists)
-				require.Equal(t, v.s.key, inCache.key)
-				require.Equal(t, v.s.name, inCache.name)
-				require.Equal(t, v.s.namespace, inCache.namespace)
-				require.Equal(t, v.s.key, inCache.key)
-				require.Equal(t, v.s.value, inCache.value)
-				require.Equal(t, v.s.apiExists, inCache.apiExists)
+				assert.Equal(t, v.s.key, inCache.key)
+				assert.Equal(t, v.s.name, inCache.name)
+				assert.Equal(t, v.s.namespace, inCache.namespace)
+				assert.Equal(t, v.s.key, inCache.key)
+				assert.Equal(t, v.s.value, inCache.value)
+				assert.Equal(t, v.s.apiExists, inCache.apiExists)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Type of change  
Please label this PR with one of the following labels, depending on the scope of your change:  
- Bug  
- Enhancement  
- Breaking change  
- Deprecation  
- Cleanup  
- Docs  
-->

## What does this PR do?

This PR introduces the following fixes and improvements:  
- **Loosens Time Constraints in Unit Tests** (needed for certain type of CI runners):  
  - The `TTLDelete` value in test configurations was increased from `2s` to `10s`, ensuring tests have more leeway in processing cache expiration.  
  - The `waitForSignal` value was adjusted from `1s` to `2s` to reduce test flakiness.  
  
- **Adds Debug Logging for Fetch When Cache is Disabled**:  [relevant comment](https://github.com/elastic/elastic-agent/pull/6841#discussion_r1970166713)
  - When the cache is disabled, fetching secrets from the API now logs the retrieved secret’s resource version for better visibility into API interactions.  

- **Fixes a Typo in a Unit Test Name**:   [relevant comment](https://github.com/elastic/elastic-agent/pull/6841#discussion_r1969983764)
  - The test case `"key in secret not found"` was incorrectly named and is now corrected to `"key in secret found"`.  

## Why is it important?

Fixes a test failure (`Test_Run/secret_no-update_and_no-signal`) that caused CI flakiness

## Checklist

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.  
- [ ] My code follows the style guidelines of this project.  
- [ ] I have commented my code, particularly in hard-to-understand areas.  
- [ ] I have made corresponding changes to the documentation.  
- [ ] I have made corresponding changes to the default configuration files.  
- [ ] I have added tests that prove my fix is effective or that my feature works.  
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog).  
- [ ] I have added an integration test or an E2E test.  

## Disruptive User Impact

No expected impact on users. These changes are limited to debugging logs and test improvements.  

## How to test this PR locally  
```sh
mage test:unit
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/6926
