### PR TITLE
Rename FIPS-compliant to FIPS-capable

### DIFF
--- a/changelog/fragments/1740773781-Add-elastic.agent.fips-to-local_metadata.yaml
+++ b/changelog/fragments/1740773781-Add-elastic.agent.fips-to-local_metadata.yaml
@@ -18,7 +18,7 @@ summary: Add elastic.agent.fips to local_metadata
 # NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
 description: |
   Add elastic.agent.fips (bool) attribute to local_metadata sent with enroll and checkin requests.
-  The value of this attribute indicates if the agent is a FIPS compliant distribution.
+  The value of this attribute indicates if the agent is a FIPS-capable distribution.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component: elastic-agent

--- a/changelog/fragments/1741808763-FIPS-Compliant-agent-file-vault.yaml
+++ b/changelog/fragments/1741808763-FIPS-Compliant-agent-file-vault.yaml
@@ -11,7 +11,7 @@
 kind: enhancement
 
 # Change summary; a 80ish characters long description of the change.
-summary: FIPS Compliant agent file vault
+summary: FIPS-capable agent file vault
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.

--- a/changelog/fragments/1741897911-fips-to-fips-upgrades.yaml
+++ b/changelog/fragments/1741897911-fips-to-fips-upgrades.yaml
@@ -11,7 +11,7 @@
 kind: enhancement
 
 # Change summary; a 80ish characters long description of the change.
-summary: With this change fips compliant agents will only be able to upgrade to other fips compliant agents. This change also restricts non-fips to fips upgrades as well.
+summary: With this change FIPS-capable agents will only be able to upgrade to other FIPS-capable agents. This change also restricts non-fips to fips upgrades as well.
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -54,7 +54,7 @@ components:
   #    packageName: <template representing the name of the archive to download/extract>
   #    binaryName: <binary name>
   #    rootDir: <template representing directory from the archive root where the binary is located>
-  #    fips: <boolean indicating if this component is FIPS compliant>
+  #    fips: <boolean indicating if this component is FIPS-capable>
   #    platforms:
   #      - <platform, use anchors for platforms above>
   #    pythonWheel: true # true if it's a package that is not platform specific
@@ -189,7 +189,7 @@ components:
       - *linux-amd64
       - *linux-arm64
     packageTypes: *all-package-types
-  # Elastic Agent core component (FIPS-compliant version), defined here because it's a dependency when packaging using elastic-agent DRA
+  # Elastic Agent core component (FIPS-capable version), defined here because it's a dependency when packaging using elastic-agent DRA
   - &comp-elastic-agent-core-fips
     projectName: elastic-agent-core
     packageName: elastic-agent-core-fips-{{.Version}}-{{.Platform}}.{{.Ext}}
@@ -241,7 +241,7 @@ shared:
       - *comp-pf-elastic-symbolizer
       - *comp-pf-host-agent
 
-  # components included in FIPS-compliant elastic-agent package specs
+  # components included in FIPS-capable elastic-agent package specs
   - &elastic_agent_fips_components
     components:
       - *comp-agentbeat-fips

--- a/dev-tools/packaging/testing/package_test.go
+++ b/dev-tools/packaging/testing/package_test.go
@@ -371,7 +371,7 @@ func checkDocker(t *testing.T, file string, fipsPackage bool) (string, int64) {
 	checkDockerUser(t, p, info, *rootUserContainer)
 	checkFilePermissions(t, p, configFilePattern, os.FileMode(0644))
 	if !fipsPackage {
-		// FIPS docker image do not contain an otelcol script, run this check only on non FIPS compliant images
+		// FIPS docker image do not contain an otelcol script, run this check only on non FIPS-capable images
 		checkFilePermissions(t, p, otelcolScriptPattern, os.FileMode(0755))
 	}
 	checkManifestPermissionsWithMode(t, p, os.FileMode(0644))

--- a/internal/pkg/release/version.go
+++ b/internal/pkg/release/version.go
@@ -20,7 +20,7 @@ const (
 // snapshot is a flag marking build as a snapshot.
 var snapshot = ""
 
-// fips is a flag for marking a FIPS compliant build.
+// fips is a flag for marking a FIPS-capable build.
 var fips = "false"
 
 // complete is an environment variable marking the image as complete.

--- a/pkg/control/v2/cproto/control_v2.pb.go
+++ b/pkg/control/v2/cproto/control_v2.pb.go
@@ -423,7 +423,7 @@ type VersionResponse struct {
 	BuildTime string `protobuf:"bytes,3,opt,name=buildTime,proto3" json:"buildTime,omitempty"`
 	// Current running version is a snapshot.
 	Snapshot bool `protobuf:"varint,4,opt,name=snapshot,proto3" json:"snapshot,omitempty"`
-	// Current running version is FIPS-compliant.
+	// Current running version is FIPS-capable.
 	Fips bool `protobuf:"varint,5,opt,name=fips,proto3" json:"fips,omitempty"`
 }
 


### PR DESCRIPTION
This PR renames any occurrences in Agent code, comments, etc. matching `/fips.*compliant/i` to "FIPS-capable".  This is done to avoid giving the inaccurate impression that Agent is FIPS-compliant.