### PR TITLE
ci: update all n1-standard-4 type runners to n2-standard-4

### DIFF
--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -394,7 +394,7 @@ steps:
             limit: 1
         agents:
           provider: "gcp"
-          machineType: "n1-standard-4"
+          machineType: "n2-standard-4"
           image: "${IMAGE_UBUNTU_2404_X86_64}"
           diskSizeGb: 80
         matrix:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR updates the machine type for a Buildkite pipeline step in `.buildkite/bk.integration.pipeline.yml`, changing it from `n1-standard-4` to `n2-standard-4`.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The `n1` machine series on GCP is older, with inferior performance and cost efficiency compared to the newer `n2` series. Moving to `n2-standard-4` aligns with the improvements adopted in previous CI upgrades (e.g., `n2-standard-8`), offering better resource availability and stability in CI jobs.

This change also ensures consistency across Buildkite steps and prepares us for any potential future deprecation of `n1` machine types by GCP.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->
None. This is a CI-only change and has no impact on the Elastic Agent runtime behavior, packaging, or user-facing interfaces.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

This change affects CI configuration only. The pipeline will be automatically exercised when the Buildkite job runs.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Follows up on [review feedback](https://github.com/elastic/elastic-agent/pull/7931#discussion_r2122697348) promoting use of `n2` series for improved performance and consistency