### PR TITLE
[flakiness]: utilise socket helper funcs in unit-tests

### DIFF
--- a/pkg/component/runtime/conn_info_server_test.go
+++ b/pkg/component/runtime/conn_info_server_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 	"github.com/elastic/elastic-agent/internal/pkg/testutils"
 	"github.com/elastic/elastic-agent/pkg/ipc"
+	"github.com/elastic/elastic-agent/pkg/utils"
 )
 
 type mockCommunicator struct {
@@ -81,11 +82,11 @@ func getAddress(dir string, isLocal bool) string {
 
 		if runtime.GOOS == "windows" {
 			u.Scheme = "npipe"
-			return u.JoinPath("/", testSock).String()
+			return utils.SocketURLWithFallback(testSock, "/")
 		}
 
 		u.Scheme = "unix"
-		return u.JoinPath(dir, testSock).String()
+		return utils.SocketURLWithFallback(testSock, dir)
 	}
 	return fmt.Sprintf("127.0.0.1:%d", testPort)
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR fixes a failing test case, `TestConnInfoConnCloseThenAnotherConn`, which was caused by the generation of overly long Unix socket paths. On macOS, UNIX-domain addresses are limited to 104 characters, while Linux imposes a 108-character limit. The previous implementation in `getAddress` did not validate or handle excessive path lengths, causing the test to fail on macOS and occasionally on Linux.

To resolve this, the PR updates `getAddress` to utilize the existing `SocketURLWithFallback` helper function from `pkg/utils/socket_unix.go`, which ensures that socket paths remain within system limits.

## Why is it important?

This change is essential to prevent flakiness in the test suite and ensure that the test runs reliably across different platforms. By leveraging the existing socket utility functions, we ensure that socket paths adhere to OS-imposed constraints, reducing test failures and improving CI stability.

## Checklist

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made corresponding changes to the default configuration files.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog).
- [ ] I have added an integration test or an E2E test.

## Disruptive User Impact

This change only affects the test suite and does not impact users.

## How to test this PR locally

Run the following test command locally and verify that it no longer fails due to socket path length issues:

```sh
mage test:unit
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/6977
