### PR TITLE
Refactor monitoring log config generation

### DIFF
--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -994,6 +994,7 @@ func dropPeriodicMetricsLogsProcessor() map[string]any {
 // routed to the elastic-agent logger get sent to the component-specific dataset.
 func useComponentDatasetProcessors() []any {
 	return []any{
+		// copy original dataset so we can drop the dataset field
 		map[string]any{
 			"copy_fields": map[string]any{
 				"fields": []any{


### PR DESCRIPTION
## What does this PR do?

Refactor how logs input configuration is generated for agent self-monitoring. This was primarily focused on readability. Assembling the configuration involved handling large maps of parameters, which are quite unwieldy to deal with in Go code.

* The configuration is now assembled from pieces returned by smaller functions, making it much easier to see the overarching logic.
* There is much less nesting, making the code more readable.
* Generating processor configuration was moved to individual functions, which are now reused across different streams and inputs.

This PR covers the logs part of #7600. The metrics part was covered by #7734.

## Why is it important?

The code is a lot more readable after this change. This will also make subsequent changes adding support for beats receivers smaller and easier to understand.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/3517 https://github.com/elastic/ingest-dev/issues/5118
- Split out from #7600.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
