### PR TITLE
Automatically update beats module versions

### DIFF
--- a/.ci/scripts/update-beats.sh
+++ b/.ci/scripts/update-beats.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# This script is executed by the automation we are putting in place
+# and it requires the git add/commit commands.
+#
+set -euo pipefail
+
+mage update:beats "${1}"

--- a/.ci/scripts/update-beats.sh
+++ b/.ci/scripts/update-beats.sh
@@ -4,5 +4,7 @@
 # and it requires the git add/commit commands.
 #
 set -euo pipefail
+TARGET_VERSION="${1:?Error: Please provide the target version to update to}"
 
-mage update:beats "${1}"
+echo "~~~ Updating to elastic/beats@${TARGET_VERSION}"
+mage update:beats "${TARGET_VERSION}"

--- a/.ci/updatecli/update-beats.yml
+++ b/.ci/updatecli/update-beats.yml
@@ -11,7 +11,7 @@ scms:
       owner: '{{ .scm.owner }}'
       repository: '{{ .scm.repository }}'
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      branch: '{{ .scm.branch }}'
+      branch: '{{ requiredEnv "BRANCH_NAME" }}'
       commitusingapi: true
 
 actions:

--- a/.ci/updatecli/update-beats.yml
+++ b/.ci/updatecli/update-beats.yml
@@ -1,0 +1,67 @@
+---
+name: Bump beats
+pipelineid: 'updatecli-update-beats-{{ requiredEnv "BRANCH_NAME" }}'
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      owner: '{{ .scm.owner }}'
+      repository: '{{ .scm.repository }}'
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      branch: '{{ .scm.branch }}'
+      commitusingapi: true
+
+actions:
+  default:
+    title: '[Automation] Update elastic/beats to {{ source "beats" }}'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      automerge: false
+      labels:
+      - dependencies
+      - backport-skip
+      - "Team:Elastic-Agent-Control-Plane"
+      description: |-
+        ### What
+        Update `elastic/beats` to the latest version on branch `{{ requiredEnv "BRANCH_NAME" }}`.
+
+        *Changeset*
+        * https://github.com/elastic/beats/commit/{{ source "beats" }}
+
+sources:
+  beats:
+    kind: json
+    spec:
+      file: 'https://api.github.com/repos/elastic/beats/commits?sha={{ requiredEnv "BRANCH_NAME" }}&per_page=1'
+      key: '.[0].sha'
+    transformers:
+    # substring 12 chars so it works for the condition
+    - findsubmatch:
+        pattern: ^(.{12}).*
+        captureindex: 1
+
+conditions:
+  is-already-updated:
+    name: Is version 'github.com/elastic/beats@{{ source "beats" }}' not updated in 'go.mod'?
+    kind: shell
+    disablesourceinput: true
+    scmid: default
+    spec:
+      command: grep {{ source "beats" }} go.mod && exit 1 || exit 0
+    failwhen: false
+
+targets:
+  beats:
+    name: 'Update to elastic/beats@{{ source "beats" }}'
+    sourceid: beats
+    scmid: default
+    kind: shell
+    spec:
+      command: .ci/scripts/update-beats.sh
+      environments:
+      - name: PATH
+      - name: HOME

--- a/.ci/updatecli/update-beats.yml
+++ b/.ci/updatecli/update-beats.yml
@@ -16,7 +16,7 @@ scms:
 
 actions:
   default:
-    title: '[Automation] Update elastic/beats to {{ source "beats" }}'
+    title: '[{{ requiredEnv "BRANCH_NAME" }}][Automation] Update elastic/beats to {{ source "beats" }}'
     kind: github/pullrequest
     scmid: default
     spec:

--- a/.ci/updatecli/update-beats.yml
+++ b/.ci/updatecli/update-beats.yml
@@ -30,7 +30,7 @@ actions:
         Update `elastic/beats` to the latest version on branch `{{ requiredEnv "BRANCH_NAME" }}`.
 
         *Changeset*
-        * https://github.com/elastic/beats/commit/{{ source "beats" }}
+        * https://github.com/elastic/beats/compare/{{ source "gomod" }}...{{ source "beats" }}
 
 sources:
   beats:
@@ -43,6 +43,16 @@ sources:
     - findsubmatch:
         pattern: ^(.{12}).*
         captureindex: 1
+  gomod:
+    kind: golang/gomod
+    spec:
+      module: github.com/elastic/beats/v7
+    transformers:
+    # the commit hash is the last 12 chars
+    - findsubmatch:
+        pattern: .*(.{12})$
+        captureindex: 1
+
 
 conditions:
   is-already-updated:
@@ -51,7 +61,7 @@ conditions:
     disablesourceinput: true
     scmid: default
     spec:
-      command: grep {{ source "beats" }} go.mod && exit 1 || exit 0
+      command: '[ ${{ source "beats"}} != {{ source "gomod" }} ]'
     failwhen: false
 
 targets:

--- a/.github/workflows/bump-beats-version.yml
+++ b/.github/workflows/bump-beats-version.yml
@@ -47,7 +47,7 @@ jobs:
         go-version-file: 'go.mod'
 
     - name: Install mage
-      uses: magefile/mage-action@v3
+      uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b # v3.1.0
       with:
         version: v1.13.0
         install-only: true

--- a/.github/workflows/bump-beats-version.yml
+++ b/.github/workflows/bump-beats-version.yml
@@ -46,11 +46,6 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
-    - name: Set git config
-      run: |
-        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config --global user.name "github-actions[bot]"
-
     - name: Install mage
       uses: magefile/mage-action@v3
       with:

--- a/.github/workflows/bump-beats-version.yml
+++ b/.github/workflows/bump-beats-version.yml
@@ -1,0 +1,85 @@
+name: update-beats
+
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: '0 0 * * 1-5'
+
+permissions:
+  contents: read
+
+jobs:
+  filter:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      matrix: ${{ steps.generator.outputs.matrix }}
+    permissions:
+      contents: read
+    steps:
+    - id: generator
+      uses: elastic/oblt-actions/elastic/active-branches@v1
+      with:
+        exclude-branches: "7.17,8.17,8.18,9.0"
+        filter-branches: true
+
+  update-beats:
+    permissions:
+      contents: write
+      pull-requests: write
+    needs:
+    - filter
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.filter.outputs.matrix) }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ matrix.branch }}
+
+    - name: Install Updatecli in the runner
+      uses: updatecli/updatecli-action@ae3030ce1710c6496214fb1f8fd3bd9437b2a69d # 2.82.0
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Set git config
+      run: |
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
+
+    - name: Install mage
+      uses: magefile/mage-action@v3
+      with:
+        version: v1.13.0
+        install-only: true
+
+    - name: Run Updatecli in Apply mode
+      run: updatecli apply --config .ci/updatecli/update-beats.yml --values .ci/updatecli/values.d/scm.yml
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - if: ${{ failure()  }}
+      uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+      with:
+        method: chat.postMessage
+        token: ${{ secrets.SLACK_BOT_TOKEN }}
+        payload: |
+          {
+            "channel": "#ingest-notifications",
+            "text": "${{ env.SLACK_MESSAGE }}",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "${{ env.SLACK_MESSAGE }}"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_MESSAGE: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, `@agent-team` please look what's going on <${{ env.JOB_URL }}|here>"

--- a/.github/workflows/bump-beats-version.yml
+++ b/.github/workflows/bump-beats-version.yml
@@ -61,6 +61,7 @@ jobs:
       run: updatecli apply --config .ci/updatecli/update-beats.yml --values .ci/updatecli/values.d/scm.yml
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH_NAME: ${{ matrix.branch }}
 
     - if: ${{ failure()  }}
       uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0

--- a/.github/workflows/bump-beats-version.yml
+++ b/.github/workflows/bump-beats-version.yml
@@ -38,9 +38,6 @@ jobs:
       with:
         ref: ${{ matrix.branch }}
 
-    - name: Install Updatecli in the runner
-      uses: updatecli/updatecli-action@ae3030ce1710c6496214fb1f8fd3bd9437b2a69d # 2.82.0
-
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
@@ -53,7 +50,9 @@ jobs:
         install-only: true
 
     - name: Run Updatecli in Apply mode
-      run: updatecli apply --config .ci/updatecli/update-beats.yml --values .ci/updatecli/values.d/scm.yml
+      uses: elastic/oblt-actions/updatecli/run@v1
+      with:
+        command: apply --config .ci/updatecli/update-beats.yml --values .ci/updatecli/values.d/scm.yml
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH_NAME: ${{ matrix.branch }}

--- a/.github/workflows/bump-beats-version.yml
+++ b/.github/workflows/bump-beats-version.yml
@@ -58,23 +58,8 @@ jobs:
         BRANCH_NAME: ${{ matrix.branch }}
 
     - if: ${{ failure()  }}
-      uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+      uses: elastic/oblt-actions/slack/send@v1
       with:
-        method: chat.postMessage
-        token: ${{ secrets.SLACK_BOT_TOKEN }}
-        payload: |
-          {
-            "channel": "#ingest-notifications",
-            "text": "${{ env.SLACK_MESSAGE }}",
-            "blocks": [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "${{ env.SLACK_MESSAGE }}"
-                }
-              }
-            ]
-          }
-      env:
-        SLACK_MESSAGE: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, `@agent-team` please look what's going on <${{ env.JOB_URL }}|here>"
+        bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+        channel-id: "#ingest-notifications"
+        message: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, `@agent-team` please look what's going on <${{ env.JOB_URL }}|here>"

