### PR TITLE
[flakiness] improve reliability of kubernetes integration tests

### DIFF
--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -144,7 +144,7 @@ steps:
           - packaging-ubuntu-x86-64
         # due to deb group present in matrix tar.gz and deb packages artifacts are required
         command: |
-          buildkite-agent artifact download build/distributions/** . --step packaging-ubuntu-x86-64          
+          buildkite-agent artifact download build/distributions/** . --step packaging-ubuntu-x86-64
           .buildkite/scripts/steps/integration_tests_tf.sh {{matrix}} true
         artifact_paths:
           - build/**
@@ -247,11 +247,50 @@ steps:
           machineType: "n1-standard-8"
           image: "family/platform-ingest-elastic-agent-rhel-8"
 
+  - group: "Kubernetes"
+    key: integration-tests-kubernetes
+    depends_on:
+      - integration-ess
+      - packaging-containers-x86-64
+    steps:
+      - label: "{{matrix.version}}:amd64:{{matrix.variants}}"
+        env:
+          K8S_VERSION: "{{matrix.version}}"
+          ASDF_KIND_VERSION: "0.24.0"
+          DOCKER_VARIANTS: "{{matrix.variants}}"
+          TARGET_ARCH: "amd64"
+          AGENT_VERSION: "9.0.0-SNAPSHOT" # Remove agent pinning once 9.0.0 is released
+        command: |
+          buildkite-agent artifact download build/distributions/elastic-agent-*-linux-amd64.docker.tar.gz . --step 'packaging-containers-x86-64'
+          .buildkite/scripts/steps/integration_tests_tf.sh kubernetes false
+        artifact_paths:
+          - build/**
+          - build/diagnostics/**
+        retry:
+          automatic:
+            limit: 1
+        agents:
+          provider: "gcp"
+          machineType: "n1-standard-4"
+          image: "family/platform-ingest-elastic-agent-ubuntu-2404"
+          diskSizeGb: 80
+        matrix:
+          setup:
+            variants:
+            - "basic,wolfi,complete,complete-wolfi,service,cloud"
+            version:
+            - v1.27.16
+            - v1.28.9
+            - v1.29.8
+            - v1.30.8
+            - v1.31.0
+
   - label: ESS stack cleanup
     depends_on:
       - integration-tests-ubuntu
       - integration-tests-win
       - integration-tests-rhel8
+      - integration-tests-kubernetes
     allow_dependency_failure: true
     command: |
       buildkite-agent artifact download "test_infra/ess/**" . --step "integration-ess"
@@ -268,6 +307,7 @@ steps:
       - integration-tests-ubuntu
       - integration-tests-win
       - integration-tests-rhel8
+      - integration-tests-kubernetes
     allow_dependency_failure: true
     command: |
       buildkite-agent artifact download "build/*.xml" .

--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -169,26 +169,3 @@ steps:
     depends_on:
       - int-packaging
     command: "buildkite-agent pipeline upload .buildkite/bk.integration.pipeline.yml"
-
-  - label: "Kubernetes Integration tests"
-    key: "k8s-integration-tests"
-    env:
-      K8S_VERSION: "v1.31.0"
-      KIND_VERSION: "v0.24.0"
-    command: ".buildkite/scripts/steps/k8s-extended-tests.sh"
-    retry:
-      automatic:
-        limit: 1
-    artifact_paths:
-      - "build/k8s-logs*/*"
-      - "build/k8s-logs*/**/*"
-      - "build/TEST-**"
-      - "build/diagnostics/*"
-    agents:
-      provider: "gcp"
-      machineType: "c2-standard-16"
-      image: "family/core-ubuntu-2204"
-      diskSizeGb: 400
-    notify:
-      - github_commit_status:
-          context: "buildkite/elastic-agent-extended-testing - Kubernetes Integration tests"

