### PR TITLE
[ci] fix update versions

### DIFF
--- a/testing/upgradetest/versions.go
+++ b/testing/upgradetest/versions.go
@@ -199,6 +199,10 @@ func findRequiredVersions(sortedParsedVersions []*version.ParsedSemVer, reqs Ver
 		case !version.Less(*parsedUpgradeToVersion):
 			continue
 
+		// same major, same minor, less or equal patch
+		case version.Major() == parsedUpgradeToVersion.Major() && version.Minor() == parsedUpgradeToVersion.Minor() && version.Patch() <= parsedUpgradeToVersion.Patch():
+			continue
+
 		case recentSnapshotsToFind > 0 && version.IsSnapshot():
 			upgradableVersions = append(upgradableVersions, version.String())
 			recentSnapshotsToFind--

--- a/testing/upgradetest/versions.go
+++ b/testing/upgradetest/versions.go
@@ -199,8 +199,8 @@ func findRequiredVersions(sortedParsedVersions []*version.ParsedSemVer, reqs Ver
 		case !version.Less(*parsedUpgradeToVersion):
 			continue
 
-		// same major, same minor, less or equal patch
-		case version.Major() == parsedUpgradeToVersion.Major() && version.Minor() == parsedUpgradeToVersion.Minor() && version.Patch() <= parsedUpgradeToVersion.Patch():
+		// never test upgrades if only the patch version changed
+		case version.Major() == parsedUpgradeToVersion.Major() && version.Minor() == parsedUpgradeToVersion.Minor():
 			continue
 
 		case recentSnapshotsToFind > 0 && version.IsSnapshot():


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR updates the upgradable version selection logic in `FetchUpgradableVersions` to explicitly exclude previous patch versions when the major and minor versions match the `UpgradeToVersion` version.

Specifically:
- It introduces a check to skip any versions with the same major and minor as the upgrade target if their patch is less than or equal to the `UpgradeToVersion` patch part.
- It rewrites `TestFetchUpgradableVersionsAfterFeatureFreeze` to use table-driven tests with self-contained version data.

## Why is it important?

- Prevents redundant patch upgrades from being included as upgrade candidates when not applicable.
- Fixes test flakiness issue in `PreviousMinor()` where versions like `9.0.1` failed to resolve a previous minor due to ambiguous or stateful data dependencies.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

None. This change only affects internal version filtering logic used in upgrade tests. There is no impact on users or runtime behaviour of Elastic Agent.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
mage unitTest
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/6667