### PR TITLE
buildkite(gcp-oidc): use least-permissive and OIDC for GCP

### DIFF
--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -2,7 +2,6 @@
 
 env:
   DOCKER_REGISTRY: "docker.elastic.co"
-  VAULT_PATH: "kv/ci-shared/observability-ingest/cloud/gcp"
   ASDF_MAGE_VERSION: 1.14.0
 
   IMAGE_UBUNTU_2404_X86_64: "family/platform-ingest-elastic-agent-ubuntu-2404"
@@ -11,6 +10,17 @@ env:
   IMAGE_DEBIAN_12: "family/platform-ingest-elastic-agent-debian-12"
   IMAGE_WIN_2022: "family/platform-ingest-elastic-agent-windows-2022"
   IMAGE_WIN_2025: "family/platform-ingest-elastic-agent-windows-2025"
+
+# This section is used to define the plugins that will be used in the pipeline.
+# See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
+common:
+  - google_oidc_plugin: &google_oidc_plugin
+      # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/elastic-agent/01-gcp-oidc.tf
+      # This plugin authenticates to Google Cloud using the OIDC token.
+      elastic/oblt-google-auth#v1.2.0:
+        lifetime: 10800 # seconds
+        project-id: "elastic-observability-ci"
+        project-number: "911195782929"
 
 steps:
   - label: Start ESS stack for integration tests
@@ -58,6 +68,8 @@ steps:
           - upgrade
           - upgrade-flavor
           - install-uninstall
+        plugins:
+          - *google_oidc_plugin
 
       - label: "Win2022:non-sudo:{{matrix}}"
         depends_on:
@@ -77,6 +89,8 @@ steps:
             limit: 1
         matrix:
           - default
+        plugins:
+          - *google_oidc_plugin
 
       - label: "Win2025:sudo:{{matrix}}"
         depends_on:
@@ -103,6 +117,8 @@ steps:
           - upgrade
           - upgrade-flavor
           - install-uninstall
+        plugins:
+          - *google_oidc_plugin
 
       - label: "Win2025:non-sudo:{{matrix}}"
         depends_on:
@@ -122,6 +138,8 @@ steps:
           image: "${IMAGE_WIN_2025}"
         matrix:
           - default
+        plugins:
+          - *google_oidc_plugin
 
   - group: "Stateful:Ubuntu"
     key: integration-tests-ubuntu
@@ -145,6 +163,8 @@ steps:
           image: "${IMAGE_UBUNTU_2404_X86_64}"
         matrix:
           - default
+        plugins:
+          - *google_oidc_plugin
 
       - label: "x86_64:sudo: {{matrix}}"
         depends_on:
@@ -178,6 +198,8 @@ steps:
           - fqdn
           - deb
           - container
+        plugins:
+          - *google_oidc_plugin
 
       - label: "arm:sudo: {{matrix}}"
         depends_on:
@@ -211,6 +233,8 @@ steps:
           # - fqdn
           # - deb
           # - container
+        plugins:
+          - *google_oidc_plugin
 
       - label: "arm:non-sudo: {{matrix}}"
         skip: true
@@ -231,6 +255,8 @@ steps:
           instanceType: "m6g.xlarge"
         matrix:
           - default
+        plugins:
+          - *google_oidc_plugin
 
   - group: "Stateful:Debian"
     key: integration-tests-debian
@@ -254,6 +280,8 @@ steps:
           image: "${IMAGE_DEBIAN_12}"
         matrix:
           - default
+        plugins:
+          - *google_oidc_plugin
 
       - label: "x86_64:sudo: {{matrix}}"
         depends_on:
@@ -288,6 +316,8 @@ steps:
           #- fqdn
           - deb
           - container
+        plugins:
+          - *google_oidc_plugin
 
   - group: "Stateful(Sudo):RHEL8"
     key: integration-tests-rhel8
@@ -310,6 +340,8 @@ steps:
           provider: "gcp"
           machineType: "n1-standard-8"
           image: "${IMAGE_RHEL_8}"
+        plugins:
+          - *google_oidc_plugin
 
   - group: "Kubernetes"
     key: integration-tests-kubernetes
@@ -355,6 +387,8 @@ steps:
               - v1.31.0
               - v1.32.0
               - v1.33.0
+        plugins:
+          - *google_oidc_plugin
 
   - label: ESS stack cleanup
     depends_on:

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -47,12 +47,6 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-agent-package" ]]; then
 fi
 
 if [[ "$BUILDKITE_STEP_KEY" == *"integration-tests"* ]]; then
