### PR TITLE
[ci] include the full containerStatus on k8s integration test failure

### DIFF
--- a/testing/integration/kubernetes_agent_standalone_test.go
+++ b/testing/integration/kubernetes_agent_standalone_test.go
@@ -925,12 +925,9 @@ func k8sDumpPods(t *testing.T, ctx context.Context, client klient.Client, testNa
 	}
 
 	type containerPodState struct {
+		corev1.ContainerStatus `json:",inline"`
 		Namespace              string `json:"namespace"`
-		PodName                string `json:"pod_name"`
-		ContainerName          string `json:"container_name"`
-		RestartCount           int32  `json:"restart_count"`
-		LastTerminationReason  string `json:"last_termination_reason"`
-		LastTerminationMessage string `json:"last_termination_message"`
+		PodName                string `json:"podName"`
 	}
 
 	var statesDump []containerPodState
@@ -942,11 +939,6 @@ func k8sDumpPods(t *testing.T, ctx context.Context, client klient.Client, testNa
 		}
 
 		for _, container := range pod.Spec.Containers {
-			state := containerPodState{
-				Namespace:     podNamespace,
-				PodName:       pod.GetName(),
-				ContainerName: container.Name,
-			}
 			previous := false
 
 			for _, containerStatus := range pod.Status.ContainerStatuses {
@@ -954,7 +946,11 @@ func k8sDumpPods(t *testing.T, ctx context.Context, client klient.Client, testNa
 					continue
 				}
 
-				state.RestartCount = containerStatus.RestartCount
+				statesDump = append(statesDump, containerPodState{
+					containerStatus,
+					podNamespace,
+					pod.GetName(),
+				})
 				if containerStatus.RestartCount == 0 {
 					break
 				}
@@ -965,12 +961,9 @@ func k8sDumpPods(t *testing.T, ctx context.Context, client klient.Client, testNa
 				containerTerminated := containerStatus.LastTerminationState.Terminated
 				if containerTerminated != nil && containerTerminated.FinishedAt.After(testStartTime) {
 					previous = true
-					state.LastTerminationReason = containerTerminated.Reason
-					state.LastTerminationMessage = containerTerminated.Message
 				}
 				break
 			}
-			statesDump = append(statesDump, state)
 
 			var logFileName string
 			if previous {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR improves the Kubernetes integration test framework by including the full `corev1.ContainerStatus` for each container in the pod state dump when a test fails.

Instead of selectively collecting fields like `RestartCount`, `LastTerminationReason`, and `LastTerminationMessage`, we now inline the entire `ContainerStatus` struct. This change gives us complete visibility into the container's lifecycle state, reasons for failure, readiness status, and other useful debug information when integration tests fail.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

A recent test failure in `TestKubernetesAgentHelm/helm_managed_agent_upgrade_older_version` (see [#7831](https://github.com/elastic/elastic-agent/issues/7831)) is difficult to debug due to limited diagnostic information. The container was stuck in `ContainerCreating`, but the logs did not provide enough context.

By dumping the entire `ContainerStatus`, we can now observe detailed container state transitions and reasons (e.g., image pull issues, readiness probe failures), which should help diagnose such issues faster and reduce flakiness in test pipelines.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None. This change only affects test diagnostics and does not impact users or production deployments.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run the Kubernetes integration test suite. On failure, inspect the test archive logs (e.g., `pod_logs_dump/${namespace}.tar.gz`) and verify that the full container statuses are included in the dump.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/7831