### PR TITLE
Generate `NOTICE-fips.txt` file

### DIFF
--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -29,42 +29,23 @@ jobs:
       - name: update NOTICE.txt and NOTICE-fips.txt
         run: make notice
 
-      - name: check for modified NOTICE.txt
+      - name: check for modified NOTICE.txt or NOTICE-fips.txt
         id: notice-check
         run: |
-          if git diff --quiet HEAD -- NOTICE.txt; then
+          if git diff --quiet HEAD -- NOTICE*.txt; then
             echo "modified=false" >> $GITHUB_OUTPUT
           else
             echo "modified=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: commit NOTICE.txt
+      - name: commit NOTICE.txt and/or NOTICE-fips.txt
         if: steps.notice-check.outputs.modified == 'true'
         run: |
           git config --global user.name 'dependabot[bot]'
           git config --global user.email 'dependabot[bot]@users.noreply.github.com'
-          git add NOTICE.txt
+          git add NOTICE*.txt
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-          git commit -m "Update NOTICE.txt"
-          git push
-
-      - name: check for modified NOTICE-fips.txt
-        id: notice-fips-check
-        run: |
-          if git diff --quiet HEAD -- NOTICE-fips.txt; then
-            echo "modified=false" >> $GITHUB_OUTPUT
-          else
-            echo "modified=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: commit NOTICE-fips.txt
-        if: steps.notice-fips-check.outputs.modified == 'true'
-        run: |
-          git config --global user.name 'dependabot[bot]'
-          git config --global user.email 'dependabot[bot]@users.noreply.github.com'
-          git add NOTICE-fips.txt
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-          git commit -m "Update NOTICE-fips.txt"
+          git commit -m "Update NOTICE.txt and/or NOTICE-fips.txt"
           git push
 
       - name: update otel README.md

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -1,7 +1,7 @@
 # Follow-on actions relating to dependabot PRs. In elastic/elastic-agent, any changes to
 # dependencies contained in go.mod requires the change to be reflected in the
-# NOTICE.txt file. When dependabot creates a branch for a go_modules change this
-# will update the NOTICE.txt file for that change.
+# NOTICE.txt and NOTICE-fips.txt files. When dependabot creates a branch for a go_modules
+# change this will update the NOTICE.txt and NOTICE-fips files for that change.
 name: post-dependabot
 
 on:
@@ -26,7 +26,7 @@ jobs:
         with:
           install-only: true
 
-      - name: update NOTICE.txt
+      - name: update NOTICE.txt and NOTICE-fips.txt
         run: make notice
 
       - name: check for modified NOTICE.txt
@@ -46,6 +46,25 @@ jobs:
           git add NOTICE.txt
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git commit -m "Update NOTICE.txt"
+          git push
+
+      - name: check for modified NOTICE-fips.txt
+        id: notice-fips-check
+        run: |
+          if git diff --quiet HEAD -- NOTICE-fips.txt; then
+            echo "modified=false" >> $GITHUB_OUTPUT
+          else
+            echo "modified=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: commit NOTICE-fips.txt
+        if: steps.notice-fips-check.outputs.modified == 'true'
+        run: |
+          git config --global user.name 'dependabot[bot]'
+          git config --global user.email 'dependabot[bot]@users.noreply.github.com'
+          git add NOTICE-fips.txt
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git commit -m "Update NOTICE-fips.txt"
           git push
 
       - name: update otel README.md

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help: Makefile
 	@printf "Variables:\n"
 	@grep -E "^[A-Za-z0-9_]*\?=" $< | awk 'BEGIN {FS = "\\?="}; { printf "  \033[36m%-25s\033[0m  Default values: %s\n", $$1, $$2}'
 
-## notice : Generates the NOTICE file.
+## notice : Generates the NOTICE.txt and NOTICE-fips.txt files.
 .PHONY: notice
 notice:
 	@mage notice

--- a/README.md
+++ b/README.md
@@ -258,8 +258,8 @@ rules implemented on our `Makefile` as well as CI will use the
 locally before submitting any PRs to have a quicker feedback instead
 of waiting for a CI failure.
 
