### PR TITLE
[Integration Tests] Do not print out curl verbose output

### DIFF
--- a/.buildkite/scripts/steps/fleet.sh
+++ b/.buildkite/scripts/steps/fleet.sh
@@ -45,7 +45,6 @@ function install_fleet_packages() {
   fi
 
   resp=$(curl \
-    -v \
     -s \
     --fail-with-body \
     -X "POST" \


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR updates the `curl` command used to preinstall packages for integration tests so that verbose output is no longer printed to the logs.

## Why is it important?

To avoid leaking sensitive information in logs.

## Related issues
- Follow up to #7651