### PR TITLE
Speed up serverless Beat tests by not testing Metricbeat or Auditbeat

### DIFF
--- a/.buildkite/scripts/steps/beats_tests.sh
+++ b/.buildkite/scripts/steps/beats_tests.sh
@@ -63,15 +63,5 @@ popd
 
 # exit $TESTS_EXIT_STATUS
 
-echo "testing metricbeat..."
-run_test_for_beat metricbeat
-
-
-
 echo "testing filebeat..."
 run_test_for_beat filebeat
-
-
-
-echo "testing auditbeat..."
-run_test_for_beat auditbeat


### PR DESCRIPTION
## What does this PR do?

Stops testing Metricbeat and Auditbeat in the serverless Beat tests. The way this step was written it re-invoked the mage integration test target serially 3 times in a row which re-does provisioning unnecessarily. The tests should be rewritten eventually.

These tests also primarily test libbeat setup functionality that is shared amongst Beats, and we already aren't testing all the Beats, so let's just smoke test the one that covers the most functionality.

## Why is it important?

These tests take too long.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-