-### Generating the `NOTICE.txt` when updating/adding dependencies
-To do so, just run `make notice`, this is also part of the `make
+### Generating the `NOTICE.txt` and `NOTICE-fips.txt` when updating/adding dependencies
+To do so, just run `mage notice`, this is also part of the `make
 check-ci` and is the same check our CI will do.
 
 At some point we will migrate it to mage (see discussion on

--- a/README.md
+++ b/README.md
@@ -261,9 +261,3 @@ of waiting for a CI failure.
 ### Generating the `NOTICE.txt` and `NOTICE-fips.txt` when updating/adding dependencies
 To do so, just run `mage notice`, this is also part of the `make
 check-ci` and is the same check our CI will do.
-
-At some point we will migrate it to mage (see discussion on
-https://github.com/elastic/elastic-agent/pull/1108 and on
-https://github.com/elastic/elastic-agent/issues/1107). However until
-we have the mage automation sorted out, it has been removed to avoid
-confusion.

--- a/changelog/fragments/1746736812-fips-notice.yaml
+++ b/changelog/fragments/1746736812-fips-notice.yaml
@@ -25,7 +25,7 @@ component: elastic-agent
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/elastic-agent/pull/8124
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.

--- a/changelog/fragments/1746736812-fips-notice.yaml
+++ b/changelog/fragments/1746736812-fips-notice.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: other
+
+# Change summary; a 80ish characters long description of the change.
+summary: A new NOTICE file, `NOTICE-fips.txt` is included in FIPS-capable Agent distributions.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -267,6 +267,7 @@ func TestPackages(options ...TestPackagesOption) error {
 	}
 
 	args = append(args, "-files", MustExpand("{{.PWD}}/build/distributions/*"))
+	args = append(args, "--source-root", MustExpand("{{.PWD}}"))
 
 	if out, err := goTest(args...); err != nil {
 		if mg.Verbose() {

--- a/dev-tools/mage/target/common/notice.go
+++ b/dev-tools/mage/target/common/notice.go
@@ -110,7 +110,7 @@ func generateNotice(outputFilename string, additionalTags ...string) error {
 		return err
 	}
 
-	// cat dev-tools/notice/NOTICE.txt.append >> outputFilename
+	// cat dev-tools/notice/NOTICE.txt.append >> {outputFilename}
 	const (
 		infn = "dev-tools/notice/NOTICE.txt.append"
 	)

--- a/dev-tools/mage/target/common/notice.go
+++ b/dev-tools/mage/target/common/notice.go
@@ -15,6 +15,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/elastic/elastic-agent/dev-tools/notice"
+
 	"github.com/magefile/mage/sh"
 )
 
@@ -30,18 +32,18 @@ func runCommand(cmd string, args ...string) error {
 
 // Notice Generates NOTICE.txt and NOTICE-fips.txt
 func Notice() (err error) {
-	if err := notice("NOTICE.txt"); err != nil {
-		return fmt.Errorf("failed to generate NOTICE.txt: %w", err)
+	if err := generateNotice(notice.NoticeFilename); err != nil {
+		return fmt.Errorf("failed to generate %s: %w", notice.NoticeFilename, err)
 	}
-	if err := notice("NOTICE-fips.txt", "requirefips"); err != nil {
-		return fmt.Errorf("failed to generate NOTICE-fips.txt: %w", err)
+	if err := generateNotice(notice.FIPSNoticeFilename, "requirefips"); err != nil {
+		return fmt.Errorf("failed to generate %s: %w", notice.FIPSNoticeFilename, err)
 	}
 	return nil
 }
 
-// notice generates a notice file with the name outputFilename.
+// generateNotice generates a generateNotice file with the name outputFilename.
 // see getDependentModules for use of additionalTags.
-func notice(outputFilename string, additionalTags ...string) error {
+func generateNotice(outputFilename string, additionalTags ...string) error {
 	fmt.Printf("Generating %s...\n", outputFilename)
 	if err := runCommand("go", "mod", "tidy"); err != nil {
 		return err

--- a/dev-tools/mage/target/common/notice.go
+++ b/dev-tools/mage/target/common/notice.go
@@ -28,9 +28,21 @@ func runCommand(cmd string, args ...string) error {
 	return nil
 }
 
-// Notice Generates NOTICE.txt.
+// Notice Generates NOTICE.txt and NOTICE-fips.txt
 func Notice() (err error) {
-	fmt.Println("Generating NOTICE")
+	if err := notice("NOTICE.txt"); err != nil {
+		return fmt.Errorf("failed to generate NOTICE.txt: %w", err)
+	}
+	if err := notice("NOTICE-fips.txt", "requirefips"); err != nil {
+		return fmt.Errorf("failed to generate NOTICE-fips.txt: %w", err)
+	}
+	return nil
+}
+
+// notice generates a notice file with the name outputFilename.
+// see getDependentModules for use of additionalTags.
+func notice(outputFilename string, additionalTags ...string) error {
+	fmt.Printf("Generating %s...\n", outputFilename)
 	if err := runCommand("go", "mod", "tidy"); err != nil {
 		return err
 	}
@@ -38,7 +50,7 @@ func Notice() (err error) {
 		return err
 	}
 
-	modules, err := getDependentModules()
+	modules, err := getDependentModules(additionalTags...)
 	if err != nil {
 		return fmt.Errorf("unable to fetch list of dependent modules: %w", err)
 	}
@@ -52,7 +64,7 @@ func Notice() (err error) {
 	// -rules dev-tools/notice/rules.json \
 	// -overrides dev-tools/notice/overrides.json \
 	// -noticeTemplate dev-tools/notice/NOTICE.txt.tmpl \
-	// -noticeOut NOTICE.txt \
+	// -noticeOut {outputFilename} \
 	// -depsOut ""
 	listCmdArgs := []string{"list", "-m", "-json"}
 	listCmdArgs = append(listCmdArgs, modules...)
@@ -62,7 +74,7 @@ func Notice() (err error) {
 		"-rules", "dev-tools/notice/rules.json",
 		"-overrides", "dev-tools/notice/overrides.json",
 		"-noticeTemplate", "dev-tools/notice/NOTICE.txt.tmpl",
-		"-noticeOut", "NOTICE.txt",
+		"-noticeOut", outputFilename,
 		"-depsOut", "")
 
 	fmt.Printf(">> %s | %s\n", strings.Join(listCmd.Args, " "), strings.Join(licDetectCmd.Args, " "))
@@ -96,12 +108,11 @@ func Notice() (err error) {
 		return err
 	}
 
-	// cat dev-tools/notice/NOTICE.txt.append >> NOTICE.txt
-	fmt.Printf(">> %s\n", "cat dev-tools/notice/NOTICE.txt.append >> NOTICE.txt")
+	// cat dev-tools/notice/NOTICE.txt.append >> outputFilename
 	const (
-		infn  = "dev-tools/notice/NOTICE.txt.append"
-		outfn = "NOTICE.txt"
+		infn = "dev-tools/notice/NOTICE.txt.append"
 	)
+	fmt.Printf(">> cat %s >> %s\n", infn, outputFilename)
 
 	f, err := os.Open(infn)
 	if err != nil {
@@ -109,9 +120,9 @@ func Notice() (err error) {
 	}
 	defer f.Close()
 
-	out, err := os.OpenFile(outfn, os.O_WRONLY|os.O_APPEND, 0644)
+	out, err := os.OpenFile(outputFilename, os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
-		return fmt.Errorf("failed to open file %s: %w", outfn, err)
+		return fmt.Errorf("failed to open file %s: %w", outputFilename, err)
 	}
 
 	defer func() {
@@ -122,23 +133,23 @@ func Notice() (err error) {
 	}()
 
 	if _, err := io.Copy(out, f); err != nil {
-		return fmt.Errorf("failed to append file %s: %w", outfn, err)
+		return fmt.Errorf("failed to append file %s: %w", outputFilename, err)
 	}
 
-	// dos2unix NOTICE.txt
-	fmt.Printf(">> %s\n", "dos2unix NOTICE.txt")
+	// dos2unix {outputFilename}
+	fmt.Printf(">> dos2unix %s\n", outputFilename)
 
-	content, err := os.ReadFile(outfn)
+	content, err := os.ReadFile(outputFilename)
 	if err != nil {
-		return fmt.Errorf("failed to read entire file %s: %w", outfn, err)
+		return fmt.Errorf("failed to read entire file %s: %w", outputFilename, err)
 	}
 
 	// Convert Windows-style line endings to Unix-style
 	newContent := strings.ReplaceAll(string(content), "\r\n", "\n")
 
-	err = os.WriteFile(outfn, []byte(newContent), 0644)
+	err = os.WriteFile(outputFilename, []byte(newContent), 0644)
 	if err != nil {
-		return fmt.Errorf("failed to rewrite file using Unix-style line endings %s: %w", outfn, err)
+		return fmt.Errorf("failed to rewrite file using Unix-style line endings %s: %w", outputFilename, err)
 	}
 
 	return nil

--- a/dev-tools/notice/notice.go
+++ b/dev-tools/notice/notice.go
@@ -1,0 +1,10 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package notice
+
+const (
+	NoticeFilename     = "NOTICE.txt"
+	FIPSNoticeFilename = "NOTICE-fips.txt"
+)

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -429,6 +429,10 @@ shared:
     files:
       <<: *agent_binary_files
       <<: *agent_unpacked_components_files
+      NOTICE.txt:
+        source: '{{ repo.RootDir }}/NOTICE-fips.txt'
+        mode: 0644
+
 
   - &agent_darwin_binary_spec
     <<: *common

--- a/dev-tools/packaging/testing/package_test.go
+++ b/dev-tools/packaging/testing/package_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent/dev-tools/mage"
+	"github.com/elastic/elastic-agent/dev-tools/notice"
 	v1 "github.com/elastic/elastic-agent/pkg/api/v1"
 )
 
@@ -67,6 +68,7 @@ var (
 
 var (
 	files             = flag.String("files", "../build/distributions/*", "filepath glob containing package files")
+	sourceRoot        = flag.String("source-root", "../", "path to root directory of Agent repository")
 	modules           = flag.Bool("modules", false, "check modules folder contents")
 	minModules        = flag.Int("min-modules", 4, "minimum number of modules to expect in modules folder")
 	modulesd          = flag.Bool("modules.d", false, "check modules.d folder contents")
@@ -229,6 +231,7 @@ func checkTar(t *testing.T, file string, fipsCheck bool) {
 	require.NoErrorf(t, err, "error extracting archive %q", file)
 
 	t.Run("check_manifest_file", testManifestFile(tempExtractionPath, fipsCheck))
+	t.Run("check_notice_file", testNoticeFile(tempExtractionPath, fipsCheck))
 
 	checkSha512PackageHash(t, file)
 
@@ -259,18 +262,29 @@ func checkZip(t *testing.T, file string) {
 	require.NoErrorf(t, err, "error extracting archive %q", file)
 
 	t.Run("check_manifest_file", testManifestFile(tempExtractionPath, false))
+	t.Run("check_notice_file", testNoticeFile(tempExtractionPath, false))
 
 	checkSha512PackageHash(t, file)
 }
 
 func testManifestFile(agentPackageRootDir string, checkFips bool) func(t *testing.T) {
 	return func(t *testing.T) {
-		dirEntries, err := os.ReadDir(agentPackageRootDir)
-		require.NoErrorf(t, err, "error listing extraction dir %q", agentPackageRootDir)
-		require.Lenf(t, dirEntries, 1, "archive should contain a single directory: found %v", dirEntries)
-		containingDir := dirEntries[0].Name()
-		checkManifestFileContents(t, filepath.Join(agentPackageRootDir, containingDir))
+		checkManifestFileContents(t, getExtractedPackageDir(agentPackageRootDir, t))
 	}
+}
+
+func testNoticeFile(agentPackageRootDir string, checkFips bool) func(t *testing.T) {
+	return func(t *testing.T) {
+		checkNoticeFileContents(t, getExtractedPackageDir(agentPackageRootDir, t), checkFips)
+	}
+}
+
+func getExtractedPackageDir(agentPackageRootDir string, t *testing.T) string {
+	dirEntries, err := os.ReadDir(agentPackageRootDir)
+	require.NoErrorf(t, err, "error listing extraction dir %q", agentPackageRootDir)
+	require.Lenf(t, dirEntries, 1, "archive should contain a single directory: found %v", dirEntries)
+
+	return filepath.Join(agentPackageRootDir, dirEntries[0].Name())
 }
 
 func checkManifestFileContents(t *testing.T, extractedPackageDir string) {
@@ -312,6 +326,47 @@ func parseManifest(t *testing.T, dir string) v1.PackageManifest {
 		t.Fatalf("unmarshaling package manifest: %v", err)
 	}
 	return *m
+}
+
+func checkNoticeFileContents(t *testing.T, extractedPackageDir string, checkFips bool) {
+	t.Logf("Checking package file NOTICE.txt; checkFips = %t", checkFips)
+
+	// Hash the source NOTICE file
+	sourceNoticeFile := filepath.Join(*sourceRoot, notice.NoticeFilename)
+	if checkFips {
+		sourceNoticeFile = filepath.Join(*sourceRoot, notice.FIPSNoticeFilename)
+	}
+	sourceNoticeFile, err := filepath.Abs(sourceNoticeFile)
+	require.NoError(t, err)
+
+	sourceNoticeFileHash, err := fileHash(sourceNoticeFile)
+	require.NoError(t, err)
+
+	// Hash the NOTICE file in the package
+	packageNoticeFile := filepath.Join(extractedPackageDir, "NOTICE.txt")
+	packageNoticeFileHash, err := fileHash(packageNoticeFile)
+	require.NoError(t, err)
+
+	// Compare the two hashes; they should be equal
+	require.Equalf(
+		t, sourceNoticeFileHash, packageNoticeFileHash,
+		"Contents of NOTICE.txt file in package are not the same as contents of %s", sourceNoticeFile,
+	)
+}
+
+func fileHash(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	h := sha512.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, err
+	}
+
+	return h.Sum(nil), nil
 }
 
 const (
@@ -717,11 +772,7 @@ func checkDockerUser(t *testing.T, p *packageFile, info *dockerInfo, expectRoot 
 }
 
 func checkFIPS(t *testing.T, agentPackageRootDir string) {
-	dirEntries, err := os.ReadDir(agentPackageRootDir)
-	require.NoErrorf(t, err, "error listing extraction dir %q", agentPackageRootDir)
-	require.Lenf(t, dirEntries, 1, "archive should contain a single directory: found %v", dirEntries)
-
-	extractedPackageDir := filepath.Join(agentPackageRootDir, dirEntries[0].Name())
+	extractedPackageDir := getExtractedPackageDir(agentPackageRootDir, t)
 	t.Logf("Checking agent binary in %q for FIPS compliance", extractedPackageDir)
 	m := parseManifest(t, extractedPackageDir)
 	versionedHome := m.Package.VersionedHome


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR introduces a number of changes to do with generating a separate NOTICE file for FIPS-capable Elastic Agent binaries, viz. `NOTICE-fips.txt`:
* Running `mage notice` now will generate both `NOTICE.txt` and `NOTICE-fips.txt`.
* The packaging spec will now copy the correct NOTICE file (`NOTICE.txt` or `NOTICE-fips.txt`) into the package.  Note that the file inside the package is always called `NOTICE.txt` for consistency from a user's perspective.
* Running `mage TestPackages` (which is internally run as part of `mage package`) will now check that the packaged NOTICE file is the correct one, depending on whether the package is FIPS-capable or not.
* The `post-dependabot` workflow will now generate the `NOTICE-fips.txt` file along with the `NOTICE.txt` file in Dependabot-created PRs.
* Developer documentation now mentions the new `NOTICE-fips.txt` file.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To help provide provenance of dependencies used in FIPS-capable Agent binaries for auditors.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

The `NOTICE.txt` file contained inside FIPS-capable Agent artifacts will contain dependencies used by the FIPS-capable binary.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Generate NOTICE files.
   ```
   mage notice
   ```
2. Check that both `NOTICE.txt` and `NOTICE-fips.txt` are generated.
   ```
   ls -l NOTICE*txt
   ```
3. Check that the `NOTICE.txt` file is unaffected.
   ```
   git diff main -- NOTICE.txt
   ```
4. Build a FIPS-capable Elastic Agent artifact.
   ```
   FIPS=true SNAPSHOT=true EXTERNAL=true PLATFORMS="linux/arm64" PACKAGES="targz" mage package
   ```
5. Extract built artifact into folder.
   ```
   tar xzf build/distributions/elastic-agent-fips-9.1.0-SNAPSHOT-linux-arm64.tar.gz --directory /tmp
   ```
6. Check that the `NOTICE.txt` included in it has the same contents as `NOTICE-fips.txt` in the repo.
   ```
   diff /tmp/elastic-agent-9.1.0-SNAPSHOT-linux-arm64/NOTICE.txt NOTICE-fips.txt
   ```
7. Build a non-FIPS-capable Elastic Agent artifact.
   ```
   SNAPSHOT=true EXTERNAL=true PLATFORMS="linux/arm64" PACKAGES="targz" mage package
   ```
8. Extract built artifact into folder.
   ```
   tar xzf build/distributions/elastic-agent-9.1.0-SNAPSHOT-linux-arm64.tar.gz --directory /tmp
   ```
9. Check that the `NOTICE.txt` included in it has the same contents as `NOTICE.txt` in the repo.
   ```
   diff /tmp/elastic-agent-9.1.0-SNAPSHOT-linux-arm64/NOTICE.txt NOTICE.txt
   ```
