### PR TITLE
feat: singleTest mage target for each integration test package

### DIFF
--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -64,21 +64,41 @@ Go to https://docker-auth.elastic.co/ and authenticate with Okta to receive your
 
 The test are run with mage using the `integration` namespace:
 
-- `mage integration:test` to execute all tests under the `testing/integration`
+#### ESS oriented tests
+
+- `mage integration:test` to execute all tests under the `testing/integration/ess`
   folder. All tests are executed on remote VMs, including those that set `Local: true`.
 
 - `mage integration:local [testName|all]` to execute only those tests under the
-  `testing/integration` folder that set `Local: true`. It'll run all the tests if
+  `testing/integration/ess` folder that set `Local: true`. It'll run all the tests if
   `all` is passed as argument, or it'll pass `[testName]` to `go test` as
   `--run=[testName]`. These tests are executed on your local machine.
 
-- `mage integration:single [testName]` to execute a single test under the `testing/integration` folder. Only the selected test will be executed on remote VMs.
+- `mage integration:single [testName]` to execute a single test under the `testing/integration/ess` folder. Only the selected test will be executed on remote VMs.
 
-- `mage integration:matrix` to run all tests on the complete matrix of supported operating systems and architectures of the Elastic Agent.
+- `mage integration:matrix` to run all tests under the `testing/integration/ess` folder on the complete matrix of supported operating systems and architectures of the Elastic Agent.
 
-- `mage integration:testKubernetes` to run kubernetes tests for the default image on the default version of kubernetes (all previous commands will not run any kubernetes tests).
+#### Kubernetes oriented tests
 
-- `mage integration:testKubernetesMatrix` to run a matrix of kubernetes tests for all image types and supported versions of kubernetes.
+- `mage integration:testKubernetes` to run kubernetes tests under the `testing/integration/k8s` folder for the default image on the default version of kubernetes (all previous commands will not run any kubernetes tests).
+
+- `mage integration:testKubernetesMatrix` to run a matrix of kubernetes tests under the `testing/integration/k8s` folder for all image types and supported versions of kubernetes.
+
+- `mage integration:testKubernetesSingle [testName|all]` to execute a single test under the `testing/integration/k8s` folder. Only the selected test will be executed.
+
+#### Serverless oriented tests
+
+- `mage integration:testServerless` to execute all tests under the `testing/integration/serverless` folder. All tests are executed on remote VMs, including those that set `Local: true`.
+
+- `mage integration:testServerlessSingle [testName|all]` to execute a single test under the `testing/integration/serverless` folder. Only the selected test will be executed on remote VMs.
+
+#### Resource leaks tests
+
+- `mage integration:testForResourceLeaks` to execute all tests under the `testing/integration/leak` folder. All tests are executed on remote VMs.
+
+- `mage integration:testForResourceLeaksSingle [testName|all]` to execute a single test under the `testing/integration/leak` folder. Only the selected test will be executed on remote VMs.
+
+You can list all available mage targets by running `mage -l`
 
 #### Selecting specific platform
 

--- a/magefile.go
+++ b/magefile.go
@@ -2340,46 +2340,47 @@ func (Integration) Single(ctx context.Context, testName string) error {
 }
 
 // TestServerless runs the integration tests defined in testing/integration/serverless
