### PR TITLE
[flaky] force the installing of packages after provisioning the ESS stack

### DIFF
--- a/testing/integration/testdata/preinstalled_packages.json
+++ b/testing/integration/testdata/preinstalled_packages.json
@@ -1,4 +1,5 @@
 {
+    "force": true,
     "packages": [
         { "name": "endpoint", "version": "9.0.0" },
         { "name": "system", "version": "1.67.3" },


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR ensures that package installation in the CI is **forced** after provisioning the ESS stack. Specifically, it updates the `fleet.sh` script to send `-d '{ "force": true }'` in the request to the Fleet API when preinstalling integrations.

This change guarantees that the expected package versions are installed regardless of the existence of newer upstream versions.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Integrations are continuously released and updated, and this can break our CI if we rely on specific package versions during preinstallation. For instance, yesterday a new version of `osquery_manager` was released ([commit](https://github.com/elastic/integrations/commit/0196b0ebbaf82c5474bb41e98de88fd929e41891)), and this caused the CI step to fail with the following error: `osquery_manager-1.16.0 is out-of-date and cannot be installed or updated`

To avoid these kinds of unexpected failures and ensure reproducible test environments, we now explicitly force the installation of packages regardless of upstream version availability.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None expected — this affects only the CI scripts and not user-facing behavior.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Try to install an epm package that is outdated without `"force": true`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
N/A
