### PR TITLE
[deb/rpm] copy run folder from old agent installation

### DIFF
--- a/changelog/fragments/1745923884-deb-rpm-preserve-run-state.yaml
+++ b/changelog/fragments/1745923884-deb-rpm-preserve-run-state.yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+summary: Preserve agent run state on DEB and RPM upgrades
+component: "elastic-agent"
+pr: https://github.com/elastic/elastic-agent/pull/7999
+issue: https://github.com/elastic/elastic-agent/issues/3832

--- a/dev-tools/packaging/templates/linux/preinstall.sh.tmpl
+++ b/dev-tools/packaging/templates/linux/preinstall.sh.tmpl
@@ -41,13 +41,23 @@ if test -L "$symlink"; then
         else
             echo "didn't find $enc_path"
         fi
+
+        old_run_path="$old_agent_dir/run"
+        new_run_path="$new_agent_dir/run"
+        if [ -d "$old_run_path" ]; then
+            echo "found $old_run_path, copy to $new_agent_dir"
+            mkdir -p "$new_run_path"
+            cp -rf "$old_run_path/." "$new_run_path/"
+        else
+            echo "didn't find $old_run_path"
+        fi
     fi
 else
     echo "no previous installation found"
 
     # create dir in case it does not exist
-    mkdir -p "$new_agent_dir" 
-    
+    mkdir -p "$new_agent_dir"
+
     # 2 is upgrade for Fedora, do not upgrade file when upgrading and file exists
     if [[ "$1" != "2" ]]; then
         if [[ -n "${ELASTIC_AGENT_FLAVOR}" ]]; then

--- a/dev-tools/packaging/templates/linux/preinstall.sh.tmpl
+++ b/dev-tools/packaging/templates/linux/preinstall.sh.tmpl
@@ -47,7 +47,7 @@ if test -L "$symlink"; then
         if [ -d "$old_run_path" ]; then
             echo "found $old_run_path, copy to $new_agent_dir"
             mkdir -p "$new_run_path"
-            cp -rf "$old_run_path/." "$new_run_path/"
+            cp -rfp "$old_run_path/." "$new_run_path/"
         else
             echo "didn't find $old_run_path"
         fi

--- a/testing/integration/linux_deb_test.go
+++ b/testing/integration/linux_deb_test.go
@@ -41,6 +41,10 @@ func TestDebLogIngestFleetManaged(t *testing.T) {
 				Type:   define.Linux,
 				Distro: "ubuntu",
 			},
+			{
+				Type:   define.Linux,
+				Distro: "debian",
+			},
 		},
 		Local: false,
 		Sudo:  true,
@@ -84,6 +88,10 @@ func TestDebInstallsServers(t *testing.T) {
 			{
 				Type:   define.Linux,
 				Distro: "ubuntu",
+			},
+			{
+				Type:   define.Linux,
+				Distro: "debian",
 			},
 		},
 		Local: false,
@@ -176,6 +184,10 @@ func TestDebFleetUpgrade(t *testing.T) {
 			{
 				Type:   define.Linux,
 				Distro: "ubuntu",
+			},
+			{
+				Type:   define.Linux,
+				Distro: "debian",
 			},
 		},
 		Local: false,

