### PR TITLE
Make ingest-otel-data owners of the otel-kube-stack config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 /.github @elastic/ingest-eng-prod
 /.github/CODEOWNERS @elastic/ingest-tech-lead
 /deploy/helm @elastic/elastic-agent-control-plane
+/deploy/helm/edot-collector @elastic/ingest-otel-data
 /deploy/kubernetes @elastic/elastic-agent-control-plane
 /dev-tools/kubernetes @elastic/elastic-agent-control-plane
 /internal/pkg/agent/application/configuration_embed_changed_test.go @elastic/cloudbeat


### PR DESCRIPTION
## What does this PR do?

Makes the @elastic/ingest-otel-data team the owners of the otel-kube-stack config hosted in this repository. This is simply recognizing the effective state of affairs in the tooling.

One slight uncertainty is that the aforementioned team will now be required to approve some version bump PRs after releases. Not sure if that's a problem.

## Why is it important?

As a general rule, changes to these files should be approved by this team.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
