### PR TITLE
[Chore] Improve error reporting when otel collector fails to start

### DIFF
--- a/internal/pkg/otel/manager/manager.go
+++ b/internal/pkg/otel/manager/manager.go
@@ -7,6 +7,7 @@ package manager
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status"
 	"go.opentelemetry.io/collector/confmap"
@@ -81,7 +82,7 @@ func (m *OTelManager) Run(ctx context.Context) error {
 				if err != nil {
 					// failed to create the collector (this is different then
 					// it's failing to run). we do not retry creation on failure
-					// as it will always fail a new configuration is required for
+					// as it will always fail. A new configuration is required for
 					// it not to fail (a new configuration will result in the retry)
 					m.reportErr(ctx, err)
 				} else {
@@ -108,6 +109,7 @@ func (m *OTelManager) Run(ctx context.Context) error {
 				}
 				// pass the error to the errCh so the coordinator, unless it's a cancel error
 				if !errors.Is(err, context.Canceled) {
+					m.logger.Errorf(fmt.Sprintf("Failed to start the collector: %w", err))
 					m.reportErr(ctx, err)
 				}
 			}
@@ -143,7 +145,7 @@ func (m *OTelManager) Run(ctx context.Context) error {
 					if err != nil {
 						// failed to create the collector (this is different then
 						// it's failing to run). we do not retry creation on failure
-						// as it will always fail a new configuration is required for
+						// as it will always fail. A new configuration is required for
 						// it not to fail (a new configuration will result in the retry)
 						m.reportErr(ctx, err)
 					} else {

--- a/internal/pkg/otel/manager/manager.go
+++ b/internal/pkg/otel/manager/manager.go
@@ -7,7 +7,6 @@ package manager
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status"
 	"go.opentelemetry.io/collector/confmap"
@@ -109,7 +108,7 @@ func (m *OTelManager) Run(ctx context.Context) error {
 				}
 				// pass the error to the errCh so the coordinator, unless it's a cancel error
 				if !errors.Is(err, context.Canceled) {
-					m.logger.Errorf(fmt.Sprintf("Failed to start the collector: %w", err))
+					m.logger.Errorf("Failed to start the collector: %s", err)
 					m.reportErr(ctx, err)
 				}
 			}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
If OTel collector fails to start say due to incorrect config - the logs do not output what went wrong. The only way to know that is by using `elastic-agent status` command.

This PR logs such errors.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
Improve error logging when collector fails to start

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test


