### PR TITLE
[Helm] support onboarding-id for kubernetes

### DIFF
--- a/deploy/helm/elastic-agent/README.md
+++ b/deploy/helm/elastic-agent/README.md
@@ -63,6 +63,7 @@ The chart built-in [kubernetes integration](https://docs.elastic.co/integrations
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | kubernetes.enabled | bool | `true` | enable Kubernetes integration. |
+| kubernetes.onboardingID | string | `""` | Specify the onboarding ID for a quick start flow. |
 | kubernetes.output | string | `"default"` | name of the output used in kubernetes integration. Note that this output needs to be defined in [outputs](#1-outputs) |
 | kubernetes.namespace | string | `"default"` | kubernetes namespace |
 | kubernetes.hints.enabled | bool | `false` | enable [elastic-agent autodiscovery](https://www.elastic.co/guide/en/fleet/current/elastic-agent-kubernetes-autodiscovery.html) feature |

--- a/deploy/helm/elastic-agent/examples/kubernetes-onboarding/README.md
+++ b/deploy/helm/elastic-agent/examples/kubernetes-onboarding/README.md
@@ -1,0 +1,57 @@
+# Example: Kubernetes Integration with default chart values and onboarding-id
+
+In this example we install the built-in `kubernetes` integration with the default built-in values and an onboarding-id for quick-start flows .
+
+## Prerequisites:
+1. Build the dependencies of the Helm chart
+    ```console
+    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    helm dependency build ../../
+    ```
+2. A k8s secret that contains the connection details to an Elasticsearch cluster such as the URL and the API key ([Kibana - Creating API Keys](https://www.elastic.co/guide/en/kibana/current/api-keys.html)):
+    ```console
+    kubectl create secret generic es-api-secret \
+       --from-literal=api_key=... \
+       --from-literal=url=...
+    ```
+
+3. `kubernetes` integration assets installed through Kibana ([Kibana - Install and uninstall Elastic Agent integration assets](https://www.elastic.co/guide/en/fleet/current/install-uninstall-integration-assets.html))
+
+## Run:
+
+#### Public image registry:
+```console
+helm install elastic-agent ../../ \
+     --set kubernetes.onboardingID: "my-onboarding-id"
+     --set kubernetes.enabled: true \
+     --set agent.unprivileged: true \
+     --set outputs.default.type=ESSecretAuthAPI \
+     --set outputs.default.secretName=es-api-secret
+```
+
+
+#### Private image registry:
+Create secret with the contents of docker auth config
+```
+kubectl create secret generic regcred --from-file=.dockerconfigjson=<your home folder here>/.docker/config.json --type=kubernetes.io/dockerconfigjson
+```
+
+Install elastic-agent
+```console
+helm install elastic-agent ../../ \
+     --set kubernetes.onboardingID: "my-onboarding-id"
+     --set kubernetes.enabled: true \
+     --set agent.unprivileged: true \
+     --set 'agent.imagePullSecrets[0].name=regcred' \
+     --set outputs.default.type=ESSecretAuthAPI \
+     --set outputs.default.secretName=es-api-secret
+```
+
+## Validate:
+
+1. `kube-state metrics` is installed with this command `kubectl get deployments -n kube-system kube-state-metrics`.
+2. The Kibana `kubernetes`-related dashboards should start showing up the respective info.
+
+## Note:
+
+1. If you want to disable kube-state-metrics installation with the elastic-agent Helm chart, you can set `kube-state-metrics.enabled=false` in the Helm chart. The helm chart will use the value of `kubernetes.state.host` to configure the elastic-agent input.

--- a/deploy/helm/elastic-agent/examples/kubernetes-onboarding/agent-kubernetes-values.yaml
+++ b/deploy/helm/elastic-agent/examples/kubernetes-onboarding/agent-kubernetes-values.yaml
@@ -1,0 +1,6 @@
+kubernetes:
+  onboardingID: "my-onboarding-id"
+  enabled: true
+
+agent:
+  unprivileged: true

--- a/deploy/helm/elastic-agent/examples/kubernetes-onboarding/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/kubernetes-onboarding/rendered/manifest.yaml
@@ -1,0 +1,1162 @@
+---
+# Source: elastic-agent/charts/kube-state-metrics/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.15.0"
+  name: kube-state-metrics
+  namespace: default
+---
+# Source: elastic-agent/templates/agent/service-account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-clusterwide-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+---
+# Source: elastic-agent/templates/agent/service-account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-pernode-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+---
+# Source: elastic-agent/templates/agent/k8s/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agent-clusterwide-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+stringData:
+
+  agent.yml: |-
+    id: agent-clusterwide-example
+    outputs:
+      default:
+        hosts:
+        - http://elasticsearch:9200
+        password: changeme
+        type: elasticsearch
+        username: elastic
+    secret_references: []
+    agent:
+      monitoring:
+        enabled: true
+        logs: true
+        metrics: true
+        namespace: default
+        use_output: default
+    inputs:
+      - data_stream:
+          namespace: default
+        id: kubernetes/metrics-kubernetes.apiserver
+        processors:
+        - add_fields:
+            fields:
+              onboarding_id: my-onboarding-id
+        streams:
+        - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.apiserver
+            type: metrics
+          hosts:
+          - https://${env.KUBERNETES_SERVICE_HOST}:${env.KUBERNETES_SERVICE_PORT}
+          id: kubernetes/metrics-kubernetes.apiserver
+          metricsets:
+          - apiserver
+          period: 30s
+          ssl.certificate_authorities:
+          - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        type: kubernetes/metrics
+        use_output: default
+      - data_stream:
+          namespace: default
+        id: kube-state-metrics-kubernetes/metrics
+        processors:
+        - add_fields:
+            fields:
+              onboarding_id: my-onboarding-id
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_container
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_container
+          metricsets:
+          - state_container
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_cronjob
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_cronjob
+          metricsets:
+          - state_cronjob
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_daemonset
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_daemonset
+          metricsets:
+          - state_daemonset
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_deployment
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_deployment
+          metricsets:
+          - state_deployment
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_job
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_job
+          metricsets:
+          - state_job
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_namespace
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_namespace
+          metricsets:
+          - state_namespace
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_node
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_node
+          metricsets:
+          - state_node
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_persistentvolumeclaim
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_persistentvolumeclaim
+          metricsets:
+          - state_persistentvolumeclaim
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_persistentvolume
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_persistentvolume
+          metricsets:
+          - state_persistentvolume
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_pod
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_pod
+          metricsets:
+          - state_pod
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_replicaset
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_replicaset
+          metricsets:
+          - state_replicaset
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_resourcequota
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_resourcequota
+          metricsets:
+          - state_resourcequota
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_service
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_service
+          metricsets:
+          - state_service
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_statefulset
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_statefulset
+          metricsets:
+          - state_statefulset
+          period: 10s
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          condition: ${kubernetes_leaderelection.leader} == true
+          data_stream:
+            dataset: kubernetes.state_storageclass
+            type: metrics
+          hosts:
+          - kube-state-metrics:8080
+          id: kubernetes/metrics-kubernetes.state_storageclass
+          metricsets:
+          - state_storageclass
+          period: 10s
+        type: kubernetes/metrics
+        use_output: default
+    providers:
+      kubernetes:
+        node: ${NODE_NAME}
+        scope: cluster
+      kubernetes_leaderelection:
+        enabled: true
+        leader_lease: example-clusterwide
+---
+# Source: elastic-agent/templates/agent/k8s/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agent-pernode-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+stringData:
+
+  agent.yml: |-
+    id: agent-pernode-example
+    outputs:
+      default:
+        hosts:
+        - http://elasticsearch:9200
+        password: changeme
+        type: elasticsearch
+        username: elastic
+    secret_references: []
+    agent:
+      monitoring:
+        enabled: true
+        logs: true
+        metrics: true
+        namespace: default
+        use_output: default
+    inputs:
+      - data_stream:
+          namespace: default
+        id: filestream-container-logs
+        streams:
+        - data_stream:
+            dataset: kubernetes.container_logs
+            type: logs
+          id: kubernetes-container-logs-${kubernetes.pod.name}-${kubernetes.container.id}
+          parsers:
+          - container:
+              format: auto
+              stream: all
+          paths:
+          - /var/log/containers/*${kubernetes.container.id}.log
+          processors:
+          - add_fields:
+              fields:
+                annotations.elastic_co/dataset: ${kubernetes.annotations.elastic.co/dataset|""}
+                annotations.elastic_co/namespace: ${kubernetes.annotations.elastic.co/namespace|""}
+                annotations.elastic_co/preserve_original_event: ${kubernetes.annotations.elastic.co/preserve_original_event|""}
+              target: kubernetes
+          - drop_fields:
+              fields:
+              - kubernetes.annotations.elastic_co/dataset
+              ignore_missing: true
+              when:
+                equals:
+                  kubernetes.annotations.elastic_co/dataset: ""
+          - drop_fields:
+              fields:
+              - kubernetes.annotations.elastic_co/namespace
+              ignore_missing: true
+              when:
+                equals:
+                  kubernetes.annotations.elastic_co/namespace: ""
+          - drop_fields:
+              fields:
+              - kubernetes.annotations.elastic_co/preserve_original_event
+              ignore_missing: true
+              when:
+                equals:
+                  kubernetes.annotations.elastic_co/preserve_original_event: ""
+          - add_tags:
+              tags:
+              - preserve_original_event
+              when:
+                and:
+                - has_fields:
+                  - kubernetes.annotations.elastic_co/preserve_original_event
+                - regexp:
+                    kubernetes.annotations.elastic_co/preserve_original_event: ^(?i)true$
+          - add_fields:
+              fields:
+                onboarding_id: my-onboarding-id
+          prospector.scanner.symlinks: true
+        type: filestream
+        use_output: default
+      - data_stream:
+          namespace: default
+        id: kubernetes/metrics-kubernetes.container
+        processors:
+        - add_fields:
+            fields:
+              onboarding_id: my-onboarding-id
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.container
+            type: metrics
+          hosts:
+          - https://${env.NODE_NAME}:10250
+          id: kubernetes/metrics-kubernetes.container
+          metricsets:
+          - container
+          period: 10s
+          ssl.verification_mode: none
+        type: kubernetes/metrics
+        use_output: default
+      - data_stream:
+          namespace: default
+        id: kubernetes/metrics-kubernetes.node
+        processors:
+        - add_fields:
+            fields:
+              onboarding_id: my-onboarding-id
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.node
+            type: metrics
+          hosts:
+          - https://${env.NODE_NAME}:10250
+          id: kubernetes/metrics-kubernetes.node
+          metricsets:
+          - node
+          period: 10s
+          ssl.verification_mode: none
+        type: kubernetes/metrics
+        use_output: default
+      - data_stream:
+          namespace: default
+        id: kubernetes/metrics-kubernetes.pod
+        processors:
+        - add_fields:
+            fields:
+              onboarding_id: my-onboarding-id
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.pod
+            type: metrics
+          hosts:
+          - https://${env.NODE_NAME}:10250
+          id: kubernetes/metrics-kubernetes.pod
+          metricsets:
+          - pod
+          period: 10s
+          ssl.verification_mode: none
+        type: kubernetes/metrics
+        use_output: default
+      - data_stream:
+          namespace: default
+        id: kubernetes/metrics-kubernetes.system
+        processors:
+        - add_fields:
+            fields:
+              onboarding_id: my-onboarding-id
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.system
+            type: metrics
+          hosts:
+          - https://${env.NODE_NAME}:10250
+          id: kubernetes/metrics-kubernetes.system
+          metricsets:
+          - system
+          period: 10s
+          ssl.verification_mode: none
+        type: kubernetes/metrics
+        use_output: default
+      - data_stream:
+          namespace: default
+        id: kubernetes/metrics-kubernetes.volume
+        processors:
+        - add_fields:
+            fields:
+              onboarding_id: my-onboarding-id
+        streams:
+        - add_metadata: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          data_stream:
+            dataset: kubernetes.volume
+            type: metrics
+          hosts:
+          - https://${env.NODE_NAME}:10250
+          id: kubernetes/metrics-kubernetes.volume
+          metricsets:
+          - volume
+          period: 10s
+          ssl.verification_mode: none
+        type: kubernetes/metrics
+        use_output: default
+    providers:
+      kubernetes:
+        node: ${NODE_NAME}
+        scope: node
+      kubernetes_leaderelection:
+        enabled: false
+        leader_lease: example-pernode
+---
+# Source: elastic-agent/charts/kube-state-metrics/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.15.0"
+  name: kube-state-metrics
+rules:
+
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - daemonsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - endpoints
+  verbs: ["list", "watch"]
+
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "networking.k8s.io"]
+  resources:
+  - ingresses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - limitranges
+  verbs: ["list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - mutatingwebhookconfigurations
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list", "watch"]
+
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - networkpolicies
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumeclaims
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumes
+  verbs: ["list", "watch"]
+
+- apiGroups: ["policy"]
+  resources:
+    - poddisruptionbudgets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - replicasets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - replicationcontrollers
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - resourcequotas
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - services
+  verbs: ["list", "watch"]
+
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - storageclasses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - validatingwebhookconfigurations
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - volumeattachments
+  verbs: ["list", "watch"]
+---
+# Source: elastic-agent/templates/agent/cluster-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-clusterWide-example-default
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+rules:
+  - apiGroups: [ "" ] # "" indicates the core API group
+    resources:
+      - nodes
+      - namespaces
+      - events
+      - pods
+      - services
+      - configmaps
+      - persistentvolumes
+      - persistentvolumeclaims
+      - persistentvolumeclaims/status
+      - nodes/metrics
+      - nodes/proxy
+      - nodes/stats
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - watch
+      - list
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups: [ "coordination.k8s.io" ]
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - nonResourceURLs:
+      - /healthz
+      - /healthz/*
+      - /livez
+      - /livez/*
+      - /metrics
+      - /metrics/slis
+      - /readyz
+      - /readyz/*
+    verbs:
+      - get
+  - apiGroups: [ "apps" ]
+    resources:
+      - replicasets
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [ "batch" ]
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: elastic-agent/templates/agent/cluster-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-perNode-example-default
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+rules:
+  - apiGroups: [ "" ] # "" indicates the core API group
+    resources:
+      - nodes
+      - namespaces
+      - events
+      - pods
+      - services
+      - configmaps
+      - persistentvolumes
+      - persistentvolumeclaims
+      - persistentvolumeclaims/status
+      - nodes/metrics
+      - nodes/proxy
+      - nodes/stats
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - watch
+      - list
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups: [ "coordination.k8s.io" ]
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - nonResourceURLs:
+      - /healthz
+      - /healthz/*
+      - /livez
+      - /livez/*
+      - /metrics
+      - /metrics/slis
+      - /readyz
+      - /readyz/*
+    verbs:
+      - get
+  - apiGroups: [ "apps" ]
+    resources:
+      - replicasets
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [ "batch" ]
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: elastic-agent/charts/kube-state-metrics/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.15.0"
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: default
+---
+# Source: elastic-agent/templates/agent/cluster-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-clusterWide-example-default
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+subjects:
+  - kind: ServiceAccount
+    name: agent-clusterwide-example
+    namespace: "default"
+roleRef:
+  kind: ClusterRole
+  name: agent-clusterWide-example-default
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: elastic-agent/templates/agent/cluster-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-perNode-example-default
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+subjects:
+  - kind: ServiceAccount
+    name: agent-pernode-example
+    namespace: "default"
+roleRef:
+  kind: ClusterRole
+  name: agent-perNode-example-default
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: elastic-agent/charts/kube-state-metrics/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: default
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.15.0"
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  type: "ClusterIP"
+  ports:
+  - name: "http"
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
+  
+  selector:    
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+---
+# Source: elastic-agent/templates/agent/k8s/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: agent-pernode-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+spec:
+  selector:
+    matchLabels:
+      name: agent-pernode-example
+  template:
+    metadata:
+      labels:
+        name: agent-pernode-example
+      annotations:
+        checksum/config: 198073338eb92731fe9f2e2f98384fff62a1df1e1440ce1bf9ce77732dba6f2c
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - -c
+        - /etc/elastic-agent/agent.yml
+        - -e
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: STATE_PATH
+          value: /usr/share/elastic-agent/state
+        - name: ELASTIC_NETINFO
+          value: "false"
+        image: docker.elastic.co/elastic-agent/elastic-agent:9.1.0-SNAPSHOT
+        imagePullPolicy: IfNotPresent
+        name: agent
+        resources:
+          limits:
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 400Mi
+        securityContext:
+          capabilities:
+            add:
+            - DAC_READ_SEARCH
+            - CHOWN
+            - SETPCAP
+            - SYS_PTRACE
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 1000
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /var/lib/docker/containers
+          name: varlibdockercontainers
+          readOnly: true
+        - mountPath: /var/log
+          name: varlog
+          readOnly: true
+        - mountPath: /usr/share/elastic-agent/state
+          name: agent-data
+        - mountPath: /etc/elastic-agent/agent.yml
+          name: config
+          readOnly: true
+          subPath: agent.yml
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: agent-pernode-example
+      volumes:
+      - hostPath:
+          path: /var/lib/docker/containers
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/log
+        name: varlog
+      - hostPath:
+          path: /etc/elastic-agent/default/agent-pernode-example/state
+          type: DirectoryOrCreate
+        name: agent-data
+      - name: config
+        secret:
+          defaultMode: 292
+          secretName: agent-pernode-example
+---
+# Source: elastic-agent/charts/kube-state-metrics/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: default
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.15.0"
+spec:
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/instance: example
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  revisionHistoryLimit: 10
+  template:
+    metadata:
+      labels:        
+        helm.sh/chart: kube-state-metrics-5.30.1
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: metrics
+        app.kubernetes.io/part-of: kube-state-metrics
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/version: "2.15.0"
+    spec:
+      automountServiceAccountToken: true
+      hostNetwork: false
+      serviceAccountName: kube-state-metrics
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: kube-state-metrics
+        args:
+        - --port=8080
+        - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
+        imagePullPolicy: IfNotPresent
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
+        ports:
+        - containerPort: 8080
+          name: "http"
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            httpHeaders:
+            path: /livez
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            httpHeaders:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+---
+# Source: elastic-agent/templates/agent/k8s/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-clusterwide-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.1.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.1.0
+spec:
+  selector:
+    matchLabels:
+      name: agent-clusterwide-example
+  template:
+    metadata:
+      labels:
+        name: agent-clusterwide-example
+      annotations:
+        checksum/config: 19faf4816a2c94cc6f666de0c59c4446e840d5af5069b37fcdf3741b3254d3a3
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - -c
+        - /etc/elastic-agent/agent.yml
+        - -e
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: STATE_PATH
+          value: /usr/share/elastic-agent/state
+        - name: ELASTIC_NETINFO
+          value: "false"
+        image: docker.elastic.co/elastic-agent/elastic-agent:9.1.0-SNAPSHOT
+        imagePullPolicy: IfNotPresent
+        name: agent
+        resources:
+          limits:
+            memory: 800Mi
+          requests:
+            cpu: 100m
+            memory: 400Mi
+        securityContext:
+          capabilities:
+            add:
+            - CHOWN
+            - SETPCAP
+            - DAC_READ_SEARCH
+            - SYS_PTRACE
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 1000
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /usr/share/elastic-agent/state
+          name: agent-data
+        - mountPath: /etc/elastic-agent/agent.yml
+          name: config
+          readOnly: true
+          subPath: agent.yml
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: agent-clusterwide-example
+      volumes:
+      - emptyDir: {}
+        name: agent-data
+      - name: config
+        secret:
+          defaultMode: 292
+          secretName: agent-clusterwide-example

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes.tpl
@@ -1,5 +1,10 @@
 {{- define "elasticagent.kubernetes.init" -}}
 {{- if eq $.Values.kubernetes.enabled true -}}
+
+{{- with $.Values.kubernetes.onboardingID -}}
+{{- $_ := set $.Values.kubernetes "_onboarding_processor" (dict "add_fields" (dict "fields" (dict "onboarding_id" .))) -}}
+{{- end -}}
+
 {{- include "elasticagent.kubernetes.config.kube_apiserver.init" $ -}}
 {{- include "elasticagent.kubernetes.config.kube_controller.init" $ -}}
 {{- include "elasticagent.kubernetes.config.state.init" $ -}}

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_apiserver.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_apiserver.tpl
@@ -16,6 +16,10 @@ Config input for kube apiserver
   data_stream:
     namespace: {{ $.Values.kubernetes.namespace }}
   use_output: {{ $.Values.kubernetes.output }}
+  {{- with $.Values.kubernetes._onboarding_processor }}
+  processors:
+  - {{ . | toYaml | nindent 4 }}
+  {{- end }}
   streams:
   - id: kubernetes/metrics-kubernetes.apiserver
     data_stream:

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_controller_manager.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_controller_manager.tpl
@@ -16,6 +16,10 @@ Config input for kube_controllermanage
   data_stream:
     namespace: {{ .Values.kubernetes.namespace }}
   use_output: {{ .Values.kubernetes.output }}
+  {{- with $.Values.kubernetes._onboarding_processor }}
+  processors:
+  - {{ . | toYaml | nindent 4 }}
+  {{- end }}
   streams:
   - id: kubernetes/metrics-kubernetes.controllermanager
     data_stream:

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_containers.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_containers.tpl
@@ -17,6 +17,10 @@
   data_stream:
     namespace: {{ $.Values.kubernetes.namespace }}
   use_output: {{ $.Values.kubernetes.output }}
+  {{- with $.Values.kubernetes._onboarding_processor }}
+  processors:
+  - {{ . | toYaml | nindent 4 }}
+  {{- end }}
   streams:
   - id: kubernetes/metrics-kubernetes.container
     data_stream:

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_nodes.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_nodes.tpl
@@ -17,6 +17,10 @@
   data_stream:
     namespace: {{ $.Values.kubernetes.namespace }}
   use_output: {{ $.Values.kubernetes.output }}
+  {{- with $.Values.kubernetes._onboarding_processor }}
+  processors:
+  - {{ . | toYaml | nindent 4 }}
+  {{- end }}
   streams:
   - id: kubernetes/metrics-kubernetes.node
     data_stream:

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_pods.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_pods.tpl
@@ -17,6 +17,10 @@
   data_stream:
     namespace: {{ $.Values.kubernetes.namespace }}
   use_output: {{ $.Values.kubernetes.output }}
+  {{- with $.Values.kubernetes._onboarding_processor }}
+  processors:
+  - {{ . | toYaml | nindent 4 }}
+  {{- end }}
   streams:
   - id: kubernetes/metrics-kubernetes.pod
     data_stream:

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_system.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_system.tpl
@@ -17,6 +17,10 @@
   data_stream:
     namespace: {{ $.Values.kubernetes.namespace }}
   use_output: {{ $.Values.kubernetes.output }}
+  {{- with $.Values.kubernetes._onboarding_processor }}
+  processors:
+  - {{ . | toYaml | nindent 4 }}
+  {{- end }}
   streams:
   - id: kubernetes/metrics-kubernetes.system
     data_stream:

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_volumes.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_kubelet_volumes.tpl
@@ -17,6 +17,10 @@
   data_stream:
     namespace: {{ $.Values.kubernetes.namespace }}
   use_output: {{ $.Values.kubernetes.output }}
+  {{- with $.Values.kubernetes._onboarding_processor }}
+  processors:
+  - {{ . | toYaml | nindent 4 }}
+  {{- end }}
   streams:
   - id: kubernetes/metrics-kubernetes.volume
     data_stream:

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_logs_audit.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_logs_audit.tpl
@@ -16,6 +16,10 @@ Config input for kube audit_logs_filestream
   data_stream:
     namespace: {{.Values.kubernetes.namespace}}
   use_output: {{ .Values.kubernetes.output }}
+  {{- with $.Values.kubernetes._onboarding_processor }}
+  processors:
+  - {{ . | toYaml | nindent 4 }}
+  {{- end }}
   streams:
   - id: filestream-kubernetes.audit_logs
     data_stream:

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_logs_containers.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_logs_containers.tpl
@@ -33,7 +33,7 @@ Config input for container logs
       {{- end }}
     {{- $additionalProcessors := dig "vars" "processors" list $.Values.kubernetes.containers.logs -}}
     {{- $builtInProcessors := dig "vars" "enabledDefaultProcessors" true $.Values.kubernetes.containers.logs -}}
-    {{- if (or $builtInProcessors $additionalProcessors) }}
+    {{- if compact (list $builtInProcessors $additionalProcessors $.Values.kubernetes._onboarding_processor) }}
     processors:
       {{- with $builtInProcessors }}
       - add_fields:
@@ -72,6 +72,9 @@ Config input for container logs
                   - kubernetes.annotations.elastic_co/preserve_original_event
               - regexp:
                   kubernetes.annotations.elastic_co/preserve_original_event: ^(?i)true$
+      {{- end }}
+      {{- with $.Values.kubernetes._onboarding_processor }}
+      - {{ . | toYaml | nindent 8 }}
       {{- end }}
       {{- with $additionalProcessors }}
       {{- . | toYaml | nindent 6 }}

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_proxy.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_proxy.tpl
@@ -17,6 +17,10 @@ Config input for kube proxy
   data_stream:
     namespace: {{ .Values.kubernetes.namespace }}
   use_output: {{ .Values.kubernetes.output }}
+  {{- with $.Values.kubernetes._onboarding_processor }}
+  processors:
+  - {{ . | toYaml | nindent 4 }}
+  {{- end }}
   streams:
   - id: kubernetes/metrics-kubernetes.proxy
     data_stream:

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_scheduler.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_scheduler.tpl
@@ -16,6 +16,10 @@ Config input for kube_scheduler
   data_stream:
     namespace: {{ .Values.kubernetes.namespace }}
   use_output: {{ .Values.kubernetes.output }}
+  {{- with $.Values.kubernetes._onboarding_processor }}
+  processors:
+  - {{ . | toYaml | nindent 4 }}
+  {{- end }}
   streams:
   - id: kubernetes/metrics-kubernetes.scheduler
     data_stream:

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_state.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_state.tpl
@@ -38,6 +38,10 @@
   data_stream:
     namespace: {{ $.Values.kubernetes.namespace }}
   use_output: {{ $.Values.kubernetes.output }}
+  {{- with $.Values.kubernetes._onboarding_processor }}
+  processors:
+  - {{ . | toYaml | nindent 4 }}
+  {{- end }}
   streams:
   {{- . | toYaml | nindent 4 }}
 {{- end -}}

--- a/deploy/helm/elastic-agent/values.schema.json
+++ b/deploy/helm/elastic-agent/values.schema.json
@@ -91,6 +91,10 @@
                     "type": "boolean",
                     "description": "Enable Kubernetes integration."
                 },
+                "onboardingID": {
+                    "type": "string",
+                    "description": "Onboarding ID for quick-start flow."
+                },
                 "output": {
                     "type": "string",
                     "description": "Name of the output used in Kubernetes integration. Must be defined in outputs."

--- a/deploy/helm/elastic-agent/values.yaml
+++ b/deploy/helm/elastic-agent/values.yaml
@@ -48,6 +48,10 @@ kubernetes:
   # @section -- 2 - Kubernetes integration
   # @sectionDescriptionTemplate -- Kubernetes
   enabled: true
+  # -- Specify the onboarding ID for a quick start flow.
+  # @section -- 2 - Kubernetes integration
+  # @sectionDescriptionTemplate -- Kubernetes
+  onboardingID: ""
   # -- name of the output used in kubernetes integration. Note that this output needs to be defined in
   # [outputs](#1-outputs)
   # @section -- 2 - Kubernetes integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR introduces support for an `onboardingID` field in the `kubernetes` integration of the Elastic Agent Helm chart. The onboarding ID is injected into all supported `kubernetes` data streams as an `add_fields` processor when specified. 


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

As part of the Observability Logs Essentials Serverless tier, metrics collection should be disabled in the onboarding quick-start flows. This PR aligns the Helm chart behavior with the intended onboarding experience by enabling an explicit onboarding identifier (`onboardingID`) to be passed to the deployed Elastic Agents, similar to the existing behavior in the Kustomize-based setup.

This onboarding ID is used by the backend to correlate logs/metrics to onboarding sessions and improve user experience and supportability during initial usage.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

This is a non-disruptive enhancement. Users who do not set `kubernetes.onboardingID` will see no change in behavior. If set, the onboarding ID is safely added as a metadata field to all collected logs and metrics for the Kubernetes integration.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
mage helm:renderExamples
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
N/A
