### PR TITLE
[Helm] allow additional processors for container logs to be defined 

### DIFF
--- a/deploy/helm/elastic-agent/README.md
+++ b/deploy/helm/elastic-agent/README.md
@@ -86,6 +86,7 @@ The chart built-in [kubernetes integration](https://docs.elastic.co/integrations
 | kubernetes.containers.state.enabled | bool | `true` | enable containers state stream (kube-state-metrics) [ref](https://www.elastic.co/guide/en/beats/metricbeat/8.11/metricbeat-metricset-kubernetes-state_container.html) |
 | kubernetes.containers.state.vars | object | `{}` | containers state stream vars |
 | kubernetes.containers.logs.enabled | bool | `true` | enable containers logs stream [ref](https://www.elastic.co/docs/current/integrations/kubernetes/container-logs) |
+| kubernetes.containers.logs.vars | object | `{}` | containers logs stream vars |
 | kubernetes.containers.audit_logs.enabled | bool | `false` | enable containers audit logs stream [ref](https://www.elastic.co/docs/current/integrations/kubernetes/audit-logs) |
 | kubernetes.pods.metrics.enabled | bool | `true` | enable pods metric stream (kubelet) [ref](https://www.elastic.co/docs/current/integrations/kubernetes/kubelet#pod) |
 | kubernetes.pods.metrics.vars | object | `{}` | pod metric stream vars |

--- a/deploy/helm/elastic-agent/values.schema.json
+++ b/deploy/helm/elastic-agent/values.schema.json
@@ -225,10 +225,46 @@
                                     "type": "boolean",
                                     "description": "Enable containers logs stream."
                                 },
-                                "additionalParsersConfig": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object"
+                                "vars": {
+                                    "type": "object",
+                                    "description": "Stream variables.",
+                                    "properties": {
+                                        "enabledDefaultProcessors": {
+                                            "type": "boolean",
+                                            "description": "Enable container logs stream default processors.",
+                                            "default": true
+                                        },
+                                        "symlinks": {
+                                            "type": "boolean",
+                                            "description": "Use Symlinks.",
+                                            "default": true
+                                        },
+                                        "additionalParsersConfig": {
+                                            "type": "array",
+                                            "description": "Additional parsers configuration.",
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "default": []
+                                        },
+                                        "containerParserStream": {
+                                            "type": "string",
+                                            "description": "Container parser's stream configuration.",
+                                            "default": "all"
+                                        },
+                                        "containerParserFormat": {
+                                            "type": "string",
+                                            "description": "Container parser's format configuration.",
+                                            "default": "auto"
+                                        },
+                                        "processors": {
+                                            "type": "array",
+                                            "description": "Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped.",
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "default": []
+                                        }
                                     }
                                 }
                             },

--- a/deploy/helm/elastic-agent/values.schema.json
+++ b/deploy/helm/elastic-agent/values.schema.json
@@ -259,7 +259,7 @@
                                         },
                                         "processors": {
                                             "type": "array",
-                                            "description": "Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped.",
+                                            "description": "Additional processors to use on the container logs streams. Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped.",
                                             "items": {
                                                 "type": "object"
                                             },

--- a/deploy/helm/elastic-agent/values.yaml
+++ b/deploy/helm/elastic-agent/values.yaml
@@ -147,7 +147,9 @@ kubernetes:
       # -- enable containers logs stream [ref](https://www.elastic.co/docs/current/integrations/kubernetes/container-logs)
       # @section -- 2 - Kubernetes integration
       enabled: true
-      additionalParsersConfig: []
+      # -- containers logs stream vars
+      # @section -- 2 - Kubernetes integration
+      vars: {}
     audit_logs:
       # -- enable containers audit logs stream [ref](https://www.elastic.co/docs/current/integrations/kubernetes/audit-logs)
       # @section -- 2 - Kubernetes integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR introduces support for configuring additional processors for the `container-logs` stream in the Helm chart. Specifically, it allows users to define a list of processors under the `kubernetes.containers.logs.vars.processors` key in `values.yaml`.

It also introduces the ability to toggle the built-in default processors via the `enabledDefaultProcessors` flag, and groups all log stream customization variables under a new `vars` section for consistency with the other stream configurations.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This enhancement addresses a gap where `container-logs` did not support user-defined processors.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

The default behavior remains unchanged unless users opt in by defining custom processors or disabling built-in ones. Existing configurations using `additionalParsersConfig` outside the new `vars` block should migrate accordingly.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Follow the `kubernetes-default` example and define custom processors under `kubernetes.containers.logs.vars.processors` in `values.yaml`.
2. Deploy the chart and verify that the `processors` block is rendered in the final configuration.
3. Toggle `enabledDefaultProcessors` to `false` and ensure built-in processors are omitted.
4. Confirm that logs are processed accordingly via Elastic Observability.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/7319
