### PR TITLE
[Integration Testing] Add support for FIPS-capable artifacts

### DIFF
--- a/pkg/testing/fetch_test.go
+++ b/pkg/testing/fetch_test.go
@@ -7,7 +7,26 @@ package testing
 import (
 	"errors"
 	gtesting "testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+func TestGetPackagePrefix(t *gtesting.T) {
+	tests := map[string]struct {
+		fipsOnly bool
+		expected string
+	}{
+		"fips":    {fipsOnly: true, expected: "fips-"},
+		"no_fips": {fipsOnly: false, expected: ""},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *gtesting.T) {
+			actual := GetPackagePrefix(tc.fipsOnly)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
 
 func TestGetPackageSuffix(t *gtesting.T) {
 	tests := map[string]struct {

--- a/pkg/testing/fetcher.go
+++ b/pkg/testing/fetcher.go
@@ -40,6 +40,15 @@ var packageArchMap = map[string]string{
 	"darwin-arm64-targz": "darwin-aarch64.tar.gz",
 }
 
+// GetPackagePrefix returns the prefix right before the version component of the Elastic
+// Agent's artifact name, based on the given parameter values.
+func GetPackagePrefix(fipsOnly bool) string {
+	if fipsOnly {
+		return "fips-"
+	}
+	return ""
+}
+
 // GetPackageSuffix returns the suffix ending for the builds of Elastic Agent based on the
 // operating system and architecture.
 func GetPackageSuffix(operatingSystem string, architecture string, packageFormat string) (string, error) {

--- a/pkg/testing/fetcher_artifact.go
+++ b/pkg/testing/fetcher_artifact.go
@@ -26,6 +26,7 @@ type httpDoer interface {
 
 type artifactFetcher struct {
 	snapshotOnly bool
+	fipsOnly     bool
 
 	doer httpDoer
 }
@@ -36,6 +37,13 @@ type artifactFetcherOpt func(f *artifactFetcher)
 func WithArtifactSnapshotOnly() artifactFetcherOpt {
 	return func(f *artifactFetcher) {
 		f.snapshotOnly = true
+	}
+}
+
+// WithArtifactFIPSOnly sets the ArtifactFetcher to only pull a FIPS-compliant build.
+func WithArtifactFIPSOnly() artifactFetcherOpt {
+	return func(f *artifactFetcher) {
+		f.fipsOnly = true
 	}
 }
 

--- a/pkg/testing/fetcher_artifact.go
+++ b/pkg/testing/fetcher_artifact.go
@@ -68,6 +68,7 @@ func (f *artifactFetcher) Name() string {
 
 // Fetch fetches the Elastic Agent and places the resulting binary at the path.
 func (f *artifactFetcher) Fetch(ctx context.Context, operatingSystem string, architecture string, version string, packageFormat string) (FetcherResult, error) {
+	prefix := GetPackagePrefix(f.fipsOnly)
 	suffix, err := GetPackageSuffix(operatingSystem, architecture, packageFormat)
 	if err != nil {
 		return nil, err
@@ -92,7 +93,7 @@ func (f *artifactFetcher) Fetch(ctx context.Context, operatingSystem string, arc
 	}
 
 	// this remote path cannot have the build metadata in it
-	srcPath := fmt.Sprintf("elastic-agent-%s-%s", ver.VersionWithPrerelease(), suffix)
+	srcPath := fmt.Sprintf("elastic-agent-%s%s-%s", prefix, ver.VersionWithPrerelease(), suffix)
 	downloadSrc := fmt.Sprintf("%s%s", uri, srcPath)
 
 	return &artifactResult{

--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -214,10 +214,19 @@ func (f *Fixture) Prepare(ctx context.Context, components ...UsableComponent) er
 	}
 	f.srcPackage = src
 	filename := filepath.Base(src)
+
+	// Determine name of extracted Agent artifact directory from
+	// the artifact filename.
 	name, _, err := splitFileType(filename)
 	if err != nil {
 		return err
 	}
+
+	// If the name has "-fips" in it, remove that part because
+	// the extracted directory does not have that in it, even though
+	// the artifact filename does.
+	name = strings.Replace(name, "-fips", "", 1)
+
 	extractDir := createTempDir(f.t)
 	finalDir := filepath.Join(extractDir, name)
 	err = ExtractArtifact(f.t, src, extractDir)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR enhances the integration testing framework by adding support for FIPS-capable artifacts.  It introduces a new `artifactFetcherOpt` named `WithArtifactFIPSOnly()`, which can be supplied when an integration test wishes to fetch a FIPS-capable artifact.  It also makes sure that the extracted artifact directory name is correctly set when extracting a FIPS-capable artifact.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So integration tests pertaining to FIPS can fetch, install, and use FIPS-capable Agent artifacts.

You can see an example of these enhancements being used in https://github.com/elastic/elastic-agent/pull/7804.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- ~[ ] I have added an integration test or an E2E test~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None; these changes only impact the integration testing framework.
