### PR TITLE
tools: use docker compose and quiet for pulling

### DIFF
--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -209,16 +209,6 @@ func dockerInfo() (*DockerInfo, error) {
 	return &info, nil
 }
 
-// HaveDockerCompose returns an error if docker-compose is not found on the
-// PATH.
-func HaveDockerCompose() error {
-	_, err := exec.LookPath("docker-compose")
-	if err != nil {
-		return fmt.Errorf("docker-compose is not available")
-	}
-	return nil
-}
-
 // HaveKubectl returns an error if kind is not found on the PATH.
 func HaveKubectl() error {
 	_, err := exec.LookPath("kubectl")

--- a/pkg/testing/ogc/provisioner.go
+++ b/pkg/testing/ogc/provisioner.go
@@ -134,6 +134,7 @@ func (p *provisioner) Clean(ctx context.Context, cfg common.Config, _ []common.I
 func (p *provisioner) ogcPull(ctx context.Context) error {
 	args := []string{
 		"pull",
+		"--quiet",
 		"docker.elastic.co/observability-ci/ogc:5.0.1",
 	}
 	var output bytes.Buffer


### PR DESCRIPTION
## What does this PR do?

Use `docker compose`
Use `--pull --quiet`

## Why is it important?

Docker-compose reached EoL last year or the year before.
Avoid too much verbose output in the logs when pulling docker images.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates to https://github.com/elastic/beats/pull/44324

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
