### PR TITLE
Fix flaky diagnostics redaction integration test

### DIFF
--- a/testing/integration/diagnostics_test.go
+++ b/testing/integration/diagnostics_test.go
@@ -258,6 +258,11 @@ func TestRedactFleetSecretPathsDiagnostics(t *testing.T) {
 	require.NoErrorf(t, err, "Error when installing agent, output: %s", out)
 	check.ConnectedToFleet(ctx, t, fixture, 5*time.Minute)
 
+	// wait until the agent acknowledges the policy change
+	require.Eventually(t, func() bool {
+		return checkinWithAcker.Acked(policyChangeAction.ActionID)
+	}, time.Minute, time.Second)
+
 	t.Log("Gather diagnostics.")
 	diagZip, err := fixture.ExecDiagnostics(ctx)
 	require.NoError(t, err, "error when gathering diagnostics")


### PR DESCRIPTION
## What does this PR do?

Fixes a flaky diagnostics redaction test. The test expects to see a particular input from a fleet policy in diagnostic output, but doesn't wait until the policy is actually applied.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/7405


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
