### PR TITLE
Generate NOTICE.txt with only modules used by binaries

### DIFF
--- a/changelog/fragments/1746636264-fix-notice.yaml
+++ b/changelog/fragments/1746636264-fix-notice.yaml
@@ -1,0 +1,34 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: other
+
+# Change summary; a 80ish characters long description of the change.
+summary: `NOTICE.txt` now contains only those modules that are used by the Elastic Agent binaries.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  The `NOTICE.txt` file now contains only those modules that the Elastic Agent binaries for various platforms directly
+  or indirectly depends on. Modules used for development tooling are now excluded from `NOTICE.txt`.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/8053
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1746636264-fix-notice.yaml
+++ b/changelog/fragments/1746636264-fix-notice.yaml
@@ -17,8 +17,9 @@ summary: NOTICE.txt now contains only those modules that are used by the Elastic
 # this field accommodate a description without length limits.
 # NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
 description: |
-  The NOTICE.txt file now contains only those modules that the Elastic Agent binaries for various platforms directly
-  or indirectly depends on. Modules used for development tooling are now excluded from NOTICE.txt.
+  Only those modules that the Elastic Agent binaries for various platforms directly
+  or indirectly depend on are now included in the NOTICE.txt file . Modules used for development
+  tooling are now excluded from NOTICE.txt.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component: elastic-agent

--- a/changelog/fragments/1746636264-fix-notice.yaml
+++ b/changelog/fragments/1746636264-fix-notice.yaml
@@ -11,14 +11,14 @@
 kind: other
 
 # Change summary; a 80ish characters long description of the change.
-summary: `NOTICE.txt` now contains only those modules that are used by the Elastic Agent binaries.
+summary: NOTICE.txt now contains only those modules that are used by the Elastic Agent binaries.
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
 # NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
 description: |
-  The `NOTICE.txt` file now contains only those modules that the Elastic Agent binaries for various platforms directly
-  or indirectly depends on. Modules used for development tooling are now excluded from `NOTICE.txt`.
+  The NOTICE.txt file now contains only those modules that the Elastic Agent binaries for various platforms directly
+  or indirectly depends on. Modules used for development tooling are now excluded from NOTICE.txt.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component: elastic-agent

