### PR TITLE
Allow using beats receivers for self-monitoring

### DIFF
--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -203,7 +203,6 @@ func (b *BeatsMonitor) MonitoringConfig(
 							}
 							uintPolicyValue := uint(parsedPolicyValue)
 							failureThreshold = &uintPolicyValue
-						case nil: // no change
 						default:
 							return nil, fmt.Errorf("unsupported type for policy failure threshold: %T", policyFailureThresholdRaw)
 						}

--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -203,6 +203,7 @@ func (b *BeatsMonitor) MonitoringConfig(
 							}
 							uintPolicyValue := uint(parsedPolicyValue)
 							failureThreshold = &uintPolicyValue
+						case nil: // no change
 						default:
 							return nil, fmt.Errorf("unsupported type for policy failure threshold: %T", policyFailureThresholdRaw)
 						}

--- a/internal/pkg/core/monitoring/config/config.go
+++ b/internal/pkg/core/monitoring/config/config.go
@@ -16,7 +16,10 @@ const (
 	defaultNamespace = "default"
 
 	// DefaultHost is used when host is not defined or empty
-	DefaultHost = "localhost"
+	DefaultHost           = "localhost"
+	ProcessRuntimeManager = "process"
+	OtelRuntimeManager    = "otel"
+	DefaultRuntimeManager = ProcessRuntimeManager
 )
 
 // MonitoringConfig describes a configuration of a monitoring
@@ -33,6 +36,7 @@ type MonitoringConfig struct {
 	MonitorTraces    bool                  `yaml:"traces" config:"traces"`
 	APM              APMConfig             `yaml:"apm,omitempty" config:"apm,omitempty" json:"apm,omitempty"`
 	Diagnostics      Diagnostics           `yaml:"diagnostics,omitempty" json:"diagnostics,omitempty"`
+	RuntimeManager   string                `yaml:"_runtime_experimental,omitempty" config:"_runtime_experimental,omitempty"`
 }
 
 // MonitoringHTTPConfig is a config defining HTTP endpoint published by agent
@@ -118,9 +122,10 @@ func DefaultConfig() *MonitoringConfig {
 			Host:    DefaultHost,
 			Port:    defaultPort,
 		},
-		Namespace:   defaultNamespace,
-		APM:         defaultAPMConfig(),
-		Diagnostics: defaultDiagnostics(),
+		Namespace:      defaultNamespace,
+		APM:            defaultAPMConfig(),
+		Diagnostics:    defaultDiagnostics(),
+		RuntimeManager: DefaultRuntimeManager,
 	}
 }
 

--- a/testing/integration/beat_receivers_test.go
+++ b/testing/integration/beat_receivers_test.go
@@ -17,13 +17,14 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/elastic-agent-libs/kibana"
 	"github.com/elastic/elastic-agent-libs/testing/estools"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools/testcontext"
-	"github.com/gofrs/uuid/v5"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -308,22 +309,19 @@ func TestAgentMonitoring(t *testing.T) {
 			// Expected to change between agentDocs and OtelDocs
 			"@timestamp",
 			"agent.ephemeral_id",
+			// agent.id is different because it's the id of the underlying beat
 			"agent.id",
+			// agent.version is different because we force version 9.0.0 in CI
 			"agent.version",
+			// elastic_agent.id is different because we currently start a new agent in the second subtest
+			// this should be fixed in the future
+			"elastic_agent.id",
 			"data_stream.namespace",
 			"log.file.inode",
 			"log.file.fingerprint",
 			"log.file.path",
 			"log.offset",
-
-			// needs investigation
-			"event.agent_id_status",
 			"event.ingested",
-
-			// elastic_agent * fields are hardcoded in processor list for now which is why they differ
-			"elastic_agent.id",
-			"elastic_agent.snapshot",
-			"elastic_agent.version",
 		}
 
 		AssertMapsEqual(t, agent, otel, ignoredFields, "expected documents to be equal")

