### PR TITLE
[Helm] fix preset outputs

### DIFF
--- a/deploy/helm/elastic-agent/examples/kubernetes-custom-output/README.md
+++ b/deploy/helm/elastic-agent/examples/kubernetes-custom-output/README.md
@@ -1,0 +1,39 @@
+# Example: Kubernetes Integration with default chart values
+
+In this example we install the built-in `kubernetes` integration with the default built-in values and a different agent output, named `test`.
+
+## Prerequisites:
+1. Build the dependencies of the Helm chart
+    ```console
+    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    helm dependency build ../../
+    ```
+2. A k8s secret that contains the connection details to an Elasticsearch cluster, such as the URL and the API key ([Kibana - Creating API Keys](https://www.elastic.co/guide/en/kibana/current/api-keys.html)):
+    ```console
+    kubectl create secret generic es-api-secret \
+       --from-literal=api_key=... \
+       --from-literal=url=...
+    ```
+
+3. `kubernetes` integration assets installed through Kibana ([Kibana - Install and uninstall Elastic Agent integration assets](https://www.elastic.co/guide/en/fleet/current/install-uninstall-integration-assets.html))
+
+## Run:
+```console
+helm install elastic-agent ../../ \
+     -f ./agent-kubernetes-values.yaml \
+     --set outputs.test.type=ESSecretAuthAPI \
+     --set outputs.test.secretName=es-api-secret \
+     --set agent.presets.perNode.agent.monitoring.use_output=test \
+     --set agent.presets.clusterWide.agent.monitoring.use_output=test \
+     --set kubernetes.output=test
+```
+
+## Validate:
+
+1. `kube-state metrics` is installed with this command `kubectl get deployments -n kube-system kube-state-metrics`.
+2. The Kibana `kubernetes`-related dashboards should start showing up the respective info.
+3. Kubernetes data ship to the Elasticsearch cluster of the `test` output.
+
+## Note:
+
+1. If you want to disable kube-state-metrics installation with the elastic-agent Helm chart, you can set `kube-state-metrics.enabled=false` in the Helm chart. The helm chart will use the value of `kubernetes.state.host` to configure the elastic-agent input.

--- a/deploy/helm/elastic-agent/examples/kubernetes-custom-output/agent-kubernetes-values.yaml
+++ b/deploy/helm/elastic-agent/examples/kubernetes-custom-output/agent-kubernetes-values.yaml
@@ -1,0 +1,21 @@
+kubernetes:
+  enabled: true
+  output: test
+  namespace: test
+
+outputs:
+  test:
+    type: ESSecretAuthAPI
+    secretName: es-api-secret
+
+agent:
+  unprivileged: true
+  presets:
+    perNode:
+      agent:
+        monitoring:
+          use_output: test
+    clusterWide:
+      agent:
+        monitoring:
+          use_output: test

--- a/deploy/helm/elastic-agent/examples/kubernetes-custom-output/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/kubernetes-custom-output/rendered/manifest.yaml
@@ -1,0 +1,1149 @@
+---
+# Source: elastic-agent/charts/kube-state-metrics/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.15.0"
+  name: kube-state-metrics
+  namespace: default
+---
+# Source: elastic-agent/templates/agent/service-account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-clusterwide-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+---
+# Source: elastic-agent/templates/agent/service-account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-pernode-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+---
+# Source: elastic-agent/templates/agent/k8s/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agent-clusterwide-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+stringData:
+
+  agent.yml: |-
+    id: agent-clusterwide-example
+    outputs:
+      test:
+        api_key: ${OUTPUT_TEST_API_KEY}
+        hosts:
+        - ${OUTPUT_TEST_URL}
+        type: elasticsearch
+    secret_references: []
+    agent:
+      monitoring:
+        enabled: true
+        logs: true
+        metrics: true
+        namespace: default
+        use_output: test
+    inputs:
+      - data_stream:
+          namespace: test
+        id: kubernetes/metrics-kubernetes.apiserver
+        streams:
+        - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.apiserver
+            type: metrics
+          hosts:
+          - https://${env.KUBERNETES_SERVICE_HOST}:${env.KUBERNETES_SERVICE_PORT}
+          id: kubernetes/metrics-kubernetes.apiserver
+          metricsets:
+          - apiserver
+          period: 30s
+          ssl.certificate_authorities:
+          - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        type: kubernetes/metrics
+        use_output: test
+      - data_stream:
+          namespace: test
+        id: kube-state-metrics-kubernetes/metrics
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_container
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_container
+          metricsets:
+          - state_container
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_cronjob
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_cronjob
+          metricsets:
+          - state_cronjob
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_daemonset
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_daemonset
+          metricsets:
+          - state_daemonset
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_deployment
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_deployment
+          metricsets:
+          - state_deployment
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_job
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_job
+          metricsets:
+          - state_job
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_namespace
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_namespace
+          metricsets:
+          - state_namespace
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_node
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_node
+          metricsets:
+          - state_node
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_persistentvolumeclaim
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_persistentvolumeclaim
+          metricsets:
+          - state_persistentvolumeclaim
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_persistentvolume
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_persistentvolume
+          metricsets:
+          - state_persistentvolume
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_pod
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_pod
+          metricsets:
+          - state_pod
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_replicaset
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_replicaset
+          metricsets:
+          - state_replicaset
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_resourcequota
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_resourcequota
+          metricsets:
+          - state_resourcequota
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_service
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_service
+          metricsets:
+          - state_service
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_statefulset
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_statefulset
+          metricsets:
+          - state_statefulset
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_storageclass
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_storageclass
+          metricsets:
+          - state_storageclass
+          period: 10s
+        type: kubernetes/metrics
+        use_output: test
+    providers:
+      kubernetes:
+        node: ${NODE_NAME}
+        scope: cluster
+      kubernetes_leaderelection:
+        enabled: true
+        leader_lease: example-clusterwide
+---
+# Source: elastic-agent/templates/agent/k8s/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agent-pernode-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+stringData:
+
+  agent.yml: |-
+    id: agent-pernode-example
+    outputs:
+      test:
+        api_key: ${OUTPUT_TEST_API_KEY}
+        hosts:
+        - ${OUTPUT_TEST_URL}
+        type: elasticsearch
+    secret_references: []
+    agent:
+      monitoring:
+        enabled: true
+        logs: true
+        metrics: true
+        namespace: default
+        use_output: test
+    inputs:
+      - data_stream:
+          namespace: test
+        id: filestream-container-logs
+        streams:
+        - data_stream:
+            dataset: kubernetes.container_logs
+            type: logs
+          id: kubernetes-container-logs-${kubernetes.pod.name}-${kubernetes.container.id}
+          parsers:
+          - container:
+              format: auto
+              stream: all
+          paths:
+          - /var/log/containers/*${kubernetes.container.id}.log
+          processors:
+          - add_fields:
+              fields:
+                annotations.elastic_co/dataset: ${kubernetes.annotations.elastic.co/dataset|""}
+                annotations.elastic_co/namespace: ${kubernetes.annotations.elastic.co/namespace|""}
+                annotations.elastic_co/preserve_original_event: ${kubernetes.annotations.elastic.co/preserve_original_event|""}
+              target: kubernetes
+          - drop_fields:
+              fields:
+              - kubernetes.annotations.elastic_co/dataset
+              ignore_missing: true
+              when:
+                equals:
+                  kubernetes.annotations.elastic_co/dataset: ""
+          - drop_fields:
+              fields:
+              - kubernetes.annotations.elastic_co/namespace
+              ignore_missing: true
+              when:
+                equals:
+                  kubernetes.annotations.elastic_co/namespace: ""
+          - drop_fields:
+              fields:
+              - kubernetes.annotations.elastic_co/preserve_original_event
+              ignore_missing: true
+              when:
+                equals:
+                  kubernetes.annotations.elastic_co/preserve_original_event: ""
+          - add_tags:
+              tags:
+              - preserve_original_event
+              when:
+                and:
+                - has_fields:
+                  - kubernetes.annotations.elastic_co/preserve_original_event
+                - regexp:
+                    kubernetes.annotations.elastic_co/preserve_original_event: ^(?i)true$
+          prospector.scanner.symlinks: true
+        type: filestream
+        use_output: test
+      - data_stream:
+          namespace: test
+        id: kubernetes/metrics-kubernetes.container
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.container
+            type: metrics
+          hosts:
+          - https://${env.NODE_NAME}:10250
+          id: kubernetes/metrics-kubernetes.container
+          metricsets:
+          - container
+          period: 10s
+          ssl.verification_mode: none
+        type: kubernetes/metrics
+        use_output: test
+      - data_stream:
+          namespace: test
+        id: kubernetes/metrics-kubernetes.node
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.node
+            type: metrics
+          hosts:
+          - https://${env.NODE_NAME}:10250
+          id: kubernetes/metrics-kubernetes.node
+          metricsets:
+          - node
+          period: 10s
+          ssl.verification_mode: none
+        type: kubernetes/metrics
+        use_output: test
+      - data_stream:
+          namespace: test
+        id: kubernetes/metrics-kubernetes.pod
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.pod
+            type: metrics
+          hosts:
+          - https://${env.NODE_NAME}:10250
+          id: kubernetes/metrics-kubernetes.pod
+          metricsets:
+          - pod
+          period: 10s
+          ssl.verification_mode: none
+        type: kubernetes/metrics
+        use_output: test
+      - data_stream:
+          namespace: test
+        id: kubernetes/metrics-kubernetes.system
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.system
+            type: metrics
+          hosts:
+          - https://${env.NODE_NAME}:10250
+          id: kubernetes/metrics-kubernetes.system
+          metricsets:
+          - system
+          period: 10s
+          ssl.verification_mode: none
+        type: kubernetes/metrics
+        use_output: test
+      - data_stream:
+          namespace: test
+        id: kubernetes/metrics-kubernetes.volume
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.volume
+            type: metrics
+          hosts:
+          - https://${env.NODE_NAME}:10250
+          id: kubernetes/metrics-kubernetes.volume
+          metricsets:
+          - volume
+          period: 10s
+          ssl.verification_mode: none
+        type: kubernetes/metrics
+        use_output: test
+    providers:
+      kubernetes:
+        node: ${NODE_NAME}
+        scope: node
+      kubernetes_leaderelection:
+        enabled: false
+        leader_lease: example-pernode
+---
+# Source: elastic-agent/charts/kube-state-metrics/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.15.0"
+  name: kube-state-metrics
+rules:
+
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - daemonsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - endpoints
+  verbs: ["list", "watch"]
+
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "networking.k8s.io"]
+  resources:
+  - ingresses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - limitranges
+  verbs: ["list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - mutatingwebhookconfigurations
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list", "watch"]
+
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - networkpolicies
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumeclaims
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumes
+  verbs: ["list", "watch"]
+
+- apiGroups: ["policy"]
+  resources:
+    - poddisruptionbudgets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - replicasets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - replicationcontrollers
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - resourcequotas
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - services
+  verbs: ["list", "watch"]
+
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - storageclasses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - validatingwebhookconfigurations
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - volumeattachments
+  verbs: ["list", "watch"]
+---
+# Source: elastic-agent/templates/agent/cluster-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-clusterWide-example-default
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+rules:
+  - apiGroups: [ "" ] # "" indicates the core API group
+    resources:
+      - nodes
+      - namespaces
+      - events
+      - pods
+      - services
+      - configmaps
+      - persistentvolumes
+      - persistentvolumeclaims
+      - persistentvolumeclaims/status
+      - nodes/metrics
+      - nodes/proxy
+      - nodes/stats
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - watch
+      - list
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups: [ "coordination.k8s.io" ]
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - nonResourceURLs:
+      - /healthz
+      - /healthz/*
+      - /livez
+      - /livez/*
+      - /metrics
+      - /metrics/slis
+      - /readyz
+      - /readyz/*
+    verbs:
+      - get
+  - apiGroups: [ "apps" ]
+    resources:
+      - replicasets
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [ "batch" ]
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: elastic-agent/templates/agent/cluster-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-perNode-example-default
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+rules:
+  - apiGroups: [ "" ] # "" indicates the core API group
+    resources:
+      - nodes
+      - namespaces
+      - events
+      - pods
+      - services
+      - configmaps
+      - persistentvolumes
+      - persistentvolumeclaims
+      - persistentvolumeclaims/status
+      - nodes/metrics
+      - nodes/proxy
+      - nodes/stats
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - watch
+      - list
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups: [ "coordination.k8s.io" ]
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - nonResourceURLs:
+      - /healthz
+      - /healthz/*
+      - /livez
+      - /livez/*
+      - /metrics
+      - /metrics/slis
+      - /readyz
+      - /readyz/*
+    verbs:
+      - get
+  - apiGroups: [ "apps" ]
+    resources:
+      - replicasets
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [ "batch" ]
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: elastic-agent/charts/kube-state-metrics/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.15.0"
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: default
+---
+# Source: elastic-agent/templates/agent/cluster-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-clusterWide-example-default
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+subjects:
+  - kind: ServiceAccount
+    name: agent-clusterwide-example
+    namespace: "default"
+roleRef:
+  kind: ClusterRole
+  name: agent-clusterWide-example-default
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: elastic-agent/templates/agent/cluster-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-perNode-example-default
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+subjects:
+  - kind: ServiceAccount
+    name: agent-pernode-example
+    namespace: "default"
+roleRef:
+  kind: ClusterRole
+  name: agent-perNode-example-default
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: elastic-agent/charts/kube-state-metrics/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: default
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.15.0"
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  type: "ClusterIP"
+  ports:
+  - name: "http"
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
+  
+  selector:    
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+---
+# Source: elastic-agent/templates/agent/k8s/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: agent-pernode-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+spec:
+  selector:
+    matchLabels:
+      name: agent-pernode-example
+  template:
+    metadata:
+      labels:
+        name: agent-pernode-example
+      annotations:
+        checksum/config: f18383bf5543384882a575ac14e8671dedaa0d3adb0aad8c0d7985d92fc0209b
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - -c
+        - /etc/elastic-agent/agent.yml
+        - -e
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: STATE_PATH
+          value: /usr/share/elastic-agent/state
+        - name: ELASTIC_NETINFO
+          value: "false"
+        - name: OUTPUT_TEST_URL
+          valueFrom:
+            secretKeyRef:
+              key: url
+              name: es-api-secret
+        - name: OUTPUT_TEST_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: api_key
+              name: es-api-secret
+        image: docker.elastic.co/elastic-agent/elastic-agent:9.1.0-SNAPSHOT
+        imagePullPolicy: IfNotPresent
+        name: agent
+        resources:
+          limits:
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 400Mi
+        securityContext:
+          capabilities:
+            add:
+            - DAC_READ_SEARCH
+            - CHOWN
+            - SETPCAP
+            - SYS_PTRACE
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 1000
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /var/lib/docker/containers
+          name: varlibdockercontainers
+          readOnly: true
+        - mountPath: /var/log
+          name: varlog
+          readOnly: true
+        - mountPath: /usr/share/elastic-agent/state
+          name: agent-data
+        - mountPath: /etc/elastic-agent/agent.yml
+          name: config
+          readOnly: true
+          subPath: agent.yml
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: agent-pernode-example
+      volumes:
+      - hostPath:
+          path: /var/lib/docker/containers
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/log
+        name: varlog
+      - hostPath:
+          path: /etc/elastic-agent/default/agent-pernode-example/state
+          type: DirectoryOrCreate
+        name: agent-data
+      - name: config
+        secret:
+          defaultMode: 292
+          secretName: agent-pernode-example
+---
+# Source: elastic-agent/charts/kube-state-metrics/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: default
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.15.0"
+spec:
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/instance: example
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  revisionHistoryLimit: 10
+  template:
+    metadata:
+      labels:        
+        helm.sh/chart: kube-state-metrics-5.30.1
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: metrics
+        app.kubernetes.io/part-of: kube-state-metrics
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/version: "2.15.0"
+    spec:
+      automountServiceAccountToken: true
+      hostNetwork: false
+      serviceAccountName: kube-state-metrics
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: kube-state-metrics
+        args:
+        - --port=8080
+        - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
+        imagePullPolicy: IfNotPresent
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
+        ports:
+        - containerPort: 8080
+          name: "http"
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            httpHeaders:
+            path: /livez
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            httpHeaders:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+---
+# Source: elastic-agent/templates/agent/k8s/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-clusterwide-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+spec:
+  selector:
+    matchLabels:
+      name: agent-clusterwide-example
+  template:
+    metadata:
+      labels:
+        name: agent-clusterwide-example
+      annotations:
+        checksum/config: c1519a2e5309ae18b80d55aa0325eafb403c7c9c549d967984507948a7bd3efc
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - -c
+        - /etc/elastic-agent/agent.yml
+        - -e
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: STATE_PATH
+          value: /usr/share/elastic-agent/state
+        - name: ELASTIC_NETINFO
+          value: "false"
+        - name: OUTPUT_TEST_URL
+          valueFrom:
+            secretKeyRef:
+              key: url
+              name: es-api-secret
+        - name: OUTPUT_TEST_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: api_key
+              name: es-api-secret
+        image: docker.elastic.co/elastic-agent/elastic-agent:9.1.0-SNAPSHOT
+        imagePullPolicy: IfNotPresent
+        name: agent
+        resources:
+          limits:
+            memory: 800Mi
+          requests:
+            cpu: 100m
+            memory: 400Mi
+        securityContext:
+          capabilities:
+            add:
+            - CHOWN
+            - SETPCAP
+            - DAC_READ_SEARCH
+            - SYS_PTRACE
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 1000
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /usr/share/elastic-agent/state
+          name: agent-data
+        - mountPath: /etc/elastic-agent/agent.yml
+          name: config
+          readOnly: true
+          subPath: agent.yml
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: agent-clusterwide-example
+      volumes:
+      - emptyDir: {}
+        name: agent-data
+      - name: config
+        secret:
+          defaultMode: 292
+          secretName: agent-clusterwide-example

--- a/deploy/helm/elastic-agent/templates/agent/_helpers.tpl
+++ b/deploy/helm/elastic-agent/templates/agent/_helpers.tpl
@@ -28,10 +28,13 @@ Entrypoint for chart initialisation
 */}}
 {{- define "elasticagent.init" -}}
 {{- if not (hasKey $.Values.agent "initialised") -}}
-{{/* init order matters */}}
+{{/* !!! init order matters !!! */}}
 {{- include (printf "elasticagent.engine.%s.init" $.Values.agent.engine) $ -}}
+{{/* initialise inputs to hydrate the correct presets according to what is enabled */}}
 {{- include "elasticagent.init.inputs" $ -}}
+{{/* initialise fleet to remove any irrelevant preset and load the certificate settings */}}
 {{- include "elasticagent.init.fleet" $ -}}
+{{/* initialise presets to set correctly default values in them */}}
 {{- include "elasticagent.init.presets" $ -}}
 {{- $_ := set $.Values.agent "initialised" dict -}}
 {{- end -}}

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_apiserver.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_apiserver.tpl
@@ -3,6 +3,7 @@
 {{- $preset := $.Values.agent.presets.clusterWide -}}
 {{- $inputVal := (include "elasticagent.kubernetes.config.kube_apiserver.input" $ | fromYamlArray) -}}
 {{- include "elasticagent.preset.mutate.inputs" (list $ $preset $inputVal) -}}
+{{- include "elasticagent.preset.mutate.outputs.byname" (list $ $preset $.Values.kubernetes.output) -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_controller_manager.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_controller_manager.tpl
@@ -3,6 +3,7 @@
 {{- $preset := $.Values.agent.presets.perNode -}}
 {{- $inputVal := (include "elasticagent.kubernetes.config.kube_controller.input" $ | fromYamlArray) -}}
 {{- include "elasticagent.preset.mutate.inputs" (list $ $preset $inputVal) -}}
+{{- include "elasticagent.preset.mutate.outputs.byname" (list $ $preset $.Values.kubernetes.output) -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_containers.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_containers.tpl
@@ -6,6 +6,7 @@
 {{- $preset := $.Values.agent.presets.perNode -}}
 {{- $inputVal := (include "elasticagent.kubernetes.config.kubelet.containers.input" $ | fromYamlArray) -}}
 {{- include "elasticagent.preset.mutate.inputs" (list $ $preset $inputVal) -}}
+{{- include "elasticagent.preset.mutate.outputs.byname" (list $ $preset $.Values.kubernetes.output) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_nodes.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_nodes.tpl
@@ -6,6 +6,7 @@
 {{- $preset := $.Values.agent.presets.perNode -}}
 {{- $inputVal := (include "elasticagent.kubernetes.config.kubelet.nodes.input" $ | fromYamlArray) -}}
 {{- include "elasticagent.preset.mutate.inputs" (list $ $preset $inputVal) -}}
+{{- include "elasticagent.preset.mutate.outputs.byname" (list $ $preset $.Values.kubernetes.output) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_pods.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_pods.tpl
@@ -6,6 +6,7 @@
 {{- $preset := $.Values.agent.presets.perNode -}}
 {{- $inputVal := (include "elasticagent.kubernetes.config.kubelet.pods.input" $ | fromYamlArray) -}}
 {{- include "elasticagent.preset.mutate.inputs" (list $ $preset $inputVal) -}}
+{{- include "elasticagent.preset.mutate.outputs.byname" (list $ $preset $.Values.kubernetes.output) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_system.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_system.tpl
@@ -6,6 +6,7 @@
 {{- $preset := $.Values.agent.presets.perNode -}}
 {{- $inputVal := (include "elasticagent.kubernetes.config.kubelet.system.input" $ | fromYamlArray) -}}
 {{- include "elasticagent.preset.mutate.inputs" (list $ $preset $inputVal) -}}
+{{- include "elasticagent.preset.mutate.outputs.byname" (list $ $preset $.Values.kubernetes.output) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_volumes.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_volumes.tpl
@@ -6,6 +6,7 @@
 {{- $preset := $.Values.agent.presets.perNode -}}
 {{- $inputVal := (include "elasticagent.kubernetes.config.kubelet.volumes.input" $ | fromYamlArray) -}}
 {{- include "elasticagent.preset.mutate.inputs" (list $ $preset $inputVal) -}}
+{{- include "elasticagent.preset.mutate.outputs.byname" (list $ $preset $.Values.kubernetes.output) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_logs_audit.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_logs_audit.tpl
@@ -3,6 +3,7 @@
 {{- $preset := $.Values.agent.presets.perNode -}}
 {{- $inputVal := (include "elasticagent.kubernetes.config.audit_logs.input" $ | fromYamlArray) -}}
 {{- include "elasticagent.preset.mutate.inputs" (list $ $preset $inputVal) -}}
+{{- include "elasticagent.preset.mutate.outputs.byname" (list $ $preset $.Values.kubernetes.output) -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_logs_containers.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_logs_containers.tpl
@@ -3,6 +3,7 @@
 {{- $preset := $.Values.agent.presets.perNode -}}
 {{- $inputVal := (include "elasticagent.kubernetes.config.container_logs.input" $ | fromYamlArray) -}}
 {{- include "elasticagent.preset.mutate.inputs" (list $ $preset $inputVal) -}}
+{{- include "elasticagent.preset.mutate.outputs.byname" (list $ $preset $.Values.kubernetes.output) -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_proxy.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_proxy.tpl
@@ -3,6 +3,7 @@
 {{- $preset := $.Values.agent.presets.perNode -}}
 {{- $inputVal := (include "elasticagent.kubernetes.config.kube_proxy.input" $ | fromYamlArray) -}}
 {{- include "elasticagent.preset.mutate.inputs" (list $ $preset $inputVal) -}}
+{{- include "elasticagent.preset.mutate.outputs.byname" (list $ $preset $.Values.kubernetes.output) -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_scheduler.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_scheduler.tpl
@@ -3,6 +3,7 @@
 {{- $preset := $.Values.agent.presets.perNode -}}
 {{- $inputVal := (include "elasticagent.kubernetes.config.kube_scheduler.input" $ | fromYamlArray) -}}
 {{- include "elasticagent.preset.mutate.inputs" (list $ $preset $inputVal) -}}
+{{- include "elasticagent.preset.mutate.outputs.byname" (list $ $preset $.Values.kubernetes.output) -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_state.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_state.tpl
@@ -3,6 +3,7 @@
 {{/* in standablone mode kube-state-metrics will be collected by the clusterWide preset */}}
 {{- with (include "elasticagent.kubernetes.config.state.input" $ | fromYamlArray) -}}
 {{- include "elasticagent.preset.mutate.inputs" (list $ $.Values.agent.presets.clusterWide .) -}}
+{{- include "elasticagent.preset.mutate.outputs.byname" (list $ $.Values.agent.presets.clusterWide $.Values.kubernetes.output) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/elastic-agent/templates/integrations/_system/_system_logs.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_system/_system_logs.tpl
@@ -4,6 +4,7 @@
 {{- $inputVal := (include "elasticagent.system.config.logs.input" $ | fromYaml) -}}
 {{- if ($inputVal).streams }}
 {{- include "elasticagent.preset.mutate.inputs" (list $ $preset (list $inputVal)) -}}
+{{- include "elasticagent.preset.mutate.outputs.byname" (list $ $preset $.Values.system.output) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/elastic-agent/templates/integrations/_system/_system_metrics.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_system/_system_metrics.tpl
@@ -3,6 +3,7 @@
 {{- $preset := $.Values.agent.presets.perNode -}}
 {{- $inputVal := (include "elasticagent.system.config.metrics.input" $ | fromYamlArray) -}}
 {{- include "elasticagent.preset.mutate.inputs" (list $ $preset $inputVal) -}}
+{{- include "elasticagent.preset.mutate.outputs.byname" (list $ $preset $.Values.system.output) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR fixes a bug where the `output` configuration for standalone agents and their integration presets was not respected when using the Helm chart.

### Fixes include:
- Ensuring that the appropriate output is assigned to each standalone preset in all relevant Kubernetes and system integration templates.
- Providing an example (`examples/kubernetes-custom-output`) to demonstrate correct usage with a custom output (`test`) and verifying output selection through `use_output`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without this fix, even if a user defines a different output and assigns it to specific integrations via Helm values, the configuration is silently ignored, and data may still be routed to the default output. This is particularly problematic in standalone mode, where fine-grained control of outputs is expected.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

This change is backward-compatible. Users who did not specify custom outputs will not be affected. Users relying on `use_output` in standalone mode will now see correct behavior.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Follow the newly introduced example `examples/kubernetes-custom-output`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
N/A
