### PR TITLE
Add a changelog note that the agent Docker container is not longer available from docker.elastic.co/beats/elastic-agent

### DIFF
--- a/changelog/fragments/1741035554-Elastic-Agent-docker-container-no-longer-availble-from-docker.elastic.co-beats-elastic-agent.yaml
+++ b/changelog/fragments/1741035554-Elastic-Agent-docker-container-no-longer-availble-from-docker.elastic.co-beats-elastic-agent.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: breaking-change
+
+# Change summary; a 80ish characters long description of the change.
+summary: The Elastic Agent docker container is no longer availble from docker.elastic.co/beats/elastic-agent. Use docker.elastic.co/elastic-agent/elastic-agent instead.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234


### PR DESCRIPTION
## What does this PR do?

What the summary says.

## Why is it important?

We haven't documented this anywhere else and it's a breaking change.

