### PR TITLE
Recreate kind cluster after each K8s test

### DIFF
--- a/pkg/testing/common/config.go
+++ b/pkg/testing/common/config.go
@@ -51,6 +51,9 @@ type Config struct {
 	// VerboseMode passed along a verbose mode flag to tests
 	VerboseMode bool
 
+	// DeleteInstanceAfterTest causes the runner to delete instances immediately after test completion.
+	DeleteInstanceAfterTest bool
+
 	// Timestamp enables timestamps on the console output.
 	Timestamp bool
 

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -282,6 +282,13 @@ func (r *Runner) runK8sInstances(ctx context.Context, instances []StateInstance)
 		resultsMx.Lock()
 		results[batch.ID] = result
 		resultsMx.Unlock()
+		if r.cfg.DeleteInstanceAfterTest {
+			logger.Logf("Cleaning up instance after test: %s", instance.Name)
+			err = r.ip.Clean(ctx, r.cfg, []common.Instance{instance.Instance})
+			if err != nil {
+				logger.Logf("Failed to clean up instance %s: %v", instance.Name, err)
+			}
+		}
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What does this PR do?

Creates a new kind cluster for each K8s test.

## Why is it important?

This is a temporary measure to improve K8s test reliability before we can run them in parallel. We run these tests sequentially right now, and each kind cluster is only used once, but is only cleaned up after all tests finish running. Creating and deleting kind clusters is fast relative to test run time, so this shouldn't impact total run time significantly.

Kubernetes tests took 2h 31m on this branch: https://buildkite.com/elastic/elastic-agent/builds/17875#01955b43-3ce0-4b43-814b-e433929b6ff2.
On main they recently took 2h 30m: https://buildkite.com/elastic/elastic-agent-extended-testing/builds/7791#01954e7c-ac7c-43fc-9987-1431e2c3b2ad

So there's little difference in runtime, and potential to fix some flakiness in the short-term.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## How to test this PR locally

```
SNAPSHOT=true EXTERNAL=true PACKAGES=docker PLATFORMS="linux/amd64" mage -v  package
Running target: Package
INSTANCE_PROVISIONER=kind STACK_PROVISIONER=stateful SNAPSHOT=true mage integration:single TestOtelKubeStackHelm

```

## Related issues

- Relates #7060 

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
