### PR TITLE
Fix version check in rollback tests

### DIFF
--- a/testing/integration/ess/upgrade_rollback_test.go
+++ b/testing/integration/ess/upgrade_rollback_test.go
@@ -144,7 +144,7 @@ inputs:
 			}
 
 			assert.Equal(t, details.StateRollback, details.State(state.UpgradeDetails.State))
-			if !startVersion.Less(*upgradetest.Version_9_1_0_SNAPSHOT) {
+			if !startVersion.Less(*upgradetest.Version_9_2_0_SNAPSHOT) {
 				assert.Equal(t, details.ReasonWatchFailed, state.UpgradeDetails.Metadata.Reason)
 			}
 		} else {
@@ -382,7 +382,7 @@ func managedRollbackRestartTest(ctx context.Context, t *testing.T, info *define.
 		require.NoError(t, fleetAgentErr, "error getting agent from Fleet")
 		require.NotNil(t, fleetAgent.UpgradeDetails, "upgrade details not set")
 		assert.Equal(t, details.StateRollback, details.State(fleetAgent.UpgradeDetails.State))
-		if !startVersion.Less(*upgradetest.Version_9_1_0_SNAPSHOT) {
+		if !startVersion.Less(*upgradetest.Version_9_2_0_SNAPSHOT) {
 			assert.Equal(t, details.ReasonWatchFailed, fleetAgent.UpgradeDetails.Metadata.Reason)
 		}
 	}
@@ -457,7 +457,7 @@ func standaloneRollbackRestartTest(ctx context.Context, t *testing.T, startFixtu
 
 		require.NotNil(t, state.UpgradeDetails)
 		assert.Equal(t, details.StateRollback, details.State(state.UpgradeDetails.State))
-		if !startVersion.Less(*upgradetest.Version_9_1_0_SNAPSHOT) {
+		if !startVersion.Less(*upgradetest.Version_9_2_0_SNAPSHOT) {
 			assert.Equal(t, details.ReasonWatchFailed, state.UpgradeDetails.Metadata.Reason)
 		}
 	}

--- a/testing/upgradetest/versions.go
+++ b/testing/upgradetest/versions.go
@@ -46,8 +46,10 @@ var (
 	Version_8_19_0_SNAPSHOT = version.NewParsedSemVer(8, 19, 0, "SNAPSHOT", "")
 
 	// Version_9_1_0_SNAPSHOT is a FIPS-capable artifact.
-	// Version_9_1_0_SNAPSHOT is the minimum version for manual rollback and rollback reason
 	Version_9_1_0_SNAPSHOT = version.NewParsedSemVer(9, 1, 0, "SNAPSHOT", "")
+
+	// Version_9_2_0_SNAPSHOT is the minimum version for manual rollback and rollback reason
+	Version_9_2_0_SNAPSHOT = version.NewParsedSemVer(9, 2, 0, "SNAPSHOT", "")
 
 	// ErrNoSnapshot is returned when a requested snapshot is not on the version list.
 	ErrNoSnapshot = errors.New("failed to find a snapshot on the version list")


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fix minimum version check to assert rollback reason when an elastic-agent upgrade is automatically rolled back.
PR #8407 didn't make it into 9.1 before the release branch is detached, so with the new version 9.1.0 being released, tests `TestStandaloneUpgradeRollback` wrongly expected to find the rollback reason from a 9.1.0 `elastic-agent status` output.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

To have correct assertions for `TestStandaloneUpgradeRollback` integration tests.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #8407

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
