### PR TITLE
Attempt to remove flakiness from `TestFIPSAgentConnectingToFIPSFleetServerInECHFRH` — take two

### DIFF
--- a/.buildkite/scripts/buildkite-integration-tests.sh
+++ b/.buildkite/scripts/buildkite-integration-tests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -o xtrace
 
 GROUP_NAME=$1
 TEST_SUDO=$2

--- a/.buildkite/scripts/buildkite-integration-tests.sh
+++ b/.buildkite/scripts/buildkite-integration-tests.sh
@@ -62,7 +62,7 @@ echo "~~~ Integration tests: ${GROUP_NAME}"
 GOTEST_ARGS=(-tags integration -test.shuffle on -test.timeout 2h0m0s "${TEST_PACKAGE}" -v -args "-integration.groups=${GROUP_NAME}" "-integration.sudo=${TEST_SUDO}" "-integration.fips=${FIPS:-false}")
 set +e
 TEST_BINARY_NAME="elastic-agent" AGENT_VERSION="${AGENT_VERSION}" SNAPSHOT=true \
-  gotestsum --no-color -f standard-quiet --junitfile-hide-skipped-tests --junitfile "${outputXML}" --jsonfile "${outputJSON}" -- "${GOTEST_ARGS[@]}"
+  gotestsum --no-color -f standard-verbose --junitfile-hide-skipped-tests --junitfile "${outputXML}" --jsonfile "${outputJSON}" -- "${GOTEST_ARGS[@]}"
 TESTS_EXIT_STATUS=$?
 set -e
 

--- a/testing/integration/fleetserver_fips_test.go
+++ b/testing/integration/fleetserver_fips_test.go
@@ -68,6 +68,8 @@ func TestFIPSAgentConnectingToFIPSFleetServerInECHFRH(t *testing.T) {
 		agents, err := info.KibanaClient.ListAgents(ctx, kibana.ListAgentsRequest{})
 		require.NoError(t, err)
 
+		t.Logf("agents from Kibana ListAgents: %#+v", agents)
+
 		// Find Fleet Server's own Agent and get its status and whether it's
 		// FIPS-capable
 		var agentStatus string
@@ -80,6 +82,9 @@ func TestFIPSAgentConnectingToFIPSFleetServerInECHFRH(t *testing.T) {
 				break
 			}
 		}
+
+		t.Logf("agentStatus: %v", agentStatus)
+		t.Logf("agentIsFIPS: %v", agentIsFIPS)
 
 		// Check that this Agent is online (i.e. healthy) and is FIPS-capable. This
 		// will prove that a FIPS-capable Agent is able to connect to a FIPS-capable

--- a/testing/integration/fleetserver_fips_test.go
+++ b/testing/integration/fleetserver_fips_test.go
@@ -70,12 +70,12 @@ func TestFIPSAgentConnectingToFIPSFleetServerInECHFRH(t *testing.T) {
 
 		// Find Fleet Server's own Agent and get its status and whether it's
 		// FIPS-capable
-		//var agentStatus string
+		var agentStatus string
 		var agentIsFIPS bool
 		for _, item := range agents.Items {
 			if item.PolicyID == cloudAgentPolicyID {
 				t.Logf("Found fleet-server entry: %+v", item)
-				//agentStatus = item.Status
+				agentStatus = item.Status
 				agentIsFIPS = item.LocalMetadata.Elastic.Agent.FIPS
 				break
 			}
@@ -84,7 +84,7 @@ func TestFIPSAgentConnectingToFIPSFleetServerInECHFRH(t *testing.T) {
 		// Check that this Agent is online (i.e. healthy) and is FIPS-capable. This
 		// will prove that a FIPS-capable Agent is able to connect to a FIPS-capable
 		// Fleet Server, with both running in ECH.
-		//require.Equal(t, "online", agentStatus) // FIXME: Uncomment after https://github.com/elastic/apm-server/issues/17063 is resolved
+		require.Equal(t, "online", agentStatus)
 		return agentIsFIPS
 	}, 30*time.Second, 500*time.Millisecond, "Fleet Server's Elastic Agent should be healthy and FIPS-capable")
 }

--- a/testing/integration/fleetserver_fips_test.go
+++ b/testing/integration/fleetserver_fips_test.go
@@ -86,5 +86,5 @@ func TestFIPSAgentConnectingToFIPSFleetServerInECHFRH(t *testing.T) {
 		// Fleet Server, with both running in ECH.
 		//require.Equal(t, "online", agentStatus) // FIXME: Uncomment after https://github.com/elastic/apm-server/issues/17063 is resolved
 		return agentIsFIPS
-	}, 10*time.Second, 200*time.Millisecond, "Fleet Server's Elastic Agent should be healthy and FIPS-capable")
+	}, 30*time.Second, 500*time.Millisecond, "Fleet Server's Elastic Agent should be healthy and FIPS-capable")
 }


### PR DESCRIPTION
Follow up to https://github.com/elastic/elastic-agent/pull/8421.

Increases the duration of the `require.Eventually` check introduced in that PR from 10s to 30s.  Also decreases the frequency of the check from 200ms to 500ms. 

Let's see if these changes help remove the flakiness of this test; if not, we have have to revive https://github.com/elastic/elastic-agent/pull/8422 and try that solution next.