--- a/.buildkite/scripts/buildkite-k8s-integration-tests.sh
+++ b/.buildkite/scripts/buildkite-k8s-integration-tests.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${K8S_VERSION:?Error: Specify Kubernetes version via K8S_VERSION env variable}"
+: "${TARGET_ARCH:?Error: Specify target architecture via ARCH env variable}"
+: "${DOCKER_IMAGE_ARCHIVES_DIR:=build/distributions}"
+
+DOCKER_VARIANTS="${DOCKER_VARIANTS:-basic,wolfi,complete,complete-wolfi,service,cloud}"
+CLUSTER_NAME="${K8S_VERSION}-kubernetes"
+
+if [[ -z "${AGENT_VERSION:-}" ]]; then
+  # If not specified, use the version in .package-version
+
+  # Ensure .package-version exists before reading
+  if [[ ! -f .package-version ]]; then
+    echo "Error: .package-version file not found" >&2
+    exit 1
+  fi
+
+  AGENT_VERSION="$(cat .package-version)"
+  AGENT_VERSION="${AGENT_VERSION}-SNAPSHOT"
+fi
+
+echo "~~~ Create kind cluster '${CLUSTER_NAME}'"
+kind create cluster --image  "kindest/node:${K8S_VERSION}" --name "${CLUSTER_NAME}" --wait 60s --config - <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    scheduler:
+      extraArgs:
+        bind-address: "0.0.0.0"
+        secure-port: "10259"
+    controllerManager:
+      extraArgs:
+        bind-address: "0.0.0.0"
+        secure-port: "10257"
+EOF
+
+IFS=',' read -r -a docker_variants <<< "${DOCKER_VARIANTS}"
+
+echo "~~~ Building k8s inner tests binary"
+GOOS=linux GOARCH="${TARGET_ARCH}" CGO_ENABLED=0 go test -tags 'kubernetes_inner' -c -o ./testsBinary ./testing/kubernetes_inner/...
+chmod +x ./testsBinary
+
+export TEST_DEFINE_PREFIX="${CLUSTER_NAME}"
+
+TESTS_EXIT_STATUS=0
+for variant in "${docker_variants[@]}"; do
+  echo "~~~ k8s Integration tests for variant: ${variant}"
+
+  # construct image archive path
+  image_archive="elastic-agent-${variant}-${AGENT_VERSION}-linux-${TARGET_ARCH}.docker.tar.gz"
+  if [[ "${variant}" == "basic" ]]; then
+    image_archive="elastic-agent-${AGENT_VERSION}-linux-${TARGET_ARCH}.docker.tar.gz"
+  fi
+  image_archive_path="${DOCKER_IMAGE_ARCHIVES_DIR}/$image_archive"
+
+  # load image
+  echo "Loading Docker image from ${image_archive_path}"
+  BUILDKIT_PROGRESS=plain docker load -i "${image_archive_path}"
+
+  # Check that manifest.json is present in image archive
+  # NOTE: Do not use --wildcards option because it is not supported on MacOS
+  # NOTE: Do not pipe tar output directly to grep as the former might take some
+  #       time before printing all contents, especially for large archives, and
+  #       the latter might exit pre-maturely
+  if ! tar_output=$(tar -tf "${image_archive_path}"); then
+      echo "Error: Failed to read tar archive ${image_archive_path}" >&2
+      exit 1
+  fi
+  if ! echo "$tar_output" | grep -q "manifest.json"; then
+      echo "Error: manifest.json not found in ${image_archive_path}" >&2
+      exit 1
+  fi
+
+  # read image name from manifest
+  image=$(tar -Oxf "${image_archive_path}" manifest.json | jq -r '.[0].RepoTags[0]')
+
+  # embed k8s inner tests binary and build again the same image
+  echo "Embedding k8s inner tests binary into ${image}"
+  BUILDKIT_PROGRESS=plain docker build --tag "${image}" . -f - <<EOF
+FROM "${image}"
+COPY testsBinary /usr/share/elastic-agent/k8s-inner-tests
+EOF
+
+  # load image to kind cluster
+  echo "Loading Docker image ${image} to kind cluster ${CLUSTER_NAME}"
+  kind load docker-image --name "${CLUSTER_NAME}" "$image"
+
+  # Run integration tests
+  echo "Running k8s integration tests for ${variant}"
+  group_name="kubernetes"
+  fully_qualified_group_name="${CLUSTER_NAME}_${TARGET_ARCH}_${variant}"
+  outputXML="build/${fully_qualified_group_name}.integration.xml"
+  outputJSON="build/${fully_qualified_group_name}.integration.out.json"
+  pod_logs_base="build/${fully_qualified_group_name}.integration"
+
+  set +e
+  K8S_TESTS_POD_LOGS_BASE="${pod_logs_base}" AGENT_IMAGE="${image}" DOCKER_VARIANT="${variant}" gotestsum --hide-summary=skipped --format testname --no-color -f standard-quiet --junitfile "${outputXML}" --jsonfile "${outputJSON}" -- -tags kubernetes,integration -test.shuffle on -test.timeout 2h0m0s github.com/elastic/elastic-agent/testing/integration -v -args -integration.groups="${group_name}" -integration.sudo="false"
+  exit_status=$?
+  set -e
+
+  if [[ $TESTS_EXIT_STATUS -eq 0 && $exit_status -ne 0 ]]; then
+    TESTS_EXIT_STATUS=$exit_status
+  fi
+done
+
+exit $TESTS_EXIT_STATUS

--- a/.buildkite/scripts/steps/integration_tests_tf.sh
+++ b/.buildkite/scripts/steps/integration_tests_tf.sh
@@ -36,7 +36,7 @@ if [[ "${BUILDKITE_RETRY_COUNT}" -gt 0 ]]; then
   echo "~~~ The steps is retried, starting the ESS stack again"
   trap 'ess_down' EXIT
   ess_up $OVERRIDE_STACK_VERSION || echo "Failed to start ESS stack" >&2
