### PR TITLE
agentless release fix

### DIFF
--- a/.buildkite/pipeline.agentless-app-release.yaml
+++ b/.buildkite/pipeline.agentless-app-release.yaml
@@ -3,7 +3,7 @@ env:
 steps:
   - label: "Mirror Elastic-Agent Snapshot DRA to internal registry"
     key: "mirror-elastic-agent"
-    command: "./build/ecp-internal-release.sh"
+    command: ".buildkite/scripts/steps/ecp-internal-release.sh"
     agents:
       image: docker.elastic.co/ci-agent-images/serverless-helm-builder:0.0.2@sha256:d00e8a7a0ab3618cfaacb0a7b1e1b06ee29728eb2b44de602374bd8f6b9b92ac
 

--- a/.buildkite/pipeline.agentless-tests.yaml
+++ b/.buildkite/pipeline.agentless-tests.yaml
@@ -19,8 +19,6 @@ steps:
     command: ".buildkite/scripts/steps/run-agentless-tests.sh"
     agents:
       image: "docker.elastic.co/ci-agent-images/quality-gate-seedling:0.0.4@sha256:b15aa65183fd9ac4b3ad2b01287ee8c47382a74450485b012bade5331fefeae9"
-    env:
-      SERVICE_VERSION: "${BUILDKITE_COMMIT:0:12}"
 
 notify:
   - slack: "${TEAM_CHANNEL}"

--- a/.buildkite/scripts/steps/run-agentless-tests.sh
+++ b/.buildkite/scripts/steps/run-agentless-tests.sh
@@ -30,7 +30,7 @@ extract_sha() {
         git pull
     )
 
-    go install github.com/mikefarah/yq/v3@v3.0.0-20201202084205-8846255d1c37
+    go install github.com/mikefarah/yq/v4@v4.45.1
 
     # Extract first matching SHA for the environment pattern
     sha=$(yq eval ".services.agentless-controller.versions | to_entries | .[] | select(.key | test(\"^${env}.*\")) | .value" serverless-gitops/services/agentless-controller/versions.yaml | head -1)


### PR DESCRIPTION
This PR follows https://github.com/elastic/elastic-agent/pull/7701 to
1. Fix reference to release script
2. Fix the service_versions that goes into quality gates (yq on v3 does not have `eval`)