### PR TITLE
[CODEOWNERS] Set `otel_samples/autoops_es.yml` ownership to OpEx team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,6 @@
 /deploy/kubernetes @elastic/elastic-agent-control-plane
 /dev-tools/kubernetes @elastic/elastic-agent-control-plane
 /internal/pkg/composable/providers/kubernetes @elastic/elastic-agent-control-plane
+/internal/pkg/otel/samples/darwin/autoops_es.yml @elastic/opex
+/internal/pkg/otel/samples/linux/autoops_es.yml @elastic/opex
+/internal/pkg/otel/samples/windows/autoops_es.yml @elastic/opex


### PR DESCRIPTION
The team will need to be given write access to the repo (like the `beats` repo) to stop `CODEOWNERS` from complaining about errors in the file.

It locally complained when I tried to wildcard the OS directory, so I just listed all three variants (which are identical) explicitly.

I'm unsure if this should be backported to 9.1 where that file also lives or not.