### PR TITLE
[ci] migrate extended runtime leak tests to buildkite

### DIFF
--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -28,6 +28,65 @@ steps:
       image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:0.5"
       useCustomGlobalHooks: true
 
+  - group: "Extended runtime leak tests"
+    key: extended-integration-tests
+    depends_on:
+      - integration-ess
+    steps:
+      - label: "Windows:2022:amd64:sudo"
+        depends_on:
+          - packaging-windows
+        env:
+          TEST_LONG_RUNNING: "true"
+        command: |
+          buildkite-agent artifact download build/distributions/** . --step 'packaging-windows'
+          .buildkite/scripts/integration-tests.ps1 fleet true TestLongRunningAgentForLeaks
+        artifact_paths:
+          - build/**
+          - build/diagnostics/**
+        agents:
+          provider: "gcp"
+          machineType: "n1-standard-8"
+          image: "${IMAGE_WIN_2022}"
+        retry:
+          automatic:
+            limit: 1
+      - label: "Windows:2025:amd64:sudo"
+        depends_on:
+          - packaging-windows
+        env:
+          TEST_LONG_RUNNING: "true"
+        command: |
+          buildkite-agent artifact download build/distributions/** . --step 'packaging-windows'
+          .buildkite/scripts/integration-tests.ps1 fleet true TestLongRunningAgentForLeaks
+        artifact_paths:
+          - build/**
+          - build/diagnostics/**
+        retry:
+          automatic:
+            limit: 1
+        agents:
+          provider: "gcp"
+          machineType: "n1-standard-8"
+          image: "${IMAGE_WIN_2025}"
+      - label: "Ubuntu:2404:amd64:sudo"
+        depends_on: packaging-ubuntu-x86-64
+        env:
+          TEST_LONG_RUNNING: "true"
+        command: |
+          buildkite-agent artifact download build/distributions/** . --step 'packaging-ubuntu-x86-64'
+          .buildkite/scripts/steps/integration_tests_tf.sh fleet true TestLongRunningAgentForLeaks
+        artifact_paths:
+          - build/**
+          - build/diagnostics/**
+        retry:
+          automatic:
+            limit: 1
+        agents:
+          provider: "gcp"
+          machineType: "n1-standard-8"
+          image: "${IMAGE_UBUNTU_2404_X86_64}"
+
   - group: "Stateful: Windows"
     key: integration-tests-win
     depends_on:
@@ -362,6 +421,7 @@ steps:
       - integration-tests-win
       - integration-tests-rhel8
       - integration-tests-kubernetes
+      - extended-integration-tests
     allow_dependency_failure: true
     command: |
       buildkite-agent artifact download "test_infra/ess/**" . --step "integration-ess"

--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -173,30 +173,6 @@ steps:
       - github_commit_status:
           context: "buildkite/elastic-agent-extended-testing - Serverless integration test"
 
-  - label: "Extended runtime leak tests"
-    key: "extended-integration-tests"
-    depends_on:
-      - int-packaging
-    concurrency_group: elastic-agent-extended-testing/leak-tests
-    concurrency: 8
-    env:
-      TEST_INTEG_AUTH_GCP_DATACENTER: "us-central1-b"
-    command: |
-      buildkite-agent artifact download "build/distributions/**" . $BUILDKITE_BUILD_ID
-      .buildkite/scripts/steps/integration_tests.sh stateful integration:TestForResourceLeaks
-    artifact_paths:
-      - "build/TEST-**"
-      - "build/diagnostics/*"
-    agents:
-      provider: "gcp"
-      machineType: "n2-standard-8"
-    retry:
-      automatic:
-        limit: 1
-    notify:
-      - github_commit_status:
-          context: "buildkite/elastic-agent-extended-testing - Extended runtime leak tests"
-
   - label: "Triggering Integration tests"
     depends_on:
       - int-packaging

--- a/.buildkite/scripts/buildkite-integration-tests.sh
+++ b/.buildkite/scripts/buildkite-integration-tests.sh
@@ -3,6 +3,7 @@
 
 GROUP_NAME=$1
 TEST_SUDO=$2
+TEST_NAME_PATTERN=${3:-""}
 
 if [ -z "$GROUP_NAME" ]; then
   echo "Error: Specify the group name: sudo-integration-tests.sh [group_name]" >&2
@@ -46,9 +47,15 @@ outputXML="build/${fully_qualified_group_name}.integration.xml"
 outputJSON="build/${fully_qualified_group_name}.integration.out.json"
 
 echo "~~~ Integration tests: ${GROUP_NAME}"
+GOTEST_ARGS=(-tags integration -test.shuffle on -test.timeout 2h0m0s)
+if [ -n "$TEST_NAME_PATTERN" ]; then
+  GOTEST_ARGS+=(-run="${TEST_NAME_PATTERN}")
+fi
+GOTEST_ARGS+=("github.com/elastic/elastic-agent/testing/integration" -v -args "-integration.groups=${GROUP_NAME}" "-integration.sudo=${TEST_SUDO}")
 
 set +e
-TEST_BINARY_NAME="elastic-agent" AGENT_VERSION="${AGENT_VERSION}" SNAPSHOT=true gotestsum --no-color -f standard-quiet --junitfile-hide-skipped-tests --junitfile "${outputXML}" --jsonfile "${outputJSON}" -- -tags integration -test.shuffle on -test.timeout 2h0m0s github.com/elastic/elastic-agent/testing/integration -v -args -integration.groups="${GROUP_NAME}" -integration.sudo="${TEST_SUDO}"
+TEST_BINARY_NAME="elastic-agent" AGENT_VERSION="${AGENT_VERSION}" SNAPSHOT=true \
+  gotestsum --no-color -f standard-quiet --junitfile-hide-skipped-tests --junitfile "${outputXML}" --jsonfile "${outputJSON}" -- "${GOTEST_ARGS[@]}"
 TESTS_EXIT_STATUS=$?
 set -e
 

--- a/.buildkite/scripts/steps/integration_tests_tf.sh
+++ b/.buildkite/scripts/steps/integration_tests_tf.sh
@@ -11,6 +11,9 @@ asdf install
 
 GROUP_NAME=$1
 TEST_SUDO=$2
+# NOTE: This argument is not used in this script, but is declared to show that it can be set
+# and passed down to downstream scripts where it may be used.
+TEST_NAME_PATTERN=${3:-""}
 if [ -z "$GROUP_NAME" ]; then
   echo "Error: Specify the group name: integration_tests_tf.sh [group_name]" >&2
   exit 1


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR migrates the **Extended Runtime Leak Tests** to Buildkite, where all other integration and Kubernetes tests now reside. The new setup runs these tests on Windows 2022, Windows 2025, and Ubuntu 24.04 using existing prebuilt VM images. The old step is removed to avoid duplication and eliminate the dependency on OGC.

Proof that we run the same tests:
* [Before this PR](https://buildkite.com/organizations/elastic/pipelines/elastic-agent-extended-testing/builds/8548/jobs/01966bdd-34a4-4cdb-877b-88899ecd5419/artifacts/01966c32-e5e2-4127-8081-2a3b365e70fb)
* [With this PR Windows 2022](https://buildkite.com/organizations/elastic/pipelines/elastic-agent/builds/21584/jobs/01971b2f-65bd-4674-83f1-78c516bf736f/artifacts/01971b51-8019-4b3d-9230-5c18d5f8ba7c), [With this PR Windows 2025](https://buildkite.com/organizations/elastic/pipelines/elastic-agent/builds/21584/jobs/01971b2f-65be-4a1c-a8b4-57fb59089d1c/artifacts/01971b52-0a77-41a6-a282-dc58d7dc92ed), [With this PR Ubuntu 24.04](https://buildkite.com/organizations/elastic/pipelines/elastic-agent/builds/21584/jobs/01971b2f-65bf-4712-9b90-7a96732eaeb8/artifacts/01971b4c-8eca-4847-985e-dd4456b29d42)

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This resolves reliability issues in the old extended testing setup, aligning them with our current CI strategy and infrastructure. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None. This change only affects internal CI configuration.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Open a PR 🙂 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/ingest-dev/issues/5269
