### PR TITLE
Add skip-changelog PR label for bump VM PRs

### DIFF
--- a/.ci/updatecli/updatecli-bump-vm-images.yml
+++ b/.ci/updatecli/updatecli-bump-vm-images.yml
@@ -26,6 +26,7 @@ actions:
       labels:
         - dependencies
         - backport-skip
+        - skip-changelog
       title: '[{{ requiredEnv "BRANCH_NAME" }}][Automation] Bump VM Image version to {{ source "latestVersion" }}'
 
 sources:


### PR DESCRIPTION
## What does this PR do?

This commit adds the `skip-changelog` GitHub label for PRs created by automation for Bump VM image PRs.

## Why is it important?

 Without it, the mandatory [fragment-in-pr](https://github.com/elastic/elastic-agent/blob/main/.github/workflows/fragment-in-pr.yml) check is failing thus preventing automerge.


## Related issues

https://github.com/elastic/elastic-agent/pull/8359
