### PR TITLE
Fix pre-command to support extended testing

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -73,6 +73,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-agent-binary-dra" ]]; then
   fi
 fi
 
-if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-agent" && "$BUILDKITE_STEP_KEY" == "integration-fips-cloud-image" ]]; then
+# BUILDKITE_PIPELINE_SLUG should match elastic-agent for PRs, and elastic-agent-extended-tests once it has merged to main
+if [[ "$BUILDKITE_PIPELINE_SLUG" == "elastic-agent"* && "$BUILDKITE_STEP_KEY" == "integration-fips-cloud-image" ]]; then
     docker_login
 fi


### PR DESCRIPTION
## What does this PR do?

Fix a pre-command hook to allow BUILDKITE_PIPELINE_SLUG to match elastic-agent for PRs, and elastic-agent-extended-tests once it has merged to main