### PR TITLE
Increase timeout for assertions in TestSetLogLevelFleetManaged

### DIFF
--- a/testing/integration/log_level_test.go
+++ b/testing/integration/log_level_test.go
@@ -41,7 +41,7 @@ func TestSetLogLevelFleetManaged(t *testing.T) {
 		Sudo:  true,
 	})
 
-	deadline := time.Now().Add(10 * time.Minute)
+	deadline := time.Now().Add(30 * time.Minute)
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), deadline)
 	defer cancel()
 
@@ -115,7 +115,7 @@ func testLogLevelSetViaFleet(ctx context.Context, f *atesting.Fixture, agentID s
 		}
 		t.Logf("Fleet metadata log level for agent %q: %q policy log level: %q", agentID, fleetMetadataLogLevel, policyLogLevel)
 		return fleetMetadataLogLevel == policyLogLevel.String()
-	}, 30*time.Second, time.Second, "agent never communicated policy log level %q to Fleet", policyLogLevel)
+	}, 6*time.Minute, 30*time.Second, "agent never communicated policy log level %q to Fleet", policyLogLevel)
 
 	// Step 2: set a different log level for the specific agent using Settings action
 	// set agent log level and verify that it takes precedence over the policy one
@@ -146,7 +146,7 @@ func testLogLevelSetViaFleet(ctx context.Context, f *atesting.Fixture, agentID s
 		}
 		t.Logf("Fleet metadata log level for agent %q: %q agent log level: %q", agentID, fleetMetadataLogLevel, agentLogLevel)
 		return fleetMetadataLogLevel == agentLogLevel
-	}, 30*time.Second, time.Second, "agent never communicated agent-specific log level %q to Fleet", agentLogLevel)
+	}, 6*time.Minute, 30*time.Second, "agent never communicated agent-specific log level %q to Fleet", agentLogLevel)
 
 	// Step 3: Clear the agent-specific log level override, verify that we revert to policy log level
 	t.Logf("Clearing agent log level, expecting log level to revert back to %q", policyLogLevel)
@@ -174,7 +174,7 @@ func testLogLevelSetViaFleet(ctx context.Context, f *atesting.Fixture, agentID s
 		}
 		t.Logf("Fleet metadata log level for agent %q: %q policy log level: %q", agentID, fleetMetadataLogLevel, policyLogLevel)
 		return fleetMetadataLogLevel == policyLogLevel.String()
-	}, 30*time.Second, time.Second, "agent never communicated reverting to policy log level %q to Fleet", policyLogLevel)
+	}, 6*time.Minute, 30*time.Second, "agent never communicated reverting to policy log level %q to Fleet", policyLogLevel)
 
 	// Step 4: Clear the log level in policy and verify that agent reverts to the initial log level
 	t.Logf("Clearing policy log level, expecting log level to revert back to %q", initialLogLevel)
@@ -202,7 +202,7 @@ func testLogLevelSetViaFleet(ctx context.Context, f *atesting.Fixture, agentID s
 		}
 		t.Logf("Fleet metadata log level for agent %q: %q initial log level: %q", agentID, fleetMetadataLogLevel, initialLogLevel)
 		return fleetMetadataLogLevel == initialLogLevel
-	}, 30*time.Second, time.Second, "agent never communicated initial log level %q to Fleet", initialLogLevel)
+	}, 6*time.Minute, 30*time.Second, "agent never communicated initial log level %q to Fleet", initialLogLevel)
 }
 
 func waitForAgentAndFleetHealthy(ctx context.Context, t *testing.T, f *atesting.Fixture) bool {


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fleet checkins may take up to 5 minutes so we need to increase timeouts for assertions in TestSetLogLevelFleetManaged to account for it as the agent may apply log level settings while there's already a Fleet check-in in progress.
Settings timeouts for retrieving the correct log level in Fleet to 6 minutes should give enough time to agent to set the log level and communicate it to Fleet in a new check-in request.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
This PR should remove flakiness coming from elastic-agent check-in timing in TestSetLogLevelFleetManaged.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #5193

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
