### PR TITLE
Add filebeat_input to beat receiver agent monitoring integration test

### DIFF
--- a/internal/pkg/agent/application/monitoring/testdata/monitoring_config_full.yaml
+++ b/internal/pkg/agent/application/monitoring/testdata/monitoring_config_full.yaml
@@ -654,6 +654,63 @@ inputs:
           id: filestream-monitoring
         target: component
   - data_stream:
+      dataset: elastic_agent.filebeat_input
+      namespace: default
+      type: metrics
+    failure_threshold: 5
+    hosts:
+    - placeholder
+    id: metrics-monitoring-filebeat-1
+    index: metrics-elastic_agent.filebeat_input-default
+    json.is_array: true
+    metricsets:
+    - json
+    namespace: filebeat_input
+    path: /inputs/
+    period: 1m0s
+    processors:
+    - add_fields:
+        fields:
+          dataset: elastic_agent.filebeat_input
+        target: event
+    - add_fields:
+        fields:
+          id: ""
+          process: filebeat
+          snapshot: false
+          version: placeholder
+        target: elastic_agent
+    - add_fields:
+        fields:
+          id: ""
+        target: agent
+    - copy_fields:
+        fail_on_error: false
+        fields:
+        - from: http.agent.beat.cpu
+          to: system.process.cpu
+        - from: http.agent.beat.memstats.memory_sys
+          to: system.process.memory.size
+        - from: http.agent.beat.handles
+          to: system.process.fd
+        - from: http.agent.beat.cgroup
+          to: system.process.cgroup
+        - from: http.agent.apm-server
+          to: apm-server
+        - from: http.filebeat_input
+          to: filebeat_input
+        ignore_missing: true
+    - drop_fields:
+        fields:
+        - http
+        - system
+        ignore_missing: true
+    - add_fields:
+        fields:
+          binary: filebeat
+          id: filestream-otel
+        target: component
+  - data_stream:
       dataset: elastic_agent.elastic_agent
       namespace: default
       type: metrics

--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -700,8 +700,7 @@ func (b *BeatsMonitor) getHttpStreams(
 			httpStreams = append(httpStreams, httpStream)
 		}
 		// specifically for filebeat, we include input metrics
-		// disabled for filebeat receiver until https://github.com/elastic/beats/issues/43418 is resolved
-		if strings.EqualFold(name, "filebeat") && compInfo.RuntimeManager != component.OtelRuntimeManager {
+		if strings.EqualFold(name, "filebeat") {
 			fbDataStreamName := "filebeat_input"
 			fbDataset := fmt.Sprintf("elastic_agent.%s", fbDataStreamName)
 			fbIndexName := fmt.Sprintf("metrics-elastic_agent.%s-%s", fbDataStreamName, monitoringNamespace)
@@ -842,7 +841,6 @@ func processorsForAgentFilestream() []any {
 		addFormattedIndexProcessor(),
 	)
 	return processors
-
 }
 
 // processorsForServiceComponentFilestream returns processors used for filestream streams for components running as

--- a/internal/pkg/agent/application/monitoring/v1_monitor_test.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor_test.go
@@ -141,7 +141,6 @@ func TestMonitoringWithEndpoint(t *testing.T) {
 				Enabled:        true,
 				MonitorMetrics: true,
 				HTTP: &monitoringcfg.MonitoringHTTPConfig{
-
 					Enabled: true,
 				},
 			},
@@ -213,7 +212,6 @@ func TestMonitoringWithEndpoint(t *testing.T) {
 						require.Equal(t, uint64(1234), streamValues["process.pid"])
 					}
 				}
-
 			}
 		}
 	}
