### PR TITLE
Dynamically set go version in test

### DIFF
--- a/pkg/testing/runner/runner_test.go
+++ b/pkg/testing/runner/runner_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/elastic-agent/dev-tools/mage"
 	"github.com/elastic/elastic-agent/pkg/testing/common"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 )
@@ -24,11 +25,14 @@ func TestNewRunner_Clean(t *testing.T) {
 	err := os.MkdirAll(stateDir, 0755)
 	require.NoError(t, err)
 
+	goVersion, err := mage.GoVersion()
+	require.NoError(t, err)
+
 	cfg := common.Config{
 		AgentVersion: "8.10.0",
 		StackVersion: "8.10.0-SNAPSHOT",
 		BuildDir:     filepath.Join(tmpdir, "build"),
-		GOVersion:    "1.24.0",
+		GOVersion:    goVersion,
 		RepoDir:      filepath.Join(tmpdir, "repo"),
 		StateDir:     stateDir,
 		ExtraEnv:     nil,


### PR DESCRIPTION
Otherwise the version hardcoded in the test is missed by automated Go version bump PRs like https://github.com/elastic/elastic-agent/pull/7736.