### PR TITLE
Guard against `nil` pointer dereference

### DIFF
--- a/testing/integration/beat_receivers_test.go
+++ b/testing/integration/beat_receivers_test.go
@@ -280,6 +280,7 @@ func TestAgentMonitoring(t *testing.T) {
 
 			// we should have filebeatreceiver and metricbeatreceiver running
 			otelCollectorStatus := status.Collector
+			assert.NotNil(t, otelCollectorStatus)
 			assert.Equal(collect, int(cproto.CollectorComponentStatus_StatusOK), otelCollectorStatus.Status)
 			pipelineStatusMap := otelCollectorStatus.ComponentStatusMap
 

--- a/testing/integration/beat_receivers_test.go
+++ b/testing/integration/beat_receivers_test.go
@@ -280,7 +280,9 @@ func TestAgentMonitoring(t *testing.T) {
 
 			// we should have filebeatreceiver and metricbeatreceiver running
 			otelCollectorStatus := status.Collector
-			assert.NotNil(t, otelCollectorStatus)
+			if !assert.NotNil(t, otelCollectorStatus) {
+				return
+			}
 			assert.Equal(collect, int(cproto.CollectorComponentStatus_StatusOK), otelCollectorStatus.Status)
 			pipelineStatusMap := otelCollectorStatus.ComponentStatusMap
 

--- a/testing/integration/beat_receivers_test.go
+++ b/testing/integration/beat_receivers_test.go
@@ -280,7 +280,7 @@ func TestAgentMonitoring(t *testing.T) {
 
 			// we should have filebeatreceiver and metricbeatreceiver running
 			otelCollectorStatus := status.Collector
-			assert.NotNil(collect, otelCollectorStatus)
+			require.NotNil(collect, otelCollectorStatus)
 			assert.Equal(collect, int(cproto.CollectorComponentStatus_StatusOK), otelCollectorStatus.Status)
 			pipelineStatusMap := otelCollectorStatus.ComponentStatusMap
 

--- a/testing/integration/beat_receivers_test.go
+++ b/testing/integration/beat_receivers_test.go
@@ -280,9 +280,7 @@ func TestAgentMonitoring(t *testing.T) {
 
 			// we should have filebeatreceiver and metricbeatreceiver running
 			otelCollectorStatus := status.Collector
-			if !assert.NotNil(t, otelCollectorStatus) {
-				return
-			}
+			assert.NotNil(collect, otelCollectorStatus)
 			assert.Equal(collect, int(cproto.CollectorComponentStatus_StatusOK), otelCollectorStatus.Status)
 			pipelineStatusMap := otelCollectorStatus.ComponentStatusMap
 


### PR DESCRIPTION
This PR adds a guard against a variable being `nil` before we try to dereference it.