### PR TITLE
fix(ci): restore `go mod tidy` in `otel-update.sh` script

### DIFF
--- a/.ci/scripts/otel-update.sh
+++ b/.ci/scripts/otel-update.sh
@@ -35,6 +35,8 @@ sed -i.bak "s/\(go\.opentelemetry\.io\/collector.*\) $current_stable_core/\1 $ne
 sed -i.bak "s/\(github\.com\/open-telemetry\/opentelemetry\-collector\-contrib\/.*\) $current_contrib/\1 $next_contrib/" go.mod
 rm go.mod.bak
 
+echo "=> Running go mod tidy"
+go mod tidy
 echo "=> Running mage notice"
 mage notice
 echo "=> Running mage otel:readme"


### PR DESCRIPTION
Without it, `mage notice` fails, because `mage tidy` fails, because magefile cannot be compiled, because the root `go.mod` file that Mage depends on is out of date.

Related to https://github.com/elastic/elastic-agent/pull/8279, discussed with @pkoutsovasilis.

## Steps to reproduce the issue

1. Pull latest `main`
2. Run `.ci/scripts/otel-update.sh v0.127.0 v1.33.0`, or make some other change in the root `go.mod` that invalidates `go.sum`.

Expected result:
- The `otel-update.sh` scripts / `mage tidy` succeeds

Actual result:
- The `otel-update.sh` script fails with `error compiling magefiles`

```console
$ .ci/scripts/otel-update.sh v0.127.0 v1.33.0
=> Updating core from v0.123.0/v1.29.0 to v0.127.0/v1.33.0
=> Updating contrib from v0.123.0 to v0.127.0
=> Running mage notice
internal/pkg/config/config.go:13:2: missing go.sum entry for module providing package go.opentelemetry.io/collector/confmap (imported by github.com/elastic/elastic-agent/internal/pkg/config); to add:
        go get github.com/elastic/elastic-agent/internal/pkg/config
Error: error compiling magefiles
$