--- a/dev-tools/mage/target/update/update.go
+++ b/dev-tools/mage/target/update/update.go
@@ -4,9 +4,28 @@
 
 package update
 
-import "github.com/magefile/mage/sh"
+import (
+	"fmt"
 
-// Update updates the generated files (aka make update).
-func Update() error {
-	return sh.Run("make", "update")
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+
+	"github.com/elastic/elastic-agent/dev-tools/mage/target/common"
+)
+
+const BeatsModulePath = "github.com/elastic/beats/v7"
+
+func Beats(targetVersion string) error {
+	mg.SerialDeps(mg.F(BeatsModule, targetVersion), common.Notice)
+
+	return nil
+}
+
+func BeatsModule(targetVersion string) error {
+	goArgs := []string{"get", fmt.Sprintf("%s@%s", BeatsModulePath, targetVersion)}
+	err := sh.RunV(mg.GoCmd(), goArgs...)
+	if err != nil {
+		return err
+	}
+	return sh.RunV(mg.GoCmd(), "mod", "tidy")
 }

--- a/magefile.go
+++ b/magefile.go
@@ -66,6 +66,8 @@ import (
 	"github.com/elastic/elastic-agent/dev-tools/mage/target/common"
 	// mage:import
 	_ "github.com/elastic/elastic-agent/dev-tools/mage/target/integtest/notests"
+	// mage:import update
+	_ "github.com/elastic/elastic-agent/dev-tools/mage/target/update"
 	// mage:import
 	"github.com/elastic/elastic-agent/dev-tools/mage/target/test"
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Adds automation for updating the beats dependency. This cannot be done using dependabot because:

* Beats isn't properly versioned. We use pseudoversions pointing at commits, which dependabot doesn't support.
* Each elastic-agent branch needs to point at the respective beats branch.

Instead, we take an approach similar to [apm-server](https://github.com/elastic/apm-server/blob/main/.github/workflows/update-beats.yml). We use a scheduled github actions job, which triggers an update using updatecli, which in turn runs the `update:beats` mage target and submits a PR with the changes.

See an example execution in a fork here: https://github.com/swiatekm/elastic-agent/actions/runs/15137576163, and the PRs it created here: https://github.com/swiatekm/elastic-agent/pull/7 https://github.com/swiatekm/elastic-agent/pull/8.

## Why is it important?

In the absence of real beats versioning, we should strive to use latest beats receivers for the given release branch.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
~~- [ ] I have added an integration test or an E2E test~~

## How to test this PR locally

Run `mage update:beats main`.

## Related issues

- Closes #8034

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
