### PR TITLE
fix: use --force-confold for deb tests in TestUpgradeAgentWithTamperProtectedEndpoint_DEB

### DIFF
--- a/testing/integration/endpoint_security_test.go
+++ b/testing/integration/endpoint_security_test.go
@@ -152,7 +152,10 @@ func getInstallCommand(ctx context.Context, packageFormat string, srcPkg string,
 
 	switch packageFormat {
 	case "deb":
-		args = append(args, "dpkg", "-i")
+		// since the previous agent is enrolled it means that the /etc/elastic-agent/elastic-agent.yml has changed
+		// and dpkg will ask if we want to overwrite it. Since this is a non-interactive install we need to
+		// force to keep the existing config
+		args = append(args, "dpkg", "--force-confold", "-i")
 	case "rpm":
 		args = append(args, "rpm", "-Uvh", "--force")
 	default:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR fixes an issue in the `TestUpgradeAgentWithTamperProtectedEndpoint_DEB` integration test where `dpkg` would prompt to overwrite the modified `elastic-agent.yml` configuration file during agent upgrade.

To make the test non-interactive and preserve the existing configuration, the test now uses the `--force-confold` flag when installing `.deb` packages via `dpkg -i`.

PS: this was already introduced in `8.19` by this PR https://github.com/elastic/elastic-agent/pull/8646 which such a failure was actually occurring 

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without this fix, the test could hang or fail because `dpkg` detects that the configuration file at `/etc/elastic-agent/elastic-agent.yml` was modified after enrollment and prompts the user to choose between keeping or replacing it. Since the test runs in a non-interactive context, the prompt leads to unexpected behavior.

Using `--force-confold` ensures that the test continues smoothly and keeps the current configuration as expected during same-version or upgrade installs since this test is featuring elastic-agents enrolled to fleet.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None. This change only affects the test harness logic and does not alter agent behavior or packaging.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
mage integration:auth
STACK_PROVISIONER=stateful mage integration:single TestUpgradeAgentWithTamperProtectedEndpoint_DEB
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Follow-up to https://github.com/elastic/elastic-agent/pull/8637
