### PR TITLE
helm: define headless service for statefulset presets

### DIFF
--- a/deploy/helm/elastic-agent/examples/statefulset-preset/README.md
+++ b/deploy/helm/elastic-agent/examples/statefulset-preset/README.md
@@ -1,0 +1,28 @@
+# Example: Custom Integration with a StatefulSet preset
+
+In this example we define a `netflow` custom integration alongside a custom agent preset of StatefulSet type defined in [agent-values.yaml](agent-values.yaml). Also, we disable all `kubernetes` related providers and creation of cluster role and service account, as they are not required for this example.
+
+## Prerequisites:
+1. A k8s secret that contains the connection details to an Elasticsearch cluster such as the URL and the API key ([Kibana - Creating API Keys](https://www.elastic.co/guide/en/kibana/current/api-keys.html)):
+    ```console
+    kubectl create secret generic es-api-secret \
+       --from-literal=api_key=... \
+       --from-literal=url=...
+    ```
+
+2. `NetFlow Records` integration assets are installed through Kibana
+
+## Run:
+1. Install Helm chart
+    ```console
+    helm install elastic-agent ../../ -f ./agent-netflow-values.yaml
+    ```
+
+2. Run the netflow data generator deployment
+    ```console
+   kubectl run -it --rm netflow-generator --image=networkstatic/nflow-generator --restart=Never -- -t agent-netflow-elastic-agent.default.svc.cluster.local -p 2055
+    ```
+
+## Validate:
+
+1. The Kibana `netflow`-related dashboards should start showing netflow related data.

--- a/deploy/helm/elastic-agent/examples/statefulset-preset/agent-values.yaml
+++ b/deploy/helm/elastic-agent/examples/statefulset-preset/agent-values.yaml
@@ -1,0 +1,65 @@
+outputs:
+  default:
+    type: ESSecretAuthAPI
+    secretName: es-api-secret
+
+kube-state-metrics:
+  enabled: false
+
+extraIntegrations:
+  netflow:
+    id: netflow-netflow-60a9d5b2-c611-4749-90bf-5e2443936c1d
+    name: netflow-1
+    preset: netflow
+    revision: 1
+    type: netflow
+    use_output: default
+    meta:
+      package:
+        name: netflow
+        version: 2.19.1
+    data_stream:
+      namespace: default
+    package_policy_id: 60a9d5b2-c611-4749-90bf-5e2443936c1d
+    streams:
+      - id: netflow-netflow.log-60a9d5b2-c611-4749-90bf-5e2443936c1d
+        data_stream:
+          dataset: netflow.log
+          type: logs
+        protocols:
+          - v1
+          - v5
+          - v6
+          - v7
+          - v8
+          - v9
+          - ipfix
+        host: '0.0.0.0:2055'
+        max_message_size: 10KiB
+        expiration_timeout: 30m
+        queue_size: 8192
+        detect_sequence_reset: true
+        tags:
+          - netflow
+          - forwarded
+        publisher_pipeline.disable_host: true
+
+kubernetes:
+  enabled: false
+
+agent:
+  unprivileged: true
+  presets:
+    netflow:
+      automountServiceAccountToken: false
+      mode: statefulset
+      service:
+        type: ClusterIP
+      ports:
+        - containerPort: 2055
+          servicePort: 2055
+          protocol: UDP
+      serviceAccount:
+        create: false
+      clusterRole:
+        create: false

--- a/deploy/helm/elastic-agent/examples/statefulset-preset/rendered/manifest.yaml
+++ b/deploy/helm/elastic-agent/examples/statefulset-preset/rendered/manifest.yaml
@@ -1,0 +1,177 @@
+---
+# Source: elastic-agent/templates/agent/k8s/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agent-netflow-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.2.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.2.0
+stringData:
+
+  agent.yml: |-
+    id: agent-netflow-example
+    outputs:
+      default:
+        api_key: ${OUTPUT_DEFAULT_API_KEY}
+        hosts:
+        - ${OUTPUT_DEFAULT_URL}
+        type: elasticsearch
+    secret_references: []
+    inputs:
+      - data_stream:
+          namespace: default
+        id: netflow-netflow-60a9d5b2-c611-4749-90bf-5e2443936c1d
+        meta:
+          package:
+            name: netflow
+            version: 2.19.1
+        name: netflow-1
+        package_policy_id: 60a9d5b2-c611-4749-90bf-5e2443936c1d
+        preset: netflow
+        revision: 1
+        streams:
+        - data_stream:
+            dataset: netflow.log
+            type: logs
+          detect_sequence_reset: true
+          expiration_timeout: 30m
+          host: 0.0.0.0:2055
+          id: netflow-netflow.log-60a9d5b2-c611-4749-90bf-5e2443936c1d
+          max_message_size: 10KiB
+          protocols:
+          - v1
+          - v5
+          - v6
+          - v7
+          - v8
+          - v9
+          - ipfix
+          publisher_pipeline.disable_host: true
+          queue_size: 8192
+          tags:
+          - netflow
+          - forwarded
+        type: netflow
+        use_output: default
+    providers:
+      kubernetes_leaderelection:
+        enabled: false
+        leader_lease: example-netflow
+---
+# Source: elastic-agent/templates/agent/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: agent-netflow-example-headless
+spec:
+  clusterIP: None
+  selector:
+    name: agent-netflow-example
+---
+# Source: elastic-agent/templates/agent/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: agent-netflow-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.2.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.2.0
+spec:
+  type: ClusterIP
+  selector:
+    name: agent-netflow-example
+  ports:
+    - port: 2055
+      targetPort: 2055
+      protocol: UDP
+---
+# Source: elastic-agent/templates/agent/k8s/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: agent-netflow-example
+  namespace: "default"
+  labels:
+    helm.sh/chart: elastic-agent-9.2.0-beta
+    app.kubernetes.io/name: elastic-agent
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: 9.2.0
+spec:
+  serviceName: agent-netflow-example-headless
+  selector:
+    matchLabels:
+      name: agent-netflow-example
+  template:
+    metadata:
+      labels:
+        name: agent-netflow-example
+      annotations:
+        checksum/config: 4e9f48f0d6ae172f2f6aa5d526b0ca3af7dd28250e7c06c9d4e67ec0a2fc4573
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - -c
+        - /etc/elastic-agent/agent.yml
+        - -e
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: STATE_PATH
+          value: /usr/share/elastic-agent/state
+        - name: OUTPUT_DEFAULT_URL
+          valueFrom:
+            secretKeyRef:
+              key: url
+              name: es-api-secret
+        - name: OUTPUT_DEFAULT_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: api_key
+              name: es-api-secret
+        image: docker.elastic.co/elastic-agent/elastic-agent:9.2.0-SNAPSHOT
+        imagePullPolicy: IfNotPresent
+        name: agent
+        ports:
+        - containerPort: 2055
+          protocol: UDP
+        securityContext:
+          capabilities:
+            add:
+            - CHOWN
+            - SETPCAP
+            - DAC_READ_SEARCH
+            - SYS_PTRACE
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 1000
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /usr/share/elastic-agent/state
+          name: agent-data
+        - mountPath: /etc/elastic-agent/agent.yml
+          name: config
+          readOnly: true
+          subPath: agent.yml
+      dnsPolicy: ClusterFirstWithHostNet
+      volumes:
+      - emptyDir: {}
+        name: agent-data
+      - name: config
+        secret:
+          defaultMode: 292
+          secretName: agent-netflow-example

--- a/deploy/helm/elastic-agent/templates/agent/eck/statefulset.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/eck/statefulset.yaml
@@ -34,6 +34,7 @@ spec:
   {{- end -}}
   {{- end }}
   statefulSet:
+    serviceName: {{ $agentName }}-headless
     {{- if hasKey $presetVal "replicaCount" }}
     replicas: {{ ($presetVal).replicaCount }}
     {{- end }}

--- a/deploy/helm/elastic-agent/templates/agent/k8s/statefulset.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/k8s/statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  serviceName: {{ $agentName }}-headless
   selector:
     matchLabels:
       name: {{ $agentName }}

--- a/deploy/helm/elastic-agent/templates/agent/service.yaml
+++ b/deploy/helm/elastic-agent/templates/agent/service.yaml
@@ -1,9 +1,20 @@
 {{- include "elasticagent.init" $ -}}
 {{- range $presetName, $presetVal := $.Values.agent.presets -}}
+{{- $agentName := include "elasticagent.preset.fullname" (list $ $presetName)  -}}
+{{- if eq ($presetVal).mode "statefulset" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $agentName }}-headless
+spec:
+  clusterIP: None
+  selector:
+    name: {{ $agentName }}
+---
+{{- end }}
 {{- $presetService := dig "service" dict $presetVal -}}
 {{- $ports := dig "ports" list $presetVal -}}
-{{- if and $presetService $ports -}}
-{{- $agentName := include "elasticagent.preset.fullname" (list $ $presetName)  -}}
+{{- if and $presetService $ports }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR adds support for deploying Elastic Agent using StatefulSet by properly defining a `serviceName`, as required by the Kubernetes specification for StatefulSets.

Specifically, it:
- Introduces a headless service (`clusterIP: None`) per preset when `mode: statefulset` is used.
- Sets the `serviceName` field in the StatefulSet template to refer to the respective headless service.
- Provides a working example under `examples/statefulset-preset/` showcasing a NetFlow integration running as a StatefulSet.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

StatefulSets in Kubernetes require the `serviceName` field to be specified to ensure stable network identities and persistent storage for each replica. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None. This is an additive change that only affects users opting into StatefulSet mode. Existing other mode-based presets are unaffected.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
mage helm:renderExamples
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/8223
