### PR TITLE
fix: correct image uri in variants

### DIFF
--- a/pkg/testing/kubernetes/supported.go
+++ b/pkg/testing/kubernetes/supported.go
@@ -89,19 +89,19 @@ var variants = []struct {
 	},
 	{
 		Name:  "elastic-otel-collector",
-		Image: "docker.elastic.co/beats-ci/elastic-otel-collector",
+		Image: "docker.elastic.co/elastic-agent/elastic-otel-collector",
 	},
 	{
 		Name:  "slim",
-		Image: "docker.elastic.co/beats-ci/elastic-agent-slim",
+		Image: "docker.elastic.co/elastic-agent/elastic-agent-slim",
 	},
 	{
 		Name:  "elastic-otel-collector-wolfi",
-		Image: "docker.elastic.co/beats-ci/elastic-otel-collector-wolfi",
+		Image: "docker.elastic.co/elastic-agent/elastic-otel-collector-wolfi",
 	},
 	{
 		Name:  "slim-wolfi",
-		Image: "docker.elastic.co/beats-ci/elastic-agent-slim-wolfi",
+		Image: "docker.elastic.co/elastic-agent/elastic-agent-slim-wolfi",
 	},
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
-->

## What does this PR do?

This PR corrects outdated Docker image URIs used in Kubernetes integration test variants. Some container image variants pointed to `docker.elastic.co/beats-ci` while our packaging produces them under the `docker.elastic.co/elastic-agent` registry.

## Why is it important?

Kubernetes integration tests when invoked through the mage-system fail and the test runner attempts to load non-existent Docker images from `beats-ci`, resulting in errors like:
```
Error: error running test: kind: load docker-image docker.elastic.co/beats-ci/elastic-agent-slim:9.1.0-SNAPSHOT-tests failed: exit status 1
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None. This is a fix for mage kubernetes integration tests, it does not affect end users of Elastic Agent or the current CI.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
INSTANCE_PROVISIONER="kind" AGENT_VERSION="9.1.0-SNAPSHOT" SNAPSHOT=true mage -v integration:kubernetes
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
N/A
