### PR TITLE
Explicitly crossbuild linux/arm with debian11.

### DIFF
--- a/changelog/fragments/1749844873-Use-Debian-11-for-linux-arm-to-match-linux-amd64.yaml
+++ b/changelog/fragments/1749844873-Use-Debian-11-for-linux-arm-to-match-linux-amd64.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Use Debian 11 for linux/arm to match linux/amd64. Upgrades linux/arm64's statically linked glibc from 2.28 to 2.31.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/8497
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1749844873-Use-Debian-11-for-linux-arm-to-match-linux-amd64.yaml
+++ b/changelog/fragments/1749844873-Use-Debian-11-for-linux-arm-to-match-linux-amd64.yaml
@@ -11,7 +11,7 @@
 kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
-summary: Use Debian 11 for linux/arm to match linux/amd64. Upgrades linux/arm64's statically linked glibc from 2.28 to 2.31.
+summary: Use Debian 11 to build linux/arm to match linux/amd64. Upgrades linux/arm64's statically linked glibc from 2.28 to 2.31.
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -229,7 +229,7 @@ func CrossBuildImage(platform string) (string, error) {
 	case platform == "darwin/arm64" || platform == "darwin/universal":
 		tagSuffix = "darwin-arm64-debian11"
 	case platform == "linux/arm64":
-		tagSuffix = "base-arm-debian9"
+		tagSuffix = "base-arm-debian11"
 	case platform == "linux/armv5" || platform == "linux/armv6":
 		tagSuffix = "armel"
 	case platform == "linux/armv7":


### PR DESCRIPTION
- Relates https://github.com/elastic/elastic-agent/pull/8471

Splitting this fix out of https://github.com/elastic/elastic-agent/pull/8471 in which we were observing a linker error previously experienced in Beats which was resolved by building with Debian11, see https://github.com/elastic/beats/issues/41270.

```
2025-06-12 17:34:34 UTC | /usr/local/go/pkg/tool/linux_arm64/link: running gcc failed: exit status 1
/usr/bin/gcc -s -Wl,-z,relro -pie -Wl,-z,now -Wl,-z,nocopyreloc -fuse-ld=gold -Wl,--build-id=0xee5395581ef98b935ea709af599bac9aa3bac678 -o $WORK/b001/exe/a.out -rdynamic -Wl,--compress-debug-sections=zlib /tmp/go-link-732555023/go.o /tmp/go-link-732555023/000000.o /tmp/go-link-732555023/000001.o /tmp/go-link-732555023/000002.o /tmp/go-link-732555023/000003.o /tmp/go-link-732555023/000004.o /tmp/go-link-732555023/000005.o /tmp/go-link-732555023/000006.o /tmp/go-link-732555023/000007.o /tmp/go-link-732555023/000008.o /tmp/go-link-732555023/000009.o /tmp/go-link-732555023/000010.o /tmp/go-link-732555023/000011.o /tmp/go-link-732555023/000012.o /tmp/go-link-732555023/000013.o /tmp/go-link-732555023/000014.o /tmp/go-link-732555023/000015.o /tmp/go-link-732555023/000016.o /tmp/go-link-732555023/000017.o /tmp/go-link-732555023/000018.o /tmp/go-link-732555023/000019.o /tmp/go-link-732555023/000020.o /tmp/go-link-732555023/000021.o /tmp/go-link-732555023/000022.o /tmp/go-link-732555023/000023.o /tmp/go-link-732555023/000024.o /tmp/go-link-732555023/000025.o /tmp/go-link-732555023/000026.o /tmp/go-link-732555023/000027.o /tmp/go-link-732555023/000028.o /tmp/go-link-732555023/000029.o /tmp/go-link-732555023/000030.o /tmp/go-link-732555023/000031.o /tmp/go-link-732555023/000032.o /tmp/go-link-732555023/000033.o /tmp/go-link-732555023/000034.o /tmp/go-link-732555023/000035.o /tmp/go-link-732555023/000036.o /tmp/go-link-732555023/000037.o /tmp/go-link-732555023/000038.o /tmp/go-link-732555023/000039.o /tmp/go-link-732555023/000040.o /tmp/go-link-732555023/000041.o /tmp/go-link-732555023/000042.o /tmp/go-link-732555023/000043.o /tmp/go-link-732555023/000044.o /tmp/go-link-732555023/000045.o /tmp/go-link-732555023/000046.o /tmp/go-link-732555023/000047.o /tmp/go-link-732555023/000048.o /tmp/go-link-732555023/000049.o /tmp/go-link-732555023/000050.o /tmp/go-link-732555023/000051.o /tmp/go-link-732555023/000052.o /tmp/go-link-732555023/000053.o /tmp/go-link-732555023/000054.o /tmp/go-link-732555023/000055.o /tmp/go-link-732555023/000056.o /tmp/go-link-732555023/000057.o /tmp/go-link-732555023/000058.o /tmp/go-link-732555023/000059.o /tmp/go-link-732555023/000060.o /tmp/go-link-732555023/000061.o /tmp/go-link-732555023/000062.o /tmp/go-link-732555023/000063.o /tmp/go-link-732555023/000064.o /tmp/go-link-732555023/000065.o /tmp/go-link-732555023/000066.o /tmp/go-link-732555023/000067.o /tmp/go-link-732555023/000068.o /tmp/go-link-732555023/000069.o /tmp/go-link-732555023/000070.o /tmp/go-link-732555023/000071.o /tmp/go-link-732555023/000072.o /tmp/go-link-732555023/000073.o /tmp/go-link-732555023/000074.o /tmp/go-link-732555023/000075.o /tmp/go-link-732555023/000076.o /tmp/go-link-732555023/000077.o /tmp/go-link-732555023/000078.o /tmp/go-link-732555023/000079.o /tmp/go-link-732555023/000080.o /tmp/go-link-732555023/000081.o /tmp/go-link-732555023/000082.o /tmp/go-link-732555023/000083.o /tmp/go-link-732555023/000084.o /tmp/go-link-732555023/000085.o /tmp/go-link-732555023/000086.o /tmp/go-link-732555023/000087.o /tmp/go-link-732555023/000088.o /tmp/go-link-732555023/000089.o -O2 -g -lresolv -O2 -g -lpthread -Wl,-wrap,pthread_create -O2 -g -lpthread -O2 -g -O2 -g -O2 -g -ldl -O2 -g -ldl -lpthread -O2 -g -O2 -g
/usr/bin/ld.gold: internal error in maybe_apply_stub, at ../../gold/aarch64.cc:5407
 collect2: error: ld returned 1 exit status
```

This PR resolves this by building linux/arm with debian11 as we already do for the other platforms.