### PR TITLE
Adding new configuration setting: `agent.upgrade.rollback.window`

### DIFF
--- a/_meta/config/common.reference.p2.yml.tmpl
+++ b/_meta/config/common.reference.p2.yml.tmpl
@@ -122,8 +122,7 @@ inputs:
 # agent.upgrade
 #   # rollback settings
 #   rollback:
-#       # duration in which an upgraded Agent may be asked to rollback to
-#       # the previous version of Agent on disk.
+#       # duration in which an upgraded Agent may be manually rolled back.
 #       window: 168h
 
 # agent.process:

--- a/_meta/config/common.reference.p2.yml.tmpl
+++ b/_meta/config/common.reference.p2.yml.tmpl
@@ -119,6 +119,13 @@ inputs:
 #   # duration will increase for subsequent retry attempts in a randomized exponential backoff manner.
 #   retry_sleep_init_duration: 30s
 
+# agent.upgrade
+#   # rollback settings
+#   rollback:
+#       # duration in which an upgraded Agent may be asked to rollback to
+#       # the previous version of Agent on disk.
+#       window: 168h
+
 # agent.process:
 #   # timeout for creating new processes. when process is not successfully created by this timeout
 #   # start operation is considered a failure

--- a/changelog/fragments/1746197293-config-rollback-window.yaml
+++ b/changelog/fragments/1746197293-config-rollback-window.yaml
@@ -18,7 +18,7 @@ summary: Adds a new configuration setting, `agent.upgrade.rollback.window`
 # NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
 description: |
   The value of the `agent.upgrade.rollback.window` setting determines the period after upgrading
-  Elastic Agent when a rollback to the previous version can be requested. This is an optional
+  Elastic Agent when a rollback to the previous version can be triggered. This is an optional
   setting, with a default value of `168h` (7 days). The value can be any string that is parseable
   by https://pkg.go.dev/time#ParseDuration.
 

--- a/changelog/fragments/1746197293-config-rollback-window.yaml
+++ b/changelog/fragments/1746197293-config-rollback-window.yaml
@@ -1,0 +1,36 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Adds a new configuration setting, `agent.upgrade.rollback.window`
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  The value of the `agent.upgrade.rollback.window` setting determines the period after upgrading
+  Elastic Agent when a rollback to the previous version can be requested. This is an optional
+  setting, with a default value of `168h` (7 days). The value can be any string that is parseable
+  by https://pkg.go.dev/time#ParseDuration.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/8065
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/6881

--- a/elastic-agent.reference.yml
+++ b/elastic-agent.reference.yml
@@ -47,10 +47,10 @@ inputs:
 #       data_stream.dataset: system.process
 #       # While running in unprivileged mode, process/process_summary metricsets can emit
 #       # partial metrics. Some metrics that require privileged access can be missing.
-#       # On Windows, non-administrator users may not be able to access protected processes, leading 
-#       # to missing details like command line and arguments. On Unix, non-root users can't access 
-#       # procfs without the right permissions. 
-#       # Errors like ERROR_ACCESS_DENIED, EPERM, and EACCESS may result in partial metrics. 
+#       # On Windows, non-administrator users may not be able to access protected processes, leading
+#       # to missing details like command line and arguments. On Unix, non-root users can't access
+#       # procfs without the right permissions.
+#       # Errors like ERROR_ACCESS_DENIED, EPERM, and EACCESS may result in partial metrics.
 #       # Enabling the config below will mark the metricset as degraded when this occurs.
 #       # You may want to enable it to identify potential permission-related issues.
 #       # If you're unable to provide the necessary access, you can disable this config to keep
@@ -124,6 +124,13 @@ inputs:
 #   # retry_sleep_init_duration is the duration to sleep for before the first retry attempt. This
 #   # duration will increase for subsequent retry attempts in a randomized exponential backoff manner.
 #   retry_sleep_init_duration: 30s
+
+# agent.upgrade
+#   # rollback settings
+#   rollback:
+#       # duration in which an upgraded Agent may be asked to rollback to
+#       # the previous version of Agent on disk.
+#       window: 168h
 
 # agent.process:
 #   # timeout for creating new processes. when process is not successfully created by this timeout

--- a/elastic-agent.reference.yml
+++ b/elastic-agent.reference.yml
@@ -128,8 +128,7 @@ inputs:
 # agent.upgrade
 #   # rollback settings
 #   rollback:
-#       # duration in which an upgraded Agent may be asked to rollback to
-#       # the previous version of Agent on disk.
+#       # duration in which an upgraded Agent may be manually rolled back.
 #       window: 168h
 
 # agent.process:

--- a/elastic-agent.reference.yml
+++ b/elastic-agent.reference.yml
@@ -47,10 +47,10 @@ inputs:
 #       data_stream.dataset: system.process
 #       # While running in unprivileged mode, process/process_summary metricsets can emit
 #       # partial metrics. Some metrics that require privileged access can be missing.
-#       # On Windows, non-administrator users may not be able to access protected processes, leading
-#       # to missing details like command line and arguments. On Unix, non-root users can't access
-#       # procfs without the right permissions.
-#       # Errors like ERROR_ACCESS_DENIED, EPERM, and EACCESS may result in partial metrics.
+#       # On Windows, non-administrator users may not be able to access protected processes, leading 
+#       # to missing details like command line and arguments. On Unix, non-root users can't access 
+#       # procfs without the right permissions. 
+#       # Errors like ERROR_ACCESS_DENIED, EPERM, and EACCESS may result in partial metrics. 
 #       # Enabling the config below will mark the metricset as degraded when this occurs.
 #       # You may want to enable it to identify potential permission-related issues.
 #       # If you're unable to provide the necessary access, you can disable this config to keep

