### PR TITLE
fix: blocking issues of runtime communicator

### DIFF
--- a/changelog/fragments/1751960319-fix-blocking-issues-inside-runtime-communicator.yaml
+++ b/changelog/fragments/1751960319-fix-blocking-issues-inside-runtime-communicator.yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+summary: Resolve deadlocks in runtime checkin communication
+component: elastic-agent
+pr: https://github.com/elastic/elastic-agent/pull/8881
+issue: https://github.com/elastic/elastic-agent/issues/7944

--- a/pkg/component/runtime/runtime_comm.go
+++ b/pkg/component/runtime/runtime_comm.go
@@ -442,7 +442,7 @@ func genServerName() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.Replace(u.String(), "-", "", -1), nil
+	return strings.ReplaceAll(u.String(), "-", ""), nil
 }
 
 func sendExpectedChunked(server proto.ElasticAgent_CheckinV2Server, msg *proto.CheckinExpected, chunkingAllowed bool, maxSize int) error {

--- a/pkg/component/runtime/runtime_comm.go
+++ b/pkg/component/runtime/runtime_comm.go
@@ -27,7 +27,7 @@ import (
 
 // Communicator provides an interface for a runtime to communicate with its running component.
 type Communicator interface {
-	// WriteConnInfo writes the connection information to the writer, informing the component it has access
+	// WriteStartUpInfo writes the connection information to the writer, informing the component it has access
 	// to the provided services.
 	WriteStartUpInfo(w io.Writer, services ...client.Service) error
 	// CheckinExpected sends the expected state to the component.
@@ -63,6 +63,7 @@ type runtimeComm struct {
 	initCheckinObserved   *proto.CheckinObserved
 	initCheckinExpectedCh chan *proto.CheckinExpected
 	initCheckinObservedMx sync.Mutex
+	runtimeCheckinDone    chan struct{}
 
 	actionsConn     bool
 	actionsDone     chan bool
@@ -85,21 +86,22 @@ func newRuntimeComm(logger *logger.Logger, listenAddr string, ca *authority.Cert
 		return nil, err
 	}
 	return &runtimeComm{
-		logger:          logger,
-		listenAddr:      listenAddr,
-		ca:              ca,
-		agentInfo:       agentInfo,
-		name:            name,
-		token:           token.String(),
-		cert:            pair,
-		maxMessageSize:  maxMessageSize,
-		chunkingAllowed: false, // not allow until the client says they support it
-		checkinConn:     true,
-		checkinExpected: make(chan *proto.CheckinExpected, 1),
-		checkinObserved: make(chan *proto.CheckinObserved),
-		actionsConn:     true,
-		actionsRequest:  make(chan *proto.ActionRequest),
-		actionsResponse: make(chan *proto.ActionResponse),
+		logger:                logger,
+		listenAddr:            listenAddr,
+		ca:                    ca,
+		agentInfo:             agentInfo,
+		name:                  name,
+		token:                 token.String(),
+		cert:                  pair,
+		maxMessageSize:        maxMessageSize,
+		chunkingAllowed:       false, // not allow until the client says they support it
+		checkinConn:           true,
+		initCheckinExpectedCh: make(chan *proto.CheckinExpected),
+		checkinExpected:       make(chan *proto.CheckinExpected, 1),
+		checkinObserved:       make(chan *proto.CheckinObserved),
+		actionsConn:           true,
+		actionsRequest:        make(chan *proto.ActionRequest),
+		actionsResponse:       make(chan *proto.ActionResponse),
 	}, nil
 }
 
@@ -152,7 +154,6 @@ func (c *runtimeComm) CheckinExpected(
 	expected *proto.CheckinExpected,
 	observed *proto.CheckinObserved,
 ) {
-	c.agentInfo.Unprivileged()
 	if c.agentInfo != nil && c.agentInfo.AgentID() != "" {
 		expected.AgentInfo = &proto.AgentInfo{
 			Id:           c.agentInfo.AgentID(),
@@ -165,35 +166,49 @@ func (c *runtimeComm) CheckinExpected(
 		expected.AgentInfo = nil
 	}
 
-	// we need to determine if the communicator is currently in the initial observed message path
-	// in the case that it is we send the expected state over a different channel
+	// we need to determine if the communicator is currently waiting to complete the initial checkin process
+	// and if the given observed message is the same as the one the communicator is waiting for
 	c.initCheckinObservedMx.Lock()
-	initObserved := c.initCheckinObserved
-	expectedCh := c.initCheckinExpectedCh
-	if initObserved != nil {
-		// the next call to `CheckinExpected` must be from the initial `CheckinObserved` message
-		if observed != initObserved {
-			// not the initial observed message; we don't send it
-			c.initCheckinObservedMx.Unlock()
-			return
-		}
-		// it is the expected from the initial observed message
-		// clear the initial state
+	// waitingForInitCheckin captures if communicator is waiting to complete the initial checkin process
+	waitingForInitCheckin := c.initCheckinObserved != nil
+	// shouldIgnore captures if we should ignore this checkin expected taking into account waitingForInitCheckin
+	shouldIgnore := waitingForInitCheckin && c.initCheckinObserved != observed
+	if waitingForInitCheckin && !shouldIgnore {
+		// here the given observed message is the same as the one the communicator is waiting for to complete
+		// the initial checkin process, thus clear the state
 		c.initCheckinObserved = nil
-		c.initCheckinExpectedCh = nil
-		c.initCheckinObservedMx.Unlock()
-		expectedCh <- expected
-		return
 	}
+	// when doneCh is closed the communicator is done and sending to any of the checkin expected channels,
+	// namely init (c.initCheckinExpectedCh) and regular (c.checkinExpected), should unblock
+	doneCh := c.runtimeCheckinDone
 	c.initCheckinObservedMx.Unlock()
 
-	// not in the initial observed message path; send it over the standard channel
-	// clear channel making it the latest expected message
-	select {
-	case <-c.checkinExpected:
-	default:
+	if shouldIgnore {
+		// ignore this checkin expected
+		return
 	}
-	c.checkinExpected <- expected
+
+	if waitingForInitCheckin {
+		// send to the init checkin expected channel
+		// no draining here as we don't want to lose any message
+		select {
+		case <-doneCh:
+		case c.initCheckinExpectedCh <- expected:
+		}
+	} else {
+		// send to the regular checkin expected channel and drain it
+		// as we care only about the last message being sent
+		select {
+		case <-c.checkinExpected:
+		default:
+		}
+
+		select {
+		case <-doneCh:
+			// this isn't exactly required but better safe than SDH
+		case c.checkinExpected <- expected:
+		}
+	}
 }
 
 func (c *runtimeComm) CheckinObserved() <-chan *proto.CheckinObserved {
@@ -225,69 +240,40 @@ func (c *runtimeComm) checkin(server proto.ElasticAgent_CheckinV2Server, init *p
 		c.checkinLock.Unlock()
 	}()
 
-	initExp := make(chan *proto.CheckinExpected)
-	recvDone := make(chan bool)
-	sendDone := make(chan bool)
-	go func() {
-		defer func() {
-			close(sendDone)
-		}()
-
-		// initial startup waits for the first expected message from the dedicated initExp channel
-		select {
-		case <-checkinDone:
-			return
-		case <-recvDone:
-			return
-		case expected := <-initExp:
-			err := sendExpectedChunked(server, expected, c.chunkingAllowed, c.maxMessageSize)
-			if err != nil {
-				if reportableErr(err) {
-					c.logger.Debugf("check-in stream failed to send initial expected state: %s", err)
-				}
-				return
-			}
-		}
-
-		for {
-			var expected *proto.CheckinExpected
-			select {
-			case <-checkinDone:
-				return
-			case <-recvDone:
-				return
-			case expected = <-c.checkinExpected:
-			}
-
-			err := sendExpectedChunked(server, expected, c.chunkingAllowed, c.maxMessageSize)
-			if err != nil {
-				if reportableErr(err) {
-					c.logger.Debugf("check-in stream failed to send expected state: %s", err)
-				}
-				return
-			}
-		}
-	}()
-
-	// at this point the client is connected, and it has sent it's first initial checkin
-	// the initial expected message must come before the sender goroutine will send any other
-	// expected messages. `CheckinExpected` method will also drop any expected messages that do not
-	// match the observed message to ensure that the expected that we receive is from the initial
-	// observed state.
 	c.initCheckinObservedMx.Lock()
-	c.initCheckinObserved = init
-	c.initCheckinExpectedCh = initExp
 	// clears the latest queued expected message
 	select {
 	case <-c.checkinExpected:
 	default:
 	}
+	c.initCheckinObserved = init
+	c.runtimeCheckinDone = make(chan struct{})
 	c.initCheckinObservedMx.Unlock()
+	defer func() {
+		close(c.runtimeCheckinDone)
+	}()
 
-	// send the initial message (manager then calls `CheckinExpected` method with the result)
-	c.checkinObserved <- init
+	// send the initial observed message, so the respective runtime (e.g. commandRuntime, serviceRuntime, etc. )
+	// then calls CheckinExpected method with the result
+	select {
+	case <-checkinDone:
+		// runtimeComm is destroyed return
+		return status.Error(codes.Unavailable, "component is being destroyed")
+	case c.checkinObserved <- init:
+	}
 
+	recvDone := make(chan bool)
 	go func() {
+		// this goroutine will not be leaked, because when the server CheckinV2 function
+		// returns (lives inside the manager) it will close the connection.
+		// That will cause the chunk.RecvObserved function to return with an error and thus
+		// this goroutine will exit. Another reason that this goroutine could exit for
+		// is if the checkinDone channel is closed which happens when the runtimeComm is
+		// destroyed (when the runtime.Run() exits).
+		defer func() {
+			close(recvDone)
+		}()
+
 		for {
 			// always allow a chunked observed message to be received
 			checkin, err := chunk.RecvObserved(server)
@@ -295,15 +281,52 @@ func (c *runtimeComm) checkin(server proto.ElasticAgent_CheckinV2Server, init *p
 				if reportableErr(err) {
 					c.logger.Debugf("check-in stream failed to receive data: %s", err)
 				}
-				close(recvDone)
 				return
 			}
-			c.checkinObserved <- checkin
+			select {
+			case <-checkinDone:
+				// runtimeComm is destroyed return
+				return
+			case c.checkinObserved <- checkin:
+			}
 		}
 	}()
 
-	<-sendDone
-	return nil
+	initCheckinCompleted := false
+	var afterInitCheckinExpectedCh chan *proto.CheckinExpected
+	for {
+		var expected *proto.CheckinExpected
+		select {
+		case <-checkinDone:
+			// runtimeComm is destroyed return
+			return status.Error(codes.Unavailable, "component is being destroyed")
+		case <-recvDone:
+			// the goroutine that receives observed messages has exited we can't continue
+			// This acts also as a proxy to the server.Context().Done() method which
+			// will be closed when the server is closed.
+			return status.Error(codes.Unavailable, "component is being destroyed")
+		case expected = <-c.initCheckinExpectedCh:
+			// unbuffered channel to receive the first expected state
+			if !initCheckinCompleted {
+				initCheckinCompleted = true
+				afterInitCheckinExpectedCh = c.checkinExpected
+			} else {
+				// this shouldn't occur, but better safe than SDH
+				c.logger.Warn("check-in stream received unexpected init expected state, ignoring...")
+				continue
+			}
+		case expected = <-afterInitCheckinExpectedCh:
+		}
+
+		err := sendExpectedChunked(server, expected, c.chunkingAllowed, c.maxMessageSize)
+		if err != nil {
+			c.logger.Debugf("check-in stream failed to send expected state: %s", err)
+			if reportableErr(err) {
+				return err
+			}
+			return nil
+		}
+	}
 }
 
 func (c *runtimeComm) actions(server proto.ElasticAgent_ActionsServer) error {

--- a/pkg/component/runtime/runtime_comm.go
+++ b/pkg/component/runtime/runtime_comm.go
@@ -247,11 +247,12 @@ func (c *runtimeComm) checkin(server proto.ElasticAgent_CheckinV2Server, init *p
 	default:
 	}
 	c.initCheckinObserved = init
-	c.runtimeCheckinDone = make(chan struct{})
+	runtimeCheckinDone := make(chan struct{})
+	c.runtimeCheckinDone = runtimeCheckinDone
 	c.initCheckinObservedMx.Unlock()
-	defer func() {
-		close(c.runtimeCheckinDone)
-	}()
+	defer func(ch chan struct{}) {
+		close(ch)
+	}(runtimeCheckinDone)
 
 	// send the initial observed message, so the respective runtime (e.g. commandRuntime, serviceRuntime, etc. )
 	// then calls CheckinExpected method with the result

--- a/pkg/component/runtime/runtime_comm_test.go
+++ b/pkg/component/runtime/runtime_comm_test.go
@@ -186,7 +186,10 @@ func TestRuntimeComm_CheckinFlow(t *testing.T) {
 				// stop the server
 				srv.stop(nil)
 				select {
-				case <-errCh:
+				case err = <-errCh:
+					s, ok := status.FromError(err)
+					assert.True(t, ok, "error must be a gRPC status")
+					assert.Equal(t, codes.Unavailable, s.Code(), "status code must be unavailable")
 				case <-time.After(waitDuration):
 					t.Fatal("timed out waiting for the checkin to return")
 				}
@@ -246,7 +249,10 @@ func TestRuntimeComm_CheckinFlow(t *testing.T) {
 				// destroy the communicator and check that it exits without blocking
 				c.destroy()
 				select {
-				case <-errCh:
+				case err := <-errCh:
+					s, ok := status.FromError(err)
+					assert.True(t, ok, "error must be a gRPC status")
+					assert.Equal(t, codes.Unavailable, s.Code(), "status code must be unavailable")
 				case <-time.After(waitDuration):
 					t.Fatal("timed out waiting for the checkin to return")
 				}
@@ -295,7 +301,10 @@ func TestRuntimeComm_CheckinFlow(t *testing.T) {
 				// stop the server and wait for communicator checkin to exit
 				srv.stop(nil)
 				select {
-				case <-errCh:
+				case err := <-errCh:
+					s, ok := status.FromError(err)
+					assert.True(t, ok, "error must be a gRPC status")
+					assert.Equal(t, codes.Unavailable, s.Code(), "status code must be unavailable")
 				case <-time.After(waitDuration):
 					t.Fatal("timed out waiting for the checkin to return")
 				}
@@ -541,7 +550,10 @@ func TestRuntimeComm_CheckinFlow(t *testing.T) {
 				// stop the server and wait for communicator checkin to exit
 				srv.stop(nil)
 				select {
-				case <-errCh:
+				case err := <-errCh:
+					s, ok := status.FromError(err)
+					assert.True(t, ok, "error must be a gRPC status")
+					assert.Equal(t, codes.Unavailable, s.Code(), "status code must be unavailable")
 				case <-time.After(waitDuration):
 					t.Fatal("timed out waiting for the checkin to return")
 				}

--- a/pkg/component/runtime/runtime_comm_test.go
+++ b/pkg/component/runtime/runtime_comm_test.go
@@ -9,15 +9,20 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
 	"github.com/elastic/elastic-agent/internal/pkg/core/authority"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
+	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
 )
 
 type agentInfoMock struct {
@@ -127,4 +132,558 @@ func TestRuntimeComm_WriteStartUpInfo_packageVersion(t *testing.T) {
 
 	assert.Equal(t, &want, clientv2.AgentInfo(),
 		"agent info returned by client must match what has been written on command input")
+}
+
+func TestRuntimeComm_CheckinFlow(t *testing.T) {
+	ca, caErr := authority.NewCA()
+	require.NoError(t, caErr, "could not create CA")
+
+	// remember we have slow runners in the CI
+	const waitDuration = 20 * time.Second
+
+	for _, tc := range []struct {
+		name         string
+		validateFlow func(t *testing.T, c *runtimeComm, srv *testServer)
+	}{
+		{
+			name: "communicator destroyed before server checkin",
+			validateFlow: func(t *testing.T, c *runtimeComm, srv *testServer) {
+				initCheckinObserved := &proto.CheckinObserved{}
+				// destroy the communicator before checkin
+				c.destroy()
+				err := c.checkin(srv, initCheckinObserved)
+				s, ok := status.FromError(err)
+				assert.True(t, ok, "error must be a gRPC status")
+				assert.Equal(t, codes.Unavailable, s.Code(), "status code must be unavailable")
+			},
+		},
+		{
+			name: "communicator re-checkin after server checkin",
+			validateFlow: func(t *testing.T, c *runtimeComm, srv *testServer) {
+				initCheckinObserved := &proto.CheckinObserved{}
+				// checkin the communicator
+				errCh := make(chan error, 1)
+				go func() {
+					errCh <- c.checkin(srv, initCheckinObserved)
+				}()
+
+				// wait for the communicator to send the init checkin observed
+				select {
+				case err := <-errCh:
+					t.Fatalf("checkin shouldn't returned an error: %v", err)
+				case observed := <-c.CheckinObserved():
+					assert.Equal(t, initCheckinObserved, observed, "checkin observed message must match the init checkin observed message")
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the init checkin observed")
+				}
+
+				// re-checkin the communicator
+				err := c.checkin(srv, &proto.CheckinObserved{})
+				s, ok := status.FromError(err)
+				assert.True(t, ok, "error must be a gRPC status")
+				assert.Equal(t, codes.AlreadyExists, s.Code(), "status code must be already exists")
+
+				// stop the server
+				srv.stop(nil)
+				select {
+				case <-errCh:
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the checkin to return")
+				}
+			},
+		},
+		{
+			name: "communicator destroyed before runtime reads init checkin observed",
+			validateFlow: func(t *testing.T, c *runtimeComm, srv *testServer) {
+				initCheckinObserved := &proto.CheckinObserved{}
+				// checkin the communicator
+				errCh := make(chan error, 1)
+				go func() {
+					errCh <- c.checkin(srv, initCheckinObserved)
+				}()
+
+				// cheat our way and check when the c.initCheckinObserved is set
+				// to the initCheckinObserved which should always happen before the
+				// communicator tries to send to the runtime the init checkin observed
+				require.Eventually(t, func() bool {
+					c.initCheckinObservedMx.Lock()
+					defer c.initCheckinObservedMx.Unlock()
+					return c.initCheckinObserved == initCheckinObserved
+				}, waitDuration, 500*time.Millisecond, "timed out waiting for the c.initCheckinObserved to be set")
+
+				// destroy the communicator and check that it exits without blocking
+				c.destroy()
+				select {
+				case err := <-errCh:
+					s, ok := status.FromError(err)
+					assert.True(t, ok, "error must be a gRPC status")
+					assert.Equal(t, codes.Unavailable, s.Code(), "status code must be unavailable")
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the checkin to return")
+				}
+			},
+		},
+		{
+			name: "communicator destroyed before runtime sends init checkin observed",
+			validateFlow: func(t *testing.T, c *runtimeComm, srv *testServer) {
+				initCheckinObserved := &proto.CheckinObserved{}
+				// checkin the communicator
+				errCh := make(chan error, 1)
+				go func() {
+					errCh <- c.checkin(srv, initCheckinObserved)
+				}()
+
+				// wait for the communicator to send the init checkin observed
+				select {
+				case err := <-errCh:
+					t.Fatalf("checkin shouldn't returned an error: %v", err)
+				case observed := <-c.CheckinObserved():
+					assert.Equal(t, initCheckinObserved, observed, "checkin observed message must match the init checkin observed message")
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the init checkin observed")
+				}
+
+				// destroy the communicator and check that it exits without blocking
+				c.destroy()
+				select {
+				case <-errCh:
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the checkin to return")
+				}
+
+				// simulate the runtime sending the checkin expected
+				expected := &proto.CheckinExpected{}
+				checkinDone := make(chan struct{})
+				go func() {
+					defer close(checkinDone)
+					c.CheckinExpected(expected, initCheckinObserved)
+				}()
+				// check that the checkin doesn't block
+				select {
+				case <-checkinDone:
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the checkin to return")
+				}
+				// check that we don't receive the checkin expected
+				select {
+				case <-srv.expected:
+					t.Fatal("we should not have received the checkin expected message")
+				case <-time.After(waitDuration):
+				}
+			},
+		},
+		{
+			name: "server stopped before runtime sends init checkin observed",
+			validateFlow: func(t *testing.T, c *runtimeComm, srv *testServer) {
+				initCheckinObserved := &proto.CheckinObserved{}
+				// checkin the communicator
+				errCh := make(chan error, 1)
+				go func() {
+					errCh <- c.checkin(srv, initCheckinObserved)
+				}()
+
+				// wait for the communicator to send the init checkin observed
+				select {
+				case err := <-errCh:
+					t.Fatalf("checkin shouldn't returned an error: %v", err)
+				case observed := <-c.CheckinObserved():
+					assert.Equal(t, initCheckinObserved, observed, "checkin observed message must match the init checkin observed message")
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the init checkin observed")
+				}
+
+				// stop the server and wait for communicator checkin to exit
+				srv.stop(nil)
+				select {
+				case <-errCh:
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the checkin to return")
+				}
+
+				// simulate the runtime sending the checkin expected with initCheckinObserved
+				expected := &proto.CheckinExpected{}
+				checkinDone := make(chan struct{})
+				go func() {
+					defer close(checkinDone)
+					c.CheckinExpected(expected, initCheckinObserved)
+				}()
+				// check that the CheckinExpected doesn't block
+				select {
+				case <-checkinDone:
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the checkin to return")
+				}
+				// check that we don't receive any expected message on the server
+				select {
+				case <-srv.expected:
+					t.Fatal("we should not have received the checkin expected message")
+				case <-time.After(waitDuration):
+				}
+			},
+		},
+		{
+			name: "runtime wrong init checkin observed",
+			validateFlow: func(t *testing.T, c *runtimeComm, srv *testServer) {
+				initCheckinObserved := &proto.CheckinObserved{}
+				// checkin the communicator
+				errCh := make(chan error, 1)
+				go func() {
+					errCh <- c.checkin(srv, initCheckinObserved)
+				}()
+
+				// wait for the communicator to send the init checkin observed
+				select {
+				case err := <-errCh:
+					t.Fatalf("checkin shouldn't returned an error: %v", err)
+				case observed := <-c.CheckinObserved():
+					assert.Equal(t, initCheckinObserved, observed, "checkin observed message must match the init checkin observed message")
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the init checkin observed")
+				}
+
+				// simulate the runtime sending a checkin with a different init checkin observed
+				expected := &proto.CheckinExpected{}
+				differentInitCheckinObserved := &proto.CheckinObserved{}
+				checkinDone := make(chan struct{})
+				go func() {
+					defer close(checkinDone)
+					c.CheckinExpected(expected, differentInitCheckinObserved)
+				}()
+				// check that the checkin doesn't block
+				select {
+				case <-checkinDone:
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the checkin to return")
+				}
+				// check that we don't receive the checkin expected
+				select {
+				case <-srv.expected:
+					t.Fatal("expected to not receive the init checkin expected message")
+				case <-time.After(waitDuration):
+				}
+
+				// simulate the runtime sending a checkin with the correct init checkin observed
+				checkinDone = make(chan struct{})
+				go func() {
+					defer close(checkinDone)
+					c.CheckinExpected(expected, initCheckinObserved)
+				}()
+				// check that the checkin doesn't block
+				select {
+				case <-checkinDone:
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the checkin to return")
+				}
+				// check that we do receive the checkin expected
+				select {
+				case receivedExpected := <-srv.expected:
+					assert.Equal(t, receivedExpected, expected, "expected to receive the checkin expected message")
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the checkin expected message")
+				}
+			},
+		},
+		{
+			name: "against all odds send a second init checkin observed",
+			validateFlow: func(t *testing.T, c *runtimeComm, srv *testServer) {
+				initCheckinObserved := &proto.CheckinObserved{}
+				// checkin the communicator
+				errCh := make(chan error, 1)
+				go func() {
+					errCh <- c.checkin(srv, initCheckinObserved)
+				}()
+
+				// wait for the communicator to send the init checkin observed
+				select {
+				case err := <-errCh:
+					t.Fatalf("checkin shouldn't returned an error: %v", err)
+				case observed := <-c.CheckinObserved():
+					assert.Equal(t, initCheckinObserved, observed, "checkin observed message must match the init checkin observed message")
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the init checkin observed")
+				}
+
+				// simulate the runtime sending the checkin expected
+				expected := &proto.CheckinExpected{}
+				checkinDone := make(chan struct{})
+				go func() {
+					defer close(checkinDone)
+					c.CheckinExpected(expected, initCheckinObserved)
+				}()
+				// check that the checkin doesn't block
+				select {
+				case <-checkinDone:
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the checkin to return")
+				}
+				// check that we do receive the checkin expected
+				select {
+				case receivedExpected := <-srv.expected:
+					assert.Equal(t, receivedExpected, expected, "expected to receive the checkin expected message")
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting to receive the checkin expected message")
+				}
+
+				// force another init checkin observed to the initCheckinExpectedCh channel
+				// and make sure that we ignore it
+				select {
+				case c.initCheckinExpectedCh <- expected:
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting to write the init checkin expected message")
+				}
+				// check that we don't receive the checkin expected
+				select {
+				case <-srv.expected:
+					t.Fatal("we should not receive any expected message")
+				case <-time.After(waitDuration):
+				}
+			},
+		},
+		{
+			name: "after init checkin observed runtime checkins flow unblocked",
+			validateFlow: func(t *testing.T, c *runtimeComm, srv *testServer) {
+				initCheckinObserved := &proto.CheckinObserved{}
+				// checkin the communicator
+				errCh := make(chan error, 1)
+				go func() {
+					errCh <- c.checkin(srv, initCheckinObserved)
+				}()
+
+				// wait for the communicator to send the init checkin observed
+				select {
+				case err := <-errCh:
+					t.Fatalf("checkin shouldn't returned an error: %v", err)
+				case observed := <-c.CheckinObserved():
+					assert.Equal(t, initCheckinObserved, observed, "checkin observed message must match the init checkin observed message")
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the init checkin observed")
+				}
+
+				// simulate the runtime sending the checkin expected
+				expected := &proto.CheckinExpected{}
+				checkinDone := make(chan struct{})
+				go func() {
+					defer close(checkinDone)
+					c.CheckinExpected(expected, initCheckinObserved)
+				}()
+				// check that the checkin doesn't block
+				select {
+				case <-checkinDone:
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the checkin to return")
+				}
+
+				// bombard the runtime with checkin expected and make sure that we receive the last expected checkin
+				lastExpectedSentCh := make(chan *proto.CheckinExpected)
+				go func() {
+					var lastExpected *proto.CheckinExpected
+					const expectedCheckinCount = 10
+					for i := 0; i < expectedCheckinCount; i++ {
+						lastExpected = &proto.CheckinExpected{}
+						c.CheckinExpected(lastExpected, nil)
+					}
+					lastExpectedSentCh <- lastExpected
+				}()
+
+				// wait for the goroutine above to exit and get the last checkin expected sent from the goroutine above
+				// it shouldn't block
+				var lastExpectedSent *proto.CheckinExpected
+				select {
+				case lastExpectedSent = <-lastExpectedSentCh:
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the checkin to return")
+				}
+
+				// wait to get the last checkin expected as reported by the communicator to the server
+				// which needs to match the above lastExpectedSent
+				seenLastExpected := false
+				for !seenLastExpected {
+					select {
+					case receivedExpected := <-srv.expected:
+						if receivedExpected != lastExpectedSent {
+							continue
+						}
+						assert.Equal(t, receivedExpected, lastExpectedSent, "expected to receive the last checkin expected message")
+						seenLastExpected = true
+					case <-time.After(waitDuration):
+						t.Fatal("timed out waiting to receive the last checkin expected message")
+					}
+				}
+
+				// make sure that we don't receive any more expected checkin messages
+				select {
+				case <-srv.expected:
+					t.Fatal("we should not receive any expected message")
+				case <-time.After(waitDuration):
+				}
+			},
+		},
+		{
+			name: "communicator can be re-used at server reconnect",
+			validateFlow: func(t *testing.T, c *runtimeComm, srv *testServer) {
+				initCheckinObserved := &proto.CheckinObserved{}
+				// checkin the communicator
+				errCh := make(chan error, 1)
+				go func() {
+					errCh <- c.checkin(srv, initCheckinObserved)
+				}()
+
+				// wait for the communicator to send the init checkin observed
+				select {
+				case err := <-errCh:
+					t.Fatalf("checkin shouldn't returned an error: %v", err)
+				case observed := <-c.CheckinObserved():
+					assert.Equal(t, initCheckinObserved, observed, "checkin observed message must match the init checkin observed message")
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the init checkin observed")
+				}
+
+				// stop the server and wait for communicator checkin to exit
+				srv.stop(nil)
+				select {
+				case <-errCh:
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the checkin to return")
+				}
+
+				// renew the context of the server and invoke again the communicator checkin
+				srv.renewContext(t.Context())
+				secondCheckinObserved := &proto.CheckinObserved{}
+				errCh = make(chan error, 1)
+				go func() {
+					errCh <- c.checkin(srv, secondCheckinObserved)
+				}()
+
+				// wait for the communicator to send the init checkin observed
+				select {
+				case err := <-errCh:
+					t.Fatalf("checkin shouldn't returned an error: %v", err)
+				case observed := <-c.CheckinObserved():
+					assert.Equal(t, secondCheckinObserved, observed, "checkin observed message must match the second init checkin observed message")
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the init checkin observed")
+				}
+
+				// simulate the runtime sending the checkin expected with the first init checkin observed
+				expected := &proto.CheckinExpected{}
+				checkinDone := make(chan struct{})
+				go func() {
+					defer close(checkinDone)
+					c.CheckinExpected(expected, initCheckinObserved)
+				}()
+				// check that the checkin doesn't block
+				select {
+				case <-checkinDone:
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the checkin to return")
+				}
+				// check that we do not receive the checkin expected from the first init checkin observed
+				select {
+				case <-srv.expected:
+					t.Fatal("we should not receive any expected message")
+				case <-time.After(waitDuration):
+				}
+
+				// simulate the runtime sending the checkin expected with the correct and second init checkin observed
+				checkinDone = make(chan struct{})
+				go func() {
+					defer close(checkinDone)
+					c.CheckinExpected(expected, secondCheckinObserved)
+				}()
+				// check that the checkin doesn't block
+				select {
+				case <-checkinDone:
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting for the checkin to return")
+				}
+				// check that we do receive the checkin expected from the second init checkin observed
+				select {
+				case receivedExpected := <-srv.expected:
+					assert.Equal(t, receivedExpected, expected, "expected to receive the checkin expected message")
+				case <-time.After(waitDuration):
+					t.Fatal("timed out waiting to receive the checkin expected message")
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			log, _ := loggertest.New("TestPolicyChangeHandler")
+			c, err := newRuntimeComm(log, "localhost", ca, agentInfoMock{}, 0)
+			require.NoError(t, err, "could not create runtime comm")
+
+			srv := newTestServer(t.Context())
+			tc.validateFlow(t, c, srv)
+		})
+	}
+}
+
+func newTestServer(ctx context.Context) *testServer {
+	ctx, cancel := context.WithCancelCause(ctx)
+	return &testServer{
+		ctx:      ctx,
+		cancel:   cancel,
+		expected: make(chan *proto.CheckinExpected),
+		observed: make(chan *proto.CheckinObserved),
+	}
+}
+
+type testServer struct {
+	ctx      context.Context
+	cancel   context.CancelCauseFunc
+	expected chan *proto.CheckinExpected
+	observed chan *proto.CheckinObserved
+}
+
+func (t *testServer) renewContext(ctx context.Context) {
+	t.ctx, t.cancel = context.WithCancelCause(ctx)
+}
+
+func (t *testServer) stop(err error) {
+	t.cancel(err)
+}
+func (t *testServer) Send(expected *proto.CheckinExpected) error {
+	select {
+	case t.expected <- expected:
+		return nil
+	case <-t.ctx.Done():
+		return context.Cause(t.ctx)
+	}
+}
+
+func (t *testServer) Recv() (*proto.CheckinObserved, error) {
+	select {
+	case observed := <-t.observed:
+		return observed, nil
+	case <-t.ctx.Done():
+		return nil, context.Cause(t.ctx)
+	}
+}
+
+func (t *testServer) SetHeader(_ metadata.MD) error {
+	// not needed for the current testing needs, thus panic if called
+	panic("unimplemented")
+}
+
+func (t *testServer) SendHeader(_ metadata.MD) error {
+	// not needed for the current testing needs, thus panic if called
+	panic("unimplemented")
+}
+
+func (t *testServer) SetTrailer(_ metadata.MD) {
+	// not needed for the current testing needs, thus panic if called
+	panic("unimplemented")
+}
+
+func (t *testServer) Context() context.Context {
+	return t.ctx
+}
+
+func (t *testServer) SendMsg(_ any) error {
+	// not needed for the current testing needs, thus panic if called
+	panic("unimplemented")
+}
+
+func (t *testServer) RecvMsg(_ any) error {
+	// not needed for the current testing needs, thus panic if called
+	panic("unimplemented")
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR fixes multiple deadlock conditions in the runtime communicator logic and improves overall lifecycle handling. Specifically, it:
- Handles potential deadlock when sending the initial observed message to the runtime if the communicator is destroyed.
- Handles deadlock when the runtime calls `CheckinExpected` (init expected check-in) and the communicator is already destroyed.
- Handles deadlock when the runtime calls `CheckinExpected` (init expected check-in) and the server has been disconnected.
- Although highly unlikely due to existing synchronisation primitives, it doesn't block against multiple init checkin messages that arrive after the first that completed the init checkin process.
- Removes a redundant goroutine in the `checkin` method, which also allows returning accurate gRPC status codes back to the client. (PS: this optimisation can be also applied for the actions handling)
- Adds comprehensive unit tests covering all the above scenarios to prevent regressions.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

These fixes ensure the runtime communicator behaves predictably and safely across lifecycle boundaries like shutdown, reconnection, and concurrent access. Without these changes, users could experience hangs or lost check-in signals in rare but critical failure modes.

You can see that the previous implementation fails to complete these scenarios under test in CI [here](https://buildkite.com/elastic/elastic-agent/builds/23728#0197e8c9-0c0d-4d32-b97e-cdb5db6e6fb9/135-642)

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

This is a bug-fix for internal lifecycle logic and is not expected to introduce changes in behaviour or configuration requirements for end users.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
mage unitTest
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/7944