### PR TITLE
[bug] do not panic when info.Metadata errors in FleetGateway execute

### DIFF
--- a/changelog/fragments/1743421027-Fix-panic-during-shutdown-in-fleetgateway.yaml
+++ b/changelog/fragments/1743421027-Fix-panic-during-shutdown-in-fleetgateway.yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+summary: Fix panic during shutdown in fleetgateway
+component: elastic-agent
+pr: https://github.com/elastic/elastic-agent/pull/7629
+issue: https://github.com/elastic/elastic-agent/issues/7309

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -337,6 +337,7 @@ func (f *FleetGateway) execute(ctx context.Context) (*fleetapi.CheckinResponse, 
 	ecsMeta, err := info.Metadata(ctx, f.log)
 	if err != nil {
 		f.log.Error(errors.New("failed to load metadata", err))
+		return nil, 0, err
 	}
 
 	// retrieve ack token from the store


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
-->

## What does this PR do?

This PR fixes a bug in the `FleetGateway.execute` method where a call to `info.Metadata` could return an error that was not being propagated. If this error occurred during shutdown (e.g. due to context is done/cancelled), the subsequent logic would attempt to use `nil` values, resulting in a panic.

The fix ensures that the `execute` function returns early if `info.Metadata` fails, avoiding a `nil` dereference and the resulting crash.

## Why is it important?

This bug was causing panics during agent shutdown, as reported in [issue #7309](https://github.com/elastic/elastic-agent/issues/7309). The error originated from the failure to load agent metadata, which led to a `SIGSEGV` (segmentation fault) because the error was logged but not returned. This led to `nil` being used downstream, triggering a crash.

Fixing this ensures more graceful shutdown behaviour and prevents unexpected restarts of the Elastic Agent under these failure conditions.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

No disruptive impact expected. The change improves error handling during shutdown, preventing panics and unnecessary agent restarts. It does not alter runtime behaviour under normal conditions.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Deploy a k8s agent pod and delete the pod, observe that it no longer panics with this reason

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/7309