### PR TITLE
Add prometheusreceiver to replace allowlist

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,6 +53,7 @@ linters:
         - github.com/dop251/goja_nodejs
         - github.com/fsnotify/fsnotify
         - github.com/openshift/api
+        - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       replace-local: false
     gomodguard:
       blocked:


### PR DESCRIPTION
## What does this PR do?

Our linter has an allowlist for packages which are allowed to be replaced. We forgot to add the Otel prometheus receiver package there after replacing it with a fork before the 9.0.0/8.18.0 releases. Fix this.

## Why is it important?

Right now, any PR that changes the go.mod will run into a linter warning for this reason.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
