### PR TITLE
feat(elastic-agent-services): use predictable artifact name

### DIFF
--- a/dev-tools/mage/pkg_test.go
+++ b/dev-tools/mage/pkg_test.go
@@ -20,8 +20,11 @@ func testPackageSpec() PackageSpec {
 		Snapshot: true,
 		OS:       "windows",
 		Arch:     "x86_64",
-		ExtraTags: []string{
-			"git-{{ substring commit 0 12 }}",
+		ExtraTags: []ExtraDockerTag{
+			{
+				Name: "ecp-internal-release",
+				Tag:  "git-{{ substring commit 0 12 }}",
+			},
 		},
 		Files: map[string]PackageFile{
 			"brewbeat.yml": PackageFile{
@@ -69,7 +72,7 @@ func testPackage(t testing.TB, pack func(PackageSpec) error) {
 	readmePath := filepath.ToSlash(filepath.Clean(readme.Source))
 	assert.True(t, strings.HasPrefix(readmePath, packageStagingDir))
 
-	commit := spec.ExtraTags[0]
+	commit := spec.ExtraTags[0].Tag
 	expected := "git-" + commitHash[:12]
 	assert.Equal(t, expected, commit)
 

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -106,13 +106,18 @@ type PackageSpec struct {
 	Qualifier         string                 `yaml:"qualifier,omitempty"`   // Optional
 	OutputFile        string                 `yaml:"output_file,omitempty"` // Optional
 	ExtraVars         map[string]string      `yaml:"extra_vars,omitempty"`  // Optional
-	ExtraTags         []string               `yaml:"extra_tags,omitempty"`  // Optional
+	ExtraTags         []ExtraDockerTag       `yaml:"extra_tags,omitempty"`  // Optional
 
 	evalContext            map[string]interface{}
 	packageDir             string
 	localPreInstallScript  string
 	localPostInstallScript string
 	localPostRmScript      string
+}
+
+type ExtraDockerTag struct {
+	Name string `yaml:"name"`
+	Tag  string `yaml:"tag"`
 }
 
 // PackageFile represents a file or directory within a package.
@@ -388,8 +393,9 @@ func (s PackageSpec) Evaluate(args ...map[string]interface{}) PackageSpec {
 	}
 
 	if s.ExtraTags != nil {
-		for i, tag := range s.ExtraTags {
-			s.ExtraTags[i] = mustExpand(tag)
+		for i, t := range s.ExtraTags {
+			data := mustExpand(t.Tag)
+			s.ExtraTags[i].Tag = data
 		}
 	}
 

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -289,7 +289,8 @@ shared:
   - &agent_docker_service_spec
     docker_variant: 'service'
     extra_tags:
-      - 'git-{{ substring commit 0 12 }}'
+      - name: ecp-internal-release 
+        tag: 'git-{{ substring commit 0 12 }}'
     files:
       'data/service/connectors-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}.zip':
         source: '{{.AgentDropPath}}/archives/{{.GOOS}}-{{.AgentArchName}}.tar.gz/connectors-{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}.zip'


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR follows the [previous](https://github.com/elastic/elastic-agent/pull/6874) one to add another tag to elastic-agent-services docker image.
To avoid exposing internals, please checkout the update why we need predictable artifact in [slack](https://elastic.slack.com/archives/C067LKJ6N03/p1741190817568829?thread_ts=1738281256.459079&cid=C067LKJ6N03).

The outcome of `package` command looks like this
Artifacts:
```bash
-rw-r--r--@  1 oleg  staff   705351626 Mar  5 15:50 elastic-agent-service-ecp-internal-release-9.1.0-SNAPSHOT-linux-arm64.docker.tar.gz
-rw-r--r--@  1 oleg  staff         213 Mar  5 15:50 elastic-agent-service-ecp-internal-release-9.1.0-SNAPSHOT-linux-arm64.docker.tar.gz.sha512
```

Docker images
```bash
docker.elastic.co/beats-ci/elastic-agent-service               git-baaeef5af213          e7182fd1977a   About a minute ago   2.85GB
```

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
