### PR TITLE
[ci][linkcheck] - Change GOBIN env

### DIFF
--- a/dev-tools/mage/check.go
+++ b/dev-tools/mage/check.go
@@ -87,7 +87,7 @@ func CheckLinksInFileAreLive(filename string) func() error {
 		fmt.Printf(">> check: Checking for invalid links in %q\n", filename)
 		mg.Deps(InstallGoLinkCheck)
 		out, _ := exec.Command("ls").Output()
-		fmt.Println(">> check: Checking for invalid links in %s\n", out)
+		fmt.Printf(">> check: Checking for invalid links in %s\n", out)
 
 		linkcheck := gotool.LinkCheck
 		return linkcheck(

--- a/dev-tools/mage/check.go
+++ b/dev-tools/mage/check.go
@@ -7,6 +7,7 @@ package mage
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 
@@ -85,6 +86,8 @@ func CheckLinksInFileAreLive(filename string) func() error {
 	return func() error {
 		fmt.Printf(">> check: Checking for invalid links in %q\n", filename)
 		mg.Deps(InstallGoLinkCheck)
+		out, _ := exec.Command("ls").Output()
+		fmt.Println(">> check: Checking for invalid links in %s\n", out)
 
 		linkcheck := gotool.LinkCheck
 		return linkcheck(

--- a/dev-tools/mage/gotool/go.go
+++ b/dev-tools/mage/gotool/go.go
@@ -37,6 +37,7 @@ func runGoInstall(opts ...ArgOpt) error {
 
 func (goInstall) Package(pkg string) ArgOpt { return posArg(pkg) }
 func (goInstall) Vendored() ArgOpt          { return flagArg("-mod", "vendor") }
+func (goInstall) BIN() ArgOpt               { return envArgIf("GOBIN", fmt.Sprintf("%s/bin", os.Getenv("PWD"))) }
 
 type goTest func(opts ...ArgOpt) error
 

--- a/dev-tools/mage/gotool/linkcheck.go
+++ b/dev-tools/mage/gotool/linkcheck.go
@@ -6,6 +6,7 @@ package gotool
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/magefile/mage/sh"
 )
@@ -17,7 +18,7 @@ var LinkCheck goLinkCheck = runGoLinkCheck
 
 func runGoLinkCheck(opts ...ArgOpt) error {
 	args := buildArgs(opts).build()
-	output, err := sh.Output("link-patrol", args...)
+	output, err := sh.Output(fmt.Sprintf("%s/bin/link-patrol", os.Getenv("PWD")), args...)
 	if err != nil {
 		fmt.Println(output)
 		return err


### PR DESCRIPTION
I'm not really sure why, but our CI is failing to run `link-patrol` and I observed two failures (there can be more):
- https://buildkite.com/elastic/elastic-agent/builds/20404#0196662a-957c-4809-af2d-201ef6cb9598
- https://buildkite.com/elastic/elastic-agent/builds/20407#01966642-a791-4f27-868b-307c215dc749

In this PR, I'm adding a new `BIN()` option which forces `go install ...` to use `$(pwd)/bin` directory to install binaries and I've updated `runGoLinkCheck` to make use of local binary.