### PR TITLE
Unpin VM images

### DIFF
--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -5,12 +5,12 @@ env:
   VAULT_PATH: "kv/ci-shared/observability-ingest/cloud/gcp"
   ASDF_MAGE_VERSION: 1.14.0
 
-  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-elastic-agent-ubuntu-2404-1744855248"
-  IMAGE_UBUNTU_2404_ARM_64: "platform-ingest-elastic-agent-ubuntu-2404-aarch64-1744855248"
-  IMAGE_RHEL_8: "platform-ingest-elastic-agent-rhel-8-1744855248"
-  IMAGE_DEBIAN_12: "platform-ingest-elastic-agent-debian-12-1744855248"
-  IMAGE_WIN_2022: "platform-ingest-elastic-agent-windows-2022-1744855248"
-  IMAGE_WIN_2025: "platform-ingest-elastic-agent-windows-2025-1744855248"
+  IMAGE_UBUNTU_2404_X86_64: "family/platform-ingest-elastic-agent-ubuntu-2404"
+  IMAGE_UBUNTU_2404_ARM_64: "platform-ingest-elastic-agent-ubuntu-2404-aarch64"
+  IMAGE_RHEL_8: "family/platform-ingest-elastic-agent-rhel-8"
+  IMAGE_DEBIAN_12: "family/platform-ingest-elastic-agent-debian-12"
+  IMAGE_WIN_2022: "family/platform-ingest-elastic-agent-windows-2022"
+  IMAGE_WIN_2025: "family/platform-ingest-elastic-agent-windows-2025"
 
 steps:
   - label: Start ESS stack for integration tests
@@ -190,7 +190,7 @@ steps:
           - build/diagnostics/**
         agents:
           provider: "aws"
-          image: "${IMAGE_UBUNTU_2404_ARM_64}"
+          imagePrefix: "${IMAGE_UBUNTU_2404_ARM_64}"
           instanceType: "m6g.2xlarge"
         retry:
           automatic:
@@ -227,7 +227,7 @@ steps:
             limit: 1
         agents:
           provider: "aws"
-          image: "${IMAGE_UBUNTU_2404_ARM_64}"
+          imagePrefix: "${IMAGE_UBUNTU_2404_ARM_64}"
           instanceType: "m6g.xlarge"
         matrix:
           - default

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,12 +4,12 @@ env:
   VAULT_PATH: "kv/ci-shared/observability-ingest/cloud/gcp"
   DOCKER_REGISTRY: "docker.elastic.co"
 
-  IMAGE_UBUNTU_2204_X86_64: "platform-ingest-elastic-agent-ubuntu-2204-1744855248"
-  IMAGE_UBUNTU_2204_ARM_64: "platform-ingest-elastic-agent-ubuntu-2204-aarch64-1744855248"
-  IMAGE_WIN_2016: "platform-ingest-elastic-agent-windows-2016-1744855248"
-  IMAGE_WIN_2022: "platform-ingest-elastic-agent-windows-2022-1744855248"
-  IMAGE_WIN_10: "platform-ingest-elastic-agent-windows-10-1744855248"
-  IMAGE_WIN_11: "platform-ingest-elastic-agent-windows-11-1744855248"
+  IMAGE_UBUNTU_2204_X86_64: "family/platform-ingest-elastic-agent-ubuntu-2204"
+  IMAGE_UBUNTU_2204_ARM_64: "platform-ingest-elastic-agent-ubuntu-2204-aarch64"
+  IMAGE_WIN_2016: "family/platform-ingest-elastic-agent-windows-2016"
+  IMAGE_WIN_2022: "family/platform-ingest-elastic-agent-windows-2022"
+  IMAGE_WIN_10: "family/platform-ingest-elastic-agent-windows-10"
+  IMAGE_WIN_11: "family/platform-ingest-elastic-agent-windows-11"
 
 steps:
   - label: "check-ci"
@@ -91,7 +91,7 @@ steps:
           - "coverage-*.out"
         agents:
           provider: "aws"
-          image: "${IMAGE_UBUNTU_2204_ARM_64}"
+          imagePrefix: "${IMAGE_UBUNTU_2204_ARM_64}"
           diskSizeGb: 200
           instanceType: "m6g.xlarge"
         retry:


### PR DESCRIPTION
## What does this PR do?

This commit reverts the version pinning done for VM images in #7958, now that VM images used a pinned version of asdf-golang.

## How to test this PR locally

Only testable in Buildkite CI -- CI ought to get green and especially the check-ci step in unit tests should be green.
