### PR TITLE
fix(ci): add missing install Mage step

### DIFF
--- a/.github/workflows/bump-otel-version.yml
+++ b/.github/workflows/bump-otel-version.yml
@@ -29,6 +29,12 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
+    - name: Install mage
+      uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b # v3.1.0
+      with:
+        version: v1.14.0
+        install-only: true
+
     - name: Run Updatecli in Apply mode
       uses: elastic/oblt-actions/updatecli/run@v1
       with:


### PR DESCRIPTION
## What does this PR do?

Fixes the `bump-otel-version` Dependabot workflow by adding missing step to install Mage. Mage is needed later in the `update-otel.sh` script, which runs `mage notice` and `mage otel:readme`.

## Why is it important?

Without it, the workflow fails: https://github.com/elastic/elastic-agent/actions/runs/15576842484/job/43863265436

> .ci/scripts/update-otel.sh: line 41: mage: command not found

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

Can this PR be tested to make sure this fixes the issue? @v1v your insight appreciated :pray: 

## Related issues

- Related to https://github.com/elastic/elastic-agent/issues/6132