### PR TITLE
Refactor binary downloads in agent packaging targets

### DIFF
--- a/dev-tools/mage/downloads/utils.go
+++ b/dev-tools/mage/downloads/utils.go
@@ -7,6 +7,7 @@ package downloads
 import (
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -15,67 +16,44 @@ import (
 	devtools "github.com/elastic/elastic-agent/dev-tools/mage"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/gofrs/uuid/v5"
 )
 
 var checksumFileRegex = regexp.MustCompile(`^([0-9a-f]{128})\s+(\w.*)$`)
 
 // downloadRequest struct contains download details ad path and URL
 type downloadRequest struct {
-	URL                 string
-	DownloadPath        string
-	UnsanitizedFilePath string
+	URL        string
+	TargetPath string
 }
 
 // downloadFile will download a url and store it in a temporary path.
 // It writes to the destination file as it downloads it, without
 // loading the entire file into memory.
 func downloadFile(downloadRequest *downloadRequest) error {
-	var filePath string
-	if downloadRequest.DownloadPath == "" {
-		u, err := uuid.NewV4()
-		if err != nil {
-			return fmt.Errorf("failed to create UUID: %w", err)
-		}
-		tempParentDir := filepath.Join(os.TempDir(), u.String())
-		err = mkdirAll(tempParentDir)
-		if err != nil {
-			return fmt.Errorf("creating directory: %w", err)
-		}
-		u, err = uuid.NewV4()
-		if err != nil {
-			return fmt.Errorf("failed to create UUID: %w", err)
-		}
-		filePath = filepath.Join(tempParentDir, u.String())
-		downloadRequest.DownloadPath = filePath
-	} else {
-		u, err := uuid.NewV4()
-		if err != nil {
-			return fmt.Errorf("failed to create UUID: %w", err)
-		}
-		filePath = filepath.Join(downloadRequest.DownloadPath, u.String())
-	}
-
-	tempFile, err := os.Create(filePath)
+	targetFile, err := os.Create(downloadRequest.TargetPath)
 	if err != nil {
 		return fmt.Errorf("creating file: %w", err)
 	}
-	defer tempFile.Close()
+	defer func() {
+		_ = targetFile.Close()
+	}()
 
-	downloadRequest.UnsanitizedFilePath = tempFile.Name()
 	exp := getExponentialBackoff(3)
 
 	retryCount := 1
-	var fileReader io.Reader
+	var fileReader io.ReadCloser
 	download := func() error {
-		r := httpRequest{URL: downloadRequest.URL}
-		bodyStr, err := get(r)
+		req, err := http.NewRequest(http.MethodGet, downloadRequest.URL, nil)
+		if err != nil {
+			return fmt.Errorf("creating request: %w", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			retryCount++
 			return fmt.Errorf("downloading file %s: %w", downloadRequest.URL, err)
 		}
 
-		fileReader = strings.NewReader(bodyStr)
+		fileReader = resp.Body
 		return nil
 	}
 
@@ -84,12 +62,16 @@ func downloadFile(downloadRequest *downloadRequest) error {
 		return err
 	}
 
-	_, err = io.Copy(tempFile, fileReader)
+	_, err = io.Copy(targetFile, fileReader)
 	if err != nil {
-		return fmt.Errorf("writing file %s: %w", tempFile.Name(), err)
+		return fmt.Errorf("writing file %s: %w", targetFile.Name(), err)
+	}
+	err = fileReader.Close()
+	if err != nil {
+		return fmt.Errorf("closing reader: %w", err)
 	}
 
-	_ = os.Chmod(tempFile.Name(), 0666)
+	_ = os.Chmod(targetFile.Name(), 0666)
 
 	return nil
 }

--- a/dev-tools/mage/downloads/utils.go
+++ b/dev-tools/mage/downloads/utils.go
@@ -5,6 +5,7 @@
 package downloads
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -43,11 +44,11 @@ func downloadFile(downloadRequest *downloadRequest) error {
 	retryCount := 1
 	var fileReader io.ReadCloser
 	download := func() error {
-		req, err := http.NewRequest(http.MethodGet, downloadRequest.URL, nil)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, downloadRequest.URL, nil)
 		if err != nil {
 			return fmt.Errorf("creating request: %w", err)
 		}
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := http.DefaultClient.Do(req) //nolint:bodyclose // we do close this outside of the function
 		if err != nil {
 			retryCount++
 			return fmt.Errorf("downloading file %s: %w", downloadRequest.URL, err)

--- a/dev-tools/mage/downloads/utils_test.go
+++ b/dev-tools/mage/downloads/utils_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -26,13 +25,12 @@ func TestDownloadFile(t *testing.T) {
 	var dRequest = downloadRequest{
 		URL: fmt.Sprintf("http://%s/some-file.txt",
 			s.Listener.Addr().String()),
-		DownloadPath: "",
+		TargetPath: filepath.Join(t.TempDir(), "some-file.txt"),
 	}
 
 	err := downloadFile(&dRequest)
 	assert.Nil(t, err)
-	assert.NotEmpty(t, dRequest.UnsanitizedFilePath)
-	defer os.Remove(filepath.Dir(dRequest.UnsanitizedFilePath))
+	assert.FileExistsf(t, dRequest.TargetPath, "file should exist")
 }
 
 func TestVerifyChecksum(t *testing.T) {

--- a/dev-tools/mage/downloads/utils_test.go
+++ b/dev-tools/mage/downloads/utils_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 

--- a/dev-tools/mage/downloads/versions.go
+++ b/dev-tools/mage/downloads/versions.go
@@ -106,49 +106,9 @@ func CheckPRVersion(version string, fallbackVersion string) string {
 	return version
 }
 
-// FetchElasticArtifact fetches an artifact from the right repository, returning binary name, path and error
-func FetchElasticArtifact(ctx context.Context, artifact string, version string, os string, arch string, extension string, isDocker bool, xpack bool) (string, string, error) {
-	useCISnapshots := GithubCommitSha1 != ""
-
-	return FetchElasticArtifactForSnapshots(ctx, useCISnapshots, artifact, version, os, arch, extension, isDocker, xpack)
-}
-
-// FetchElasticArtifactForSnapshots fetches an artifact from the right repository, returning binary name, path and error
-func FetchElasticArtifactForSnapshots(ctx context.Context, useCISnapshots bool, artifact string, version string, os string, arch string, extension string, isDocker bool, xpack bool) (string, string, error) {
-	binaryName := buildArtifactName(artifact, version, os, arch, extension, isDocker)
-	binaryPath, err := FetchProjectBinaryForSnapshots(ctx, useCISnapshots, artifact, binaryName, artifact, version, timeoutFactor, xpack, "", false)
-	if err != nil {
-		logger.Error("Could not download the binary for the Elastic artifact",
-			slog.String("artifact", artifact),
-			slog.String("version", version),
-			slog.String("os", os),
-			slog.String("arch", arch),
-			slog.String("extension", extension),
-			slog.String("error", err.Error()),
-		)
-		return "", "", err
-	}
-
-	return binaryName, binaryPath, nil
-}
-
 // GetCommitVersion returns a version including the version and the git commit, if it exists
 func GetCommitVersion(version string) string {
 	return newElasticVersion(version).HashedVersion
-}
-
-// GetElasticArtifactURL returns the URL of a released artifact, which its full name is defined in the first argument,
-// from Elastic's artifact repository, building the JSON path query based on the full name
-// It also returns the URL of the sha512 file of the released artifact.
-// i.e. GetElasticArtifactURL("elastic-agent-$VERSION-$ARCH.deb", "elastic-agent", "$VERSION")
-// i.e. GetElasticArtifactURL("elastic-agent-$VERSION-x86_64.rpm", "elastic-agent","$VERSION")
-// i.e. GetElasticArtifactURL("elastic-agent-$VERSION-linux-$ARCH.tar.gz", "elastic-agent","$VERSION")
-func GetElasticArtifactURL(artifactName string, artifact string, version string) (string, string, error) {
-	resolver := NewArtifactURLResolver(artifactName, artifact, version)
-	if resolver == nil {
-		return "", "", errors.New("nil resolver returned")
-	}
-	return resolver.Resolve()
 }
 
 // GetElasticArtifactVersion returns the current version:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Refactors how the agent packaging target downloads binaries. The intent is to make it possible to cache the binaries locally and avoid having to redownload them. See https://github.com/elastic/elastic-agent/pull/9133 for the full context.

The PR consists of the following changes:

* The download function now always gets a target path as an input, so it doesn't need to create it on its own conditionally.
* We use standard library functions for the download, so we don't need to pass the content as a string, and can instead write it directly to the target file, saving memory.
* Remove some unused functions.

## Why is it important?

This makes the download code more maintainable and more performant. It also unlocks further packaging improvements.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates https://github.com/elastic/observability-dev/issues/4702

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
