### PR TITLE
Wait for policy action to be acked in TestInspect

### DIFF
--- a/testing/integration/ess/inspect_test.go
+++ b/testing/integration/ess/inspect_test.go
@@ -74,7 +74,7 @@ func TestInspect(t *testing.T) {
 			}})
 	require.NoErrorf(t, err, "Error when installing agent, output: %s", out)
 	check.ConnectedToFleet(ctx, t, fixture, 5*time.Minute)
-	assert.Eventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		return checkinWithAcker.Acked(policyChangeAction.ActionID)
 	}, 5*time.Minute, time.Second, "Policy change action should have been acked")
 

--- a/testing/integration/ess/inspect_test.go
+++ b/testing/integration/ess/inspect_test.go
@@ -74,6 +74,9 @@ func TestInspect(t *testing.T) {
 			}})
 	require.NoErrorf(t, err, "Error when installing agent, output: %s", out)
 	check.ConnectedToFleet(ctx, t, fixture, 5*time.Minute)
+	assert.Eventually(t, func() bool {
+		return checkinWithAcker.Acked(policyChangeAction.ActionID)
+	}, 5*time.Minute, time.Second, "Policy change action should have been acked")
 
 	p, err := fixture.Exec(ctx, []string{"inspect"})
 	require.NoErrorf(t, err, "Error when running inspect, output: %s", p)


### PR DESCRIPTION
## What does this PR do?

Fix a race condition in an integration test by waiting until a policy change action is acked before running the inspect command.

## Why is it important?

The test is flaky without the change. The inspect command and the config change from the policy race against each other, and the test fails if inspect wins.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/7171

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
