### PR TITLE
ci: extend updatecli to bump wrappers/windows/archive-proxy golang version

### DIFF
--- a/.ci/updatecli/updatecli-bump-golang.yml
+++ b/.ci/updatecli/updatecli-bump-golang.yml
@@ -113,6 +113,15 @@ targets:
       content: 'go {{ source "latestGoVersion" }}'
       file: go.mod
       matchpattern: 'go \d+.\d+.\d+'
+  update-wrapper-windows-archive-gomod-full-version:
+    name: "Update wrapper/windows/archive-proxy/go.mod version"
+    sourceid: latestGoVersion
+    scmid: githubConfig
+    kind: file
+    spec:
+      content: 'go {{ source "latestGoVersion" }}'
+      file: wrapper/windows/archive-proxy/go.mod
+      matchpattern: 'go \d+.\d+.\d+'
   update-buildkite-pipeline:
     name: "Update .buildkite/pipeline.yml"
     sourceid: latestGoVersion


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR extends the existing Updatecli configuration to automatically bump the Go version in wrapper/windows/archive-proxy/go.mod, aligning it with the latest Go version used across the project. This ensures consistency in Go versioning for the Windows archive proxy wrapper.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

We need to be consistent 🙂 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Not sure how you can run this locally 🙂 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
N/A