### PR TITLE
6875 do not kill process on windows

### DIFF
--- a/changelog/fragments/1743191647-gracefully-terminate-windows-process.yaml
+++ b/changelog/fragments/1743191647-gracefully-terminate-windows-process.yaml
@@ -1,0 +1,38 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: gracefully terminate windows process
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Calling proc.Kill causes the process to exit immediately, which
+  prevents Beats from executing some clean up functions.
+  
+  Now windows.GenerateConsoleCtrlEvent to send a CTRL+C signal that is
+  haled as a SIGINT, thus allowing the Beat to execute all necessary
+  clean up.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/7624
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/6875

--- a/magefile.go
+++ b/magefile.go
@@ -2269,6 +2269,11 @@ func askForStack() (tcommon.Stack, error) {
 		return tcommon.Stack{}, fmt.Errorf("could not read state file: %w", err)
 	}
 
+	if len(state.Stacks) == 0 {
+		fmt.Println("There is no stack, skipping it")
+		return tcommon.Stack{}, nil
+	}
+
 	if len(state.Stacks) == 1 {
 		fmt.Println("There is only one Stack, auto-selecting it")
 		return state.Stacks[0], nil

--- a/pkg/component/runtime/runtime.go
+++ b/pkg/component/runtime/runtime.go
@@ -7,11 +7,13 @@ package runtime
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent/internal/pkg/runner"
 	"github.com/elastic/elastic-agent/pkg/component"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
@@ -173,10 +175,14 @@ func (s *componentRuntimeState) getLatest() ComponentState {
 }
 
 func (s *componentRuntimeState) start() error {
+	fmt.Println("++++++++++++++++++++ TRACE START ", s.id)
+	logp.L().Named("trace-debug").Info("++++++++++++++++++++ TRACE START ", s.id)
 	return s.runtime.Start()
 }
 
 func (s *componentRuntimeState) stop(teardown bool, signed *component.Signed) error {
+	fmt.Println("++++++++++++++++++++ TRACE 05 ", s.id, " Teardow?", teardown)
+	logp.L().Named("trace-debug").Info("++++++++++++++++++++ TRACE 05 ", s.id, " Teardow?", teardown)
 	if !s.shuttingDown.CompareAndSwap(false, true) {
 		// already stopping
 		return nil

--- a/pkg/core/process/cmd.go
+++ b/pkg/core/process/cmd.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"golang.org/x/sys/windows"
 )
 
 func getCmd(ctx context.Context, path string, env []string, uid, gid int, arg ...string) (*exec.Cmd, error) {
@@ -27,10 +29,14 @@ func getCmd(ctx context.Context, path string, env []string, uid, gid int, arg ..
 	return cmd, nil
 }
 
+// killCmd calls Process.Kill
 func killCmd(proc *os.Process) error {
 	return proc.Kill()
 }
 
+// terminateCmd sends the CTRL+C (SIGINT) to the process
 func terminateCmd(proc *os.Process) error {
-	return proc.Kill()
+	// Send the CTRL+C signal that is tread as a SIGINT
+	// https://learn.microsoft.com/en-us/windows/console/ctrl-c-and-ctrl-break-signals
+	return windows.GenerateConsoleCtrlEvent(0, uint32(proc.Pid))
 }

--- a/pkg/core/process/cmd.go
+++ b/pkg/core/process/cmd.go
@@ -8,11 +8,13 @@ package process
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"syscall"
 
+	"github.com/elastic/elastic-agent-libs/logp"
 	"golang.org/x/sys/windows"
 )
 
@@ -38,6 +40,8 @@ func getCmd(ctx context.Context, path string, env []string, uid, gid int, arg ..
 		// https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
 		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP,
 	}
+	fmt.Println("==================== Creating command with CREATE_NEW_PROCESS_GROUP: ", path, arg[0])
+	logp.L().Named("trace-debug").Info("==================== Creating command with CREATE_NEW_PROCESS_GROUP: ", path, arg[0])
 
 	return cmd, nil
 }
@@ -53,5 +57,9 @@ func terminateCmd(proc *os.Process) error {
 	// it CTLR_C_EVENT is disabled, so the only way to gracefully terminate
 	// the child process is to send a CTRL_BREAK_EVENT.
 	// https://learn.microsoft.com/en-us/windows/console/generateconsolectrlevent
+	fmt.Println("==================== Sending CTRL_BREAK_EVENT to PID:", proc.Pid)
+	logp.L().Named("trace-debug").Info("==================== Sending CTRL_BREAK_EVENT to PID:", proc.Pid)
+	fmt.Println("++++++++++++++++++++ TRACE 00 ", proc.Pid)
+	logp.L().Named("trace-debug").Info("++++++++++++++++++++ TRACE 00 ", proc.Pid)
 	return windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(proc.Pid))
 }

