### PR TITLE
[otel/kube-stack] Drop deprecated parameter from routing connector

### DIFF
--- a/deploy/helm/edot-collector/kube-stack/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/values.yaml
@@ -559,7 +559,6 @@ collectors:
         routing:
           default_pipelines: [metrics/otel]
           error_mode: ignore
-          match_once: true
           table:
             - context: metric
               statement: route() where instrumentation_scope.name == "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver" or IsMatch(instrumentation_scope.name, "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/*")


### PR DESCRIPTION
## What does this PR do?

Remove a deprecated attribute from the routing connector configuration for otel-kube-stack. This removal has no effect on the connector behaviour. See: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37708.

## Why is it important?

We can't upgrade to Otel 0.120.x without this change.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] I have made corresponding change to the default configuration files

## How to test this PR locally

```
SNAPSHOT=true mage integration:single TestOtelKubeStackHelm
SNAPSHOT=true EXTERNAL=true PACKAGES=docker PLATFORMS="linux/amd64" mage -v  package

```


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
