### PR TITLE
Fix minor typo in beats update job

### DIFF
--- a/.ci/updatecli/update-beats.yml
+++ b/.ci/updatecli/update-beats.yml
@@ -61,7 +61,7 @@ conditions:
     disablesourceinput: true
     scmid: default
     spec:
-      command: '[ ${{ source "beats"}} != {{ source "gomod" }} ]'
+      command: '[ {{ source "beats" }} != {{ source "gomod" }} ]'
     failwhen: false
 
 targets:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

In the updatecli condition check if the update was necessary, here was an unnecessary `$`. As a result, we never skipped the update.

Tested this locally and it looked correct.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
