### PR TITLE
fix: increase context timeout to accommodate for slower machines in Test_checkForUnprivilegedVault

### DIFF
--- a/internal/pkg/agent/install/uninstall_test.go
+++ b/internal/pkg/agent/install/uninstall_test.go
@@ -94,7 +94,7 @@ func Test_checkForUnprivilegedVault(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
 			defer cancel()
 			testVaultPath := filepath.Join(tempDir, filepath.Base(paths.AgentVaultPath()))
 

--- a/internal/pkg/agent/install/uninstall_test.go
+++ b/internal/pkg/agent/install/uninstall_test.go
@@ -177,7 +177,7 @@ func TestNotifyFleetAuditUnenroll(t *testing.T) {
 		err: fmt.Errorf("unretryable return status: 409"),
 	}}
 
-	log, _ := logp.NewInMemory("test", zap.NewDevelopmentEncoderConfig())
+	log, _ := logp.NewInMemoryLocal("test", zap.NewDevelopmentEncoderConfig())
 	pt := progressbar.NewOptions(-1, progressbar.OptionSetWriter(io.Discard))
 	var agentID agentInfo = "testID"
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR addresses increases the test context timeout from 5s to 20s of `Test_checkForUnprivilegedVault` to accommodate for slower machines, such as Mac CI runners, and to avoid intermittent failures due to timing out while trying to acquire a file lock.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The test `Test_checkForUnprivilegedVault/file_vault_exists_but_it's_unreadable_-_return_error` was observed to fail intermittently on slower environments (e.g., Mac runners) due to `context deadline exceeded` errors when attempting to acquire a file lock. These failures were not related to the actual logic being tested, but rather to insufficient timeout settings. Increasing the timeout ensures test stability across environments. In addition, updating the deprecated `logp.NewInMemory` call eliminates static analysis warnings.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None. This change only affects a unit test and does not impact production behavior or configurations.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
mage unitTest
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/8373