### PR TITLE
Adding test for enrolling local FIPS agent into ECH FIPS Fleet Server

### DIFF
--- a/pkg/testing/define/define.go
+++ b/pkg/testing/define/define.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/gofrs/uuid/v5"
 
 	"github.com/elastic/elastic-agent-libs/kibana"
@@ -83,33 +85,31 @@ func Version() string {
 // NewFixtureFromLocalBuild returns a new Elastic Agent testing fixture with a LocalFetcher and
 // the agent logging to the test logger.
 func NewFixtureFromLocalBuild(t *testing.T, version string, opts ...atesting.FixtureOpt) (*atesting.Fixture, error) {
-	buildsDir := os.Getenv("AGENT_BUILD_DIR")
-	if buildsDir == "" {
-		projectDir, err := findProjectRoot()
-		if err != nil {
-			return nil, err
-		}
-		buildsDir = filepath.Join(projectDir, "build", "distributions")
-	}
+	return NewFixtureWithBinary(t, version, "elastic-agent", buildsDir(t), false, opts...)
+}
 
-	return NewFixtureWithBinary(t, version, "elastic-agent", buildsDir, opts...)
-
+// NewFixtureFromLocalFIPSBuild returns a new FIPS-capable Elastic Agent testing fixture with a LocalFetcher
+// and the agent logging to the test logger.
+func NewFixtureFromLocalFIPSBuild(t *testing.T, version string, opts ...atesting.FixtureOpt) (*atesting.Fixture, error) {
+	return NewFixtureWithBinary(t, version, "elastic-agent", buildsDir(t), true, opts...)
 }
 
 // NewFixtureWithBinary returns a new Elastic Agent testing fixture with a LocalFetcher and
 // the agent logging to the test logger.
-func NewFixtureWithBinary(t *testing.T, version string, binary string, buildsDir string, opts ...atesting.FixtureOpt) (*atesting.Fixture, error) {
+func NewFixtureWithBinary(t *testing.T, version string, binary string, buildsDir string, fips bool, opts ...atesting.FixtureOpt) (*atesting.Fixture, error) {
 	ver, err := semver.ParseVersion(version)
 	if err != nil {
 		return nil, fmt.Errorf("%q is an invalid agent version: %w", version, err)
 	}
 
-	var binFetcher atesting.Fetcher
+	localFetcherOpts := []atesting.LocalFetcherOpt{atesting.WithCustomBinaryName(binary)}
 	if ver.IsSnapshot() {
-		binFetcher = atesting.LocalFetcher(buildsDir, atesting.WithLocalSnapshotOnly(), atesting.WithCustomBinaryName(binary))
-	} else {
-		binFetcher = atesting.LocalFetcher(buildsDir, atesting.WithCustomBinaryName(binary))
+		localFetcherOpts = append(localFetcherOpts, atesting.WithLocalSnapshotOnly())
 	}
+	if fips {
+		localFetcherOpts = append(localFetcherOpts, atesting.WithLocalFIPSOnly())
+	}
+	binFetcher := atesting.LocalFetcher(buildsDir, localFetcherOpts...)
 
 	opts = append(opts, atesting.WithFetcher(binFetcher), atesting.WithLogOutput())
 	if binary != "elastic-agent" {
@@ -300,4 +300,17 @@ func getKibanaClient() (*kibana.Client, error) {
 		return nil, fmt.Errorf("failed to create kibana client: %w", err)
 	}
 	return c, nil
+}
+
+func buildsDir(t *testing.T) string {
+	t.Helper()
+
+	buildsDir := os.Getenv("AGENT_BUILD_DIR")
+	if buildsDir == "" {
+		projectDir, err := findProjectRoot()
+		require.NoError(t, err)
+		buildsDir = filepath.Join(projectDir, "build", "distributions")
+	}
+
+	return buildsDir
 }

--- a/pkg/testing/fetcher_local_test.go
+++ b/pkg/testing/fetcher_local_test.go
@@ -57,7 +57,7 @@ func TestLocalFetcher(t *testing.T) {
 	tcs := []struct {
 		name     string
 		version  string
-		opts     []localFetcherOpt
+		opts     []LocalFetcherOpt
 		want     []byte
 		wantHash []byte
 	}{
@@ -69,7 +69,7 @@ func TestLocalFetcher(t *testing.T) {
 		}, {
 			name:     "SnapshotOnly",
 			version:  baseVersion,
-			opts:     []localFetcherOpt{WithLocalSnapshotOnly()},
+			opts:     []LocalFetcherOpt{WithLocalSnapshotOnly()},
 			want:     snapshotContent,
 			wantHash: snapshotContentHash,
 		}, {
@@ -80,13 +80,13 @@ func TestLocalFetcher(t *testing.T) {
 		}, {
 			name:     "version with snapshot and SnapshotOnly",
 			version:  baseVersion + "-SNAPSHOT",
-			opts:     []localFetcherOpt{WithLocalSnapshotOnly()},
+			opts:     []LocalFetcherOpt{WithLocalSnapshotOnly()},
 			want:     snapshotContent,
 			wantHash: snapshotContentHash,
 		}, {
 			name:     "version with snapshot and build ID",
 			version:  baseVersion + "-SNAPSHOT+l5snflwr",
-			opts:     []localFetcherOpt{},
+			opts:     []LocalFetcherOpt{},
 			want:     snapshotContent,
 			wantHash: snapshotContentHash,
 		},

--- a/testing/integration/enroll_fips_test.go
+++ b/testing/integration/enroll_fips_test.go
@@ -1,0 +1,85 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/kibana"
+	"github.com/elastic/elastic-agent-libs/testing/estools"
+	atesting "github.com/elastic/elastic-agent/pkg/testing"
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+	"github.com/elastic/elastic-agent/pkg/testing/tools"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnrollFIPS enrolls the locally-built FIPS-capable Elastic Agent into a
+// FIPS-capable Fleet Server running in ECH, adds an integration
+// to this Agent, and checks that data from the integration shows up in Elasticsearch.
+// This test proves that it's possible for a local (on-prem) FIPS-capable Elastic Agent
+// to enroll into a FIPS-capable Fleet Server (aka Integrations Server) running in ECH,
+// while also exercising the connection between Fleet and the Elastic Package Registry (EPR)
+// and also ensuring that the data path from Agent to Elasticsearch works as well.
+func TestEnrollFIPS(t *testing.T) {
+	info := define.Require(t, define.Requirements{
+		Group: Fleet,
+		Stack: &define.Stack{},
+		Local: false, // requires Agent installation
+		Sudo:  true,  // requires Agent installation
+		OS: []define.OS{
+			{Type: define.Linux},
+		},
+		FIPS: true,
+	})
+
+	// Select FIPS-capable local Agent artifact
+	fixture, err := define.NewFixtureFromLocalFIPSBuild(t, define.Version())
+	require.NoError(t, err)
+
+	// Enroll Agent
+	policyUUID := uuid.Must(uuid.NewV4()).String()
+	basePolicy := kibana.AgentPolicy{
+		Name:        "test-policy-" + policyUUID,
+		Namespace:   "default",
+		Description: "Test policy " + policyUUID,
+		MonitoringEnabled: []kibana.MonitoringEnabledOption{
+			kibana.MonitoringEnabledLogs,
+			kibana.MonitoringEnabledMetrics,
+		},
+	}
+
+	installOpts := atesting.InstallOpts{
+		NonInteractive: true,
+		Force:          true,
+		Privileged:     true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	policyResp, _, err := tools.InstallAgentWithPolicy(ctx, t, installOpts, fixture, info.KibanaClient, basePolicy)
+	require.NoError(t, err)
+
+	// Install system integration
+	_, err = tools.InstallPackageFromDefaultFile(ctx, info.KibanaClient, "system", preinstalledPackages["system"], "system_integration_setup.json", uuid.Must(uuid.NewV4()).String(), policyResp.ID)
+	require.NoError(t, err)
+
+	// Ensure data from system integration shows up in Elasticsearch
+	status, err := fixture.ExecStatus(ctx)
+	require.NoError(t, err)
+
+	docs, err := estools.GetResultsForAgentAndDatastream(ctx, info.ESClient, "system.cpu", status.Info.ID)
+	assert.NoError(t, err, "error fetching system metrics")
+	assert.Greater(t, docs.Hits.Total.Value, 0, "could not find any matching system metrics for agent ID %s", status.Info.ID)
+	t.Logf("Generated %d system events", docs.Hits.Total.Value)
+
+}


### PR DESCRIPTION
⚠️  _Currently blocked on https://github.com/elastic/ingest-dev/issues/5264 and https://github.com/elastic/elastic-agent/pull/8035 for CI being able to actually run these tests on a FIPS-configured VM._ ⚠️ 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR adds an integration test that a) enrolls a locally-built FIPS-capable Elastic Agent into a FIPS-capable Fleet Server running in ECH, b) adds the `system` integration to that Agent's policy, and c) ensures that data from the `system` integration shows up in Elasticsearch.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This test proves that it's possible for a local (on-prem) FIPS-capable Elastic Agent to enroll into a FIPS-capable Fleet Server (aka Integrations Server) running in EC;  while also exercising the connection between Fleet and the Elastic Package Registry (EPR) by installing the `system` integration; and also ensuring that the data path from Agent to Elasticsearch works as well.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None; this PR adds an integration test.
