### PR TITLE
skip: TestUpgradeAgentWithTamperProtectedEndpoint_DEB 

### DIFF
--- a/testing/integration/ess/endpoint_security_test.go
+++ b/testing/integration/ess/endpoint_security_test.go
@@ -82,6 +82,7 @@ func TestUpgradeAgentWithTamperProtectedEndpoint_DEB(t *testing.T) {
 	})
 
 	t.Run("Install same version over the installed agent", func(t *testing.T) {
+		t.Skip("This constantly fails, so skipping until further investigation is done and a fix is implemented")
 		testTamperProtectedInstallUpgrade(t, info, "deb", define.Version(), false, false)
 	})
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR temporarily skips the `TestUpgradeAgentWithTamperProtectedEndpoint_DEB/Install_same_version_over_the_installed_agent` integration test.  
The test has started failing consistently in the last few days on `main` and also in draft PR pipelines.  
Reference failures: 
- [Main branch failure](https://buildkite.com/elastic/elastic-agent-extended-testing/builds/9611#019872a0-3088-40e5-a584-d4e93ac76c1f/381-732)  
- [Draft PR pipeline](https://buildkite.com/elastic/elastic-agent/builds/24748#01986997-a763-4569-b26e-90046657d3fa/220-566)  

The test will remain skipped until the root cause is identified and a fix is implemented cc @ebeahan 

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

- Keeps the CI green while the root cause of the failures is being investigated.  
- Prevents unrelated PRs from being blocked by a known failing test. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

No direct user-facing impact.  
This change only affects the **integration test suite** for tamper-protected `deb` upgrades.  
Skipping the test does **not** affect Elastic Agent functionality or behavior in production environments.  Although this failure definitely hints at underlying issue

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

N/A

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- N/A