### PR TITLE
internal/pkg/agent/cmd: remove redundant addCommandIfNotNil func

### DIFF
--- a/internal/pkg/agent/cmd/cmd_test.go
+++ b/internal/pkg/agent/cmd/cmd_test.go
@@ -6,9 +6,6 @@ package cmd
 
 import (
 	"testing"
-
-	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAgent(t *testing.T) {
@@ -32,19 +29,4 @@ func TestAgent(t *testing.T) {
 	// 	}
 	// 	assert.True(t, strings.Contains(string(contents), "Hello I am running"))
 	// })
-}
-
-func TestAddCommandIfNotNil(t *testing.T) {
-	cmd := &cobra.Command{}
-
-	parent := &cobra.Command{}
-	addCommandIfNotNil(parent, cmd)
-	require.Equal(t, 1, len(parent.Commands()))
-
-	parent = &cobra.Command{}
-	addCommandIfNotNil(parent, nil)
-	require.Equal(t, 0, len(parent.Commands()))
-
-	// this should not panic
-	addCommandIfNotNil(nil, cmd)
 }

--- a/internal/pkg/agent/cmd/common.go
+++ b/internal/pkg/agent/cmd/common.go
@@ -80,21 +80,21 @@ func NewCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Command {
 	cmd.AddCommand(basecmd.NewDefaultCommandsWithArgs(args, streams)...)
 	cmd.AddCommand(run)
 
-	addCommandIfNotNil(cmd, newInstallCommandWithArgs(args, streams))
-	addCommandIfNotNil(cmd, newUninstallCommandWithArgs(args, streams))
-	addCommandIfNotNil(cmd, newUpgradeCommandWithArgs(args, streams))
-	addCommandIfNotNil(cmd, newEnrollCommandWithArgs(args, streams))
-	addCommandIfNotNil(cmd, newInspectCommandWithArgs(args, streams))
-	addCommandIfNotNil(cmd, newPrivilegedCommandWithArgs(args, streams))
-	addCommandIfNotNil(cmd, newUnprivilegedCommandWithArgs(args, streams))
-	addCommandIfNotNil(cmd, newWatchCommandWithArgs(args, streams))
-	addCommandIfNotNil(cmd, newContainerCommand(args, streams))
-	addCommandIfNotNil(cmd, newStatusCommand(args, streams))
-	addCommandIfNotNil(cmd, newDiagnosticsCommand(args, streams))
-	addCommandIfNotNil(cmd, newComponentCommandWithArgs(args, streams))
-	addCommandIfNotNil(cmd, newLogsCommandWithArgs(args, streams))
-	addCommandIfNotNil(cmd, newOtelCommandWithArgs(args, streams))
-	addCommandIfNotNil(cmd, newApplyFlavorCommandWithArgs(args, streams))
+	cmd.AddCommand(newInstallCommandWithArgs(args, streams))
+	cmd.AddCommand(newUninstallCommandWithArgs(args, streams))
+	cmd.AddCommand(newUpgradeCommandWithArgs(args, streams))
+	cmd.AddCommand(newEnrollCommandWithArgs(args, streams))
+	cmd.AddCommand(newInspectCommandWithArgs(args, streams))
+	cmd.AddCommand(newPrivilegedCommandWithArgs(args, streams))
+	cmd.AddCommand(newUnprivilegedCommandWithArgs(args, streams))
+	cmd.AddCommand(newWatchCommandWithArgs(args, streams))
+	cmd.AddCommand(newContainerCommand(args, streams))
+	cmd.AddCommand(newStatusCommand(args, streams))
+	cmd.AddCommand(newDiagnosticsCommand(args, streams))
+	cmd.AddCommand(newComponentCommandWithArgs(args, streams))
+	cmd.AddCommand(newLogsCommandWithArgs(args, streams))
+	cmd.AddCommand(newOtelCommandWithArgs(args, streams))
+	cmd.AddCommand(newApplyFlavorCommandWithArgs(args, streams))
 
 	// windows special hidden sub-command (only added on Windows)
 	reexec := newReExecWindowsCommand(args, streams)
@@ -105,12 +105,4 @@ func NewCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Command {
 	cmd.RunE = run.RunE
 
 	return cmd
-}
-
-func addCommandIfNotNil(parent, cmd *cobra.Command) {
-	if cmd == nil || parent == nil {
-		return
-	}
-
-	parent.AddCommand(cmd)
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

None of the subcommand construction functions return a nil *cobra.Command, althought this was apparently the case in the past. So remove the wrapper func and its tests.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Reduce complexity and bugspace.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
