### PR TITLE
[ci]: parse agent version from version/version.go for k8s integration tests

### DIFF
--- a/.buildkite/scripts/buildkite-k8s-integration-tests.sh
+++ b/.buildkite/scripts/buildkite-k8s-integration-tests.sh
@@ -10,7 +10,7 @@ CLUSTER_NAME="${K8S_VERSION}-kubernetes"
 
 if [[ -z "${AGENT_VERSION:-}" ]]; then
   # If not specified, use the version in version/version.go
-  AGENT_VERSION="$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+(\-[a-zA-Z]+[0-9]+)?' "version/version.go")"
+  AGENT_VERSION="$(grep "const defaultBeatVersion =" version/version.go | cut -d\" -f2)"
   AGENT_VERSION="${AGENT_VERSION}-SNAPSHOT"
 fi
 

--- a/.buildkite/scripts/buildkite-k8s-integration-tests.sh
+++ b/.buildkite/scripts/buildkite-k8s-integration-tests.sh
@@ -9,15 +9,8 @@ DOCKER_VARIANTS="${DOCKER_VARIANTS:-basic,wolfi,complete,complete-wolfi,service,
 CLUSTER_NAME="${K8S_VERSION}-kubernetes"
 
 if [[ -z "${AGENT_VERSION:-}" ]]; then
-  # If not specified, use the version in .package-version
-
-  # Ensure .package-version exists before reading
-  if [[ ! -f .package-version ]]; then
-    echo "Error: .package-version file not found" >&2
-    exit 1
-  fi
-
-  AGENT_VERSION="$(cat .package-version)"
+  # If not specified, use the version in version/version.go
+  AGENT_VERSION="$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+(\-[a-zA-Z]+[0-9]+)?' "version/version.go")"
   AGENT_VERSION="${AGENT_VERSION}-SNAPSHOT"
 fi
 


### PR DESCRIPTION
## Why is it important?

This change updates the way the `AGENT_VERSION` is determined in the buildkite Kubernetes integration tests script. Instead of relying on the existence of a `.package-version` file (which is not correct), the version is now extracted directly from the `version/version.go` file using a regular expression (which is correct).

## Checklist

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made corresponding change to the default configuration files.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog).
- [ ] I have added an integration test or an E2E test.

## Disruptive User Impact

There is no disruptive user impact expected from this change. 

## How to test this PR locally

Open a draft PR

## Relates issues
N/A