### PR TITLE
Refactor self-monitoring metrics config generation

### DIFF
--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -616,89 +616,6 @@ func (b *BeatsMonitor) injectMetricsInput(
 		failureThreshold = &defaultValue
 	}
 	monitoringNamespace := b.monitoringNamespace()
-	fixedAgentName := strings.ReplaceAll(agentName, "-", "_")
-	// beatStreams and streams MUST be []interface{} even if in reality they are []map[string]interface{}:
-	// if those are declared as slices of maps the message "proto: invalid type: []map[string]interface{}" will pop up
-	beatsStreams := make([]interface{}, 0, len(componentIDToBinary))
-	streams := []interface{}{
-		map[string]interface{}{
-			idKey: fmt.Sprintf("%s-agent", monitoringMetricsUnitID),
-			"data_stream": map[string]interface{}{
-				"type":      "metrics",
-				"dataset":   fmt.Sprintf("elastic_agent.%s", fixedAgentName),
-				"namespace": monitoringNamespace,
-			},
-			"metricsets": []interface{}{"json"},
-			"path":       "/stats",
-			"hosts":      []interface{}{HttpPlusAgentMonitoringEndpoint(b.operatingSystem, b.config.C)},
-			"namespace":  "agent",
-			"period":     metricsCollectionIntervalString,
-			"index":      fmt.Sprintf("metrics-elastic_agent.%s-%s", fixedAgentName, monitoringNamespace),
-			"processors": []interface{}{
-				map[string]interface{}{
-					"add_fields": map[string]interface{}{
-						"target": "data_stream",
-						"fields": map[string]interface{}{
-							"type":      "metrics",
-							"dataset":   fmt.Sprintf("elastic_agent.%s", fixedAgentName),
-							"namespace": monitoringNamespace,
-						},
-					},
-				},
-				map[string]interface{}{
-					"add_fields": map[string]interface{}{
-						"target": "event",
-						"fields": map[string]interface{}{
-							"dataset": fmt.Sprintf("elastic_agent.%s", fixedAgentName),
-						},
-					},
-				},
-				map[string]interface{}{
-					"add_fields": map[string]interface{}{
-						"target": "elastic_agent",
-						"fields": map[string]interface{}{
-							"id":       b.agentInfo.AgentID(),
-							"version":  b.agentInfo.Version(),
-							"snapshot": b.agentInfo.Snapshot(),
-							"process":  "elastic-agent",
-						},
-					},
-				},
-				map[string]interface{}{
-					"add_fields": map[string]interface{}{
-						"target": "agent",
-						"fields": map[string]interface{}{
-							"id": b.agentInfo.AgentID(),
-						},
-					},
-				},
-				map[string]interface{}{
-					"copy_fields": map[string]interface{}{
-						"fields":         httpCopyRules(),
-						"ignore_missing": true,
-						"fail_on_error":  false,
-					},
-				},
-				map[string]interface{}{
-					"drop_fields": map[string]interface{}{
-						"fields": []interface{}{
-							"http",
-						},
-						"ignore_missing": true,
-					},
-				},
-				map[string]interface{}{
-					"add_fields": map[string]interface{}{
-						"target": "component",
-						"fields": map[string]interface{}{
-							"id":     "elastic-agent",
-							"binary": "elastic-agent",
-						},
-					},
-				},
-			},
-		},
-	}
 
 	//create a new map with the monitoring beats included
 	componentListWithMonitoring := map[string]string{
@@ -710,240 +627,10 @@ func (b *BeatsMonitor) injectMetricsInput(
 		componentListWithMonitoring[k] = v
 	}
 
-	// ensure consistent ordering
-	unitIDs := slices.Sorted(maps.Keys(componentListWithMonitoring))
-	for _, unit := range unitIDs {
-		binaryName := componentListWithMonitoring[unit]
-		if !isSupportedMetricsBinary(binaryName) {
-			continue
-		}
-
-		endpoints := []interface{}{prefixedEndpoint(utils.SocketURLWithFallback(unit, paths.TempDir()))}
-		name := strings.ReplaceAll(strings.ReplaceAll(binaryName, "-", "_"), "/", "_") // conform with index naming policy
-
-		if isSupportedBeatsBinary(binaryName) {
-			beatsStreams = append(beatsStreams, map[string]interface{}{
-				idKey: fmt.Sprintf("%s-", monitoringMetricsUnitID) + name,
-				"data_stream": map[string]interface{}{
-					"type":      "metrics",
-					"dataset":   fmt.Sprintf("elastic_agent.%s", name),
-					"namespace": monitoringNamespace,
-				},
-				"metricsets": []interface{}{"stats"},
-				"hosts":      endpoints,
-				"period":     metricsCollectionIntervalString,
-				"index":      fmt.Sprintf("metrics-elastic_agent.%s-%s", name, monitoringNamespace),
-				"processors": []interface{}{
-					map[string]interface{}{
-						"add_fields": map[string]interface{}{
-							"target": "data_stream",
-							"fields": map[string]interface{}{
-								"type":      "metrics",
-								"dataset":   fmt.Sprintf("elastic_agent.%s", name),
-								"namespace": monitoringNamespace,
-							},
-						},
-					},
-					map[string]interface{}{
-						"add_fields": map[string]interface{}{
-							"target": "event",
-							"fields": map[string]interface{}{
-								"dataset": fmt.Sprintf("elastic_agent.%s", name),
-							},
-						},
-					},
-					map[string]interface{}{
-						"add_fields": map[string]interface{}{
-							"target": "elastic_agent",
-							"fields": map[string]interface{}{
-								"id":       b.agentInfo.AgentID(),
-								"version":  b.agentInfo.Version(),
-								"snapshot": b.agentInfo.Snapshot(),
-								"process":  binaryName,
-							},
-						},
-					},
-					map[string]interface{}{
-						"add_fields": map[string]interface{}{
-							"target": "agent",
-							"fields": map[string]interface{}{
-								"id": b.agentInfo.AgentID(),
-							},
-						},
-					},
-					map[string]interface{}{
-						"add_fields": map[string]interface{}{
-							"target": "component",
-							"fields": map[string]interface{}{
-								"id":     unit,
-								"binary": binaryName,
-							},
-						},
-					},
-				},
-			})
-		}
-
-		streams = append(streams, map[string]interface{}{
-			idKey: fmt.Sprintf("%s-%s-1", monitoringMetricsUnitID, name),
-			"data_stream": map[string]interface{}{
-				"type":      "metrics",
-				"dataset":   fmt.Sprintf("elastic_agent.%s", fixedAgentName),
-				"namespace": monitoringNamespace,
-			},
-			"metricsets": []interface{}{"json"},
-			"hosts":      endpoints,
-			"path":       "/stats",
-			"namespace":  "agent",
-			"period":     metricsCollectionIntervalString,
-			"index":      fmt.Sprintf("metrics-elastic_agent.%s-%s", fixedAgentName, monitoringNamespace),
-			"processors": []interface{}{
-				map[string]interface{}{
-					"add_fields": map[string]interface{}{
-						"target": "event",
-						"fields": map[string]interface{}{
-							"dataset": fmt.Sprintf("elastic_agent.%s", fixedAgentName),
-						},
-					},
-				},
-				map[string]interface{}{
-					"add_fields": map[string]interface{}{
-						"target": "elastic_agent",
-						"fields": map[string]interface{}{
-							"id":       b.agentInfo.AgentID(),
-							"version":  b.agentInfo.Version(),
-							"snapshot": b.agentInfo.Snapshot(),
-							"process":  name,
-						},
-					},
-				},
-				map[string]interface{}{
-					"add_fields": map[string]interface{}{
-						"target": "agent",
-						"fields": map[string]interface{}{
-							"id": b.agentInfo.AgentID(),
-						},
-					},
-				},
-				map[string]interface{}{
-					"copy_fields": map[string]interface{}{
-						"fields":         httpCopyRules(),
-						"ignore_missing": true,
-						"fail_on_error":  false,
-					},
-				},
-				map[string]interface{}{
-					"drop_fields": map[string]interface{}{
-						"fields": []interface{}{
-							"http",
-						},
-						"ignore_missing": true,
-					},
-				},
-				map[string]interface{}{
-					"add_fields": map[string]interface{}{
-						"target": "component",
-						"fields": map[string]interface{}{
-							"id":     unit,
-							"binary": binaryName,
-						},
-					},
-				},
-			},
-		})
-
-		if strings.EqualFold(name, "filebeat") {
-			fbDataStreamName := "filebeat_input"
-			streams = append(streams, map[string]interface{}{
-				idKey: fmt.Sprintf("%s-%s-1", monitoringMetricsUnitID, name),
-				"data_stream": map[string]interface{}{
-					"type":      "metrics",
-					"dataset":   fmt.Sprintf("elastic_agent.%s", fbDataStreamName),
-					"namespace": monitoringNamespace,
-				},
-				"metricsets":    []interface{}{"json"},
-				"hosts":         endpoints,
-				"path":          "/inputs/",
-				"namespace":     fbDataStreamName,
-				"json.is_array": true,
-				"period":        metricsCollectionIntervalString,
-				"index":         fmt.Sprintf("metrics-elastic_agent.%s-%s", fbDataStreamName, monitoringNamespace),
-				"processors": []interface{}{
-					map[string]interface{}{
-						"add_fields": map[string]interface{}{
-							"target": "event",
-							"fields": map[string]interface{}{
-								"dataset": fmt.Sprintf("elastic_agent.%s", fbDataStreamName),
-							},
-						},
-					},
-					map[string]interface{}{
-						"add_fields": map[string]interface{}{
-							"target": "elastic_agent",
-							"fields": map[string]interface{}{
-								"id":       b.agentInfo.AgentID(),
-								"version":  b.agentInfo.Version(),
-								"snapshot": b.agentInfo.Snapshot(),
-								"process":  name,
-							},
-						},
-					},
-					map[string]interface{}{
-						"add_fields": map[string]interface{}{
-							"target": "agent",
-							"fields": map[string]interface{}{
-								"id": b.agentInfo.AgentID(),
-							},
-						},
-					},
-					map[string]interface{}{
-						"copy_fields": map[string]interface{}{
-							"fields":         httpCopyRules(),
-							"ignore_missing": true,
-							"fail_on_error":  false,
-						},
-					},
-					map[string]interface{}{
-						"drop_fields": map[string]interface{}{
-							"fields": []interface{}{
-								"http",
-							},
-							"ignore_missing": true,
-						},
-					},
-					map[string]interface{}{
-						"add_fields": map[string]interface{}{
-							"target": "component",
-							"fields": map[string]interface{}{
-								"id":     unit,
-								"binary": binaryName,
-							},
-						},
-					},
-				},
-			})
-		}
-
-	}
-
-	if failureThreshold != nil {
-		// add failure threshold to all streams and beatStreams
-		for _, s := range streams {
-			if streamMap, ok := s.(map[string]interface{}); ok {
-				streamMap[failureThresholdKey] = *failureThreshold
-			} else {
-				return fmt.Errorf("unable to set %s: %d in monitoring stream %q: unexpected type %T", failureThresholdKey, *failureThreshold, s, s)
-			}
-
-		}
-		for _, s := range beatsStreams {
-			if streamMap, ok := s.(map[string]interface{}); ok {
-				streamMap[failureThresholdKey] = *failureThreshold
-			} else {
-				return fmt.Errorf("unable to set %s: %d in monitoring stream %q: unexpected type %T", failureThresholdKey, *failureThreshold, s, s)
-			}
-		}
-	}
+	// beatStreams and streams MUST be []interface{} even if in reality they are []map[string]interface{}:
+	// if those are declared as slices of maps the message "proto: invalid type: []map[string]interface{}" will pop up
+	beatsStreams := b.getBeatsStreams(componentListWithMonitoring, failureThreshold, metricsCollectionIntervalString)
+	httpStreams := b.getHttpStreams(componentListWithMonitoring, failureThreshold, metricsCollectionIntervalString)
 
 	inputs := []interface{}{
 		map[string]interface{}{
@@ -964,92 +651,13 @@ func (b *BeatsMonitor) injectMetricsInput(
 			"data_stream": map[string]interface{}{
 				"namespace": monitoringNamespace,
 			},
-			"streams": streams,
+			"streams": httpStreams,
 		},
 	}
 
 	// add system/process metrics for services that can't be monitored via json/beats metrics
-	// If there's a checkin PID and the corresponding component has a service spec section, add a system/process config
-	for _, compState := range componentList {
-		if compState.InputSpec != nil && compState.InputSpec.Spec.Service != nil {
-			if comp, ok := existingStateServicePids[compState.ID]; ok && comp != 0 {
-				name := strings.ReplaceAll(strings.ReplaceAll(compState.BinaryName(), "-", "_"), "/", "_")
-				inputs = append(inputs, map[string]interface{}{
-					idKey:        fmt.Sprintf("%s-%s", monitoringMetricsUnitID, name),
-					"name":       fmt.Sprintf("%s-%s", monitoringMetricsUnitID, name),
-					"type":       "system/metrics",
-					useOutputKey: monitoringOutput,
-					"data_stream": map[string]interface{}{
-						"namespace": monitoringNamespace,
-					},
-					"streams": []interface{}{
-						map[string]interface{}{
-							idKey: fmt.Sprintf("%s-%s", monitoringMetricsUnitID, name),
-							"data_stream": map[string]interface{}{
-								"type":      "metrics",
-								"dataset":   fmt.Sprintf("elastic_agent.%s", name),
-								"namespace": monitoringNamespace,
-							},
-							"metricsets":              []interface{}{"process"},
-							"period":                  metricsCollectionIntervalString,
-							"index":                   fmt.Sprintf("metrics-elastic_agent.%s-%s", name, monitoringNamespace),
-							"process.pid":             comp,
-							"process.cgroups.enabled": false,
-							"processors": []interface{}{
-								map[string]interface{}{
-									"add_fields": map[string]interface{}{
-										"target": "data_stream",
-										"fields": map[string]interface{}{
-											"type":      "metrics",
-											"dataset":   fmt.Sprintf("elastic_agent.%s", name),
-											"namespace": monitoringNamespace,
-										},
-									},
-								},
-								map[string]interface{}{
-									"add_fields": map[string]interface{}{
-										"target": "event",
-										"fields": map[string]interface{}{
-											"dataset": fmt.Sprintf("elastic_agent.%s", name),
-										},
-									},
-								},
-								map[string]interface{}{
-									"add_fields": map[string]interface{}{
-										"target": "elastic_agent",
-										"fields": map[string]interface{}{
-											"id":       b.agentInfo.AgentID(),
-											"version":  b.agentInfo.Version(),
-											"snapshot": b.agentInfo.Snapshot(),
-											"process":  name,
-										},
-									},
-								},
-								map[string]interface{}{
-									"add_fields": map[string]interface{}{
-										"target": "agent",
-										"fields": map[string]interface{}{
-											"id": b.agentInfo.AgentID(),
-										},
-									},
-								},
-								map[string]interface{}{
-									"add_fields": map[string]interface{}{
-										"target": "component",
-										"fields": map[string]interface{}{
-											"binary": name,
-											"id":     compState.ID,
-										},
-									},
-								},
-							},
-						},
-					},
-				})
-			}
-
-		}
-	}
+	inputs = append(inputs, b.getServiceComponentProcessMetricInputs(
+		componentList, existingStateServicePids, metricsCollectionIntervalString)...)
 
 	inputsNode, found := cfg[inputsKey]
 	if !found {
@@ -1064,6 +672,341 @@ func (b *BeatsMonitor) injectMetricsInput(
 	inputsCfg = append(inputsCfg, inputs...)
 	cfg[inputsKey] = inputsCfg
 	return nil
+}
+
+// getHttpStreams returns stream definitions for http/metrics inputs.
+func (b *BeatsMonitor) getHttpStreams(
+	componentIDToBinary map[string]string,
+	failureThreshold *uint,
+	metricsCollectionIntervalString string,
+) []any {
+	monitoringNamespace := b.monitoringNamespace()
+	sanitizedAgentName := sanitizeName(agentName)
+	indexName := fmt.Sprintf("metrics-elastic_agent.%s-%s", sanitizedAgentName, monitoringNamespace)
+	dataset := fmt.Sprintf("elastic_agent.%s", sanitizedAgentName)
+	httpStreams := make([]any, 0, len(componentIDToBinary))
+
+	agentStream := map[string]any{
+		idKey: fmt.Sprintf("%s-agent", monitoringMetricsUnitID),
+		"data_stream": map[string]interface{}{
+			"type":      "metrics",
+			"dataset":   dataset,
+			"namespace": monitoringNamespace,
+		},
+		"metricsets": []interface{}{"json"},
+		"path":       "/stats",
+		"hosts":      []interface{}{HttpPlusAgentMonitoringEndpoint(b.operatingSystem, b.config.C)},
+		"namespace":  "agent",
+		"period":     metricsCollectionIntervalString,
+		"index":      indexName,
+		"processors": processorsForAgentHttpStream(monitoringNamespace, dataset, b.agentInfo),
+	}
+	if failureThreshold != nil {
+		agentStream[failureThresholdKey] = *failureThreshold
+	}
+	httpStreams = append(httpStreams, agentStream)
+
+	// ensure consistent ordering
+	unitIDs := slices.Sorted(maps.Keys(componentIDToBinary))
+	for _, unit := range unitIDs {
+		binaryName := componentIDToBinary[unit]
+		if !isSupportedMetricsBinary(binaryName) {
+			continue
+		}
+
+		endpoints := []interface{}{prefixedEndpoint(utils.SocketURLWithFallback(unit, paths.TempDir()))}
+		name := strings.ReplaceAll(strings.ReplaceAll(binaryName, "-", "_"), "/", "_") // conform with index naming policy
+
+		httpStream := map[string]interface{}{
+			idKey: fmt.Sprintf("%s-%s-1", monitoringMetricsUnitID, name),
+			"data_stream": map[string]interface{}{
+				"type":      "metrics",
+				"dataset":   dataset,
+				"namespace": monitoringNamespace,
+			},
+			"metricsets": []interface{}{"json"},
+			"hosts":      endpoints,
+			"path":       "/stats",
+			"namespace":  "agent",
+			"period":     metricsCollectionIntervalString,
+			"index":      indexName,
+			"processors": processorsForHttpStream(binaryName, unit, dataset, b.agentInfo),
+		}
+		if failureThreshold != nil {
+			httpStream[failureThresholdKey] = *failureThreshold
+		}
+		httpStreams = append(httpStreams, httpStream)
+
+		// specifically for filebeat, we include input metrics
+		if strings.EqualFold(name, "filebeat") {
+			fbDataStreamName := "filebeat_input"
+			fbDataset := fmt.Sprintf("elastic_agent.%s", fbDataStreamName)
+			fbIndexName := fmt.Sprintf("metrics-elastic_agent.%s-%s", fbDataStreamName, monitoringNamespace)
+			fbStream := map[string]any{
+				idKey: fmt.Sprintf("%s-%s-1", monitoringMetricsUnitID, name),
+				"data_stream": map[string]interface{}{
+					"type":      "metrics",
+					"dataset":   fbDataset,
+					"namespace": monitoringNamespace,
+				},
+				"metricsets":    []interface{}{"json"},
+				"hosts":         endpoints,
+				"path":          "/inputs/",
+				"namespace":     fbDataStreamName,
+				"json.is_array": true,
+				"period":        metricsCollectionIntervalString,
+				"index":         fbIndexName,
+				"processors":    processorsForHttpStream(binaryName, unit, fbDataset, b.agentInfo),
+			}
+			if failureThreshold != nil {
+				fbStream[failureThresholdKey] = *failureThreshold
+			}
+			httpStreams = append(httpStreams, fbStream)
+		}
+	}
+
+	return httpStreams
+}
+
+// getBeatsStreams returns stream definitions for beats inputs.
+func (b *BeatsMonitor) getBeatsStreams(
+	componentIDToBinary map[string]string,
+	failureThreshold *uint,
+	metricsCollectionIntervalString string,
+) []any {
+	monitoringNamespace := b.monitoringNamespace()
+	beatsStreams := make([]any, 0, len(componentIDToBinary))
+
+	// ensure consistent ordering
+	unitIDs := slices.Sorted(maps.Keys(componentIDToBinary))
+	for _, unit := range unitIDs {
+		binaryName := componentIDToBinary[unit]
+		if !isSupportedBeatsBinary(binaryName) {
+			continue
+		}
+
+		endpoints := []interface{}{prefixedEndpoint(utils.SocketURLWithFallback(unit, paths.TempDir()))}
+		name := strings.ReplaceAll(strings.ReplaceAll(binaryName, "-", "_"), "/", "_") // conform with index naming policy
+		dataset := fmt.Sprintf("elastic_agent.%s", name)
+		indexName := fmt.Sprintf("metrics-elastic_agent.%s-%s", name, monitoringNamespace)
+
+		beatsStream := map[string]interface{}{
+			idKey: fmt.Sprintf("%s-", monitoringMetricsUnitID) + name,
+			"data_stream": map[string]interface{}{
+				"type":      "metrics",
+				"dataset":   dataset,
+				"namespace": monitoringNamespace,
+			},
+			"metricsets": []interface{}{"stats"},
+			"hosts":      endpoints,
+			"period":     metricsCollectionIntervalString,
+			"index":      indexName,
+			"processors": processorsForBeatsStream(binaryName, unit, monitoringNamespace, dataset, b.agentInfo),
+		}
+
+		if failureThreshold != nil {
+			beatsStream[failureThresholdKey] = *failureThreshold
+		}
+
+		beatsStreams = append(beatsStreams, beatsStream)
+	}
+
+	return beatsStreams
+}
+
+// getServiceComponentProcessMetricInputs returns input definitions for collecting process metrics of components
+// running as services.
+func (b *BeatsMonitor) getServiceComponentProcessMetricInputs(
+	components []component.Component,
+	existingStateServicePids map[string]uint64,
+	metricsCollectionIntervalString string,
+) []any {
+	monitoringNamespace := b.monitoringNamespace()
+	inputs := []any{}
+	for _, comp := range components {
+		if comp.InputSpec == nil || comp.InputSpec.Spec.Service == nil {
+			continue
+		}
+		compPid, ok := existingStateServicePids[comp.ID]
+		if !ok || compPid == 0 {
+			continue
+		}
+		// If there's a checkin PID and the corresponding component has a service spec section, add a system/process config
+		name := sanitizeName(comp.BinaryName())
+		dataset := fmt.Sprintf("elastic_agent.%s", name)
+		input := map[string]interface{}{
+			idKey:        fmt.Sprintf("%s-%s", monitoringMetricsUnitID, name),
+			"name":       fmt.Sprintf("%s-%s", monitoringMetricsUnitID, name),
+			"type":       "system/metrics",
+			useOutputKey: monitoringOutput,
+			"data_stream": map[string]interface{}{
+				"namespace": monitoringNamespace,
+			},
+			"streams": []interface{}{
+				map[string]interface{}{
+					idKey: fmt.Sprintf("%s-%s", monitoringMetricsUnitID, name),
+					"data_stream": map[string]interface{}{
+						"type":      "metrics",
+						"dataset":   dataset,
+						"namespace": monitoringNamespace,
+					},
+					"metricsets":              []interface{}{"process"},
+					"period":                  metricsCollectionIntervalString,
+					"index":                   fmt.Sprintf("metrics-elastic_agent.%s-%s", name, monitoringNamespace),
+					"process.pid":             compPid,
+					"process.cgroups.enabled": false,
+					"processors":              processorsForProcessMetrics(name, comp.ID, monitoringNamespace, dataset, b.agentInfo),
+				},
+			},
+		}
+		inputs = append(inputs, input)
+	}
+	return inputs
+}
+
+// processorsForProcessMetrics returns processors used for process metrics.
+func processorsForProcessMetrics(binaryName, unitID, namespace, dataset string, agentInfo info.Agent) []any {
+	return []any{
+		addDataStreamFieldsProcessor(dataset, namespace),
+		addEventFieldsProcessor(dataset),
+		addElasticAgentFieldsProcessor(binaryName, agentInfo),
+		addAgentFieldsProcessor(agentInfo.AgentID()),
+		addComponentFieldsProcessor(binaryName, unitID),
+	}
+}
+
+// processorsForBeatsStream returns the processors used for metric streams in the beats input.
+func processorsForBeatsStream(binaryName, unitID, namespace, dataset string, agentInfo info.Agent) []any {
+	return []any{
+		addDataStreamFieldsProcessor(dataset, namespace),
+		addEventFieldsProcessor(dataset),
+		addElasticAgentFieldsProcessor(binaryName, agentInfo),
+		addAgentFieldsProcessor(agentInfo.AgentID()),
+		addComponentFieldsProcessor(binaryName, unitID),
+	}
+}
+
+// processorsForBeatsStream returns the processors used for metric streams in the beats input.
+func processorsForHttpStream(binaryName, unitID, dataset string, agentInfo info.Agent) []any {
+	sanitizedName := sanitizeName(binaryName)
+	return []interface{}{
+		addEventFieldsProcessor(dataset),
+		addElasticAgentFieldsProcessor(sanitizedName, agentInfo),
+		addAgentFieldsProcessor(agentInfo.AgentID()),
+		map[string]interface{}{
+			"copy_fields": map[string]interface{}{
+				"fields":         httpCopyRules(),
+				"ignore_missing": true,
+				"fail_on_error":  false,
+			},
+		},
+		map[string]interface{}{
+			"drop_fields": map[string]interface{}{
+				"fields": []interface{}{
+					"http",
+				},
+				"ignore_missing": true,
+			},
+		},
+		addComponentFieldsProcessor(binaryName, unitID),
+	}
+}
+
+// processorsForAgentHttpStream returns the processors used for the agent metric stream in the beats input.
+func processorsForAgentHttpStream(namespace, dataset string, agentInfo info.Agent) []any {
+	return []interface{}{
+		addDataStreamFieldsProcessor(dataset, namespace),
+		addEventFieldsProcessor(dataset),
+		addElasticAgentFieldsProcessor(agentName, agentInfo),
+		addAgentFieldsProcessor(agentInfo.AgentID()),
+		map[string]interface{}{
+			"copy_fields": map[string]interface{}{
+				"fields":         httpCopyRules(),
+				"ignore_missing": true,
+				"fail_on_error":  false,
+			},
+		},
+		map[string]interface{}{
+			"drop_fields": map[string]interface{}{
+				"fields": []interface{}{
+					"http",
+				},
+				"ignore_missing": true,
+			},
+		},
+		addComponentFieldsProcessor(agentName, agentName),
+	}
+}
+
+// addElasticAgentFieldsProcessor returns a processor definition that adds agent information in an `elastic_agent` field.
+func addElasticAgentFieldsProcessor(binaryName string, agentInfo info.Agent) map[string]any {
+	return map[string]any{
+		"add_fields": map[string]any{
+			"target": "elastic_agent",
+			"fields": map[string]any{
+				"id":       agentInfo.AgentID(),
+				"version":  agentInfo.Version(),
+				"snapshot": agentInfo.Snapshot(),
+				"process":  binaryName,
+			},
+		},
+	}
+}
+
+// addAgentFieldsProcessor returns a processor definition that adds the agent ID under an `agent.id` field.
+func addAgentFieldsProcessor(agentID string) map[string]any {
+	return map[string]interface{}{
+		"add_fields": map[string]interface{}{
+			"target": "agent",
+			"fields": map[string]interface{}{
+				"id": agentID,
+			},
+		},
+	}
+}
+
+// addComponentFieldsProcessor returns a processor definition that adds component information.
+func addComponentFieldsProcessor(binaryName, unitID string) map[string]any {
+	return map[string]interface{}{
+		"add_fields": map[string]interface{}{
+			"target": "component",
+			"fields": map[string]interface{}{
+				"id":     unitID,
+				"binary": binaryName,
+			},
+		},
+	}
+}
+
+// addDataStreamFieldsProcessor returns a processor definition that adds datastream information.
+func addDataStreamFieldsProcessor(dataset, namespace string) map[string]any {
+	return map[string]interface{}{
+		"add_fields": map[string]interface{}{
+			"target": "data_stream",
+			"fields": map[string]interface{}{
+				"type":      "metrics",
+				"dataset":   dataset,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+// addEventFieldsProcessor returns a processor definition that adds an `event.dataset` field.
+func addEventFieldsProcessor(dataset string) map[string]any {
+	return map[string]interface{}{
+		"add_fields": map[string]interface{}{
+			"target": "event",
+			"fields": map[string]interface{}{
+				"dataset": dataset,
+			},
+		},
+	}
+}
+
+// sanitizeName sanitizes the input name to make it a valid part of ES index names.
+func sanitizeName(name string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(name, "-", "_"), "/", "_")
 }
 
 func loggingPath(id, operatingSystem string) string {


### PR DESCRIPTION
## What does this PR do?

Refactor how metrics input configuration is generated for agent self-monitoring. This was primarily focused on readability. Assembling the configuration involved handling large maps of parameters, which are quite unwieldy to deal with in Go code.

* The configuration is now assembled from pieces returned by smaller functions, making it much easier to see the overarching logic.
* There is much less nesting, making the code more readable.
* Generating processor configuration was moved to individual functions, which are now reused across different streams and inputs.

This PR covers the metrics part of #7600. The logs part will be covered in a follow-up.

## Why is it important?

The code is a lot more readable after this change. This will also make subsequent changes adding support for beats receivers smaller and easier to understand.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/3517 https://github.com/elastic/ingest-dev/issues/5118
- Split out from #7600.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
