### PR TITLE
[Helm]: do not package with an SNAPSHOT image when SNAPSHOT=false

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -3726,12 +3726,16 @@ func (Helm) BuildDependencies() error {
 func (h Helm) Package() error {
 	mg.SerialDeps(h.BuildDependencies)
 
-	agentVersion := bversion.GetParsedAgentPackageVersion()
-	agentCoreVersion := agentVersion.CoreVersion()
-	agentImageTag := agentCoreVersion + "-SNAPSHOT"
-
 	// need to explicitly set SNAPSHOT="false" to produce a production-ready package
 	productionPackage := os.Getenv("SNAPSHOT") == "false"
+
+	agentVersion := bversion.GetParsedAgentPackageVersion()
+	agentCoreVersion := agentVersion.CoreVersion()
+	agentImageTag := agentCoreVersion
+	if !productionPackage {
+		// always use the SNAPSHOT version for image tag if not a production package
+		agentImageTag = agentImageTag + "-SNAPSHOT"
+	}
 
 	agentChartVersion := agentCoreVersion + "-beta"
 	switch {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR fixes an issue where the Helm chart would always package the Elastic Agent image using a `-SNAPSHOT` image tag, even when the `SNAPSHOT` environment variable was explicitly set to `false` (i.e., production mode).


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

When doing a production-targeted packaging, we must avoid using `-SNAPSHOT` image tags.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None. This fix aligns the packaging logic with documented expectations. Users relying on `SNAPSHOT=false` will now get the correct image tag in their Helm chart package.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

run 
`SNAPSHOT=false mage helm:package`
and 
`mage helm:package`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
N/A
