### PR TITLE
Use a fast watcher configuration to speed up managed upgrade integration tests

### DIFF
--- a/testing/integration/ess/upgrade_fleet_test.go
+++ b/testing/integration/ess/upgrade_fleet_test.go
@@ -41,6 +41,12 @@ import (
 	"github.com/elastic/elastic-agent/testing/upgradetest"
 )
 
+const fastWatcherCfg = `
+agent.upgrade.watcher:
+  grace_period: 2m
+  error_check.interval: 5s
+`
+
 // TestFleetManagedUpgradeUnprivileged tests that the build under test can retrieve an action from
 // Fleet and perform the upgrade as an unprivileged Elastic Agent. It does not need to test
 // all the combinations of versions as the standalone tests already perform those tests and
@@ -52,7 +58,7 @@ func TestFleetManagedUpgradeUnprivileged(t *testing.T) {
 		Local: false, // requires Agent installation
 		Sudo:  true,  // requires Agent installation
 	})
-	testFleetManagedUpgrade(t, info, true, false)
+	testFleetManagedUpgrade(t, info, true, false, upgradetest.WithCustomWatcherConfig(fastWatcherCfg))
 }
 
 // TestFleetManagedUpgradePrivileged tests that the build under test can retrieve an action from
@@ -66,7 +72,7 @@ func TestFleetManagedUpgradePrivileged(t *testing.T) {
 		Local: false, // requires Agent installation
 		Sudo:  true,  // requires Agent installation
 	})
-	testFleetManagedUpgrade(t, info, false, false)
+	testFleetManagedUpgrade(t, info, false, false, upgradetest.WithCustomWatcherConfig(fastWatcherCfg))
 }
 
 // TestFleetManagedUpgradeUnprivilegedFIPS tests that the build under test can retrieve an action from
@@ -100,7 +106,7 @@ func TestFleetManagedUpgradeUnprivilegedFIPS(t *testing.T) {
 	}
 
 	postWatcherSuccessHook := upgradetest.PostUpgradeAgentIsFIPSCapable
-	upgradeOpts := []upgradetest.UpgradeOpt{upgradetest.WithPostWatcherSuccessHook(postWatcherSuccessHook)}
+	upgradeOpts := []upgradetest.UpgradeOpt{upgradetest.WithPostWatcherSuccessHook(postWatcherSuccessHook), upgradetest.WithCustomWatcherConfig(fastWatcherCfg)}
 	testFleetManagedUpgrade(t, info, true, true, upgradeOpts...)
 }
 
@@ -312,7 +318,7 @@ func TestFleetUpgradeToPRBuild(t *testing.T) {
 	t.Logf("policy %s using DownloadSourceID: %s",
 		policy.ID, policy.DownloadSourceID)
 
-	testUpgradeFleetManagedElasticAgent(ctx, t, stack, fromFixture, toFixture, policy, false)
+	testUpgradeFleetManagedElasticAgent(ctx, t, stack, fromFixture, toFixture, policy, false, upgradetest.WithCustomWatcherConfig(fastWatcherCfg))
 }
 
 func testFleetAirGappedUpgrade(t *testing.T, stack *define.Info, unprivileged bool) {
@@ -380,7 +386,7 @@ func testFleetAirGappedUpgrade(t *testing.T, stack *define.Info, unprivileged bo
 	policy := defaultPolicy()
 	policy.DownloadSourceID = src.Item.ID
 
-	testUpgradeFleetManagedElasticAgent(ctx, t, stack, fixture, upgradeTo, policy, unprivileged)
+	testUpgradeFleetManagedElasticAgent(ctx, t, stack, fixture, upgradeTo, policy, unprivileged, upgradetest.WithCustomWatcherConfig(fastWatcherCfg))
 }
 
 func testUpgradeFleetManagedElasticAgent(


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR uses a faster watcher configuration with Fleet integration tests in order to speed up execution times.
It builds upon changes brought in main by PR #8407.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
To have a quicker integration test execution time
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
