### PR TITLE
Reword fips to fips-distribution to make purpose clear

### DIFF
--- a/internal/pkg/release/version.go
+++ b/internal/pkg/release/version.go
@@ -116,7 +116,7 @@ func (v VersionInfo) String() string {
 	sb.WriteString(" (build: ")
 	sb.WriteString(v.Commit)
 	if v.FIPSDistribution {
-		sb.WriteString(" fips: true")
+		sb.WriteString(" fips-distribution: true")
 	}
 	sb.WriteString(" at ")
 	sb.WriteString(v.BuildTime.Format("2006-01-02 15:04:05 -0700 MST"))


### PR DESCRIPTION
Reword fips to fips-distribution to make purpose clear; we don't want it to be confused with other FIPS indicators (i.e. a self-test has passed)