### PR TITLE
Add beat metrics to beat receiver diagnostics

### DIFF
--- a/internal/pkg/agent/application/monitoring/process.go
+++ b/internal/pkg/agent/application/monitoring/process.go
@@ -120,8 +120,8 @@ func isProcessRedirectable(componentID string) bool {
 }
 
 func redirectToPath(w http.ResponseWriter, r *http.Request, id, path, operatingSystem string) error {
-	endpoint := prefixedEndpoint(utils.SocketURLWithFallback(id, paths.TempDir()))
-	metricsBytes, statusCode, metricsErr := processMetrics(r.Context(), endpoint, path)
+	endpoint := PrefixedEndpoint(utils.SocketURLWithFallback(id, paths.TempDir()))
+	metricsBytes, statusCode, metricsErr := GetProcessMetrics(r.Context(), endpoint, path)
 	if metricsErr != nil {
 		return metricsErr
 	}
@@ -134,7 +134,7 @@ func redirectToPath(w http.ResponseWriter, r *http.Request, id, path, operatingS
 	return nil
 }
 
-func processMetrics(ctx context.Context, endpoint, path string) ([]byte, int, error) {
+func GetProcessMetrics(ctx context.Context, endpoint, path string) ([]byte, int, error) {
 	hostData, err := parseURL(endpoint, "http", "", "", path, "")
 	if err != nil {
 		return nil, 0, errorWithStatus(http.StatusInternalServerError, err)

--- a/internal/pkg/agent/application/monitoring/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/v1_monitor.go
@@ -674,7 +674,7 @@ func (b *BeatsMonitor) getHttpStreams(
 			continue
 		}
 
-		endpoints := []interface{}{prefixedEndpoint(utils.SocketURLWithFallback(compInfo.ID, paths.TempDir()))}
+		endpoints := []interface{}{PrefixedEndpoint(BeatsMonitoringEndpoint(compInfo.ID))}
 		name := sanitizeName(binaryName)
 
 		// Do not create http streams if runtime-manager is otel and binary is of beat type
@@ -746,7 +746,7 @@ func (b *BeatsMonitor) getBeatsStreams(
 			continue
 		}
 
-		endpoints := []interface{}{prefixedEndpoint(utils.SocketURLWithFallback(compInfo.ID, paths.TempDir()))}
+		endpoints := []interface{}{PrefixedEndpoint(utils.SocketURLWithFallback(compInfo.ID, paths.TempDir()))}
 		name := sanitizeName(binaryName)
 		dataset := fmt.Sprintf("elastic_agent.%s", name)
 		indexName := fmt.Sprintf("metrics-elastic_agent.%s-%s", name, monitoringNamespace)
@@ -1190,7 +1190,7 @@ func loggingPath(id, operatingSystem string) string {
 	return fmt.Sprintf(logFileFormat, paths.Home(), id)
 }
 
-func prefixedEndpoint(endpoint string) string {
+func PrefixedEndpoint(endpoint string) string {
 	if endpoint == "" || strings.HasPrefix(endpoint, httpPlusPrefix) || strings.HasPrefix(endpoint, httpPrefix) {
 		return endpoint
 	}
@@ -1248,7 +1248,7 @@ func changeOwner(path string, uid, gid int) error {
 
 // HttpPlusAgentMonitoringEndpoint provides an agent monitoring endpoint path with a `http+` prefix.
 func HttpPlusAgentMonitoringEndpoint(operatingSystem string, cfg *monitoringCfg.MonitoringConfig) string {
-	return prefixedEndpoint(AgentMonitoringEndpoint(operatingSystem, cfg))
+	return PrefixedEndpoint(AgentMonitoringEndpoint(operatingSystem, cfg))
 }
 
 // AgentMonitoringEndpoint provides an agent monitoring endpoint path.

--- a/internal/pkg/otel/manager/diagnostics.go
+++ b/internal/pkg/otel/manager/diagnostics.go
@@ -135,7 +135,7 @@ func (m *OTelManager) PerformComponentDiagnostics(
 		if translate.GetBeatNameForComponent(&diag.Component) == "filebeat" {
 			// include filebeat registry, reimplementation of a filebeat diagnostic hook
 			registryTarGzBytes, err := FileBeatRegistryTarGz(m.logger, diag.Component.ID)
-			errs = append(errs, err)
+			errs = append(errs, fmt.Errorf("failed to create filebeat registry archive: %w", err))
 			if registryTarGzBytes != nil {
 				m.logger.Debugf("created registry tar.gz, size %d", len(registryTarGzBytes))
 				results = append(results, &proto.ActionDiagnosticUnitResult{

--- a/internal/pkg/otel/manager/diagnostics.go
+++ b/internal/pkg/otel/manager/diagnostics.go
@@ -135,7 +135,9 @@ func (m *OTelManager) PerformComponentDiagnostics(
 		if translate.GetBeatNameForComponent(&diag.Component) == "filebeat" {
 			// include filebeat registry, reimplementation of a filebeat diagnostic hook
 			registryTarGzBytes, err := FileBeatRegistryTarGz(m.logger, diag.Component.ID)
-			errs = append(errs, fmt.Errorf("failed to create filebeat registry archive: %w", err))
+			if err != nil {
+				errs = append(errs, fmt.Errorf("failed to get filebeat registry archive: %w", err))
+			}
 			if registryTarGzBytes != nil {
 				m.logger.Debugf("created registry tar.gz, size %d", len(registryTarGzBytes))
 				results = append(results, &proto.ActionDiagnosticUnitResult{

--- a/internal/pkg/otel/manager/diagnostics.go
+++ b/internal/pkg/otel/manager/diagnostics.go
@@ -136,7 +136,7 @@ func (m *OTelManager) PerformComponentDiagnostics(
 			// include filebeat registry, reimplementation of a filebeat diagnostic hook
 			registryTarGzBytes, err := FileBeatRegistryTarGz(m.logger, diag.Component.ID)
 			errs = append(errs, err)
-			if err != nil {
+			if registryTarGzBytes != nil {
 				m.logger.Debugf("created registry tar.gz, size %d", len(registryTarGzBytes))
 				results = append(results, &proto.ActionDiagnosticUnitResult{
 					Name:        "registry",

--- a/internal/pkg/otel/manager/diagnostics.go
+++ b/internal/pkg/otel/manager/diagnostics.go
@@ -163,12 +163,12 @@ func GetBeatJsonMetricsDiagnostics(ctx context.Context, componentID string) ([]*
 	var results []*proto.ActionDiagnosticUnitResult
 	beatMetrics, err := GetBeatMetricsPayload(ctx, componentID, "/stats")
 	if err != nil {
-		return nil, fmt.Errorf("failed to get beat metrics: %w", err)
+		return nil, fmt.Errorf("failed to get stats beat metrics: %w", err)
 	}
 
 	beatMetrics, err = formatJSON(beatMetrics)
 	if err != nil {
-		return nil, fmt.Errorf("failed to format beat metrics: %w", err)
+		return nil, fmt.Errorf("failed to format stats beat metrics: %w", err)
 	}
 
 	results = append(results, &proto.ActionDiagnosticUnitResult{
@@ -186,12 +186,12 @@ func GetBeatInputMetricsDiagnostics(ctx context.Context, componentID string) ([]
 	var results []*proto.ActionDiagnosticUnitResult
 	inputMetrics, err := GetBeatMetricsPayload(ctx, componentID, "/inputs/")
 	if err != nil {
-		return nil, fmt.Errorf("failed to get input metrics: %w", err)
+		return nil, fmt.Errorf("failed to get input beat metrics: %w", err)
 	}
 
 	inputMetrics, err = formatJSON(inputMetrics)
 	if err != nil {
-		return nil, fmt.Errorf("failed to format input metrics: %w", err)
+		return nil, fmt.Errorf("failed to format input beat metrics: %w", err)
 	}
 
 	results = append(results, &proto.ActionDiagnosticUnitResult{

--- a/internal/pkg/otel/manager/diagnostics_test.go
+++ b/internal/pkg/otel/manager/diagnostics_test.go
@@ -167,13 +167,13 @@ func TestBeatMetrics(t *testing.T) {
 
 	diags, err := m.PerformComponentDiagnostics(context.Background(), nil)
 	require.NoError(t, err)
-	assert.Len(t, obs.All(), 1) // one debug log line about the registry
+	assert.Len(t, obs.All(), 0)
 	require.Len(t, diags, 1)
 
 	diag := diags[0]
 	assert.Equal(t, filebeatComp, diag.Component)
 	// two metrics diagnostics and one filebeat registry
-	require.Len(t, diag.Results, 3, "expected 3 diagnostics, got error: %w", diag.Err)
+	require.Len(t, diag.Results, 2, "expected 2 diagnostics, got error: %w", diag.Err)
 
 	t.Run("beat metrics", func(t *testing.T) {
 		beatMetrics := diag.Results[0]

--- a/internal/pkg/otel/manager/diagnostics_test.go
+++ b/internal/pkg/otel/manager/diagnostics_test.go
@@ -68,6 +68,7 @@ func TestPerformComponentDiagnostics(t *testing.T) {
 		require.NotNil(t, d.Err)
 		assert.ErrorContains(t, d.Err, "failed to get beat metrics")
 		assert.ErrorContains(t, d.Err, "failed to get input metrics")
+		assert.ErrorContains(t, d.Err, "no such file or directory")
 	}
 }
 

--- a/internal/pkg/otel/manager/diagnostics_test.go
+++ b/internal/pkg/otel/manager/diagnostics_test.go
@@ -67,8 +67,8 @@ func TestPerformComponentDiagnostics(t *testing.T) {
 		assert.Equal(t, expectedDiags[i].Component.ID, d.Component.ID)
 		// we should have errors set about not being able to connect to monitoring endpoints
 		require.NotNil(t, d.Err)
-		assert.ErrorContains(t, d.Err, "failed to get beat metrics")
-		assert.ErrorContains(t, d.Err, "failed to get input metrics")
+		assert.ErrorContains(t, d.Err, "failed to get stats beat metrics")
+		assert.ErrorContains(t, d.Err, "failed to get input beat metrics")
 		if translate.GetBeatNameForComponent(&d.Component) == "filebeat" {
 			assert.ErrorContains(t, d.Err, "failed to get filebeat registry archive")
 		}
@@ -178,7 +178,7 @@ func TestBeatMetrics(t *testing.T) {
 	// two metrics diagnostics and one filebeat registry
 	require.Len(t, diag.Results, 2, "expected 2 diagnostics, got error: %w", diag.Err)
 
-	t.Run("beat metrics", func(t *testing.T) {
+	t.Run("stats beat metrics", func(t *testing.T) {
 		beatMetrics := diag.Results[0]
 		assert.Equal(t, "beat_metrics", beatMetrics.Name)
 		assert.Equal(t, "Metrics from the default monitoring namespace and expvar.", beatMetrics.Description)
@@ -187,7 +187,7 @@ func TestBeatMetrics(t *testing.T) {
 		assert.Equal(t, expectedMetricData, beatMetrics.Content)
 	})
 
-	t.Run("input metrics", func(t *testing.T) {
+	t.Run("input beat metrics", func(t *testing.T) {
 		inputMetrics := diag.Results[1]
 		assert.Equal(t, "input_metrics", inputMetrics.Name)
 		assert.Equal(t, "Metrics from active inputs.", inputMetrics.Description)

--- a/internal/pkg/otel/manager/diagnostics_test.go
+++ b/internal/pkg/otel/manager/diagnostics_test.go
@@ -70,7 +70,7 @@ func TestPerformComponentDiagnostics(t *testing.T) {
 		assert.ErrorContains(t, d.Err, "failed to get beat metrics")
 		assert.ErrorContains(t, d.Err, "failed to get input metrics")
 		if translate.GetBeatNameForComponent(&d.Component) == "filebeat" {
-			assert.ErrorContains(t, d.Err, "failed to create filebeat registry archive")
+			assert.ErrorContains(t, d.Err, "failed to get filebeat registry archive")
 		}
 	}
 }

--- a/internal/pkg/otel/manager/diagnostics_test.go
+++ b/internal/pkg/otel/manager/diagnostics_test.go
@@ -131,7 +131,10 @@ func TestPerformDiagnostics(t *testing.T) {
 
 func TestBeatMetrics(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("Skip test on Windows, it's annoying to set up an npipe http server.")
+		t.Skip("Skip test on Windows.",
+			"It's technically cumbersome to set up an npipe http server.",
+			"And it doesn't have anything to do with the code paths being tested.",
+		)
 	}
 	setTemporaryAgentPath(t)
 	logger, obs := loggertest.New("test")

--- a/testing/integration/ess/diagnostics_test.go
+++ b/testing/integration/ess/diagnostics_test.go
@@ -324,14 +324,6 @@ agent.monitoring.enabled: false
 	var filebeatSetup = map[string]integrationtest.ComponentState{
 		"filestream-default": {
 			State: integrationtest.NewClientState(client.Healthy),
-			Units: map[integrationtest.ComponentUnitKey]integrationtest.ComponentUnitState{
-				integrationtest.ComponentUnitKey{UnitType: client.UnitTypeOutput, UnitID: "filestream-default"}: {
-					State: integrationtest.NewClientState(client.Healthy),
-				},
-				integrationtest.ComponentUnitKey{UnitType: client.UnitTypeInput, UnitID: "filestream-default-filestream-filebeat"}: {
-					State: integrationtest.NewClientState(client.Healthy),
-				},
-			},
 		},
 	}
 
@@ -343,6 +335,7 @@ agent.monitoring.enabled: false
 		runtime                      string
 		expectedCompDiagnosticsFiles []string
 		expectedAgentState           *client.State
+		expectedComponentState       map[string]integrationtest.ComponentState
 	}{
 		{
 			name:    "filebeat process",
@@ -353,13 +346,24 @@ agent.monitoring.enabled: false
 				"beat_metrics.json",
 				"beat-rendered-config.yml",
 				"global_processors.txt",
-				"filestream-filebeat/error.txt",
-				"filestream-default/error.txt",
 			),
 			expectedAgentState: integrationtest.NewClientState(client.Healthy),
+			expectedComponentState: map[string]integrationtest.ComponentState{
+				"filestream-default": {
+					State: integrationtest.NewClientState(client.Healthy),
+					Units: map[integrationtest.ComponentUnitKey]integrationtest.ComponentUnitState{
+						integrationtest.ComponentUnitKey{UnitType: client.UnitTypeOutput, UnitID: "filestream-default"}: {
+							State: integrationtest.NewClientState(client.Healthy),
+						},
+						integrationtest.ComponentUnitKey{UnitType: client.UnitTypeInput, UnitID: "filestream-default-filestream-filebeat"}: {
+							State: integrationtest.NewClientState(client.Healthy),
+						},
+					},
+				},
+			},
 		},
 		{
-			name:    "filebeat container",
+			name:    "filebeat receiver",
 			runtime: "otel",
 			expectedCompDiagnosticsFiles: []string{
 				"registry.tar.gz",
@@ -397,7 +401,7 @@ agent.monitoring.enabled: false
 			err = f.Run(ctx, integrationtest.State{
 				Configure:  configBuffer.String(),
 				AgentState: tc.expectedAgentState,
-				Components: filebeatSetup,
+				Components: tc.expectedComponentState,
 				After:      testDiagnosticsFactory(t, filebeatSetup, diagnosticsFiles, tc.expectedCompDiagnosticsFiles, f, []string{"diagnostics", "collect"}),
 			})
 			assert.NoError(t, err)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

It adds beat stats and input metrics to beat receiver diagnostics.

Note that this currently targets #9095, and will switch to main once that is merged. 

## Why is it important?

Diagnostics for beat receivers should contain the same information as they do for beat processes.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [x] I have added an integration test or an E2E test

## How to test this PR locally

Build agent from this PR, then start it with self-monitoring in otel mode and generate diagnostics. You should see `beats_metrics.json` and `input_metrics.json` in the components' respective subdirectories in the diagnostics archive.

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/8208

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
