### PR TITLE
Fix otel extension status reporting

### DIFF
--- a/internal/pkg/otel/translate/status.go
+++ b/internal/pkg/otel/translate/status.go
@@ -64,7 +64,10 @@ func DropComponentStateFromOtelStatus(otelStatus *status.AggregateStatus) (*stat
 	newStatus := deepCopyStatus(otelStatus)
 	for pipelineStatusId := range newStatus.ComponentStatusMap {
 		pipelineId := &pipeline.ID{}
-		componentKind, pipelineIdStr := parseEntityStatusId(pipelineStatusId)
+		componentKind, pipelineIdStr, parseErr := parseEntityStatusId(pipelineStatusId)
+		if parseErr != nil {
+			return nil, parseErr
+		}
 		if componentKind == "extensions" {
 			continue
 		}
@@ -94,7 +97,10 @@ func getOtelRuntimePipelineStatuses(otelStatus *status.AggregateStatus) (map[str
 
 	for pipelineStatusId, pipelineStatus := range otelStatus.ComponentStatusMap {
 		pipelineId := &pipeline.ID{}
-		componentKind, pipelineIdStr := parseEntityStatusId(pipelineStatusId)
+		componentKind, pipelineIdStr, parseErr := parseEntityStatusId(pipelineStatusId)
+		if parseErr != nil {
+			return nil, parseErr
+		}
 		if componentKind == "extensions" {
 			continue
 		}
@@ -182,8 +188,11 @@ func getUnitOtelStatuses(pipelineStatus *status.AggregateStatus) (
 
 	for otelCompStatusId, otelCompStatus := range pipelineStatus.ComponentStatusMap {
 		var otelComponentID otelcomponent.ID
-		componentKind, otelComponentIDStr := parseEntityStatusId(otelCompStatusId)
-		err := otelComponentID.UnmarshalText([]byte(otelComponentIDStr))
+		componentKind, otelComponentIDStr, parseErr := parseEntityStatusId(otelCompStatusId)
+		if parseErr != nil {
+			return nil, nil, parseErr
+		}
+		err = otelComponentID.UnmarshalText([]byte(otelComponentIDStr))
 		if err != nil {
 			return nil, nil, err
 		}
@@ -275,15 +284,15 @@ func otelStatusToUnitState(status componentstatus.Status) client.UnitState {
 // The ID is expected to be in the format "kind:entityId", where kind is either "pipeline" or the otel component type (e.g., "receiver", "exporter").
 // The returned entityId may be empty - this is true for the top-level "extensions" key.
 // This format is used by the healthcheckv2 extension.
-func parseEntityStatusId(id string) (kind string, entityId string) {
+func parseEntityStatusId(id string) (kind string, entityId string, err error) {
 	if id == "extensions" {
-		return "extensions", ""
+		return "extensions", "", nil
 	}
 	parts := strings.SplitN(id, ":", 2)
 	if len(parts) != 2 {
-		return "", ""
+		return "", "", fmt.Errorf("couldn't parse otel status id: %s", id)
 	}
-	return parts[0], parts[1]
+	return parts[0], parts[1], nil
 }
 
 // deepCopyStatus makes a deep copy of the status.

--- a/internal/pkg/otel/translate/status_test.go
+++ b/internal/pkg/otel/translate/status_test.go
@@ -78,7 +78,7 @@ func TestGetAllComponentState(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: fmt.Errorf("pipeline status id %s is not a pipeline", fmt.Sprintf("logs/%sfilestream-default", OtelNamePrefix)),
+			expectedErr: fmt.Errorf("couldn't parse otel status id: %s", fmt.Sprintf("logs/%sfilestream-default", OtelNamePrefix)),
 		},
 		{
 			name:       "one otel component, one process component",
@@ -213,7 +213,7 @@ func TestDropComponentStateFromOtelStatus(t *testing.T) {
 		s, err := DropComponentStateFromOtelStatus(otelStatus)
 		require.Error(t, err)
 		require.Nil(t, s)
-		assert.Equal(t, "pipeline status id logs is not a pipeline", err.Error())
+		assert.Equal(t, "couldn't parse otel status id: logs", err.Error())
 	})
 
 	t.Run("ignore extensions", func(t *testing.T) {
@@ -275,7 +275,7 @@ func TestGetOtelRuntimePipelineStatuses(t *testing.T) {
 				},
 			},
 			expected: nil,
-			err:      "pipeline status id invalid-format is not a pipeline",
+			err:      "couldn't parse otel status id: invalid-format",
 		},
 		{
 			name: "extensions are ignored",
@@ -512,17 +512,20 @@ func TestParseEntityStatusId(t *testing.T) {
 		id               string
 		expectedKind     string
 		expectedEntityID string
+		expectedErr      error
 	}{
-		{"pipeline:logs", "pipeline", "logs"},
-		{"pipeline:logs/filestream-monitoring", "pipeline", "logs/filestream-monitoring"},
-		{"receiver:filebeat/filestream-monitoring", "receiver", "filebeat/filestream-monitoring"},
-		{"exporter:elasticsearch/default", "exporter", "elasticsearch/default"},
-		{"invalid", "", ""},
-		{"extensions", "extensions", ""},
+		{"pipeline:logs", "pipeline", "logs", nil},
+		{"pipeline:logs/filestream-monitoring", "pipeline", "logs/filestream-monitoring", nil},
+		{"receiver:filebeat/filestream-monitoring", "receiver", "filebeat/filestream-monitoring", nil},
+		{"exporter:elasticsearch/default", "exporter", "elasticsearch/default", nil},
+		{"invalid", "", "", fmt.Errorf("couldn't parse otel status id: %s", "invalid")},
+		{"", "", "", fmt.Errorf("couldn't parse otel status id: %s", "")},
+		{"extensions", "extensions", "", nil},
 	}
 
 	for _, test := range tests {
-		componentKind, pipelineId := parseEntityStatusId(test.id)
+		componentKind, pipelineId, err := parseEntityStatusId(test.id)
+		assert.Equal(t, test.expectedErr, err)
 		assert.Equal(t, test.expectedKind, componentKind, "component kind")
 		assert.Equal(t, test.expectedEntityID, pipelineId, "pipeline id")
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fix a bug where Elastic Agent would enter a failed state if components were running as beats receivers and the otel collector also had an extension defined via hybrid mode.

The result would be the following agent status:

```
┌─ fleet
│  └─ status: (STOPPED) Not enrolled into Fleet
└─ elastic-agent
   ├─ status: (FAILED) OTel manager failed: pipeline status id extensions is not a pipeline
   ├─ extensions
   │  ├─ status: StatusOK
   │  └─ extension:health_check/v2
   │     └─ status: StatusOK
```

## Why is it important?

We should report status for otel extensions correctly.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

Build agent locally and run it with the following configuration:

```yaml
outputs:
  default:
    type: elasticsearch
    hosts: [127.0.0.1:9200]
    username: "elastic"
    password: ""

agent:
  monitoring:
    enabled: true
    _runtime_experimental: otel

inputs: []

# Embedded Otel configuration
receivers:
  nop:
exporters:
  nop:
extensions:
  health_check/v2:
service:
  extensions: [health_check/v2]
  pipelines:
    logs:
      receivers: [nop]
      exporters: [nop]
```

Then run `elastic-agent status`. You should see the extension status and the statuses of monitoring components:

```
┌─ fleet
│  └─ status: (STOPPED) Not enrolled into Fleet
└─ elastic-agent
   ├─ status: (DEGRADED) 1 or more components/units in a degraded state
   ├─ beat/metrics-monitoring
   │  ├─ status: (DEGRADED) DEGRADED
   │  └─ beat/metrics-monitoring
   │     └─ status: (DEGRADED) Elasticsearch request failed: dial tcp 127.0.0.1:9200: connect: connection refused
   ├─ filestream-monitoring
   │  ├─ status: (DEGRADED) DEGRADED
   │  └─ filestream-monitoring
   │     └─ status: (DEGRADED) Elasticsearch request failed: dial tcp 127.0.0.1:9200: connect: connection refused
   ├─ http/metrics-monitoring
   │  ├─ status: (DEGRADED) DEGRADED
   │  └─ http/metrics-monitoring
   │     └─ status: (DEGRADED) Elasticsearch request failed: dial tcp 127.0.0.1:9200: connect: connection refused
   ├─ extensions
   │  ├─ status: StatusOK
   │  └─ extension:health_check/v2
   │     └─ status: StatusOK
   └─ pipeline:logs
      ├─ status: StatusOK
      ├─ exporter:nop
      │  └─ status: StatusOK
      └─ receiver:nop
         └─ status: StatusOK

```

## Related issues

- Closes https://github.com/elastic/ingest-dev/issues/5751
