### PR TITLE
Add `backport-active-all` label to Golang bump PRs

### DIFF
--- a/.ci/updatecli/updatecli-bump-golang.yml
+++ b/.ci/updatecli/updatecli-bump-golang.yml
@@ -24,7 +24,7 @@ actions:
       automerge: false
       labels:
         - dependencies
-        - backport-skip
+        - backport-active-all
       title: '[Automation] Bump Golang version to {{ source "latestGoVersion" }}'
       description: |
         It requires the version to be bumped first in golang-crossbuild project, then a new release will be added to:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

We have [automation](https://github.com/elastic/elastic-agent/blob/main/.ci/updatecli/updatecli-bump-golang.yml) to bump Golang versions in this repository.  This PR updates that automation to add the `backport-active-all` label on generated PRs so that, when those PRs are merged into `main`, Mergify automatically creates their backports to all active branches.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To keep the Golang version in sync across all active branches.

(Also to get @pkoutsovasilis [off my back](https://github.com/elastic/elastic-agent/pull/8919#issuecomment-3054217371) 😉) 
