### PR TITLE
[9.0] Use beats dependency from 9.0 branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/docker/docker v27.5.1+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/dolmen-go/contextio v0.0.0-20200217195037-68fc5150bcd5
-	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20250423112141-6fd122401512
+	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20250429233941-bce373f7dcd5
 	github.com/elastic/cloud-on-k8s/v2 v2.0.0-20250327073047-b624240832ae
 	github.com/elastic/elastic-agent-autodiscover v0.9.0
 	github.com/elastic/elastic-agent-client/v7 v7.17.2
@@ -346,7 +346,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
@@ -434,7 +434,6 @@ require (
 	github.com/mattn/go-ieproxy v0.0.1 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
-	github.com/microsoft/wmi v0.25.1 // indirect
 	github.com/miekg/dns v1.1.62 // indirect
 	github.com/mileusna/useragent v1.3.4 // indirect
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -473,8 +473,8 @@ github.com/eclipse/paho.mqtt.golang v1.3.5 h1:sWtmgNxYM9P2sP+xEItMozsR3w0cqZFlqn
 github.com/eclipse/paho.mqtt.golang v1.3.5/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+Jgm1PklsYT/eo8Hcc=
 github.com/elastic/bayeux v1.0.5 h1:UceFq01ipmT3S8DzFK+uVAkbCdiPR0Bqei8qIGmUeY0=
 github.com/elastic/bayeux v1.0.5/go.mod h1:CSI4iP7qeo5MMlkznGvYKftp8M7qqP/3nzmVZoXHY68=
-github.com/elastic/beats/v7 v7.0.0-alpha2.0.20250423112141-6fd122401512 h1:e3ZR00hrRx2JyR4Wd/gqg1Sir2SfyvepZW1gxFE6W0Q=
-github.com/elastic/beats/v7 v7.0.0-alpha2.0.20250423112141-6fd122401512/go.mod h1:aMTmS4PStEA9SXSbujjnyCmrCzS4BYoPQY80LRuDEE8=
+github.com/elastic/beats/v7 v7.0.0-alpha2.0.20250429233941-bce373f7dcd5 h1:PcEOj1RU/WWsXqb+T1fs8WFXKq49X7Ssb1slnyOrpBk=
+github.com/elastic/beats/v7 v7.0.0-alpha2.0.20250429233941-bce373f7dcd5/go.mod h1:wZ3qQ66p34+HQnxTaFDA4pV5Fo4h0spUJjO+spC98mI=
 github.com/elastic/cloud-on-k8s/v2 v2.0.0-20250327073047-b624240832ae h1:OiShmbWAyGU0MS0ADJWr1/QgeLIZliMk9xsrFicR3/s=
 github.com/elastic/cloud-on-k8s/v2 v2.0.0-20250327073047-b624240832ae/go.mod h1:D2IckZVXARugvikE4fv1glvaJMohKSZRzrPsxCjo9O0=
 github.com/elastic/elastic-agent-autodiscover v0.9.0 h1:+iWIKh0u3e8I+CJa3FfWe9h0JojNasPgYIA47gpuuns=
@@ -689,8 +689,9 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
-github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 h1:au07oEsX2xN0ktxqI+Sida1w446QrXBRJ0nee3SNZlA=
@@ -1076,8 +1077,6 @@ github.com/maxmind/mmdbwriter v1.0.0 h1:bieL4P6yaYaHvbtLSwnKtEvScUKKD6jcKaLiTM3W
 github.com/maxmind/mmdbwriter v1.0.0/go.mod h1:noBMCUtyN5PUQ4H8ikkOvGSHhzhLok51fON2hcrpKj8=
 github.com/microsoft/go-mssqldb v1.7.2 h1:CHkFJiObW7ItKTJfHo1QX7QBBD1iV+mn1eOyRP3b/PA=
 github.com/microsoft/go-mssqldb v1.7.2/go.mod h1:kOvZKUdrhhFQmxLZqbwUV0rHkNkZpthMITIb2Ko1IoA=
-github.com/microsoft/wmi v0.25.1 h1:sQv9hCEHtW5K6yEVL78T6XGRMGxk4aTpcJwCiB5rLN0=
-github.com/microsoft/wmi v0.25.1/go.mod h1:1zbdSF0A+5OwTUII5p3hN7/K6KF2m3o27pSG6Y51VU8=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/miekg/dns v1.1.62 h1:cN8OuEF1/x5Rq6Np+h1epln8OiyPWV+lROx9LxcGgIQ=

--- a/internal/pkg/otel/configtranslate/otelconfig_test.go
+++ b/internal/pkg/otel/configtranslate/otelconfig_test.go
@@ -214,8 +214,6 @@ func TestGetOtelConfig(t *testing.T) {
 				"enabled": true,
 			},
 			"num_workers":       1,
-			"api_key":           "",
-			"logs_index":        "filebeat-9.0.0",
 			"timeout":           90 * time.Second,
 			"idle_conn_timeout": 3 * time.Second,
 		},

