### PR TITLE
fix: don't override log level from state for standalone agents

### DIFF
--- a/changelog/fragments/1751455886-correct-log-level-for-standalone-agents.yaml
+++ b/changelog/fragments/1751455886-correct-log-level-for-standalone-agents.yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+summary: Ensure standalone Elastic Agent uses log level from configuration instead of persisted state
+component: elastic-agent
+pr: https://github.com/elastic/elastic-agent/pull/8784
+issue: https://github.com/elastic/elastic-agent/issues/8137

--- a/internal/pkg/agent/application/info/agent_info.go
+++ b/internal/pkg/agent/application/info/agent_info.go
@@ -60,6 +60,9 @@ type AgentInfo struct {
 	esHeaders map[string]string
 }
 
+// for unit testing
+var doLoadAgentInfoWithBackoff = loadAgentInfoWithBackoff
+
 // NewAgentInfoWithLog creates a new agent information.
 // In case when agent ID was already created it returns,
 // this created ID otherwise it generates
@@ -67,7 +70,7 @@ type AgentInfo struct {
 // If agent config file does not exist it gets created.
 // Initiates log level to predefined value.
 func NewAgentInfoWithLog(ctx context.Context, level string, createAgentID bool) (*AgentInfo, error) {
-	agentInfo, isStandalone, err := loadAgentInfoWithBackoff(ctx, false, level, createAgentID)
+	agentInfo, isStandalone, err := doLoadAgentInfoWithBackoff(ctx, false, level, createAgentID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/agent/application/info/agent_info.go
+++ b/internal/pkg/agent/application/info/agent_info.go
@@ -76,9 +76,13 @@ func NewAgentInfoWithLog(ctx context.Context, level string, createAgentID bool) 
 		return nil, fmt.Errorf("failed to determine root/Administrator: %w", err)
 	}
 
+	if !isStandalone {
+		level = agentInfo.LogLevel
+	}
+
 	return &AgentInfo{
 		agentID:      agentInfo.ID,
-		logLevel:     agentInfo.LogLevel,
+		logLevel:     level,
 		unprivileged: !isRoot,
 		esHeaders:    agentInfo.Headers,
 		isStandalone: isStandalone,

--- a/internal/pkg/agent/application/info/agent_info_test.go
+++ b/internal/pkg/agent/application/info/agent_info_test.go
@@ -1,0 +1,73 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package info
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAgentInfoWithLog(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		levelFromConfig     string
+		isStandalone        bool
+		persistentAgentInfo *persistentAgentInfo
+		expected            *AgentInfo
+	}{
+		{
+			name:            "standalone agent",
+			levelFromConfig: "debug",
+			isStandalone:    true,
+			persistentAgentInfo: &persistentAgentInfo{
+				ID:             "testID",
+				Headers:        nil,
+				LogLevel:       "info",
+				MonitoringHTTP: nil,
+			},
+			expected: &AgentInfo{
+				agentID:      "testID",
+				logLevel:     "debug",
+				unprivileged: true,
+				esHeaders:    nil,
+				isStandalone: true,
+			},
+		},
+		{
+			name:            "fleet managed agent",
+			levelFromConfig: "debug",
+			isStandalone:    false,
+			persistentAgentInfo: &persistentAgentInfo{
+				ID:             "testID",
+				Headers:        nil,
+				LogLevel:       "info",
+				MonitoringHTTP: nil,
+			},
+			expected: &AgentInfo{
+				agentID:      "testID",
+				logLevel:     "info",
+				unprivileged: true,
+				esHeaders:    nil,
+				isStandalone: false,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prevDoLoadAgentInfoWithBackoff := doLoadAgentInfoWithBackoff
+			defer func() {
+				doLoadAgentInfoWithBackoff = prevDoLoadAgentInfoWithBackoff
+			}()
+			doLoadAgentInfoWithBackoff = func(ctx context.Context, forceUpdate bool, logLevel string, createAgentID bool) (*persistentAgentInfo, bool, error) {
+				return tc.persistentAgentInfo, tc.isStandalone, nil
+			}
+
+			ai, err := NewAgentInfoWithLog(context.Background(), tc.levelFromConfig, true)
+			assert.NoError(t, err, "could not create agent info")
+			assert.Equal(t, tc.expected, ai, "agent info does not match")
+		})
+	}
+}

--- a/internal/pkg/agent/application/info/agent_info_test.go
+++ b/internal/pkg/agent/application/info/agent_info_test.go
@@ -8,10 +8,17 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/pkg/utils"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewAgentInfoWithLog(t *testing.T) {
+	hasRoot, err := utils.HasRoot()
+	require.NoError(t, err, "failed to check for root")
+
 	for _, tc := range []struct {
 		name                string
 		levelFromConfig     string
@@ -32,7 +39,7 @@ func TestNewAgentInfoWithLog(t *testing.T) {
 			expected: &AgentInfo{
 				agentID:      "testID",
 				logLevel:     "debug",
-				unprivileged: true,
+				unprivileged: !hasRoot,
 				esHeaders:    nil,
 				isStandalone: true,
 			},
@@ -50,7 +57,7 @@ func TestNewAgentInfoWithLog(t *testing.T) {
 			expected: &AgentInfo{
 				agentID:      "testID",
 				logLevel:     "info",
-				unprivileged: true,
+				unprivileged: !hasRoot,
 				esHeaders:    nil,
 				isStandalone: false,
 			},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR fixes a bug where the log level for standalone Elastic Agent installations was incorrectly restored from the persisted state directory (`/var/lib/elastic-agent-standalone/...`) instead of being sourced from the current configuration file. This resulted in stale configuration values after updates to the ConfigMap, particularly when the pod was restarted without clearing the state directory.

The change ensures that for standalone mode, the `log.level` value is always taken from the configuration, not restored from previously persisted agent state. For managed (Fleet) mode, the previous behavior is preserved.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This fix addresses an issue where changes to logging configuration were not taking effect unless the agent's state directory was manually deleted. This led to operational confusion and could cause logs to be emitted at incorrect verbosity levels.

Ensuring that the standalone agent reliably reflects the current configuration helps users maintain observability and avoid side effects like duplicated logs when restarting pods.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

This change should not cause disruption. It fixes the logic so that standalone agents correctly reflect updated configuration values after pod restarts, without requiring manual state cleanup. Users relying on previously persisted log levels (instead of ConfigMap changes) may see a difference in behavior, but this aligns with the intended functionality.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
helm install elastic-agent ./deploy/helm/elastic-agent -n kube-system  --set outputs.default.type=ESPlainAuthBasic --set outputs.default.url='...' --set outputs.default.username='...' --set outputs.default.password='...' --set agent.presets.perNode.agent.logging.level=info

helm upgrade elastic-agent ./deploy/helm/elastic-agent -n kube-system  --set outputs.default.type=ESPlainAuthBasic --set outputs.default.url='...' --set outputs.default.username='...' --set outputs.default.password='...' --set agent.presets.perNode.agent.logging.level=debug
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/8137