--- a/testing/integration/beat_receivers_test.go
+++ b/testing/integration/beat_receivers_test.go
@@ -293,10 +293,8 @@ func TestAgentMonitoring(t *testing.T) {
 			assert.Contains(collect, pipelineStatusMap, httpMetricsPipeline)
 			assert.Contains(collect, pipelineStatusMap, beatsMetricsPipeline)
 
-			// and they should be healthy
-			assert.Equal(collect, int(cproto.CollectorComponentStatus_StatusOK), pipelineStatusMap[fileStreamPipeline].Status)
-			assert.Equal(collect, int(cproto.CollectorComponentStatus_StatusOK), pipelineStatusMap[httpMetricsPipeline].Status)
-			assert.Equal(collect, int(cproto.CollectorComponentStatus_StatusOK), pipelineStatusMap[beatsMetricsPipeline].Status)
+			// and all the components should be healthy
+			assertCollectorComponentsHealthy(collect, otelCollectorStatus)
 
 			return
 		}, 1*time.Minute, 1*time.Second)
@@ -356,4 +354,12 @@ func TestAgentMonitoring(t *testing.T) {
 		AssertMapsEqual(t, agent, otel, ignoredFields, "expected documents to be equal")
 	})
 
+}
+
+func assertCollectorComponentsHealthy(t *assert.CollectT, status *atesting.AgentStatusCollectorOutput) {
+	assert.Equal(t, int(cproto.CollectorComponentStatus_StatusOK), status.Status, "component status should be ok")
+	assert.Equal(t, "", status.Error, "component status should not have an error")
+	for _, componentStatus := range status.ComponentStatusMap {
+		assertCollectorComponentsHealthy(t, componentStatus)
+	}
 }

--- a/testing/integration/beat_receivers_test.go
+++ b/testing/integration/beat_receivers_test.go
@@ -268,7 +268,7 @@ func TestAgentMonitoring(t *testing.T) {
 		require.NoError(t, err, "error configuring fixture")
 
 		output, err := fixture.InstallWithoutEnroll(ctx, &installOpts)
-		require.NoErrorf(t, err, "error install withouth enroll: %s\ncombinedoutput:\n%s", err, string(output))
+		require.NoErrorf(t, err, "error install without enroll: %s\ncombinedoutput:\n%s", err, string(output))
 
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			status, statusErr := fixture.ExecStatus(ctx)

--- a/testing/integration/beat_receivers_test.go
+++ b/testing/integration/beat_receivers_test.go
@@ -7,26 +7,21 @@
 package integration
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"runtime"
 	"testing"
-	"text/template"
 	"time"
 
 	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/elastic-agent-libs/kibana"
 	"github.com/elastic/elastic-agent-libs/testing/estools"
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools/testcontext"
-	"github.com/elastic/elastic-agent/pkg/utils"
-
 	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/require"
 )
@@ -79,6 +74,64 @@ func TestAgentMonitoring(t *testing.T) {
 		Force:          true,
 	}
 
