### PR TITLE
ci: add kubernetes v1.32 to test matrix

### DIFF
--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -338,6 +338,8 @@ steps:
             - "basic,slim,complete,service,elastic-otel-collector"
             - "wolfi,slim-wolfi,complete-wolfi,elastic-otel-collector-wolfi"
             version:
+            - v1.27.16
+            - v1.28.9
             - v1.29.8
             - v1.30.8
             - v1.31.0

--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -313,7 +313,7 @@ steps:
       - label: "{{matrix.version}}:amd64:{{matrix.variants}}"
         env:
           K8S_VERSION: "{{matrix.version}}"
-          ASDF_KIND_VERSION: "0.24.0"
+          ASDF_KIND_VERSION: "0.27.0"
           DOCKER_VARIANTS: "{{matrix.variants}}"
           TARGET_ARCH: "amd64"
           AGENT_VERSION: "9.0.0-SNAPSHOT" # Remove agent pinning once 9.0.0 is released
@@ -338,11 +338,10 @@ steps:
             - "basic,slim,complete,service,elastic-otel-collector"
             - "wolfi,slim-wolfi,complete-wolfi,elastic-otel-collector-wolfi"
             version:
-            - v1.27.16
-            - v1.28.9
             - v1.29.8
             - v1.30.8
             - v1.31.0
+            - v1.32.0
 
   - label: ESS stack cleanup
     depends_on:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -215,7 +215,7 @@ steps:
       - label: "K8s tests: {{matrix.k8s_version}}"
         env:
           K8S_VERSION: "v{{matrix.k8s_version}}"
-          KIND_VERSION: "v0.24.0"
+          KIND_VERSION: "v0.27.0"
         command: ".buildkite/scripts/steps/k8s-tests.sh"
         agents:
           provider: "gcp"
@@ -223,10 +223,10 @@ steps:
         matrix:
           setup:
             k8s_version:
+              - "1.32.0"
               - "1.31.0"
               - "1.30.0"
               - "1.29.4"
-              - "1.28.9"
         retry:
           manual:
             allowed: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -227,6 +227,7 @@ steps:
               - "1.31.0"
               - "1.30.0"
               - "1.29.4"
+              - "1.28.9"
         retry:
           manual:
             allowed: true

--- a/.buildkite/scripts/install-kubectl.sh
+++ b/.buildkite/scripts/install-kubectl.sh
@@ -34,7 +34,7 @@ else
     ARCH_SUFFIX=amd64
 fi
 
-if curl -sSLo "${KUBECTL_CMD}" "https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/${OS}/${ARCH_SUFFIX}/kubectl" ; then
+if curl -sSLo "${KUBECTL_CMD}" "https://dl.k8s.io/release/${K8S_VERSION}/bin/${OS}/${ARCH_SUFFIX}/kubectl"; then
     chmod +x "${KUBECTL_CMD}"
 else
     echo "Something bad with the download, let's delete the corrupted binary"

--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -83,7 +83,7 @@ between, and it can be very specific or not very specific.
 - `TEST_PLATFORMS="linux/amd64/ubuntu/20.04 mage integration:test` to execute tests only on Ubuntu 20.04 ARM64.
 - `TEST_PLATFORMS="windows/amd64/2022 mage integration:test` to execute tests only on Windows Server 2022.
 - `TEST_PLATFORMS="linux/amd64 windows/amd64/2022 mage integration:test` to execute tests on Linux AMD64 and Windows Server 2022.
-- `TEST_PLATFORMS="kubernetes/arm64/1.31.0/wolfi" mage integration:kubernetes` to execute kubernetes tests on Kubernetes version 1.31.0 with wolfi docker variant.
+- `TEST_PLATFORMS="kubernetes/arm64/1.32.0/wolfi" mage integration:kubernetes` to execute kubernetes tests on Kubernetes version 1.32.0 with wolfi docker variant.
 
 > **_NOTE:_**  This only filters down the tests based on the platform. It will not execute a tests on a platform unless
 > the test defines as supporting it.

--- a/pkg/testing/kubernetes/supported.go
+++ b/pkg/testing/kubernetes/supported.go
@@ -18,6 +18,11 @@ var arches = []string{define.AMD64, define.ARM64}
 
 // versions defines the list of supported version of Kubernetes.
 var versions = []define.OS{
+	// Kubernetes 1.32
+	{
+		Type:    define.Kubernetes,
+		Version: "1.32.0",
+	},
 	// Kubernetes 1.31
 	{
 		Type:    define.Kubernetes,
@@ -32,11 +37,6 @@ var versions = []define.OS{
 	{
 		Type:    define.Kubernetes,
 		Version: "1.29.4",
-	},
-	// Kubernetes 1.28
-	{
-		Type:    define.Kubernetes,
-		Version: "1.28.9",
 	},
 }
 

--- a/pkg/testing/kubernetes/supported.go
+++ b/pkg/testing/kubernetes/supported.go
@@ -38,6 +38,16 @@ var versions = []define.OS{
 		Type:    define.Kubernetes,
 		Version: "1.29.4",
 	},
+	// Kubernetes 1.28
+	{
+		Type:    define.Kubernetes,
+		Version: "1.28.9",
+	},
+	// Kubernetes 1.27
+	{
+		Type:    define.Kubernetes,
+		Version: "1.27.16",
+	},
 }
 
 // variants defines the list of variants and the image name for that variant.


### PR DESCRIPTION
## What does this PR do?

Kubernetes v1.32 released on Dec 11 2024, add it to test matrix.

## Checklist

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Related issues

- For https://github.com/elastic/ingest-dev/issues/4743