-else 
+else
   # For the first run, we start the stack in the start_ess.sh step and it sets the meta-data
   echo "~~~ Receiving ESS stack metadata"
   export ELASTICSEARCH_HOST=$(buildkite-agent meta-data get "es.host")
@@ -56,9 +56,14 @@ export BUILDKITE_ANALYTICS_TOKEN
 # Run integration tests
 echo "~~~ Running integration tests"
 
-if [ "$TEST_SUDO" == "true" ]; then
-  sudo -E .buildkite/scripts/buildkite-integration-tests.sh $@
+if [[ "${GROUP_NAME}" == "kubernetes" ]]; then
+  source .buildkite/scripts/install-kubectl.sh
+  .buildkite/scripts/buildkite-k8s-integration-tests.sh $@
 else
-  .buildkite/scripts/buildkite-integration-tests.sh $@
+  if [ "$TEST_SUDO" == "true" ]; then
+    sudo -E .buildkite/scripts/buildkite-integration-tests.sh $@
+  else
+    .buildkite/scripts/buildkite-integration-tests.sh $@
+  fi
 fi
 

--- a/pkg/testing/define/define.go
+++ b/pkg/testing/define/define.go
@@ -186,7 +186,8 @@ func runOrSkip(t *testing.T, req Requirements, local bool, kubernetes bool) *Inf
 	if err != nil {
 		panic("failed to get OS information")
 	}
-	if !req.runtimeAllowed(runtime.GOOS, runtime.GOARCH, osInfo.Version, osInfo.Platform) {
+	dockerVariant := os.Getenv("DOCKER_VARIANT")
+	if !req.runtimeAllowed(runtime.GOOS, runtime.GOARCH, osInfo.Version, osInfo.Platform, dockerVariant) {
 		t.Skipf("platform: %s, architecture: %s, version: %s, and distro: %s combination is not supported by test.  required: %v", runtime.GOOS, runtime.GOARCH, osInfo.Version, osInfo.Platform, req.OS)
 		return nil
 	}

--- a/pkg/testing/define/requirements.go
+++ b/pkg/testing/define/requirements.go
@@ -137,7 +137,7 @@ func (r Requirements) Validate() error {
 }
 
 // runtimeAllowed returns true if the runtime matches a valid OS.
-func (r Requirements) runtimeAllowed(os string, arch string, version string, distro string) bool {
+func (r Requirements) runtimeAllowed(os string, arch string, version string, distro string, dockerVariant string) bool {
 	if len(r.OS) == 0 {
 		// all allowed
 		return true
@@ -157,6 +157,10 @@ func (r Requirements) runtimeAllowed(os string, arch string, version string, dis
 		}
 		if o.Distro != "" && o.Distro != distro {
 			// not allowed on specific distro
+			continue
+		}
+		if o.Type == Kubernetes && dockerVariant != "" && o.DockerVariant != "" && o.DockerVariant != dockerVariant {
+			// not allowed on specific image variant
 			continue
 		}
 		// allowed


### PR DESCRIPTION
## What does this PR do?

This PR modifies the execution of Kubernetes integration tests by running them on separate runners per Kubernetes version. This change helps mitigate resource contention issues caused by running multiple `kind` clusters on a single host, which has been identified as a potential source of flaky test failures. 

The PR introduces the following:

- Creates a new integration test group `integration-tests-kubernetes` in Buildkite.
- Runs Kubernetes integration tests in parallel for different Kubernetes versions (`v1.27.16`, `v1.28.9`, `v1.29.8`, `v1.30.8`, `v1.31.0`).
- Ensures each Kubernetes version runs on a dedicated Buildkite runner with separate resource allocation.
- Implements a new script `.buildkite/scripts/buildkite-k8s-integration-tests.sh` to manage cluster creation, Docker image loading, and test execution.
- Updates the test runtime checks in `pkg/testing/define/define.go` and `pkg/testing/define/requirements.go` to consider `DOCKER_VARIANT`, ensuring that only the appropriate kubernetes test are being run under each elastic-agent image variant.

## Why is it important?

This change is essential to improve the stability of Kubernetes integration tests (also as a side-effect, duration of k8s integration tests reduced from ~ 2.5 hours to ~ 1 hour). Previously, running multiple `kind` clusters on the same host led to resource contention and flaky test failures. By distributing tests across separate runners, we can:

- Improve kubernetes tests reliability.
- Allow for finer-grained concurrency control and future scaling.

This PR is a potential mitigation for the issue [#7060](https://github.com/elastic/elastic-agent/issues/7060) by ensuring Kubernetes integration tests are run in a more isolated and controlled manner.

## Checklist

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made corresponding changes to the default configuration files.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog).
- [ ] I have added an integration test or an E2E test.

## Disruptive User Impact

There are no user-facing disruptions. The changes are limited to Buildkite test infrastructure and will improve test reliability without affecting end users.

## Checklist

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

There are no user-facing disruptions. The changes are limited to Buildkite test infrastructure and will improve test reliability without affecting end users.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Open a draft PR 🙂 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/7060