### PR TITLE
[ci] migrate serverless integration tests to buildkite

### DIFF
--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -60,7 +60,7 @@ steps:
         agents:
           provider: "gcp"
           machineType: "n1-standard-8"
-          image: "family/platform-ingest-elastic-agent-windows-2022"
+          image: "${IMAGE_WIN_2022}"
         retry:
           automatic:
             limit: 1
@@ -79,7 +79,7 @@ steps:
         agents:
           provider: "gcp"
           machineType: "n1-standard-8"
-          image: "family/platform-ingest-elastic-agent-windows-2025"
+          image: "${IMAGE_WIN_2025}"
       - label: "Ubuntu:2404:amd64:sudo"
         depends_on: packaging-ubuntu-x86-64
         command: |
@@ -94,7 +94,7 @@ steps:
         agents:
           provider: "gcp"
           machineType: "n1-standard-8"
-          image: "family/platform-ingest-elastic-agent-ubuntu-2404"
+          image: "${IMAGE_UBUNTU_2404_X86_64}"
 
   - group: "Stateful: Windows"
     key: integration-tests-win

--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -52,8 +52,9 @@ steps:
         depends_on:
           - packaging-windows
         command: |
+          #right now, run a single test in serverless mode as a sort of smoke test, instead of re-running the entire suite
           buildkite-agent artifact download build/distributions/** . --step 'packaging-windows'
-          .buildkite/scripts/integration-tests.ps1 fleet true TestLogIngestionFleetManaged serverless #right now, run a single test in serverless mode as a sort of smoke test, instead of re-running the entire suite
+          .buildkite/scripts/integration-tests.ps1 fleet true TestLogIngestionFleetManaged serverless
         artifact_paths:
           - build/**
           - build/diagnostics/**
@@ -68,8 +69,9 @@ steps:
         depends_on:
           - packaging-windows
         command: |
+          #right now, run a single test in serverless mode as a sort of smoke test, instead of re-running the entire suite
           buildkite-agent artifact download build/distributions/** . --step 'packaging-windows'
-          .buildkite/scripts/integration-tests.ps1 fleet true TestLogIngestionFleetManaged serverless #right now, run a single test in serverless mode as a sort of smoke test, instead of re-running the entire suite
+          .buildkite/scripts/integration-tests.ps1 fleet true TestLogIngestionFleetManaged serverless
         artifact_paths:
           - build/**
           - build/diagnostics/**
@@ -83,8 +85,9 @@ steps:
       - label: "Ubuntu:2404:amd64:sudo"
         depends_on: packaging-ubuntu-x86-64
         command: |
+          #right now, run a single test in serverless mode as a sort of smoke test, instead of re-running the entire suite
           buildkite-agent artifact download build/distributions/** . --step 'packaging-ubuntu-x86-64'
-          .buildkite/scripts/steps/integration_tests_tf.sh fleet true TestLogIngestionFleetManaged serverless #right now, run a single test in serverless mode as a sort of smoke test, instead of re-running the entire suite
+          .buildkite/scripts/steps/integration_tests_tf.sh fleet true TestLogIngestionFleetManaged serverless
         artifact_paths:
           - build/**
           - build/diagnostics/**

--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -28,6 +28,74 @@ steps:
       image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:0.5"
       useCustomGlobalHooks: true
 
+  - label: Start Serverless project
+    key: integration-serverless
+    env:
+      ASDF_TERRAFORM_VERSION: 1.9.2
+    command: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      source .buildkite/scripts/steps/serverless_start.sh
+    artifact_paths:
+      - test_infra/serverless/*.tfstate
+      - test_infra/serverless/*.lock.hcl
+    agents:
+      image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:0.5"
+      useCustomGlobalHooks: true
+
+  - group: "Serverless"
+    key: serverless-integration-tests
+    depends_on:
+      - integration-serverless
+    steps:
+      - label: "Windows:2022:amd64:sudo"
+        depends_on:
+          - packaging-windows
+        command: |
+          buildkite-agent artifact download build/distributions/** . --step 'packaging-windows'
+          .buildkite/scripts/integration-tests.ps1 fleet true TestLogIngestionFleetManaged serverless #right now, run a single test in serverless mode as a sort of smoke test, instead of re-running the entire suite
+        artifact_paths:
+          - build/**
+          - build/diagnostics/**
+        agents:
+          provider: "gcp"
+          machineType: "n1-standard-8"
+          image: "family/platform-ingest-elastic-agent-windows-2022"
+        retry:
+          automatic:
+            limit: 1
+      - label: "Windows:2025:amd64:sudo"
+        depends_on:
+          - packaging-windows
+        command: |
+          buildkite-agent artifact download build/distributions/** . --step 'packaging-windows'
+          .buildkite/scripts/integration-tests.ps1 fleet true TestLogIngestionFleetManaged serverless #right now, run a single test in serverless mode as a sort of smoke test, instead of re-running the entire suite
+        artifact_paths:
+          - build/**
+          - build/diagnostics/**
+        retry:
+          automatic:
+            limit: 1
+        agents:
+          provider: "gcp"
+          machineType: "n1-standard-8"
+          image: "family/platform-ingest-elastic-agent-windows-2025"
+      - label: "Ubuntu:2404:amd64:sudo"
+        depends_on: packaging-ubuntu-x86-64
+        command: |
+          buildkite-agent artifact download build/distributions/** . --step 'packaging-ubuntu-x86-64'
+          .buildkite/scripts/steps/integration_tests_tf.sh fleet true TestLogIngestionFleetManaged serverless #right now, run a single test in serverless mode as a sort of smoke test, instead of re-running the entire suite
+        artifact_paths:
+          - build/**
+          - build/diagnostics/**
+        retry:
+          automatic:
+            limit: 1
+        agents:
+          provider: "gcp"
+          machineType: "n1-standard-8"
+          image: "family/platform-ingest-elastic-agent-ubuntu-2404"
+
   - group: "Stateful: Windows"
     key: integration-tests-win
     depends_on:
@@ -363,6 +431,18 @@ steps:
       buildkite-agent artifact download "test_infra/ess/**" . --step "integration-ess"
       ls -lah test_infra/ess
       .buildkite/scripts/steps/ess_down.sh
+    agents:
+      image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:0.5"
+      useCustomGlobalHooks: true
+
+  - label: Serverless cleanup
+    depends_on:
+      - serverless-integration-tests
+    allow_dependency_failure: true
+    command: |
+      buildkite-agent artifact download "test_infra/serverless/**" . --step "integration-serverless"
+      ls -lah test_infra/serverless
+      .buildkite/scripts/steps/serverless_down.sh
     agents:
       image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:0.5"
       useCustomGlobalHooks: true

--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -148,31 +148,6 @@ steps:
           imagePrefix: "core-ubuntu-2204-aarch64"
           diskSizeGb: 200
 
-  - label: "Serverless integration test"
-    key: "serverless-integration-tests"
-    depends_on:
-      - int-packaging
-    concurrency_group: elastic-agent-extended-testing/serverless-integration
-    concurrency: 8
-    env:
-      # we run each step in a different data center to spread the load
-      TEST_INTEG_AUTH_GCP_DATACENTER: "us-central1-a"
-    command: |
-      buildkite-agent artifact download "build/distributions/**" . $BUILDKITE_BUILD_ID
-      .buildkite/scripts/steps/integration_tests.sh serverless integration:single TestLogIngestionFleetManaged #right now, run a single test in serverless mode as a sort of smoke test, instead of re-running the entire suite
-    artifact_paths:
-      - "build/TEST-**"
-      - "build/diagnostics/*"
-    agents:
-      provider: "gcp"
-      machineType: "n2-standard-8"
-    retry:
-      automatic:
-        limit: 1
-    notify:
-      - github_commit_status:
-          context: "buildkite/elastic-agent-extended-testing - Serverless integration test"
-
   - label: "Extended runtime leak tests"
     key: "extended-integration-tests"
     depends_on:

--- a/.buildkite/scripts/buildkite-integration-tests.sh
+++ b/.buildkite/scripts/buildkite-integration-tests.sh
@@ -3,6 +3,7 @@
 
 GROUP_NAME=$1
 TEST_SUDO=$2
+TEST_NAME_PATTERN=${3:-""}
 
 if [ -z "$GROUP_NAME" ]; then
   echo "Error: Specify the group name: sudo-integration-tests.sh [group_name]" >&2
@@ -49,9 +50,15 @@ outputXML="build/${fully_qualified_group_name}.integration.xml"
 outputJSON="build/${fully_qualified_group_name}.integration.out.json"
 
 echo "~~~ Integration tests: ${GROUP_NAME}"
+GOTEST_ARGS=(-tags integration -test.shuffle on -test.timeout 2h0m0s)
+if [ -n "$TEST_NAME_PATTERN" ]; then
+  GOTEST_ARGS+=(-run="${TEST_NAME_PATTERN}")
+fi
+GOTEST_ARGS+=("github.com/elastic/elastic-agent/testing/integration" -v -args "-integration.groups=${GROUP_NAME}" "-integration.sudo=${TEST_SUDO}")
 
 set +e
-TEST_BINARY_NAME="elastic-agent" AGENT_VERSION="${AGENT_VERSION}" SNAPSHOT=true gotestsum --no-color -f standard-quiet --junitfile "${outputXML}" --jsonfile "${outputJSON}" -- -tags integration -test.shuffle on -test.timeout 2h0m0s github.com/elastic/elastic-agent/testing/integration -v -args -integration.groups="${GROUP_NAME}" -integration.sudo="${TEST_SUDO}"
+TEST_BINARY_NAME="elastic-agent" AGENT_VERSION="${AGENT_VERSION}" SNAPSHOT=true \
+  gotestsum --no-color -f standard-quiet --junitfile "${outputXML}" --jsonfile "${outputJSON}" -- "${GOTEST_ARGS[@]}"
 TESTS_EXIT_STATUS=$?
 set -e
 

--- a/.buildkite/scripts/integration-tests.ps1
+++ b/.buildkite/scripts/integration-tests.ps1
@@ -1,13 +1,19 @@
 param (
     [string]$GROUP_NAME,
-    [string]$TEST_SUDO
+    [string]$TEST_SUDO,
+    [string]$TEST_NAME_PATTERN = "",
+    [string]$STACK_TYPE = "ess"
 )
 
 echo "~~~ Preparing environment"
 
 $PSVersionTable.PSVersion
 
-. "$PWD\.buildkite\scripts\steps\ess.ps1"
+if ($STACK_TYPE -eq "ess") {
+    . "$PWD\.buildkite\scripts\steps\ess.ps1"
+} else {
+    . "$PWD\.buildkite\scripts\steps\serverless.ps1"
+}
 
 go install gotest.tools/gotestsum
 gotestsum --version
@@ -30,7 +36,7 @@ $env:SNAPSHOT = $true
 
 echo "~~~ Building test binaries"
 & mage build:testBinaries
-if ($LASTEXITCODE -ne 0) {    
+if ($LASTEXITCODE -ne 0) {
     Write-Error "Failed to build test binaries"
     exit 1
 }
@@ -44,13 +50,26 @@ $outputXML = "build/${fully_qualified_group_name}.integration.xml"
 $outputJSON = "build/${fully_qualified_group_name}.integration.out.json"
 $TestsExitCode = 0
 try {
-    Get-Ess-Stack -StackVersion $PACKAGE_VERSION
+    if ($STACK_TYPE -eq "ess") {
+        Get-Ess-Stack -StackVersion $PACKAGE_VERSION
+    } else {
+        Get-Serverless-Project
+    }
     Write-Output "~~~ Running integration test group: $GROUP_NAME as user: $env:USERNAME"
-    & gotestsum --no-color -f standard-quiet --junitfile "${outputXML}" --jsonfile "${outputJSON}" -- -tags=integration -shuffle=on -timeout=2h0m0s "github.com/elastic/elastic-agent/testing/integration" -v -args "-integration.groups=$GROUP_NAME" "-integration.sudo=$TEST_SUDO"
-    $TestsExitCode = $LASTEXITCODE    
+    $gotestArgs = @("-tags=integration", "-shuffle=on", "-timeout=2h0m0s")
+    if ($TEST_NAME_PATTERN -ne "") {
+        $gotestArgs += "-run=${TEST_NAME_PATTERN}"
+    }
+    $gotestArgs += @("github.com/elastic/elastic-agent/testing/integration", "-v", "-args", "-integration.groups=$GROUP_NAME", "-integration.sudo=$TEST_SUDO")
+    & gotestsum --no-color -f standard-quiet --junitfile "${outputXML}" --jsonfile "${outputJSON}" -- @gotestArgs
+    $TestsExitCode = $LASTEXITCODE
 } finally {
-    ess_down
-    
+    if ($STACK_TYPE -eq "ess") {
+        ess_down
+    } else {
+        serverless_down
+    }
+
     if (Test-Path $outputXML) {
         # Install junit2html if not installed
         go install github.com/alexec/junit2html@latest
@@ -60,6 +79,6 @@ try {
     }
 }
 
-if ($TestsExitCode -ne 0) {    
+if ($TestsExitCode -ne 0) {
     exit 1
 }

--- a/.buildkite/scripts/steps/integration_tests_tf.sh
+++ b/.buildkite/scripts/steps/integration_tests_tf.sh
@@ -10,7 +10,7 @@ GROUP_NAME=$1
 TEST_SUDO=$2
 # NOTE: This argument is not used in this script, but is declared to show that it can be set
 # and passed down to downstream scripts where it may be used.
-TEST_NAME_PATTERN=$3
+TEST_NAME_PATTERN=${3:-""}
 STACK_TYPE=${4:-"ess"}
 if [ -z "$GROUP_NAME" ]; then
   echo "Error: Specify the group name: integration_tests_tf.sh [group_name]" >&2

--- a/.buildkite/scripts/steps/integration_tests_tf.sh
+++ b/.buildkite/scripts/steps/integration_tests_tf.sh
@@ -3,14 +3,12 @@ set -euo pipefail
 
 source .buildkite/scripts/common2.sh
 
-source .buildkite/scripts/steps/ess.sh
-source .buildkite/scripts/steps/fleet.sh
-
 # Make sure that all tools are installed
 asdf install
 
 GROUP_NAME=$1
 TEST_SUDO=$2
+STACK_TYPE=${4:-"ess"}
 if [ -z "$GROUP_NAME" ]; then
   echo "Error: Specify the group name: integration_tests_tf.sh [group_name]" >&2
   exit 1
@@ -19,6 +17,14 @@ fi
 if [ -z "$TEST_SUDO" ]; then
   echo "Error: Specify the test sudo: integration_tests_tf.sh [group_name] [test_sudo]" >&2
   exit 1
+fi
+
+# Load correct stack script
+if [ "$STACK_TYPE" == "ess" ]; then
+  source .buildkite/scripts/steps/ess.sh
+  source .buildkite/scripts/steps/fleet.sh
+else
+  source .buildkite/scripts/steps/serverless.sh
 fi
 
 # Override the agent package version using a string with format <major>.<minor>.<patch>
@@ -34,19 +40,36 @@ mage build:testBinaries
 # BUILDKITE_RETRY_COUNT == "0" for the first run
 # BUILDKITE_RETRY_COUNT > 0 for the retries
 if [[ "${BUILDKITE_RETRY_COUNT}" -gt 0 ]]; then
-  echo "~~~ The steps is retried, starting the ESS stack again"
-  trap 'ess_down' EXIT
-  ess_up $OVERRIDE_STACK_VERSION || echo "Failed to start ESS stack" >&2
-  preinstall_fleet_packages
+  if [ "$STACK_TYPE" == "ess" ]; then
+    echo "~~~ The steps is retried, starting the ESS stack again"
+    trap 'ess_down' EXIT
+    ess_up $OVERRIDE_STACK_VERSION || echo "Failed to start ESS stack" >&2
+    preinstall_fleet_packages
+  else
+    echo "~~~ The steps is retried, starting the Serverless project again"
+    trap 'serverless_down' EXIT
+    serverless_up || echo "Failed to start Serverless observability object" >&2
+  fi
 else
-  # For the first run, we start the stack in the start_ess.sh step and it sets the meta-data
-  echo "~~~ Receiving ESS stack metadata"
-  export ELASTICSEARCH_HOST=$(buildkite-agent meta-data get "es.host")
-  export ELASTICSEARCH_USERNAME=$(buildkite-agent meta-data get "es.username")
-  export ELASTICSEARCH_PASSWORD=$(buildkite-agent meta-data get "es.pwd")
-  export KIBANA_HOST=$(buildkite-agent meta-data get "kibana.host")
-  export KIBANA_USERNAME=$(buildkite-agent meta-data get "kibana.username")
-  export KIBANA_PASSWORD=$(buildkite-agent meta-data get "kibana.pwd")
+  if [ "$STACK_TYPE" == "ess" ]; then
+    # For the first run, we start the stack in the ess_start.sh step and it sets the meta-data
+    echo "~~~ Receiving ESS stack metadata"
+    export ELASTICSEARCH_HOST=$(buildkite-agent meta-data get "es.host")
+    export ELASTICSEARCH_USERNAME=$(buildkite-agent meta-data get "es.username")
+    export ELASTICSEARCH_PASSWORD=$(buildkite-agent meta-data get "es.pwd")
+    export KIBANA_HOST=$(buildkite-agent meta-data get "kibana.host")
+    export KIBANA_USERNAME=$(buildkite-agent meta-data get "kibana.username")
+    export KIBANA_PASSWORD=$(buildkite-agent meta-data get "kibana.pwd")
+  else
+    # For the first run, we start the serverless project in the serverless_start.sh step and it sets the meta-data
+    echo "~~~ Receiving Serverless project metadata"
+    export ELASTICSEARCH_HOST=$(buildkite-agent meta-data get "serverless.es.host")
+    export ELASTICSEARCH_USERNAME=$(buildkite-agent meta-data get "serverless.es.username")
+    export ELASTICSEARCH_PASSWORD=$(buildkite-agent meta-data get "serverless.es.pwd")
+    export KIBANA_HOST=$(buildkite-agent meta-data get "serverless.kibana.host")
+    export KIBANA_USERNAME=$(buildkite-agent meta-data get "serverless.kibana.username")
+    export KIBANA_PASSWORD=$(buildkite-agent meta-data get "serverless.kibana.pwd")
+  fi
 fi
 
 # TODO: move to common.sh when it's refactored

--- a/.buildkite/scripts/steps/integration_tests_tf.sh
+++ b/.buildkite/scripts/steps/integration_tests_tf.sh
@@ -8,6 +8,9 @@ asdf install
 
 GROUP_NAME=$1
 TEST_SUDO=$2
+# NOTE: This argument is not used in this script, but is declared to show that it can be set
+# and passed down to downstream scripts where it may be used.
+TEST_NAME_PATTERN=$3
 STACK_TYPE=${4:-"ess"}
 if [ -z "$GROUP_NAME" ]; then
   echo "Error: Specify the group name: integration_tests_tf.sh [group_name]" >&2

--- a/.buildkite/scripts/steps/serverless.ps1
+++ b/.buildkite/scripts/steps/serverless.ps1
@@ -1,0 +1,94 @@
+function serverless_up {
+  Write-Output "~~~ Starting Serverless Observability project"
+
+  $Workspace = & git rev-parse --show-toplevel
+  $TfDir = Join-Path -Path $Workspace -ChildPath "test_infra/serverless/"
+
+  $Env:EC_API_KEY = Retry-Command -ScriptBlock {
+    vault kv get -field=apiKey kv/ci-shared/platform-ingest/platform-ingest-ec-prod
+  }
+
+  if (-not $Env:EC_API_KEY) {
+      Write-Error "Error: Failed to get EC API key from vault"
+      exit 1
+  }
+
+  Push-Location -Path $TfDir
+  & terraform init
+  & terraform apply -auto-approve
+
+  $Env:ELASTICSEARCH_HOST = & terraform output -raw es_host
+  $Env:ELASTICSEARCH_USERNAME = & terraform output -raw es_username
+  $Env:ELASTICSEARCH_PASSWORD = & terraform output -raw es_password
+  $Env:KIBANA_HOST = & terraform output -raw kibana_endpoint
+  $Env:KIBANA_USERNAME = $Env:ELASTICSEARCH_USERNAME
+  $Env:KIBANA_PASSWORD = $Env:ELASTICSEARCH_PASSWORD
+  Pop-Location
+}
+
+function serverless_down {
+  $Workspace = & git rev-parse --show-toplevel
+  $TfDir = Join-Path -Path $Workspace -ChildPath "test_infra/serverless/"
+  $stateFilePath = Join-Path -Path $TfDir -ChildPath "terraform.tfstate"
+
+  if (-not (Test-Path -Path $stateFilePath)) {
+    Write-Output "Terraform state file not found. Skipping Serverless Observability project destroy."
+    return 0
+  }
+  Write-Output "~~~ Tearing down the Serverless Observability project Stack(created for this step)"
+  try {
+    $Env:EC_API_KEY = Retry-Command -ScriptBlock {
+      vault kv get -field=apiKey kv/ci-shared/platform-ingest/platform-ingest-ec-prod
+    }
+    Push-Location -Path $TfDir
+    & terraform init
+    & terraform destroy -auto-approve
+    Pop-Location
+  } catch {
+    Write-Output "Error: Failed to destroy Serverless Observability project(it will be auto-deleted later): $_"
+  }
+}
+
+function Retry-Command {
+  param (
+      [scriptblock]$ScriptBlock,
+      [int]$MaxRetries = 3,
+      [int]$DelaySeconds = 5
+  )
+
+  $lastError = $null
+
+  for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+      try {
+        $result = & $ScriptBlock
+        return $result
+      }
+      catch {
+          $lastError = $_
+          Write-Warning "Attempt $attempt failed: $($_.Exception.Message)"
+          Write-Warning "Retrying in $DelaySeconds seconds..."
+          Start-Sleep -Seconds $DelaySeconds
+      }
+  }
+
+  Write-Error "All $MaxRetries attempts failed. Original error: $($lastError.Exception.Message)"
+  throw $lastError.Exception
+}
+
+function Get-Serverless-Project {
+  if ($Env:BUILDKITE_RETRY_COUNT -gt 0) {
+      Write-Output "The step is retried, starting the Serverless project again"
+      serverless_up
+      Write-Output "Serverless project is up. ES_HOST: $Env:ELASTICSEARCH_HOST"
+  } else {
+      # For the first run, we retrieve ESS stack metadata
+      Write-Output "~~~ Receiving Serverless project metadata"
+      $Env:ELASTICSEARCH_HOST = & buildkite-agent meta-data get "serverless.es.host"
+      $Env:ELASTICSEARCH_USERNAME = & buildkite-agent meta-data get "serverless.es.username"
+      $Env:ELASTICSEARCH_PASSWORD = & buildkite-agent meta-data get "serverless.es.pwd"
+      $Env:KIBANA_HOST = & buildkite-agent meta-data get "serverless.kibana.host"
+      $Env:KIBANA_USERNAME = & buildkite-agent meta-data get "serverless.kibana.username"
+      $Env:KIBANA_PASSWORD = & buildkite-agent meta-data get "serverless.kibana.pwd"
+      Write-Output "Received Serverless project data from previous step. ES_HOST: $Env:ELASTICSEARCH_HOST"
+  }
+}

--- a/.buildkite/scripts/steps/serverless.sh
+++ b/.buildkite/scripts/steps/serverless.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function serverless_up() {
+  echo "~~~ Starting Serverless Observability project"
+  local WORKSPACE=$(git rev-parse --show-toplevel)
+  local TF_DIR="${WORKSPACE}/test_infra/serverless/"
+
+  export EC_API_KEY=$(retry -t 5 -- vault kv get -field=apiKey kv/ci-shared/platform-ingest/platform-ingest-ec-prod)
+
+  if [[ -z "${EC_API_KEY}" ]]; then
+    echo "Error: Failed to get EC API key from vault" >&2
+    exit 1
+  fi
+
+  pushd "${TF_DIR}"
+  terraform init
+  terraform apply -auto-approve
+
+  export ELASTICSEARCH_HOST=$(terraform output -raw es_host)
+  export ELASTICSEARCH_USERNAME=$(terraform output -raw es_username)
+  export ELASTICSEARCH_PASSWORD=$(terraform output -raw es_password)
+  export KIBANA_HOST=$(terraform output -raw kibana_endpoint)
+  export KIBANA_USERNAME=$ELASTICSEARCH_USERNAME
+  export KIBANA_PASSWORD=$ELASTICSEARCH_PASSWORD
+  popd
+}
+
+function serverless_down() {
+  echo "~~~ Tearing down the Serverless Observability project"
+  local WORKSPACE=$(git rev-parse --show-toplevel)
+  local TF_DIR="${WORKSPACE}/test_infra/serverless/"
+  if [ -z "${EC_API_KEY:-}" ]; then
+    export EC_API_KEY=$(retry -t 5 -- vault kv get -field=apiKey kv/ci-shared/platform-ingest/platform-ingest-ec-prod)
+  fi
+
+  pushd "${TF_DIR}"
+  terraform init
+  terraform destroy -auto-approve
+  popd
+}

--- a/.buildkite/scripts/steps/serverless_down.sh
+++ b/.buildkite/scripts/steps/serverless_down.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source .buildkite/scripts/common2.sh
+source .buildkite/scripts/steps/serverless.sh
+
+serverless_down || echo "Failed to unprovision the Serverless Observability project" >&2

--- a/.buildkite/scripts/steps/serverless_start.sh
+++ b/.buildkite/scripts/steps/serverless_start.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source .buildkite/scripts/common2.sh
+source .buildkite/scripts/steps/serverless.sh
+
+serverless_up
+
+echo "ES_HOST: ${ELASTICSEARCH_HOST}"
+buildkite-agent meta-data set "serverless.es.host" $ELASTICSEARCH_HOST
+buildkite-agent meta-data set "serverless.es.username" $ELASTICSEARCH_USERNAME
+buildkite-agent meta-data set "serverless.es.pwd" $ELASTICSEARCH_PASSWORD
+buildkite-agent meta-data set "serverless.kibana.host" $KIBANA_HOST
+buildkite-agent meta-data set "serverless.kibana.username" $KIBANA_USERNAME
+buildkite-agent meta-data set "serverless.kibana.pwd" $KIBANA_PASSWORD

--- a/test_infra/serverless/.gitignore
+++ b/test_infra/serverless/.gitignore
@@ -1,0 +1,4 @@
+.terraform
+terraform.tfstate
+terraform.tfstate.backup
+.terraform.lock.hcl

--- a/test_infra/serverless/deployment.tf
+++ b/test_infra/serverless/deployment.tf
@@ -1,0 +1,25 @@
+variable "serverless_project_name" {
+  type        = string
+  default     = ""
+  description = "The Serverless project name to use"
+}
+
+variable "serverless_region_id" {
+  type        = string
+  default     = "aws-us-east-1"
+  description = "The Serverless region to use"
+}
+
+resource "random_uuid" "project_name_suffix" {
+}
+
+locals {
+  project_name = coalesce(var.serverless_project_name, join("-", [
+    "elastic-agent-ci", substr(random_uuid.project_name_suffix.result, 0, 8)
+  ]))
+}
+
+resource "ec_observability_project" "project" {
+  name      = local.project_name
+  region_id = var.serverless_region_id
+}

--- a/test_infra/serverless/output.tf
+++ b/test_infra/serverless/output.tf
@@ -1,0 +1,26 @@
+output "cloud_id" {
+  value       = ec_observability_project.project.cloud_id
+  description = "Cloud ID (cloud_id)"
+}
+
+output "es_password" {
+  value       = ec_observability_project.project.credentials.password
+  description = "Password (cloud_id)"
+  sensitive   = true
+}
+
+output "es_username" {
+  value       = ec_observability_project.project.credentials.username
+  description = "Password (cloud_id)"
+  sensitive   = true
+}
+
+output "es_host" {
+  value       = ec_observability_project.project.endpoints.elasticsearch
+  description = "The endpoint to access elasticsearch"
+}
+
+output "kibana_endpoint" {
+  value = ec_observability_project.project.endpoints.kibana
+  description = "The endpoint to access kibana"
+}

--- a/test_infra/serverless/terraform.tf
+++ b/test_infra/serverless/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    ec = {
+      source  = "elastic/ec"
+      version = ">= 0.10.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
-->

This PR migrates the Serverless integration tests from a single-step setup using OGC to a multi-step, Buildkite-native pipeline. The new approach provisions the Serverless Observability project using Terraform and executes the test suite across prebuilt VM images split by OS, similar to existing ESS and Kubernetes integration tests.

Key changes:
- Adds Terraform-based provisioning for Serverless stack and the necessary cleanup logic; "fun" fact: even with this PR, we still don't control the Serverless stack version 
- Refactors integration test scripts (`buildkite-integration-tests.sh`, `integration-tests.ps1`, `integration_tests_tf.sh`) to accept parameters for `test_name_pattern` and `stack_type`, allowing selective test execution and proper environment setup for either ESS or Serverless.
- Removes the legacy single-step, OGC-based `serverless-integration-tests`.

Proof that we run the same tests for Serverless as before:
* [Before](https://buildkite.com/organizations/elastic/pipelines/elastic-agent-extended-testing/builds/8511/jobs/01965e67-49b5-43ef-94f0-69751e9ff075/artifacts/01965ea5-c59d-4653-826c-01dc4efc8386)
* [With this PR Windows 2022](https://buildkite.com/organizations/elastic/pipelines/elastic-agent/builds/20335/jobs/01965ebd-8ea7-4a77-99d1-a216298f5ad4/artifacts/01965ecf-44e7-45f0-9f24-b5be90ed5f3e), [With this PR Windows 2025](https://buildkite.com/organizations/elastic/pipelines/elastic-agent/builds/20335/jobs/01965ebd-8ea8-44c3-b3c9-6a39b13736bb/artifacts/01965ecf-4692-405f-8164-3b1fa9b988c9), [With this PR Ubuntu 24.04](https://buildkite.com/organizations/elastic/pipelines/elastic-agent/builds/20335/jobs/01965ebd-8eac-4851-8aa9-f1a5645bff4f/artifacts/01965eca-7a68-40b0-a365-b14f5374214e)

## Why is it important?

The previous OGC-based Serverless test step has shown recurring transient failures—especially around test output fetching—across various runners. These issues likely stem from instability in the OGC setup.

Migrating to Buildkite-native steps:
- Improves test stability.
- Aligns Serverless tests with the structure of other integration pipelines (e.g., ESS, Kubernetes).
- Lays the groundwork for further parallelisation and modular test execution.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

No user-facing impact is expected. Changes are isolated to CI infrastructure for internal testing workflows.

## How to test this PR locally

Open a draft PR 🙂 

## Related issues

- Closes https://github.com/elastic/ingest-dev/issues/5271