### PR TITLE
[Helm] Allow providing CA certificate of the Fleet Server when running the agent in fleet mode

### DIFF
--- a/deploy/helm/elastic-agent/README.md
+++ b/deploy/helm/elastic-agent/README.md
@@ -5,7 +5,7 @@
 
 # elastic-agent
 
-![Version: 9.0.0-beta](https://img.shields.io/badge/Version-9.0.0--beta-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.0.0](https://img.shields.io/badge/AppVersion-9.0.0-informational?style=flat-square)
+![Version: 9.1.0-beta](https://img.shields.io/badge/Version-9.1.0--beta-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.1.0](https://img.shields.io/badge/AppVersion-9.1.0-informational?style=flat-square)
 
 Elastic-Agent Helm Chart
 
@@ -144,8 +144,8 @@ The chart built-in [kubernetes integration](https://docs.elastic.co/integrations
 ### 6 - Elastic-Agent Configuration
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| agent.version | string | `"9.0.0"` | elastic-agent version |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"docker.elastic.co/elastic-agent/elastic-agent","tag":"9.0.0-SNAPSHOT"}` | image configuration |
+| agent.version | string | `"9.1.0"` | elastic-agent version |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"docker.elastic.co/elastic-agent/elastic-agent","tag":"9.1.0-SNAPSHOT"}` | image configuration |
 | agent.imagePullSecrets | list | `[]` | image pull secrets |
 | agent.engine | string | `"k8s"` | generate kubernetes manifests or [ECK](https://github.com/elastic/cloud-on-k8s) CRDs |
 | agent.unprivileged | bool | `false` | enable unprivileged mode |
@@ -157,9 +157,25 @@ The chart built-in [kubernetes integration](https://docs.elastic.co/integrations
 | agent.fleet.enabled | bool | `false` | enable elastic-agent managed |
 | agent.fleet.url | string | `""` | Fleet server URL |
 | agent.fleet.token | string | `""` | Fleet enrollment token |
-| agent.fleet.insecure | bool | `false` | Fleet insecure url |
+| agent.fleet.insecure | bool | `false` | Communicate with Fleet with either insecure HTTP or unverified HTTPS |
+| agent.fleet.force | bool | `false` | Enforce enrollment even if agent is already enrolled |
+| agent.fleet.ca.value | string | `""` | Value of the CA certificate for connecting to Fleet |
+| agent.fleet.ca.valueFromSecret.name | string | `""` | Secret name for the CA certificate |
+| agent.fleet.ca.valueFromSecret.key | string | `""` | Secret key for the CA certificate |
+| agent.fleet.agentCert.value | string | `""` | Value of Elastic Agent client certificate for Fleet Server mTLS |
+| agent.fleet.agentCert.valueFromSecret.name | string | `""` | Secret name for the Elastic Agent client certificate |
+| agent.fleet.agentCert.valueFromSecret.key | string | `""` | Key in the secret for the Elastic Agent client certificate |
+| agent.fleet.agentCertKey.value | string | `""` | Value of Elastic Agent client private key for Fleet Server mTLS |
+| agent.fleet.agentCertKey.valueFromSecret.name | string | `""` | Secret name for the Elastic Agent client private key |
+| agent.fleet.agentCertKey.valueFromSecret.key | string | `""` | Key in the secret for the Elastic Agent client private key |
+| agent.fleet.tokenName | string | `""` | Token name to use for fetching token from Kibana if the enrollment token is not supplied |
+| agent.fleet.policyName | string | `""` | Token policy name to use for fetching token from Kibana if the enrollment token is not supplied |
 | agent.fleet.kibanaHost | string | `""` | Kibana host to fallback if enrollment token is not supplied |
 | agent.fleet.kibanaUser | string | `""` | Kibana username to fallback if enrollment token is not supplied |
 | agent.fleet.kibanaPassword | string | `""` | Kibana password to fallback if enrollment token is not supplied |
+| agent.fleet.kibanaCA.value | string | `""` | Value of the CA certificate for Kibana if the enrollment token is not supplied |
+| agent.fleet.kibanaCA.valueFromSecret.name | string | `""` | Secret name for the Kibana CA certificate |
+| agent.fleet.kibanaCA.valueFromSecret.key | string | `""` | Key in the secret for the Kibana CA certificate |
+| agent.fleet.kibanaServiceToken | string | `""` | Service token to use when connecting to Kibana if the enrollment token is not supplied |
 | agent.fleet.preset | string | `"perNode"` | Agent preset to deploy |
 

--- a/deploy/helm/elastic-agent/examples/fleet-managed-certificates/README.md
+++ b/deploy/helm/elastic-agent/examples/fleet-managed-certificates/README.md
@@ -1,0 +1,38 @@
+# Example: Managed by Fleet Elastic Agent with self-signed certificates
+
+This example demonstrates deploying an Elastic Agent that is managed by Fleet with custom fleet-related certificates, including CA certificates and client certificates for mutual TLS (mTLS).
+
+## Prerequisites:
+## Prerequisites
+
+Before deploying, you should:
+
+1. Set up an [Agent policy](https://www.elastic.co/guide/en/fleet/current/install-fleet-managed-elastic-agent.html#elastic-agent-installation-steps) in Fleet.
+2. Follow [this guide](https://www.elastic.co/guide/en/fleet/8.17/add-fleet-server-kubernetes.html#add-fleet-server-kubernetes-cert-prereq) to set up an agent policy and enroll an agent to it. Do not download any binary, from the proposed enrollment command just extract the Fleet URL (`--url=$FLEET_URL`) and Enrollment token (`--enrollment-token=$FLEET_TOKEN`).
+3. Create Kubernetes secrets holding the necessary certificates (CA certificate, client certificate, and client private key) or have the certificate files available locally to use with the `--set-file` Helm CLI argument.
+4. Build the dependencies of the Helm chart
+    ```console
+    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    helm dependency build ../../
+    ```
+## Run:
+
+```console
+helm install elastic-agent ../../ \
+     --set agent.fleet.enabled=true \
+     --set agent.fleet.url=$FLEET_URL \
+     --set agent.fleet.token=$FLEET_TOKEN \
+     --set agent.fleet.preset=perNode \
+     --set-file agent.fleet.ca.value=path/to/ca.crt \
+     --set-file agent.fleet.agentCert.value=path/to/agent.crt \
+     --set-file agent.fleet.agentCertKey.value=agent.key \
+     --set-file agent.fleet.kibanaCA.value=path/to/kibanaca.crt \
+     -n kube-system
+```
+
+## Validate:
+
+1. `kube-state metrics` is installed with this command `kubectl get deployments -n kube-system kube-state-metrics`.
+2. Install Kubernetes integration to the agent policy that corresponds to the enrolled agents.
+3. The Kibana `kubernetes`-related dashboards should start showing the respective info.
+

--- a/deploy/helm/elastic-agent/examples/fleet-managed-certificates/fleet-values.yaml
+++ b/deploy/helm/elastic-agent/examples/fleet-managed-certificates/fleet-values.yaml
@@ -1,0 +1,41 @@
+kubernetes:
+  enabled: true
+system:
+  enabled: true
+agent:
+  fleet:
+    enabled: true
+    url: http://localhost:8220
+    token: fleetToken
+    ca:
+      value: |-
+        -----BEGIN CERTIFICATE-----
+        MIIBaDCCARCgAWIBAgIQNJyw4xhweOFK3/FqGLQF6TAKBggqhkjOPQQDAJAVMRMw
+        EQYDVQQDEwpjbHVzdGVyLWNhMB4XDTI1MDEWODAOMDIyMFoXDTM1IMDEwNjAOMDIy
+        MFowFTETMBEGA1UEAXMKY2x1c3R1Ucil1jYTBZMBMGByqGSM49AgEGCCqGSM49AWEH
+        A0TABPcDLjOSlwAmeHbHFerT+SmTNqxckANmRPItCPRgkp2cq12a1C/ckQEebE1A
+        B7WpiRaUQQkBpmNjcAPVIdfdnbWjQjBAMA4GA1UdDWEB/wQEAwICpDAPBgNVHRMB
+        Af8EBTADAQH/MBOGA1UdDgQWBBTA5SRUKOE90/xKntDXcpZSvlL1JDBDAKBggqhkj0
+        PQQDAGNGADBDAiAFghoM1M53abi968RyR+DwVX3S92aiu7MogtnuKCgPLQIFRRza
+        Ondv3U1X2Qwo2ZELignHs3JLWucWvCIqmbW2+A==
+        -----END CERTIFICATE-----
+    agentCert:
+      valueFromSecret:
+        name: agent-cert
+        key: crt
+    agentCertKey:
+      valueFromSecret:
+        name: agent-cert
+        key: private
+    kibanaCA:
+      value: |-
+        -----BEGIN CERTIFICATE-----
+        MIIBaDCCARCgAWIBAgIQNJyw4xhweOFK3/FqGLQF6TAKBggqhkjOPQQDAJAVMRMw
+        EQYDVQQDEwpjbHVzdGVyLWNhMB4XDTI1MDEWODAOMDIyMFoXDTM1IMDEwNjAOMDIy
+        MFowFTETMBEGA1UEAXMKY2x1c3R1Ucil1jYTBZMBMGByqGSM49AgEGCCqGSM49AWEH
+        A0TABPcDLjOSlwAmeHbHFerT+SmTNqxckANmRPItCPRgkp2cq12a1C/ckQEebE1A
+        B7WpiRaUQQkBpmNjcAPVIdfdnbWjQjBAMA4GA1UdDWEB/wQEAwICpDAPBgNVHRMB
+        Af8EBTADAQH/MBOGA1UdDgQWBBTA5SRUKOE90/xKntDXcpZSvlL1JDBDAKBggqhkj0
+        PQQDAGNGADBDAiAFghoM1M53abi968RyR+DwVX3S92aiu7MogtnuKCgPLQIFRRza
+        Ondv3U1X2Qwo2ZELignHs3JLWucWvCIqmbW2+B==
+        -----END CERTIFICATE-----

--- a/deploy/helm/elastic-agent/examples/fleet-managed-certificates/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/fleet-managed-certificates/rendered/manifest.yaml
@@ -50,6 +50,28 @@ stringData:
       kubernetes_leaderelection:
         enabled: true
         leader_lease: example-pernode
+  fleet.ca : |-
+    -----BEGIN CERTIFICATE-----
+    MIIBaDCCARCgAWIBAgIQNJyw4xhweOFK3/FqGLQF6TAKBggqhkjOPQQDAJAVMRMw
+    EQYDVQQDEwpjbHVzdGVyLWNhMB4XDTI1MDEWODAOMDIyMFoXDTM1IMDEwNjAOMDIy
+    MFowFTETMBEGA1UEAXMKY2x1c3R1Ucil1jYTBZMBMGByqGSM49AgEGCCqGSM49AWEH
+    A0TABPcDLjOSlwAmeHbHFerT+SmTNqxckANmRPItCPRgkp2cq12a1C/ckQEebE1A
+    B7WpiRaUQQkBpmNjcAPVIdfdnbWjQjBAMA4GA1UdDWEB/wQEAwICpDAPBgNVHRMB
+    Af8EBTADAQH/MBOGA1UdDgQWBBTA5SRUKOE90/xKntDXcpZSvlL1JDBDAKBggqhkj0
+    PQQDAGNGADBDAiAFghoM1M53abi968RyR+DwVX3S92aiu7MogtnuKCgPLQIFRRza
+    Ondv3U1X2Qwo2ZELignHs3JLWucWvCIqmbW2+A==
+    -----END CERTIFICATE-----
+  fleet.kibana.ca : |-
+    -----BEGIN CERTIFICATE-----
+    MIIBaDCCARCgAWIBAgIQNJyw4xhweOFK3/FqGLQF6TAKBggqhkjOPQQDAJAVMRMw
+    EQYDVQQDEwpjbHVzdGVyLWNhMB4XDTI1MDEWODAOMDIyMFoXDTM1IMDEwNjAOMDIy
+    MFowFTETMBEGA1UEAXMKY2x1c3R1Ucil1jYTBZMBMGByqGSM49AgEGCCqGSM49AWEH
+    A0TABPcDLjOSlwAmeHbHFerT+SmTNqxckANmRPItCPRgkp2cq12a1C/ckQEebE1A
+    B7WpiRaUQQkBpmNjcAPVIdfdnbWjQjBAMA4GA1UdDWEB/wQEAwICpDAPBgNVHRMB
+    Af8EBTADAQH/MBOGA1UdDgQWBBTA5SRUKOE90/xKntDXcpZSvlL1JDBDAKBggqhkj0
+    PQQDAGNGADBDAiAFghoM1M53abi968RyR+DwVX3S92aiu7MogtnuKCgPLQIFRRza
+    Ondv3U1X2Qwo2ZELignHs3JLWucWvCIqmbW2+B==
+    -----END CERTIFICATE-----
 ---
 # Source: elastic-agent/charts/kube-state-metrics/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -375,7 +397,7 @@ spec:
       labels:
         name: agent-pernode-example
       annotations:
-        checksum/config: cd7c5c4f03cc8377d18ee22cf236428090959fc194ee647bd97a39b79f38c807
+        checksum/config: 509d5f84e4687cb90ad2a381455fde090ef4e6eeb548e789a2de66f441963695
     spec:
       automountServiceAccountToken: true
       containers:
@@ -396,6 +418,14 @@ spec:
           value: /usr/share/elastic-agent/state
         - name: ELASTIC_NETINFO
           value: "false"
+        - name: FLEET_CA
+          value: /mnt/secrets/elastic-agent/fleet.ca
+        - name: ELASTIC_AGENT_CERT
+          value: /mnt/secrets/elastic-agent/agent-cert.crt
+        - name: ELASTIC_AGENT_CERT_KEY
+          value: /mnt/secrets/elastic-agent/agent-cert.private
+        - name: KIBANA_FLEET_CA
+          value: /mnt/secrets/elastic-agent/fleet.kibana.ca
         - name: FLEET_URL
           value: http://localhost:8220
         - name: FLEET_ENROLLMENT_TOKEN
@@ -432,6 +462,22 @@ spec:
         - mountPath: /hostfs/etc
           name: etc-full
           readOnly: true
+        - mountPath: /mnt/secrets/elastic-agent/fleet.ca
+          name: config
+          readOnly: true
+          subPath: fleet.ca
+        - mountPath: /mnt/secrets/elastic-agent/agent-cert.crt
+          name: agent-cert
+          readOnly: true
+          subPath: crt
+        - mountPath: /mnt/secrets/elastic-agent/agent-cert.private
+          name: agent-cert
+          readOnly: true
+          subPath: private
+        - mountPath: /mnt/secrets/elastic-agent/fleet.kibana.ca
+          name: config
+          readOnly: true
+          subPath: fleet.kibana.ca
         - mountPath: /usr/share/elastic-agent/state
           name: agent-data
         - mountPath: /etc/elastic-agent/agent.yml
@@ -462,6 +508,10 @@ spec:
       - hostPath:
           path: /var/lib
         name: var-lib
+      - name: agent-cert
+        secret:
+          defaultMode: 292
+          secretName: agent-cert
       - hostPath:
           path: /etc/elastic-agent/default/agent-pernode-example-managed/state
           type: DirectoryOrCreate

--- a/deploy/helm/elastic-agent/examples/fleet-managed-ksm-sharding/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/fleet-managed-ksm-sharding/rendered/manifest.yaml
@@ -22,6 +22,7 @@ metadata:
   name: agent-ksm
   namespace: "default"
 stringData:
+
   agent.yml: |-
     fleet:
       enabled: true
@@ -328,7 +329,7 @@ spec:
         app.kubernetes.io/version: "2.15.0"
       annotations:
       
-        checksum/config: 23ea9986d03b780c70c0a67796c271f1336b53e217163de5b5971495c39e2ff9
+        checksum/config: 3ffd84be56846b5601fb4376e7c2e6056e929f4a78f3697ac266fd0269ba41af
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -411,10 +412,8 @@ spec:
           value: http://localhost:8220
         - name: FLEET_ENROLLMENT_TOKEN
           value: fleetToken
-        - name: FLEET_INSECURE
-          value: "false"
         - name: FLEET_ENROLL
-          value: "1"
+          value: "true"
         image: docker.elastic.co/elastic-agent/elastic-agent:9.1.0-SNAPSHOT
         imagePullPolicy: IfNotPresent
         name: agent

--- a/deploy/helm/elastic-agent/examples/kubernetes-ksm-sharding/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/kubernetes-ksm-sharding/rendered/manifest.yaml
@@ -284,7 +284,16 @@ metadata:
   name: agent-ksm
   namespace: "default"
 stringData:
+
   agent.yml: |-
+    id: agent-ksm
+    outputs:
+      default:
+        api_key: ${OUTPUT_DEFAULT_API_KEY}
+        hosts:
+        - ${OUTPUT_DEFAULT_URL}
+        type: elasticsearch
+    secret_references: []
     inputs:
       - data_stream:
           namespace: default
@@ -457,12 +466,6 @@ stringData:
           period: 10s
         type: kubernetes/metrics
         use_output: default
-    outputs:
-      default:
-        api_key: ${OUTPUT_DEFAULT_API_KEY}
-        hosts:
-        - ${OUTPUT_DEFAULT_URL}
-        type: elasticsearch
     providers:
       kubernetes:
         enabled: false
@@ -1161,7 +1164,7 @@ spec:
         app.kubernetes.io/version: "2.15.0"
       annotations:
       
-        checksum/config: 80abdbb9b473f2336713dacdae362b6a0982ca46324fbe02e7d20492b8ea8014
+        checksum/config: d86c07ea79de1388d0a81565edd84ba54f07ce89dc2d060514a1c744104e8f90
     spec:
       automountServiceAccountToken: true
       hostNetwork: false

--- a/deploy/helm/elastic-agent/templates/agent/_helpers.tpl
+++ b/deploy/helm/elastic-agent/templates/agent/_helpers.tpl
@@ -56,6 +56,11 @@ Validate fleet configuration
 {{- $_ := unset $.Values.agent.presets $presetName}}
 {{- end -}}
 {{- end -}}
+{{/* init any fleet-related values that derive from valueFrom schema */}}
+{{- include "elasticagent.init.valueFrom" (list $ $.Values.agent.fleet.ca "fleet.ca") -}}
+{{- include "elasticagent.init.valueFrom" (list $ $.Values.agent.fleet.agentCert "fleet.agentcert") -}}
+{{- include "elasticagent.init.valueFrom" (list $ $.Values.agent.fleet.agentCertKey "fleet.agentcert.key") -}}
+{{- include "elasticagent.init.valueFrom" (list $ $.Values.agent.fleet.kibanaCA "fleet.kibana.ca") -}}
 {{- end -}}
 {{- end -}}
 
@@ -169,54 +174,86 @@ Mutate an agent preset based on agent.fleet
 {{- define "elasticagent.preset.mutate.fleet" -}}
 {{- $ := index . 0 -}}
 {{- $preset := index . 1 -}}
-{{- if eq $.Values.agent.fleet.enabled true -}}
-{{- $fleetEnvVars := list -}}
+{{- $extraVolumeMounts := list -}}
+{{- $extraVolumes := list -}}
+{{- $extraEnvs := list -}}
+{{- if ($.Values.agent.fleet.ca)._mountPath -}}
+{{- $extraEnvs = append $extraEnvs (dict "name" "FLEET_CA" "value" ($.Values.agent.fleet.ca)._mountPath) -}}
+{{- end -}}
+{{- if ($.Values.agent.fleet.ca)._volume -}}
+{{- $extraVolumes = append $extraVolumes ($.Values.agent.fleet.ca)._volume -}}
+{{- end -}}
+{{- if ($.Values.agent.fleet.ca)._volumeMount -}}
+{{- $extraVolumeMounts = append $extraVolumeMounts ($.Values.agent.fleet.ca)._volumeMount -}}
+{{- end -}}
+{{- if ($.Values.agent.fleet.agentCert)._mountPath -}}
+{{- $extraEnvs = append $extraEnvs (dict "name" "ELASTIC_AGENT_CERT" "value" ($.Values.agent.fleet.agentCert)._mountPath) -}}
+{{- end -}}
+{{- if ($.Values.agent.fleet.agentCert)._volume -}}
+{{- $extraVolumes = append $extraVolumes ($.Values.agent.fleet.agentCert)._volume -}}
+{{- end -}}
+{{- if ($.Values.agent.fleet.agentCert)._volumeMount -}}
+{{- $extraVolumeMounts = append $extraVolumeMounts ($.Values.agent.fleet.agentCert)._volumeMount -}}
+{{- end -}}
+{{- if ($.Values.agent.fleet.agentCertKey)._mountPath -}}
+{{- $extraEnvs = append $extraEnvs (dict "name" "ELASTIC_AGENT_CERT_KEY" "value" ($.Values.agent.fleet.agentCertKey)._mountPath) -}}
+{{- end -}}
+{{- if ($.Values.agent.fleet.agentCertKey)._volume -}}
+{{- $extraVolumes = append $extraVolumes ($.Values.agent.fleet.agentCertKey)._volume -}}
+{{- end -}}
+{{- if ($.Values.agent.fleet.agentCertKey)._volumeMount -}}
+{{- $extraVolumeMounts = append $extraVolumeMounts ($.Values.agent.fleet.agentCertKey)._volumeMount -}}
+{{- end -}}
+{{- if ($.Values.agent.fleet.kibanaCA)._mountPath -}}
+{{- $extraEnvs = append $extraEnvs (dict "name" "KIBANA_FLEET_CA" "value" ($.Values.agent.fleet.kibanaCA)._mountPath) -}}
+{{- end -}}
+{{- if ($.Values.agent.fleet.kibanaCA)._volume -}}
+{{- $extraVolumes = append $extraVolumes ($.Values.agent.fleet.kibanaCA)._volume -}}
+{{- end -}}
+{{- if ($.Values.agent.fleet.kibanaCA)._volumeMount -}}
+{{- $extraVolumeMounts = append $extraVolumeMounts ($.Values.agent.fleet.kibanaCA)._volumeMount -}}
+{{- end -}}
 {{- if $.Values.agent.fleet.url -}}
-{{- $fleetURL := dict }}
-{{- $_ := set $fleetURL "name" "FLEET_URL" -}}
-{{- $_ := set $fleetURL "value" $.Values.agent.fleet.url -}}
-{{- $fleetEnvVars = append $fleetEnvVars $fleetURL  -}}
+{{- $extraEnvs = append $extraEnvs (dict "name" "FLEET_URL" "value" $.Values.agent.fleet.url) -}}
 {{- end -}}
 {{- if $.Values.agent.fleet.token -}}
-{{- $fleetToken := dict }}
-{{- $_ := set $fleetToken "name" "FLEET_ENROLLMENT_TOKEN" -}}
-{{- $_ := set $fleetToken "value" $.Values.agent.fleet.token -}}
-{{- $fleetEnvVars = append $fleetEnvVars $fleetToken  -}}
+{{- $extraEnvs = append $extraEnvs (dict "name" "FLEET_ENROLLMENT_TOKEN" "value" $.Values.agent.fleet.token) -}}
 {{- end -}}
-{{- $fleetInsecure := dict }}
-{{- $_ := set $fleetInsecure "name" "FLEET_INSECURE" -}}
-{{- $_ := set $fleetInsecure "value" (printf "%t" $.Values.agent.fleet.insecure) -}}
-{{- $fleetEnvVars = append $fleetEnvVars $fleetInsecure  -}}
+{{- if $.Values.agent.fleet.insecure -}}
+{{- $extraEnvs = append $extraEnvs (dict "name" "FLEET_INSECURE" "value" (quote $.Values.agent.fleet.insecure)) -}}
+{{- end -}}
+{{- if $.Values.agent.fleet.force -}}
+{{- $extraEnvs = append $extraEnvs (dict "name" "FLEET_FORCE" "value" (quote $.Values.agent.fleet.force)) -}}
+{{- end -}}
+{{- if $.Values.agent.fleet.tokenName -}}
+{{- $extraEnvs = append $extraEnvs (dict "name" "FLEET_TOKEN_NAME" "value" $.Values.agent.fleet.tokenName) -}}
+{{- end -}}
+{{- if $.Values.agent.fleet.policyName -}}
+{{- $extraEnvs = append $extraEnvs (dict "name" "FLEET_TOKEN_POLICY_NAME" "value" $.Values.agent.fleet.policyName) -}}
+{{- end -}}
 {{- if $.Values.agent.fleet.kibanaHost -}}
-{{- $fleetKibanaHost := dict }}
-{{- $_ := set $fleetKibanaHost "name" "KIBANA_HOST" -}}
-{{- $_ := set $fleetKibanaHost "value" $.Values.agent.fleet.kibanaHost -}}
-{{- $fleetEnvVars = append $fleetEnvVars $fleetKibanaHost  -}}
+{{- $extraEnvs = append $extraEnvs (dict "name" "KIBANA_FLEET_HOST" "value" $.Values.agent.fleet.kibanaHost) -}}
 {{- end -}}
 {{- if $.Values.agent.fleet.kibanaUser -}}
-{{- $fleetKibanaUser := dict }}
-{{- $_ := set $fleetKibanaUser "name" "KIBANA_FLEET_USERNAME" -}}
-{{- $_ := set $fleetKibanaUser "value" $.Values.agent.fleet.kibanaUser -}}
-{{- $fleetEnvVars = append $fleetEnvVars $fleetKibanaUser  -}}
+{{- $extraEnvs = append $extraEnvs (dict "name" "KIBANA_FLEET_USERNAME" "value" $.Values.agent.fleet.kibanaUser) -}}
 {{- end -}}
 {{- if $.Values.agent.fleet.kibanaPassword -}}
-{{- $fleetKibanaPassword := dict }}
-{{- $_ := set $fleetKibanaPassword "name" "KIBANA_FLEET_PASSWORD" -}}
-{{- $_ := set $fleetKibanaPassword "value" $.Values.agent.fleet.kibanaPassword -}}
-{{- $fleetEnvVars = append $fleetEnvVars $fleetKibanaPassword  -}}
+{{- $extraEnvs = append $extraEnvs (dict "name" "KIBANA_FLEET_PASSWORD" "value" $.Values.agent.fleet.kibanaPassword) -}}
 {{- end -}}
-{{- if not (empty $fleetEnvVars) -}}
-{{- $fleetEnroll := dict -}}
-{{- $_ := set $fleetEnroll "name" "FLEET_ENROLL" -}}
-{{- $_ := set $fleetEnroll "value" "1" -}}
-{{- $fleetEnvVars = append $fleetEnvVars $fleetEnroll -}}
-{{- if not (hasKey $preset "extraEnvs") -}}
-{{- $_ := set $preset "extraEnvs" list -}}
+{{- if $.Values.agent.fleet.kibanaServiceToken -}}
+{{- $extraEnvs = append $extraEnvs (dict "name" "KIBANA_FLEET_SERVICE_TOKEN" "value" $.Values.agent.fleet.kibanaServiceToken) -}}
 {{- end -}}
-{{- $presetEnvVars := get $preset "extraEnvs" -}}
-{{- $presetEnvVars = uniq (concat $presetEnvVars $fleetEnvVars) -}}
-{{- $_ := set $preset "extraEnvs" $presetEnvVars -}}
+{{- if $.Values.agent.fleet.enabled -}}
+{{- $extraEnvs = append $extraEnvs (dict "name" "FLEET_ENROLL" "value" "true") -}}
 {{- end -}}
+{{- with uniq $extraVolumes -}}
+{{- include "elasticagent.preset.mutate.volumes" (list $preset (dict "extraVolumes" .)) -}}
+{{- end -}}
+{{- with uniq $extraVolumeMounts -}}
+{{- include "elasticagent.preset.mutate.volumemounts" (list $preset (dict "extraVolumeMounts" .)) -}}
+{{- end -}}
+{{- with uniq $extraEnvs -}}
+{{- include "elasticagent.preset.mutate.envs" (list $preset (dict "extraEnvs" .)) -}}
 {{- end -}}
 {{- end -}}
 
@@ -236,6 +273,31 @@ app.kubernetes.io/name: {{ include "elasticagent.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Values.agent.version}}
 {{- end }}
+
+{{- define "elasticagent.init.valueFrom" -}}
+{{- $ := index . 0 -}}
+{{- $valueFrom := index . 1 -}}
+{{- $id := index . 2 -}}
+{{- if ($valueFrom).value -}}
+{{- $secretKey := $id -}}
+{{- $mountPath := (printf "/mnt/secrets/elastic-agent/%s" $secretKey) -}}
+{{- $_ := set $valueFrom "_mountPath" $mountPath -}}
+{{- $_ := set $valueFrom "_key" $secretKey -}}
+{{/* we don't need to define volume, this will be part of the already existing volumemount with name config */}}
+{{- $_ := set $valueFrom "_volumeMount" (dict "name" "config" "mountPath" $mountPath "readOnly" true "subPath" $secretKey) -}}
+{{- else if (($valueFrom).valueFromSecret).name -}}
+{{/* we don't have to check valueFrom.valueFromSecret.key as values.schema.json enforces it */}}
+{{- $secretName := (($valueFrom).valueFromSecret).name -}}
+{{- $secretKey := (($valueFrom).valueFromSecret).key -}}
+{{- $mountPath := (printf "/mnt/secrets/elastic-agent/%s.%s" $secretName $secretKey) -}}
+{{- $volumeName := $secretName -}}
+{{- $_ := set $valueFrom "_mountPath" $mountPath -}}
+{{- $_ := set $valueFrom "_key" $secretKey -}}
+{{- $_ := set $valueFrom "_volume" (dict "name" $volumeName "secret" (dict "secretName" $secretName "defaultMode" 0444)) -}}
+{{- $_ := set $valueFrom "_volumeMount" (dict "name" $volumeName "mountPath" $mountPath "readOnly" true "subPath" $secretKey) -}}
+{{- end -}}
+{{- end -}}
+
 
 {{- define "elasticagent.preset.mutate.inputs" -}}
 {{- $ := index . 0 -}}
@@ -320,6 +382,15 @@ app.kubernetes.io/version: {{ .Values.agent.version}}
 {{- $volumeMountsToAdd := dig "extraVolumeMounts" (list) $volumeMounts}}
 {{- $presetVolumeMounts = uniq (concat $presetVolumeMounts $volumeMountsToAdd) -}}
 {{- $_ := set $preset "extraVolumeMounts" $presetVolumeMounts -}}
+{{- end -}}
+
+{{- define "elasticagent.preset.mutate.envs" -}}
+{{- $preset := index . 0 -}}
+{{- $envVars := index . 1 -}}
+{{- $presetEnvVars := dig "extraEnvs" (list) $preset -}}
+{{- $envVarsToAdd := dig "extraEnvs" (list) $envVars}}
+{{- $presetEnvVars = uniq (concat $presetEnvVars $envVarsToAdd) -}}
+{{- $_ := set $preset "extraEnvs" $presetEnvVars -}}
 {{- end -}}
 
 {{- define "elasticagent.preset.mutate.outputs.byname" -}}

--- a/deploy/helm/elastic-agent/templates/agent/k8s/_secret.tpl
+++ b/deploy/helm/elastic-agent/templates/agent/k8s/_secret.tpl
@@ -28,4 +28,22 @@
     providers:
       {{- . | toYaml | nindent 6 }}
     {{- end }}
+  {{- if eq $.Values.agent.fleet.enabled true }}
+  {{- if $.Values.agent.fleet.ca.value }}
+  {{ ($.Values.agent.fleet.ca)._key }} : |-
+    {{- ($.Values.agent.fleet.ca).value | nindent 4 }}
+  {{- end }}
+  {{- if $.Values.agent.fleet.agentCert.value }}
+  {{ ($.Values.agent.fleet.agentCert)._key }} : |-
+    {{- ($.Values.agent.fleet.agentCert).value | nindent 4 }}
+  {{- end }}
+  {{- if $.Values.agent.fleet.agentCertKey.value }}
+  {{ ($.Values.agent.fleet.agentCertKey)._key }} : |-
+    {{- ($.Values.agent.fleet.agentCertKey).value | nindent 4 }}
+  {{- end }}
+  {{- if $.Values.agent.fleet.kibanaCA.value }}
+  {{ ($.Values.agent.fleet.kibanaCA)._key }} : |-
+    {{- ($.Values.agent.fleet.kibanaCA).value | nindent 4 }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/deploy/helm/elastic-agent/values.schema.json
+++ b/deploy/helm/elastic-agent/values.schema.json
@@ -341,6 +341,38 @@
                             "description": "Enable Elastic-Agent managed mode.",
                             "default": false
                         },
+                        "ca": {
+                            "$ref": "#/definitions/ValueFrom",
+                            "description": "CA certificate to use when connecting to Fleet."
+                        },
+                        "force": {
+                            "type": "boolean",
+                            "description": "Elastic Agent client certificate to use with Fleet Server during mTLS authentication."
+                        },
+                        "agentCert": {
+                            "$ref": "#/definitions/ValueFrom",
+                            "description": "Elastic Agent client private key to use with Fleet Server during mTLS authentication."
+                        },
+                        "agentCertKey": {
+                            "$ref": "#/definitions/ValueFrom",
+                            "description": "Elastic Agent client private key to use with Fleet Server during mTLS authentication."
+                        },
+                        "kibanaCA" : {
+                            "$ref": "#/definitions/ValueFrom",
+                            "description": "CA certificate to use when connecting to Kibana if the enrollment token is not supplied."
+                        },
+                        "kibanaServiceToken" : {
+                            "type": "string",
+                            "description": "Service token to use when connecting to Kibana if the enrollment token is not supplied."
+                        },
+                        "tokenName": {
+                            "type": "string",
+                            "description": "Token name to use for fetching token from Kibana if the enrollment token is not supplied."
+                        },
+                        "policyName": {
+                            "type": "string",
+                            "description": "Token policy name to use for fetching token from Kibana if the enrollment token is not supplied."
+                        },
                         "url": {
                             "type": "string",
                             "description": "Fleet server URL."
@@ -351,7 +383,7 @@
                         },
                         "insecure": {
                             "type": "boolean",
-                            "description": "Fleet insecure URL."
+                            "description": "Communicate with Fleet with either insecure HTTP or unverified HTTPS."
                         },
                         "kibanaHost": {
                             "type": "string",
@@ -406,6 +438,8 @@
                                 "required": [
                                     "preset",
                                     "url",
+                                    "tokenName",
+                                    "policyName",
                                     "kibanaHost",
                                     "kibanaUser",
                                     "kibanaPassword"
@@ -417,6 +451,14 @@
                                     "url": {
                                         "type": "string",
                                         "format": "uri"
+                                    },
+                                    "tokenName":  {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "policyName":  {
+                                        "type": "string",
+                                        "minLength": 1
                                     },
                                     "kibanaHost": {
                                         "type": "string",
@@ -967,6 +1009,118 @@
                     }
                 ]
             }
+        },
+        "ValueFrom": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": "string"
+                },
+                "valueFromSecret": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "key": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "value": {
+                                "type": "string",
+                                "minLength": 1
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "valueFromSecret": {
+                                "type": "object",
+                                "properties": {
+                                    "key": {
+                                        "type": "string",
+                                        "maxLength": 0
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "maxLength": 0
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "valueFromSecret": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "valueFromSecret": {
+                                "type": "object",
+                                "properties": {
+                                    "key": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    }
+                                }
+                            },
+                            "value": {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "valueFromSecret": {
+                                "type": "object",
+                                "properties": {
+                                    "key": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "valueFromSecret": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    }
+                                }
+                            },
+                            "value": {
+                                "type": "string",
+                                "maxLength": 0
+                            }
+                        }
+                    }
+                }
+            ]
         },
         "AgentPreset": {
             "type": "object",

--- a/deploy/helm/elastic-agent/values.yaml
+++ b/deploy/helm/elastic-agent/values.yaml
@@ -358,9 +358,51 @@ agent:
     # -- Fleet enrollment token
     # @section -- 6.1 - Elastic-Agent Managed Configuration
     token: ""
-    # -- Fleet insecure url
+    # -- Communicate with Fleet with either insecure HTTP or unverified HTTPS
     # @section -- 6.1 - Elastic-Agent Managed Configuration
     insecure: false
+    # -- Enforce enrollment even if agent is already enrolled
+    # @section -- 6.1 - Elastic-Agent Managed Configuration
+    force: false
+    ca:
+      # -- Value of the CA certificate for connecting to Fleet
+      # @section -- 6.1 - Elastic-Agent Managed Configuration
+      value: ""
+      valueFromSecret:
+        # -- Secret name for the CA certificate
+        # @section -- 6.1 - Elastic-Agent Managed Configuration
+        name: ""
+        # -- Secret key for the CA certificate
+        # @section -- 6.1 - Elastic-Agent Managed Configuration
+        key: ""
+    agentCert:
+      # -- Value of Elastic Agent client certificate for Fleet Server mTLS
+      # @section -- 6.1 - Elastic-Agent Managed Configuration
+      value: ""
+      valueFromSecret:
+        # -- Secret name for the Elastic Agent client certificate
+        # @section -- 6.1 - Elastic-Agent Managed Configuration
+        name: ""
+        # -- Key in the secret for the Elastic Agent client certificate
+        # @section -- 6.1 - Elastic-Agent Managed Configuration
+        key: ""
+    agentCertKey:
+      # -- Value of Elastic Agent client private key for Fleet Server mTLS
+      # @section -- 6.1 - Elastic-Agent Managed Configuration
+      value: ""
+      valueFromSecret:
+        # -- Secret name for the Elastic Agent client private key
+        # @section -- 6.1 - Elastic-Agent Managed Configuration
+        name: ""
+        # -- Key in the secret for the Elastic Agent client private key
+        # @section -- 6.1 - Elastic-Agent Managed Configuration
+        key: ""
+    # -- Token name to use for fetching token from Kibana if the enrollment token is not supplied
+    # @section -- 6.1 - Elastic-Agent Managed Configuration
+    tokenName: ""
+    # -- Token policy name to use for fetching token from Kibana if the enrollment token is not supplied
+    # @section -- 6.1 - Elastic-Agent Managed Configuration
+    policyName: ""
     # -- Kibana host to fallback if enrollment token is not supplied
     # @section -- 6.1 - Elastic-Agent Managed Configuration
     kibanaHost: ""
@@ -370,6 +412,20 @@ agent:
     # -- Kibana password to fallback if enrollment token is not supplied
     # @section -- 6.1 - Elastic-Agent Managed Configuration
     kibanaPassword: ""
+    kibanaCA:
+      # -- Value of the CA certificate for Kibana if the enrollment token is not supplied
+      # @section -- 6.1 - Elastic-Agent Managed Configuration
+      value: ""
+      valueFromSecret:
+        # -- Secret name for the Kibana CA certificate
+        # @section -- 6.1 - Elastic-Agent Managed Configuration
+        name: ""
+        # -- Key in the secret for the Kibana CA certificate
+        # @section -- 6.1 - Elastic-Agent Managed Configuration
+        key: ""
+    # -- Service token to use when connecting to Kibana if the enrollment token is not supplied
+    # @section -- 6.1 - Elastic-Agent Managed Configuration
+    kibanaServiceToken: ""
     # -- Agent preset to deploy
     # @section -- 6.1 - Elastic-Agent Managed Configuration
     preset: perNode


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR introduces support for configuring Fleet-related certificates (CA certificates and client certificates for mutual TLS authentication) in the Elastic Agent Helm chart. It allows users to specify these certificates directly via Helm CLI arguments (using `--set-file`), define them in `values.yaml`, or reference Kubernetes secrets. The necessary certificates can be provided through chart values such as:

- `agent.fleet.ca`
- `agent.fleet.agentCert`
- `agent.fleet.agentCertKey`
- `agent.fleet.kibanaCA`

Additionally, it exposes more options of the fleet config that a user may want to tune accordingly, such as:

- `agent.fleet.force`
- `agent.fleet.kibanaServiceToken`
- `agent.fleet.tokenName`
- `agent.fleet.policyName`

As usual with this Helm chart related PRs I introduce multiple commits:
https://github.com/elastic/elastic-agent/commit/349a1459cd884ad2e25aef8e3252e78f4f0a6903 (main code changes +392 -67 lines changed)
https://github.com/elastic/elastic-agent/commit/d77906626fe989cf7b89fc2e2844f09d26888778 (example +700 -14 lines changed)

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Currently, when deploying Elastic Agents managed by Fleet, if the Fleet Server uses a certificate signed by a corporate, custom, or intermediate CA, the Elastic Agent must trust this CA at enrollment time. Without specifying the CA certificate, users have to rely on insecure communication (`agent.fleet.insecure=true`) as a workaround.

This PR resolves that limitation by allowing secure deployments, making it possible for Elastic Agent to securely communicate with Fleet servers using custom or intermediate CA certificates.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

This change is non-disruptive and backward-compatible. Users who previously used the insecure mode (`agent.fleet.insecure=true`) due to custom or intermediate CAs can now transition to a secure deployment by specifying their CA certificates.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Follow the newly introduced example

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/6285
