### PR TITLE
Pass `--header` enrollment option to fleet-server

### DIFF
--- a/internal/pkg/agent/cmd/enroll.go
+++ b/internal/pkg/agent/cmd/enroll.go
@@ -506,6 +506,7 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command) error {
 		UserProvidedMetadata: make(map[string]interface{}),
 		Staging:              staging,
 		FixPermissions:       fixPermissions,
+		Headers:              mapFromEnvList(fHeaders),
 		ProxyURL:             proxyURL,
 		ProxyDisabled:        proxyDisabled,
 		ProxyHeaders:         mapFromEnvList(proxyHeaders),

--- a/internal/pkg/agent/cmd/enroll.go
+++ b/internal/pkg/agent/cmd/enroll.go
@@ -81,7 +81,7 @@ func addEnrollFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("fleet-server-cert-key", "", "", "Private key for the certificate used by Fleet Server for exposed HTTPS endpoint")
 	cmd.Flags().StringP("fleet-server-cert-key-passphrase", "", "", "Path for private key passphrase file used to decrypt Fleet Server certificate key")
 	cmd.Flags().StringP("fleet-server-client-auth", "", "none", "Fleet Server mTLS client authentication for connecting Elastic Agents. Must be one of [none, optional, required]")
-	cmd.Flags().StringSliceP("header", "", []string{}, "Headers used by Fleet Server when communicating with Elasticsearch")
+	cmd.Flags().StringSliceP("header", "", []string{}, "Headers used by Agent to communicate with Fleet Server, and when a bootstrapped Fleet Server communicates with Elasticsearch")
 	cmd.Flags().BoolP("fleet-server-insecure-http", "", false, "Expose Fleet Server over HTTP (not recommended; insecure)")
 	cmd.Flags().StringP("certificate-authorities", "a", "", "Comma-separated list of root certificates for server verification used by Elastic Agent and Fleet Server")
 	cmd.Flags().StringP("ca-sha256", "p", "", "Comma-separated list of certificate authority hash pins for server verification used by Elastic Agent and Fleet Server")

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -122,6 +122,7 @@ type enrollCmdOption struct {
 	ReplaceToken         string                     `yaml:"replace_token,omitempty"`
 	EnrollAPIKey         string                     `yaml:"enrollment_key,omitempty"`
 	Staging              string                     `yaml:"staging,omitempty"`
+	Headers              map[string]string          `yaml:"headers,omitempty"`
 	ProxyURL             string                     `yaml:"proxy_url,omitempty"`
 	ProxyDisabled        bool                       `yaml:"proxy_disabled,omitempty"`
 	ProxyHeaders         map[string]string          `yaml:"proxy_headers,omitempty"`

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -145,6 +145,7 @@ func (e *enrollCmdOption) remoteConfig() (remote.Config, error) {
 	if cfg.Protocol == remote.ProtocolHTTP && !e.Insecure {
 		return remote.Config{}, fmt.Errorf("connection to fleet-server is insecure, strongly recommended to use a secure connection (override with --insecure)")
 	}
+	cfg.Headers = e.Headers
 
 	var tlsCfg tlscommon.Config
 

--- a/internal/pkg/remote/config.go
+++ b/internal/pkg/remote/config.go
@@ -13,11 +13,12 @@ import (
 
 // Config is the configuration for the client.
 type Config struct {
-	Protocol Protocol `config:"protocol" yaml:"protocol,omitempty"`
-	SpaceID  string   `config:"space.id" yaml:"space.id,omitempty"`
-	Path     string   `config:"path" yaml:"path,omitempty"`
-	Host     string   `config:"host" yaml:"host,omitempty"`
-	Hosts    []string `config:"hosts" yaml:"hosts,omitempty"`
+	Protocol Protocol          `config:"protocol" yaml:"protocol,omitempty"`
+	SpaceID  string            `config:"space.id" yaml:"space.id,omitempty"`
+	Path     string            `config:"path" yaml:"path,omitempty"`
+	Host     string            `config:"host" yaml:"host,omitempty"`
+	Hosts    []string          `config:"hosts" yaml:"hosts,omitempty"`
+	Headers  map[string]string `config:"headers" yaml:"headers,omitempty"`
 
 	Transport httpcommon.HTTPTransportSettings `config:",inline" yaml:",inline"`
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Currently the `--header` enrollment flag is used when bootstrapping Fleet Server. Those headers should also be used when communicating with Fleet Server that is not being bootstrapped.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

When enrolling to a Fleet Server that is behind a proxy that requires specific headers for communication it is not possible to enroll the Elastic Agent into the Fleet Server.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~ (covered well in unit tests)

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Setup a Fleet Server behind a proxy that requires a specific header for traffic to flow. Then enroll the elastic-agent with the required header:

`./elastic-agent enroll --url http://proxy-url --enrollment-token ${token} --header X-Custom-Header=TEST`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #6823

