### PR TITLE
[AutoOps] Support Temporary Resource ID

### DIFF
--- a/internal/pkg/otel/samples/darwin/autoops_es.yml
+++ b/internal/pkg/otel/samples/darwin/autoops_es.yml
@@ -25,6 +25,7 @@ receivers:
       - add_fields:
           target: autoops_es
           fields:
+            temp_resource_id: ${env:TEMPORARY_RESOURCE_ID}
             token: ${env:AUTOOPS_TOKEN}
     output:
       otelconsumer:

--- a/internal/pkg/otel/samples/darwin/autoops_es.yml
+++ b/internal/pkg/otel/samples/darwin/autoops_es.yml
@@ -25,7 +25,7 @@ receivers:
       - add_fields:
           target: autoops_es
           fields:
-            temp_resource_id: ${env:TEMPORARY_RESOURCE_ID}
+            temp_resource_id: ${env:AUTOOPS_TEMP_RESOURCE_ID}
             token: ${env:AUTOOPS_TOKEN}
     output:
       otelconsumer:

--- a/internal/pkg/otel/samples/linux/autoops_es.yml
+++ b/internal/pkg/otel/samples/linux/autoops_es.yml
@@ -25,6 +25,7 @@ receivers:
       - add_fields:
           target: autoops_es
           fields:
+            temp_resource_id: ${env:TEMPORARY_RESOURCE_ID}
             token: ${env:AUTOOPS_TOKEN}
     output:
       otelconsumer:

--- a/internal/pkg/otel/samples/linux/autoops_es.yml
+++ b/internal/pkg/otel/samples/linux/autoops_es.yml
@@ -25,7 +25,7 @@ receivers:
       - add_fields:
           target: autoops_es
           fields:
-            temp_resource_id: ${env:TEMPORARY_RESOURCE_ID}
+            temp_resource_id: ${env:AUTOOPS_TEMP_RESOURCE_ID}
             token: ${env:AUTOOPS_TOKEN}
     output:
       otelconsumer:

--- a/internal/pkg/otel/samples/windows/autoops_es.yml
+++ b/internal/pkg/otel/samples/windows/autoops_es.yml
@@ -25,6 +25,7 @@ receivers:
       - add_fields:
           target: autoops_es
           fields:
+            temp_resource_id: ${env:TEMPORARY_RESOURCE_ID}
             token: ${env:AUTOOPS_TOKEN}
     output:
       otelconsumer:

--- a/internal/pkg/otel/samples/windows/autoops_es.yml
+++ b/internal/pkg/otel/samples/windows/autoops_es.yml
@@ -25,7 +25,7 @@ receivers:
       - add_fields:
           target: autoops_es
           fields:
-            temp_resource_id: ${env:TEMPORARY_RESOURCE_ID}
+            temp_resource_id: ${env:AUTOOPS_TEMP_RESOURCE_ID}
             token: ${env:AUTOOPS_TOKEN}
     output:
       otelconsumer:


### PR DESCRIPTION
This forces the AutoOps data to provide a module level field named "temp_resource_id" that can be associated during the handshake period.

## What does this PR do?

Adds a field that is needed during registration.

## Why is it important?

The resource (orchestrator) does not exist until after registration, so to associate events, such as errors, it needs this ID to associate them.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
