### PR TITLE
[flakiness] Correct group for TestEndpointAgentServiceMonitoring

### DIFF
--- a/testing/integration/monitoring_endpoint_test.go
+++ b/testing/integration/monitoring_endpoint_test.go
@@ -34,7 +34,7 @@ type EndpointMetricsMonRunner struct {
 
 func TestEndpointAgentServiceMonitoring(t *testing.T) {
 	info := define.Require(t, define.Requirements{
-		Group: Fleet,
+		Group: FleetEndpointSecurity,
 		Stack: &define.Stack{},
 		Local: false, // requires Agent installation
 		Sudo:  true,  // requires Agent installation

--- a/testing/integration/monitoring_endpoint_test.go
+++ b/testing/integration/monitoring_endpoint_test.go
@@ -135,18 +135,19 @@ func (runner *EndpointMetricsMonRunner) TestEndpointMetricsAfterRestart() {
 	}
 
 	// kill endpoint
-	cmd := exec.Command("pgrep", "-f", "endpoint")
+	cmd := exec.Command("pgrep", "-f", "/opt/Elastic/Endpoint/elastic-endpoint")
 	pgrep, err := cmd.CombinedOutput()
+	require.NoError(runner.T(), err)
 	runner.T().Logf("killing pid: %s", string(pgrep))
 
-	cmd = exec.Command("pkill", "--signal", "SIGKILL", "-f", "endpoint")
+	cmd = exec.Command("pkill", "--signal", "SIGKILL", "-f", "/opt/Elastic/Endpoint/elastic-endpoint")
 	_, err = cmd.CombinedOutput()
 	require.NoError(runner.T(), err)
 
 	// wait for endpoint to come back up. We use `pgrep`
 	// since the agent health status won't imidately register that the endpoint process itself is gone.
 	require.Eventually(runner.T(), func() bool {
-		cmd := exec.Command("pgrep", "-f", "endpoint")
+		cmd := exec.Command("pgrep", "-f", "/opt/Elastic/Endpoint/elastic-endpoint")
 		pgrep, err := cmd.CombinedOutput()
 		runner.T().Logf("found pid: %s", string(pgrep))
 		if err == nil {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR relocates TestEndpointAgentServiceMonitoring to the FleetEndpointSecurity execution group to prevent test failures caused by concurrent installation attempts of the Endpoint package when tests run in different groups.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Reduces flakiness of Endpoint related tests that run in our CI

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/6969
- Relates https://github.com/elastic/elastic-agent/issues/4883
- Relates https://github.com/elastic/elastic-agent/issues/7221
