### PR TITLE
Don't overwrite existing headers when mapping agentInfo headers into elasticsearch output

### DIFF
--- a/changelog/fragments/1753906482-Don't-overwrite-elasticsearch-output-headers-from-enrollment---headers-flag.yaml
+++ b/changelog/fragments/1753906482-Don't-overwrite-elasticsearch-output-headers-from-enrollment---headers-flag.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Don't overwrite elasticsearch output headers from enrollment --headers flag
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/9199
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/9197

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -591,7 +591,10 @@ func toIntermediate(policy map[string]interface{}, aliasMapping map[string]strin
 				}
 
 				for headerName, headerVal := range agentHeaders {
-					headers[headerName] = headerVal
+					// only set headers for those that are not already set
+					if _, ok := headers[headerName]; !ok {
+						headers[headerName] = headerVal
+					}
 				}
 
 				output[headersKey] = headers

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -2166,7 +2166,8 @@ func TestToComponents(t *testing.T) {
 						"type":    "elasticsearch",
 						"enabled": true,
 						"headers": map[string]interface{}{
-							"header-two": "val-2",
+							"header-two":   "val-2",
+							"header-three": "val-3",
 						},
 					},
 				},
@@ -2195,8 +2196,9 @@ func TestToComponents(t *testing.T) {
 							Config: MustExpectedConfig(map[string]interface{}{
 								"type": "elasticsearch",
 								"headers": map[string]interface{}{
-									"header-two": "val-2",
-									"header-one": "val-1",
+									"header-two":   "val-2",
+									"header-one":   "val-1",
+									"header-three": "val-3",
 								},
 							}),
 						},
@@ -2214,7 +2216,8 @@ func TestToComponents(t *testing.T) {
 				},
 			},
 			headers: &testHeadersProvider{headers: map[string]string{
-				"header-one": "val-1",
+				"header-one":   "val-1",
+				"header-three": "val-3-diff",
 			}},
 		},
 		{
@@ -2227,6 +2230,7 @@ func TestToComponents(t *testing.T) {
 						"enabled": true,
 						"headers": map[string]interface{}{
 							"cloud1": "beat1",
+							"cloud3": "beat3",
 						},
 					},
 				},
@@ -2257,6 +2261,7 @@ func TestToComponents(t *testing.T) {
 								"headers": map[string]interface{}{
 									"cloud1": "beat1",
 									"cloud2": "beat2",
+									"cloud3": "beat3",
 								},
 							}),
 						},
@@ -2275,6 +2280,7 @@ func TestToComponents(t *testing.T) {
 			},
 			headers: &testHeadersProvider{headers: map[string]string{
 				"cloud2": "beat2",
+				"cloud3": "beat3-diff",
 			}},
 		},
 		{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Changes the behavior of `toIntermediate` to only add headers to an output if the output doesn't already have that header defined.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This allows the use-case where the same header name is used for Fleet and Elasticsearch, but the value of each is different.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~ (covered by unit tests)

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #9197 

