### PR TITLE
Revert "Allow locally building multiplatform docker images"

### DIFF
--- a/dev-tools/mage/dockerbuilder.go
+++ b/dev-tools/mage/dockerbuilder.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -24,29 +23,20 @@ import (
 type dockerBuilder struct {
 	PackageSpec
 
-	imageName       string
-	buildDir        string
-	beatDir         string
-	isBuildxEnabled bool
+	imageName string
+	buildDir  string
+	beatDir   string
 }
 
 func newDockerBuilder(spec PackageSpec) (*dockerBuilder, error) {
 	buildDir := filepath.Join(spec.packageDir, "docker-build")
 	beatDir := filepath.Join(buildDir, "beat")
 
-	buildxEnabled := isBuildxEnabled()
-	if buildxEnabled {
-		fmt.Println("Docker buildx is available, cross-platform builds are possible")
-	} else {
-		fmt.Println("Docker buildx is not available")
-	}
-
 	return &dockerBuilder{
-		PackageSpec:     spec,
-		imageName:       spec.ImageName(),
-		buildDir:        buildDir,
-		beatDir:         beatDir,
-		isBuildxEnabled: buildxEnabled,
+		PackageSpec: spec,
+		imageName:   spec.ImageName(),
+		buildDir:    buildDir,
+		beatDir:     beatDir,
 	}, nil
 }
 
@@ -198,18 +188,6 @@ func (b *dockerBuilder) dockerBuild() (string, error) {
 	if repository := b.ExtraVars["repository"]; repository != "" {
 		tag = fmt.Sprintf("%s/%s", repository, tag)
 	}
-
-	platform := fmt.Sprintf("%s/%s", "linux", b.Arch)
-
-	if runtime.GOARCH != b.Arch { // we need a cross-platform build, check if buildx is available
-		if !b.isBuildxEnabled {
-			return "", fmt.Errorf("cross-platform docker build requested, but buildx is not available")
-		}
-		// if building cross-platform, add the arch name to the tag
-		tag = fmt.Sprintf("%s-%s", tag, b.Arch)
-		return tag, sh.Run("docker", "buildx", "build", "-t", tag, "--platform", platform, "--load", b.buildDir)
-	}
-
 	return tag, sh.Run("docker", "build", "-t", tag, b.buildDir)
 }
 
@@ -274,8 +252,4 @@ func (b *dockerBuilder) dockerSave(tag string) error {
 		return fmt.Errorf("failed to create .sha512 file: %w", err)
 	}
 	return nil
-}
-
-func isBuildxEnabled() bool {
-	return sh.Run("docker", "buildx", "version") == nil
 }

--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 
 	"github.com/magefile/mage/mg"
@@ -48,6 +49,11 @@ func Package() error {
 
 				if pkgType == Docker && !isDockerVariantSelected(pkg.Spec.DockerVariant) {
 					log.Printf("Skipping %s docker variant type because it is not selected", pkg.Spec.DockerVariant)
+					continue
+				}
+
+				if target.Name == "linux/arm64" && pkgType == Docker && runtime.GOARCH != "arm64" {
+					log.Printf("Skipping Docker package type because build host isn't arm")
 					continue
 				}
 


### PR DESCRIPTION
Reverts elastic/elastic-agent#6256

Change contained in PR #6256 seems to affect our CI which was unintended (see original PR description).

Extract from docker build logs:

```shell
>> package: Building linux-amd64
>> package: Building elastic-agent type=docker for platform=linux/amd64 fips=false
>> package: Building elastic-agent type=docker for platform=linux/amd64 fips=false
>> package: Building elastic-agent type=docker for platform=linux/amd64 fips=false
>> package: Building elastic-agent type=docker for platform=linux/amd64 fips=false
>> package: Building elastic-agent type=docker for platform=linux/amd64 fips=false
>> package: Building elastic-agent type=rpm for platform=linux/amd64 fips=false
>> package: Building elastic-agent type=docker for platform=linux/amd64 fips=false
>> package: Building elastic-agent type=docker for platform=linux/amd64 fips=false
>> package: Building elastic-agent type=tar.gz for platform=linux/amd64 fips=false
>> package: Building elastic-agent type=deb for platform=linux/amd64 fips=false
Docker buildx is available, cross-platform builds are possible
Docker buildx is available, cross-platform builds are possible
Docker buildx is available, cross-platform builds are possible
Docker buildx is available, cross-platform builds are possible
Docker buildx is available, cross-platform builds are possible
Docker buildx is available, cross-platform builds are possible
Docker buildx is available, cross-platform builds are possible
```

We are seeing failures while building docker images on amd64 buildkite agents, for example:
```shell
[+] Building 13.7s (7/19)                                                                                                                        docker:default
 => [internal] load .dockerignore                                                                                                                          0.0s
 => [internal] load metadata for docker.elastic.co/ubi9/ubi-minimal:latest                                                                                 0.2s
 => => transferring context: 2B                                                                                                                            0.0s
 => [internal] load metadata for cgr.dev/chainguard/wolfi-base:latest                                                                                      0.0s
 => [internal] load build definition from Dockerfile                                                                                                       0.0s
 => CACHED [home 1/5] FROM cgr.dev/chainguard/wolfi-base@sha256:9c86299eaeb27bfec41728fc56a19fa00656c001c0f01228b203379e5ac3ef28                           0.0s
 => [home 2/5] RUN for iter in {1..10}; do         apk update &&         apk add --no-cache shadow libcap-utils &&         exit_code=0 && break || exit_  13.7s
 => => transferring dockerfile: 6.44kB                                                                                                                     0.0s
 => => # exec /bin/sh: exec format error                                                                                                                       
 => [internal] load metadata for cgr.dev/chainguard/wolfi-base:latest                                                                                      0.0s
 => CACHED [stage-1  1/15] FROM docker.elastic.co/ubi9/ubi-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0                 0.0s
 => CACHED [home 1/5] FROM cgr.dev/chainguard/wolfi-base@sha256:9c86299eaeb27bfec41728fc56a19fa00656c001c0f01228b203379e5ac3ef28                           0.0s
 => [internal] load build context                                                                                                                          9.3s
 => [internal] load build context                                                                                                                         10.4s
 => => transferring context: 1.19GB                                                                                                                        9.2s
 => => transferring context: 1.13GB                                                                                                                       10.0s
 => [stage-1  2/15] RUN for iter in {1..10}; do         microdnf update -y &&         microdnf install -y tar gzip findutils shadow-utils ca-certificate  13.5s
 => ERROR [stage-1  2/11] RUN for iter in {1..10}; do         apk update &&         apk add --no-cache ca-certificates curl gawk shadow bash &&           11.0sy
 => => # exec /bin/sh: exec format error                                                                                                                       
 => CANCELED [home 2/5] RUN for iter in {1..10}; do         apk update &&         apk add --no-cache shadow libcap-utils &&         exit_code=0 && break  11.0s
------
 > [stage-1  2/11] RUN for iter in {1..10}; do         apk update &&         apk add --no-cache ca-certificates curl gawk shadow bash &&         exit_code=0 && break || exit_code=$? && echo "apk error: retry $iter in 10s" && sleep 10;     done;     (exit $exit_code):
0.576 exec /bin/sh: exec format error
------
```
