### PR TITLE
[ci] capture logs of pods in the test namespace and kube-system

### DIFF
--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -266,6 +266,7 @@ steps:
         artifact_paths:
           - build/**
           - build/diagnostics/**
+          - build/*.pod_logs_dump/*
         retry:
           automatic:
             limit: 1

--- a/.buildkite/scripts/buildkite-k8s-integration-tests.sh
+++ b/.buildkite/scripts/buildkite-k8s-integration-tests.sh
@@ -90,7 +90,7 @@ EOF
   fully_qualified_group_name="${CLUSTER_NAME}_${TARGET_ARCH}_${variant}"
   outputXML="build/${fully_qualified_group_name}.integration.xml"
   outputJSON="build/${fully_qualified_group_name}.integration.out.json"
-  pod_logs_base="build/${fully_qualified_group_name}.integration"
+  pod_logs_base="${PWD}/build/${fully_qualified_group_name}.pod_logs_dump"
 
   set +e
   K8S_TESTS_POD_LOGS_BASE="${pod_logs_base}" AGENT_IMAGE="${image}" DOCKER_VARIANT="${variant}" gotestsum --hide-summary=skipped --format testname --no-color -f standard-quiet --junitfile "${outputXML}" --jsonfile "${outputJSON}" -- -tags kubernetes,integration -test.shuffle on -test.timeout 2h0m0s github.com/elastic/elastic-agent/testing/integration -v -args -integration.groups="${group_name}" -integration.sudo="false"

--- a/testing/integration/kubernetes_agent_service_test.go
+++ b/testing/integration/kubernetes_agent_service_test.go
@@ -44,9 +44,7 @@ func TestKubernetesAgentService(t *testing.T) {
 
 	testSteps := []k8sTestStep{
 		k8sStepCreateNamespace(),
-		k8sStepDeployKustomize(agentK8SKustomize, "elastic-agent-standalone", k8sKustomizeOverrides{
-			agentContainerMemoryLimit: "700Mi",
-		}, func(obj k8s.Object) {
+		k8sStepDeployKustomize(agentK8SKustomize, "elastic-agent-standalone", k8sKustomizeOverrides{}, func(obj k8s.Object) {
 			// update the configmap to only run the connectors input
 			switch objWithType := obj.(type) {
 			case *corev1.ConfigMap:

--- a/testing/integration/kubernetes_agent_service_test.go
+++ b/testing/integration/kubernetes_agent_service_test.go
@@ -44,7 +44,9 @@ func TestKubernetesAgentService(t *testing.T) {
 
 	testSteps := []k8sTestStep{
 		k8sStepCreateNamespace(),
-		k8sStepDeployKustomize(agentK8SKustomize, "elastic-agent-standalone", k8sKustomizeOverrides{}, func(obj k8s.Object) {
+		k8sStepDeployKustomize(agentK8SKustomize, "elastic-agent-standalone", k8sKustomizeOverrides{
+			agentContainerMemoryLimit: "700Mi",
+		}, func(obj k8s.Object) {
 			// update the configmap to only run the connectors input
 			switch objWithType := obj.(type) {
 			case *corev1.ConfigMap:

--- a/testing/integration/kubernetes_agent_standalone_test.go
+++ b/testing/integration/kubernetes_agent_standalone_test.go
@@ -98,9 +98,7 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 			name: "default deployment - rootful agent",
 			steps: []k8sTestStep{
 				k8sStepCreateNamespace(),
-				k8sStepDeployKustomize(agentK8SKustomize, "elastic-agent-standalone", k8sKustomizeOverrides{
-					agentContainerMemoryLimit: "700Mi",
-				}, nil),
+				k8sStepDeployKustomize(agentK8SKustomize, "elastic-agent-standalone", k8sKustomizeOverrides{}, nil),
 				k8sStepCheckAgentStatus("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone", nil),
 			},
 		},
@@ -112,7 +110,6 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 					agentContainerRunUser:          int64Ptr(0),
 					agentContainerCapabilitiesAdd:  []corev1.Capability{},
 					agentContainerCapabilitiesDrop: []corev1.Capability{"ALL"},
-					agentContainerMemoryLimit:      "700Mi",
 				}, nil),
 				k8sStepCheckAgentStatus("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone", nil),
 			},
@@ -125,7 +122,6 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 					agentContainerRunUser:          int64Ptr(0),
 					agentContainerCapabilitiesAdd:  []corev1.Capability{"CHOWN", "SETPCAP"},
 					agentContainerCapabilitiesDrop: []corev1.Capability{"ALL"},
-					agentContainerMemoryLimit:      "700Mi",
 				}, nil),
 				k8sStepCheckAgentStatus("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone", nil),
 				k8sStepRunInnerTests("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone"),
@@ -140,7 +136,6 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 					agentContainerRunGroup:         int64Ptr(1000),
 					agentContainerCapabilitiesAdd:  []corev1.Capability{"CHOWN", "SETPCAP", "DAC_READ_SEARCH", "SYS_PTRACE"},
 					agentContainerCapabilitiesDrop: []corev1.Capability{"ALL"},
-					agentContainerMemoryLimit:      "700Mi",
 				}, nil),
 				k8sStepCheckAgentStatus("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone", nil),
 				k8sStepRunInnerTests("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone"),
@@ -155,7 +150,6 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 					agentContainerRunGroup:         int64Ptr(500),
 					agentContainerCapabilitiesAdd:  []corev1.Capability{"CHOWN", "SETPCAP", "DAC_READ_SEARCH", "SYS_PTRACE"},
 					agentContainerCapabilitiesDrop: []corev1.Capability{"ALL"},
-					agentContainerMemoryLimit:      "700Mi",
 				}, nil),
 				k8sStepCheckAgentStatus("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone", nil),
 				k8sStepRunInnerTests("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone"),
@@ -213,9 +207,8 @@ func TestKubernetesAgentOtel(t *testing.T) {
 			steps: []k8sTestStep{
 				k8sStepCreateNamespace(),
 				k8sStepDeployKustomize(agentK8SKustomize, "elastic-agent-standalone", k8sKustomizeOverrides{
-					agentContainerMemoryLimit: "700Mi",
-					agentContainerExtraEnv:    []corev1.EnvVar{{Name: "ELASTIC_AGENT_OTEL", Value: "true"}},
-					agentContainerArgs:        []string{}, // clear default args
+					agentContainerExtraEnv: []corev1.EnvVar{{Name: "ELASTIC_AGENT_OTEL", Value: "true"}},
+					agentContainerArgs:     []string{}, // clear default args
 				}, nil),
 			},
 		},

--- a/testing/integration/kubernetes_agent_standalone_test.go
+++ b/testing/integration/kubernetes_agent_standalone_test.go
@@ -1242,12 +1242,10 @@ func k8sCreateObjects(ctx context.Context, client klient.Client, opts k8sCreateO
 				for idx := range objWithType.Subjects {
 					objWithType.Subjects[idx].Namespace = opts.namespace
 				}
-				continue
 			case *rbacv1.RoleBinding:
 				for idx := range objWithType.Subjects {
 					objWithType.Subjects[idx].Namespace = opts.namespace
 				}
-				continue
 			}
 		}
 		if err := client.Resources().Create(ctx, obj); err != nil {
@@ -1586,7 +1584,7 @@ func k8sStepDeployKustomize(kustomizePath string, containerName string, override
 			}
 		})
 
-		err = k8sCreateObjects(ctx, kCtx.client, k8sCreateOpts{wait: true}, objects...)
+		err = k8sCreateObjects(ctx, kCtx.client, k8sCreateOpts{wait: true, namespace: namespace}, objects...)
 		require.NoError(t, err, "failed to create objects")
 	}
 }

--- a/testing/integration/kubernetes_agent_standalone_test.go
+++ b/testing/integration/kubernetes_agent_standalone_test.go
@@ -98,7 +98,9 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 			name: "default deployment - rootful agent",
 			steps: []k8sTestStep{
 				k8sStepCreateNamespace(),
-				k8sStepDeployKustomize(agentK8SKustomize, "elastic-agent-standalone", k8sKustomizeOverrides{}, nil),
+				k8sStepDeployKustomize(agentK8SKustomize, "elastic-agent-standalone", k8sKustomizeOverrides{
+					agentContainerMemoryLimit: "700Mi",
+				}, nil),
 				k8sStepCheckAgentStatus("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone", nil),
 			},
 		},
@@ -110,6 +112,7 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 					agentContainerRunUser:          int64Ptr(0),
 					agentContainerCapabilitiesAdd:  []corev1.Capability{},
 					agentContainerCapabilitiesDrop: []corev1.Capability{"ALL"},
+					agentContainerMemoryLimit:      "700Mi",
 				}, nil),
 				k8sStepCheckAgentStatus("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone", nil),
 			},
@@ -122,6 +125,7 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 					agentContainerRunUser:          int64Ptr(0),
 					agentContainerCapabilitiesAdd:  []corev1.Capability{"CHOWN", "SETPCAP"},
 					agentContainerCapabilitiesDrop: []corev1.Capability{"ALL"},
+					agentContainerMemoryLimit:      "700Mi",
 				}, nil),
 				k8sStepCheckAgentStatus("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone", nil),
 				k8sStepRunInnerTests("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone"),
@@ -136,6 +140,7 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 					agentContainerRunGroup:         int64Ptr(1000),
 					agentContainerCapabilitiesAdd:  []corev1.Capability{"CHOWN", "SETPCAP", "DAC_READ_SEARCH", "SYS_PTRACE"},
 					agentContainerCapabilitiesDrop: []corev1.Capability{"ALL"},
+					agentContainerMemoryLimit:      "700Mi",
 				}, nil),
 				k8sStepCheckAgentStatus("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone", nil),
 				k8sStepRunInnerTests("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone"),
@@ -150,6 +155,7 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 					agentContainerRunGroup:         int64Ptr(500),
 					agentContainerCapabilitiesAdd:  []corev1.Capability{"CHOWN", "SETPCAP", "DAC_READ_SEARCH", "SYS_PTRACE"},
 					agentContainerCapabilitiesDrop: []corev1.Capability{"ALL"},
+					agentContainerMemoryLimit:      "700Mi",
 				}, nil),
 				k8sStepCheckAgentStatus("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone", nil),
 				k8sStepRunInnerTests("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone"),
@@ -207,8 +213,9 @@ func TestKubernetesAgentOtel(t *testing.T) {
 			steps: []k8sTestStep{
 				k8sStepCreateNamespace(),
 				k8sStepDeployKustomize(agentK8SKustomize, "elastic-agent-standalone", k8sKustomizeOverrides{
-					agentContainerExtraEnv: []corev1.EnvVar{{Name: "ELASTIC_AGENT_OTEL", Value: "true"}},
-					agentContainerArgs:     []string{}, // clear default args
+					agentContainerMemoryLimit: "700Mi",
+					agentContainerExtraEnv:    []corev1.EnvVar{{Name: "ELASTIC_AGENT_OTEL", Value: "true"}},
+					agentContainerArgs:        []string{}, // clear default args
 				}, nil),
 			},
 		},

--- a/testing/integration/kubernetes_agent_standalone_test.go
+++ b/testing/integration/kubernetes_agent_standalone_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/kibana"
@@ -1262,9 +1263,13 @@ type k8sContext struct {
 }
 
 // getNamespace returns a unique namespace for the current test
-func (k8sContext) getNamespace(t *testing.T) string {
+func (k k8sContext) getNamespace(t *testing.T) string {
+	nsUUID, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("error generating namespace UUID: %v", err)
+	}
 	hasher := sha256.New()
-	hasher.Write([]byte(t.Name()))
+	hasher.Write([]byte(nsUUID.String()))
 	testNamespace := strings.ToLower(base64.URLEncoding.EncodeToString(hasher.Sum(nil)))
 	return noSpecialCharsRegexp.ReplaceAllString(testNamespace, "")
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR enhances Kubernetes integration test logging with the following improvements:

- Logs from **all pods** within both the test namespace and the `kube-system` namespace are now captured and archived.
- A **UUID-based namespace** is used instead of a test-name-derived one, ensuring uniqueness and preventing namespace conflicts.
- The path for dumping pod logs is adjusted, organizing logs into a structured archive that is easier to retrieve and analyze.
- Improves the `ExecInPod` calls by applying **timeouts** to prevent indefinite hangs in test runs.
- Captures **container restarts** explicitly in `k8sCheckAgentStatus`, making test failures more informative.
- Introduces structured logging for test artifacts, ensuring all relevant data is collected in Buildkite.

I did "force" the k8s integration tests to run with restrictive memory limits until this commit https://github.com/elastic/elastic-agent/pull/7341/commits/5d50a680bdf6c90926b3866b9c0527f20d2d3dc2 and thus caused flakiness. An example of the new archive containing pod logs and container status can be found [here](https://buildkite.com/organizations/elastic/pipelines/elastic-agent/builds/18752/jobs/019591ed-f6c7-4131-86c0-9eb849eddb85/artifacts/0195923f-5ff1-4e72-b43b-9833a55058cc). Shown below are the contents of the archive and the restart reason of elastic-agent container

<img width="1451" alt="image" src="https://github.com/user-attachments/assets/b98cb2bf-0777-4fe6-8c9b-598421ce34dc" />


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

- Capturing logs from both the test namespace and the `kube-system` namespace **improves debugging visibility**, especially when tests interact with Kubernetes components.
- Using a **UUID-based namespace** eliminates test flakiness due to namespace collisions, improving test reliability.
- The introduction of **timeouts on ExecInPod calls** prevents Kubernetes API hangs from blocking test execution.
- Recording **container restarts** provides more meaningful failure diagnostics for unstable test environments.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made corresponding changes to the default configuration files.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog).
- [ ] I have added an integration test or an E2E test.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

This PR introduces no disruptive changes for end users.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Run the Kubernetes integration tests in Buildkite.
2. Ensure the test logs are captured in the `build/*.pod_logs_dump/` path.
3. Verify the generated tar.gz archive includes logs from both test namespace pods and `kube-system` pods.
4. Check that the namespace is derived from a UUID and does not conflict with previously used namespaces.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/7060