### PR TITLE
[deb/rpm] restart endpoint with tamper protection after elastic-agent 

### DIFF
--- a/dev-tools/packaging/templates/linux/postinstall.sh.tmpl
+++ b/dev-tools/packaging/templates/linux/postinstall.sh.tmpl
@@ -15,6 +15,7 @@ if test -L "$symlink"; then
 fi
 
 SERVICE_NAME="ElasticEndpoint"
+should_restart_endpoint=false
 
 echo "Checking if $SERVICE_NAME is installed"
 if systemctl list-unit-files --type=service | grep -q "^${SERVICE_NAME}.service"; then
@@ -27,8 +28,7 @@ if systemctl list-unit-files --type=service | grep -q "^${SERVICE_NAME}.service"
         echo "$SERVICE_NAME is installed but not running"
         if [[ "$installed_endpoint_version" == "$archive_endpoint_version" ]]; then
             echo "New endpoint and installed endpoint versions are the same: \"${installed_endpoint_version}\""
-            echo "Starting $SERVICE_NAME"
-            sudo systemctl start ${SERVICE_NAME}
+            should_restart_endpoint=true
         else
             echo "New endpoint version  \"${archive_endpoint_version}\" is different than the one that's already
             installed  \"${installed_endpoint_version}\""
@@ -53,4 +53,9 @@ echo "systemd enable/restart elastic-agent"
 systemctl daemon-reload 2> /dev/null
 systemctl enable elastic-agent 2> /dev/null || true
 systemctl restart elastic-agent 2> /dev/null || true
+# restart endpoint if needed
+if [ "$should_restart_endpoint" = true ]; then
+    echo "Starting $SERVICE_NAME after elastic-agent"
+    systemctl restart "$SERVICE_NAME" 2> /dev/null || true
+fi
 exit 0

--- a/testing/integration/endpoint_security_test.go
+++ b/testing/integration/endpoint_security_test.go
@@ -109,8 +109,6 @@ func TestUpgradeAgentWithTamperProtectedEndpoint_RPM(t *testing.T) {
 		},
 	})
 