--- a/dev-tools/mage/target/common/notice.go
+++ b/dev-tools/mage/target/common/notice.go
@@ -151,10 +151,7 @@ func Notice() (err error) {
 // Equivalent to running the following on the command line:
 // go list -deps -f "{{with .Module}}{{if not .Main}}{{.Path}}{{end}}{{end}}" -tags "linux,darwin,windows,{additionalTags...}"
 func getDependentModules(additionalTags ...string) ([]string, error) {
-	tags := []string{"linux", "darwin", "windows"}
-	if len(additionalTags) > 0 {
-		tags = append(tags, additionalTags...)
-	}
+	tags := []string{"linux", "darwin", "windows", additionalTags...}
 
 	cmdArgs := []string{
 		"list",

--- a/dev-tools/mage/target/common/notice.go
+++ b/dev-tools/mage/target/common/notice.go
@@ -151,7 +151,7 @@ func Notice() (err error) {
 // Equivalent to running the following on the command line:
 // go list -deps -f "{{with .Module}}{{if not .Main}}{{.Path}}{{end}}{{end}}" -tags "linux,darwin,windows,{additionalTags...}"
 func getDependentModules(additionalTags ...string) ([]string, error) {
-	tags := []string{"linux", "darwin", "windows", additionalTags...}
+	tags := append([]string{"linux", "darwin", "windows"}, additionalTags...)
 
 	cmdArgs := []string{
 		"list",

--- a/dev-tools/mage/target/common/notice.go
+++ b/dev-tools/mage/target/common/notice.go
@@ -9,8 +9,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 
 	"github.com/magefile/mage/sh"
@@ -36,17 +38,25 @@ func Notice() (err error) {
 		return err
 	}
 
+	modules, err := getDependentModules()
+	if err != nil {
+		return fmt.Errorf("unable to fetch list of dependent modules: %w", err)
+	}
+	slices.Sort(modules)
+
 	// piping output of the first command to the second
 	// similar to former Makefile implementation
 	//
-	// go list -m -json all | go run go.elastic.co/go-licence-detector \
+	// go list -m -json {modules} | go run go.elastic.co/go-licence-detector \
 	// -includeIndirect \
 	// -rules dev-tools/notice/rules.json \
 	// -overrides dev-tools/notice/overrides.json \
 	// -noticeTemplate dev-tools/notice/NOTICE.txt.tmpl \
 	// -noticeOut NOTICE.txt \
 	// -depsOut ""
-	listCmd := exec.Command("go", "list", "-m", "-json", "all")
+	listCmdArgs := []string{"list", "-m", "-json"}
+	listCmdArgs = append(listCmdArgs, modules...)
+	listCmd := exec.Command("go", listCmdArgs...)
 	licDetectCmd := exec.Command("go", "run", "go.elastic.co/go-licence-detector",
 		"-includeIndirect",
 		"-rules", "dev-tools/notice/rules.json",
@@ -132,4 +142,50 @@ func Notice() (err error) {
 	}
 
 	return nil
+}
+
+// getDependentModules returns the unique list paths of modules that the
+// github.com/elastic/elastic-agent module recursively depends on. If
+// additionalTags are specified, only files that would be compiled with
+// those build tags + "linux,darwin,windows" are examined.
+// Equivalent to running the following on the command line:
+// go list -deps -f "{{with .Module}}{{if not .Main}}{{.Path}}{{end}}{{end}}" -tags "linux,darwin,windows,{additionalTags...}"
+func getDependentModules(additionalTags ...string) ([]string, error) {
+	tags := []string{"linux", "darwin", "windows"}
+	if len(additionalTags) > 0 {
+		tags = append(tags, additionalTags...)
+	}
+
+	cmdArgs := []string{
+		"list",
+		"-deps",
+		"-f",
+		"{{with .Module}}{{if not .Main}}{{.Path}}{{end}}{{end}}",
+		"-tags",
+		strings.Join(tags, ","),
+	}
+
+	cmd := exec.Command("go", cmdArgs...)
+	fmt.Printf(">> %s\n", strings.Join(cmd.Args, " "))
+
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			fmt.Println(string(exitErr.Stderr))
+		}
+		return nil, err
+	}
+
+	// Parse out list of modules from command output, while also
+	// de-duplicating the list.
+	modulesMap := map[string]struct{}{}
+	for _, line := range bytes.Split(output, []byte("\n")) {
+		if len(line) > 0 {
+			modulesMap[string(line)] = struct{}{}
+		}
+	}
+
+	// Convert to list and return
+	modules := slices.Collect(maps.Keys(modulesMap))
+	return modules, nil
 }

--- a/dev-tools/mage/target/common/notice.go
+++ b/dev-tools/mage/target/common/notice.go
@@ -170,7 +170,8 @@ func getDependentModules(additionalTags ...string) ([]string, error) {
 
 	output, err := cmd.Output()
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) { // double pointer is necessary because Error() is defined on *exec.ExitError receiver
 			fmt.Println(string(exitErr.Stderr))
 		}
 		return nil, err


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR updates the code for `mage notice` so that the generated `NOTICE.txt` contains only those Go modules that are used by Elastic Agent binaries.  Specifically, it excludes any Go modules used only in tests, developer tooling, etc.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To generate an accurate `NOTICE.txt`.  We will build upon the changes in this PR to generate a separate `NOTICE-fips.txt` containing Go modules used in the FIPS-capable Elastic Agent binary. 

The code in this PR is inspired by [how APM Server is generating their `NOTICE.txt`](https://github.com/elastic/apm-server/blob/67b1d34a8faa9cee52f652e9dfb740b4089607b1/Makefile#L261-L274). 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- ~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- ~[ ] I have added an integration test or an E2E test~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

NOTICE.txt will now contain fewer modules than before.  Modules that are used for testing or build-time tooling will be excluded. Only modules that are used in the binaries that are packaged for released will be included.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run `mage notice`.
