### PR TITLE
Rename OTel collector config file in diagnostics to otel-merged.yaml

### DIFF
--- a/changelog/fragments/1752754955-rename-otel-diagnostic-file.yaml
+++ b/changelog/fragments/1752754955-rename-otel-diagnostic-file.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Rename OTel collector config file in diagnostics from otel-final.yaml to otel-merged.yaml
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -1236,8 +1236,8 @@ func (c *Coordinator) DiagnosticHooks() diagnostics.Hooks {
 			},
 		},
 		diagnostics.Hook{
-			Name:        "otel-final",
-			Filename:    "otel-final.yaml",
+			Name:        "otel-merged",
+			Filename:    "otel-merged.yaml",
 			Description: "Final otel configuration used by the Elastic Agent. Includes hybrid mode config and component config.",
 			ContentType: "application/yaml",
 			Hook: func(_ context.Context) []byte {

--- a/internal/pkg/agent/application/coordinator/diagnostics_test.go
+++ b/internal/pkg/agent/application/coordinator/diagnostics_test.go
@@ -45,7 +45,7 @@ func TestCoordinatorExpectedDiagnosticHooks(t *testing.T) {
 		"components-actual",
 		"state",
 		"otel",
-		"otel-final",
+		"otel-merged",
 	}
 
 	coord := &Coordinator{}

--- a/testing/integration/ess/diagnostics_test.go
+++ b/testing/integration/ess/diagnostics_test.go
@@ -48,7 +48,7 @@ var diagnosticsFiles = []string{
 	"local-config.yaml",
 	"mutex.pprof.gz",
 	"otel.yaml",
-	"otel-final.yaml",
+	"otel-merged.yaml",
 	"pre-config.yaml",
 	"local-config.yaml",
 	"state.yaml",


### PR DESCRIPTION
## What does this PR do?

Changes the name of the file containing the merged otel collector configuration in diagnostics from `otel-final.yaml` to `otel-merged.yaml`.

## Why is it important?

This makes our naming consistent with the rest of the agent's codebase. It's also what we agreed on with @lucabelluccini in https://github.com/elastic/elastic-agent/issues/8208.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

The otel config files are relatively new, as EDOT is GA starting in 9.0, and hybrid mode isn't recommended for use anywhere. Support engineers are the main consumers of this data right now, and they've been notified of the change and acked it. 

## How to test this PR locally

Run agent in hybrid mode and generate diagnostics.

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/8208

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
