### PR TITLE
[flaky] ignore os.IsNotExist in agent_paths_ownership_test.go

### DIFF
--- a/testing/kubernetes_inner/agent_paths_ownership_test.go
+++ b/testing/kubernetes_inner/agent_paths_ownership_test.go
@@ -24,11 +24,17 @@ func TestAgentPathsPermissions(t *testing.T) {
 
 	err := filepath.WalkDir("/usr/share/elastic-agent", func(walkPath string, d fs.DirEntry, err error) error {
 		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
 			return fmt.Errorf("failed to walk path %s: %w", walkPath, err)
 		}
 
 		info, err := d.Info()
 		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
 			return fmt.Errorf("failed to get info of path %s: %w", walkPath, err)
 		}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR updates the `TestAgentPathsPermissions` test in `agent_paths_ownership_test.go` to ignore `os.IsNotExist` errors when walking the `/usr/share/elastic-agent` directory.

Specifically, it ensures that transient or race-condition-related missing files (such as `.new` or `.tmp` files) during test execution do not cause test failures by returning `nil` when `os.IsNotExist(err)` is encountered, both during the walk and when retrieving file info.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This change addresses flakiness in the `TestKubernetesAgentStandaloneKustomize` integration test suite observed in CI builds. Ignoring `os.IsNotExist` errors makes the test more robust and aligns with the actual behaviour of the system, where such files may not exist by the time the test accesses them.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None. This is a fix to a test to avoid false negatives during CI runs and does not affect user-facing behaviour or agent functionality.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

N/A

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/7763