+	// prepare the policy and marshalled configuration
+	policyCtx, policyCancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
+	t.Cleanup(policyCancel)
+
+	// 1. Create and install policy with just monitoring
+	createPolicyReq := kibana.AgentPolicy{
+		Name:        fmt.Sprintf("%s-%s", t.Name(), uuid.Must(uuid.NewV4()).String()),
+		Namespace:   info.Namespace,
+		Description: fmt.Sprintf("%s policy", t.Name()),
+		MonitoringEnabled: []kibana.MonitoringEnabledOption{
+			kibana.MonitoringEnabledLogs,
+			kibana.MonitoringEnabledMetrics,
+		},
+	}
+	policyResponse, err := info.KibanaClient.CreatePolicy(policyCtx, createPolicyReq)
+	require.NoError(t, err, "error creating policy")
+
+	// 2. Download the policy, add the API key
+	downloadURL := fmt.Sprintf("/api/fleet/agent_policies/%s/download", policyResponse.ID)
+	resp, err := info.KibanaClient.Connection.SendWithContext(policyCtx, http.MethodGet, downloadURL, nil, nil, nil)
+	require.NoError(t, err, "error downloading policy")
+	policyBytes, err := io.ReadAll(resp.Body)
+	require.NoError(t, err, "error reading policy response")
+	defer resp.Body.Close()
+
+	apiKeyResponse, err := createESApiKey(info.ESClient)
+	require.NoError(t, err, "failed to get api key")
+	require.True(t, len(apiKeyResponse.Encoded) > 1, "api key is invalid %q", apiKeyResponse)
+	apiKey, err := getDecodedApiKey(apiKeyResponse)
+	require.NoError(t, err, "error decoding api key")
+
+	type PolicyOutputs struct {
+		Type   string   `yaml:"type"`
+		Hosts  []string `yaml:"hosts"`
+		Preset string   `yaml:"preset"`
+		ApiKey string   `yaml:"api_key"`
+	}
+	type PolicyStruct struct {
+		ID                string                   `yaml:"id"`
+		Revision          int                      `yaml:"revision"`
+		Outputs           map[string]PolicyOutputs `yaml:"outputs"`
+		Fleet             map[string]any           `yaml:"fleet"`
+		OutputPermissions map[string]any           `yaml:"output_permissions"`
+		Agent             map[string]any           `yaml:"agent"`
+		Inputs            []map[string]any         `yaml:"inputs"`
+		Signed            map[string]any           `yaml:"signed"`
+		SecretReferences  []map[string]any         `yaml:"secret_references"`
+		Namespaces        []map[string]any         `yaml:"namespaces"`
+	}
+
+	policy := PolicyStruct{}
+	err = yaml.Unmarshal(policyBytes, &policy)
+	require.NoError(t, err, "error unmarshalling policy")
+	d, prs := policy.Outputs["default"]
+	require.True(t, prs, "default must be in outputs")
+	d.ApiKey = string(apiKey)
+	policy.Outputs["default"] = d
+
 	// Flow
 	// 1. Create and install policy with just monitoring
 	// 2. Download the policy, add the API key
