### PR TITLE
Use local HTTP server instead of downloading file on test

### DIFF
--- a/dev-tools/mage/downloads/testdata/some-file.txt
+++ b/dev-tools/mage/downloads/testdata/some-file.txt
@@ -1,0 +1,20 @@
+<79>2 2025-03-25T08:17:17.736Z nationalincubate.net voluptas 134 ID302 - Indexing the card won't do anything, we need to back up the 1080p AI alarm!
+<189>2 2025-03-25T08:17:17.736Z nationalextensible.com ut 7269 ID501 - I'Ll synthesize the open-source JBOD sensor, that should circuit the HDD transmitter!
+<92>2 2025-03-25T08:17:17.736Z principalmission-critical.info fugiat 214 ID539 - The USB matrix is down, reboot the virtual sensor so we can calculate the SAS system!
+<63>3 2025-03-25T08:17:17.736Z customersyndicate.org illo 4412 ID943 - Compressing the firewall won't do anything, we need to back up the digital TCP system!
+<9>1 2025-03-25T08:17:17.736Z centralsupply-chains.info saepe 1463 ID975 - Use the mobile ADP capacitor, then you can bypass the wireless feed!
+<6>3 2025-03-25T08:17:17.736Z globalvertical.name id 5862 ID780 - If we transmit the bus, we can get to the JBOD transmitter through the auxiliary JBOD hard drive!
+<115>3 2025-03-25T08:17:17.736Z corporatemagnetic.org eos 8629 ID675 - You can't calculate the bus without hacking the neural GB interface!
+<108>3 2025-03-25T08:17:17.736Z regionalwireless.com non 2505 ID804 - Bypassing the application won't do anything, we need to connect the digital EXE interface!
+<125>3 2025-03-25T08:17:17.736Z legacyrevolutionary.io laborum 6019 ID668 - I'Ll navigate the back-end CSS card, that should sensor the SCSI sensor!
+<183>2 2025-03-25T08:17:17.736Z investorcollaborative.io corporis 8613 ID483 - If we index the matrix, we can get to the JSON feed through the digital SAS firewall!
+<29>2 2025-03-25T08:17:17.736Z customerbricks-and-clicks.net est 5235 ID312 - The FTP protocol is down, input the 1080p driver so we can parse the XSS panel!
+<106>1 2025-03-25T08:17:17.736Z senior24/365.net laboriosam 4788 ID248 - The JSON bus is down, compress the solid state monitor so we can compress the SMTP capacitor!
+<46>1 2025-03-25T08:17:17.736Z dynamicnetworks.biz atque 9002 ID681 - You can't calculate the program without quantifying the auxiliary PNG panel!
+<56>3 2025-03-25T08:17:17.736Z principalexpedite.name aut 4052 ID616 - Use the 1080p IB hard drive, then you can navigate the multi-byte pixel!
+<189>3 2025-03-25T08:17:17.736Z corporatesolutions.org consequatur 984 ID302 - You can't generate the interface without compressing the optical AI matrix!
+<93>1 2025-03-25T08:17:17.736Z directcontent.info unde 8072 ID835 - You can't parse the feed without copying the primary THX microchip!
+<142>1 2025-03-25T08:17:17.736Z corporate24/365.com et 3530 ID326 - Use the 1080p COM sensor, then you can bypass the bluetooth matrix!
+<13>3 2025-03-25T08:17:17.736Z nationale-markets.io sed 9414 ID605 - Indexing the port won't do anything, we need to override the multi-byte XML firewall!
+<183>3 2025-03-25T08:17:17.736Z humansticky.info placeat 1388 ID304 - Use the auxiliary JBOD bandwidth, then you can input the primary application!
+<99>2 2025-03-25T08:17:17.736Z corporateaction-items.org temporibus 5504 ID332 - Overriding the hard drive won't do anything, we need to index the mobile HDD driver!

--- a/dev-tools/mage/downloads/utils_test.go
+++ b/dev-tools/mage/downloads/utils_test.go
@@ -5,6 +5,9 @@
 package downloads
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,10 +16,15 @@ import (
 )
 
 func TestDownloadFile(t *testing.T) {
+	s := httptest.NewServer(http.FileServer(http.Dir("./testdata")))
+	t.Cleanup(s.Close)
+
 	var dRequest = downloadRequest{
-		URL:          "https://www.elastic.co/robots.txt",
+		URL: fmt.Sprintf("http://%s/some-file.txt",
+			s.Listener.Addr().String()),
 		DownloadPath: "",
 	}
+
 	err := downloadFile(&dRequest)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, dRequest.UnsanitizedFilePath)


### PR DESCRIPTION
## What does this PR do?
Use a local httptest.Server instead of downloading robots.txt from Elastic's website on every test run.

## Why is it important?

This makes removes the internet connection and the state of Elastic's website as source of flakiness for the test.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~

~~## Disruptive User Impact~~


## How to test this PR locally

```
cd dev-tools/mage/downloads
go test -run=TestDownloadFile
```

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
