### PR TITLE
ci: don't preinstall fleet packages on retried CI steps

### DIFF
--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -403,7 +403,6 @@ steps:
         command: |
           buildkite-agent artifact download build/distributions/** . --step packaging-ubuntu-x86-64
           .buildkite/scripts/steps/integration_tests_tf.sh rpm true
-          exit 1
         artifact_paths:
           - build/**
           - build/diagnostics/**


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR reverts a previous change that force-failed CI on RHEL and removes the `preinstall_fleet_packages` call for retried CI steps using dedicated ESS stacks.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

In our CI setup, when a test step fails, Buildkite automatically retries it once more. During this retry, we provision a **dedicated ESS stack** for isolation. However, the retry path still attempts to run `preinstall_fleet_packages`, which uses a `curl` command requiring the `--fail-with-body` flag — a flag not supported in all Unix distros (e.g., older RHEL runners).

Since the dedicated ESS stack is not shared across runners (unlike the original one), **preinstalling Fleet integration assets is not necessary** on retried steps. Removing this logic avoids compatibility issues and unnecessary preinstallation.

As part of validating this, I introduced an artificial failure on the RHEL runner in commit [`44c6afa`](https://github.com/elastic/elastic-agent/pull/8636/commits/44c6afa29c07d53ea1d6aa659596477cbf4015ca). In the retried run, all tests passed successfully without requiring the fleet asset preinstallation:  
https://buildkite.com/elastic/elastic-agent/builds/22912#01979e6b-61ec-44bd-ae83-f870999b1781/360-361 [[test report](https://buildkite.com/organizations/elastic/pipelines/elastic-agent/builds/22912/jobs/01979e6b-61ec-44bd-ae83-f870999b1781/artifacts/01979e7f-12cf-49a6-973b-6bb7a4667c19)]

This confirms that preinstallation is only needed for the **shared** ESS stack provisioned during the initial CI run.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None expected. This only affects CI test step retries and does not change product behavior.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

This is a Buildkite oriented change

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
N/A
