### PR TITLE
Correctly inject dependency list when packaging using DROP_PATH

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -1333,7 +1333,7 @@ func collectPackageDependencies(platforms []string, packageVersion string, packa
 			}
 		}
 	} else {
-		archivePath = movePackagesToArchive(dropPath, platforms, packageVersion, nil)
+		archivePath = movePackagesToArchive(dropPath, platforms, packageVersion, dependencies)
 	}
 	return archivePath, dropPath
 }
@@ -1875,7 +1875,10 @@ func movePackagesToArchive(dropPath string, platforms []string, packageVersion s
 			}
 
 			// Platform-independent packages need to be placed in the archive sub-folders for all platforms, copy instead of moving
-			if isPlatformIndependentPackage(f, packageVersion, nil) {
+			if isPlatformIndependentPackage(f, packageVersion, dependencies) {
+				if mg.Verbose() {
+					log.Printf("copying %s to %s as it is a platform independent package", f, packageVersion)
+				}
 				if err := copyFile(f, targetPath); err != nil {
 					panic(fmt.Errorf("failed copying file: %w", err))
 				}
@@ -1922,12 +1925,27 @@ func copyFile(src, dst string) error {
 
 func isPlatformIndependentPackage(f string, packageVersion string, dependencies []packaging.BinarySpec) bool {
 	fileBaseName := filepath.Base(f)
+	if mg.Verbose() {
+		log.Printf("isPlatformIndependentPackage(%s, %s, %v)", f, packageVersion, dependencies)
+	}
 	for _, spec := range dependencies {
+		if mg.Verbose() {
+			log.Printf("evaluating if %s is a platform independent package", f)
+		}
 		packageName := spec.GetPackageName(packageVersion, "")
 		// as of now only python wheels packages are platform-independent
+		if mg.Verbose() {
+			log.Printf("checking expected package name %s against actual file name %s", packageName, fileBaseName)
+		}
 		if spec.PythonWheel && (fileBaseName == packageName || fileBaseName == packageName+sha512FileExt) {
+			if mg.Verbose() {
+				log.Printf("%s is a platform independent package", f)
+			}
 			return true
 		}
+	}
+	if mg.Verbose() {
+		log.Printf("%s is NOT a platform independent package", f)
 	}
 	return false
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
Fix a bug introduced by https://github.com/elastic/elastic-agent/pull/7690 where dependency list is not correctly passed to `isPlatformIndependentPackage()`.
Without dependency list `isPlatformIndependentPackage()` did not recognize `connectors-9.1.0-SNAPSHOT.zip` as a platform independent package  so it wasn't copied in the `archives` directory.

This in turn would make the `elastic-agent-service` docker image spec fail because of these [lines](https://github.com/elastic/elastic-agent/blob/6abd585e55cbb27500b9821ddd94b80263ca150b/dev-tools/packaging/packages.yml#L582-L584) that expects the connectors zip to exist in the archive directory.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

To fix unified release for elastic-agent

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact
None
<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