-  echo "Setting credentials"
-  # Set GCP credentials
-  export GOOGLE_APPLICATION_GCP_SECRET=$(retry 5 vault kv get -format=json -field=data ${CI_GCP_OBS_PATH})
-  echo "${GOOGLE_APPLICATION_GCP_SECRET}" > ./gcp.json
-  export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ./gcp.json)
-  export TEST_INTEG_AUTH_GCP_SERVICE_TOKEN_FILE=$(realpath ./gcp.json)
 
   # ESS credentials
   export API_KEY_TOKEN=$(vault kv get -field apiKey ${CI_ESS_PATH})

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -16,7 +16,6 @@ fi
 DOCKER_REGISTRY="docker.elastic.co"
 DOCKER_REGISTRY_SECRET_PATH="kv/ci-shared/platform-ingest/docker_registry_prod"
 CI_DRA_ROLE_PATH="kv/ci-shared/release/dra-role"
-CI_GCP_OBS_PATH="kv/ci-shared/observability-ingest/cloud/gcp"
 CI_ESS_PATH="kv/ci-shared/platform-ingest/platform-ingest-ec-prod"
 CI_DRA_ROLE_PATH="kv/ci-shared/release/dra-role"
 

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -14,18 +14,6 @@ if [[ "$BUILDKITE_STEP_KEY" == *"integration-tests"* ]]; then
   SNAPSHOT=true mage integration:clean
 fi
 
