### PR TITLE
[mergify] Remove 8.16 as an active branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -407,7 +407,6 @@ pull_request_rules:
           - "8.x"
           - "8.18"
           - "8.17"
-          - "8.16"
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
@@ -440,7 +439,6 @@ pull_request_rules:
           - "9.0"
           - "8.18"
           - "8.17"
-          - "8.16"
           - "8.x"
           - "7.17"
         labels:


### PR DESCRIPTION
Removes `8.16` as a targeted branch for the `backport-active-all` and `backport-active-8` labels used by Mergify.