### PR TITLE
Don't fail otel tests if both documents don't contain an ignored field

### DIFF
--- a/testing/integration/ess/otel_test.go
+++ b/testing/integration/ess/otel_test.go
@@ -1648,13 +1648,15 @@ func AssertMapsEqual(t *testing.T, m1, m2 mapstr.M, ignoredFields []string, msg 
 	flatM1 := m1.Flatten()
 	flatM2 := m2.Flatten()
 	for _, f := range ignoredFields {
-		hasKeyM1, _ := flatM1.HasKey(f)
-		hasKeyM2, _ := flatM2.HasKey(f)
-
-		if !hasKeyM1 && !hasKeyM2 {
-			assert.Failf(t, msg, "ignored field %q does not exist in either map, please remove it from the ignored fields", f)
-		}
-
+		// Checking ignored fields is disabled until we resolve an issue with event.ingested not being set
+		// in some cases.
+		// See https://github.com/elastic/elastic-agent/issues/8486 for details.
+		//hasKeyM1, _ := flatM1.HasKey(f)
+		//hasKeyM2, _ := flatM2.HasKey(f)
+		//
+		//if !hasKeyM1 && !hasKeyM2 {
+		//	assert.Failf(t, msg, "ignored field %q does not exist in either map, please remove it from the ignored fields", f)
+		//}
 		flatM1.Delete(f)
 		flatM2.Delete(f)
 	}


### PR DESCRIPTION
## What does this PR do?

Changes the logic of comparing documents produced by agent in non-otel and otel modes. Up until now, if neither document contained a field that should be ignored, the test would fail. After the change, the test proceeds with comparing the remaining fields.

## Why is it important?

There's some flakiness related to the ignored fields, which may sometimes not appear. This is largely unrelated to what these tests are actually checking, so disabling it temporarily shouldn't impact us negatively.

This should be re-enabled once we figure out the root cause of https://github.com/elastic/elastic-agent/issues/8486.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/8486

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
