### PR TITLE
fix: push the cloud images from packaging steps

### DIFF
--- a/.buildkite/bk.integration-fips.pipeline.yml
+++ b/.buildkite/bk.integration-fips.pipeline.yml
@@ -18,31 +18,8 @@ common:
         env_var: "EC_API_KEY"
 
 steps:
-  - label: Build and push custom elastic-agent image
-    depends_on:
-      - 'packaging-containers-x86-64-fips' # Reuse artifacts produced in .buildkite/integration.pipeline.yml
-    key: integration-fips-cloud-image
-    env:
-      FIPS: "true"
-      CUSTOM_IMAGE_TAG: "git-${BUILDKITE_COMMIT:0:12}"
-      CI_ELASTIC_AGENT_DOCKER_IMAGE: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips"
-      TF_VAR_integration_server_docker_image: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips:git-${BUILDKITE_COMMIT:0:12}"
-    command: |
-      buildkite-agent artifact download build/distributions/elastic-agent-cloud-fips-*-linux-amd64.docker.tar.gz . --step 'packaging-containers-x86-64-fips'
-      mage cloud:load
-      mage cloud:push
-    agents:
-      provider: "gcp"
-      machineType: "n1-standard-8"
-      image: "${IMAGE_UBUNTU_2404_X86_64}"
-    plugins:
-      - elastic/vault-docker-login#v0.5.2:
-          secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
-
   - label: Start ESS stack for FIPS integration tests
     key: integration-fips-ess
-    depends_on:
-      - integration-fips-cloud-image
     env:
       ASDF_TERRAFORM_VERSION: 1.9.2
       FIPS: "true"

--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -9,6 +9,11 @@ env:
   IMAGE_UBUNTU_2204_X86_64: "platform-ingest-elastic-agent-ubuntu-2204-1753491662"
   IMAGE_UBUNTU_2204_ARM_64: "platform-ingest-elastic-agent-ubuntu-2204-aarch64-1753491662"
 
+common:
+  - vault_docker_login: &vault_docker_login
+      elastic/vault-docker-login#v0.5.2:
+        secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
+
 steps:
   - group: "Integration tests: packaging"
     key: "int-packaging"
@@ -108,6 +113,7 @@ steps:
           PLATFORMS: "linux/amd64"
         command: |
           .buildkite/scripts/steps/integration-package.sh
+          .buildkite/scripts/steps/integration-cloud-image-push.sh
         artifact_paths:
           - build/distributions/**
         agents:
@@ -115,6 +121,8 @@ steps:
           machineType: "n2-standard-8"
           diskSizeGb: 200
           image: "${IMAGE_UBUNTU_2204_X86_64}"
+        plugins:
+          - *vault_docker_login
 
       - label: "Packaging: Containers linux/arm64"
         key: packaging-containers-arm64
@@ -139,6 +147,7 @@ steps:
           FIPS: "true"
         command: |
           .buildkite/scripts/steps/integration-package.sh
+          .buildkite/scripts/steps/integration-cloud-image-push.sh
         artifact_paths:
           - build/distributions/**
         agents:
@@ -146,6 +155,8 @@ steps:
           machineType: "n2-standard-8"
           diskSizeGb: 200
           image: "${IMAGE_UBUNTU_2204_X86_64}"
+        plugins:
+          - *vault_docker_login
 
       - label: "Packaging: Containers linux/arm64 FIPS"
         key: packaging-containers-arm64-fips


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

During the backport of https://github.com/elastic/elastic-agent/pull/9282 I missed the fact that this https://github.com/elastic/elastic-agent/pull/8337 never got backported to 9.1. This leads to certain failures [context here](https://github.com/elastic/elastic-agent/pull/9262#issuecomment-3166096573)

So, this PR ensures that cloud images built as part of the packaging steps for integration tests are properly pushed to the Docker registry. Previously, this push step was part of a separate FIPS-specific step (`integration-fips-cloud-image`), which has now been removed.

The logic to load and push the cloud image has been relocated to the packaging steps themselves (`packaging-containers-x86-64-fips` and others), specifically using the new `integration-cloud-image-push.sh` script. In addition, a shared Vault Docker login plugin has been introduced and reused via anchors across these steps.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This fix ensures that the required images for FIPS integration tests are available without relying on a separate Buildkite step and most importantly they do use the `USE_PACKAGE_VERSION` env var

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None. This is a CI-only change and has no impact on users of the Elastic Agent.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

This is a CI-only change thus maybe open a draft PR

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- N/A
