### PR TITLE
Retry enrollment requests when an error is returned, add enrollment timeout

### DIFF
--- a/changelog/fragments/1746113477-Retry-enrollment-for-all-errors.yaml
+++ b/changelog/fragments/1746113477-Retry-enrollment-for-all-errors.yaml
@@ -8,7 +8,7 @@
 # - security: impacts on the security of a product or a user’s deployment.
 # - upgrade: important information for someone upgrading from a prior version
 # - other: does not fit into any of the other categories
-kind: bug-fix
+kind: enhancement
 
 # Change summary; a 80ish characters long description of the change.
 summary: Retry enrollment requests on any error

--- a/changelog/fragments/1746113477-Retry-enrollment-for-all-errors.yaml
+++ b/changelog/fragments/1746113477-Retry-enrollment-for-all-errors.yaml
@@ -11,14 +11,14 @@
 kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
-summary: Retry enrollment requests on any error
+summary: Retry enrollment requests on any network error
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
 # NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
 description: |
-  If any error is encountered during an attempted enrollment, the elastic-agent
-  will backoff and retry.
+  If any network error is encountered during an attempted enrollment, the
+  elastic-agent will backoff and retry.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component: elastic-agent

--- a/changelog/fragments/1746113477-Retry-enrollment-for-all-errors.yaml
+++ b/changelog/fragments/1746113477-Retry-enrollment-for-all-errors.yaml
@@ -11,12 +11,14 @@
 kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
-summary: Retry enrollment for all errors
+summary: Retry enrollment requests on any error
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
 # NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
-#description:
+description: |
+  If any error is encountered during an attempted enrollment, the elastic-agent
+  will backoff and retry.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component: elastic-agent
@@ -25,7 +27,7 @@ component: elastic-agent
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/elastic-agent/pull/8056
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.

--- a/changelog/fragments/1746113477-Retry-enrollment-for-all-errors.yaml
+++ b/changelog/fragments/1746113477-Retry-enrollment-for-all-errors.yaml
@@ -19,7 +19,7 @@ summary: Retry enrollment requests on any error
 description: |
   If any error is encountered during an attempted enrollment, the elastic-agent
   will backoff and retry. Add a new --enrollement-timeout flag and
-  FLEET_ENROLLMENT_TIMEOUT env var to set how long it tries for, default 10m.
+  FLEET_ENROLL_TIMEOUT env var to set how long it tries for, default 10m.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component: elastic-agent

--- a/changelog/fragments/1746113477-Retry-enrollment-for-all-errors.yaml
+++ b/changelog/fragments/1746113477-Retry-enrollment-for-all-errors.yaml
@@ -18,7 +18,7 @@ summary: Retry enrollment requests on any error
 # NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
 description: |
   If any error is encountered during an attempted enrollment, the elastic-agent
-  will backoff and retry. Add a new --enrollement-timeout flag and
+  will backoff and retry. Add a new --enroll-timeout flag and
   FLEET_ENROLL_TIMEOUT env var to set how long it tries for, default 10m.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.

--- a/changelog/fragments/1746113477-Retry-enrollment-for-all-errors.yaml
+++ b/changelog/fragments/1746113477-Retry-enrollment-for-all-errors.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Retry enrollment for all errors
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1746113477-Retry-enrollment-for-all-errors.yaml
+++ b/changelog/fragments/1746113477-Retry-enrollment-for-all-errors.yaml
@@ -11,14 +11,15 @@
 kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
-summary: Retry enrollment requests on any network error
+summary: Retry enrollment requests on any error
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
 # NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
 description: |
-  If any network error is encountered during an attempted enrollment, the
-  elastic-agent will backoff and retry.
+  If any error is encountered during an attempted enrollment, the elastic-agent
+  will backoff and retry. Add a new --enrollement-timeout flag and
+  FLEET_ENROLLMENT_TIMEOUT env var to set how long it tries for, default 10m.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component: elastic-agent

--- a/changelog/fragments/1746113477-Retry-enrollment-for-all-errors.yaml
+++ b/changelog/fragments/1746113477-Retry-enrollment-for-all-errors.yaml
@@ -19,7 +19,8 @@ summary: Retry enrollment requests on any error
 description: |
   If any error is encountered during an attempted enrollment, the elastic-agent
   will backoff and retry. Add a new --enroll-timeout flag and