@@ -86,66 +139,12 @@ func TestAgentMonitoring(t *testing.T) {
 	// 4. Make sure logs and metrics for agent monitoring are being received
 	t.Run("verify elastic-agent monitoring functionality", func(t *testing.T) {
 		ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
-		defer cancel()
-
-		// 1. Create and install policy with just monitoring
-		createPolicyReq := kibana.AgentPolicy{
-			Name:        fmt.Sprintf("%s-%s", t.Name(), uuid.Must(uuid.NewV4()).String()),
-			Namespace:   info.Namespace,
-			Description: fmt.Sprintf("%s policy", t.Name()),
-			MonitoringEnabled: []kibana.MonitoringEnabledOption{
-				kibana.MonitoringEnabledLogs,
-				kibana.MonitoringEnabledMetrics,
-			},
-		}
-		policyResponse, err := info.KibanaClient.CreatePolicy(ctx, createPolicyReq)
-		require.NoError(t, err, "error creating policy")
-
-		// 2. Download the policy, add the API key
-		downloadURL := fmt.Sprintf("/api/fleet/agent_policies/%s/download", policyResponse.ID)
-		resp, err := info.KibanaClient.Connection.SendWithContext(ctx, http.MethodGet, downloadURL, nil, nil, nil)
-		require.NoError(t, err, "error downloading policy")
-		policy, err := io.ReadAll(resp.Body)
-		require.NoError(t, err, "error reading policy response")
-		defer resp.Body.Close()
-
-		apiKeyResponse, err := createESApiKey(info.ESClient)
-		require.NoError(t, err, "failed to get api key")
-		require.True(t, len(apiKeyResponse.Encoded) > 1, "api key is invalid %q", apiKeyResponse)
-		apiKey, err := getDecodedApiKey(apiKeyResponse)
-		require.NoError(t, err, "error decoding api key")
-
-		type PolicyOutputs struct {
-			Type   string   `yaml:"type"`
-			Hosts  []string `yaml:"hosts"`
-			Preset string   `yaml:"preset"`
-			ApiKey string   `yaml:"api_key"`
-		}
-		type PolicyStruct struct {
-			ID                string                   `yaml:"id"`
-			Revision          int                      `yaml:"revision"`
-			Outputs           map[string]PolicyOutputs `yaml:"outputs"`
-			Fleet             map[string]any           `yaml:"fleet"`
-			OutputPermissions map[string]any           `yaml:"output_permissions"`
-			Agent             map[string]any           `yaml:"agent"`
-			Inputs            []map[string]any         `yaml:"inputs"`
-			Signed            map[string]any           `yaml:"signed"`
-			SecretReferences  []map[string]any         `yaml:"secret_references"`
-			Namespaces        []map[string]any         `yaml:"namespaces"`
-		}
-
-		y := PolicyStruct{}
-		err = yaml.Unmarshal(policy, &y)
-		require.NoError(t, err, "error unmarshalling policy")
-		d, prs := y.Outputs["default"]
-		require.True(t, prs, "default must be in outputs")
-		d.ApiKey = string(apiKey)
-		y.Outputs["default"] = d
-		policyBytes, err := yaml.Marshal(y)
-		require.NoErrorf(t, err, "error marshalling policy, struct was %v", y)
+		t.Cleanup(cancel)
+		updatedPolicyBytes, err := yaml.Marshal(policy)
+		require.NoErrorf(t, err, "error marshalling policy, struct was %v", policy)
 		t.Cleanup(func() {
 			if t.Failed() {
-				t.Logf("policy was %s", string(policyBytes))
+				t.Logf("policy was %s", string(updatedPolicyBytes))
 			}
 		})
 
@@ -156,7 +155,7 @@ func TestAgentMonitoring(t *testing.T) {
 		err = fixture.Prepare(ctx)
 		require.NoError(t, err, "error preparing fixture")
 
-		err = fixture.Configure(ctx, policyBytes)
+		err = fixture.Configure(ctx, updatedPolicyBytes)
 		require.NoError(t, err, "error configuring fixture")
 
 		output, err := fixture.InstallWithoutEnroll(ctx, &installOpts)
@@ -225,37 +224,42 @@ func TestAgentMonitoring(t *testing.T) {
 			}, "monitoring logs from elastic-agent should exist before proceeding",
 		)
 
-		type configOptions struct {
-			InputPath      string
-			ESEndpoint     string
-			ESApiKey       string
-			SocketEndpoint string
-			Namespace      string
-		}
-		esEndpoint, err := getESHost()
-		require.NoError(t, err, "error getting elasticsearch endpoint")
-		esApiKey, err := createESApiKey(info.ESClient)
-		require.NoError(t, err, "error creating API key")
-		require.NotEmptyf(t, esApiKey.Encoded, "api key is invalid %q", esApiKey)
+		ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
+		t.Cleanup(cancel)
 
-		// Start monitoring in otel mode
+		// switch monitoring to the otel runtime
+		monitoring := policy.Agent["monitoring"]
+		monitoringMap := monitoring.(map[any]any)
+		monitoringMap["_runtime_experimental"] = "otel"
+		policy.Agent["monitoring"] = monitoringMap
+
+		updatedPolicyBytes, err := yaml.Marshal(policy)
+		require.NoErrorf(t, err, "error marshalling policy, struct was %v", policy)
+		t.Cleanup(func() {
+			if t.Failed() {
+				t.Logf("policy was %s", string(updatedPolicyBytes))
+			}
+		})
+
+		// 3. Install without enrolling in fleet
 		fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 		require.NoError(t, err)
 
-		ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
-		defer cancel()
-
 		err = fixture.Prepare(ctx)
-		require.NoError(t, err)
+		require.NoError(t, err, "error preparing fixture")
 
-		// installs elastic-agent with empty elastic-agent.yml to get its working dir first
-		err = fixture.Configure(ctx, []byte{})
-		require.NoError(t, err)
+		err = fixture.Configure(ctx, updatedPolicyBytes)
+		require.NoError(t, err, "error configuring fixture")
+
+		// Get the timestamp before starting. Required to separate logs from agent and otel.
+		timestamp := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+
+		fmt.Println(time.Now())
 
 		output, err := fixture.InstallWithoutEnroll(ctx, &installOpts)
 		require.NoErrorf(t, err, "error install withouth enroll: %s\ncombinedoutput:\n%s", err, string(output))
 
-		// Ensure elastic-agent is healthy, otherwise we cannot perform retstart operation
+		// Ensure elastic-agent is healthy, otherwise we cannot perform restart operation
 		require.Eventually(t, func() bool {
 			err = fixture.IsHealthy(ctx)
 			if err != nil {
@@ -263,160 +267,7 @@ func TestAgentMonitoring(t *testing.T) {
 				return false
 			}
 			return true
-		}, 30*time.Second, 1*time.Second)
-
-		configTemplateOTel := `
-receivers:
-  filebeatreceiver/filestream-monitoring:
-    filebeat:
-      inputs:
-        - type: filestream
-          enabled: true
-          id: filestream-monitoring-agent
-          paths:
-            -  {{.InputPath}}/data/elastic-agent-*/logs/elastic-agent-*.ndjson
-            -  {{.InputPath}}/data/elastic-agent-*/logs/elastic-agent-watcher-*.ndjson
-          close:
-            on_state_change:
-              inactive: 5m
-          parsers:
-            - ndjson:
-                add_error_key: true
-                message_key: message
-                overwrite_keys: true
-                target: ""
-          processors:
-            - add_fields:
-                fields:
-                  dataset: elastic_agent
-                  namespace: {{.Namespace}}
-                  type: logs
-                target: data_stream
-            - add_fields:
-                fields:
-                  dataset: elastic_agent
-                target: event
-            - add_fields:
-                fields:
-                  id: 0ddca301-e7c0-4eac-8432-7dd05bc9cb06
-                  snapshot: false
-                  version: 8.19.0
-                target: elastic_agent
-            - add_fields:
-                fields:
-                  id: 0879f47d-df41-464d-8462-bc2b8fef45bf
-                target: agent
-            - drop_event:
-                when:
-                  regexp:
-                    component.id: .*-monitoring$
-            - drop_event:
-                when:
-                  regexp:
-                    message: ^Non-zero metrics in the last
-            - copy_fields:
-                fields:
-                  - from: data_stream.dataset
-                    to: data_stream.dataset_original
-            - drop_fields:
-                fields:
-                  - data_stream.dataset
-            - copy_fields:
-                fail_on_error: false
-                fields:
-                  - from: component.dataset
-                    to: data_stream.dataset
-                ignore_missing: true
-            - copy_fields:
-                fail_on_error: false
-                fields:
-                  - from: data_stream.dataset_original
-                    to: data_stream.dataset
-            - drop_fields:
-                fields:
-                  - data_stream.dataset_original
-                  - event.dataset
-            - copy_fields:
-                fields:
-                  - from: data_stream.dataset
-                    to: event.dataset
-            - drop_fields:
-                fields:
-                  - ecs.version
-                ignore_missing: true
-    output:
-      otelconsumer:
-    queue:
-      mem:
-        flush:
-          timeout: 0s
-    logging:
-      level: info
-      selectors:
-        - '*'
-    http.enabled: true
-    http.host: {{ .SocketEndpoint }}
-exporters:
-  debug:
-    use_internal_logger: false
-    verbosity: detailed
-  elasticsearch/log:
-    endpoints:
-      - {{.ESEndpoint}}
-    compression: none
-    api_key: {{.ESApiKey}}
-    logs_dynamic_index:
-      enabled: true
-    batcher:
-      enabled: true
-      flush_timeout: 0.5s
-    mapping:
-      mode: bodymap
-service:
-  pipelines:
-    logs:
-      receivers:
-        - filebeatreceiver/filestream-monitoring
-      exporters:
-        - elasticsearch/log
-`
-		socketEndpoint := utils.SocketURLWithFallback(uuid.Must(uuid.NewV4()).String(), paths.TempDir())
-
-		// configure elastic-agent.yml with new config
-		var configBuffer bytes.Buffer
-		template.Must(template.New("config").Parse(configTemplateOTel)).Execute(&configBuffer,
-			configOptions{
-				InputPath:      fixture.WorkDir(),
-				ESEndpoint:     esEndpoint,
-				ESApiKey:       esApiKey.Encoded,
-				SocketEndpoint: socketEndpoint,
-				Namespace:      info.Namespace,
-			})
-		configOTelContents := configBuffer.Bytes()
-		t.Cleanup(func() {
-			if t.Failed() {
-				t.Logf("Contents of agent config file:\n%s\n", string(configOTelContents))
-			}
-		})
-		err = fixture.Configure(ctx, configOTelContents)
-		require.NoError(t, err)
-
-		// Get the timestamp before restarting. Required to separate logs from agent and otel
-		timestamp := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
-
-		fmt.Println(time.Now())
-		// Restart elastic-agent
-		output, err = fixture.Exec(ctx, []string{"restart"})
-		require.NoErrorf(t, err, "error restarting agent: %s\ncombinedoutput:\n%s", err, string(output))
-
-		require.Eventually(t, func() bool {
-			err = fixture.IsHealthy(ctx)
-			if err != nil {
-				t.Logf("waiting for agent healthy: %s", err.Error())
-				return false
-			}
-			return true
-		}, 30*time.Second, 1*time.Second)
+		}, 1*time.Minute, 1*time.Second)
 
 		// run this only for logs for now
 		tc := tests[0]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Adds the ability to use beats receivers for agent self-monitoring. To do so, we add a new configuration key to `agent.monitoring` named `_runtime_experimental` - identical to how you can currently switch inputs to the Otel runtime.

In terms of implementation, the changes are very straightforward. In the monitoring injection manager, we set the runtime manager for inputs we add, if it's set in the monitoring configuration.

Most of this PR's code changes lie in tests, and more specifically in the `TestAgentMonitoring` E2E test. This test compares the data collected by agent self-monitoring using beats processes to an equivalent Otel configuration of beats receivers in Hybrid mode. Instead of doing that, we can now just change `agent.monitoring._runtime_experimental`, so the test becomes much simpler conceptually.

I have simplified some of the test logic, but I haven't yet made it compare metrics. This should be doable now, but we have another PR (https://github.com/elastic/elastic-agent/pull/8009 ) in-flight doing it, so I held off.

## Why is it important?

We want to be able to use beats receivers for agent self-monitoring.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [x] I have added an integration test or an E2E test

## How to test this PR locally

Build the agent locally and use the following configuration:

```yaml
outputs:
  default:
    type: elasticsearch
    hosts: [...]
    username: elastic
    password: "..."

inputs: []

agent:
  monitoring:
    metrics: true
    logs: true
    _runtime_experimental: otel
```

Looking at Kibana dashboards for the agent integration can prove the data is actually being ingested. You can verify that beats receivers are being used for self-monitoring by looking at their CPU usage - it should be 0.

## Related issues

- Closes https://github.com/elastic/ingest-dev/issues/3517


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
