### PR TITLE
Fix some minor issues with the beats version update job

### DIFF
--- a/.ci/updatecli/update-beats.yml
+++ b/.ci/updatecli/update-beats.yml
@@ -22,8 +22,8 @@ actions:
     spec:
       automerge: false
       labels:
-      - dependencies
-      - backport-skip
+      - automation
+      - skip-changelog
       - "Team:Elastic-Agent-Control-Plane"
       description: |-
         ### What

--- a/.github/workflows/bump-beats-version.yml
+++ b/.github/workflows/bump-beats-version.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
 jobs:
   filter:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this PR do?

Fixes two minor issues with the recently added beats update job:

* The labels are now consistent with dependabot PRs
* The job url in Slack messages is now correct

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
