### PR TITLE
[AutoOps] Add `autoops-es.yml` to Packages

### DIFF
--- a/autoops-es.yml
+++ b/autoops-es.yml
@@ -1,0 +1,43 @@
+receivers:
+  metricbeatreceiver:
+    metricbeat:
+      modules:
+        # Metrics
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 10s
+          metricsets:
+            - cat_shards
+            - cluster_health
+            - cluster_settings
+            - license
+            - node_stats
+            - tasks_management
+        # Templates
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 24h
+          metricsets:
+            - cat_template
+            - component_template
+            - index_template
+    processors:
+      - add_fields:
+          target: autoops_es
+          fields:
+            token2: ${env:AUTOOPS_TOKEN}
+    output:
+      otelconsumer:
+    telemetry_types: ["logs"]
+
+exporters:
+  otlphttp:
+    headers:
+      Authorization: "AutoOpsToken ${env:AUTOOPS_TOKEN}"
+    endpoint: ${env:AUTOOPS_OTEL_URL}
+
+service:
+  pipelines:  
+    logs:
+      receivers: [metricbeatreceiver]
+      exporters: [otlphttp]

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -270,6 +270,10 @@ shared:
         content: >
           {{ commit }}
         mode: 0644
+      /etc/{{.BeatName}}/autoops-es.yml:
+        source: 'autoops-es.yml'
+        mode: 0600
+        config: true
       /etc/{{.BeatName}}/elastic-agent.reference.yml:
         source: 'elastic-agent.reference.yml'
         mode: 0644
@@ -339,6 +343,10 @@ shared:
       content: >
         {{ commit }}
       mode: 0644
+    'autoops-es.yml':
+      source: 'autoops-es.yml'
+      mode: 0600
+      config: true
     'elastic-agent.reference.yml':
       source: 'elastic-agent.reference.yml'
       mode: 0644
@@ -512,6 +520,10 @@ shared:
       linux_capabilities: ''
       beats_install_path: "install"
     files:
+      'autoops-es.yml':
+        source: 'autoops-es.yml'
+        mode: 0600
+        config: true
       'elastic-agent.yml':
         source: 'elastic-agent.docker.yml'
         mode: 0600
@@ -607,6 +619,10 @@ shared:
       linux_capabilities: ''
       beats_install_path: "install"
     files:
+      'autoops-es.yml':
+        source: 'autoops-es.yml'
+        mode: 0600
+        config: true
       'elastic-agent.yml':
         source: 'elastic-agent.docker.yml'
         mode: 0600
@@ -638,6 +654,10 @@ shared:
       linux_capabilities: ''
       beats_install_path: "install"
     files:
+      'autoops-es.yml':
+        source: 'autoops-es.yml'
+        mode: 0600
+        config: true
       'elastic-agent.yml':
         source: 'elastic-agent.docker.yml'
         mode: 0600


### PR DESCRIPTION
This adds the `autoops-es.yml` to enable simpler configuration for users that would like to make use of AutoOps to ship data.

## What does this PR do?

Adds a configuration to all non-FIPS releases for AutoOps (AutoOps is untested in FIPS environments) so that users can run (directly or indirectly) `elastic-agent otel autoops-es.yml` with the supplied environment variables.

## Why is it important?

Rather than forcing users to provide their own configuration for what is a standard one, we can help them all by providing one source of truth.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

This only adds a configuration file. There is no disruption beyond an extra file for those that do not want it.

## How to test this PR locally

Run the OTel configuration:

```
./elastic-agent otel --config autoops-es.yml
```

## Related issues

- Relates https://github.com/elastic/opex-product/issues/475

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
