### PR TITLE
updatecli: create PRs per active branch and refactor slack notifications

### DIFF
--- a/.ci/updatecli/updatecli-bump-vm-images.yml
+++ b/.ci/updatecli/updatecli-bump-vm-images.yml
@@ -43,6 +43,8 @@ conditions:
     spec:
       command: 'grep -q -v {{ source "latestVersion" }} .buildkite/pipeline.yml #'
 
+# NOTE: if you add a new target file, please update the .mergify.yml file
+#       to include the new file for the approval and automatic merge
 targets:
   update-buildkite-pipeline:
     name: "Update .buildkite/pipeline.yml"

--- a/.ci/updatecli/updatecli-bump-vm-images.yml
+++ b/.ci/updatecli/updatecli-bump-vm-images.yml
@@ -12,7 +12,7 @@ scms:
       repository: '{{ .scm.repository }}'
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       commitusingapi: true
-      branch: '{{ .scm.branch }}'
+      branch: '{{ requiredEnv "BRANCH_NAME" }}'
       force: false
 
 actions:
@@ -24,8 +24,8 @@ actions:
       automerge: false
       labels:
         - dependencies
-        - backport-active-all
-      title: '[Automation] Bump VM Image version to {{ source "latestVersion" }}'
+        - backport-skip
+      title: '[{{ requiredEnv "BRANCH_NAME" }}][Automation] Bump VM Image version to {{ source "latestVersion" }}'
 
 sources:
   latestVersion:

--- a/.ci/updatecli/updatecli-bump-vm-images.yml
+++ b/.ci/updatecli/updatecli-bump-vm-images.yml
@@ -1,6 +1,7 @@
 # update-cli configuration for automated VM image version bumping
 ---
 name: Bump vm-images to latest version
+pipelineid: 'updatecli-update-vm-images-{{ requiredEnv "BRANCH_NAME" }}'
 
 scms:
   githubConfig:

--- a/.github/workflows/bump-vm-images.yml
+++ b/.github/workflows/bump-vm-images.yml
@@ -4,7 +4,10 @@ name: bump-vm-images
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 10 * * 0"
+    # Since the CI Agent images are produced weekly on Saturday at 0am UTC
+    # and we can only bump the version after the images are available
+    # let's try on Saturday at 12:00 UTC.
+    - cron: "0 12 * * 6"
 
 permissions:
   contents: read
@@ -13,11 +16,29 @@ env:
   JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
 jobs:
+  filter:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      matrix: ${{ steps.generator.outputs.matrix }}
+    permissions:
+      contents: read
+    steps:
+    - id: generator
+      uses: elastic/oblt-actions/elastic/active-branches@v1
+      with:
+        filter-branches: true
+
   bump:
     permissions:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
+    needs:
+      - filter
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.filter.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -26,26 +47,11 @@ jobs:
           command: apply --config .ci/updatecli/updatecli-bump-vm-images.yml --values .ci/updatecli/values.d/scm.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ matrix.branch }}
 
       - if: ${{ failure()  }}
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        uses: elastic/oblt-actions/slack/send@v1
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {
-              "channel": "#ingest-notifications",
-              "text": "${{ env.SLACK_MESSAGE }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "${{ env.SLACK_MESSAGE }}"
-                  }
-                }
-              ]
-            }
-        env:
-          #SLACK_MESSAGE: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, `@agent-team` please look what's going on <${{ env.JOB_URL }}|here>"
-          SLACK_MESSAGE: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`"
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#ingest-notifications"
+          message: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @robots-ci please look what's going on <${{ env.JOB_URL }}|here>"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,6 +19,26 @@ defaults:
       labels:
         - "backport"
 pull_request_rules:
+  - name: automatic approval for updatecli pull requests with changes in .buildkite
+    conditions:
+      - author=github-actions[bot]
+      - check-success=buildkite/elastic-agent
+      - files~=^.buildkite/(pipeline.yml|bk.integration.pipeline.yml)$
+      - head~=^updatecli_.*
+    actions:
+      review:
+        type: APPROVE
+        message: Automatically approving mergify
+  - name: automatic squash and merge with success checks and the files matching the regex .buildkite is modified.
+    conditions:
+      - author=github-actions[bot]
+      - check-success=buildkite/elastic-agent
+      - files~=^.buildkite/(pipeline.yml|bk.integration.pipeline.yml)$
+      - head~=^updatecli_.*
+      - "#approved-reviews-by>=1"
+    actions:
+      queue:
+        name: default
   - name: self-assign PRs
     conditions:
       - -merged


### PR DESCRIPTION
## What does this PR do?

* Run on Saturdays, a few hours after VM images are produced.
* Create PRs per active branch instead of using the backport labels.
* Use slack composite action.
* Notify the robots team if something goes wrong with the GH actions.
* Enable auto approval and auto-merge with `Mergify` [Need to configure the branch protections accordingly]

## Why is it important?

A follow-up from https://github.com/elastic/elastic-agent/pull/8211

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

```bash
$ GITHUB_TOKEN=$(gh auth token) \
  GITHUB_ACTOR=v1v \
  BRANCH_NAME=main updatecli apply \
    --config .ci/updatecli/updatecli-bump-vm-images.yml \
    --values .ci/updatecli/values.d/scm.yml
```

Produced https://github.com/v1v/elastic-agent/pull/7

Then I targeted a different branch

```bash
$ GITHUB_TOKEN=$(gh auth token) \
  GITHUB_ACTOR=v1v \
  BRANCH_NAME=main updatecli apply \
    --config .ci/updatecli/updatecli-bump-vm-images.yml \
    --values .ci/updatecli/values.d/scm.yml
```

Produced https://github.com/v1v/elastic-agent/pull/8

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
