### PR TITLE
Include beat command line args in beat receiver config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,6 +53,7 @@ linters:
         - github.com/dop251/goja_nodejs
         - github.com/fsnotify/fsnotify
         - github.com/openshift/api
+        - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       replace-local: false
     gomodguard:
       blocked:

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.6
 	github.com/josephspurrier/goversioninfo v1.4.1
 	github.com/kardianos/service v1.2.1-0.20210728001519-a323c3813bc7
+	github.com/knadh/koanf/maps v0.1.1
 	github.com/magefile/mage v1.15.0
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.121.0
@@ -411,7 +412,6 @@ require (
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.8 // indirect
-	github.com/knadh/koanf/maps v0.1.1 // indirect
 	github.com/knadh/koanf/providers/confmap v0.1.0 // indirect
 	github.com/knadh/koanf/v2 v2.1.2 // indirect
 	github.com/kolo/xmlrpc v0.0.0-20220921171641-a4b6fa1dd06b // indirect

--- a/internal/pkg/otel/configtranslate/otelconfig.go
+++ b/internal/pkg/otel/configtranslate/otelconfig.go
@@ -414,7 +414,7 @@ func translateEsOutputToExporter(cfg *config.C) (map[string]any, error) {
 func getBeatConfigFromCommandLineArgs(args []string) map[string]any {
 	beatConfig := make(map[string]any)
 	ignoredPrefixes := []string{
-		"filebeat.config.modules.enabled",   // TODO: figure out if this is necessary
+		"filebeat.config.modules.enabled",   // TODO: figure out if this is necessary, see https://github.com/elastic/ingest-dev/issues/5119
 		"metricbeat.config.modules.enabled", // we pass our own modules via the config, so we can't enable this
 		"setup",                             // only used by beats if output is of type elasticsearch
 		"management",                        // beats receivers don't use the management protocol


### PR DESCRIPTION
## What does this PR do?

Beats processes are partially configured via command-line arguments. For example, see the filebeat arguments defined in the [agentbeat spec](https://github.com/elastic/beats/blob/dff69fd1158617bd66b3be4dae9a05b49a9df734/x-pack/agentbeat/agentbeat.spec.yml#L74). For beats receivers, we can't pass these arguments this way, and need to incorporate them into the beats receiver configuration instead. However, the majority of them don't actually make sense for a beats receiver, and can safely be discarded. This is what this change accomplishes.

Worth noting that elastic-agent also dynamically adds more arguments - most importantly, to set the monitoring endpoints. This PR ignores these, they will be handled in a follow up.

## Why is it important?

We should include the relevant command-line arguments, and ignore the irrelevant ones. This is particularly important for monitoring beats receivers, which will be added in a follow-up.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
~~- [ ] I have added an integration test or an E2E test~~

## Related issues

- Addresses most of https://github.com/elastic/ingest-dev/issues/5119.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
