### PR TITLE
Add nopexporter

### DIFF
--- a/changelog/fragments/1744198660-add-nopexporter.yaml
+++ b/changelog/fragments/1744198660-add-nopexporter.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add nopexporter to EDOT Collector
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/go.mod
+++ b/go.mod
@@ -134,6 +134,7 @@ require (
 	go.opentelemetry.io/collector/connector v0.121.0
 	go.opentelemetry.io/collector/exporter v0.121.0
 	go.opentelemetry.io/collector/exporter/debugexporter v0.121.0
+	go.opentelemetry.io/collector/exporter/nopexporter v0.121.0
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.121.0
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.121.0
 	go.opentelemetry.io/collector/extension v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -1681,6 +1681,8 @@ go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.121.0 h
 go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.121.0/go.mod h1:T9HNG2z0MPzfSJvDEFqgl0cc7gcZ50A7DHVbDVyGQR4=
 go.opentelemetry.io/collector/exporter/exportertest v0.121.0 h1:kjtZwZd0Mj5VZv3JGxuQBnqmfmOCcCdhpz0G4INd6o0=
 go.opentelemetry.io/collector/exporter/exportertest v0.121.0/go.mod h1:xGIi17/Ffteh308BRruHXVzq51o7wxYcUch0zXzyrqA=
+go.opentelemetry.io/collector/exporter/nopexporter v0.121.0 h1:sgEtYYqzrqLtyhRr1afnmcOG3Il2i6soY7GdYhqrCgw=
+go.opentelemetry.io/collector/exporter/nopexporter v0.121.0/go.mod h1:KHLzB4ahpYu1YD4RPnhEArzh0L7/NtV1W2U4bzKH/Xo=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.121.0 h1:vF9JaTm4VdxTPvwSpxjyh39NbH7jKjGlFmmplvHRnTA=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.121.0/go.mod h1:PPV7nVIWc9/cmItLt/bRUKrcdFY5bkpaUYXfAkXBhu4=
 go.opentelemetry.io/collector/exporter/otlphttpexporter v0.121.0 h1:2DjqdAFiCYWAWk011tAzXmKCZeAVa1u34GWIxHze1Mw=

--- a/internal/pkg/otel/README.md
+++ b/internal/pkg/otel/README.md
@@ -61,6 +61,7 @@ This section provides a summary of components included in the Elastic Distributi
 | [fileexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/exporter/fileexporter/v0.121.0/exporter/fileexporter/README.md) | v0.121.0 |
 | [kafkaexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/exporter/kafkaexporter/v0.121.0/exporter/kafkaexporter/README.md) | v0.121.0 |
 | [loadbalancingexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/exporter/loadbalancingexporter/v0.121.0/exporter/loadbalancingexporter/README.md) | v0.121.0 |
+| [nopexporter](https://github.com/open-telemetry/opentelemetry-collector/blob/exporter/nopexporter/v0.121.0/exporter/nopexporter/README.md) | v0.121.0 |
 | [otlpexporter](https://github.com/open-telemetry/opentelemetry-collector/blob/exporter/otlpexporter/v0.121.0/exporter/otlpexporter/README.md) | v0.121.0 |
 | [otlphttpexporter](https://github.com/open-telemetry/opentelemetry-collector/blob/exporter/otlphttpexporter/v0.121.0/exporter/otlphttpexporter/README.md) | v0.121.0 |
 

--- a/internal/pkg/otel/components.go
+++ b/internal/pkg/otel/components.go
@@ -51,6 +51,7 @@ import (
 	fileexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter" // for e2e tests
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
 	debugexporter "go.opentelemetry.io/collector/exporter/debugexporter" // for dev
+	nopexporter "go.opentelemetry.io/collector/exporter/nopexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	otlphttpexporter "go.opentelemetry.io/collector/exporter/otlphttpexporter"
 
@@ -126,6 +127,7 @@ func components(extensionFactories ...extension.Factory) func() (otelcol.Factori
 			elasticsearchexporter.NewFactory(),
 			loadbalancingexporter.NewFactory(),
 			otlphttpexporter.NewFactory(),
+			nopexporter.NewFactory(),
 		}
 		// some exporters should only be available when
 		// not in fips mode due to restrictions on crypto usage

--- a/internal/pkg/otel/manager/manager_test.go
+++ b/internal/pkg/otel/manager/manager_test.go
@@ -32,7 +32,7 @@ var (
 			"batch": map[string]interface{}{},
 		},
 		"exporters": map[string]interface{}{
-			"debug": map[string]interface{}{},
+			"nop": map[string]interface{}{},
 		},
 		"service": map[string]interface{}{
 			"telemetry": map[string]interface{}{
@@ -45,17 +45,17 @@ var (
 				"traces": map[string]interface{}{
 					"receivers":  []string{"nop"},
 					"processors": []string{"batch"},
-					"exporters":  []string{"debug"},
+					"exporters":  []string{"nop"},
 				},
 				"metrics": map[string]interface{}{
 					"receivers":  []string{"nop"},
 					"processors": []string{"batch"},
-					"exporters":  []string{"debug"},
+					"exporters":  []string{"nop"},
 				},
 				"logs": map[string]interface{}{
 					"receivers":  []string{"nop"},
 					"processors": []string{"batch"},
-					"exporters":  []string{"debug"},
+					"exporters":  []string{"nop"},
 				},
 			},
 		},

--- a/internal/pkg/otel/testdata/all-components.yml
+++ b/internal/pkg/otel/testdata/all-components.yml
@@ -9,6 +9,7 @@ exporters:
     endpoint: localhots:4317
   otlphttp:
     endpoint: https://localhost.com:4318
+  nop:
 
 extensions:
   health_check:
@@ -39,6 +40,7 @@ processors:
   elastictrace:
 
 receivers:
+  nop:
   filelog:
     include:
       - /filelog/path
@@ -97,6 +99,7 @@ service:
   pipelines:
     logs:
       exporters:
+        - nop
         - debug
         - elasticsearch
         - file
@@ -112,9 +115,11 @@ service:
       receivers:
         - filelog
         - otlp
+        - nop
 
     metrics:
       exporters:
+        - nop
         - debug
         - otlp
       processors:
@@ -126,6 +131,7 @@ service:
         - resourcedetection
         - transform
       receivers:
+        - nop
         - otlp
         - httpcheck
         - spanmetrics
@@ -141,6 +147,7 @@ service:
 
     traces:
       exporters:
+        - nop
         - debug
         - elasticsearch
         - otlp
@@ -156,6 +163,7 @@ service:
         - transform
         - elastictrace
       receivers:
+        - nop
         - otlp
         - jaeger
         - zipkin


### PR DESCRIPTION
## What does this PR do?

Adds the nopexporter component to EDOT. This is an exporter that drops all data sent to it. It only depends on otel core, so it doesn't pull in any new dependencies.

## Why is it important?
This exporter is useful for debugging, tests, and creating configurations which intentionally don't transmit any data, but do run extensions. 

We already include the nopreceiver, so we should include the exporter as well.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## How to test this PR locally

Build agent locally and run it using the following configuration

```
receivers:
  nop:
exporters:
  nop:
service:
  pipelines:
    logs:
      exporters: [nop]
      receivers: [nop]
```

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
