### PR TITLE
Ensure consistent input order in self-monitoring configuration

### DIFF
--- a/changelog/fragments/1744022861-consistent-monitoring-config.yaml
+++ b/changelog/fragments/1744022861-consistent-monitoring-config.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Ensure consistent input order in self-monitoring configuration
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/monitoring/server_test.go
+++ b/internal/pkg/agent/application/monitoring/server_test.go
@@ -117,7 +117,6 @@ func TestHTTPReloadEnableBehavior(t *testing.T) {
 }
 
 func TestBasicLivenessConfig(t *testing.T) {
-	_ = logp.DevelopmentSetup()
 	testAPIConfig := api.Config{}
 	testConfig := config.MonitoringConfig{
 		Enabled: true,
@@ -126,7 +125,9 @@ func TestBasicLivenessConfig(t *testing.T) {
 			Port:    0,
 		},
 	}
-	serverReloader, err := NewServer(logp.L(), testAPIConfig, nil, nil, fakeCoordCfg, "linux", &testConfig)
+	logger, err := logp.NewDevelopmentLogger("")
+	require.NoError(t, err)
+	serverReloader, err := NewServer(logger, testAPIConfig, nil, nil, fakeCoordCfg, "linux", &testConfig)
 	require.NoError(t, err)
 
 	t.Logf("starting server...")
@@ -143,7 +144,6 @@ func TestBasicLivenessConfig(t *testing.T) {
 }
 
 func TestPprofEnabled(t *testing.T) {
-	_ = logp.DevelopmentSetup()
 	testAPIConfig := api.Config{}
 	testConfig := config.MonitoringConfig{
 		Enabled: true,
@@ -155,7 +155,9 @@ func TestPprofEnabled(t *testing.T) {
 			Enabled: true,
 		},
 	}
-	serverReloader, err := NewServer(logp.L(), testAPIConfig, nil, nil, fakeCoordCfg, "linux", &testConfig)
+	logger, err := logp.NewDevelopmentLogger("")
+	require.NoError(t, err)
+	serverReloader, err := NewServer(logger, testAPIConfig, nil, nil, fakeCoordCfg, "linux", &testConfig)
 	require.NoError(t, err)
 
 	t.Logf("starting server...")

--- a/internal/pkg/agent/application/monitoring/testdata/monitoring_config_full.yaml
+++ b/internal/pkg/agent/application/monitoring/testdata/monitoring_config_full.yaml
@@ -1,0 +1,713 @@
+agent:
+  monitoring:
+    http:
+      enabled: false
+    metrics: true
+inputs:
+- id: filestream-monitoring-agent
+  name: filestream-monitoring-agent
+  streams:
+  - close:
+      on_state_change:
+        inactive: 5m
+    data_stream:
+      dataset: elastic_agent
+      namespace: default
+      type: logs
+    id: filestream-monitoring-agent
+    parsers:
+    - ndjson:
+        add_error_key: true
+        message_key: message
+        overwrite_keys: true
+        target: ""
+    paths:
+    - /opt/Elastic/Agent/data/elastic-agent-placeholder-unknow/logs/elastic-agent-*.ndjson
+    - /opt/Elastic/Agent/data/elastic-agent-placeholder-unknow/logs/elastic-agent-watcher-*.ndjson
+    processors:
+    - drop_event:
+        when:
+          regexp:
+            component.id: .*-monitoring$
+    - drop_event:
+        when:
+          regexp:
+            message: ^Non-zero metrics in the last
+    - copy_fields:
+        fields:
+        - from: data_stream.dataset
+          to: data_stream.dataset_original
+    - drop_fields:
+        fields:
+        - data_stream.dataset
+    - copy_fields:
+        fail_on_error: false
+        fields:
+        - from: component.dataset
+          to: data_stream.dataset
+        ignore_missing: true
+    - copy_fields:
+        fail_on_error: false
+        fields:
+        - from: data_stream.dataset_original
+          to: data_stream.dataset
+        when:
+          not:
+            has_fields:
+            - data_stream.dataset
+    - drop_fields:
+        fields:
+        - data_stream.dataset_original
+        - event.dataset
+    - copy_fields:
+        fields:
+        - from: data_stream.dataset
+          to: event.dataset
+    - drop_fields:
+        fields:
+        - ecs.version
+        ignore_missing: true
+    - add_formatted_index:
+        index: '%{[data_stream.type]}-%{[data_stream.dataset]}-%{[data_stream.namespace]}'
+    type: filestream
+  - close:
+      on_state_change:
+        inactive: 5m
+    data_stream:
+      dataset: elastic_agent.endpoint_security
+      namespace: default
+      type: logs
+    id: filestream-monitoring-endpoint-default
+    parsers:
+    - ndjson:
+        add_error_key: true
+        message_key: message
+        overwrite_keys: true
+        target: ""
+    paths:
+    - /var/log/endpoint.log
+    processors:
+    - add_fields:
+        fields:
+          binary: endpoint-security
+          dataset: elastic_agent.endpoint_security
+          id: endpoint-default
+          type: ""
+        target: component
+    - add_fields:
+        fields:
+          source: endpoint-default
+        target: log
+    type: filestream
+  type: filestream
+  use_output: monitoring
+- data_stream:
+    namespace: default
+  id: metrics-monitoring-beats
+  name: metrics-monitoring-beats
+  streams:
+  - data_stream:
+      dataset: elastic_agent.metricbeat
+      namespace: default
+      type: metrics
+    failure_threshold: 5
+    hosts:
+    - http+unix:///opt/Elastic/Agent/data/tmp/Hk6rvk9TDibMPcDvpl0jkLE-qDsHWVYL.sock
+    id: metrics-monitoring-metricbeat
+    index: metrics-elastic_agent.metricbeat-default
+    metricsets:
+    - stats
+    period: 1m0s
+    processors:
+    - add_fields:
+        fields:
+          dataset: elastic_agent.metricbeat
+          namespace: default
+          type: metrics
+        target: data_stream
+    - add_fields:
+        fields:
+          dataset: elastic_agent.metricbeat
+        target: event
+    - add_fields:
+        fields:
+          id: ""
+          process: metricbeat
+          snapshot: false
+          version: placeholder
+        target: elastic_agent
+    - add_fields:
+        fields:
+          id: ""
+        target: agent
+    - add_fields:
+        fields:
+          binary: metricbeat
+          id: beat/metrics-monitoring
+        target: component
+  - data_stream:
+      dataset: elastic_agent.filebeat
+      namespace: default
+      type: metrics
+    failure_threshold: 5
+    hosts:
+    - http+unix:///opt/Elastic/Agent/data/tmp/o2aP56OJCFn3ykwxdcxCyFmFlZVurVZ9.sock
+    id: metrics-monitoring-filebeat
+    index: metrics-elastic_agent.filebeat-default
+    metricsets:
+    - stats
+    period: 1m0s
+    processors:
+    - add_fields:
+        fields:
+          dataset: elastic_agent.filebeat
+          namespace: default
+          type: metrics
+        target: data_stream
+    - add_fields:
+        fields:
+          dataset: elastic_agent.filebeat
+        target: event
+    - add_fields:
+        fields:
+          id: ""
+          process: filebeat
+          snapshot: false
+          version: placeholder
+        target: elastic_agent
+    - add_fields:
+        fields:
+          id: ""
+        target: agent
+    - add_fields:
+        fields:
+          binary: filebeat
+          id: filebeat-default
+        target: component
+  - data_stream:
+      dataset: elastic_agent.filebeat
+      namespace: default
+      type: metrics
+    failure_threshold: 5
+    hosts:
+    - http+unix:///opt/Elastic/Agent/data/tmp/xTEtpJ7117ppc6OYvJCaYHbDW8mLjXGe.sock
+    id: metrics-monitoring-filebeat
+    index: metrics-elastic_agent.filebeat-default
+    metricsets:
+    - stats
+    period: 1m0s
+    processors:
+    - add_fields:
+        fields:
+          dataset: elastic_agent.filebeat
+          namespace: default
+          type: metrics
+        target: data_stream
+    - add_fields:
+        fields:
+          dataset: elastic_agent.filebeat
+        target: event
+    - add_fields:
+        fields:
+          id: ""
+          process: filebeat
+          snapshot: false
+          version: placeholder
+        target: elastic_agent
+    - add_fields:
+        fields:
+          id: ""
+        target: agent
+    - add_fields:
+        fields:
+          binary: filebeat
+          id: filestream-monitoring
+        target: component
+  - data_stream:
+      dataset: elastic_agent.metricbeat
+      namespace: default
+      type: metrics
+    failure_threshold: 5
+    hosts:
+    - http+unix:///opt/Elastic/Agent/data/tmp/akSPbdqgaHaTY0_J01-dsfYK6JpMz2zn.sock
+    id: metrics-monitoring-metricbeat
+    index: metrics-elastic_agent.metricbeat-default
+    metricsets:
+    - stats
+    period: 1m0s
+    processors:
+    - add_fields:
+        fields:
+          dataset: elastic_agent.metricbeat
+          namespace: default
+          type: metrics
+        target: data_stream
+    - add_fields:
+        fields:
+          dataset: elastic_agent.metricbeat
+        target: event
+    - add_fields:
+        fields:
+          id: ""
+          process: metricbeat
+          snapshot: false
+          version: placeholder
+        target: elastic_agent
+    - add_fields:
+        fields:
+          id: ""
+        target: agent
+    - add_fields:
+        fields:
+          binary: metricbeat
+          id: http/metrics-monitoring
+        target: component
+  type: beat/metrics
+  use_output: monitoring
+- data_stream:
+    namespace: default
+  id: metrics-monitoring-agent
+  name: metrics-monitoring-agent
+  streams:
+  - data_stream:
+      dataset: elastic_agent.elastic_agent
+      namespace: default
+      type: metrics
+    failure_threshold: 5
+    hosts:
+    - http://:0
+    id: metrics-monitoring-agent
+    index: metrics-elastic_agent.elastic_agent-default
+    metricsets:
+    - json
+    namespace: agent
+    path: /stats
+    period: 1m0s
+    processors:
+    - add_fields:
+        fields:
+          dataset: elastic_agent.elastic_agent
+          namespace: default
+          type: metrics
+        target: data_stream
+    - add_fields:
+        fields:
+          dataset: elastic_agent.elastic_agent
+        target: event
+    - add_fields:
+        fields:
+          id: ""
+          process: elastic-agent
+          snapshot: false
+          version: placeholder
+        target: elastic_agent
+    - add_fields:
+        fields:
+          id: ""
+        target: agent
+    - copy_fields:
+        fail_on_error: false
+        fields:
+        - from: http.agent.beat.cpu
+          to: system.process.cpu
+        - from: http.agent.beat.memstats.memory_sys
+          to: system.process.memory.size
+        - from: http.agent.beat.handles
+          to: system.process.fd
+        - from: http.agent.beat.cgroup
+          to: system.process.cgroup
+        - from: http.agent.apm-server
+          to: apm-server
+        - from: http.filebeat_input
+          to: filebeat_input
+        ignore_missing: true
+    - drop_fields:
+        fields:
+        - http
+        ignore_missing: true
+    - add_fields:
+        fields:
+          binary: elastic-agent
+          id: elastic-agent
+        target: component
+  - data_stream:
+      dataset: elastic_agent.elastic_agent
+      namespace: default
+      type: metrics
+    failure_threshold: 5
+    hosts:
+    - http+unix:///opt/Elastic/Agent/data/tmp/Hk6rvk9TDibMPcDvpl0jkLE-qDsHWVYL.sock
+    id: metrics-monitoring-metricbeat-1
+    index: metrics-elastic_agent.elastic_agent-default
+    metricsets:
+    - json
+    namespace: agent
+    path: /stats
+    period: 1m0s
+    processors:
+    - add_fields:
+        fields:
+          dataset: elastic_agent.elastic_agent
+        target: event
+    - add_fields:
+        fields:
+          id: ""
+          process: metricbeat
+          snapshot: false
+          version: placeholder
+        target: elastic_agent
+    - add_fields:
+        fields:
+          id: ""
+        target: agent
+    - copy_fields:
+        fail_on_error: false
+        fields:
+        - from: http.agent.beat.cpu
+          to: system.process.cpu
+        - from: http.agent.beat.memstats.memory_sys
+          to: system.process.memory.size
+        - from: http.agent.beat.handles
+          to: system.process.fd
+        - from: http.agent.beat.cgroup
+          to: system.process.cgroup
+        - from: http.agent.apm-server
+          to: apm-server
+        - from: http.filebeat_input
+          to: filebeat_input
+        ignore_missing: true
+    - drop_fields:
+        fields:
+        - http
+        ignore_missing: true
+    - add_fields:
+        fields:
+          binary: metricbeat
+          id: beat/metrics-monitoring
+        target: component
+  - data_stream:
+      dataset: elastic_agent.elastic_agent
+      namespace: default
+      type: metrics
+    failure_threshold: 5
+    hosts:
+    - http+unix:///opt/Elastic/Agent/data/tmp/o2aP56OJCFn3ykwxdcxCyFmFlZVurVZ9.sock
+    id: metrics-monitoring-filebeat-1
+    index: metrics-elastic_agent.elastic_agent-default
+    metricsets:
+    - json
+    namespace: agent
+    path: /stats
+    period: 1m0s
+    processors:
+    - add_fields:
+        fields:
+          dataset: elastic_agent.elastic_agent
+        target: event
+    - add_fields:
+        fields:
+          id: ""
+          process: filebeat
+          snapshot: false
+          version: placeholder
+        target: elastic_agent
+    - add_fields:
+        fields:
+          id: ""
+        target: agent
+    - copy_fields:
+        fail_on_error: false
+        fields:
+        - from: http.agent.beat.cpu
+          to: system.process.cpu
+        - from: http.agent.beat.memstats.memory_sys
+          to: system.process.memory.size
+        - from: http.agent.beat.handles
+          to: system.process.fd
+        - from: http.agent.beat.cgroup
+          to: system.process.cgroup
+        - from: http.agent.apm-server
+          to: apm-server
+        - from: http.filebeat_input
+          to: filebeat_input
+        ignore_missing: true
+    - drop_fields:
+        fields:
+        - http
+        ignore_missing: true
+    - add_fields:
+        fields:
+          binary: filebeat
+          id: filebeat-default
+        target: component
+  - data_stream:
+      dataset: elastic_agent.filebeat_input
+      namespace: default
+      type: metrics
+    failure_threshold: 5
+    hosts:
+    - http+unix:///opt/Elastic/Agent/data/tmp/o2aP56OJCFn3ykwxdcxCyFmFlZVurVZ9.sock
+    id: metrics-monitoring-filebeat-1
+    index: metrics-elastic_agent.filebeat_input-default
+    json.is_array: true
+    metricsets:
+    - json
+    namespace: filebeat_input
+    path: /inputs/
+    period: 1m0s
+    processors:
+    - add_fields:
+        fields:
+          dataset: elastic_agent.filebeat_input
+        target: event
+    - add_fields:
+        fields:
+          id: ""
+          process: filebeat
+          snapshot: false
+          version: placeholder
+        target: elastic_agent
+    - add_fields:
+        fields:
+          id: ""
+        target: agent
+    - copy_fields:
+        fail_on_error: false
+        fields:
+        - from: http.agent.beat.cpu
+          to: system.process.cpu
+        - from: http.agent.beat.memstats.memory_sys
+          to: system.process.memory.size
+        - from: http.agent.beat.handles
+          to: system.process.fd
+        - from: http.agent.beat.cgroup
+          to: system.process.cgroup
+        - from: http.agent.apm-server
+          to: apm-server
+        - from: http.filebeat_input
+          to: filebeat_input
+        ignore_missing: true
+    - drop_fields:
+        fields:
+        - http
+        ignore_missing: true
+    - add_fields:
+        fields:
+          binary: filebeat
+          id: filebeat-default
+        target: component
+  - data_stream:
+      dataset: elastic_agent.elastic_agent
+      namespace: default
+      type: metrics
+    failure_threshold: 5
+    hosts:
+    - http+unix:///opt/Elastic/Agent/data/tmp/xTEtpJ7117ppc6OYvJCaYHbDW8mLjXGe.sock
+    id: metrics-monitoring-filebeat-1
+    index: metrics-elastic_agent.elastic_agent-default
+    metricsets:
+    - json
+    namespace: agent
+    path: /stats
+    period: 1m0s
+    processors:
+    - add_fields:
+        fields:
+          dataset: elastic_agent.elastic_agent
+        target: event
+    - add_fields:
+        fields:
+          id: ""
+          process: filebeat
+          snapshot: false
+          version: placeholder
+        target: elastic_agent
+    - add_fields:
+        fields:
+          id: ""
+        target: agent
+    - copy_fields:
+        fail_on_error: false
+        fields:
+        - from: http.agent.beat.cpu
+          to: system.process.cpu
+        - from: http.agent.beat.memstats.memory_sys
+          to: system.process.memory.size
+        - from: http.agent.beat.handles
+          to: system.process.fd
+        - from: http.agent.beat.cgroup
+          to: system.process.cgroup
+        - from: http.agent.apm-server
+          to: apm-server
+        - from: http.filebeat_input
+          to: filebeat_input
+        ignore_missing: true
+    - drop_fields:
+        fields:
+        - http
+        ignore_missing: true
+    - add_fields:
+        fields:
+          binary: filebeat
+          id: filestream-monitoring
+        target: component
+  - data_stream:
+      dataset: elastic_agent.filebeat_input
+      namespace: default
+      type: metrics
+    failure_threshold: 5
+    hosts:
+    - http+unix:///opt/Elastic/Agent/data/tmp/xTEtpJ7117ppc6OYvJCaYHbDW8mLjXGe.sock
+    id: metrics-monitoring-filebeat-1
+    index: metrics-elastic_agent.filebeat_input-default
+    json.is_array: true
+    metricsets:
+    - json
+    namespace: filebeat_input
+    path: /inputs/
+    period: 1m0s
+    processors:
+    - add_fields:
+        fields:
+          dataset: elastic_agent.filebeat_input
+        target: event
+    - add_fields:
+        fields:
+          id: ""
+          process: filebeat
+          snapshot: false
+          version: placeholder
+        target: elastic_agent
+    - add_fields:
+        fields:
+          id: ""
+        target: agent
+    - copy_fields:
+        fail_on_error: false
+        fields:
+        - from: http.agent.beat.cpu
+          to: system.process.cpu
+        - from: http.agent.beat.memstats.memory_sys
+          to: system.process.memory.size
+        - from: http.agent.beat.handles
+          to: system.process.fd
+        - from: http.agent.beat.cgroup
+          to: system.process.cgroup
+        - from: http.agent.apm-server
+          to: apm-server
+        - from: http.filebeat_input
+          to: filebeat_input
+        ignore_missing: true
+    - drop_fields:
+        fields:
+        - http
+        ignore_missing: true
+    - add_fields:
+        fields:
+          binary: filebeat
+          id: filestream-monitoring
+        target: component
+  - data_stream:
+      dataset: elastic_agent.elastic_agent
+      namespace: default
+      type: metrics
+    failure_threshold: 5
+    hosts:
+    - http+unix:///opt/Elastic/Agent/data/tmp/akSPbdqgaHaTY0_J01-dsfYK6JpMz2zn.sock
+    id: metrics-monitoring-metricbeat-1
+    index: metrics-elastic_agent.elastic_agent-default
+    metricsets:
+    - json
+    namespace: agent
+    path: /stats
+    period: 1m0s
+    processors:
+    - add_fields:
+        fields:
+          dataset: elastic_agent.elastic_agent
+        target: event
+    - add_fields:
+        fields:
+          id: ""
+          process: metricbeat
+          snapshot: false
+          version: placeholder
+        target: elastic_agent
+    - add_fields:
+        fields:
+          id: ""
+        target: agent
+    - copy_fields:
+        fail_on_error: false
+        fields:
+        - from: http.agent.beat.cpu
+          to: system.process.cpu
+        - from: http.agent.beat.memstats.memory_sys
+          to: system.process.memory.size
+        - from: http.agent.beat.handles
+          to: system.process.fd
+        - from: http.agent.beat.cgroup
+          to: system.process.cgroup
+        - from: http.agent.apm-server
+          to: apm-server
+        - from: http.filebeat_input
+          to: filebeat_input
+        ignore_missing: true
+    - drop_fields:
+        fields:
+        - http
+        ignore_missing: true
+    - add_fields:
+        fields:
+          binary: metricbeat
+          id: http/metrics-monitoring
+        target: component
+  type: http/metrics
+  use_output: monitoring
+- data_stream:
+    namespace: default
+  id: metrics-monitoring-endpoint_security
+  name: metrics-monitoring-endpoint_security
+  streams:
+  - data_stream:
+      dataset: elastic_agent.endpoint_security
+      namespace: default
+      type: metrics
+    id: metrics-monitoring-endpoint_security
+    index: metrics-elastic_agent.endpoint_security-default
+    metricsets:
+    - process
+    period: 1m0s
+    process.cgroups.enabled: false
+    process.pid: 1234
+    processors:
+    - add_fields:
+        fields:
+          dataset: elastic_agent.endpoint_security
+          namespace: default
+          type: metrics
+        target: data_stream
+    - add_fields:
+        fields:
+          dataset: elastic_agent.endpoint_security
+        target: event
+    - add_fields:
+        fields:
+          id: ""
+          process: endpoint_security
+          snapshot: false
+          version: placeholder
+        target: elastic_agent
+    - add_fields:
+        fields:
+          id: ""
+        target: agent
+    - add_fields:
+        fields:
+          binary: endpoint_security
+          id: endpoint-default
+        target: component
+  type: system/metrics
+  use_output: monitoring
+outputs:
+  monitoring: {}

--- a/internal/pkg/agent/application/monitoring/testdata/monitoring_config_full.yaml
+++ b/internal/pkg/agent/application/monitoring/testdata/monitoring_config_full.yaml
@@ -22,8 +22,7 @@ inputs:
         overwrite_keys: true
         target: ""
     paths:
-    - /opt/Elastic/Agent/data/elastic-agent-placeholder-unknow/logs/elastic-agent-*.ndjson
-    - /opt/Elastic/Agent/data/elastic-agent-placeholder-unknow/logs/elastic-agent-watcher-*.ndjson
+    - placeholder
     processors:
     - drop_event:
         when:
@@ -85,7 +84,7 @@ inputs:
         overwrite_keys: true
         target: ""
     paths:
-    - /var/log/endpoint.log
+    - placeholder
     processors:
     - add_fields:
         fields:
@@ -112,7 +111,7 @@ inputs:
       type: metrics
     failure_threshold: 5
     hosts:
-    - http+unix:///opt/Elastic/Agent/data/tmp/Hk6rvk9TDibMPcDvpl0jkLE-qDsHWVYL.sock
+    - placeholder
     id: metrics-monitoring-metricbeat
     index: metrics-elastic_agent.metricbeat-default
     metricsets:
@@ -151,7 +150,7 @@ inputs:
       type: metrics
     failure_threshold: 5
     hosts:
-    - http+unix:///opt/Elastic/Agent/data/tmp/o2aP56OJCFn3ykwxdcxCyFmFlZVurVZ9.sock
+    - placeholder
     id: metrics-monitoring-filebeat
     index: metrics-elastic_agent.filebeat-default
     metricsets:
@@ -190,7 +189,7 @@ inputs:
       type: metrics
     failure_threshold: 5
     hosts:
-    - http+unix:///opt/Elastic/Agent/data/tmp/xTEtpJ7117ppc6OYvJCaYHbDW8mLjXGe.sock
+    - placeholder
     id: metrics-monitoring-filebeat
     index: metrics-elastic_agent.filebeat-default
     metricsets:
@@ -229,7 +228,7 @@ inputs:
       type: metrics
     failure_threshold: 5
     hosts:
-    - http+unix:///opt/Elastic/Agent/data/tmp/akSPbdqgaHaTY0_J01-dsfYK6JpMz2zn.sock
+    - placeholder
     id: metrics-monitoring-metricbeat
     index: metrics-elastic_agent.metricbeat-default
     metricsets:
@@ -275,7 +274,7 @@ inputs:
       type: metrics
     failure_threshold: 5
     hosts:
-    - http://:0
+    - placeholder
     id: metrics-monitoring-agent
     index: metrics-elastic_agent.elastic_agent-default
     metricsets:
@@ -336,7 +335,7 @@ inputs:
       type: metrics
     failure_threshold: 5
     hosts:
-    - http+unix:///opt/Elastic/Agent/data/tmp/Hk6rvk9TDibMPcDvpl0jkLE-qDsHWVYL.sock
+    - placeholder
     id: metrics-monitoring-metricbeat-1
     index: metrics-elastic_agent.elastic_agent-default
     metricsets:
@@ -391,7 +390,7 @@ inputs:
       type: metrics
     failure_threshold: 5
     hosts:
-    - http+unix:///opt/Elastic/Agent/data/tmp/o2aP56OJCFn3ykwxdcxCyFmFlZVurVZ9.sock
+    - placeholder
     id: metrics-monitoring-filebeat-1
     index: metrics-elastic_agent.elastic_agent-default
     metricsets:
@@ -446,7 +445,7 @@ inputs:
       type: metrics
     failure_threshold: 5
     hosts:
-    - http+unix:///opt/Elastic/Agent/data/tmp/o2aP56OJCFn3ykwxdcxCyFmFlZVurVZ9.sock
+    - placeholder
     id: metrics-monitoring-filebeat-1
     index: metrics-elastic_agent.filebeat_input-default
     json.is_array: true
@@ -502,7 +501,7 @@ inputs:
       type: metrics
     failure_threshold: 5
     hosts:
-    - http+unix:///opt/Elastic/Agent/data/tmp/xTEtpJ7117ppc6OYvJCaYHbDW8mLjXGe.sock
+    - placeholder
     id: metrics-monitoring-filebeat-1
     index: metrics-elastic_agent.elastic_agent-default
     metricsets:
@@ -557,7 +556,7 @@ inputs:
       type: metrics
     failure_threshold: 5
     hosts:
-    - http+unix:///opt/Elastic/Agent/data/tmp/xTEtpJ7117ppc6OYvJCaYHbDW8mLjXGe.sock
+    - placeholder
     id: metrics-monitoring-filebeat-1
     index: metrics-elastic_agent.filebeat_input-default
     json.is_array: true
@@ -613,7 +612,7 @@ inputs:
       type: metrics
     failure_threshold: 5
     hosts:
-    - http+unix:///opt/Elastic/Agent/data/tmp/akSPbdqgaHaTY0_J01-dsfYK6JpMz2zn.sock
+    - placeholder
     id: metrics-monitoring-metricbeat-1
     index: metrics-elastic_agent.elastic_agent-default
     metricsets:

--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -7,12 +7,14 @@ package monitoring
 import (
 	"crypto/sha256"
 	"fmt"
+	"maps"
 	"math"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -708,7 +710,10 @@ func (b *BeatsMonitor) injectMetricsInput(
 		componentListWithMonitoring[k] = v
 	}
 
-	for unit, binaryName := range componentListWithMonitoring {
+	// ensure consistent ordering
+	unitIDs := slices.Sorted(maps.Keys(componentListWithMonitoring))
+	for _, unit := range unitIDs {
+		binaryName := componentListWithMonitoring[unit]
 		if !isSupportedMetricsBinary(binaryName) {
 			continue
 		}


### PR DESCRIPTION
## What does this PR do?

When generating the agent self-monitoring config, inputs were added by iterating over a map. This caused the output to be non-deterministic. This didn't have any effect on the logic, as input order doesn't have any effect on agent or beats behavior, but it would've resulted in some unnecessary configuration reloads.

I've also added a golden file test for the self-monitoring. This test enables as many options as possible and then checks the resulting configuration against a static file checked into the repository. This both makes it easier to understand what we generate, and makes future refactors (like the one in #7600) less risky.

## Why is it important?

Our configuration generation should be pure for a given environment. We should avoid unnecessary config reloading - this can be expensive in some environments, like Kubernetes.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Related issues

- Split out of #7600 

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