--- a/testing/integration/beat_receivers_test.go
+++ b/testing/integration/beat_receivers_test.go
@@ -9,7 +9,6 @@ package integration
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -113,7 +112,7 @@ func TestAgentMonitoring(t *testing.T) {
 		apiKeyResponse, err := createESApiKey(info.ESClient)
 		require.NoError(t, err, "failed to get api key")
 		require.True(t, len(apiKeyResponse.Encoded) > 1, "api key is invalid %q", apiKeyResponse)
-		apiKey, err := base64.StdEncoding.DecodeString(apiKeyResponse.Encoded)
+		apiKey, err := getDecodedApiKey(apiKeyResponse)
 		require.NoError(t, err, "error decoding api key")
 
 		type PolicyOutputs struct {
@@ -275,11 +274,11 @@ receivers:
           enabled: true
           id: filestream-monitoring-agent
           paths:
-            -  {{.InputPath}}/data/elastic-agent-*/logs/elastic-agent-*.ndjson 
+            -  {{.InputPath}}/data/elastic-agent-*/logs/elastic-agent-*.ndjson
             -  {{.InputPath}}/data/elastic-agent-*/logs/elastic-agent-watcher-*.ndjson
           close:
             on_state_change:
-              inactive: 5m	  
+              inactive: 5m
           parsers:
             - ndjson:
                 add_error_key: true
@@ -372,14 +371,14 @@ exporters:
       enabled: true
       flush_timeout: 0.5s
     mapping:
-      mode: bodymap	  
+      mode: bodymap
 service:
   pipelines:
     logs:
       receivers:
         - filebeatreceiver/filestream-monitoring
       exporters:
-        - elasticsearch/log  
+        - elasticsearch/log
 `
 		socketEndpoint := utils.SocketURLWithFallback(uuid.Must(uuid.NewV4()).String(), paths.TempDir())
 

--- a/testing/integration/otel_test.go
+++ b/testing/integration/otel_test.go
@@ -696,6 +696,15 @@ func createESApiKey(esClient *elasticsearch.Client) (estools.APIKeyResponse, err
 	return estools.CreateAPIKey(context.Background(), esClient, estools.APIKeyRequest{Name: "test-api-key", Expiration: "1d"})
 }
 
+// getDecodedApiKey returns a decoded API key appropriate for use in beats configurations.
+func getDecodedApiKey(keyResponse estools.APIKeyResponse) (string, error) {
+	decoded, err := base64.StdEncoding.DecodeString(keyResponse.Encoded)
+	if err != nil {
+		return "", err
+	}
+	return string(decoded), nil
+}
+
 func linesTrackMap(lines []string) map[string]bool {
 	mm := make(map[string]bool)
 	for _, l := range lines {
@@ -1018,16 +1027,17 @@ func TestOtelFilestreamInput(t *testing.T) {
 
 	// Create the otel configuration file
 	type otelConfigOptions struct {
-		InputPath       string
-		ESEndpoint      string
-		ESApiKey        string
-		ESApiKeyEncoded string
+		InputPath  string
+		ESEndpoint string
+		ESApiKey   string
 	}
 	esEndpoint, err := getESHost()
 	require.NoError(t, err, "error getting elasticsearch endpoint")
 	esApiKey, err := createESApiKey(info.ESClient)
 	require.NoError(t, err, "error creating API key")
 	require.True(t, len(esApiKey.Encoded) > 1, "api key is invalid %q", esApiKey)
+	decodedApiKey, err := getDecodedApiKey(esApiKey)
+	require.NoError(t, err)
 	configTemplate := `inputs:
   - type: filestream
     id: filestream-e2e
@@ -1045,7 +1055,7 @@ outputs:
   default:
     type: elasticsearch
     hosts: [{{.ESEndpoint}}]
-    api_key: "{{.ESApiKeyEncoded}}"
+    api_key: "{{.ESApiKey}}"
     preset: "balanced"
   monitoring:
     type: elasticsearch
@@ -1060,15 +1070,12 @@ agent:
 `
 	index := ".ds-logs-e2e-*"
 	var configBuffer bytes.Buffer
-	decodedApiKey, err := base64.StdEncoding.DecodeString(esApiKey.Encoded)
-	require.NoError(t, err)
 	require.NoError(t,
 		template.Must(template.New("config").Parse(configTemplate)).Execute(&configBuffer,
 			otelConfigOptions{
-				InputPath:       inputFilePath,
-				ESEndpoint:      esEndpoint,
-				ESApiKey:        string(decodedApiKey),
-				ESApiKeyEncoded: esApiKey.Encoded,
+				InputPath:  inputFilePath,
+				ESEndpoint: esEndpoint,
+				ESApiKey:   decodedApiKey,
 			}))
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
@@ -1171,6 +1178,8 @@ func TestOTelHTTPMetricsInput(t *testing.T) {
 	esApiKey, err := createESApiKey(info.ESClient)
 	require.NoError(t, err, "error creating API key")
 	require.True(t, len(esApiKey.Encoded) > 1, "api key is invalid %q", esApiKey)
+	decodedApiKey, err := getDecodedApiKey(esApiKey)
+	require.NoError(t, err)
 	configTemplate := `
 inputs:
   - type: http/metrics
@@ -1206,7 +1215,7 @@ agent.monitoring:
 	template.Must(template.New("config").Parse(configTemplate)).Execute(&configBuffer,
 		otelConfigOptions{
 			ESEndpoint: esEndpoint,
-			ESApiKey:   esApiKey.Encoded,
+			ESApiKey:   decodedApiKey,
 		})
 
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
@@ -1530,7 +1539,7 @@ service:
         - debug
 `
 
-	beatsApiKey, err := base64.StdEncoding.DecodeString(esApiKey.Encoded)
+	beatsApiKey, err := getDecodedApiKey(esApiKey)
 	require.NoError(t, err, "error decoding api key")
 
 	var configBuffer bytes.Buffer


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

We depend on beats as a library for beats receivers. Up until now, the agent 9.0 branch depended on the beats main branch in this respect. This PR changes that, and fixes any test failures due to the effective update. These changes are the same as https://github.com/elastic/elastic-agent/pull/8041.

## Why is it important?

Agent branches should depend on the appropriate beats branch, rather than `main`.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
