### PR TITLE
Set force in update-beats scm configuration.

### DIFF
--- a/.ci/updatecli/update-beats.yml
+++ b/.ci/updatecli/update-beats.yml
@@ -13,6 +13,7 @@ scms:
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       branch: '{{ requiredEnv "BRANCH_NAME" }}'
       commitusingapi: true
+      force: false
 
 actions:
   default:


### PR DESCRIPTION
- Fixes https://github.com/elastic/elastic-agent/issues/8382

Set `force: false` in the beats-bump updatecli SCM configuration to ensure concurrent runs in different branches can succeed as suggested in https://github.com/elastic/elastic-agent/issues/8382#issuecomment-2982893920