### PR TITLE
Rename FIPS indicator to FIPSDistribution

### DIFF
--- a/internal/pkg/agent/application/info/agent_metadata.go
+++ b/internal/pkg/agent/application/info/agent_metadata.go
@@ -169,7 +169,7 @@ func (i *AgentInfo) ECSMetadata(l *logger.Logger) (*ECSMeta, error) {
 				Upgradeable:  release.Upgradeable() || (paths.RunningInstalled() && RunningUnderSupervisor()),
 				LogLevel:     i.LogLevel(),
 				Unprivileged: i.unprivileged,
-				FIPS:         release.FIPS(),
+				FIPS:         release.FIPSDistribution(),
 			},
 		},
 		Host: &HostECSMeta{

--- a/internal/pkg/agent/application/info/agent_metadata_test.go
+++ b/internal/pkg/agent/application/info/agent_metadata_test.go
@@ -48,7 +48,7 @@ func TestECSMetadata(t *testing.T) {
 	assert.Equal(t, release.Upgradeable() || (paths.RunningInstalled() && RunningUnderSupervisor()), metadata.Elastic.Agent.Upgradeable)
 	assert.Equal(t, agentInfo.logLevel, metadata.Elastic.Agent.LogLevel)
 	assert.Equal(t, agentInfo.unprivileged, metadata.Elastic.Agent.Unprivileged)
-	assert.Equal(t, release.FIPS(), metadata.Elastic.Agent.FIPS)
+	assert.Equal(t, release.FIPSDistribution(), metadata.Elastic.Agent.FIPS)
 
 	assert.Equal(t, info.Architecture, metadata.Host.Arch)
 	assert.Equal(t, hostname, metadata.Host.Hostname)

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -192,7 +192,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 		version:  release.Version(),
 		snapshot: release.Snapshot(),
 		hash:     release.Commit(),
-		fips:     release.FIPS(),
+		fips:     release.FIPSDistribution(),
 	}
 
 	// Compare versions and exit before downloading anything if the upgrade

--- a/internal/pkg/release/version.go
+++ b/internal/pkg/release/version.go
@@ -80,28 +80,28 @@ func Complete() bool {
 	return ok && isComplete == "true"
 }
 
-func FIPS() bool {
+func FIPSDistribution() bool {
 	f, err := strconv.ParseBool(fips)
 	return err == nil && f
 }
 
 // VersionInfo is structure used by `version --yaml`.
 type VersionInfo struct {
-	Version   string    `yaml:"version"`
-	Commit    string    `yaml:"commit"`
-	BuildTime time.Time `yaml:"build_time"`
-	Snapshot  bool      `yaml:"snapshot"`
-	FIPS      bool      `yaml:"fips"`
+	Version          string    `yaml:"version"`
+	Commit           string    `yaml:"commit"`
+	BuildTime        time.Time `yaml:"build_time"`
+	Snapshot         bool      `yaml:"snapshot"`
+	FIPSDistribution bool      `yaml:"fips"`
 }
 
 // Info returns current version information.
 func Info() VersionInfo {
 	return VersionInfo{
-		Version:   Version(),
-		Commit:    Commit(),
-		BuildTime: BuildTime(),
-		Snapshot:  Snapshot(),
-		FIPS:      FIPS(),
+		Version:          Version(),
+		Commit:           Commit(),
+		BuildTime:        BuildTime(),
+		Snapshot:         Snapshot(),
+		FIPSDistribution: FIPSDistribution(),
 	}
 }
 
@@ -115,7 +115,7 @@ func (v VersionInfo) String() string {
 	}
 	sb.WriteString(" (build: ")
 	sb.WriteString(v.Commit)
-	if v.FIPS {
+	if v.FIPSDistribution {
 		sb.WriteString(" fips: true")
 	}
 	sb.WriteString(" at ")

--- a/internal/pkg/release/version_test.go
+++ b/internal/pkg/release/version_test.go
@@ -75,9 +75,9 @@ func TestVersion(t *testing.T) {
 
 func Test_VersionInfo_WithFIPS(t *testing.T) {
 	info := Info()
-	info.FIPS = false
+	info.FIPSDistribution = false
 	assert.NotContains(t, info.String(), "fips:", "found fips indicator")
-	info.FIPS = true
+	info.FIPSDistribution = true
 	assert.Contains(t, info.String(), "fips: true", "did not find fips indicator")
 }
 
@@ -88,9 +88,9 @@ func TestFIPS(t *testing.T) {
 	})
 
 	fips = ""
-	assert.False(t, FIPS(), "expected FIPS indicator to be false")
+	assert.False(t, FIPSDistribution(), "expected FIPS indicator to be false")
 	fips = "false"
-	assert.False(t, FIPS(), "expected FIPS indicator to be false")
+	assert.False(t, FIPSDistribution(), "expected FIPS indicator to be false")
 	fips = "true"
-	assert.True(t, FIPS(), "expected FIPS indicator to be true")
+	assert.True(t, FIPSDistribution(), "expected FIPS indicator to be true")
 }

--- a/pkg/control/v2/control_test.go
+++ b/pkg/control/v2/control_test.go
@@ -40,7 +40,7 @@ func TestServerClient_Version(t *testing.T) {
 		Commit:    release.Commit(),
 		BuildTime: release.BuildTime(),
 		Snapshot:  release.Snapshot(),
-		Fips:      release.FIPS(),
+		Fips:      release.FIPSDistribution(),
 	}, ver)
 }
 

--- a/pkg/control/v2/server/server.go
+++ b/pkg/control/v2/server/server.go
@@ -129,7 +129,7 @@ func (s *Server) Version(_ context.Context, _ *cproto.Empty) (*cproto.VersionRes
 		Commit:    release.Commit(),
 		BuildTime: release.BuildTime().Format(control.TimeFormat()),
 		Snapshot:  release.Snapshot(),
-		Fips:      release.FIPS(),
+		Fips:      release.FIPSDistribution(),
 	}, nil
 }
 


### PR DESCRIPTION
## What does this PR do?

Rename FIPS indicator to FIPSDistribution

## Why is it important?

Renaming to FIPSDistribution makes the purpose of the attribute more clear (indicates that it is a build time property instead of a runtime one).

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

N/A