### PR TITLE
bk: refactor env variables that are not redacted

### DIFF
--- a/.buildkite/scripts/steps/sync-k8s.sh
+++ b/.buildkite/scripts/steps/sync-k8s.sh
@@ -6,12 +6,6 @@ export PATH=$HOME/bin:${PATH}
 source .buildkite/scripts/install-gh.sh
 source .buildkite/scripts/common.sh
 
-echo "--- [Prepare env] Create required env variables"
-GITHUB_USERNAME_SECRET="elasticmachine"
-export GITHUB_USERNAME_SECRET=$GITHUB_USERNAME_SECRET
-export GITHUB_EMAIL_SECRET="elasticmachine@elastic.co"
-export GITHUB_TOKEN_SECRET=$VAULT_GITHUB_TOKEN
-
 cd deploy/kubernetes
 
 echo "--- [File Creation] Create-Needed-Manifest"

--- a/deploy/kubernetes/Makefile
+++ b/deploy/kubernetes/Makefile
@@ -10,6 +10,8 @@ ELASTIC_AGENT_REPO=kibana
 ELASTIC_AGENT_REPO_PATH=x-pack/plugins/fleet/server/services/
 FILE_REPO=elastic_agent_manifest.ts
 ELASTIC_AGENT_BRANCH=update-k8s-templates-$(shell date "+%Y%m%d%H%M%S")
+GITHUB_USERNAME?=elasticmachine
+GITHUB_EMAIL?=elasticmachine@elastic.co
 
 #variable needed for kustomize build
 KUSTOMIZE=elastic-agent-kustomize
@@ -69,9 +71,9 @@ $(eval HASDIFF =$(shell sh -c "git status | grep $(FILE_REPO) | wc -l"))
 ci-create-kubernetes-templates-pull-request:
 ifeq ($(HASDIFF),1)
 	echo "INFO: Create branch to update k8s templates"	
-	@git config user.name "elasticmachine"
-	@git config user.email "elasticmachine@elastic.co"
-	@git config remote.origin.url "https://elasticmachine:${VAULT_GITHUB_TOKEN}@github.com/elastic/kibana.git"
+	@git config user.name "$(GITHUB_USERNAME)"
+	@git config user.email "$(GITHUB_EMAIL)"
+	@git config remote.origin.url "https://$(GITHUB_USERNAME):${VAULT_GITHUB_TOKEN}@github.com/elastic/kibana.git"
 	git checkout -b $(ELASTIC_AGENT_BRANCH)
 	echo "INFO: add files if any"
 	git add $(ELASTIC_AGENT_REPO_PATH)$(FILE_REPO)

--- a/deploy/kubernetes/Makefile
+++ b/deploy/kubernetes/Makefile
@@ -69,9 +69,9 @@ $(eval HASDIFF =$(shell sh -c "git status | grep $(FILE_REPO) | wc -l"))
 ci-create-kubernetes-templates-pull-request:
 ifeq ($(HASDIFF),1)
 	echo "INFO: Create branch to update k8s templates"	
-	@git config user.name "${GITHUB_USERNAME_SECRET}"
-	@git config user.email "${GITHUB_EMAIL_SECRET}"
-	@git config remote.origin.url "https://${GITHUB_USERNAME_SECRET}:${GITHUB_TOKEN_SECRET}@github.com/elastic/kibana.git"
+	@git config user.name "elasticmachine"
+	@git config user.email "elasticmachine@elastic.co"
+	@git config remote.origin.url "https://elasticmachine:${VAULT_GITHUB_TOKEN}@github.com/elastic/kibana.git"
 	git checkout -b $(ELASTIC_AGENT_BRANCH)
 	echo "INFO: add files if any"
 	git add $(ELASTIC_AGENT_REPO_PATH)$(FILE_REPO)
@@ -86,7 +86,7 @@ else
 	echo "INFO: push branch"
 	@git push --set-upstream origin $(ELASTIC_AGENT_BRANCH)
 	echo "INFO: create pull request"
-	@GITHUB_TOKEN=$(GITHUB_TOKEN_SECRET) gh pr create \
+	@GITHUB_TOKEN=$(VAULT_GITHUB_TOKEN) gh pr create \
 		--title "Update kubernetes templates for elastic-agent" \
 		--body "Automated by ${BUILDKITE_BUILD_URL}" \
 		--label automation \


### PR DESCRIPTION
## What does this PR do?

Simplify the scripts and use the variables with default values where they are actually used.

## Why is it important?

https://github.com/elastic/elastic-agent/pull/4528 introduced some env variables but those env variables are not redacted, that's only happening when using the `pre-command` hook. 

<img width="1086" alt="image" src="https://github.com/user-attachments/assets/b58da09d-e27a-4d9c-9f86-70da6da99e95" />


https://github.com/elastic/elastic-agent/pull/5027 changed to use the ephemeral GitHub token.

Since those variables are used in the Makefile, I decided to create them with some default values in the Makefile itself. They can be changed if needed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
