### PR TITLE
[CI][FIPS] Remove unnecessary env vars from FIPS build pipeline steps

### DIFF
--- a/.buildkite/bk.integration-fips.pipeline.yml
+++ b/.buildkite/bk.integration-fips.pipeline.yml
@@ -36,8 +36,6 @@ steps:
       - integration-fips-cloud-image
     env:
       ASDF_TERRAFORM_VERSION: 1.9.2
-      CUSTOM_IMAGE_TAG: "git-${BUILDKITE_COMMIT:0:12}"
-      CI_ELASTIC_AGENT_DOCKER_IMAGE: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips"
       TF_VAR_integration_server_docker_image: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips:git-${BUILDKITE_COMMIT:0:12}"
     command: |
       source .buildkite/scripts/steps/ess_start.sh
@@ -58,8 +56,6 @@ steps:
           - packaging-ubuntu-x86-64-fips # Reuse artifacts produced in .buildkite/integration.pipeline.yml
         env:
           FIPS: "true"
-          CUSTOM_IMAGE_TAG: "git-${BUILDKITE_COMMIT:0:12}"
-          CI_ELASTIC_AGENT_DOCKER_IMAGE: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips"
           TF_VAR_integration_server_docker_image: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips:git-${BUILDKITE_COMMIT:0:12}"
           TEST_PACKAGE: "github.com/elastic/elastic-agent/testing/integration/ess"
         command: |
@@ -88,8 +84,6 @@ steps:
           - packaging-ubuntu-arm64-fips
         env:
           FIPS: "true"
-          CUSTOM_IMAGE_TAG: "git-${BUILDKITE_COMMIT:0:12}"
-          CI_ELASTIC_AGENT_DOCKER_IMAGE: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips"
           TF_VAR_integration_server_docker_image: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips:git-${BUILDKITE_COMMIT:0:12}"
           TEST_PACKAGE: "github.com/elastic/elastic-agent/testing/integration/ess"
         command: |


### PR DESCRIPTION
This PR removes some environment variables from steps in the FIPS build pipeline, `.buildkite/bk.integration-fips.pipeline.yml`.  It turns out these environment variables are not actually needed in these steps.

Thanks to @pkoutsovasilis for spotting this while reviewing https://github.com/elastic/elastic-agent/pull/8417.