### PR TITLE
ci: update all n1-standard-8 type runners to n2-standard-8

### DIFF
--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -46,7 +46,7 @@ steps:
           - build/diagnostics/**
         agents:
           provider: "gcp"
-          machineType: "n1-standard-8"
+          machineType: "n2-standard-8"
           image: "${IMAGE_WIN_2022}"
         retry:
           automatic:
@@ -67,7 +67,7 @@ steps:
             limit: 1
         agents:
           provider: "gcp"
-          machineType: "n1-standard-8"
+          machineType: "n2-standard-8"
           image: "${IMAGE_WIN_2025}"
       - label: "Ubuntu:2404:amd64:sudo"
         depends_on: packaging-ubuntu-x86-64
@@ -84,7 +84,7 @@ steps:
             limit: 1
         agents:
           provider: "gcp"
-          machineType: "n1-standard-8"
+          machineType: "n2-standard-8"
           image: "${IMAGE_UBUNTU_2404_X86_64}"
 
   - group: "Stateful: Windows"
@@ -103,7 +103,7 @@ steps:
           - build/diagnostics/**
         agents:
           provider: "gcp"
-          machineType: "n1-standard-8"
+          machineType: "n2-standard-8"
           image: "${IMAGE_WIN_2022}"
         retry:
           automatic:
@@ -129,7 +129,7 @@ steps:
           - build/diagnostics/**
         agents:
           provider: "gcp"
-          machineType: "n1-standard-8"
+          machineType: "n2-standard-8"
           image: "${IMAGE_WIN_2022}"
         retry:
           automatic:
@@ -148,7 +148,7 @@ steps:
           - build/diagnostics/**
         agents:
           provider: "gcp"
-          machineType: "n1-standard-8"
+          machineType: "n2-standard-8"
           image: "${IMAGE_WIN_2025}"
         retry:
           automatic:
@@ -177,7 +177,7 @@ steps:
             limit: 1
         agents:
           provider: "gcp"
-          machineType: "n1-standard-8"
+          machineType: "n2-standard-8"
           image: "${IMAGE_WIN_2025}"
         matrix:
           - default
@@ -200,7 +200,7 @@ steps:
             limit: 1
         agents:
           provider: "gcp"
-          machineType: "n1-standard-8"
+          machineType: "n2-standard-8"
           image: "${IMAGE_UBUNTU_2404_X86_64}"
         matrix:
           - default
@@ -220,7 +220,7 @@ steps:
             limit: 1
         agents:
           provider: "gcp"
-          machineType: "n1-standard-8"
+          machineType: "n2-standard-8"
           image: "${IMAGE_UBUNTU_2404_X86_64}"
         matrix:
           - default
@@ -309,7 +309,7 @@ steps:
             limit: 1
         agents:
           provider: "gcp"
-          machineType: "n1-standard-8"
+          machineType: "n2-standard-8"
           image: "${IMAGE_DEBIAN_12}"
         matrix:
           - default
@@ -329,7 +329,7 @@ steps:
             limit: 1
         agents:
           provider: "gcp"
-          machineType: "n1-standard-8"
+          machineType: "n2-standard-8"
           image: "${IMAGE_DEBIAN_12}"
         matrix:
           - default
@@ -367,7 +367,7 @@ steps:
             limit: 1
         agents:
           provider: "gcp"
-          machineType: "n1-standard-8"
+          machineType: "n2-standard-8"
           image: "${IMAGE_RHEL_8}"
 
   - group: "Kubernetes"

--- a/.buildkite/pipeline.elastic-agent-helm-charts.yml
+++ b/.buildkite/pipeline.elastic-agent-helm-charts.yml
@@ -16,4 +16,4 @@ steps:
           project-number: "911195782929"
     agents:
       provider: "gcp"
-      machineType: "n1-standard-8"
+      machineType: "n2-standard-8"

--- a/.buildkite/pipeline.integration-test-matrix.yml
+++ b/.buildkite/pipeline.integration-test-matrix.yml
@@ -12,7 +12,7 @@ steps:
       - build/distributions/**
     agents:
       provider: "gcp"
-      machineType: "n1-standard-8"
+      machineType: "n2-standard-8"
 
   - label: "Integration test matrix"
     key: "integration-tests-matrix"
@@ -26,4 +26,4 @@ steps:
       - "build/diagnostics/*"
     agents:
       provider: "gcp"
-      machineType: "n1-standard-8"
+      machineType: "n2-standard-8"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR updates all Buildkite pipeline steps that were previously using `n1-standard-8` GCP machine types to instead use `n2-standard-8`.

The following pipeline YAML files were updated:
- `.buildkite/bk.integration.pipeline.yml`
- `.buildkite/pipeline.elastic-agent-helm-charts.yml`
- `.buildkite/pipeline.integration-test-matrix.yml`

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The `n1` machine series is deprecated and offers worse performance and price efficiency compared to the `n2` series. As noted in the review of a prior PR, using `n2-standard-8` helps prevent resource limitations and improves overall CI stability and performance. This change ensures consistency across all CI steps and aligns with best practices for machine type selection in GCP (context [here](https://github.com/elastic/elastic-agent/pull/7931#discussion_r2122697348)).


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None. This is a CI-only change and does not affect the behavior of the Elastic Agent or its packaging. No user-facing configuration or interface is impacted.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

These changes affect the CI configuration and will be automatically exercised by Buildkite when the pipeline runs.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Follows up on [review feedback](https://github.com/elastic/elastic-agent/pull/7931#discussion_r2122697348) in a previous PR: use of `n2-standard-8` for better performance and consistency