-	t.Skip("https://github.com/elastic/elastic-agent/issues/8613: Flaky uninstall token issue")
-
 	t.Run("Upgrade from older version to newer version", func(t *testing.T) {
 		upgradeFromVersion, err := upgradetest.PreviousMinor()
 		require.NoError(t, err)

--- a/testing/integration/endpoint_security_test.go
+++ b/testing/integration/endpoint_security_test.go
@@ -195,14 +195,22 @@ func addEndpointCleanup(t *testing.T, uninstallToken string) {
 }
 
 func installFirstAgent(ctx context.Context, t *testing.T, info *define.Info, isProtected bool, packageFormat string, upgradeFromVersion string) (*atesting.Fixture, string) {
-	fixture, err := atesting.NewFixture(
-		t,
-		upgradeFromVersion,
-		atesting.WithFetcher(atesting.ArtifactFetcher()),
-		atesting.WithPackageFormat(packageFormat),
-	)
-	require.NoError(t, err)
-	fixture.Prepare(ctx)
+	var fixture *atesting.Fixture
+	var err error
+
+	if upgradeFromVersion == define.Version() {
+		fixture, err = define.NewFixtureFromLocalBuild(t, define.Version(), atesting.WithPackageFormat(packageFormat))
+	} else {
+		fixture, err = atesting.NewFixture(
+			t,
+			upgradeFromVersion,
+			atesting.WithFetcher(atesting.ArtifactFetcher()),
+			atesting.WithPackageFormat(packageFormat),
+		)
+	}
+	require.NoError(t, err, "failed to create fixture")
+	err = fixture.Prepare(ctx)
+	require.NoError(t, err, "failed to prepare fixture")
 
 	t.Log("Creating a generic policy and enrollment token")
 	policy := createBasicPolicy()
@@ -223,11 +231,12 @@ func installFirstAgent(ctx context.Context, t *testing.T, info *define.Info, isP
 
 	t.Log("Get the policy uninstall token")
 	uninstallToken, err := tools.GetUninstallToken(ctx, info.KibanaClient, policyResp.ID)
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to get uninstall token")
 
 	opts := atesting.InstallOpts{}
 	t.Log("Install and enroll the first agent")
-	tools.InstallAgentForPolicyWithToken(ctx, t, opts, fixture, info.KibanaClient, enrollKeyResp)
+	_, err = tools.InstallAgentForPolicyWithToken(ctx, t, opts, fixture, info.KibanaClient, enrollKeyResp)
+	require.NoError(t, err, "failed to install agent for policy with token")
 
 	addEndpointCleanup(t, uninstallToken)
 
@@ -243,9 +252,6 @@ func installFirstAgent(ctx context.Context, t *testing.T, info *define.Info, isP
 	)
 
 	t.Log("The initial installation of both the agent and endpoint are healthy")
-
-	initEndpointVersion := getEndpointVersion(t)
-	t.Logf("The initial endpoint version is %s", initEndpointVersion)
 
 	return fixture, uninstallToken
 }
@@ -268,7 +274,8 @@ func testUnprotectedInstallUpgrade(
 	t.Log("Setup agent fixture with the test build")
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), atesting.WithPackageFormat(packageFormat))
 	require.NoError(t, err)
-	fixture.Prepare(ctx)
+	err = fixture.Prepare(ctx)
+	require.NoError(t, err, "failed to prepare fixture")
 
 	t.Log("Getting source package")
 	srcPkg, err := fixture.SrcPackage(ctx)
@@ -282,7 +289,8 @@ func testUnprotectedInstallUpgrade(
 	t.Log(string(out))
 	require.NoError(t, err, "agent installation with package manager should not fail")
 
-	fixture.SetDebRpmClient()
+	err = fixture.SetDebRpmClient()
+	require.NoError(t, err, "could not set DEB/RPM client")
 
 	upgradedAgentClient := fixture.Client()
 	err = upgradedAgentClient.Connect(ctx)
@@ -351,23 +359,25 @@ func testTamperProtectedInstallUpgrade(
 	if checkVersionUpgrade {
 		t.Log("Setup agent fixture with the test build")
 		fixture, err = define.NewFixtureFromLocalBuild(t, define.Version(), atesting.WithPackageFormat(packageFormat))
-		require.NoError(t, err)
-		fixture.Prepare(ctx)
+		require.NoError(t, err, "failed to create agent fixture")
+		err = fixture.Prepare(ctx)
+		require.NoError(t, err, "failed to prepare agent fixture")
 	}
 
 	t.Log("Getting source package")
 	srcPkg, err := fixture.SrcPackage(ctx)
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to get source package")
 
 	t.Log("Installing the second agent, upgrading from the older version")
 	installCmd, err := getInstallCommand(ctx, fixture.PackageFormat(), srcPkg, nil)
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to get install command")
 
 	out, err = installCmd.CombinedOutput()
 	t.Log(string(out))
 	require.NoError(t, err, "agent installation with package manager should not fail")
 
-	fixture.SetDebRpmClient()
+	err = fixture.SetDebRpmClient()
+	require.NoError(t, err, "failed to set deb/rpm client")
 
 	upgradedAgentClient := fixture.Client()
 	err = upgradedAgentClient.Connect(ctx)
@@ -386,30 +396,30 @@ func testTamperProtectedInstallUpgrade(
 		t.Logf("The upgraded endpoint version is %s", upgradedEndpointVersion)
 
 		startEndpointVersion, err := version.ParseVersion(initEndpointVersion)
-		require.NoError(t, err)
+		require.NoError(t, err, "failed to parse initial endpoint version")
 
 		parsedUpgradedVersion, err := version.ParseVersion(upgradedEndpointVersion)
-		require.NoError(t, err)
+		require.NoError(t, err, "failed to parse upgraded endpoint version")
 
 		t.Logf("Comparing start version %s to upgraded version %s", startEndpointVersion.String(), parsedUpgradedVersion.String())
 		require.True(t, startEndpointVersion.Less(*parsedUpgradedVersion))
 	}
 
 	// try to uninstall the agent without token and assert that endpoint is not removed
-	t.Log("trying to uinstall without token, expecting error")
+	t.Log("trying to uninstall without token, expecting error")
 	out, err = exec.Command("sudo", "elastic-agent", "uninstall", "-f").CombinedOutput()
 	t.Log(string(out))
 	require.Error(t, err, "uninstalling agent without a token should fail because of tamper protection")
 	t.Log("tamper protection for the upgraded agent is enabled")
 
-	// uninstall with the uninstall token and assert that endpoint is indeed removed.
-	t.Log("trying to uinstall with token, not expecting any error")
+	// uninstall with the token and assert that endpoint is indeed removed.
+	t.Log("trying to uninstall with token, not expecting any error")
 	out, err = exec.Command("sudo", "elastic-agent", "uninstall", "-f", "--uninstall-token", uninstallToken).CombinedOutput()
 	t.Log(string(out))
 	require.NoError(t, err, string(out))
 
 	_, err = exec.LookPath("elastic-agent")
-	require.Error(t, err)
+	require.Error(t, err, "expected elastic-agent binary to not exist in PATH after uninstall")
 
 	t.Log("successfully uninstalled endpoint using the uninstall token")
 }
@@ -1237,14 +1247,14 @@ func TestForceInstallOverProtectedPolicy(t *testing.T) {
 		PolicyID: policy.ID,
 	})
 	require.NoError(t, err)
-	url, err := fleettools.DefaultURL(ctx, info.KibanaClient)
+	fleetURL, err := fleettools.DefaultURL(ctx, info.KibanaClient)
 	require.NoError(t, err)
 
 	args := []string{
 		"install",
 		"--force",
 		"--url",
-		url,
+		fleetURL,
 		"--enrollment-token",
 		token.APIKey,
 	}


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR fixes a regression introduced by #6907, which updated the RPM/DEB preinstall script to stop the `ElasticEndpoint` service during agent upgrades to work around tamper protection restrictions. While effective in stopping the service, the original change restarted the endpoint **before** restarting the agent. This sequence causes most of the time endpoint to try and reconnect to elastic-agent but without any time guarantees when this is gonna be successful.

To address this, the PR:
- Restart of the `ElasticEndpoint` service **after** the `elastic-agent` service has been restarted to guarantee that elastic-endpoint can connect to elastic-agent.
- Enhances integration tests to:
  - Use locally built artifacts when testing same-version upgrades.
  - Improve error messages and fixture preparation robustness.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Improper ordering of service restarts during DEB/RPM upgrades with endpoint tamper protection enabled was causing the endpoint to start independently of the agent, resulting in "always-retrying" and sporadic degraded operation. This fix ensures the services are brought up in the correct order to maintain endpoint health.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
mage integration:auth
STACK_PROVISIONER=stateful mage integration:single TestUpgradeAgentWithTamperProtectedEndpoint_RPM
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/8613