@@ -222,7 +220,6 @@ func TestMonitoringWithEndpoint(t *testing.T) {
 }
 
 func TestMonitoringConfigMetricsInterval(t *testing.T) {
-
 	agentInfo, err := info.NewAgentInfo(context.Background(), false)
 	require.NoError(t, err, "Error creating agent info")
 	components := []component.Component{{ID: "foobeat", InputSpec: &component.InputRuntimeSpec{BinaryName: "filebeat"}}}
@@ -317,7 +314,6 @@ func TestMonitoringConfigMetricsInterval(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-
 		t.Run(tc.name, func(t *testing.T) {
 			b := &BeatsMonitor{
 				enabled:         true,
@@ -370,7 +366,6 @@ func TestMonitoringConfigMetricsInterval(t *testing.T) {
 }
 
 func TestMonitoringConfigMetricsFailureThreshold(t *testing.T) {
-
 	agentInfo, err := info.NewAgentInfo(context.Background(), false)
 	require.NoError(t, err, "Error creating agent info")
 	components := []component.Component{{ID: "foobeat", InputSpec: &component.InputRuntimeSpec{BinaryName: "filebeat"}}}
@@ -552,7 +547,6 @@ func TestMonitoringConfigMetricsFailureThreshold(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-
 		t.Run(tc.name, func(t *testing.T) {
 			b := &BeatsMonitor{
 				enabled:         true,
@@ -603,7 +597,6 @@ func TestMonitoringConfigMetricsFailureThreshold(t *testing.T) {
 }
 
 func TestErrorMonitoringConfigMetricsFailureThreshold(t *testing.T) {
-
 	agentInfo, err := info.NewAgentInfo(context.Background(), false)
 	components := []component.Component{{ID: "foobeat", InputSpec: &component.InputRuntimeSpec{BinaryName: "filebeat"}}}
 	require.NoError(t, err, "Error creating agent info")
@@ -729,7 +722,6 @@ func TestErrorMonitoringConfigMetricsFailureThreshold(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-
 		t.Run(tc.name, func(t *testing.T) {
 			b := &BeatsMonitor{
 				enabled:         true,
@@ -936,7 +928,7 @@ func TestMonitoringConfigForBeatsReceivers(t *testing.T) {
 			}
 		}
 	}
-	assert.Len(t, streamsForInputMetrics, 2)
+	assert.Len(t, streamsForInputMetrics, 3)
 }
 
 func TestMonitoringWithOtelRuntime(t *testing.T) {

--- a/testing/integration/beat_receivers_test.go
+++ b/testing/integration/beat_receivers_test.go
@@ -725,6 +725,7 @@ func genIgnoredFields(goos string) []string {
 			"log.file.fingerprint",
 			"log.file.idxhi",
 			"log.file.idxlo",
+			"log.offset",
 		}
 	default:
 		return []string{
@@ -732,6 +733,7 @@ func genIgnoredFields(goos string) []string {
 			"log.file.fingerprint",
 			"log.file.inode",
 			"log.file.path",
+			"log.offset",
 		}
 	}
 }

--- a/testing/integration/beat_receivers_test.go
+++ b/testing/integration/beat_receivers_test.go
@@ -1,7 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
-
 //go:build integration
 
 package integration
@@ -13,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"runtime"
 	"strings"
 	"testing"
 	"text/template"
@@ -42,6 +42,7 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 		OS: []define.OS{
 			{Type: define.Linux},
 			{Type: define.Darwin},
+			{Type: define.Windows},
 		},
 		Stack: &define.Stack{},
 		Sudo:  true,
@@ -56,69 +57,80 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 	type test struct {
 		dsType          string
 		dsDataset       string
-		dsNamespace     string
-		query           map[string]any
+		query           []map[string]any
 		onlyCompareKeys bool
 		ignoreFields    []string
 	}
 
 	tests := []test{
 		{
-			dsType:          "logs",
-			dsDataset:       "elastic_agent",
-			dsNamespace:     info.Namespace,
-			query:           map[string]any{"match_phrase": map[string]any{"message": "Determined allowed capabilities"}},
+			dsType:    "logs",
+			dsDataset: "elastic_agent",
+			query: []map[string]any{
+				{"match_phrase": map[string]any{"message": "Determined allowed capabilities"}},
+			},
 			onlyCompareKeys: false,
+			ignoreFields:    genIgnoredFields(runtime.GOOS),
 		},
 
 		{
-			dsType:          "metrics",
-			dsDataset:       "elastic_agent.filebeat",
-			dsNamespace:     info.Namespace,
-			query:           map[string]any{"exists": map[string]any{"field": "beat.stats.libbeat.pipeline.queue.acked"}},
+			dsType:    "metrics",
+			dsDataset: "elastic_agent.filebeat",
+			query: []map[string]any{
+				{"match_phrase": map[string]any{"metricset.name": "stats"}},
+				{"match_phrase": map[string]any{"component.id": "filestream-monitoring"}},
+				{"exists": map[string]any{"field": "beat.stats.libbeat.pipeline.queue.acked"}},
+			},
 			onlyCompareKeys: true,
 			ignoreFields: []string{
-				// all process related metrics are dropped for beatreceivers
+				"beat.elasticsearch.cluster.id",
 				"beat.stats.cgroup",
 				"beat.stats.cpu",
 				"beat.stats.handles",
-				"beat.stats.memstats",
-				"beat.stats.runtime",
-				"beat.elasticsearch.cluster.id",
 				"beat.stats.libbeat.config",
+				"beat.stats.memstats",
+				"beat.stats.runtime.goroutines",
 			},
 		},
 		{
-			dsType:          "metrics",
-			dsDataset:       "elastic_agent.metricbeat",
-			dsNamespace:     info.Namespace,
-			query:           map[string]any{"exists": map[string]any{"field": "beat.stats.libbeat.pipeline.queue.acked"}},
+			dsType:    "metrics",
+			dsDataset: "elastic_agent.metricbeat",
+			query: []map[string]any{
+				{"match_phrase": map[string]any{"metricset.name": "stats"}},
+				{"match_phrase": map[string]any{"component.id": "http/metrics-monitoring"}},
+				{"exists": map[string]any{"field": "beat.stats.libbeat.pipeline.queue.acked"}},
+			},
 			onlyCompareKeys: true,
 			ignoreFields: []string{
-				//  all process related metrics are dropped for beatreceivers
+				"beat.elasticsearch.cluster.id",
 				"beat.stats.cgroup",
 				"beat.stats.cpu",
 				"beat.stats.handles",
-				"beat.stats.memstats",
-				"beat.stats.runtime",
-				"beat.elasticsearch.cluster.id",
 				"beat.stats.libbeat.config",
+				"beat.stats.memstats",
+				"beat.stats.runtime.goroutines",
 			},
 		},
 		{
 			dsType:          "metrics",
 			dsDataset:       "elastic_agent.elastic_agent",
-			dsNamespace:     info.Namespace,
 			onlyCompareKeys: true,
-			query:           map[string]any{"exists": map[string]any{"field": "system.process.memory.size"}},
+			query: []map[string]any{
+				{"match_phrase": map[string]any{"metricset.name": "json"}},
+				{"match_phrase": map[string]any{"component.id": "elastic-agent"}},
+				{"exists": map[string]any{"field": "system.process.memory.size"}},
+			},
 		},
-		// TODO: fbreceiver must support /inputs/ endpoint for this to work
-		// {
-		// 	dsType:      "metrics",
-		// 	dsDataset:   "elastic_agent.filebeat_input",
-		// 	dsNamespace: info.Namespace,
-		// 	query:       map[string]any{"exists": map[string]any{"field": "filebeat_input.bytes_processed_total"}},
-		// },
+		{
+			dsType:          "metrics",
+			dsDataset:       "elastic_agent.filebeat_input",
+			onlyCompareKeys: true,
+			query: []map[string]any{
+				{"match_phrase": map[string]any{"metricset.name": "json"}},
+				{"match_phrase": map[string]any{"component.id": "filestream-monitoring"}},
+				{"exists": map[string]any{"field": "filebeat_input.bytes_processed_total"}},
+			},
+		},
 	}
 
 	installOpts := atesting.InstallOpts{
@@ -203,6 +215,9 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 	d.ApiKey = string(apiKey)
 	policy.Outputs["default"] = d
 
+	processNamespace := fmt.Sprintf("%s-%s", info.Namespace, "process")
+	policy.Agent.Monitoring["namespace"] = processNamespace
+
 	updatedPolicyBytes, err := yaml.Marshal(policy)
 	require.NoErrorf(t, err, "error marshalling policy, struct was %v", policy)
 	t.Cleanup(func() {
@@ -252,11 +267,16 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 			func() bool {
 				findCtx, findCancel := context.WithTimeout(ctx, 10*time.Second)
 				defer findCancel()
-
+				mustClauses := []map[string]any{
+					{"match": map[string]any{"data_stream.type": tc.dsType}},
+					{"match": map[string]any{"data_stream.dataset": tc.dsDataset}},
+					{"match": map[string]any{"data_stream.namespace": processNamespace}},
+				}
+				mustClauses = append(mustClauses, tc.query...)
 				rawQuery := map[string]any{
 					"query": map[string]any{
 						"bool": map[string]any{
-							"must":   tc.query,
+							"must":   mustClauses,
 							"filter": map[string]any{"range": map[string]any{"@timestamp": map[string]any{"gte": timestamp}}},
 						},
 					},
@@ -265,16 +285,16 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 					},
 				}
 
-				index := tc.dsType + "-" + tc.dsDataset + "-" + tc.dsNamespace
-				docs, err := estools.PerformQueryForRawQuery(findCtx, rawQuery, ".ds-"+index+"*", info.ESClient)
+				docs, err := estools.PerformQueryForRawQuery(findCtx, rawQuery, tc.dsType+"-*", info.ESClient)
 				require.NoError(t, err)
 				if docs.Hits.Total.Value != 0 {
-					agentDocs[index] = docs
+					key := tc.dsType + "-" + tc.dsDataset + "-" + processNamespace
+					agentDocs[key] = docs
 				}
 				return docs.Hits.Total.Value > 0
 			},
 			2*time.Minute, 5*time.Second,
-			"agent monitoring classic no documents found for timestamp: %s, type: %s, dataset: %s, namespace: %s, query: %v", timestamp, tc.dsType, tc.dsDataset, tc.dsNamespace, tc.query)
+			"agent monitoring classic no documents found for timestamp: %s, type: %s, dataset: %s, namespace: %s, query: %v", timestamp, tc.dsType, tc.dsDataset, processNamespace, tc.query)
 	}
 
 	// 3. Uninstall
@@ -283,6 +303,8 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 
 	// 4. switch monitoring to the otel runtime
 	policy.Agent.Monitoring["_runtime_experimental"] = "otel"
+	receiverNamespace := fmt.Sprintf("%s-%s", info.Namespace, "otel")
+	policy.Agent.Monitoring["namespace"] = receiverNamespace
 	updatedPolicyBytes, err = yaml.Marshal(policy)
 	require.NoErrorf(t, err, "error marshalling policy, struct was %v", policy)
 	t.Cleanup(func() {
@@ -330,11 +352,17 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 			func() bool {
 				findCtx, findCancel := context.WithTimeout(ctx, 10*time.Second)
 				defer findCancel()
+				mustClauses := []map[string]any{
+					{"match": map[string]any{"data_stream.type": tc.dsType}},
+					{"match": map[string]any{"data_stream.dataset": tc.dsDataset}},
+					{"match": map[string]any{"data_stream.namespace": receiverNamespace}},
+				}
+				mustClauses = append(mustClauses, tc.query...)
 
 				rawQuery := map[string]any{
 					"query": map[string]any{
 						"bool": map[string]any{
-							"must":   tc.query,
+							"must":   mustClauses,
 							"filter": map[string]any{"range": map[string]any{"@timestamp": map[string]any{"gte": timestampBeatReceiver}}},
 						},
 					},
@@ -343,17 +371,16 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 					},
 				}
 
-				index := tc.dsType + "-" + tc.dsDataset + "-" + tc.dsNamespace
-				docs, err := estools.PerformQueryForRawQuery(findCtx, rawQuery, ".ds-"+index+"*", info.ESClient)
+				docs, err := estools.PerformQueryForRawQuery(findCtx, rawQuery, tc.dsType+"-*", info.ESClient)
 				require.NoError(t, err)
 				if docs.Hits.Total.Value != 0 {
-					key := tc.dsType + "-" + tc.dsDataset + "-" + tc.dsNamespace
+					key := tc.dsType + "-" + tc.dsDataset + "-" + receiverNamespace
 					otelDocs[key] = docs
 				}
 				return docs.Hits.Total.Value > 0
 			},
 			4*time.Minute, 5*time.Second,
-			"agent monitoring beats receivers no documents found for timestamp: %s, type: %s, dataset: %s, namespace: %s, query: %v", timestampBeatReceiver, tc.dsType, tc.dsDataset, tc.dsNamespace, tc.query)
+			"agent monitoring beats receivers no documents found for timestamp: %s, type: %s, dataset: %s, namespace: %s, query: %v", timestampBeatReceiver, tc.dsType, tc.dsDataset, receiverNamespace, tc.query)
 	}
 
 	// 6. Uninstall
@@ -362,9 +389,8 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 
 	// 7. Compare both documents are equivalent
 	for _, tc := range tests[:3] {
-		key := tc.dsType + "-" + tc.dsDataset + "-" + tc.dsNamespace
-		agent := agentDocs[key].Hits.Hits[0].Source
-		otel := otelDocs[key].Hits.Hits[0].Source
+		agent := agentDocs[tc.dsType+"-"+tc.dsDataset+"-"+processNamespace].Hits.Hits[0].Source
+		otel := otelDocs[tc.dsType+"-"+tc.dsDataset+"-"+receiverNamespace].Hits.Hits[0].Source
 		ignoredFields := []string{
 			// Expected to change between agentDocs and OtelDocs
 			"@timestamp",
@@ -373,18 +399,15 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 			"agent.id",
 			// agent.version is different because we force version 9.0.0 in CI
 			"agent.version",
+			"data_stream.namespace",
 			"elastic_agent.id",
-			"log.file.inode",
-			"log.file.fingerprint",
-			"log.file.path",
-			"log.offset",
 			"event.ingested",
 		}
 		switch tc.onlyCompareKeys {
 		case true:
-			AssertMapstrKeysEqual(t, agent, otel, append(ignoredFields, tc.ignoreFields...), fmt.Sprintf("expected document keys to be equal for dataset: %s", key))
+			AssertMapstrKeysEqual(t, agent, otel, append(ignoredFields, tc.ignoreFields...), "expected document keys to be equal for "+tc.dsType+"-"+tc.dsDataset)
 		case false:
-			AssertMapsEqual(t, agent, otel, ignoredFields, fmt.Sprintf("expected document to be equal for dataset: %s", key))
+			AssertMapsEqual(t, agent, otel, append(ignoredFields, tc.ignoreFields...), "expected document to be equal for "+tc.dsType+"-"+tc.dsDataset)
 		}
 	}
 
@@ -683,7 +706,6 @@ outputs:
 				AssertMapstrKeysEqual(t, agentDoc, otelDoc, nil, "expected documents keys to be equal for metricset "+tt.metricset)
 				AssertMapsEqual(t, agentDoc, otelDoc, ignoredFields, "expected documents to be equal for metricset "+tt.metricset)
 			})
-
 		}
 	})
 }
@@ -693,5 +715,23 @@ func assertCollectorComponentsHealthy(t *assert.CollectT, status *atesting.Agent
 	assert.Equal(t, "", status.Error, "component status should not have an error")
 	for _, componentStatus := range status.ComponentStatusMap {
 		assertCollectorComponentsHealthy(t, componentStatus)
+	}
+}
+
+func genIgnoredFields(goos string) []string {
+	switch goos {
+	case "windows":
+		return []string{
+			"log.file.fingerprint",
+			"log.file.idxhi",
+			"log.file.idxlo",
+		}
+	default:
+		return []string{
+			"log.file.device_id",
+			"log.file.fingerprint",
+			"log.file.inode",
+			"log.file.path",
+		}
 	}
 }

--- a/testing/integration/otel_test.go
+++ b/testing/integration/otel_test.go
@@ -1658,11 +1658,10 @@ func AssertMapsEqual(t *testing.T, m1, m2 mapstr.M, ignoredFields []string, msg 
 		flatM1.Delete(f)
 		flatM2.Delete(f)
 	}
-	require.Equal(t, "", cmp.Diff(flatM1, flatM2), "expected maps to be equal")
+	require.Zero(t, cmp.Diff(flatM1, flatM2), msg)
 }
 
 func AssertMapstrKeysEqual(t *testing.T, m1, m2 mapstr.M, ignoredFields []string, msg string) {
-
 	t.Helper()
 	// Delete all ignored fields.
 	for _, f := range ignoredFields {


### PR DESCRIPTION
## What does this PR do?

Adds last part of comparing process based monitoring vs beat receiver based monitoring

- Adds Windows as test case
- adds filebeat_input metrics to config
- adds filebeat_input metrics to integration test

## Why is it important?

We need to make sure that both implementations produce the same documents.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

None.  Unit test and changes to producing configuration when experimental runtime is used.

## How to test this PR locally

```shell
mage integration:single TestClassicAndReceiverAgentMonitoring
```


## Related issues

- Closes #8188
- Closes elastic/ingest-dev#4876

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
