### PR TITLE
Enhancement/5039 remove x crypto fips

### DIFF
--- a/internal/pkg/agent/vault/vault_file_notwindows.go
+++ b/internal/pkg/agent/vault/vault_file_notwindows.go
@@ -7,6 +7,7 @@
 package vault
 
 import (
+	"crypto/pbkdf2"
 	"crypto/rand"
 	"crypto/sha256"
 	"errors"
@@ -15,14 +16,14 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"golang.org/x/crypto/pbkdf2"
-
 	"github.com/elastic/elastic-agent/internal/pkg/agent/vault/aesgcm"
 	"github.com/elastic/elastic-agent/pkg/utils"
 )
 
 const (
-	saltSize = 8
+	saltSize      = 8
+	keyLen    int = 32
+	iterCount int = 12022
 )
 
 func (v *FileVault) encrypt(data []byte) ([]byte, error) {
@@ -56,7 +57,13 @@ func deriveKey(pw []byte, salt []byte) ([]byte, []byte, error) {
 			return nil, nil, err
 		}
 	}
-	return pbkdf2.Key(pw, salt, 12022, 32, sha256.New), salt, nil
+
+	key, err := pbkdf2.Key(sha256.New, string(pw), salt, iterCount, keyLen)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return key, salt, nil
 }
 
 func tightenPermissions(path string, ownership utils.FileOwner) error {

--- a/internal/pkg/crypto/hash.go
+++ b/internal/pkg/crypto/hash.go
@@ -33,7 +33,10 @@ func GeneratePBKDF2FromPassword(password []byte) ([]byte, error) {
 
 	// Write hash
 	// SALT|KEY
-	key := stretchPassword(password, salt, hashIterations, hashKeyLength)
+	key, err := stretchPassword(password, salt, hashIterations, hashKeyLength)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stretch password: %w", err)
+	}
 	hash := new(bytes.Buffer)
 	hash.Write(salt)
 	hash.Write(key)
@@ -55,7 +58,10 @@ func ComparePBKDF2HashAndPassword(hash []byte, password []byte) error {
 	// SALT|KEY
 	salt := hash[:hashSaltLength]
 	keyFromHash := hash[hashSaltLength:hashTotalLength]
-	keyFromPassword := stretchPassword(password, salt, hashIterations, hashKeyLength)
+	keyFromPassword, err := stretchPassword(password, salt, hashIterations, hashKeyLength)
+	if err != nil {
+		return fmt.Errorf("failed to stretch password: %w", err)
+	}
 	if !hmac.Equal(keyFromHash, keyFromPassword) {
 		return ErrMismatchedHashAndPassword
 	}

--- a/internal/pkg/crypto/io.go
+++ b/internal/pkg/crypto/io.go
@@ -196,7 +196,7 @@ func (w *Writer) writeBlock(b []byte) error {
 	encodedBytes := w.gcm.Seal(nil, iv, b, nil)
 
 	l := make([]byte, 4)
-	binary.LittleEndian.PutUint32(l, uint32(len(encodedBytes)))
+	binary.LittleEndian.PutUint32(l, uint32(len(encodedBytes))) //nolint:gosec // ignoring unsafe type conversion
 	//nolint:errcheck // Ignore the error at this point.
 	w.writer.Write(l)
 


### PR DESCRIPTION
- Enhancement

## What does this PR do?

Removes x/crypto usage

## Why is it important?

We need to move away from using x/crypto for fips compliance

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

None

## How to test this PR locally

Ci tests should be enough

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Requires #6932 
- Requires https://github.com/elastic/elastic-agent-libs/pull/291

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
