### PR TITLE
[bug]: fix permissions for windows on not found paths and files errors

### DIFF
--- a/changelog/fragments/1741622468-Do-not-fail-Windows-permission-updates-on-missing-files-paths..yaml
+++ b/changelog/fragments/1741622468-Do-not-fail-Windows-permission-updates-on-missing-files-paths..yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+summary: Do not fail Windows permission updates on missing files/paths.
+component: elastic-agent
+pr: https://github.com/elastic/elastic-agent/pull/7305
+issue: https://github.com/elastic/elastic-agent/issues/7301

--- a/internal/pkg/acl/acl_windows.go
+++ b/internal/pkg/acl/acl_windows.go
@@ -210,7 +210,7 @@ func SetEntriesInAcl(entries []ExplicitAccess, oldAcl windows.Handle, newAcl *wi
 		uintptr(unsafe.Pointer(newAcl)),
 	)
 	if ret != 0 {
-		return fmt.Errorf("call to SetEntriesInAclW failed: ret=%d", ret)
+		return fmt.Errorf("call to SetEntriesInAclW failed: ret=%d, error=%w", ret, windows.Errno(ret))
 	}
 	return nil
 }
@@ -229,7 +229,7 @@ func GetNamedSecurityInfo(objectName string, objectType int32, secInfo uint32, o
 		uintptr(unsafe.Pointer(secDesc)),
 	)
 	if ret != 0 {
-		return fmt.Errorf("call to GetNamedSecurityInfoW failed: ret=%d", ret)
+		return fmt.Errorf("call to GetNamedSecurityInfoW failed: ret=%d, error=%w", ret, windows.Errno(ret))
 	}
 	return nil
 }
@@ -247,7 +247,7 @@ func SetNamedSecurityInfo(objectName string, objectType int32, secInfo uint32, o
 		uintptr(sacl),
 	)
 	if ret != 0 {
-		return fmt.Errorf("call to SetNamedSecurityInfoW failed: ret=%d", ret)
+		return fmt.Errorf("call to SetNamedSecurityInfoW failed: ret=%d, error=%w", ret, windows.Errno(ret))
 	}
 	return nil
 }

--- a/internal/pkg/agent/perms/windows_test.go
+++ b/internal/pkg/agent/perms/windows_test.go
@@ -1,0 +1,102 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build windows
+
+package perms
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFixPermissions(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("skipping test on non-windows platform")
+	}
+
+	// Create a temporary file
+	tmpDir := t.TempDir()
+
+	// arbitrary number of files
+	for i := 0; i < 5; i++ {
+		tmpFile, err := os.CreateTemp(tmpDir, "testfile")
+		if err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = os.Remove(tmpFile.Name()) // Ensure cleanup
+		})
+
+		// Close file before changing permissions
+		err = tmpFile.Close()
+		require.NoError(t, err, "failed to close file")
+	}
+
+	err := FixPermissions(tmpDir)
+	require.NoError(t, err, "failed to fix permissions")
+}
+
+func Test_applyPermissions(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("skipping test on non-windows platform")
+	}
+
+	// Create a temporary file
+	tmpDir := t.TempDir()
+	tmpFile, err := os.CreateTemp(tmpDir, "testfile")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer func() {
+		_ = os.Remove(tmpFile.Name()) // Ensure cleanup
+	}()
+
+	// Close file before changing permissions
+	err = tmpFile.Close()
+	require.NoError(t, err, "failed to close file")
+
+	for _, tc := range []struct {
+		name        string
+		filePath    string
+		expectedErr error
+	}{
+		{
+			name:        "should succeed",
+			filePath:    tmpFile.Name(),
+			expectedErr: nil,
+		},
+		{
+			name:        "non existing file, no error",
+			filePath:    fmt.Sprintf(`%s\non-existing`, tmpDir),
+			expectedErr: nil,
+		},
+		{
+			name:        "non existing path, no error",
+			filePath:    `C:\non-existing\non-existing`,
+			expectedErr: nil,
+		},
+		{
+			name:        "invalid path",
+			filePath:    `??INVALID_PATH??`,
+			expectedErr: windows.ERROR_INVALID_NAME,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := applyPermissions(tc.filePath, true, false, nil, nil)
+			if tc.expectedErr != nil {
+				require.Error(t, err, "expected error, got nil")
+				require.ErrorIs(t, err, tc.expectedErr, "errors do not match")
+			} else {
+				require.NoError(t, err, "expected no error, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR fixes a bug in the Windows permissions handling where the process would fail if a file or directory was missing. The changes include:

- **Improved Error Reporting:**  
  Enhanced error messages by wrapping errors (using `%w`) to provide better context for failures in Windows API calls (e.g., `SetEntriesInAclW`, `GetNamedSecurityInfoW`, and `SetNamedSecurityInfoW`).

- **Graceful Handling of Missing Files/Paths:**  
  Introduced a helper function, `filterNotFoundErrno`, that explicitly ignores `ERROR_FILE_NOT_FOUND` and `ERROR_PATH_NOT_FOUND` errors. This allows the permission update process to continue even when certain files or directories are not present.

- **Code Restructuring for Testability:**  
  Refactored the permission application logic into a new function (`applyPermissions`) to simplify unit testing and ensure that the logic for applying ACLs and taking ownership is isolated.

- **Enhanced Unit Tests:**  
  Updated tests to use `require.ErrorIs` for proper error comparison and added tests to verify that missing files or directories do not cause the entire operation to fail.

## Why is it important?

This change is important because it increases the robustness and reliability of the Elastic Agent on Windows systems. In environments where files or directories may be transient or missing, the previous behavior could lead to failures during permission updates, causing the agent to error out. By ignoring specific non-critical errors, the agent now continues to update permissions on available files, reducing false-positive failures and improving overall system stability.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made corresponding changes to the default configuration files.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog).
- [ ] I have added an integration test or an E2E test.

## Disruptive User Impact

There is no disruptive user impact with this change. The modifications only affect the error handling for Windows permission updates. Users will benefit from improved stability since missing files or directories will no longer cause the permission update process to fail. All valid permissions updates will continue as expected.

## How to test this PR locally

1. **Prerequisites:**  
   Ensure you are testing on a Windows system.

2. **Run Unit Tests:**  
   - Execute `go test ./internal/pkg/acl/...` and `go test ./internal/pkg/agent/perms/...` to run the updated unit tests.
   - Confirm that the tests pass when processing both existing and non-existing file paths.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/7301