-if [ -n "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
-  if test -f "$GOOGLE_APPLICATION_CREDENTIALS"; then
-    rm $GOOGLE_APPLICATION_CREDENTIALS
-  fi
-fi
-
-if [ -n "$TEST_INTEG_AUTH_GCP_SERVICE_TOKEN_FILE" ]; then
-  if test -f "$TEST_INTEG_AUTH_GCP_SERVICE_TOKEN_FILE"; then
-    rm $TEST_INTEG_AUTH_GCP_SERVICE_TOKEN_FILE
-  fi
-fi
-
 if command -v docker &>/dev/null; then
   DOCKER_REGISTRY="docker.elastic.co"
   docker logout $DOCKER_REGISTRY

--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -3,6 +3,17 @@
 env:
   DOCKER_REGISTRY: "docker.elastic.co"
 
+# This section is used to define the plugins that will be used in the pipeline.
+# See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
+common:
+  - google_oidc_plugin: &google_oidc_plugin
+      # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/elastic-agent/01-gcp-oidc.tf
+      # This plugin authenticates to Google Cloud using the OIDC token.
+      elastic/oblt-google-auth#v1.2.0:
+        lifetime: 10800 # seconds
+        project-id: "elastic-observability-ci"
+        project-number: "911195782929"
+
 steps:
   - group: "Integration tests: packaging"
     key: "int-packaging"
@@ -168,6 +179,8 @@ steps:
     retry:
       automatic:
         limit: 1
+    plugins:
+      - *google_oidc_plugin
     notify:
       - github_commit_status:
           context: "buildkite/elastic-agent-extended-testing - Serverless integration test"
@@ -192,6 +205,8 @@ steps:
     retry:
       automatic:
         limit: 1
+    plugins:
+      - *google_oidc_plugin
     notify:
       - github_commit_status:
           context: "buildkite/elastic-agent-extended-testing - Extended runtime leak tests"

--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -2,7 +2,6 @@
 
 env:
   DOCKER_REGISTRY: "docker.elastic.co"
-  VAULT_PATH: "kv/ci-shared/observability-ingest/cloud/gcp"
 
 steps:
   - group: "Integration tests: packaging"

--- a/.buildkite/pipeline.elastic-agent-gce-cleanup.yml
+++ b/.buildkite/pipeline.elastic-agent-gce-cleanup.yml
@@ -3,11 +3,24 @@
 # Removes stale GCE instances having matching labels, name prefixes and older than 24 hours
 # See gce-cleanup.sh and .buildkite/misc/gce-cleanup.yml
 env:
-  VAULT_PATH: "kv/ci-shared/observability-ingest/cloud/gcp"
   DOCKER_REGISTRY: "docker.elastic.co"
+
+# This section is used to define the plugins that will be used in the pipeline.
+# See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
+common:
+  - google_oidc_plugin: &google_oidc_plugin
+      # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/elastic-agent/01-gcp-oidc.tf
+      # This plugin authenticates to Google Cloud using the OIDC token.
+      elastic/oblt-google-auth#v1.2.0:
+        lifetime: 10800 # seconds
+        project-id: "elastic-observability-ci"
+        project-number: "911195782929"
+
 steps:
   - label: "GCE Cleanup"
     key: "gce-cleanup"
     command: ".buildkite/scripts/steps/gce-cleanup.sh"
     agents:
       provider: "gcp"
+    plugins:
+      - *google_oidc_plugin

--- a/.buildkite/pipeline.integration-test-matrix.yml
+++ b/.buildkite/pipeline.integration-test-matrix.yml
@@ -2,7 +2,17 @@
 
 env:
   DOCKER_REGISTRY: "docker.elastic.co"
-  VAULT_PATH: "kv/ci-shared/observability-ingest/cloud/gcp"
+
+# This section is used to define the plugins that will be used in the pipeline.
+# See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
+common:
+  - google_oidc_plugin: &google_oidc_plugin
+      # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/elastic-agent/01-gcp-oidc.tf
+      # This plugin authenticates to Google Cloud using the OIDC token.
+      elastic/oblt-google-auth#v1.2.0:
+        lifetime: 10800 # seconds
+        project-id: "elastic-observability-ci"
+        project-number: "911195782929"
 
 steps:
   - label: "Integration tests: packaging"
@@ -27,3 +37,5 @@ steps:
     agents:
       provider: "gcp"
       machineType: "n1-standard-8"
+    plugins:
+      - *google_oidc_plugin

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
-  VAULT_PATH: "kv/ci-shared/observability-ingest/cloud/gcp"
   DOCKER_REGISTRY: "docker.elastic.co"
 
   IMAGE_UBUNTU_2204_X86_64: "family/platform-ingest-elastic-agent-ubuntu-2204"

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -82,14 +82,6 @@ go(){
     return $ACTUAL_EXIT_CODE
 }
 
-google_cloud_auth() {
-    local keyFile=$1
-
-    gcloud auth activate-service-account --key-file ${keyFile} 2> /dev/null
-
-    export GOOGLE_APPLICATION_CREDENTIALS=${secretFileLocation}
-}
-
 retry() {
     local retries=$1
     shift

--- a/.buildkite/scripts/common2.sh
+++ b/.buildkite/scripts/common2.sh
@@ -43,11 +43,3 @@ getOSOptions() {
       ;;
   esac
 }
-
-google_cloud_auth() {
-    local keyFile=$1
-
-    gcloud auth activate-service-account --key-file ${keyFile} 2> /dev/null
-
-    export GOOGLE_APPLICATION_CREDENTIALS=${secretFileLocation}
-}

--- a/.buildkite/scripts/steps/gce-cleanup.sh
+++ b/.buildkite/scripts/steps/gce-cleanup.sh
@@ -2,9 +2,6 @@
 
 set -euo pipefail
 
-export ACCOUNT_KEY_SECRET=$(vault kv get -field=client_email $VAULT_PATH)
-export ACCOUNT_SECRET=$(vault kv get -field=private_key $VAULT_PATH)
-export ACCOUNT_PROJECT_SECRET=$(vault kv get -field=project_id $VAULT_PATH)
 export DELETE_CREATED_AFTER_DATE=$(date -Is -d "5 hours ago")
 
 docker run -v $(pwd)/.buildkite/misc/gce-cleanup.yml:/etc/cloud-reaper/config.yml \

--- a/.buildkite/serverless.beats.tests.yml
+++ b/.buildkite/serverless.beats.tests.yml
@@ -2,7 +2,6 @@
 
 env:
   DOCKER_REGISTRY: "docker.elastic.co"
-  VAULT_PATH: "kv/ci-shared/observability-ingest/cloud/gcp"
 
 steps:
   - label: "Serverless Beats Tests"

--- a/magefile.go
+++ b/magefile.go
@@ -3396,7 +3396,7 @@ func gceFindMissingRoles(actual []string, expected []string) []string {
 }
 
 func getGCEServiceTokenPath() (string, bool, error) {
-	serviceTokenPath := os.Getenv("TEST_INTEG_AUTH_GCP_SERVICE_TOKEN_FILE")
+	serviceTokenPath := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
 	if serviceTokenPath == "" {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {


### PR DESCRIPTION
## What does this PR do?

Enable GCP OIDC

## Why is it important?

Use `least-permissive` and shorter live tokens.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- [ ] Support for serverless `Serverless integration test` and `Extended runtime leak tests`

```
Error: error creating test runner: not a service account token at /tmp/tmp.eOLGEgfcMh/credentials.json; type != service_account
  |  
```
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
