### PR TITLE
Make components in packages configurable

### DIFF
--- a/dev-tools/mage/checksums.go
+++ b/dev-tools/mage/checksums.go
@@ -15,6 +15,7 @@ import (
 	"github.com/otiai10/copy"
 
 	"github.com/elastic/elastic-agent/dev-tools/mage/manifest"
+	"github.com/elastic/elastic-agent/dev-tools/packaging"
 )
 
 const ComponentSpecFileSuffix = ".spec.yml"
@@ -108,7 +109,7 @@ func ChecksumsWithManifest(requiredPackage string, versionedFlatPath string, ver
 			// Only care about packages that match the required package constraint (os/arch)
 			if strings.Contains(pkgName, requiredPackage) {
 				// Iterate over the external binaries that we care about for packaging agent
-				for _, spec := range manifest.ExpectedBinaries {
+				for _, spec := range packaging.ExpectedBinaries {
 					// If the individual package doesn't match the expected prefix, then continue
 					// FIXME temporarily skip fips packages until elastic-agent FIPS is in place
 					if !strings.HasPrefix(pkgName, spec.BinaryName) || strings.Contains(pkgName, "-fips-") {
@@ -199,7 +200,7 @@ func getComponentVersion(componentName string, requiredPackage string, component
 	// Iterate over all the packages in the component project
 	for pkgName := range componentProject.Packages {
 		// Only care about the external binaries that we want to package
-		for _, spec := range manifest.ExpectedBinaries {
+		for _, spec := range packaging.ExpectedBinaries {
 			// If the given component name doesn't match the external binary component, skip
 			// FIXME temporarily skip fips packages until elastic-agent FIPS is in place
 			if componentName != spec.ProjectName || strings.Contains(pkgName, "-fips-") {

--- a/dev-tools/mage/checksums.go
+++ b/dev-tools/mage/checksums.go
@@ -95,157 +95,76 @@ func ChecksumsWithoutManifest(versionedFlatPath string, versionedDropPath string
 }
 
 // This is a helper function for flattenDependencies that's used when building from a manifest
-func ChecksumsWithManifest(requiredPackage string, versionedFlatPath string, versionedDropPath string, manifestResponse *manifest.Build) map[string]string {
+func ChecksumsWithManifest(platform, dependenciesVersion string, versionedFlatPath string, versionedDropPath string, manifestResponse *manifest.Build) map[string]string {
 	checksums := make(map[string]string)
 	if manifestResponse == nil {
 		return checksums
 	}
 
-	// Iterate over the component projects in the manifest
-	projects := manifestResponse.Projects
-	for componentName := range projects {
-		// Iterate over the individual package files within each component project
-		for pkgName := range projects[componentName].Packages {
-			// Only care about packages that match the required package constraint (os/arch)
-			if strings.Contains(pkgName, requiredPackage) {
-				// Iterate over the external binaries that we care about for packaging agent
-				for _, spec := range packaging.ExpectedBinaries {
-					// If the individual package doesn't match the expected prefix, then continue
-					// FIXME temporarily skip fips packages until elastic-agent FIPS is in place
-					if !strings.HasPrefix(pkgName, spec.BinaryName) || strings.Contains(pkgName, "-fips-") {
-						if mg.Verbose() {
-							log.Printf(">>>>>>> Package [%s] skipped", pkgName)
-						}
-						continue
-					}
+	// Iterate over the external binaries that we care about for packaging agent
+	for _, spec := range packaging.ExpectedBinaries {
 
-					if mg.Verbose() {
-						log.Printf(">>>>>>> Package [%s] matches requiredPackage [%s]", pkgName, requiredPackage)
-					}
-
-					// Get the version from the component based on the version in the package name
-					// This is useful in the case where it's an Independent Agent Release, where
-					// the opted-in projects will be one patch version ahead of the rest of the
-					// opted-out/previously-released projects
-					componentVersion := getComponentVersion(componentName, requiredPackage, projects[componentName])
-					if mg.Verbose() {
-						log.Printf(">>>>>>> Component [%s]/[%s] version is [%s]", componentName, requiredPackage, componentVersion)
-					}
-
-					// Combine the package name w/ the versioned flat path
-					fullPath := filepath.Join(versionedFlatPath, pkgName)
-
-					// Eliminate the file extensions to get the proper directory
-					// name that we need to copy
-					var dirToCopy string
-					if strings.HasSuffix(fullPath, ".tar.gz") {
-						dirToCopy = fullPath[:strings.LastIndex(fullPath, ".tar.gz")]
-					} else if strings.HasSuffix(fullPath, ".zip") {
-						dirToCopy = fullPath[:strings.LastIndex(fullPath, ".zip")]
-					} else {
-						dirToCopy = fullPath
-					}
-					if mg.Verbose() {
-						log.Printf(">>>>>>> Calculated directory to copy: [%s]", dirToCopy)
-					}
-
-					// Set copy options
-					options := copy.Options{
-						OnSymlink: func(_ string) copy.SymlinkAction {
-							return copy.Shallow
-						},
-						Sync: true,
-					}
-					if mg.Verbose() {
-						log.Printf("> prepare to copy %s into %s ", dirToCopy, versionedDropPath)
-					}
-
-					// Do the copy
-					err := copy.Copy(dirToCopy, versionedDropPath, options)
-					if err != nil {
-						panic(err)
-					}
-
-					// copy spec file for match
-					specName := filepath.Base(dirToCopy)
-					idx := strings.Index(specName, "-"+componentVersion)
-					if idx != -1 {
-						specName = specName[:idx]
-					}
-					if mg.Verbose() {
-						log.Printf(">>>> Looking to copy spec file: [%s]", specName)
-					}
-
-					checksum, err := CopyComponentSpecs(specName, versionedDropPath)
-					if err != nil {
-						panic(err)
-					}
-
-					checksums[specName+ComponentSpecFileSuffix] = checksum
-				}
+		if spec.PythonWheel {
+			if mg.Verbose() {
+				log.Printf(">>>>>>> Component %s/%s is a Python wheel, skipping", spec.ProjectName, spec.BinaryName)
 			}
+			continue
 		}
+
+		if !spec.SupportsPlatform(platform) {
+			log.Printf(">>>>>>> Component %s/%s does not support platform %s, skipping", spec.ProjectName, spec.BinaryName, platform)
+			continue
+		}
+
+		manifestPackage, err := manifest.ResolveManifestPackage(manifestResponse.Projects[spec.ProjectName], spec, dependenciesVersion, platform)
+		if err != nil {
+			if mg.Verbose() {
+				log.Printf(">>>>>>> Error resolving package for [%s/%s]", spec.BinaryName, platform)
+			}
+			continue
+		}
+
+		// Combine the package name w/ the versioned flat path
+		fullPath := filepath.Join(versionedFlatPath, manifestPackage.Name)
+
+		// Eliminate the file extensions to get the proper directory
+		// name that we need to copy
+		var dirToCopy string
+		if strings.HasSuffix(fullPath, ".tar.gz") {
+			dirToCopy = fullPath[:strings.LastIndex(fullPath, ".tar.gz")]
+		} else if strings.HasSuffix(fullPath, ".zip") {
+			dirToCopy = fullPath[:strings.LastIndex(fullPath, ".zip")]
+		} else {
+			dirToCopy = fullPath
+		}
+		if mg.Verbose() {
+			log.Printf(">>>>>>> Calculated directory to copy: [%s]", dirToCopy)
+		}
+
+		// Set copy options
+		options := copy.Options{
+			OnSymlink: func(_ string) copy.SymlinkAction {
+				return copy.Shallow
+			},
+			Sync: true,
+		}
+		if mg.Verbose() {
+			log.Printf("> prepare to copy %s into %s ", dirToCopy, versionedDropPath)
+		}
+
+		// Do the copy
+		err = copy.Copy(dirToCopy, versionedDropPath, options)
+		if err != nil {
+			panic(err)
+		}
+
+		checksum, err := CopyComponentSpecs(spec.BinaryName, versionedDropPath)
+		if err != nil {
+			panic(err)
+		}
+
+		checksums[spec.BinaryName+ComponentSpecFileSuffix] = checksum
 	}
 
 	return checksums
-}
-
-// This function is used when building with a Manifest.  In that manifest, it's possible
-// for projects in an Independent Agent Release to have different versions since the opted-in
-// ones will be one patch version higher than the opted-out/previously released projects.
-// This function tries to find the versions from the package name
-func getComponentVersion(componentName string, requiredPackage string, componentProject manifest.Project) string {
-	var componentVersion string
-	var foundIt bool
-	// Iterate over all the packages in the component project
-	for pkgName := range componentProject.Packages {
-		// Only care about the external binaries that we want to package
-		for _, spec := range packaging.ExpectedBinaries {
-			// If the given component name doesn't match the external binary component, skip
-			// FIXME temporarily skip fips packages until elastic-agent FIPS is in place
-			if componentName != spec.ProjectName || strings.Contains(pkgName, "-fips-") {
-				continue
-			}
-
-			// Split the package name on the binary name prefix plus a dash
-			firstSplit := strings.Split(pkgName, spec.BinaryName+"-")
-			if len(firstSplit) < 2 {
-				continue
-			}
-
-			// Get the second part of the first split
-			secondHalf := firstSplit[1]
-			if len(secondHalf) < 2 {
-				continue
-			}
-
-			// Make sure the second half matches the required package
-			if strings.Contains(secondHalf, requiredPackage) {
-				// ignore packages with names where this splitting doesn't results in proper version
-				if strings.Contains(secondHalf, "docker-image") {
-					continue
-				}
-				if strings.Contains(secondHalf, "oss-") {
-					continue
-				}
-
-				// The component version should be the first entry after splitting w/ the requiredPackage
-				componentVersion = strings.Split(secondHalf, "-"+requiredPackage)[0]
-				foundIt = true
-				// break out of inner loop
-				break
-			}
-		}
-		if foundIt {
-			// break out of outer loop
-			break
-		}
-	}
-
-	if componentVersion == "" {
-		errMsg := fmt.Sprintf("Unable to determine component version for [%s]", componentName)
-		panic(errMsg)
-	}
-
-	return componentVersion
 }

--- a/dev-tools/mage/manifest/manifest.go
+++ b/dev-tools/mage/manifest/manifest.go
@@ -158,7 +158,13 @@ func (p Platform) Platform() string {
 	return p.OS + "/" + p.Arch
 }
 
-var AllPlatforms = []Platform{{"linux", "x86_64"}, {"linux", "arm64"}, {"windows", "x86_64"}, {"darwin", "x86_64"}, {"darwin", "aarch64"}}
+var AllPlatforms = []Platform{
+	{"linux", "x86_64"},
+	{"linux", "arm64"},
+	{"windows", "x86_64"},
+	{"darwin", "x86_64"},
+	{"darwin", "aarch64"},
+}
 
 // DownloadManifest is going to download the given manifest file and return the ManifestResponse
 func DownloadManifest(ctx context.Context, manifest string) (Build, error) {

--- a/dev-tools/mage/manifest/manifest.go
+++ b/dev-tools/mage/manifest/manifest.go
@@ -191,13 +191,16 @@ func resolveManifestPackage(project Project, spec packaging.BinarySpec, version 
 
 	// Try the normal/easy case first
 	packageName := spec.GetPackageName(version, platform)
+	if mg.Verbose() {
+		log.Printf(">>>>>>>>>>> Got packagename [%s], looking for exact match", packageName)
+	}
 	val, ok = project.Packages[packageName]
 	if !ok {
 		// If we didn't find it, it may be an Independent Agent Release, where
 		// the opted-in projects will have a patch version one higher than
 		// the rest of the projects, so we need to seek that out
 		if mg.Verbose() {
-			log.Printf(">>>>>>>>>>> Looking for package [%s] of type [%s]", spec.BinaryName, PlatformPackages[platform])
+			log.Printf(">>>>>>>>>>> Couldn't find exact match, looking for package [%s] of type [%s]", spec.BinaryName, PlatformPackages[platform])
 		}
 
 		var foundIt bool

--- a/dev-tools/mage/manifest/manifest.go
+++ b/dev-tools/mage/manifest/manifest.go
@@ -288,8 +288,15 @@ func relaxVersion(version string) (string, error) {
 	// check if there's more characters after the patch version
 	remainderIndex := matchIndices[3]
 	if remainderIndex < len(version) {
+		// This is a stricter regexp that allows flexibility ONLY on the patch version (prerelease and build metadata must be the same)
 		// if we have a remainder from the original version, add it escaping it once more
-		relaxedVersion += regexp.QuoteMeta(version[remainderIndex:])
+		// relaxedVersion += regexp.QuoteMeta(version[remainderIndex:])
+
+		// This is a looser regexp that allows anything beyond the major version to change (while still enforcing a valid patch version though)
+		// TODO: check with @dwhyrock why we allow more than just the patch version to change
+		// see TestResolveManifestPackage/Independent_Agent_Staging_8.14_apm-server and TestResolveManifestPackage/Independent_Agent_Staging_8.14_endpoint-dev
+		// Be more relaxed and allow for any character sequence after this
+		relaxedVersion += `.*`
 	}
 	return relaxedVersion, nil
 }

--- a/dev-tools/mage/manifest/manifest.go
+++ b/dev-tools/mage/manifest/manifest.go
@@ -288,12 +288,7 @@ func relaxVersion(version string) (string, error) {
 	// check if there's more characters after the patch version
 	remainderIndex := matchIndices[3]
 	if remainderIndex < len(version) {
-		// This is a stricter regexp that allows flexibility ONLY on the patch version (prerelease and build metadata must be the same)
-		// if we have a remainder from the original version, add it escaping it once more
-		// relaxedVersion += regexp.QuoteMeta(version[remainderIndex:])
-
 		// This is a looser regexp that allows anything beyond the major version to change (while still enforcing a valid patch version though)
-		// TODO: check with @dwhyrock why we allow more than just the patch version to change
 		// see TestResolveManifestPackage/Independent_Agent_Staging_8.14_apm-server and TestResolveManifestPackage/Independent_Agent_Staging_8.14_endpoint-dev
 		// Be more relaxed and allow for any character sequence after this
 		relaxedVersion += `.*`

--- a/dev-tools/mage/manifest/manifest_test.go
+++ b/dev-tools/mage/manifest/manifest_test.go
@@ -7,12 +7,15 @@ package manifest
 import (
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"log"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/dev-tools/packaging"
 )
 
 var (
@@ -143,22 +146,61 @@ func TestResolveManifestPackage(t *testing.T) {
 				return
 			}
 
-			urlList, err := resolveManifestPackage(projects[tc.projectName], spec, manifestJson.Version, tc.platform)
+			resolvedPackage, err := ResolveManifestPackage(projects[tc.projectName], spec, manifestJson.Version, tc.platform)
 			require.NoError(t, err)
+			require.NotNil(t, resolvedPackage)
 
-			assert.Len(t, urlList, 3)
-			for _, url := range urlList {
+			assert.Len(t, resolvedPackage.URLs, 3)
+			for _, url := range resolvedPackage.URLs {
 				assert.Contains(t, tc.expectedUrlList, url)
 			}
 		})
 	}
 }
 
-func findBinarySpec(name string) (BinarySpec, bool) {
-	for _, spec := range ExpectedBinaries {
+func findBinarySpec(name string) (packaging.BinarySpec, bool) {
+	for _, spec := range packaging.ExpectedBinaries {
 		if spec.BinaryName == name {
 			return spec, true
 		}
 	}
-	return BinarySpec{}, false
+	return packaging.BinarySpec{}, false
+}
+
+func TestRelaxVersion(t *testing.T) {
+	type args struct {
+		version string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "major-minor-patch",
+			args: args{
+				version: "1.2.3",
+			},
+			want:    `1\.2\.(?:0|[1-9]\d*)`,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "major-minor-patch-snapshot",
+			args: args{
+				version: "1.2.3-SNAPSHOT",
+			},
+			want:    `1\.2\.(?:0|[1-9]\d*)-SNAPSHOT`,
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := relaxVersion(tt.args.version)
+			if !tt.wantErr(t, err, fmt.Sprintf("relaxVersion(%v)", tt.args.version)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "relaxVersion(%v)", tt.args.version)
+		})
+	}
 }

--- a/dev-tools/mage/manifest/manifest_test.go
+++ b/dev-tools/mage/manifest/manifest_test.go
@@ -190,8 +190,24 @@ func TestRelaxVersion(t *testing.T) {
 			args: args{
 				version: "1.2.3-SNAPSHOT",
 			},
-			want:    `1\.2\.(?:0|[1-9]\d*)-SNAPSHOT`,
+			want:    `1\.2\.(?:0|[1-9]\d*).*`,
 			wantErr: assert.NoError,
+		},
+		{
+			name: "major-minor-patch-snapshot-buildmeta",
+			args: args{
+				version: "1.2.3-SNAPSHOT+build20250328112233",
+			},
+			want:    `1\.2\.(?:0|[1-9]\d*).*`,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "not a semver",
+			args: args{
+				version: "foobar",
+			},
+			want:    "",
+			wantErr: assert.Error,
 		},
 	}
 	for _, tt := range tests {

--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -222,7 +222,7 @@ func TestPackages(options ...TestPackagesOption) error {
 		args = append(args, "-v")
 	}
 
-	args = append(args, MustExpand("{{ elastic_beats_dir }}/dev-tools/packaging/package_test.go"))
+	args = append(args, MustExpand("{{ elastic_beats_dir }}/dev-tools/packaging/testing/package_test.go"))
 
 	if params.HasModules {
 		args = append(args, "--modules")

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -584,6 +584,115 @@ shared:
         source: '{{ repo.RootDir }}/dev-tools/licenses/ELASTIC-LICENSE-2.0.txt'
         mode: 0644
 
+platforms: &all-platforms
+  - &linux-amd64
+    os: linux
+    arch: x86_64
+  - &linux-arm64
+    os: linux
+    arch: arm64
+  - &windows-amd64
+    os: windows
+    arch: x86_64
+  - &darwin-amd64
+    os: darwin
+    arch: x86_64
+  - &darwin-arm
+    os: darwin
+    arch: aarch64
+
+packageTypes: &all-package-types
+  - &pkg-type-rpm
+    1 # RPM
+  - &pkg-type-deb
+    2 # Deb
+  - &pkg-type-zip
+    3 # zip
+  - &pkg-type-targz
+    4 # tar.gz
+  - &pkg-type-docker
+    5 # docker
+
+components:
+  # general template for new components
+#  - &comp-<anchor name>
+#    projectName: <project name under manifest>
+#    packageName: <template representing the name of the archive to download/extract>
+#    binaryName: <binary name>
+#    platforms:
+#      - <platform, use anchors for platforms above>
+#    pythonWheel: true # true if it's a package that is not platform specific
+#    packageTypes: *all-package-types # package types it should be included in
+  - &comp-agentbeat
+    projectName: beats
+    packageName: agentbeat-{{.Version}}-{{.Platform}}.{{.Ext}}
+    binaryName: agentbeat
+    platforms: *all-platforms
+    packageTypes: *all-package-types
+  - &comp-apm_server
+    projectName: apm-server
+    packageName: apm-server-{{.Version}}-{{.Platform}}.{{.Ext}}
+    binaryName: apm-server
+    platforms:
+      - *linux-amd64
+      - *linux-arm64
+      - *windows-amd64
+      - *darwin-amd64
+    packageTypes: *all-package-types
+  - &comp-cloudbeat
+    projectName: cloudbeat
+    packageName: cloudbeat-{{.Version}}-{{.Platform}}.{{.Ext}}
+    binaryName: cloudbeat
+    platforms:
+      - *linux-amd64
+      - *linux-arm64
+    packageTypes: *all-package-types
+  - &comp-connectors
+    projectName: connectors
+    packageName: connectors-{{.Version}}.zip
+    binaryName: connectors
+    platforms:
+      - *linux-amd64
+      - *linux-arm64
+    pythonWheel: true
+    packageTypes: *all-package-types
+  - &comp-endpoint
+    projectName: endpoint-dev
+    packageName: endpoint-security-{{.Version}}-{{.Platform}}.{{.Ext}}
+    binaryName: endpoint-security
+    platforms: *all-platforms
+    packageTypes: *all-package-types
+  - &comp-fleet-server
+    projectName: fleet-server
+    packageName: fleet-server-{{.Version}}-{{.Platform}}.{{.Ext}}
+    binaryName: fleet-server
+    platforms: *all-platforms
+    packageTypes: *all-package-types
+  - &comp-pf-elastic-collector
+    projectName: prodfiler
+    packageName: pf-elastic-collector-{{.Version}}-{{.Platform}}.{{.Ext}}
+    binaryName: pf-elastic-collector
+    platforms:
+      - *linux-amd64
+      - *linux-arm64
+    packageTypes: *all-package-types
+  - &comp-pf-elastic-collector
+    projectName: prodfiler
+    packageName: pf-elastic-symbolizer-{{.Version}}-{{.Platform}}.{{.Ext}}
+    binaryName: pf-elastic-symbolizer
+    platforms:
+      - *linux-amd64
+      - *linux-arm64
+    packageTypes: *all-package-types
+  - &comp-pf-host-agent
+    projectName: prodfiler
+    packageName: pf-host-agent-{{.Version}}-{{.Platform}}.{{.Ext}}
+    binaryName: pf-host-agent
+    platforms:
+      - *linux-amd64
+      - *linux-arm64
+    packageTypes: *all-package-types
+
 # specs is a list of named packaging "flavors".
 specs:
   # Community Beats

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -597,7 +597,7 @@ platforms: &all-platforms
   - &darwin-amd64
     os: darwin
     arch: x86_64
-  - &darwin-arm
+  - &darwin-arm64
     os: darwin
     arch: aarch64
 

--- a/dev-tools/packaging/settings.go
+++ b/dev-tools/packaging/settings.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package packaging
 
 import (

--- a/dev-tools/packaging/settings.go
+++ b/dev-tools/packaging/settings.go
@@ -1,0 +1,108 @@
+package packaging
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"io"
+	"log"
+
+	"github.com/magefile/mage/mg"
+	"gopkg.in/yaml.v3"
+
+	"github.com/elastic/elastic-agent/dev-tools/mage/pkgcommon"
+)
+
+var PlatformPackages = map[string]string{
+	"darwin/amd64":  "darwin-x86_64.tar.gz",
+	"darwin/arm64":  "darwin-aarch64.tar.gz",
+	"linux/amd64":   "linux-x86_64.tar.gz",
+	"linux/arm64":   "linux-arm64.tar.gz",
+	"windows/amd64": "windows-x86_64.zip",
+}
+
+type BinarySpec struct {
+	BinaryName   string                  `yaml:"binaryName"`
+	ProjectName  string                  `yaml:"projectName"`
+	Platforms    []Platform              `yaml:"platforms"`
+	PythonWheel  bool                    `yaml:"pythonWheel"`
+	PackageTypes []pkgcommon.PackageType `yaml:"packageTypes"`
+}
+
+func (proj BinarySpec) SupportsPlatform(platform string) bool {
+	for _, p := range proj.Platforms {
+		if p.Platform() == platform {
+			return true
+		}
+	}
+	return false
+}
+
+func (proj BinarySpec) SupportsPackageType(pkgType pkgcommon.PackageType) bool {
+	for _, p := range proj.PackageTypes {
+		if p == pkgType {
+			return true
+		}
+	}
+	return false
+}
+
+func (proj BinarySpec) GetPackageName(version string, platform string) string {
+	if proj.PythonWheel {
+		return fmt.Sprintf("%s-%s.zip", proj.BinaryName, version)
+	}
+	return fmt.Sprintf("%s-%s-%s", proj.BinaryName, version, PlatformPackages[platform])
+}
+
+// ExpectedBinaries  is a map of binaries agent needs to their project in the unified-release manager.
+// The project names are those used in the "projects" list in the unified release manifest.
+// See the sample manifests in the testdata directory.
+var ExpectedBinaries []BinarySpec
+
+type Platform struct {
+	OS   string
+	Arch string
+}
+
+// Converts to the format expected on the mage command line "linux", "x86_64" = "linux/amd64"
+func (p Platform) Platform() string {
+	if p.Arch == "x86_64" {
+		p.Arch = "amd64"
+	}
+	if p.Arch == "aarch64" {
+		p.Arch = "arm64"
+	}
+	return p.OS + "/" + p.Arch
+}
+
+//go:embed packages.yml
+var packageSpecBytes []byte
+
+func init() {
+	packageSettings, err := parsePackageSettings(bytes.NewReader(packageSpecBytes))
+	if err != nil {
+		log.Printf("Error loading package settings: %v", err)
+		return
+	}
+
+	ExpectedBinaries = packageSettings.Components
+}
+
+type packagesConfig struct {
+	Platforms    []Platform              `yaml:"platforms"`
+	PackageTypes []pkgcommon.PackageType `yaml:"packageTypes"`
+	Components   []BinarySpec            `yaml:"components"`
+}
+
+func parsePackageSettings(r io.Reader) (*packagesConfig, error) {
+	packagesConf := new(packagesConfig)
+	err := yaml.NewDecoder(r).Decode(packagesConf)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshalling package spec yaml: %w", err)
+	}
+
+	if mg.Verbose() {
+		log.Printf("Read packages config: %+v", packagesConf)
+	}
+	return packagesConf, nil
+}

--- a/dev-tools/packaging/testing/package_test.go
+++ b/dev-tools/packaging/testing/package_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-package packaging
+package testing
 
 // This file contains tests that can be run on the generated packages.
 // To run these tests use `go test package_test.go`.

--- a/magefile.go
+++ b/magefile.go
@@ -43,6 +43,7 @@ import (
 	"github.com/elastic/elastic-agent/dev-tools/mage/downloads"
 	"github.com/elastic/elastic-agent/dev-tools/mage/manifest"
 	"github.com/elastic/elastic-agent/dev-tools/mage/pkgcommon"
+	"github.com/elastic/elastic-agent/dev-tools/packaging"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact/download"
 	"github.com/elastic/elastic-agent/pkg/testing/buildkite"
 	tcommon "github.com/elastic/elastic-agent/pkg/testing/common"
@@ -1071,7 +1072,7 @@ func collectPackageDependencies(platforms []string, packageVersion string, platf
 
 			errGroup, ctx := errgroup.WithContext(context.Background())
 			completedDownloads := &atomic.Int32{}
-			for _, spec := range manifest.ExpectedBinaries {
+			for _, spec := range packaging.ExpectedBinaries {
 				for _, platform := range platforms {
 					if !spec.SupportsPlatform(platform) {
 						fmt.Printf("--- Binary %s does not support %s, download skipped\n", spec.BinaryName, platform)
@@ -1169,7 +1170,7 @@ func removePythonWheels(matches []string, version string) []string {
 	}
 
 	var wheels []string
-	for _, spec := range manifest.ExpectedBinaries {
+	for _, spec := range packaging.ExpectedBinaries {
 		if spec.PythonWheel {
 			wheels = append(wheels, spec.GetPackageName(version, ""))
 		}
@@ -1703,7 +1704,7 @@ func copyFile(src, dst string) error {
 
 func isPlatformIndependentPackage(f string, packageVersion string) bool {
 	fileBaseName := filepath.Base(f)
-	for _, spec := range manifest.ExpectedBinaries {
+	for _, spec := range packaging.ExpectedBinaries {
 		packageName := spec.GetPackageName(packageVersion, "")
 		// as of now only python wheels packages are platform-independent
 		if spec.PythonWheel && (fileBaseName == packageName || fileBaseName == packageName+sha512FileExt) {

--- a/magefile.go
+++ b/magefile.go
@@ -1442,7 +1442,7 @@ func downloadDRAArtifacts(ctx context.Context, manifestUrl string, downloadDir s
 	draDownloadDir := filepath.Join(downloadDir, build.BuildID)
 	err = os.MkdirAll(draDownloadDir, 0o770)
 	if err != nil {
-		return nil, fmt.Errorf("creating %q directory: %w", err)
+		return nil, fmt.Errorf("creating %q directory: %w", draDownloadDir, err)
 	}
 
 	// sync access to the downloadedArtifacts map

--- a/pkg/version/version_parser.go
+++ b/pkg/version/version_parser.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 )
 
-// regexp taken from https://semver.org/ (see the FAQ section/Is there a suggested regular expression (RegEx) to check a SemVer string?)
+// semVerFormat is a regexp taken from https://semver.org/ (see the FAQ section/Is there a suggested regular expression (RegEx) to check a SemVer string?)
 const semVerFormat = `^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`
 const numericPrereleaseTokenFormat = `\d+`
 const preReleaseSeparator = "-"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR allows declarative definitions of elastic-agent components in `dev-tools/packaging/packages.yml`.
In the declaration of such components it's now possible to specify a `packageName` template that will be rendered using platform and version during packaging.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

This is a prerequisite for selecting different component packages for specific packaging specs.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

No disruptive user impact as neither the mage  build targets nor the final packages changed

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

### Package using a manifest
```shell
MANIFEST_URL="https://snapshots.elastic.co/9.1.0-15b6399f/agent-package/agent-artifacts-9.1.0-SNAPSHOT.json" AGENT_DROP_PATH=build/elastic-agent-drop  PLATFORMS="linux/amd64 windows/amd64 darwin/amd64" mage clean downloadManifest package
```

### Package without using a manifest
```shell
EXTERNAL=true PLATFORMS="linux/amd64" mage clean package
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #7610

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
