### PR TITLE
Add InfoSec's pre-commit hook for secrets detection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,14 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
-    hooks:
-    -   id: check-executables-have-shebangs
-        exclude: (.*/.*.(ps1|bat|bash)$)
-    -   id: check-shebang-scripts-are-executable
-        exclude: (.*/.*.(tmpl|tftpl)$)
-    -   id: check-merge-conflict
-        args: ['--assume-in-merge']
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.6.0
+  hooks:
+  - id: check-executables-have-shebangs
+    exclude: (.*/.*.(ps1|bat|bash)$)
+  - id: check-shebang-scripts-are-executable
+    exclude: (.*/.*.(tmpl|tftpl)$)
+  - id: check-merge-conflict
+    args: ['--assume-in-merge']
+- repo: https://github.com/elastic/infosec-precommit
+  rev: v1.0.0
+  hooks:
+  - id: infosec-precommit

--- a/.pre-commit-hooks.yml
+++ b/.pre-commit-hooks.yml
@@ -1,6 +1,6 @@
 - id: infosec-precommit
   name: PreCommit from InfoSec for Secret Scanning
-  description: This hook detects whehter a secret is being committed
+  description: This hook detects whether a secret is being committed
   entry: pre-commit
   language: script
   stages:

--- a/.pre-commit-hooks.yml
+++ b/.pre-commit-hooks.yml
@@ -1,0 +1,7 @@
+- id: infosec-precommit
+  name: PreCommit from InfoSec for Secret Scanning
+  description: This hook detects whehter a secret is being committed
+  entry: pre-commit
+  language: script
+  stages:
+    - pre-commit


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR adds the pre-commit hook for detecting if secrets are being committed, as recommended by Elastic's InfoSec team.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
To prevent secrets from committed to the Elastic Agent repository.