--- a/internal/pkg/agent/configuration/upgrade.go
+++ b/internal/pkg/agent/configuration/upgrade.go
@@ -12,11 +12,16 @@ const (
 
 	// interval between checks for new (upgraded) Agent returning an error status.
 	defaultStatusCheckInterval = 30 * time.Second
+
+	// period during which an upgraded Agent can be asked to rollback to the previous
+	// Agent version on disk.
+	defaultRollbackWindowDuration = 7 * 24 * time.Hour // 7 days
 )
 
 // UpgradeConfig is the configuration related to Agent upgrades.
 type UpgradeConfig struct {
-	Watcher *UpgradeWatcherConfig `yaml:"watcher" config:"watcher" json:"watcher"`
+	Watcher  *UpgradeWatcherConfig  `yaml:"watcher" config:"watcher" json:"watcher"`
+	Rollback *UpgradeRollbackConfig `yaml:"rollback" config:"rollback" json:"rollback"`
 }
 
 type UpgradeWatcherConfig struct {
@@ -27,6 +32,10 @@ type UpgradeWatcherCheckConfig struct {
 	Interval time.Duration `yaml:"interval" config:"interval" json:"interval"`
 }
 
+type UpgradeRollbackConfig struct {
+	Window time.Duration `yaml:"window" config:"window" json:"window"`
+}
+
 func DefaultUpgradeConfig() *UpgradeConfig {
 	return &UpgradeConfig{
 		Watcher: &UpgradeWatcherConfig{
@@ -34,6 +43,9 @@ func DefaultUpgradeConfig() *UpgradeConfig {
 			ErrorCheck: UpgradeWatcherCheckConfig{
 				Interval: defaultStatusCheckInterval,
 			},
+		},
+		Rollback: &UpgradeRollbackConfig{
+			Window: defaultRollbackWindowDuration,
 		},
 	}
 }

--- a/internal/pkg/agent/configuration/upgrade_test.go
+++ b/internal/pkg/agent/configuration/upgrade_test.go
@@ -1,0 +1,99 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package configuration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/internal/pkg/config"
+)
+
+func TestParseUpgradeConfig(t *testing.T) {
+	tests := map[string]struct {
+		cfg      map[string]any
+		expected UpgradeConfig
+	}{
+		"default": {
+			cfg: map[string]any{},
+			expected: UpgradeConfig{
+				Watcher: &UpgradeWatcherConfig{
+					GracePeriod: defaultGracePeriodDuration,
+					ErrorCheck: UpgradeWatcherCheckConfig{
+						Interval: defaultStatusCheckInterval,
+					},
+				},
+				Rollback: &UpgradeRollbackConfig{
+					Window: defaultRollbackWindowDuration,
+				},
+			},
+		},
+		"watcher_grace_period": {
+			cfg: map[string]any{
+				"watcher": map[string]any{
+					"grace_period": "2m",
+				},
+			},
+			expected: UpgradeConfig{
+				Watcher: &UpgradeWatcherConfig{
+					GracePeriod: 2 * time.Minute,
+					ErrorCheck: UpgradeWatcherCheckConfig{
+						Interval: defaultStatusCheckInterval,
+					},
+				},
+				Rollback: &UpgradeRollbackConfig{
+					Window: defaultRollbackWindowDuration,
+				},
+			},
+		},
+		"watcher_error_check_interval": {
+			cfg: map[string]any{
+				"watcher": map[string]any{
+					"error_check": map[string]any{
+						"interval": "1h",
+					},
+				},
+			},
+			expected: UpgradeConfig{
+				Watcher: &UpgradeWatcherConfig{
+					GracePeriod: defaultGracePeriodDuration,
+					ErrorCheck: UpgradeWatcherCheckConfig{
+						Interval: 1 * time.Hour,
+					},
+				},
+				Rollback: &UpgradeRollbackConfig{
+					Window: defaultRollbackWindowDuration,
+				},
+			},
+		},
+		"rollback_window": {
+			cfg: map[string]any{
+				"rollback.window": "8h",
+			},
+			expected: UpgradeConfig{
+				Watcher: &UpgradeWatcherConfig{
+					GracePeriod: defaultGracePeriodDuration,
+					ErrorCheck: UpgradeWatcherCheckConfig{
+						Interval: defaultStatusCheckInterval,
+					},
+				},
+				Rollback: &UpgradeRollbackConfig{
+					Window: 8 * time.Hour,
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := DefaultUpgradeConfig()
+			cfg := config.MustNewConfigFrom(test.cfg)
+			require.NoError(t, cfg.UnpackTo(c))
+			require.Equal(t, test.expected, *c)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR adds a new optional Agent configuration setting, `agent.upgrade.rollback.window`.  This setting takes a string parseable by `time.Duration()`.  The default value of this setting is `168h` (== 7 days).  The value of this setting will determine how long after users upgrade an Agent will they be permitted to request a rollback to the previous version of the Agent on disk.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To allow users to perform manual rollbacks of upgraded Elastic Agent within a certain time window.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None; this PR adds a new, optional setting.  Further, older versions of Elastic Agent will ignore this setting if they encounter it.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
$ echo "agent.upgrade.rollback.window: 12h" >> ./elastic-agent.yml
$ go build .
$ ./elastic-agent inspect    # check that this contains the new setting in it
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Resolves #6881

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