-  FLEET_ENROLL_TIMEOUT env var to set how long it tries for, default 10m.
+  FLEET_ENROLL_TIMEOUT env var to set how long it tries for, default 10m. A
+  negative value disables the timeout.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component: elastic-agent

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -391,7 +391,7 @@ func ensureServiceToken(streams *cli.IOStreams, cfg *setupConfig) error {
 	if err != nil {
 		return err
 	}
-	code, r, err := client.Connection.Request("POST", "/api/fleet/service_tokens", nil, nil, nil)
+	code, r, err := client.Request("POST", "/api/fleet/service_tokens", nil, nil, nil)
 	if err != nil {
 		return fmt.Errorf("request to get security token from Kibana failed: %w", err)
 	}
@@ -698,14 +698,14 @@ func isTrue(val string) bool {
 func performGET(cfg setupConfig, client *kibana.Client, path string, response interface{}, writer io.Writer, msg string) error {
 	var lastErr error
 	for i := 0; i < cfg.Kibana.RetryMaxCount; i++ {
-		code, result, err := client.Connection.Request("GET", path, nil, nil, nil)
+		code, result, err := client.Request("GET", path, nil, nil, nil)
 		if err != nil || code != 200 {
 			if err != nil {
 				err = fmt.Errorf("http GET request to %s%s fails: %w. Response: %s",
-					client.Connection.URL, path, err, truncateString(result))
+					client.URL, path, err, truncateString(result))
 			} else {
 				err = fmt.Errorf("http GET request to %s%s fails. StatusCode: %d Response: %s",
-					client.Connection.URL, path, code, truncateString(result))
+					client.URL, path, code, truncateString(result))
 			}
 			fmt.Fprintf(writer, "%s failed: %s\n", msg, err)
 			<-time.After(cfg.Kibana.RetrySleepDuration)
@@ -726,7 +726,7 @@ func truncateString(b []byte) string {
 		runes = append(runes[:maxLength], []rune("... (truncated)")...)
 	}
 
-	return strings.Replace(string(runes), "\n", " ", -1)
+	return strings.ReplaceAll(string(runes), "\n", " ")
 }
 
 // runLegacyAPMServer extracts the bundled apm-server from elastic-agent

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -517,6 +517,10 @@ func buildEnrollArgs(cfg setupConfig, token string, policyID string) ([]string, 
 		args = append(args, "--daemon-timeout")
 		args = append(args, cfg.Fleet.DaemonTimeout.String())
 	}
+	if cfg.Fleet.EnrollTimeout != 0 {
+		args = append(args, "--enroll-timeout")
+		args = append(args, cfg.Fleet.EnrollTimeout.String())
+	}
 	if cfg.Fleet.Cert != "" {
 		args = append(args, "--elastic-agent-cert", cfg.Fleet.Cert)
 	}

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -81,6 +81,7 @@ The following actions are possible and grouped based on the actions.
   FLEET_ENROLL - set to 1 for enrollment into Fleet Server. If not set, Elastic Agent is run in standalone mode.
   FLEET_URL - URL of the Fleet Server to enroll into
   FLEET_ENROLLMENT_TOKEN - token to use for enrollment. This is not needed in case FLEET_SERVER_ENABLED and FLEET_ENROLL is set. Then the token is fetched from Kibana.
+  FLEET_ENROLL_TIMEOUT - The timeout duration for the enroll commnd. Defaults to 10m. A negative value disables the timeout.
   FLEET_CA - path to certificate authority to use with communicate with Fleet Server [$KIBANA_CA]
   FLEET_INSECURE - communicate with Fleet with either insecure HTTP or unverified HTTPS
   ELASTIC_AGENT_CERT - path to certificate to use for connecting to fleet-server.

--- a/internal/pkg/agent/cmd/enroll.go
+++ b/internal/pkg/agent/cmd/enroll.go
@@ -481,7 +481,7 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command) error {
 	key, _ := cmd.Flags().GetString("elastic-agent-cert-key")
 	keyPassphrase, _ := cmd.Flags().GetString("elastic-agent-cert-key-passphrase")
 
-	ctx := handelSignal(context.Background())
+	ctx := handleSignal(context.Background())
 
 	if enrollTimeout > 0 {
 		eCtx, cancel := context.WithTimeout(ctx, enrollTimeout)

--- a/internal/pkg/agent/cmd/enroll.go
+++ b/internal/pkg/agent/cmd/enroll.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -95,6 +96,7 @@ func addEnrollFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceP("proxy-header", "", []string{}, "Proxy headers used with CONNECT request: when bootstrapping Fleet Server, it's the proxy used by Fleet Server to connect to Elasticsearch; when enrolling the Elastic Agent to Fleet Server, it's the proxy used by the Elastic Agent to connect to Fleet Server")
 	cmd.Flags().BoolP("delay-enroll", "", false, "Delays enrollment to occur on first start of the Elastic Agent service")
 	cmd.Flags().DurationP("daemon-timeout", "", 0, "Timeout waiting for Elastic Agent daemon")
+	cmd.Flags().DurationP("enroll-timeout", "", 10*time.Minute, "Timeout waiting for Elastic Agent enroll command.")
 	cmd.Flags().DurationP("fleet-server-timeout", "", 0, "When bootstrapping Fleet Server, timeout waiting for Fleet Server to be ready to start enrollment")
 	cmd.Flags().Bool("skip-daemon-reload", false, "Skip daemon reload after enrolling")
 	cmd.Flags().StringSliceP("tag", "", []string{}, "User-set tags")
@@ -205,6 +207,7 @@ func buildEnrollmentFlags(cmd *cobra.Command, url string, token string) []string
 	fProxyHeaders, _ := cmd.Flags().GetStringSlice("proxy-header")
 	delayEnroll, _ := cmd.Flags().GetBool("delay-enroll")
 	daemonTimeout, _ := cmd.Flags().GetDuration("daemon-timeout")
+	enrollTimeout, _ := cmd.Flags().GetDuration("enroll-timeout")
 	fTimeout, _ := cmd.Flags().GetDuration("fleet-server-timeout")
 	skipDaemonReload, _ := cmd.Flags().GetBool("skip-daemon-reload")
 	fTags, _ := cmd.Flags().GetStringSlice("tag")
@@ -284,6 +287,10 @@ func buildEnrollmentFlags(cmd *cobra.Command, url string, token string) []string
 	if daemonTimeout != 0 {
 		args = append(args, "--daemon-timeout")
 		args = append(args, daemonTimeout.String())
+	}
+	if enrollTimeout != 0 {
+		args = append(args, "--enroll-timeout")
+		args = append(args, enrollTimeout.String())
 	}
 	if fTimeout != 0 {
 		args = append(args, "--fleet-server-timeout")
@@ -461,6 +468,7 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command) error {
 	proxyHeaders, _ := cmd.Flags().GetStringSlice("proxy-header")
 	delayEnroll, _ := cmd.Flags().GetBool("delay-enroll")
 	daemonTimeout, _ := cmd.Flags().GetDuration("daemon-timeout")
+	enrollTimeout, _ := cmd.Flags().GetDuration("enroll-timeout")
 	fTimeout, _ := cmd.Flags().GetDuration("fleet-server-timeout")
 	skipDaemonReload, _ := cmd.Flags().GetBool("skip-daemon-reload")
 	tags, _ := cmd.Flags().GetStringSlice("tag")
@@ -473,7 +481,8 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command) error {
 	key, _ := cmd.Flags().GetString("elastic-agent-cert-key")
 	keyPassphrase, _ := cmd.Flags().GetString("elastic-agent-cert-key-passphrase")
 
-	ctx := handleSignal(context.Background())
+	ctx, cancel := context.WithTimeout(handleSignal(context.Background()), enrollTimeout)
+	defer cancel()
 
 	// On MacOS Ventura and above, fixing the permissions on enrollment during installation fails with the error:
 	//  Error: failed to fix permissions: chown /Library/Elastic/Agent/data/elastic-agent-c13f91/elastic-agent.app: operation not permitted

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -544,22 +544,16 @@ func (c *enrollCmd) enrollWithBackoff(ctx context.Context, persistentConfig map[
 	backExp := c.backoffFactory(signal)
 
 	for {
-		retry := false
 		switch {
 		case errors.Is(err, fleetapi.ErrTooManyRequests):
 			c.log.Warn("Too many requests on the remote server, will retry in a moment.")
-			retry = true
 		case errors.Is(err, fleetapi.ErrConnRefused):
 			c.log.Warn("Remote server is not ready to accept connections(Connection Refused), will retry in a moment.")
-			retry = true
 		case errors.Is(err, fleetapi.ErrTemporaryServerError):
 			c.log.Warnf("Remote server failed to handle the request(%s), will retry in a moment.", err.Error())
-			retry = true
 		case err != nil:
 			c.log.Warnf("Enrollment failed: %s", err.Error())
-			retry = true
-		}
-		if !retry {
+		case err == nil:
 			break
 		}
 		backExp.Wait()

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -555,18 +555,11 @@ RETRYLOOP:
 		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded), err == nil:
 			break RETRYLOOP
 		case err != nil:
-			var agentError errors.Error
-			if errors.As(err, &agentError) {
-				// Network errors should be retried, all other errors are not.
-				if agentError.Type() == errors.TypeNetwork {
-					c.log.Warnf("Network error detected: %s, will retry in a moment.", err.Error())
-					break
-				}
-			}
-			c.log.Warnf("Enrollment failed: %s", err.Error())
-			break RETRYLOOP
+			c.log.Warnf("Error detected: %s, will retry in a moment.", err.Error())
 		}
-		backExp.Wait()
+		if !backExp.Wait() {
+			break
+		}
 		c.log.Infof("Retrying enrollment to URL: %s", c.client.URI())
 		err = c.enroll(ctx, persistentConfig)
 	}

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -557,6 +557,7 @@ func (c *enrollCmd) enrollWithBackoff(ctx context.Context, persistentConfig map[
 			retry = true
 		case err != nil:
 			c.log.Warnf("Enrollment failed: %s", err.Error())
+			retry = true
 		}
 		if !retry {
 			break

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -551,10 +551,10 @@ func (c *enrollCmd) enrollWithBackoff(ctx context.Context, persistentConfig map[
 			c.log.Warn("Remote server is not ready to accept connections(Connection Refused), will retry in a moment.")
 		case errors.Is(err, fleetapi.ErrTemporaryServerError):
 			c.log.Warnf("Remote server failed to handle the request(%s), will retry in a moment.", err.Error())
-		case err != nil:
-			c.log.Warnf("Enrollment failed: %s", err.Error())
-		case err == nil:
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded), err == nil:
 			break
+		case err != nil:
+			c.log.Warnf("Enrollment failed: %s, will retry in a moment.", err.Error())
 		}
 		backExp.Wait()
 		c.log.Infof("Retrying enrollment to URL: %s", c.client.URI())

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -602,7 +602,7 @@ func (c *enrollCmd) enroll(ctx context.Context, persistentConfig map[string]inte
 
 	resp, err := cmd.Execute(ctx, r)
 	if err != nil {
-		return fmt.Errorf("failed to execute fleet-server: %w", err)
+		return fmt.Errorf("failed to execute request to fleet-server: %w", err)
 	}
 
 	fleetConfig, err := createFleetConfigFromEnroll(resp.Item.AccessAPIKey, c.options.EnrollAPIKey, c.options.ReplaceToken, c.remoteConfig)

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -543,6 +543,7 @@ func (c *enrollCmd) enrollWithBackoff(ctx context.Context, persistentConfig map[
 	defer close(signal)
 	backExp := c.backoffFactory(signal)
 
+RETRYLOOP:
 	for {
 		switch {
 		case errors.Is(err, fleetapi.ErrTooManyRequests):
@@ -552,7 +553,7 @@ func (c *enrollCmd) enrollWithBackoff(ctx context.Context, persistentConfig map[
 		case errors.Is(err, fleetapi.ErrTemporaryServerError):
 			c.log.Warnf("Remote server failed to handle the request(%s), will retry in a moment.", err.Error())
 		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded), err == nil:
-			break
+			break RETRYLOOP
 		case err != nil:
 			c.log.Warnf("Enrollment failed: %s, will retry in a moment.", err.Error())
 		}

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -558,7 +558,7 @@ RETRYLOOP:
 			c.log.Warnf("Error detected: %s, will retry in a moment.", err.Error())
 		}
 		if !backExp.Wait() {
-			break
+			break RETRYLOOP
 		}
 		c.log.Infof("Retrying enrollment to URL: %s", c.client.URI())
 		err = c.enroll(ctx, persistentConfig)

--- a/internal/pkg/agent/cmd/enroll_cmd_test.go
+++ b/internal/pkg/agent/cmd/enroll_cmd_test.go
@@ -177,7 +177,7 @@ func TestEnroll(t *testing.T) {
 				if err != nil {
 					return false
 				}
-				return host == cfg.Client.Host && "my-access-api-key" == cfg.AccessAPIKey
+				return cfg.Client.Host == host && cfg.AccessAPIKey == "my-access-api-key"
 			})).Return(nil).Once()
 
 			cmd, err := newEnrollCmd(
@@ -247,7 +247,7 @@ func TestEnroll(t *testing.T) {
 				if err != nil {
 					return false
 				}
-				return host == cfg.Client.Host && "my-access-api-key" == cfg.AccessAPIKey
+				return cfg.Client.Host == host && cfg.AccessAPIKey == "my-access-api-key"
 			})).Return(nil).Once()
 			cmd, err := newEnrollCmd(
 				log,
@@ -317,7 +317,7 @@ func TestEnroll(t *testing.T) {
 				if err != nil {
 					return false
 				}
-				return host == cfg.Client.Host && "my-access-api-key" == cfg.AccessAPIKey
+				return cfg.Client.Host == host && cfg.AccessAPIKey == "my-access-api-key"
 			})).Return(nil).Once()
 			cmd, err := newEnrollCmd(
 				log,
@@ -440,7 +440,7 @@ func TestEnroll(t *testing.T) {
 				if err != nil {
 					return false
 				}
-				return host == cfg.Client.Host && "my-access-api-key" == cfg.AccessAPIKey
+				return cfg.Client.Host == host && cfg.AccessAPIKey == "my-access-api-key"
 			})).Return(nil).Once()
 			cmd, err := newEnrollCmd(
 				log,

--- a/internal/pkg/agent/cmd/enroll_cmd_test.go
+++ b/internal/pkg/agent/cmd/enroll_cmd_test.go
@@ -114,7 +114,9 @@ func TestEnroll(t *testing.T) {
 			require.NoError(t, err)
 
 			streams, _, _, _ := cli.NewTestingIOStreams()
-			err = cmd.Execute(context.Background(), streams)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			err = cmd.Execute(ctx, streams)
 			require.Error(t, err)
 		},
 	))
@@ -170,7 +172,7 @@ func TestEnroll(t *testing.T) {
 			require.NoError(t, err)
 
 			streams, _, _, _ := cli.NewTestingIOStreams()
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 			defer cancel()
 
 			if err := cmd.Execute(ctx, streams); err != nil {
@@ -233,7 +235,7 @@ func TestEnroll(t *testing.T) {
 			require.NoError(t, err)
 
 			streams, _, _, _ := cli.NewTestingIOStreams()
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 			defer cancel()
 
 			if err := cmd.Execute(ctx, streams); err != nil {
@@ -298,7 +300,7 @@ func TestEnroll(t *testing.T) {
 			require.NoError(t, err)
 
 			streams, _, _, _ := cli.NewTestingIOStreams()
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 			defer cancel()
 			err = cmd.Execute(ctx, streams)
 			require.NoError(t, err, "enroll command should return no error")
@@ -343,7 +345,9 @@ func TestEnroll(t *testing.T) {
 			require.NoError(t, err)
 
 			streams, _, _, _ := cli.NewTestingIOStreams()
-			err = cmd.Execute(context.Background(), streams)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			err = cmd.Execute(ctx, streams)
 			require.Error(t, err)
 			require.False(t, store.Called)
 		},
@@ -412,7 +416,7 @@ func TestEnroll(t *testing.T) {
 			require.NoError(t, err)
 
 			streams, _, _, _ := cli.NewTestingIOStreams()
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 			defer cancel()
 			err = cmd.Execute(ctx, streams)
 			require.NoError(t, err, "enroll command should return no error")
@@ -439,7 +443,7 @@ func TestValidateArgs(t *testing.T) {
 		require.NoError(t, err)
 		args := buildEnrollmentFlags(cmd, url, enrolmentToken)
 		require.NotNil(t, args)
-		require.Equal(t, len(args), 11)
+		require.Len(t, args, 13)
 		require.Contains(t, args, "--tag")
 		require.Contains(t, args, "windows")
 		require.Contains(t, args, "production")
@@ -448,6 +452,7 @@ func TestValidateArgs(t *testing.T) {
 		require.Contains(t, args, url)
 		require.Contains(t, args, "--fleet-server-client-auth")
 		require.Contains(t, args, "none")
+		require.Contains(t, args, "--enroll-timeout")
 		cleanedTags := cleanTags(args)
 		require.Contains(t, cleanedTags, "windows")
 		require.Contains(t, cleanedTags, "production")
@@ -467,8 +472,8 @@ func TestValidateArgs(t *testing.T) {
 		require.Contains(t, cleanedTags, "windows")
 		require.Contains(t, cleanedTags, "production")
 		// Validate that we remove the duplicates
-		require.Equal(t, len(args), 12)
-		require.Equal(t, len(cleanedTags), 9)
+		require.Len(t, args, 14)
+		require.Len(t, cleanedTags, 11)
 	})
 
 	t.Run("valid tag and empty tag", func(t *testing.T) {

--- a/internal/pkg/agent/cmd/enroll_cmd_test.go
+++ b/internal/pkg/agent/cmd/enroll_cmd_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/testing/certutil"
@@ -36,6 +37,15 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
 )
+
+type mockSaver struct {
+	mock.Mock
+}
+
+func (m *mockSaver) Save(in io.Reader) error {
+	args := m.Called(in)
+	return args.Error(0)
+}
 
 type mockStore struct {
 	Err     error
@@ -61,7 +71,7 @@ func TestEnroll(t *testing.T) {
 
 	log, _ := logger.New("tst", false)
 
-	t.Run("fail to save is propagated", withTLSServer(
+	t.Run("fail to save is retried", withTLSServer(
 		func(t *testing.T) *http.ServeMux {
 			mux := http.NewServeMux()
 			mux.HandleFunc("/api/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
@@ -94,7 +104,9 @@ func TestEnroll(t *testing.T) {
 			defer os.Remove(caFile)
 
 			url := "https://" + host
-			store := &mockStore{Err: errors.New("fail to save")}
+			store := &mockSaver{}
+			failCall := store.On("Save", mock.Anything).Return(errors.New("fail to save")).Once()
+			store.On("Save", mock.Anything).Return(nil).NotBefore(failCall).Once()
 			cmd, err := newEnrollCmd(
 				log,
 				&enrollCmdOption{
@@ -103,6 +115,7 @@ func TestEnroll(t *testing.T) {
 					EnrollAPIKey:         "my-enrollment-token",
 					UserProvidedMetadata: map[string]interface{}{"custom": "customize"},
 					SkipCreateSecret:     skipCreateSecret,
+					SkipDaemonRestart:    true,
 				},
 				"",
 				store,
@@ -114,7 +127,8 @@ func TestEnroll(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 			defer cancel()
 			err = cmd.Execute(ctx, streams)
-			require.Error(t, err)
+			require.NoError(t, err)
+			store.AssertExpectations(t)
 		},
 	))
 
@@ -151,7 +165,21 @@ func TestEnroll(t *testing.T) {
 			defer os.Remove(caFile)
 
 			url := "https://" + host
-			store := &mockStore{}
+
+			store := &mockSaver{}
+			store.On("Save", mock.MatchedBy(func(in io.Reader) bool {
+				buf := new(bytes.Buffer)
+				_, err := io.Copy(buf, in)
+				if err != nil {
+					return false
+				}
+				cfg, err := readConfig(buf.Bytes())
+				if err != nil {
+					return false
+				}
+				return host == cfg.Client.Host && "my-access-api-key" == cfg.AccessAPIKey
+			})).Return(nil).Once()
+
 			cmd, err := newEnrollCmd(
 				log,
 				&enrollCmdOption{
@@ -175,12 +203,7 @@ func TestEnroll(t *testing.T) {
 			if err := cmd.Execute(ctx, streams); err != nil {
 				t.Fatalf("enroll command returned and unexpected error: %v", err)
 			}
-
-			config, err := readConfig(store.Content)
-			require.NoError(t, err)
-
-			assert.Equal(t, "my-access-api-key", config.AccessAPIKey)
-			assert.Equal(t, host, config.Client.Host)
+			store.AssertExpectations(t)
 		},
 	))
 
@@ -213,7 +236,19 @@ func TestEnroll(t *testing.T) {
 			return mux
 		}, func(t *testing.T, host string) {
 			url := "http://" + host + "/"
-			store := &mockStore{}
+			store := &mockSaver{}
+			store.On("Save", mock.MatchedBy(func(in io.Reader) bool {
+				buf := new(bytes.Buffer)
+				_, err := io.Copy(buf, in)
+				if err != nil {
+					return false
+				}
+				cfg, err := readConfig(buf.Bytes())
+				if err != nil {
+					return false
+				}
+				return host == cfg.Client.Host && "my-access-api-key" == cfg.AccessAPIKey
+			})).Return(nil).Once()
 			cmd, err := newEnrollCmd(
 				log,
 				&enrollCmdOption{
@@ -238,14 +273,7 @@ func TestEnroll(t *testing.T) {
 			if err := cmd.Execute(ctx, streams); err != nil {
 				t.Fatalf("enroll command returned and unexpected error: %v", err)
 			}
-
-			assert.True(t, store.Called)
-			config, err := readConfig(store.Content)
-			require.NoError(t, err, "readConfig returned an error")
-			assert.Equal(t, "my-access-api-key", config.AccessAPIKey,
-				"The stored 'Access API Key' must be the same returned by Fleet-Server")
-			assert.Equal(t, host, config.Client.Host,
-				"The stored Fleet-Server host must match the one used during enrol")
+			store.AssertExpectations(t)
 		},
 	))
 
@@ -278,7 +306,19 @@ func TestEnroll(t *testing.T) {
 			return mux
 		}, func(t *testing.T, host string) {
 			url := "http://" + host
-			store := &mockStore{}
+			store := &mockSaver{}
+			store.On("Save", mock.MatchedBy(func(in io.Reader) bool {
+				buf := new(bytes.Buffer)
+				_, err := io.Copy(buf, in)
+				if err != nil {
+					return false
+				}
+				cfg, err := readConfig(buf.Bytes())
+				if err != nil {
+					return false
+				}
+				return host == cfg.Client.Host && "my-access-api-key" == cfg.AccessAPIKey
+			})).Return(nil).Once()
 			cmd, err := newEnrollCmd(
 				log,
 				&enrollCmdOption{
@@ -301,16 +341,11 @@ func TestEnroll(t *testing.T) {
 			defer cancel()
 			err = cmd.Execute(ctx, streams)
 			require.NoError(t, err, "enroll command should return no error")
-
-			assert.True(t, store.Called)
-			config, err := readConfig(store.Content)
-			require.NoError(t, err)
-			assert.Equal(t, "my-access-api-key", config.AccessAPIKey)
-			assert.Equal(t, host, config.Client.Host)
+			store.AssertExpectations(t)
 		},
 	))
 
-	t.Run("fail to enroll without TLS", withServer(
+	t.Run("fail to enroll without TLS times out", withServer(
 		func(t *testing.T) *http.ServeMux {
 			mux := http.NewServeMux()
 			mux.HandleFunc("/api/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
@@ -324,7 +359,7 @@ func TestEnroll(t *testing.T) {
 			return mux
 		}, func(t *testing.T, host string) {
 			url := "http://" + host
-			store := &mockStore{}
+			store := &mockSaver{}
 			cmd, err := newEnrollCmd(
 				log,
 				&enrollCmdOption{
@@ -345,8 +380,8 @@ func TestEnroll(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 			defer cancel()
 			err = cmd.Execute(ctx, streams)
-			require.Error(t, err)
-			require.False(t, store.Called)
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+			store.AssertExpectations(t)
 		},
 	))
 
@@ -394,7 +429,19 @@ func TestEnroll(t *testing.T) {
 			return mux
 		}, func(t *testing.T, host string) {
 			url := "http://" + host
-			store := &mockStore{}
+			store := &mockSaver{}
+			store.On("Save", mock.MatchedBy(func(in io.Reader) bool {
+				buf := new(bytes.Buffer)
+				_, err := io.Copy(buf, in)
+				if err != nil {
+					return false
+				}
+				cfg, err := readConfig(buf.Bytes())
+				if err != nil {
+					return false
+				}
+				return host == cfg.Client.Host && "my-access-api-key" == cfg.AccessAPIKey
+			})).Return(nil).Once()
 			cmd, err := newEnrollCmd(
 				log,
 				&enrollCmdOption{
@@ -417,12 +464,7 @@ func TestEnroll(t *testing.T) {
 			defer cancel()
 			err = cmd.Execute(ctx, streams)
 			require.NoError(t, err, "enroll command should return no error")
-
-			assert.True(t, store.Called, "the store should have been called")
-			config, err := readConfig(store.Content)
-			require.NoError(t, err)
-			assert.Equal(t, "my-access-api-key", config.AccessAPIKey)
-			assert.Equal(t, host, config.Client.Host)
+			store.AssertExpectations(t)
 		},
 	))
 }
@@ -526,6 +568,24 @@ func TestValidateArgs(t *testing.T) {
 		require.Contains(t, args, "/path/to/cert")
 		require.Contains(t, args, "--elastic-agent-cert-key")
 		require.Contains(t, args, "/path/to/key")
+	})
+
+	t.Run("enroll-timeout value is passed", func(t *testing.T) {
+		cmd := newEnrollCommandWithArgs([]string{}, streams)
+		err := cmd.Flags().Set("enroll-timeout", "1m")
+		require.NoError(t, err)
+		args := buildEnrollmentFlags(cmd, url, enrolmentToken)
+		require.Contains(t, args, "--enroll-timeout")
+		require.Contains(t, args, "1m0s")
+	})
+
+	t.Run("negative enroll-timeout value is passed", func(t *testing.T) {
+		cmd := newEnrollCommandWithArgs([]string{}, streams)
+		err := cmd.Flags().Set("enroll-timeout", "-1s")
+		require.NoError(t, err)
+		args := buildEnrollmentFlags(cmd, url, enrolmentToken)
+		require.Contains(t, args, "--enroll-timeout")
+		require.Contains(t, args, "-1s")
 	})
 }
 

--- a/internal/pkg/agent/cmd/enroll_cmd_test.go
+++ b/internal/pkg/agent/cmd/enroll_cmd_test.go
@@ -57,10 +57,7 @@ func (m *mockStore) Save(in io.Reader) error {
 
 func TestEnroll(t *testing.T) {
 	testutils.InitStorage(t)
-	skipCreateSecret := false
-	if runtime.GOOS == "darwin" {
-		skipCreateSecret = true
-	}
+	skipCreateSecret := runtime.GOOS == "darwin"
 
 	log, _ := logger.New("tst", false)
 

--- a/internal/pkg/agent/cmd/setup_config.go
+++ b/internal/pkg/agent/cmd/setup_config.go
@@ -26,6 +26,7 @@ type fleetConfig struct {
 	TokenPolicyName string        `config:"token_policy_name"`
 	URL             string        `config:"url"`
 	DaemonTimeout   time.Duration `config:"daemon_timeout"`
+	EnrollTimeout   time.Duration `config:"enroll_timeout"`
 	Cert            string        `config:"cert"`
 	CertKey         string        `config:"cert_key"`
 }
@@ -96,6 +97,7 @@ func defaultAccessConfig() (setupConfig, error) {
 			TokenPolicyName: envWithDefault("", "FLEET_TOKEN_POLICY_NAME"),
 			URL:             envWithDefault("", "FLEET_URL"),
 			DaemonTimeout:   envTimeout("FLEET_DAEMON_TIMEOUT"),
+			EnrollTimeout:   envTimeout("FLEET_ENROLL_TIMEOUT"),
 			Cert:            envWithDefault("", "ELASTIC_AGENT_CERT"),
 			CertKey:         envWithDefault("", "ELASTIC_AGENT_CERT_KEY"),
 		},


### PR DESCRIPTION
## What does this PR do?

Retry enrollment requests when an error is returned until a timeout is reached.
Add `--enroll-timeout` and `FLEET_ENROLL_TIMEOUT` to control how long the timeout is; default 10m.

## Why is it important?

Increase reliability of enrollments.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

Agents running via container, or command line **without** the delay enrollment option will retry for 10m instead of indefinitely. 