### PR TITLE
mage: clean up .agent-testing folder on mage clean

### DIFF
--- a/dev-tools/mage/clean.go
+++ b/dev-tools/mage/clean.go
@@ -12,6 +12,7 @@ import (
 // The values may contain variables and will be expanded at the time of use.
 var DefaultCleanPaths = []string{
 	"build",
+	".agent-testing",
 	"docker-compose.yml.lock",
 	"{{.BeatName}}",
 	"{{.BeatName}}.exe",

--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -436,6 +436,10 @@ If you encounter any errors mentioning `ogc`, try running `mage integration:clea
 re-running whatever `mage integration:*` target you were trying to run originally when you
 encountered the error.
 
+### Tests seemingly using a stale Elastic Agent package
+
+If your integration tests seem to be using a stale or outdated version of Elastic Agent, it might be due to a cached copy in the .agent-testing directory. To fix this, run `mage clean` to remove cached artifacts, then rebuild the agent with `mage package`, and finally run the integration tests again.
+
 ### Using a different agent version from the stack version
 
 The agent version is used as a fallback for the stack version to use in integration tests


### PR DESCRIPTION
## What does this PR do?

This PR adds the .agent-testing folder to the mage clean target. This is necessary because, in some cases, stale Elastic Agent packages from .agent-testing may be used locally instead of the newer packages from build/distributions. This can lead to confusing test failures.

For example, it took hours to track down a failure caused by a leftover agent package at version 0.119.0, even though the main branch was already on version 0.123.0. Running mage clean and repackaging had no effect because the cached folder wasn't being cleared due to a permission issue.

This PR updates the mage clean task to explicitly remove the .agent-testing folder and adds a troubleshooting tip to help others avoid this issue.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test
