### PR TITLE
kustomize: pin kube-state-metrics version

### DIFF
--- a/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-managed/kustomization.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-managed/kustomization.yaml
@@ -15,7 +15,7 @@ configMapGenerator:
 
 resources:
   - ./base
-  - https://github.com/kubernetes/kube-state-metrics
+  - https://github.com/kubernetes/kube-state-metrics/?ref=v2.15.0
 
 patches:
 - path: environmental-variables-remove.yaml

--- a/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/kustomization.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/kustomization.yaml
@@ -16,7 +16,7 @@ configMapGenerator:
   
 resources:
   - ./base
-  - https://github.com/kubernetes/kube-state-metrics/
+  - https://github.com/kubernetes/kube-state-metrics/?ref=v2.15.0
 
 patches:
 - path: environmental-variables-remove.yaml

--- a/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-managed/kustomization.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-managed/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: kube-system
 
 resources:
   - ./base
-  - https://github.com/kubernetes/kube-state-metrics/examples/autosharding
+  - https://github.com/kubernetes/kube-state-metrics/examples/autosharding?ref=v2.15.0
 replicas:
   - name: kube-state-metrics
     count: 2

--- a/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/kustomization.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 namespace: kube-system
 
 resources:
-  - https://github.com/kubernetes/kube-state-metrics/examples/autosharding
+  - https://github.com/kubernetes/kube-state-metrics/examples/autosharding?ref=v2.15.0
   - ./base
 replicas:
   - name: kube-state-metrics


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

The check-ci step started failing today ([link](https://buildkite.com/elastic/elastic-agent/builds/23277#0197c130-dde9-405d-a05e-281e85036fd1/409-428)). After examining the failure reason, I realised that we don't pin kube-state-metrics in the kustomize templates and because the check-ci detects differences it fails. IMO we should always ship artifacts with pinned dependencies, and every dependency version bump should first pass through our CI and then get released. So this PR pins kube-state-metrics in kustomize to version `v2.15.0`

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

It is important to control the version of dependencies in the artifacts we maintain.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None the pinning is already happening to a version that customer should be already at.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
mage integration:buildKubernetesTestData

EXTERNAL=true SNAPSHOT=true PACKAGES=docker DOCKER_VARIANTS=basic PLATFORMS=linux/arm64 mage package

INSTANCE_PROVISIONER="kind" TEST_PLATFORMS="kubernetes/arm64/1.33.0/basic" mage integration:TestKubernetes
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
N/A
