### PR TITLE
flaky: skip TestAPMConfig

### DIFF
--- a/testing/integration/ess/apm_propagation_test.go
+++ b/testing/integration/ess/apm_propagation_test.go
@@ -56,6 +56,8 @@ func TestAPMConfig(t *testing.T) {
 		Group: integration.Default,
 		Stack: &define.Stack{},
 	})
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/5890")
+
 	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR skips the `TestAPMConfig` test in `apm_propagation_test.go` due to its flaky behavior. The flaky runs of this test fail with `index_not_found_exception` for the `traces-apm-default` index in Elasticsearch.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Flaky tests erode confidence in CI signal and can obscure genuine regressions. Skipping `TestAPMConfig` prevents CI failures while the root cause is investigated and resolved in [issue #5890](https://github.com/elastic/elastic-agent/issues/5890). This helps restore signal quality and developer productivity.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

None. This change only affects the test suite by skipping a known-flaky test. There is no impact to users of the Elastic Agent.

```
mage integration:auth
STACK_PROVISIONER=stateful TEST_PLATFORMS="linux/amd64" mage integration:single TestAPMConfig
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/5890