### PR TITLE
Capture in progress the error of uninstalling elastic-agent service

### DIFF
--- a/internal/pkg/agent/install/switch.go
+++ b/internal/pkg/agent/install/switch.go
@@ -74,7 +74,11 @@ func SwitchExecutingMode(topPath string, pt *progressbar.ProgressBar, username s
 	//
 	// the install error below will include an error about the service still existing if this failed
 	// to uninstall (really this should never fail, but the unexpected can happen)
-	_ = UninstallService(topPath)
+	err = UninstallService(topPath)
+	if err != nil {
+		// error context already added by UninstallService
+		pt.Describe(err.Error())
+	}
 
 	// re-install service
 	pt.Describe("Installing service")

--- a/internal/pkg/agent/install/switch.go
+++ b/internal/pkg/agent/install/switch.go
@@ -67,13 +67,9 @@ func SwitchExecutingMode(topPath string, pt *progressbar.ProgressBar, username s
 
 	// the service has to be uninstalled
 	pt.Describe("Removing service")
-	// error is ignored because it's possible that its already uninstalled
-	//
+
 	// this can happen if this action failed in the middle of this critical section, so to allow the
-	// command to be called again we don't error on the uninstall
-	//
-	// the install error below will include an error about the service still existing if this failed
-	// to uninstall (really this should never fail, but the unexpected can happen)
+	// command to be called again we don't return the error on the uninstall
 	err = UninstallService(topPath)
 	if err != nil {
 		// error context already added by UninstallService


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR captures and reports errors encountered during the uninstallation of the Elastic Agent service instead of silently ignoring them. Previously, the error returned by `UninstallService` was ignored, potentially hiding valuable information during troubleshooting. Now, any errors encountered during service uninstallation will be logged through the existing `pt.Describe()` method, providing better context for debugging.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Ignoring errors during service uninstallation can lead to ambiguous failures in subsequent service installation attempts, such as the "service already exists" error observed in integration tests (`TestSwitchPrivilegedWithBasePath`). Reporting these errors helps to identify and diagnose issues related to permissions or service management, particularly on Windows, improving the reliability of tests and operational clarity.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

This change is not disruptive.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

I don't have a good answer as the uninstalling service failures are observed only during Flaky runs of CI tests 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/6970
