### PR TITLE
flaky: ignore errors about non existing files in validateFileTree

### DIFF
--- a/testing/installtest/checks_unix.go
+++ b/testing/installtest/checks_unix.go
@@ -130,6 +130,9 @@ func checkPlatform(ctx context.Context, _ *atesting.Fixture, topPath string, opt
 func validateFileTree(dir string, uid uint32, gid uint32) error {
 	return filepath.WalkDir(dir, func(file string, d fs.DirEntry, err error) error {
 		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
 			return fmt.Errorf("error traversing the file tree: %w", err)
 		}
 		if d.Type() == os.ModeSymlink {
@@ -138,6 +141,9 @@ func validateFileTree(dir string, uid uint32, gid uint32) error {
 		}
 		info, err := d.Info()
 		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
 			return fmt.Errorf("error caling info: %w", err)
 		}
 		fs, ok := info.Sys().(*syscall.Stat_t)

--- a/testing/installtest/checks_unix.go
+++ b/testing/installtest/checks_unix.go
@@ -141,7 +141,7 @@ func validateFileTree(dir string, uid uint32, gid uint32) error {
 		}
 		info, err := d.Info()
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				return nil
 			}
 			return fmt.Errorf("error caling info: %w", err)

--- a/testing/installtest/checks_unix.go
+++ b/testing/installtest/checks_unix.go
@@ -130,7 +130,7 @@ func checkPlatform(ctx context.Context, _ *atesting.Fixture, topPath string, opt
 func validateFileTree(dir string, uid uint32, gid uint32) error {
 	return filepath.WalkDir(dir, func(file string, d fs.DirEntry, err error) error {
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				return nil
 			}
 			return fmt.Errorf("error traversing the file tree: %w", err)

--- a/testing/installtest/checks_unix.go
+++ b/testing/installtest/checks_unix.go
@@ -8,6 +8,7 @@ package installtest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"math"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR adjusts the `validateFileTree` function in `installtest/checks_unix.go` to gracefully ignore `os.ErrNotExist` errors when traversing the Elastic Agent installation directory. Specifically, during file tree validation, if a file or directory no longer exists at the time of inspection, the function will now skip over it instead of failing the entire validation.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This change addresses flakiness in the `TestRepeatedInstallUninstallFleet` test. The test occasionally fails due to transient files (e.g., `.new` files) being deleted or replaced during the validation process. Since some of these files are expected to be short-lived or replaced atomically, their absence should not be treated as a fatal error.

By skipping over non-existent files, we reduce false negatives in tests and make the test suite more stable and reliable.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None. This change affects internal test logic only and does not impact user-facing functionality.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
mage unitTest
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/8376