--- a/testing/integration/linux_deb_test.go
+++ b/testing/integration/linux_deb_test.go
@@ -298,8 +298,8 @@ func testDebUpgrade(t *testing.T, upgradeFromVersion *version.ParsedSemVer, info
 	newRunDir, err := atesting.FindRunDir(endFixture)
 	require.NoError(t, err, "failed at getting run dir")
 	require.NotEqual(t, runDir, newRunDir, "the run dirs from upgrade should not match")
-	newRunMigrationMarket := filepath.Join(newRunDir, migrationMarkerFile)
-	require.FileExistsf(t, newRunMigrationMarket, "%q is missing", newRunMigrationMarket)
+	newRunMigrationMarker := filepath.Join(newRunDir, migrationMarkerFile)
+	require.FileExistsf(t, newRunMigrationMarker, "%q is missing", newRunMigrationMarker)
 
 	// 4. Wait for version in Fleet to match
 	// Fleet will not include the `-SNAPSHOT` in the `GetAgentVersion` result

--- a/testing/integration/linux_rpm_test.go
+++ b/testing/integration/linux_rpm_test.go
@@ -284,8 +284,8 @@ func testRpmUpgrade(t *testing.T, upgradeFromVersion *version.ParsedSemVer, info
 	newRunDir, err := atesting.FindRunDir(endFixture)
 	require.NoError(t, err, "failed at getting run dir")
 	require.NotEqual(t, runDir, newRunDir, "the run dirs from upgrade should not match")
-	newRunMigrationMarket := filepath.Join(newRunDir, migrationMarkerFile)
-	require.FileExistsf(t, newRunMigrationMarket, "%q is missing", newRunMigrationMarket)
+	newRunMigrationMarker := filepath.Join(newRunDir, migrationMarkerFile)
+	require.FileExistsf(t, newRunMigrationMarker, "%q is missing", newRunMigrationMarker)
 
 	// 4. Wait for version in Fleet to match
 	// Fleet will not include the `-SNAPSHOT` in the `GetAgentVersion` result

--- a/testing/integration/linux_rpm_test.go
+++ b/testing/integration/linux_rpm_test.go
@@ -9,7 +9,9 @@ package integration
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -264,11 +266,26 @@ func testRpmUpgrade(t *testing.T, upgradeFromVersion *version.ParsedSemVer, info
 
 	check.ConnectedToFleet(ctx, t, startFixture, 5*time.Minute)
 
+	const migrationMarkerFile = "migration_marker.file"
+	runDir, err := atesting.FindRunDir(startFixture)
+	require.NoError(t, err, "failed at getting run dir")
+
+	runMigrationMarker := filepath.Join(runDir, migrationMarkerFile)
+	f, err := os.Create(runMigrationMarker)
+	require.NoErrorf(t, err, "failed to create %q file", runMigrationMarker)
+	_ = f.Close()
+
 	// 3. Upgrade rpm to the build version
 	srcPackage, err := endFixture.SrcPackage(ctx)
 	require.NoError(t, err)
 	out, err := exec.CommandContext(ctx, "sudo", "rpm", "-U", "-v", srcPackage).CombinedOutput() // #nosec G204 -- Need to pass in name of package
 	require.NoError(t, err, string(out))
+
+	newRunDir, err := atesting.FindRunDir(endFixture)
+	require.NoError(t, err, "failed at getting run dir")
+	require.NotEqual(t, runDir, newRunDir, "the run dirs from upgrade should not match")
+	newRunMigrationMarket := filepath.Join(newRunDir, migrationMarkerFile)
+	require.FileExistsf(t, newRunMigrationMarket, "%q is missing", newRunMigrationMarket)
 
 	// 4. Wait for version in Fleet to match
 	// Fleet will not include the `-SNAPSHOT` in the `GetAgentVersion` result

--- a/testing/integration/restrict_upgrade_deb_test.go
+++ b/testing/integration/restrict_upgrade_deb_test.go
@@ -28,6 +28,10 @@ func TestRestrictUpgradeDeb(t *testing.T) {
 				Type:   define.Linux,
 				Distro: "ubuntu",
 			},
+			{
+				Type:   define.Linux,
+				Distro: "debian",
+			},
 		},
 	})
 	t.Run("when agent is deployed via deb, a user should not be able to upgrade the agent using the cli", func(t *testing.T) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
This PR improves the upgrade experience of Elastic Agent installed via DEB and RPM packages. It updates the pre-installation script (`preinstall.sh.tmpl`) to copy the `run` directory from the previous agent installation into the new version's folder during an upgrade, preserving agent state that would otherwise be lost.

Additionally, it extends integration tests to:
- Introduce validation to ensure the `run` directory and migration marker are properly copied across an upgrade.
- Add Debian OS support in DEB-related upgrade tests.

A new helper function `FindRunDir` is also introduced in the testing framework to locate the agent's `run` directory based on versioned data paths.

Based on my investigation:
1. Fleet-related configuration is at `/etc/elastic-agent/fleet.enc` which is preserved across upgrades
2. Elastic-agent config file is at `/etc/elastic-agent/elastic-agent.yml` which is preserved across upgrades
3. Legacy `state.yml` and `state.enc` are getting copied during upgrades
4. With this PR, `run` folder which contains components registry is also copied during ugprades

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Currently, when an Elastic Agent installed via a DEB or RPM package is upgraded using a package manager (`apt`/`rpm`), it does not preserve the previous state saved under `run` folder resulting in a poor upgrade experience. This PR ensures that the `run` directory is correctly migrated, matching the behaviour expected during upgrades.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->
No disruptive impact expected. This change improves the upgrade process without altering current workflows for users. Upgrades will now correctly migrate the agent’s runtime state.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- Install an Elastic Agent via a DEB package on Ubuntu or Debian.
- Enroll and start the agent.
- Place a marker file inside the agent's `run` directory.
- Upgrade the agent using `apt install` or `dpkg -i`.
- Verify that the marker file is preserved in the new `run` directory after upgrade.
- Run the updated integration tests under `testing/integration/`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/3832