### PR TITLE
Fix issue with ToMapStr not expanding path separator when reading configuration

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -44,13 +44,20 @@ func VarSkipKeys(keys ...string) Option {
 	}
 }
 
+// noResolveOptions don't do any resolve of variables.
+var noResolveOptions = []ucfg.Option{
+	ucfg.PathSep("."),
+	ucfg.IgnoreCommas,
+	ucfg.ResolveNOOP,
+}
+
 // DefaultOptions defaults options used to read the configuration
 var DefaultOptions = []interface{}{
 	ucfg.PathSep("."),
+	ucfg.IgnoreCommas,
 	ucfg.ResolveEnv,
 	ucfg.VarExp,
 	VarSkipKeys("inputs", "outputs"),
-	ucfg.IgnoreCommas,
 	OTelKeys("connectors", "receivers", "processors", "exporters", "extensions", "service"),
 }
 
@@ -130,7 +137,7 @@ func NewConfigFrom(from interface{}, opts ...interface{}) (*Config, error) {
 		return nil, err
 	}
 	if len(skippedKeys) > 0 {
-		err = cfg.Merge(skippedKeys, ucfg.ResolveNOOP)
+		err = cfg.Merge(skippedKeys, noResolveOptions...)
 		if err != nil {
 			return nil, err
 		}
@@ -231,14 +238,14 @@ func (c *Config) ToMapStr(opts ...interface{}) (map[string]interface{}, error) {
 			var subUnpacked interface{}
 			if subCfg.IsDict() {
 				var subDict map[string]interface{}
-				err = subCfg.Unpack(&subDict, ucfg.ResolveNOOP)
+				err = subCfg.Unpack(&subDict, noResolveOptions...)
 				if err != nil {
 					return nil, fmt.Errorf("error unpacking subdict object in config for skip key %s: %w", skip, err)
 				}
 				subUnpacked = subDict
 			} else if subCfg.IsArray() {
 				var subArr []interface{}
-				err = subCfg.Unpack(&subArr, ucfg.ResolveNOOP)
+				err = subCfg.Unpack(&subArr, noResolveOptions...)
 				if err != nil {
 					return nil, fmt.Errorf("error unpacking subarray in config for skip key %s: %w ", skip, err)
 				}
@@ -266,7 +273,7 @@ func (c *Config) ToMapStr(opts ...interface{}) (map[string]interface{}, error) {
 		m[k] = v
 	}
 	if len(skippedKeysOrig) > 0 {
-		err := c.access().Merge(skippedKeysOrig, ucfg.ResolveNOOP)
+		err := c.access().Merge(skippedKeysOrig, noResolveOptions...)
 		if err != nil {
 			return nil, fmt.Errorf("error merging config with skipped key config: %w", err)
 		}

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -9,12 +9,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/elastic/go-ucfg"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
 	"gopkg.in/yaml.v2"
+
+	"github.com/elastic/go-ucfg"
 )
 
 func TestInputsResolveNOOP(t *testing.T) {

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -5,9 +5,9 @@
 package config
 
 import (
+	"github.com/google/go-cmp/cmp"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,11 +17,6 @@ import (
 
 	"github.com/elastic/go-ucfg"
 )
-
-func TestConfig(t *testing.T) {
-	testToMapStr(t)
-	testLoadFiles(t)
-}
 
 func TestInputsResolveNOOP(t *testing.T) {
 	contents := map[string]interface{}{
@@ -65,18 +60,56 @@ func TestInputsResolveNOOP(t *testing.T) {
 	assert.Equal(t, contents, cfgData)
 }
 
-func testToMapStr(t *testing.T) {
-	m := map[string]interface{}{
-		"hello": map[string]interface{}{
-			"what": "who",
+func TestToMapStr(t *testing.T) {
+	input := map[string]interface{}{
+		"outputs": map[string]interface{}{
+			"default": map[string]interface{}{
+				"type":                        "elasticsearch",
+				"hosts":                       []interface{}{"127.0.0.1:9200"},
+				"ssl.certificate_authorities": "ca.crt",
+				"ssl.ca_trusted_fingerprint":  "fingerprint",
+			},
+		},
+		"inputs": []interface{}{
+			map[string]interface{}{
+				"id":                          "endpoint-0",
+				"type":                        "endpoint",
+				"ssl.certificate_authorities": "ca.crt",
+				"ssl.ca_trusted_fingerprint":  "fingerprint",
+			},
+		},
+	}
+	expected := map[string]interface{}{
+		"outputs": map[string]interface{}{
+			"default": map[string]interface{}{
+				"type":  "elasticsearch",
+				"hosts": []interface{}{"127.0.0.1:9200"},
+				"ssl": map[string]interface{}{
+					"certificate_authorities": "ca.crt",
+					"ca_trusted_fingerprint":  "fingerprint",
+				},
+			},
+		},
+		"inputs": []interface{}{
+			map[string]interface{}{
+				"id":   "endpoint-0",
+				"type": "endpoint",
+				"ssl": map[string]interface{}{
+					"certificate_authorities": "ca.crt",
+					"ca_trusted_fingerprint":  "fingerprint",
+				},
+			},
 		},
 	}
 
-	c := MustNewConfigFrom(m)
-	nm, err := c.ToMapStr()
+	c := MustNewConfigFrom(input)
+	observed, err := c.ToMapStr()
 	require.NoError(t, err)
 
-	assert.True(t, reflect.DeepEqual(m, nm))
+	diff := cmp.Diff(expected, observed)
+	if diff != "" {
+		t.Error(diff)
+	}
 }
 
 func TestCommaParsing(t *testing.T) {
@@ -95,7 +128,7 @@ func TestCommaParsing(t *testing.T) {
 	require.Equal(t, outMap, parsedMap)
 }
 
-func testLoadFiles(t *testing.T) {
+func TestLoadFiles(t *testing.T) {
 	tmp := t.TempDir()
 
 	f1 := filepath.Join(tmp, "1.yml")

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -5,17 +5,16 @@
 package config
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/elastic/go-ucfg"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
 	"gopkg.in/yaml.v2"
-
-	"github.com/elastic/go-ucfg"
 )
 
 func TestInputsResolveNOOP(t *testing.T) {

--- a/internal/pkg/config/loader_test.go
+++ b/internal/pkg/config/loader_test.go
@@ -130,13 +130,17 @@ func TestExternalConfigLoading(t *testing.T) {
 				},
 				"inputs": []interface{}{
 					map[string]interface{}{
-						"type":                  "system/metrics",
-						"data_stream.namespace": "default",
-						"use_output":            "default",
+						"type": "system/metrics",
+						"data_stream": map[string]interface{}{
+							"namespace": "default",
+						},
+						"use_output": "default",
 						"streams": []interface{}{
 							map[string]interface{}{
-								"metricset":           "cpu",
-								"data_stream.dataset": "system.cpu",
+								"metricset": "cpu",
+								"data_stream": map[string]interface{}{
+									"dataset": "system.cpu",
+								},
 							},
 						},
 					},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes an issue where the `ucfg.PathSeperator(".")` was not being applied to `VarSkipKeys` option in the configuration loading code. `outputs` where added to the configuration loader in https://github.com/elastic/elastic-agent/pull/6602 which caused the issue to appear. Before when `outputs` was present in `VarSkipKeys` the paths where expanded when `ToMapStr` was called causing entries like `ssl.certificate_authorities` to be expanded correctly.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without this change components can get invalid YAML as they do not all understand dot notation inside of YAML configuration.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~ (no changelog issue never released)
- ~~[ ] I have added an integration test or an E2E test~~ (covered by unit test)

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #7226 
