### PR TITLE
Increase endpoint verify command timeout to 60s.

### DIFF
--- a/changelog/fragments/1754077561-Increase-timeout-of-endpoint-security-verify-command-from-30s-to-60s.yaml
+++ b/changelog/fragments/1754077561-Increase-timeout-of-endpoint-security-verify-command-from-30s-to-60s.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Increase timeout of endpoint-security verify command from 30s to 60s.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/9227
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/specs/endpoint-security.spec.yml
+++ b/specs/endpoint-security.spec.yml
@@ -1,5 +1,5 @@
 version: 2
-component_files: 
+component_files:
  - endpoint-security-resources.zip
 inputs:
   - name: endpoint
@@ -35,7 +35,7 @@ inputs:
             - "verify"
             - "--log"
             - "stderr"
-          timeout: 30s
+          timeout: 60s
         install:
           args:
             - "install"


### PR DESCRIPTION
Increase the timeout of the endpoint-security verify command to 60s.

This implements the `check` function used to determine if we need to call `endpoint-security install`. 

https://github.com/elastic/elastic-agent/blob/1aa5e6d5494ae72381e579eaa1f50b4c7dede39a/pkg/component/runtime/service.go#L353-L364

The `verify` command is responsible for upgrades, and is gaining some self-healing capabilities that could take additional time like (re)starting the endpoint OS service. Increasing to 60s as suggested by @bjmcnic 