### PR TITLE
Bump beats dependency version to 20250429215007-4c1bf91fe423

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/docker/docker v27.5.1+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/dolmen-go/contextio v0.0.0-20200217195037-68fc5150bcd5
-	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20250423112141-6fd122401512
+	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20250429215007-4c1bf91fe423
 	github.com/elastic/cloud-on-k8s/v2 v2.0.0-20250327073047-b624240832ae
 	github.com/elastic/elastic-agent-autodiscover v0.9.0
 	github.com/elastic/elastic-agent-client/v7 v7.17.2
@@ -347,7 +347,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -472,8 +472,8 @@ github.com/eclipse/paho.mqtt.golang v1.3.5 h1:sWtmgNxYM9P2sP+xEItMozsR3w0cqZFlqn
 github.com/eclipse/paho.mqtt.golang v1.3.5/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+Jgm1PklsYT/eo8Hcc=
 github.com/elastic/bayeux v1.0.5 h1:UceFq01ipmT3S8DzFK+uVAkbCdiPR0Bqei8qIGmUeY0=
 github.com/elastic/bayeux v1.0.5/go.mod h1:CSI4iP7qeo5MMlkznGvYKftp8M7qqP/3nzmVZoXHY68=
-github.com/elastic/beats/v7 v7.0.0-alpha2.0.20250423112141-6fd122401512 h1:e3ZR00hrRx2JyR4Wd/gqg1Sir2SfyvepZW1gxFE6W0Q=
-github.com/elastic/beats/v7 v7.0.0-alpha2.0.20250423112141-6fd122401512/go.mod h1:aMTmS4PStEA9SXSbujjnyCmrCzS4BYoPQY80LRuDEE8=
+github.com/elastic/beats/v7 v7.0.0-alpha2.0.20250429215007-4c1bf91fe423 h1:PE7zs/vb9VcGIw+7zL4d/f0ArxXJy+Y/EWYO5gSsqSQ=
+github.com/elastic/beats/v7 v7.0.0-alpha2.0.20250429215007-4c1bf91fe423/go.mod h1:EE2te8yzxH30S/k0QTUaVnUsI1xj5j7Gl7l+Vuy/al8=
 github.com/elastic/cloud-on-k8s/v2 v2.0.0-20250327073047-b624240832ae h1:OiShmbWAyGU0MS0ADJWr1/QgeLIZliMk9xsrFicR3/s=
 github.com/elastic/cloud-on-k8s/v2 v2.0.0-20250327073047-b624240832ae/go.mod h1:D2IckZVXARugvikE4fv1glvaJMohKSZRzrPsxCjo9O0=
 github.com/elastic/elastic-agent-autodiscover v0.9.0 h1:+iWIKh0u3e8I+CJa3FfWe9h0JojNasPgYIA47gpuuns=
@@ -683,8 +683,9 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
-github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 h1:au07oEsX2xN0ktxqI+Sida1w446QrXBRJ0nee3SNZlA=

--- a/internal/pkg/otel/configtranslate/otelconfig_test.go
+++ b/internal/pkg/otel/configtranslate/otelconfig_test.go
@@ -215,7 +215,6 @@ func TestGetOtelConfig(t *testing.T) {
 				"enabled": true,
 			},
 			"num_workers":       1,
-			"api_key":           "",
 			"timeout":           90 * time.Second,
 			"idle_conn_timeout": 3 * time.Second,
 		},

--- a/testing/integration/beat_receivers_test.go
+++ b/testing/integration/beat_receivers_test.go
@@ -9,7 +9,6 @@ package integration
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -113,7 +112,7 @@ func TestAgentMonitoring(t *testing.T) {
 		apiKeyResponse, err := createESApiKey(info.ESClient)
 		require.NoError(t, err, "failed to get api key")
 		require.True(t, len(apiKeyResponse.Encoded) > 1, "api key is invalid %q", apiKeyResponse)
-		apiKey, err := base64.StdEncoding.DecodeString(apiKeyResponse.Encoded)
+		apiKey, err := getDecodedApiKey(apiKeyResponse)
 		require.NoError(t, err, "error decoding api key")
 
 		type PolicyOutputs struct {
@@ -275,11 +274,11 @@ receivers:
           enabled: true
           id: filestream-monitoring-agent
           paths:
-            -  {{.InputPath}}/data/elastic-agent-*/logs/elastic-agent-*.ndjson 
+            -  {{.InputPath}}/data/elastic-agent-*/logs/elastic-agent-*.ndjson
             -  {{.InputPath}}/data/elastic-agent-*/logs/elastic-agent-watcher-*.ndjson
           close:
             on_state_change:
-              inactive: 5m	  
+              inactive: 5m
           parsers:
             - ndjson:
                 add_error_key: true
@@ -372,14 +371,14 @@ exporters:
       enabled: true
       flush_timeout: 0.5s
     mapping:
-      mode: bodymap	  
+      mode: bodymap
 service:
   pipelines:
     logs:
       receivers:
         - filebeatreceiver/filestream-monitoring
       exporters:
-        - elasticsearch/log  
+        - elasticsearch/log
 `
 		socketEndpoint := utils.SocketURLWithFallback(uuid.Must(uuid.NewV4()).String(), paths.TempDir())
 


### PR DESCRIPTION
## What does this PR do?

Bumps the beats dependency to the commit currently at the tip of main. Here are the changes affecting beats receivers that this pulls in:

- https://github.com/elastic/beats/commit/11df15387613f652ec19f34f4ea8d8d6fd8e2956
- https://github.com/elastic/beats/commit/2da0cdd5e3afd8d1a44851b886d122f7a8b1e0b9
- https://github.com/elastic/beats/commit/cf9ed29bb06ad52fed779223a0fd2c351ae44271

The test fixes in this PR are solely due to the last commit, which requires us to use ES api keys in the right format depending on if we're configuring an elasticsearch output or an elasticsearch exporter.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
