### PR TITLE
fix(diagnostics): handle log rotation races

### DIFF
--- a/changelog/fragments/1747938268-fix-diag-race-condition.yaml
+++ b/changelog/fragments/1747938268-fix-diag-race-condition.yaml
@@ -1,0 +1,4 @@
+kind: bug-fix
+summary: Address a race condition that can occur in Agent diagnostics if log rotation runs while logs are being zipped.
+component: elastic-agent
+pull_request: https://github.com/elastic/elastic-agent/pull/8215

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -314,7 +314,7 @@ func writeErrorResult(zw *zip.Writer, path string, errBody string) error {
 	if err != nil {
 		return fmt.Errorf("error writing header for error.txt file for component: %w", err)
 	}
-	_, err = w.Write([]byte(fmt.Sprintf("%s\n", errBody)))
+	_, err = fmt.Fprintf(w, "%s\n", errBody)
 	if err != nil {
 		return fmt.Errorf("error writing error.txt file for component: %w", err)
 	}

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -507,7 +507,12 @@ func zipLogsWithPath(pathsHome, commitName string, collectServices, excludeEvent
 			return nil
 		}
 
-		return saveLogs(name, path, zw)
+		// Add the file to the zip.
+		// Ignore files that don't exist to account for races with log rotation.
+		if err := saveLogs(name, path, zw); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+		return nil
 	})
 }
 


### PR DESCRIPTION
## What does this PR do?

Handle a race condition that can occur in Agent diagnostics if log rotation happens while logs are being zipped. There is a time window between when `filepath.WalkDir` reads the directory contents and when log files are opened for reading. During this time window, log rotation can happen, resulting in files that no longer exist and cannot be added to the diagnostic archive.

To handle this, `fs.ErrNotExist` errors are ignored when attempting to add log files.

## Why is it important?

This race can happen at any time, so any user could be affected. The problem is worse if debug logging is enabled and logs are being rotated quickly.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Screenshots

This is the user reported error:

![diag-error](https://github.com/user-attachments/assets/3adf55c8-8a43-4057-9fa1-8894215af6b6)

via OCR, it says:

> Error generating file: unable to open log file: open /opt/Elastic/Agent/ data/elastic-agent-8.17.0-96f2b9/ logs/elastic-agent-20250220-42457.ndjson: no such file or directory

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
