### PR TITLE
Remove logs indicating unprivileged installation mode is still in beta

### DIFF
--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -59,7 +59,7 @@ would like the Agent to operate.
 	cmd.Flags().BoolP("force", "f", false, "Force overwrite the current installation and do not prompt for confirmation")
 	cmd.Flags().BoolP("non-interactive", "n", false, "Install Elastic Agent in non-interactive mode which will not prompt on missing parameters but fails instead.")
 	cmd.Flags().String(flagInstallBasePath, paths.DefaultBasePath, "The path where the Elastic Agent will be installed. It must be an absolute path.")
-	cmd.Flags().Bool(flagInstallUnprivileged, false, "Install in unprivileged mode, limiting the access of the Elastic Agent. (beta)")
+	cmd.Flags().Bool(flagInstallUnprivileged, false, "Install in unprivileged mode, limiting the access of the Elastic Agent.")
 	cmd.Flags().Bool(flagInstallServers, false, "Install larger version of agent that includes server components")
 
 	cmd.Flags().Bool(flagInstallRunUninstallFromBinary, false, "Run the uninstall command from this binary instead of using the binary found in the system's path.")
@@ -111,7 +111,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 
 	unprivileged, _ := cmd.Flags().GetBool(flagInstallUnprivileged)
 	if unprivileged {
-		fmt.Fprintln(streams.Out, "Unprivileged installation mode enabled; this feature is currently in beta.")
+		fmt.Fprintln(streams.Out, "Unprivileged installation mode enabled.")
 	}
 
 	isDevelopmentMode, _ := cmd.Flags().GetBool(flagInstallDevelopment)


### PR DESCRIPTION
- Closes https://github.com/elastic/elastic-agent/issues/868

Unprivileged installations came out of beta in 8.17 but we forgot to remove the logging around it. This does that.