### PR TITLE
flaky: increase time constraints in TestUpgradeCmd

### DIFF
--- a/internal/pkg/agent/cmd/upgrade_test.go
+++ b/internal/pkg/agent/cmd/upgrade_test.go
@@ -75,7 +75,7 @@ func TestUpgradeCmd(t *testing.T) {
 		require.Eventually(t, func() bool {
 			counter := atomic.LoadInt32(&mock.upgrades)
 			return counter > 0
-		}, 5*time.Second, 100*time.Millisecond)
+		}, 30*time.Second, 100*time.Millisecond)
 
 		// then we close the tcp server which is supposed to interrupt the connection
 		s.Stop()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR adjusts the timeout duration in the `TestUpgradeCmd/no_error_when_connection_gets_interrupted` test case. Specifically, it increases the duration of the `require.Eventually` assertion that waits for the mock upgrade to trigger.

The previous 5-second timeout proved to be too tight on certain platforms, especially Windows, leading to intermittent flakiness. The test failed with various errors depending on where exactly the server was forcefully shut down during the upgrade flow. Theoretically speaking, by relaxing the time constraint, we give enough room for the expected RPC connection failure to happen gracefully.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Stabilizing this test helps improve overall CI reliability and removes false negatives from our test results.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None expected. This change only affects test code and does not alter production behavior.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
mage unitTest
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes [#7070](https://github.com/elastic/elastic-agent/issues/7070)
