### PR TITLE
[FIPS] Only consider versions available in ECH region for `TestUpgradeIntegrationsServer`

### DIFF
--- a/testing/integration/ess/upgrade_integrations_server_test.go
+++ b/testing/integration/ess/upgrade_integrations_server_test.go
@@ -58,7 +58,7 @@ func TestUpgradeIntegrationsServer(t *testing.T) {
 	statefulProv, ok := prov.(*ess.StatefulProvisioner)
 	require.True(t, ok)
 
-	startVersions = filterVersionsForECH(t, startVersions)
+	startVersions = filterVersionsForECH(t, startVersions, statefulProv)
 
 	t.Logf("Running test cases for upgrade from versions [%v] to version [%s]", startVersions, endVersion)
 	for _, startVersion := range startVersions {

--- a/testing/integration/ess/upgrade_integrations_server_test.go
+++ b/testing/integration/ess/upgrade_integrations_server_test.go
@@ -45,6 +45,9 @@ func TestUpgradeIntegrationsServer(t *testing.T) {
 		t.Fatal("ECH API key missing")
 	}
 
+	startVersions := getUpgradeableFIPSVersions(t)
+	endVersion := define.Version()
+
 	prov, err := ess.NewProvisioner(ess.ProvisionerConfig{
 		Identifier: "it-upgrade-integrations-server",
 		APIKey:     echApiKey,
@@ -55,8 +58,7 @@ func TestUpgradeIntegrationsServer(t *testing.T) {
 	statefulProv, ok := prov.(*ess.StatefulProvisioner)
 	require.True(t, ok)
 
-	startVersions := getUpgradeableFIPSVersions(t, statefulProv)
-	endVersion := define.Version()
+	startVersions = filterVersionsForECH(t, startVersions)
 
 	t.Logf("Running test cases for upgrade from versions [%v] to version [%s]", startVersions, endVersion)
 	for _, startVersion := range startVersions {
@@ -109,15 +111,9 @@ func TestUpgradeIntegrationsServer(t *testing.T) {
 }
 
 // getUpgradeableFIPSVersions returns stack versions to use as the start version for an upgrade.
-func getUpgradeableFIPSVersions(t *testing.T, prov *ess.StatefulProvisioner) version.SortableParsedVersions {
-	// Get the list of versions we use in upgrade integration tests in general.
+func getUpgradeableFIPSVersions(t *testing.T) version.SortableParsedVersions {
 	versions, err := upgradetest.GetUpgradableVersions()
 	require.NoError(t, err, "could not get upgradable versions")
-
-	// Filter the list down to versions that are FIPS-capable and actually available
-	// in the ECH region
-	echVersions, err := prov.AvailableVersions()
-	require.NoError(t, err)
 
 	filteredVersions := make([]*version.ParsedSemVer, 0)
 	for _, ver := range versions {
@@ -126,19 +122,26 @@ func getUpgradeableFIPSVersions(t *testing.T, prov *ess.StatefulProvisioner) ver
 			continue
 		}
 
-		// Filter out versions that are not available in the ECH region
-		if !isVersionInList(ver, echVersions) {
-			continue
-		}
-
 		filteredVersions = append(filteredVersions, ver)
 	}
 
-	// Sort the final list so the test cases are run in a sorted order,
-	// making it easier for humans to follow and consume the output.
 	sortedVers := version.SortableParsedVersions(filteredVersions)
 	sort.Sort(sortedVers)
 	return sortedVers
+}
+
+func filterVersionsForECH(t *testing.T, versions []*version.ParsedSemVer, echProv *ess.StatefulProvisioner) []*version.ParsedSemVer {
+	echVersions, err := echProv.AvailableVersions()
+	require.NoError(t, err)
+
+	filteredVersions := make([]*version.ParsedSemVer, 0)
+	for _, ver := range versions {
+		if isVersionInList(ver, echVersions) {
+			filteredVersions = append(filteredVersions, ver)
+		}
+	}
+
+	return filteredVersions
 }
 
 func isVersionInList(candidateVersion *version.ParsedSemVer, allowedVersions []*version.ParsedSemVer) bool {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR restricts the versions used as start versions in `TestUpgradeIntegrationsServer` to those actually available in the ECH region where the integrations server is being run.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The test should not attempt to use a start version that doesn't actually exist in the ECH region where the integrations server deployment will be created.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None; this PR modifies an integration test.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
Follow up to https://github.com/elastic/elastic-agent/pull/9207#issuecomment-3157529153

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