-func (Integration) TestServerless(ctx context.Context) error {
+func (i Integration) TestServerless(ctx context.Context) error {
+	return i.testServerless(ctx, false, "")
+}
+
+// TestServerlessSingle runs a single integration test defined in testing/integration/serverless
+func (i Integration) TestServerlessSingle(ctx context.Context, testName string) error {
+	return i.testServerless(ctx, false, testName)
+}
+
+func (i Integration) testServerless(ctx context.Context, matrix bool, testName string) error {
 	err := os.Setenv("STACK_PROVISIONER", "serverless")
 	if err != nil {
 		return fmt.Errorf("error setting serverless stack env var: %w", err)
 	}
 
-	return integRunner(ctx, "testing/integration/serverless", false, "")
+	return integRunner(ctx, "testing/integration/serverless", matrix, testName)
 }
 
-// TestKubernetes runs kubernetes integration tests
-func (Integration) TestKubernetes(ctx context.Context) error {
+// TestKubernetes runs the integration tests defined in testing/integration/k8s
+func (i Integration) TestKubernetes(ctx context.Context) error {
+	return i.testKubernetes(ctx, false, "")
+}
+
+// TestKubernetesSingle runs a single integration test defined in testing/integration/k8s
+func (i Integration) TestKubernetesSingle(ctx context.Context, testName string) error {
+	return i.testKubernetes(ctx, false, testName)
+}
+
+// TestKubernetesMatrix runs a matrix of integration tests defined in testing/integration/k8s
+func (i Integration) TestKubernetesMatrix(ctx context.Context) error {
+	return i.testKubernetes(ctx, true, "")
+}
+
+func (i Integration) testKubernetes(ctx context.Context, matrix bool, testName string) error {
 	mg.Deps(Integration.BuildKubernetesTestData)
 	// invoke integration tests
 	if err := os.Setenv("TEST_GROUPS", "kubernetes"); err != nil {
 		return err
 	}
 
-	return integRunner(ctx, "testing/integration/k8s", false, "")
-}
-
-// TestKubernetesSingle runs single k8s integration test
-func (Integration) TestKubernetesSingle(ctx context.Context, testName string) error {
-	mg.Deps(Integration.BuildKubernetesTestData)
-	// invoke integration tests
-	if err := os.Setenv("TEST_GROUPS", "kubernetes"); err != nil {
-		return err
-	}
-
-	return integRunner(ctx, "testing/integration/k8s", false, testName)
-}
-
-// TestKubernetesMatrix runs a matrix of kubernetes integration tests
-func (Integration) TestKubernetesMatrix(ctx context.Context) error {
-	mg.Deps(Integration.BuildKubernetesTestData)
-	// invoke integration tests
-	if err := os.Setenv("TEST_GROUPS", "kubernetes"); err != nil {
-		return err
-	}
-
-	return integRunner(ctx, "testing/integration/k8s", true, "")
+	return integRunner(ctx, "testing/integration/k8s", matrix, testName)
 }
 
 // BuildKubernetesTestData builds the test data required to run k8s integration tests
@@ -2897,9 +2898,18 @@ func (Integration) TestBeatServerless(ctx context.Context, beatname string) erro
 	return integRunner(ctx, "testing/integration/beats/serverless", false, "TestBeatsServerless")
 }
 
-// TestForResourceLeaks runs tests that check for resource leaks
-func (Integration) TestForResourceLeaks(ctx context.Context) error {
-	return integRunner(ctx, "testing/integration/leak", false, "TestLongRunningAgentForLeaks")
+// TestForResourceLeaks runs the integration tests defined in testing/integration/leak
+func (i Integration) TestForResourceLeaks(ctx context.Context) error {
+	return i.testForResourceLeaks(ctx, false, "")
+}
+
+// TestForResourceLeaksSingle runs a single integration test defined in testing/integration/leak
+func (i Integration) TestForResourceLeaksSingle(ctx context.Context, testName string) error {
+	return i.testForResourceLeaks(ctx, false, testName)
+}
+
+func (i Integration) testForResourceLeaks(ctx context.Context, matrix bool, testName string) error {
+	return integRunner(ctx, "testing/integration/leak", matrix, testName)
 }
 
 // TestOnRemote shouldn't be called locally (called on remote host to perform testing)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

As request in previous [PR reviews](https://github.com/elastic/elastic-agent/pull/8396#discussion_r2136156702) this PR introduces `Single` mage targets for the `serverless` and `leak` integration test packages, similar to the existing `TestKubernetesSingle` target. It adds the following functions to the `magefile.go`:

- `TestServerlessSingle`
- `TestForResourceLeaksSingle`

Internally, both new targets delegate to shared helper functions that support selecting a specific test by name. This unifies the way we run individual integration tests across packages and prepares the mage targets for further package splits.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

As part of the effort to split the increasingly large integration test suite into smaller dedicated packages (see parent issue), we also need to ensure that developers can run individual tests from each new package using a consistent interface.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None. This PR only introduces new mage targets for developer convenience without affecting existing workflows.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Invoke the new mage targets 🙂 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/8414
- Relates https://github.com/elastic/elastic-agent/issues/8087
