### PR TITLE
Fix Kibana policy parsing in monitoring integration test

### DIFF
--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -209,12 +209,12 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 		Inputs           []map[string]any `yaml:"inputs"`
 		Signed           map[string]any   `yaml:"signed"`
 		SecretReferences []map[string]any `yaml:"secret_references"`
-		Namespaces       []map[string]any `yaml:"namespaces"`
+		Namespaces       []string         `yaml:"namespaces"`
 	}
 
 	policy := PolicyStruct{}
 	err = yaml.Unmarshal(policyBytes, &policy)
-	require.NoError(t, err, "error unmarshalling policy")
+	require.NoError(t, err, "error unmarshalling policy: %s", string(policyBytes))
 	d, prs := policy.Outputs["default"]
 	require.True(t, prs, "default must be in outputs")
 	d.ApiKey = string(apiKey)


### PR DESCRIPTION
## What does this PR do?

Fixes a struct we parse a Kibana policy into in the monitoring integration test.

## Why is it important?

The type of the `namespaces` field was wrong. This happened to work fine as long as the field was empty, but with Spaces enabled by default, it would fail to parse and subsequently fail the test. 

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

The first failure was observed in https://github.com/elastic/elastic-agent/pull/8815. That was fixed in the PR, so I'm not backporting this change to 9.1.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
