### PR TITLE
Exclude NOTICE files from merge conflict detection.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,4 @@ repos:
         exclude: (.*/.*.(tmpl|tftpl)$)
     -   id: check-merge-conflict
         args: ['--assume-in-merge']
+        exclude: (^NOTICE.*\.txt$)


### PR DESCRIPTION
Ports https://github.com/elastic/beats/pull/42382 to agent.

See pre-commit check false positive failures in https://github.com/elastic/beats/pull/44696. Agent imports Beats so ends up with the same set of dependencies that include `======` strings in the notice file.