### PR TITLE
Mount Go build cache into crossbuild container

### DIFF
--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -166,6 +166,17 @@ func GolangCrossBuild(params BuildArgs) error {
 			"only be executed within the golang-crossbuild docker environment")
 	}
 
+	defer DockerChown(filepath.Join(params.OutputDir, params.Name+binaryExtension(GOOS)))
+	defer DockerChown(filepath.Join(params.OutputDir))
+
+	mountPoint, err := ElasticBeatsDir()
+	if err != nil {
+		return err
+	}
+	if err := sh.Run("git", "config", "--global", "--add", "safe.directory", mountPoint); err != nil {
+		return err
+	}
+
 	return Build(params)
 }
 

--- a/dev-tools/mage/clean.go
+++ b/dev-tools/mage/clean.go
@@ -25,7 +25,7 @@ var DefaultCleanPaths = []string{
 	"_meta/kibana/7/index-pattern/{{.BeatName}}.json",
 }
 
-// Clean clean generated build artifacts.
+// Clean clean generated build artifacts and caches.
 func Clean(pathLists ...[]string) error {
 	if len(pathLists) == 0 {
 		pathLists = [][]string{DefaultCleanPaths}
@@ -37,6 +37,9 @@ func Clean(pathLists ...[]string) error {
 				return err
 			}
 		}
+	}
+	if CrossBuildMountBuildCache {
+		return sh.Run("docker", "volume", "rm", "-f", CrossBuildBuildCacheVolumeName)
 	}
 	return nil
 }

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -9,7 +9,6 @@ import (
 	"go/build"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -334,14 +333,9 @@ func (b GolangCrossBuilder) Build() error {
 
 	buildCacheLocation := "/tmp/.cache/go-build"
 	if CrossBuildMountBuildCache {
-		// Mount the go build cache into the container.
-		out, err := exec.Command("go", "env", "GOCACHE").Output()
-		if err != nil {
-			return fmt.Errorf("failed to get GOCACHE: %w", err)
-		}
-		cacheDir := strings.TrimSpace(string(out))
+		// Mount the go build cache volume into the container.
 		args = append(args,
-			"-v", fmt.Sprintf("%s:%s", cacheDir, buildCacheLocation),
+			"-v", fmt.Sprintf("%s:%s", CrossBuildBuildCacheVolumeName, buildCacheLocation),
 		)
 	}
 
@@ -368,7 +362,6 @@ func (b GolangCrossBuilder) Build() error {
 		"--env", fmt.Sprintf("DEV=%v", DevBuild),
 		"--env", fmt.Sprintf("EXTERNAL=%v", ExternalBuild),
 		"--env", fmt.Sprintf("FIPS=%v", FIPSBuild),
-		"--user", fmt.Sprintf("%d:%d", uid, gid),
 		"-v", repoInfo.RootDir+":"+mountPoint,
 		"-w", workDir,
 		image,

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -75,7 +75,8 @@ var (
 	CrossBuildMountModcache = EnvOr("CROSSBUILD_MOUNT_MODCACHE", "true") == "true"
 
 	// CrossBuildMountBuildCache mounts the Go build cache into golang-crossbuild containers
-	CrossBuildMountBuildCache = EnvOr("CROSSBUILD_MOUNT_GOCACHE", "true") == "true"
+	CrossBuildMountBuildCache      = EnvOr("CROSSBUILD_MOUNT_GOCACHE", "true") == "true"
+	CrossBuildBuildCacheVolumeName = "elastic-agent-crossbuild-build-cache"
 
 	BeatName        = EnvOr("BEAT_NAME", defaultName)
 	BeatServiceName = EnvOr("BEAT_SERVICE_NAME", BeatName)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Mounts the Go build cache into the golang-crossbuild container. To facilitate this and allow the container to generate the build cache, it also changes the crossbuild container to run as the host user.

This has been tested locally on both Mac and Linux, and the CI passes for this PR. It probably requires somewhat more careful testing, as permission changes in the host build cache could potentially result in breakage for unified releases.

## Why is it important?

This reduces the build time of agent during packaging by around 75%. On my machine, the same-architecture build goes from 2 minutes to 25 seconds.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

Run `mage crossbuild` and time it.

## Related issues

- Relates https://github.com/elastic/observability-dev/issues/4702

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