--- a/pkg/core/process/cmd_darwin.go
+++ b/pkg/core/process/cmd_darwin.go
@@ -45,10 +45,12 @@ func isInt32(val int) bool {
 	return val >= 0 && val <= math.MaxInt32
 }
 
+// killCmd calls Process.Kill
 func killCmd(proc *os.Process) error {
 	return proc.Kill()
 }
 
+// terminateCmd sends SIGTERM to the process
 func terminateCmd(proc *os.Process) error {
 	return proc.Signal(syscall.SIGTERM)
 }

--- a/pkg/core/process/cmd_darwin.go
+++ b/pkg/core/process/cmd_darwin.go
@@ -14,6 +14,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"syscall"
+
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func getCmd(ctx context.Context, path string, env []string, uid, gid int, arg ...string) (*exec.Cmd, error) {
@@ -52,5 +54,9 @@ func killCmd(proc *os.Process) error {
 
 // terminateCmd sends SIGTERM to the process
 func terminateCmd(proc *os.Process) error {
+	fmt.Println("==================== Sending CTRL_BREAK_EVENT to PID:", proc.Pid)
+	logp.L().Named("trace-debug").Info("==================== Sending CTRL_BREAK_EVENT to PID:", proc.Pid)
+	fmt.Println("++++++++++++++++++++ TRACE 00 ", proc.Pid)
+	logp.L().Named("trace-debug").Info("++++++++++++++++++++ TRACE 00 ", proc.Pid)
 	return proc.Signal(syscall.SIGTERM)
 }

--- a/pkg/core/process/cmd_linux.go
+++ b/pkg/core/process/cmd_linux.go
@@ -48,10 +48,12 @@ func isInt32(val int) bool {
 	return val >= 0 && val <= math.MaxInt32
 }
 
+// killCmd calls Process.Kill
 func killCmd(proc *os.Process) error {
 	return proc.Kill()
 }
 
+// terminateCmd sends SIGTERM to the process
 func terminateCmd(proc *os.Process) error {
 	return proc.Signal(syscall.SIGTERM)
 }

--- a/pkg/core/process/cmd_linux.go
+++ b/pkg/core/process/cmd_linux.go
@@ -14,6 +14,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"syscall"
+
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func getCmd(ctx context.Context, path string, env []string, uid, gid int, arg ...string) (*exec.Cmd, error) {
@@ -55,5 +57,9 @@ func killCmd(proc *os.Process) error {
 
 // terminateCmd sends SIGTERM to the process
 func terminateCmd(proc *os.Process) error {
+	fmt.Println("==================== Sending CTRL_BREAK_EVENT to PID:", proc.Pid)
+	logp.L().Named("trace-debug").Info("==================== Sending CTRL_BREAK_EVENT to PID:", proc.Pid)
+	fmt.Println("++++++++++++++++++++ TRACE 00 ", proc.Pid)
+	logp.L().Named("trace-debug").Info("++++++++++++++++++++ TRACE 00 ", proc.Pid)
 	return proc.Signal(syscall.SIGTERM)
 }

--- a/pkg/core/process/process.go
+++ b/pkg/core/process/process.go
@@ -35,6 +35,10 @@ type StartConfig struct {
 type StartOption func(cfg *StartConfig)
 
 // Start starts a new process
+// If process.WithCmdOptions is not used to overwrite cmd.Stderr,
+// cmd.StderrPipe is called and the io.ReadCloser returned is set
+// to Info.Stderr. If this ReadCloser is not read, then calls to
+// StopWait will never return. See cmd.StderrPipe for more details.an
 func Start(path string, opts ...StartOption) (proc *Info, err error) {
 	// Apply options
 	c := StartConfig{

--- a/pkg/core/process/process.go
+++ b/pkg/core/process/process.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 // Info groups information about fresh new process
@@ -110,16 +112,22 @@ func (i *Info) Kill() error {
 
 // Stop stops the process cleanly.
 func (i *Info) Stop() error {
+	fmt.Println("++++++++++++++++++++ TRACE 01", i.PID)
+	logp.L().Named("trace-debug").Info("++++++++++++++++++++ TRACE 01", i.PID)
 	return terminateCmd(i.Process)
 }
 
 // StopWait stops the process and waits for it to exit.
 func (i *Info) StopWait() error {
 	err := i.Stop()
+	fmt.Println("++++++++++++++++++++ TRACE 01.1 - Waiting ", i.PID)
+	logp.L().Named("trace-debug").Info("++++++++++++++++++++ TRACE 01.1 - Waiting ", i.PID)
 	if err != nil {
 		return err
 	}
 	_, err = i.Process.Wait()
+	fmt.Println("++++++++++++++++++++ TRACE 01.1 - Waiting DONE", i.PID)
+	logp.L().Named("trace-debug").Info("++++++++++++++++++++ TRACE 01.1 - Waiting DONE", i.PID)
 	return err
 }
 

--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -337,7 +337,7 @@ func (f *Fixture) RunBeat(ctx context.Context) error {
 	args = append(args, f.additionalArgs...)
 
 	proc, err := process.Start(
-		f.binaryPath(),
+		f.BinaryPath(),
 		process.WithContext(ctx),
 		process.WithArgs(args),
 		process.WithCmdOptions(attachOutErr(stdOut, stdErr)))
@@ -540,7 +540,7 @@ func (f *Fixture) executeWithClient(ctx context.Context, command string, disable
 	args = append(args, f.additionalArgs...)
 
 	proc, err := process.Start(
-		f.binaryPath(),
+		f.BinaryPath(),
 		process.WithContext(ctx),
 		process.WithArgs(args),
 		process.WithCmdOptions(attachOutErr(stdOut, stdErr)))
@@ -675,7 +675,7 @@ func (f *Fixture) PrepareAgentCommand(ctx context.Context, args []string, opts .
 	}
 
 	// #nosec G204 -- Not so many ways to support variadic arguments to the elastic-agent command :(
-	cmd := exec.CommandContext(ctx, f.binaryPath(), args...)
+	cmd := exec.CommandContext(ctx, f.BinaryPath(), args...)
 	for _, o := range opts {
 		if err := o(cmd); err != nil {
 			return nil, fmt.Errorf("error adding opts to Exec: %w", err)
@@ -915,7 +915,8 @@ func (f *Fixture) EnsurePrepared(ctx context.Context) error {
 	return nil
 }
 
-func (f *Fixture) binaryPath() string {
+// BinaryPath returns the path for the Elastic-Agent binary
+func (f *Fixture) BinaryPath() string {
 	workDir := f.workDir
 	if f.installed {
 		installDir := "Agent"

--- a/testing/integration/foo_all_test.go
+++ b/testing/integration/foo_all_test.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package integration
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func stopCmd(cmd *exec.Cmd) error {
+	return cmd.Process.Signal(syscall.SIGINT)
+}
+
+func getProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}

--- a/testing/integration/foo_test.go
+++ b/testing/integration/foo_test.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package integration
+
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func stopCmd(cmd *exec.Cmd) error {
+	return windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(cmd.Process.Pid))
+}
+
+func getProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP,
+	}
+}

--- a/testing/integration/shutdown_test.go
+++ b/testing/integration/shutdown_test.go
@@ -1,0 +1,215 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package integration
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/pkg/core/process"
+	atesting "github.com/elastic/elastic-agent/pkg/testing"
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/testcontext"
+)
+
+func TestGracefullyShutdownComponents(t *testing.T) {
+	define.Require(t, define.Requirements{
+		Group: Default,
+		Local: true,
+		Sudo:  false,
+	})
+
+	logFilepath := filepath.Join(t.TempDir(), t.Name())
+	generateLogFile(t, logFilepath, time.Millisecond*100, 20)
+
+	// We just need a configuration with any Beat that works and
+	// we can assert whether the Beat has successfully shutdown,
+	// so we borrow the config from TestEventLogFile that uses
+	// only Filebeat and ES.
+	esURL := startMockES(t, 0, 0, 0, 0)
+	cfg := fmt.Sprintf(eventLogConfig, esURL, logFilepath)
+
+	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
+	require.NoError(t, err, "cannot create fixture from local build")
+
+	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	defer cancel()
+
+	// ==================== Prepare
+	err = f.Prepare(ctx)
+	require.NoError(t, err, "cannot prepare fixture with 'fakeComponent'")
+
+	// ==================== Configure
+	if err := f.Configure(ctx, []byte(cfg)); err != nil {
+		t.Fatalf("cannot configure Elastic-Agent: %s", err)
+	}
+
+	output := strings.Builder{}
+	// We use process.Start to ensure it is sending the correct signal
+	proc, err := process.Start(
+		f.BinaryPath(),
+		process.WithContext(ctx),
+		process.WithCmdOptions(func(c *exec.Cmd) error {
+			c.Stderr = &output
+			c.Stdout = &output
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Errorf("failed to start Elastic-Agent process")
+		t.Logf("Elastic-Agent output: %s", output.String())
+	}
+
+	// Wait the Elastic-Agent to be healthy
+	healthOutput := strings.Builder{}
+	require.Eventuallyf(
+		t,
+		func() bool {
+			if err := f.IsHealthy(ctx); err != nil {
+				healthOutput.Reset()
+				healthOutput.WriteString(err.Error())
+				return false
+			}
+			return true
+		},
+		5*time.Minute,
+		200*time.Millisecond,
+		"Elastic-Agent did not report healthy. Agent status error: '%s'. Process Output: %s",
+		&healthOutput, output.String())
+
+	// Stop the Elastic-Agent process and wait for it to return
+	if err := proc.StopWait(); err != nil {
+		t.Fatalf(
+			"failed to stop Elastic-Agent process: %s. Process output: %s",
+			err,
+			output.String())
+	}
+
+	assertInLogs(t, f, "elastic-agent", `signal "terminated" received`)
+	assertInLogs(t, f, "filestream-default", `Received signal "terminated", stopping`)
+	assertInLogs(t, f, "filestream-default", "Stopping filebeat")
+	assertInLogs(t, f, "filestream-default", "filebeat stopped.")
+}
+
+type elasticAgentLogs struct {
+	Log struct {
+		Source string `json:"source"`
+	} `json:"log"`
+	Message string `json:"message"`
+}
+
+// assertInLogs search for str as a substring of the message field
+// in the log of a component. The component is selected by matching log.source with
+// the provided source. If the entry is not found the test fails with an error.
+// If found, the message is returned.
+//
+// The log files searched are the ones in the `logs` folder of the running
+// Elastic-Agent from the provided fixture
+func assertInLogs(
+	t *testing.T,
+	f *atesting.Fixture,
+	source,
+	str string,
+) string {
+	logs, eventLogs := getLogFileNamesFromFixture(t, f)
+
+	for _, f := range append(logs, eventLogs...) {
+		found, msg := findMsgInComponentLogs(t, f, source, str)
+		if found {
+			return msg
+		}
+	}
+
+	t.Errorf("%q not found in logs from %q", str, source)
+	return ""
+}
+
+// findMsgInComponentLogs preforms all the heavy lifting of searching components
+// logs in a given file.
+// The returned values are a boolean indicating whether the
+// str was found, and the message from the log entry.
+func findMsgInComponentLogs(
+	t *testing.T,
+	logfile, source, str string,
+) (bool, string) {
+
+	f, err := os.Open(logfile)
+	if err != nil {
+		t.Fatalf("cannot open file '%s': %s", logfile, err)
+	}
+
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Logf("could not close log file: %s", err)
+		}
+	}()
+
+	r := bufio.NewReader(f)
+	for {
+		data, err := r.ReadBytes('\n')
+		entry := elasticAgentLogs{}
+
+		if err != nil {
+			if err != io.EOF {
+				t.Fatalf("error reading log file '%s': %s", f.Name(), err)
+			}
+			break
+		}
+
+		if err := json.Unmarshal(data, &entry); err != nil {
+			t.Fatalf("cannot parse Elastic-Agent logs: %s", err)
+		}
+
+		if entry.Log.Source != source {
+			continue
+		}
+
+		if strings.Contains(entry.Message, str) {
+			return true, entry.Message
+		}
+	}
+
+	return false, ""
+}
+
+func getLogFileNamesFromFixture(t *testing.T, f *atesting.Fixture) (logFiles, eventLogFiles []string) {
+	basepath := filepath.Join(f.WorkDir(),
+		"data",
+		"elastic-agent-*",
+		"logs")
+
+	logFilesGlob := filepath.Join(basepath, "*.ndjson")
+	logFilesPath, err := filepath.Glob(logFilesGlob)
+	if err != nil {
+		t.Fatalf("could not get log file names:%s", err)
+	}
+
+	for _, f := range logFilesPath {
+		logFiles = append(logFiles, f)
+	}
+
+	eventLogFilesGlob := filepath.Join(basepath, "events", "*.ndjson")
+	eventLogFilesPath, err := filepath.Glob(eventLogFilesGlob)
+	if err != nil {
+		t.Fatalf("could not get log file names:%s", err)
+	}
+
+	for _, f := range eventLogFilesPath {
+		eventLogFiles = append(eventLogFiles, f)
+	}
+
+	return logFiles, eventLogFiles
+}


### PR DESCRIPTION
## What does this PR do?

Calling proc.Kill causes the process to exit immediately, which
prevents Beats from executing some clean up functions.

Now windows.GenerateConsoleCtrlEvent to send a CTRL+C signal that is
haled as a SIGINT, thus allowing the Beat to execute all necessary
clean up.


## Why is it important?

It allows Beats or any subprocess from the Elastic-Agent to gracefully terminate

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

~~## Disruptive User Impact~~

## How to test this PR locally

TODO

## Related issues
- Closes https://github.com/elastic/elastic-agent/issues/6875

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
