### PR TITLE
feat add kubernetes events to helm chart presets (elastic#9125)

### DIFF
--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes.tpl
@@ -17,5 +17,6 @@
 {{- include "elasticagent.kubernetes.config.kubelet.volumes.init" $ -}}
 {{- include "elasticagent.kubernetes.config.kube_proxy.init" $ -}}
 {{- include "elasticagent.kubernetes.config.kube_scheduler.init" $ -}}
+{{- include "elasticagent.kubernetes.config.kube_event.init" $ -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_events.tpl
+++ b/deploy/helm/elastic-agent/templates/integrations/_kubernetes/_kubernetes_events.tpl
@@ -1,0 +1,42 @@
+{{- define "elasticagent.kubernetes.config.kube_event.init" -}}
+{{- if eq $.Values.kubernetes.containers.kube_event.enabled true -}}
+{{- $preset := $.Values.agent.presets.clusterWide -}}
+{{- $inputVal := (include "elasticagent.kubernetes.config.kube_event.input" $ | fromYamlArray) -}}
+{{- include "elasticagent.preset.mutate.inputs" (list $ $preset $inputVal) -}}
+{{- include "elasticagent.preset.mutate.outputs.byname" (list $ $preset $.Values.kubernetes.output) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Config input for kube_event
+*/}}
+{{- define "elasticagent.kubernetes.config.kube_event.input" -}}
+- id: kubernetes/metrics-kubernetes.event
+  type: kubernetes/metrics
+  data_stream:
+    namespace: {{.Values.kubernetes.namespace}}
+  use_output: {{ .Values.kubernetes.output }}
+  {{- with $.Values.kubernetes._onboarding_processor }}
+  processors:
+  - {{ . | toYaml | nindent 4 }}
+  {{- end }}
+  streams:
+  - id: kubernetes/metrics-kubernetes.event
+    data_stream:
+      type: metrics
+      dataset: kubernetes.event
+    metricsets:
+      - event
+{{- $vars := (include "elasticagent.kubernetes.config.kube_event.default_vars" .) | fromYaml -}}
+{{- mergeOverwrite $vars .Values.kubernetes.event.vars | toYaml | nindent 4 }}
+{{- end -}}
+
+
+{{/*
+Defaults for kube_event input streams
+*/}}
+{{- define "elasticagent.kubernetes.config.kube_event.default_vars" -}}
+period: 10s
+add_metadata: true
+{{- end -}}
+

--- a/deploy/helm/elastic-agent/values.yaml
+++ b/deploy/helm/elastic-agent/values.yaml
@@ -300,6 +300,15 @@ kubernetes:
       # -- system metric stream vars
       # @section -- 2 - Kubernetes integration
       vars: {}
+  event:
+    # -- enable [event](https://www.elastic.co/guide/en/beats/metricbeat/8.11/metricbeat-metricset-kubernetes-event.html)
+    # input
+    # @section -- 2 - Kubernetes integration
+    enabled: false
+    # -- event stream variables such as `hosts`, `period`, `bearer_token_file`,
+    # `ssl.verification_mode`, `condition`.
+    # @section -- 2 - Kubernetes integration
+    vars: {}
 system:
   # -- enable System integration.
   # @section -- 4 - System integration


### PR DESCRIPTION
<!-- Type of change
- Enhancement
-->

## What does this PR do?

I have added a new helm template to allow the use of Kuberenetes events

## Why is it important?

It allows the configuration to collate events, which is possible in the examples for the Kustomize resources 

## Checklist

- [X] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

None as the default value is false

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

Closes #9125 

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
