### PR TITLE
[flaky] fix kustomize integration tests

### DIFF
--- a/testing/integration/kubernetes_agent_service_test.go
+++ b/testing/integration/kubernetes_agent_service_test.go
@@ -44,9 +44,7 @@ func TestKubernetesAgentService(t *testing.T) {
 
 	testSteps := []k8sTestStep{
 		k8sStepCreateNamespace(),
-		k8sStepDeployKustomize(agentK8SKustomize, "elastic-agent-standalone", k8sKustomizeOverrides{
-			agentContainerMemoryLimit: "800Mi",
-		}, func(obj k8s.Object) {
+		k8sStepDeployKustomize(agentK8SKustomize, "elastic-agent-standalone", k8sKustomizeOverrides{}, func(obj k8s.Object) {
 			// update the configmap to only run the connectors input
 			switch objWithType := obj.(type) {
 			case *corev1.ConfigMap:

--- a/testing/integration/kubernetes_agent_standalone_test.go
+++ b/testing/integration/kubernetes_agent_standalone_test.go
@@ -80,8 +80,6 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 		Group: define.Kubernetes,
 	})
 
-	t.Skip("Flaky test https://github.com/elastic/elastic-agent/issues/7356")
-
 	ctx := context.Background()
 	kCtx := k8sGetContext(t, info)
 
@@ -98,9 +96,7 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 			name: "default deployment - rootful agent",
 			steps: []k8sTestStep{
 				k8sStepCreateNamespace(),
-				k8sStepDeployKustomize(agentK8SKustomize, "elastic-agent-standalone", k8sKustomizeOverrides{
-					agentContainerMemoryLimit: "800Mi",
-				}, nil),
+				k8sStepDeployKustomize(agentK8SKustomize, "elastic-agent-standalone", k8sKustomizeOverrides{}, nil),
 				k8sStepCheckAgentStatus("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone", nil),
 			},
 		},
@@ -112,7 +108,6 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 					agentContainerRunUser:          int64Ptr(0),
 					agentContainerCapabilitiesAdd:  []corev1.Capability{},
 					agentContainerCapabilitiesDrop: []corev1.Capability{"ALL"},
-					agentContainerMemoryLimit:      "800Mi",
 				}, nil),
 				k8sStepCheckAgentStatus("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone", nil),
 			},
@@ -125,7 +120,6 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 					agentContainerRunUser:          int64Ptr(0),
 					agentContainerCapabilitiesAdd:  []corev1.Capability{"CHOWN", "SETPCAP"},
 					agentContainerCapabilitiesDrop: []corev1.Capability{"ALL"},
-					agentContainerMemoryLimit:      "800Mi",
 				}, nil),
 				k8sStepCheckAgentStatus("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone", nil),
 				k8sStepRunInnerTests("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone"),
@@ -140,7 +134,6 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 					agentContainerRunGroup:         int64Ptr(1000),
 					agentContainerCapabilitiesAdd:  []corev1.Capability{"CHOWN", "SETPCAP", "DAC_READ_SEARCH", "SYS_PTRACE"},
 					agentContainerCapabilitiesDrop: []corev1.Capability{"ALL"},
-					agentContainerMemoryLimit:      "800Mi",
 				}, nil),
 				k8sStepCheckAgentStatus("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone", nil),
 				k8sStepRunInnerTests("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone"),
@@ -155,7 +148,6 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 					agentContainerRunGroup:         int64Ptr(500),
 					agentContainerCapabilitiesAdd:  []corev1.Capability{"CHOWN", "SETPCAP", "DAC_READ_SEARCH", "SYS_PTRACE"},
 					agentContainerCapabilitiesDrop: []corev1.Capability{"ALL"},
-					agentContainerMemoryLimit:      "800Mi",
 				}, nil),
 				k8sStepCheckAgentStatus("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone", nil),
 				k8sStepRunInnerTests("app=elastic-agent-standalone", schedulableNodeCount, "elastic-agent-standalone"),
@@ -213,9 +205,8 @@ func TestKubernetesAgentOtel(t *testing.T) {
 			steps: []k8sTestStep{
 				k8sStepCreateNamespace(),
 				k8sStepDeployKustomize(agentK8SKustomize, "elastic-agent-standalone", k8sKustomizeOverrides{
-					agentContainerMemoryLimit: "800Mi",
-					agentContainerExtraEnv:    []corev1.EnvVar{{Name: "ELASTIC_AGENT_OTEL", Value: "true"}},
-					agentContainerArgs:        []string{}, // clear default args
+					agentContainerExtraEnv: []corev1.EnvVar{{Name: "ELASTIC_AGENT_OTEL", Value: "true"}},
+					agentContainerArgs:     []string{}, // clear default args
 				}, nil),
 			},
 		},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR fixes intermittent failures in Kubernetes Kustomize integration tests (`TestKubernetesAgentStandaloneKustomize`) by removing the previously hardcoded container memory limit of `800Mi` at the test-code level. This memory limit apparently has become too restrictive following probably recent changes in Beats components, causing test instability and timeouts during agent health checks. Instead now the tests fallback to the memory limit of `1Gi` that exists in the kustomize manifests. 

The only PR that seems to align with the `800Mi` starting to be restrictive is this one https://github.com/elastic/beats/pull/43105. As soon as this landed on `main` and on `8.x` and it was picked by elastic-agent CI, k8s integration tests started failing. As of now `9:11 PM UTC` this is not yet merged in `9.0` and there k8s integration tests that do not fail on `9.0` but do fail on `8.x`

9.0 -> https://github.com/elastic/elastic-agent/commit/4cf43f8fb2accc76b21b55a28b6b2fa510f6a9ea
8.x -> https://github.com/elastic/elastic-agent/commit/e24bc7f8b8c92bc6a791143d0398ab48299d3740

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The Kubernetes integration tests (`TestKubernetesAgentStandaloneKustomize`) have become flaky and this change is required to guarantee test reliability.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

No disruptive impact. This change only affects k8s integration tests.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run the k8s integration tests locally.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/7356