### PR TITLE
Update kubernetes_leaderelection.go

### DIFF
--- a/internal/pkg/composable/providers/kubernetesleaderelection/kubernetes_leaderelection.go
+++ b/internal/pkg/composable/providers/kubernetesleaderelection/kubernetes_leaderelection.go
@@ -58,8 +58,7 @@ var getK8sClientFunc = func(kubeconfig string, opt kubernetes.KubeClientOptions)
 func (p *contextProvider) Run(ctx context.Context, comm corecomp.ContextProviderComm) error {
 	client, err := getK8sClientFunc(p.config.KubeConfig, p.config.KubeClientOptions)
 	if err != nil {
-		p.logger.Debugf("Kubernetes leaderelection provider skipped, unable to connect: %s", err)
-		return nil
+		return fmt.Errorf("Kubernetes leader election provider skipped, unable to connect: %w", err)
 	}
 
 	agentInfo, err := info.NewAgentInfo(ctx, false)


### PR DESCRIPTION
# return wrapped err.

- Bug

## What does this PR do?

Change return value to wrapped errors.

## Why is it important?

Simply return the wrapped error and allow Elastic Agent to report Kubernetes Leader Election errors when the log level is not equal to Debug, enabling DevOps and system administrators to troubleshoot and monitor the issue, rather than pretending nothing happened.

Meaningless logs:

```json
{"log.level":"error","@timestamp":"2025-06-13T12:05:45.658Z","log.logger":"composable.providers.kubernetes_leaderelection","log.origin":{"function":"github.com/elastic/elastic-agent/internal/pkg/composable.(*controller).startContextProvider.func1","file.name":"composable/controller.go","file.line":472},"message":"provider \"kubernetes_leaderelection\" failed to run (will retry in 30s): %!s(<nil>)","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
```

Valuable logs, especially for large-scale cluster administrators:

```json
{"log.level":"info","@timestamp":"2025-06-13T12:06:15.658Z","log.logger":"composable.providers.kubernetes_leaderelection","log.origin":{"function":"github.com/elastic/elastic-agent/internal/pkg/composable.(*controller).startContextProvider.func1","file.name":"composable/controller.go","file.line":442},"message":"Starting context provider \"kubernetes_leaderelection\"","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-06-13T12:06:15.658Z","log.logger":"composable.providers.kubernetes_leaderelection","log.origin":{"function":"github.com/elastic/elastic-agent/internal/pkg/composable/providers/kubernetesleaderelection.(*contextProvider).Run","file.name":"kubernetesleaderelection/kubernetes_leaderelection.go","file.line":61},"message":"Kubernetes leaderelection provider skipped, unable to connect: unable to build kube config due to error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable","log":{"source":"elastic-agent"},"ecs.version":"1.6.0"}
```

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~I have made corresponding change to the default configuration files~~
~~I have added tests that prove my fix is effective or that my feature works~~
~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
~~I have added an integration test or an E2E test~~

## Disruptive User Impact

No, make it easier for users to get started with Elastic Agent's supported Kubernetes integrations!

## How to test this PR locally

We possess a production-grade server cluster with massive computing power based on NVIDIA GPUs, which has already undergone production-level testing. Below is the configuration file, which has been sanitized:"

```yaml
# ECK Agent Helm Charts Values: default-collect.yaml
nameOverride: "default"
fullnameOverride: "default"
version: 9.0.2
labels: {}
annotations: {}
image: docker.io/elastic/elastic-agent:9.0.2
kibanaRef:
  name: infra
  namespace: elastic
fleetServerRef:
  name: fleet
  namespace: elastic
elasticsearchRefs: []
config: null
mode: "fleet"
policyID: ""
daemonSet:
  updateStrategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 50
  podTemplate:
    spec:
      automountServiceAccountToken: true
      serviceAccountName: elastic-agent
      tolerations:
        - key: node-role.kubernetes.io/control-plane
          effect: NoSchedule
        - key: node-role.kubernetes.io/master
          effect: NoSchedule
      hostNetwork: true
      dnsPolicy: ClusterFirstWithHostNet
      containers:
      - name: agent
        securityContext:
          runAsUser: 0
        env:
        - name: FLEET_ENROLL
          value: "1"
        - name: FLEET_INSECURE
          value: "true"
        - name: FLEET_ENROLLMENT_TOKEN
          value: ""
        - name: NODE_NAME
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName
        - name: POD_NAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        - name: ELASTIC_NETINFO
          value: "false"
        resources:
          limits:
            memory: 4Gi
            cpu: 1
          requests:
            cpu: 100m
            memory: 500Mi
        volumeMounts:
          - name: proc
            mountPath: /hostfs/proc
            readOnly: true
          - name: cgroup
            mountPath: /hostfs/sys/fs/cgroup
            readOnly: true
          - name: varlog
            mountPath: /var/log
            readOnly: true
          - name: etc-full
            mountPath: /hostfs/etc
            readOnly: true
          - name: var-lib
            mountPath: /hostfs/var/lib
            readOnly: true
          - name: etc-mid
            mountPath: /etc/machine-id
            readOnly: true
          - name: sys-kernel-debug
            mountPath: /sys/kernel/debug
          - name: elastic-agent-state
            mountPath: /usr/share/elastic-agent/state
          - name: containerd-socket
            mountPath: /var/run/containerd/containerd.sock
            readOnly: true
      volumes:
        - name: proc
          hostPath:
            path: /proc
        - name: cgroup
          hostPath:
            path: /sys/fs/cgroup
        - name: varlog
          hostPath:
            path: /var/log
        - name: etc-full
          hostPath:
            path: /etc
        - name: var-lib
          hostPath:
            path: /var/lib
        - name: etc-mid
          hostPath:
            path: /etc/machine-id
            type: File
        - name: sys-kernel-debug
          hostPath:
            path: /sys/kernel/debug
        - name: elastic-agent-state
          hostPath:
            path: /var/lib/elastic-agent-managed/elastic/state
            type: DirectoryOrCreate
        - name: containerd-socket
          hostPath:
            path: /run/containerd/containerd.sock
secureSettings: []
revisionHistoryLimit: 2
serviceAccount:
  name: elastic-agent
clusterRoleBinding:
  name: elastic-agent
  subjects:
  - kind: ServiceAccount
    name: elastic-agent
  roleRef:
    kind: ClusterRole
    name: elastic-agent
    apiGroup: rbac.authorization.k8s.io
clusterRole:
  name: elastic-agent
  rules:
  - apiGroups: [""]
    resources:
    - pods
    - nodes
    - namespaces
    - events
    - services
    - configmaps
    verbs:
    - get
    - watch
    - list
  - apiGroups: ["coordination.k8s.io"]
    resources:
    - leases
    verbs:
    - get
    - create
    - update
    - patch
  - nonResourceURLs:
    - "/metrics"
    verbs:
    - get
  - apiGroups: ["extensions"]
    resources:
      - replicasets
    verbs: 
    - "get"
    - "list"
    - "watch"
  - apiGroups:
    - "apps"
    resources:
    - statefulsets
    - deployments
    - replicasets
    - daemonsets
    verbs:
    - "get"
    - "list"
    - "watch"
  - apiGroups:
    - ""
    resources:
    - nodes/stats
    verbs:
    - get
  - nonResourceURLs:
    - "/metrics"
    verbs:
    - get
  - apiGroups:
    - "batch"
    resources:
    - jobs
    - cronjobs
    verbs:
    - "get"
    - "list"
    - "watch"
  - apiGroups:
    - "storage.k8s.io"
    resources:
    - storageclasses
    verbs:
    - "get"
    - "list"
    - "watch"
```

## Related issues

## Questions to ask yourself
