### PR TITLE
Make the elasticinframetrics processor as deprecated and schedule for removal

### DIFF
--- a/deploy/helm/edot-collector/kube-stack/README.md
+++ b/deploy/helm/edot-collector/kube-stack/README.md
@@ -33,7 +33,6 @@ The Cluster Deployment collector handles the following data:
 The OpenTelemetry components deployed within the `Gateway` Deployment collectors focus on processing and exporting OTLP data to Elasticsearch. Processing components:
 
 - [Elastic Trace processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/elastictraceprocessor): The processor enriches traces with elastic specific requirements. It uses opentelemetry-lib to perform the actual enrichments.
-- [Elastic Infra Metrics processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/elasticinframetricsprocessor): The Elastic Infra Metrics Processor is used to bridge the gap between OTEL and Elastic Infra Metrics.
 - [Elastic APM connector](https://github.com/elastic/opentelemetry-collector-components/tree/main/connector/elasticapmconnector): The Elastic APM connector produces aggregated Elastic APM-specific metrics from all telemetry signals.
 
 ### Auto-instrumentation

--- a/deploy/helm/edot-collector/kube-stack/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/values.yaml
@@ -535,10 +535,11 @@ collectors:
               endpoint: ${env:MY_POD_IP}:4318
       processors:
         # [Elastic Infra Metrics Processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/elasticinframetricsprocessor)
-        elasticinframetrics:
-          add_system_metrics: true
-          add_k8s_metrics: true
-          drop_original: true
+        # DEPRECATED: The elasticinframetrics processor is deprecated and will be removed in 9.2.0.
+        # elasticinframetrics:
+        #   add_system_metrics: true
+        #   add_k8s_metrics: true
+        #   drop_original: true
         # [Attributes Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor)
         attributes/dataset:
           actions:

--- a/internal/pkg/otel/samples/darwin/logs_metrics_traces.yml
+++ b/internal/pkg/otel/samples/darwin/logs_metrics_traces.yml
@@ -49,7 +49,8 @@ connectors:
   elasticapm:
 
 processors:
-  elasticinframetrics:
+  # DEPRECATED: The elasticinframetrics processor is deprecated and will be removed in 9.2.0.
+  # elasticinframetrics:
   resourcedetection:
     detectors: ["system"]
     system:

--- a/internal/pkg/otel/samples/darwin/platformlogs_hostmetrics.yml
+++ b/internal/pkg/otel/samples/darwin/platformlogs_hostmetrics.yml
@@ -40,7 +40,8 @@ extensions:
     directory: ${env:STORAGE_DIR}
 
 processors:
-  elasticinframetrics:
+  # DEPRECATED: The elasticinframetrics processor is deprecated and will be removed in 9.2.0.
+  # elasticinframetrics:
   resourcedetection:
     detectors: ["system"]
     system:

--- a/internal/pkg/otel/samples/linux/gateway.yml
+++ b/internal/pkg/otel/samples/linux/gateway.yml
@@ -20,9 +20,10 @@ connectors:
   elasticapm: {} # Elastic APM Connector
 
 processors:
-  elasticinframetrics:
-    add_system_metrics: true
-    drop_original: true
+  # DEPRECATED: The elasticinframetrics processor is deprecated and will be removed in 9.2.0.
+  # elasticinframetrics:
+  #   add_system_metrics: true
+  #   drop_original: true
   attributes/dataset:
     actions:
       - key: event.dataset

--- a/internal/pkg/otel/samples/linux/logs_metrics_traces.yml
+++ b/internal/pkg/otel/samples/linux/logs_metrics_traces.yml
@@ -56,7 +56,8 @@ connectors:
   elasticapm:
 
 processors:
-  elasticinframetrics:
+  # DEPRECATED: The elasticinframetrics processor is deprecated and will be removed in 9.2.0.
+  # elasticinframetrics:
   resourcedetection:
     detectors: ["system"]
     system:

--- a/internal/pkg/otel/samples/linux/platformlogs_hostmetrics.yml
+++ b/internal/pkg/otel/samples/linux/platformlogs_hostmetrics.yml
@@ -47,7 +47,8 @@ extensions:
     directory: ${env:STORAGE_DIR}
 
 processors:
-  elasticinframetrics:
+  # DEPRECATED: The elasticinframetrics processor is deprecated and will be removed in 9.2.0.
+  # elasticinframetrics:
   resourcedetection:
     detectors: ["system"]
     system:


### PR DESCRIPTION
The elasticinframetrics processor is no longer necessary. It is marked as deprecated and scheduled for removal in 9.2.0. For 9.1.0 it will be left commented out in reference configurations and will remain included as a collector component.