### PR TITLE
[Helm] support creating priority class

### DIFF
--- a/deploy/helm/elastic-agent/examples/priority-class/README.md
+++ b/deploy/helm/elastic-agent/examples/priority-class/README.md
@@ -1,0 +1,74 @@
+# Example: Kubernetes Integration with default chart values
+
+In this example we install the built-in `kubernetes` integration with the default built-in values and we adjust the priority class of the two built-in presets, namely `perNode` and `clusterWide`.
+
+## Chart Values
+
+Below we showcase how to adjust the priority class of the two built-in presets, namely `perNode` and `clusterWide`.
+
+```yaml
+# part of values.yaml
+agent:
+  presets:
+    perNode:
+      priorityClass:
+        create: true # instruct helm to create this priority class
+        value: 456
+        globalDefault: true
+        preemptionPolicy: "Never"
+        description: "Elastic Agent per-node preset priority class"
+    clusterWide:
+      priorityClass:
+        create: false # instruct helm to use a pre-existing priority class
+        name: "agent-clusterwide-pc"
+```
+
+## Prerequisites:
+1. Build the dependencies of the Helm chart
+    ```console
+    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    helm dependency build ../../
+    ```
+2. A k8s secret that contains the connection details to an Elasticsearch cluster such as the URL and the API key ([Kibana - Creating API Keys](https://www.elastic.co/guide/en/kibana/current/api-keys.html)):
+    ```console
+    kubectl create secret generic es-api-secret \
+       --from-literal=api_key=... \
+       --from-literal=url=...
+    ```
+
+3. `kubernetes` integration assets installed through Kibana ([Kibana - Install and uninstall Elastic Agent integration assets](https://www.elastic.co/guide/en/fleet/current/install-uninstall-integration-assets.html))
+
+## Run:
+
+#### Public image registry:
+```console
+helm install elastic-agent ../../ \
+     -f ./values.yaml \
+     --set outputs.default.type=ESSecretAuthAPI \
+     --set outputs.default.secretName=es-api-secret
+```
+
+
+#### Private image registry:
+Create secret with the contents of docker auth config
+```
+kubectl create secret generic regcred --from-file=.dockerconfigjson=<your home folder here>/.docker/config.json --type=kubernetes.io/dockerconfigjson
+```
+
+Install elastic-agent
+```console
+helm install elastic-agent ../../ \
+     -f ./agent-kubernetes-values.yaml \
+     --set 'agent.imagePullSecrets[0].name=regcred' \
+     --set outputs.default.type=ESSecretAuthAPI \
+     --set outputs.default.secretName=es-api-secret
+```
+
+## Validate:
+
+1. `kube-state metrics` is installed with this command `kubectl get deployments -n kube-system kube-state-metrics`.
+2. The Kibana `kubernetes`-related dashboards should start showing up the respective info.
+
+## Note:
+
+1. If you want to disable kube-state-metrics installation with the elastic-agent Helm chart, you can set `kube-state-metrics.enabled=false` in the Helm chart. The helm chart will use the value of `kubernetes.state.host` to configure the elastic-agent input.

--- a/deploy/helm/elastic-agent/examples/priority-class/priority-class-values.yaml
+++ b/deploy/helm/elastic-agent/examples/priority-class/priority-class-values.yaml
@@ -1,0 +1,17 @@
+kubernetes:
+  enabled: true
+
+agent:
+  unprivileged: true
+  presets:
+    perNode:
+      priorityClass:
+        create: true
+        value: 456
+        globalDefault: true
+        preemptionPolicy: "Never"
+        description: "Elastic Agent per-node preset priority class"
+    clusterWide:
+      priorityClass:
+        create: false
+        name: "agent-clusterwide-pc"

--- a/deploy/helm/elastic-agent/examples/priority-class/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/priority-class/rendered/manifest.yaml
@@ -1,0 +1,1143 @@
+---
+# Source: elastic-agent/templates/agent/priority-class.yaml
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: agent-pernode-example-default
+value: 456
+preemptionPolicy: Never
+globalDefault: true
+description: Elastic Agent per-node preset priority class
+---
+# Source: elastic-agent/charts/kube-state-metrics/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.15.0"
+  name: kube-state-metrics
+  namespace: default
+---
+# Source: elastic-agent/templates/agent/service-account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-clusterwide-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+---
+# Source: elastic-agent/templates/agent/service-account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-pernode-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+---
+# Source: elastic-agent/templates/agent/k8s/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agent-clusterwide-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+stringData:
+
+  agent.yml: |-
+    id: agent-clusterwide-example
+    outputs:
+      default:
+        hosts:
+        - http://elasticsearch:9200
+        password: changeme
+        type: elasticsearch
+        username: elastic
+    secret_references: []
+    agent:
+      monitoring:
+        enabled: true
+        logs: true
+        metrics: true
+        namespace: default
+        use_output: default
+    inputs:
+      - data_stream:
+          namespace: default
+        id: kubernetes/metrics-kubernetes.apiserver
+        streams:
+        - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.apiserver
+            type: metrics
+          hosts:
+          - https://${env.KUBERNETES_SERVICE_HOST}:${env.KUBERNETES_SERVICE_PORT}
+          id: kubernetes/metrics-kubernetes.apiserver
+          metricsets:
+          - apiserver
+          period: 30s
+          ssl.certificate_authorities:
+          - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        type: kubernetes/metrics
+        use_output: default
+      - data_stream:
+          namespace: default
+        id: kube-state-metrics-kubernetes/metrics
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_container
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_container
+          metricsets:
+          - state_container
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_cronjob
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_cronjob
+          metricsets:
+          - state_cronjob
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_daemonset
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_daemonset
+          metricsets:
+          - state_daemonset
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_deployment
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_deployment
+          metricsets:
+          - state_deployment
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_job
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_job
+          metricsets:
+          - state_job
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_namespace
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_namespace
+          metricsets:
+          - state_namespace
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_node
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_node
+          metricsets:
+          - state_node
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_persistentvolumeclaim
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_persistentvolumeclaim
+          metricsets:
+          - state_persistentvolumeclaim
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_persistentvolume
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_persistentvolume
+          metricsets:
+          - state_persistentvolume
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_pod
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_pod
+          metricsets:
+          - state_pod
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_replicaset
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_replicaset
+          metricsets:
+          - state_replicaset
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_resourcequota
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_resourcequota
+          metricsets:
+          - state_resourcequota
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_service
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_service
+          metricsets:
+          - state_service
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_statefulset
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_statefulset
+          metricsets:
+          - state_statefulset
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_storageclass
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_storageclass
+          metricsets:
+          - state_storageclass
+          period: 10s
+        type: kubernetes/metrics
+        use_output: default
+    providers:
+      kubernetes:
+        node: ${NODE_NAME}
+        scope: cluster
+      kubernetes_leaderelection:
+        enabled: true
+        leader_lease: example-clusterwide
+---
+# Source: elastic-agent/templates/agent/k8s/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agent-pernode-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+stringData:
+
+  agent.yml: |-
+    id: agent-pernode-example
+    outputs:
+      default:
+        hosts:
+        - http://elasticsearch:9200
+        password: changeme
+        type: elasticsearch
+        username: elastic
+    secret_references: []
+    agent:
+      monitoring:
+        enabled: true
+        logs: true
+        metrics: true
+        namespace: default
+        use_output: default
+    inputs:
+      - data_stream:
+          namespace: default
+        id: filestream-container-logs
+        streams:
+        - data_stream:
+            dataset: kubernetes.container_logs
+            type: logs
+          id: kubernetes-container-logs-${kubernetes.pod.name}-${kubernetes.container.id}
+          parsers:
+          - container:
+              format: auto
+              stream: all
+          paths:
+          - /var/log/containers/*${kubernetes.container.id}.log
+          processors:
+          - add_fields:
+              fields:
+                annotations.elastic_co/dataset: ${kubernetes.annotations.elastic.co/dataset|""}
+                annotations.elastic_co/namespace: ${kubernetes.annotations.elastic.co/namespace|""}
+                annotations.elastic_co/preserve_original_event: ${kubernetes.annotations.elastic.co/preserve_original_event|""}
+              target: kubernetes
+          - drop_fields:
+              fields:
+              - kubernetes.annotations.elastic_co/dataset
+              ignore_missing: true
+              when:
+                equals:
+                  kubernetes.annotations.elastic_co/dataset: ""
+          - drop_fields:
+              fields:
+              - kubernetes.annotations.elastic_co/namespace
+              ignore_missing: true
+              when:
+                equals:
+                  kubernetes.annotations.elastic_co/namespace: ""
+          - drop_fields:
+              fields:
+              - kubernetes.annotations.elastic_co/preserve_original_event
+              ignore_missing: true
+              when:
+                equals:
+                  kubernetes.annotations.elastic_co/preserve_original_event: ""
+          - add_tags:
+              tags:
+              - preserve_original_event
+              when:
+                and:
+                - has_fields:
+                  - kubernetes.annotations.elastic_co/preserve_original_event
+                - regexp:
+                    kubernetes.annotations.elastic_co/preserve_original_event: ^(?i)true$
+          prospector.scanner.symlinks: true
+        type: filestream
+        use_output: default
+      - data_stream:
+          namespace: default
+        id: kubernetes/metrics-kubernetes.container
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.container
+            type: metrics
+          hosts:
+          - https://${env.NODE_NAME}:10250
+          id: kubernetes/metrics-kubernetes.container
+          metricsets:
+          - container
+          period: 10s
+          ssl.verification_mode: none
+        type: kubernetes/metrics
+        use_output: default
+      - data_stream:
+          namespace: default
+        id: kubernetes/metrics-kubernetes.node
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.node
+            type: metrics
+          hosts:
+          - https://${env.NODE_NAME}:10250
+          id: kubernetes/metrics-kubernetes.node
+          metricsets:
+          - node
+          period: 10s
+          ssl.verification_mode: none
+        type: kubernetes/metrics
+        use_output: default
+      - data_stream:
+          namespace: default
+        id: kubernetes/metrics-kubernetes.pod
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.pod
+            type: metrics
+          hosts:
+          - https://${env.NODE_NAME}:10250
+          id: kubernetes/metrics-kubernetes.pod
+          metricsets:
+          - pod
+          period: 10s
+          ssl.verification_mode: none
+        type: kubernetes/metrics
+        use_output: default
+      - data_stream:
+          namespace: default
+        id: kubernetes/metrics-kubernetes.system
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.system
+            type: metrics
+          hosts:
+          - https://${env.NODE_NAME}:10250
+          id: kubernetes/metrics-kubernetes.system
+          metricsets:
+          - system
+          period: 10s
+          ssl.verification_mode: none
+        type: kubernetes/metrics
+        use_output: default
+      - data_stream:
+          namespace: default
+        id: kubernetes/metrics-kubernetes.volume
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.volume
+            type: metrics
+          hosts:
+          - https://${env.NODE_NAME}:10250
+          id: kubernetes/metrics-kubernetes.volume
+          metricsets:
+          - volume
+          period: 10s
+          ssl.verification_mode: none
+        type: kubernetes/metrics
+        use_output: default
+    providers:
+      kubernetes:
+        node: ${NODE_NAME}
+        scope: node
+      kubernetes_leaderelection:
+        enabled: false
+        leader_lease: example-pernode
+---
+# Source: elastic-agent/charts/kube-state-metrics/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.15.0"
+  name: kube-state-metrics
+rules:
+
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - daemonsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - endpoints
+  verbs: ["list", "watch"]
+
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "networking.k8s.io"]
+  resources:
+  - ingresses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - limitranges
+  verbs: ["list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - mutatingwebhookconfigurations
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list", "watch"]
+
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - networkpolicies
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumeclaims
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumes
+  verbs: ["list", "watch"]
+
+- apiGroups: ["policy"]
+  resources:
+    - poddisruptionbudgets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - replicasets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - replicationcontrollers
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - resourcequotas
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - services
+  verbs: ["list", "watch"]
+
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - storageclasses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - validatingwebhookconfigurations
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - volumeattachments
+  verbs: ["list", "watch"]
+---
+# Source: elastic-agent/templates/agent/cluster-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-clusterWide-example-default
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+rules:
+  - apiGroups: [ "" ] # "" indicates the core API group
+    resources:
+      - nodes
+      - namespaces
+      - events
+      - pods
+      - services
+      - configmaps
+      - persistentvolumes
+      - persistentvolumeclaims
+      - persistentvolumeclaims/status
+      - nodes/metrics
+      - nodes/proxy
+      - nodes/stats
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - watch
+      - list
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups: [ "coordination.k8s.io" ]
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - nonResourceURLs:
+      - /healthz
+      - /healthz/*
+      - /livez
+      - /livez/*
+      - /metrics
+      - /metrics/slis
+      - /readyz
+      - /readyz/*
+    verbs:
+      - get
+  - apiGroups: [ "apps" ]
+    resources:
+      - replicasets
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [ "batch" ]
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: elastic-agent/templates/agent/cluster-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-perNode-example-default
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+rules:
+  - apiGroups: [ "" ] # "" indicates the core API group
+    resources:
+      - nodes
+      - namespaces
+      - events
+      - pods
+      - services
+      - configmaps
+      - persistentvolumes
+      - persistentvolumeclaims
+      - persistentvolumeclaims/status
+      - nodes/metrics
+      - nodes/proxy
+      - nodes/stats
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - watch
+      - list
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups: [ "coordination.k8s.io" ]
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - nonResourceURLs:
+      - /healthz
+      - /healthz/*
+      - /livez
+      - /livez/*
+      - /metrics
+      - /metrics/slis
+      - /readyz
+      - /readyz/*
+    verbs:
+      - get
+  - apiGroups: [ "apps" ]
+    resources:
+      - replicasets
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [ "batch" ]
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: elastic-agent/charts/kube-state-metrics/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.15.0"
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: default
+---
+# Source: elastic-agent/templates/agent/cluster-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-clusterWide-example-default
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+subjects:
+  - kind: ServiceAccount
+    name: agent-clusterwide-example
+    namespace: "default"
+roleRef:
+  kind: ClusterRole
+  name: agent-clusterWide-example-default
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: elastic-agent/templates/agent/cluster-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-perNode-example-default
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+subjects:
+  - kind: ServiceAccount
+    name: agent-pernode-example
+    namespace: "default"
+roleRef:
+  kind: ClusterRole
+  name: agent-perNode-example-default
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: elastic-agent/charts/kube-state-metrics/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: default
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.15.0"
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  type: "ClusterIP"
+  ports:
+  - name: "http"
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
+  
+  selector:    
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+---
+# Source: elastic-agent/templates/agent/k8s/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: agent-pernode-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+spec:
+  selector:
+    matchLabels:
+      name: agent-pernode-example
+  template:
+    metadata:
+      labels:
+        name: agent-pernode-example
+      annotations:
+        checksum/config: 233affcd72143e637a130b5f099c30e194d90042eb00a26512f51c844c65a821
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - -c
+        - /etc/elastic-agent/agent.yml
+        - -e
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: STATE_PATH
+          value: /usr/share/elastic-agent/state
+        - name: ELASTIC_NETINFO
+          value: "false"
+        image: docker.elastic.co/elastic-agent/elastic-agent:9.1.0-SNAPSHOT
+        imagePullPolicy: IfNotPresent
+        name: agent
+        resources:
+          limits:
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 400Mi
+        securityContext:
+          capabilities:
+            add:
+            - DAC_READ_SEARCH
+            - CHOWN
+            - SETPCAP
+            - SYS_PTRACE
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 1000
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /var/lib/docker/containers
+          name: varlibdockercontainers
+          readOnly: true
+        - mountPath: /var/log
+          name: varlog
+          readOnly: true
+        - mountPath: /usr/share/elastic-agent/state
+          name: agent-data
+        - mountPath: /etc/elastic-agent/agent.yml
+          name: config
+          readOnly: true
+          subPath: agent.yml
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: agent-pernode-example-default
+      serviceAccountName: agent-pernode-example
+      volumes:
+      - hostPath:
+          path: /var/lib/docker/containers
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/log
+        name: varlog
+      - hostPath:
+          path: /etc/elastic-agent/default/agent-pernode-example/state
+          type: DirectoryOrCreate
+        name: agent-data
+      - name: config
+        secret:
+          defaultMode: 292
+          secretName: agent-pernode-example
+---
+# Source: elastic-agent/charts/kube-state-metrics/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: default
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.15.0"
+spec:
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/instance: example
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  revisionHistoryLimit: 10
+  template:
+    metadata:
+      labels:        
+        helm.sh/chart: kube-state-metrics-5.30.1
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: metrics
+        app.kubernetes.io/part-of: kube-state-metrics
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/version: "2.15.0"
+    spec:
+      automountServiceAccountToken: true
+      hostNetwork: false
+      serviceAccountName: kube-state-metrics
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: kube-state-metrics
+        args:
+        - --port=8080
+        - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
+        imagePullPolicy: IfNotPresent
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
+        ports:
+        - containerPort: 8080
+          name: "http"
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            httpHeaders:
+            path: /livez
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            httpHeaders:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+---
+# Source: elastic-agent/templates/agent/k8s/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-clusterwide-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+spec:
+  selector:
+    matchLabels:
+      name: agent-clusterwide-example
+  template:
+    metadata:
+      labels:
+        name: agent-clusterwide-example
+      annotations:
+        checksum/config: d5c563235f87ab23840416f6679b42b15c094cf361b8794d087b4fdfb8285b4b
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - -c
+        - /etc/elastic-agent/agent.yml
+        - -e
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: STATE_PATH
+          value: /usr/share/elastic-agent/state
+        - name: ELASTIC_NETINFO
+          value: "false"
+        image: docker.elastic.co/elastic-agent/elastic-agent:9.1.0-SNAPSHOT
+        imagePullPolicy: IfNotPresent
+        name: agent
+        resources:
+          limits:
+            memory: 800Mi
+          requests:
+            cpu: 100m
+            memory: 400Mi
+        securityContext:
+          capabilities:
+            add:
+            - CHOWN
+            - SETPCAP
+            - DAC_READ_SEARCH
+            - SYS_PTRACE
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 1000
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /usr/share/elastic-agent/state
+          name: agent-data
+        - mountPath: /etc/elastic-agent/agent.yml
+          name: config
+          readOnly: true
+          subPath: agent.yml
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: agent-clusterwide-pc
+      serviceAccountName: agent-clusterwide-example
+      volumes:
+      - emptyDir: {}
+        name: agent-data
+      - name: config
+        secret:
+          defaultMode: 292
+          secretName: agent-clusterwide-example

--- a/deploy/helm/elastic-agent/templates/agent/eck/_pod_template.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/eck/_pod_template.yaml
@@ -2,6 +2,7 @@
 {{- $ := index . 0 -}}
 {{- $presetVal := index . 1 -}}
 {{- $agentName := index . 2 }}
+{{- $presetName := index . 3 }}
 {{- $agentVolumes := (include "elasticagent.preset.render.volumes"  (list $ $presetVal $agentName) | fromYaml) -}}
 apiVersion: v1
 kind: PodTemplate
@@ -35,6 +36,13 @@ template:
     {{- with ($presetVal).tolerations }}
     tolerations:
       {{- . | toYaml | nindent 6 }}
+    {{- end }}
+    {{- with ($presetVal).priorityClass }}
+    {{- if (.).name }}
+    priorityClassName: {{ (.).name }}
+    {{- else }}
+    priorityClassName: {{ printf "agent-%s-%s-%s" $presetName $.Release.Name $.Release.Namespace | lower }}
+    {{- end }}
     {{- end }}
     {{- with ($presetVal).topologySpreadConstraints }}
     topologySpreadConstraints:

--- a/deploy/helm/elastic-agent/templates/agent/eck/daemonset.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/eck/daemonset.yaml
@@ -2,7 +2,7 @@
 {{- range $presetName, $presetVal := $.Values.agent.presets -}}
 {{- if and (eq ($presetVal).mode "daemonset") (eq $.Values.agent.engine "eck") -}}
 {{- $agentName := include "elasticagent.preset.fullname" (list $ $presetName)  -}}
-{{- $podTemplateResource := include "elasticagent.engine.eck.podTemplate" (list $ $presetVal $agentName) | fromYaml }}
+{{- $podTemplateResource := include "elasticagent.engine.eck.podTemplate" (list $ $presetVal $agentName $presetName) | fromYaml }}
 apiVersion: agent.k8s.elastic.co/v1alpha1
 kind: Agent
 metadata:

--- a/deploy/helm/elastic-agent/templates/agent/eck/deployment.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/eck/deployment.yaml
@@ -2,7 +2,7 @@
 {{- range $presetName, $presetVal := $.Values.agent.presets -}}
 {{- if and (eq ($presetVal).mode "deployment") (eq $.Values.agent.engine "eck") -}}
 {{- $agentName := include "elasticagent.preset.fullname" (list $ $presetName)  -}}
-{{- $podTemplateResource := include "elasticagent.engine.eck.podTemplate" (list $ $presetVal $agentName) | fromYaml }}
+{{- $podTemplateResource := include "elasticagent.engine.eck.podTemplate" (list $ $presetVal $agentName $presetName) | fromYaml }}
 apiVersion: agent.k8s.elastic.co/v1alpha1
 kind: Agent
 metadata:

--- a/deploy/helm/elastic-agent/templates/agent/eck/statefulset.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/eck/statefulset.yaml
@@ -2,7 +2,7 @@
 {{- range $presetName, $presetVal := $.Values.agent.presets -}}
 {{- if and (eq ($presetVal).mode "statefulset") (eq $.Values.agent.engine "eck") -}}
 {{- $agentName := include "elasticagent.preset.fullname" (list $ $presetName)  -}}
-{{- $podTemplateResource := include "elasticagent.engine.eck.podTemplate" (list $ $presetVal $agentName) | fromYaml }}
+{{- $podTemplateResource := include "elasticagent.engine.eck.podTemplate" (list $ $presetVal $agentName $presetName) | fromYaml }}
 apiVersion: agent.k8s.elastic.co/v1alpha1
 kind: Agent
 metadata:

--- a/deploy/helm/elastic-agent/templates/agent/k8s/_pod_template.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/k8s/_pod_template.yaml
@@ -1,7 +1,8 @@
 {{- define "elasticagent.engine.k8s.podTemplate" }}
 {{- $ := index . 0 -}}
 {{- $presetVal := index . 1 -}}
-{{- $agentName := index . 2 }}
+{{- $agentName := index . 2 -}}
+{{- $presetName := index . 3 -}}
 {{- $agentVolumes := (include "elasticagent.preset.render.volumes"  (list $ $presetVal $agentName) | fromYaml) -}}
 apiVersion: v1
 kind: PodTemplate
@@ -35,6 +36,13 @@ template:
     {{- with ($presetVal).tolerations }}
     tolerations:
       {{- . | toYaml | nindent 6 }}
+    {{- end }}
+    {{- with ($presetVal).priorityClass }}
+    {{- if (.).name }}
+    priorityClassName: {{ (.).name }}
+    {{- else }}
+    priorityClassName: {{ printf "agent-%s-%s-%s" $presetName $.Release.Name $.Release.Namespace | lower }}
+    {{- end }}
     {{- end }}
     {{- with ($presetVal).topologySpreadConstraints }}
     topologySpreadConstraints:

--- a/deploy/helm/elastic-agent/templates/agent/k8s/daemonset.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/k8s/daemonset.yaml
@@ -2,7 +2,7 @@
 {{- range $presetName, $presetVal := $.Values.agent.presets -}}
 {{- if and (eq ($presetVal).mode "daemonset") (eq $.Values.agent.engine "k8s") -}}
 {{- $agentName := include "elasticagent.preset.fullname" (list $ $presetName)  -}}
-{{- $podTemplateResource := include "elasticagent.engine.k8s.podTemplate" (list $ $presetVal $agentName) | fromYaml }}
+{{- $podTemplateResource := include "elasticagent.engine.k8s.podTemplate" (list $ $presetVal $agentName $presetName) | fromYaml }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/deploy/helm/elastic-agent/templates/agent/k8s/deployment.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/k8s/deployment.yaml
@@ -2,7 +2,7 @@
 {{- range $presetName, $presetVal := $.Values.agent.presets -}}
 {{- if and (eq ($presetVal).mode "deployment") (eq $.Values.agent.engine "k8s") -}}
 {{- $agentName := include "elasticagent.preset.fullname" (list $ $presetName)  -}}
-{{- $podTemplateResource := include "elasticagent.engine.k8s.podTemplate" (list $ $presetVal $agentName) | fromYaml }}
+{{- $podTemplateResource := include "elasticagent.engine.k8s.podTemplate" (list $ $presetVal $agentName $presetName) | fromYaml }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/helm/elastic-agent/templates/agent/k8s/statefulset.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/k8s/statefulset.yaml
@@ -2,7 +2,7 @@
 {{- range $presetName, $presetVal := $.Values.agent.presets -}}
 {{- if and (eq ($presetVal).mode "statefulset") (eq $.Values.agent.engine "k8s") -}}
 {{- $agentName := include "elasticagent.preset.fullname" (list $ $presetName)  -}}
-{{- $podTemplateResource := include "elasticagent.engine.k8s.podTemplate" (list $ $presetVal $agentName) | fromYaml }}
+{{- $podTemplateResource := include "elasticagent.engine.k8s.podTemplate" (list $ $presetVal $agentName $presetName) | fromYaml }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/deploy/helm/elastic-agent/templates/agent/priority-class.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/priority-class.yaml
@@ -1,0 +1,25 @@
+{{- include "elasticagent.init" $ -}}
+{{- range $presetName, $presetVal := $.Values.agent.presets -}}
+{{- if ($presetVal).priorityClass -}}
+{{- $presetPriorityClass := ($presetVal).priorityClass -}}
+{{- if eq ($presetPriorityClass).create true -}}
+{{/* priority class is not namespace bound so let's try to give it a unique enough name */}}
+{{- $priorityClassName := printf "agent-%s-%s-%s" $presetName $.Release.Name $.Release.Namespace | lower }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ $priorityClassName }}
+value: {{ ($presetPriorityClass).value }}
+{{- with ($presetPriorityClass).preemptionPolicy }}
+preemptionPolicy: {{ . }}
+{{- end }}
+{{- with ($presetPriorityClass).globalDefault }}
+globalDefault: {{ . }}
+{{- end }}
+{{- with ($presetPriorityClass).description }}
+description: {{ . }}
+{{- end }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/elastic-agent/values.schema.json
+++ b/deploy/helm/elastic-agent/values.schema.json
@@ -1276,6 +1276,9 @@
                 "clusterRole": {
                     "$ref": "#/definitions/AgentPresetClusterRole"
                 },
+                "priorityClass": {
+                    "$ref": "#/definitions/AgentPriorityClass"
+                },
                 "envFrom": {
                     "type": "array",
                     "items": {
@@ -1483,6 +1486,94 @@
                 "mode",
                 "serviceAccount",
                 "clusterRole"
+            ]
+        },
+        "AgentPriorityClass": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Create the priority class.",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the priority class to use if create is set to false."
+                },
+                "value": {
+                    "type": "integer",
+                    "description": "Value of the priority class."
+                },
+                "preemptionPolicy": {
+                    "type": "string",
+                    "enum": [
+                        "Never",
+                        "PreemptLowerPriority"
+                    ],
+                    "description": "Preemption policy for the priority class."
+                },
+                "globalDefault": {
+                    "type": "boolean",
+                    "description": "Set the priority class as the global default."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Description of the priority class."
+                }
+            },
+            "examples": [
+                {
+                    "create": true,
+                    "value": 1000000,
+                    "preemptionPolicy": "Never",
+                    "globalDefault": true,
+                    "description": "Elastic Agent priority class"
+                }
+            ],
+            "required": [
+                "create"
+            ],
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "create": {
+                                "const": true
+                            }
+                        }
+                    },
+                    "then": {
+                        "required": [
+                            "value"
+                        ],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "create": {
+                                "const": false
+                            }
+                        }
+                    },
+                    "then": {
+                        "required": [
+                            "name"
+                        ],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "minLength": 1
+                            }
+                        }
+                    }
+                }
             ]
         },
         "AgentPresetClusterRole": {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
-->

## What does this PR do?

This PR extends the Elastic Agent Helm chart to support defining and managing Kubernetes PriorityClasses for agent presets. With this change, users can specify custom priority classes within the Helm values, ensuring that critical workloads receive appropriate scheduling precedence in resource-constrained environments.

PS: The actual logic changes of this PR are captured in [this commit ](https://github.com/elastic/elastic-agent/commit/e7d381c45205c2e5fd246268d913a28f5c3bd7bf) (+139 -7 lines changed). However there is another [extra commit](https://github.com/elastic/elastic-agent/pull/7274/commits/72e675a4ff225912ce3f4f5f11dded1e7f88cc07) that introduces an example of using this that bumps the changes of this PR.

## Why is it important?

In multi-tenant Kubernetes environments, ensuring that critical Elastic Agent workloads have the necessary scheduling priority is essential for maintaining observability and system reliability. 

## Checklist

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made corresponding changes to the default configuration files.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog).
- [ ] I have added an integration test or an E2E test.

## Disruptive User Impact

This change is backward compatible. If users do not define `priorityClass`, no changes will occur.

## How to test this PR locally

Install in a k8s cluster the newly introduced example with priority classes

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/6025
