### PR TITLE
Added support for user defined hooks - prerun

### DIFF
--- a/internal/pkg/agent/install/install_windows.go
+++ b/internal/pkg/agent/install/install_windows.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/sys/windows/svc/eventlog"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/install/usermgmt"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/perms"
 	"github.com/elastic/elastic-agent/pkg/utils"
 	"github.com/elastic/elastic-agent/version"
@@ -82,11 +83,11 @@ func withServiceOptions(username string, groupName string, password string) ([]s
 
 	// service requires a password to launch as the use
 	// this sets it to a random password that is only known by the service
-	password, err := RandomPassword()
+	password, err := usermgmt.RandomPassword()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate random password: %w", err)
 	}
-	err = SetUserPassword(username, password)
+	err = usermgmt.SetUserPassword(username, password)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set user %s password for service: %w", username, err)
 	}

--- a/internal/pkg/agent/install/usermgmt/user.go
+++ b/internal/pkg/agent/install/usermgmt/user.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-package install
+package usermgmt
 
 import "errors"
 

--- a/internal/pkg/agent/install/usermgmt/user_darwin.go
+++ b/internal/pkg/agent/install/usermgmt/user_darwin.go
@@ -4,7 +4,7 @@
 
 //go:build darwin
 
-package install
+package usermgmt
 
 import (
 	"bufio"

--- a/internal/pkg/agent/install/usermgmt/user_linux.go
+++ b/internal/pkg/agent/install/usermgmt/user_linux.go
@@ -4,7 +4,7 @@
 
 //go:build linux
 
-package install
+package usermgmt
 
 import (
 	"errors"

--- a/internal/pkg/agent/install/usermgmt/user_test.go
+++ b/internal/pkg/agent/install/usermgmt/user_test.go
@@ -1,0 +1,18 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build !windows
+
+package usermgmt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnsureRights(t *testing.T) {
+	// no-op function testing for coverage
+	assert.NoError(t, EnsureRights("custom"))
+}

--- a/internal/pkg/agent/install/usermgmt/user_windows.go
+++ b/internal/pkg/agent/install/usermgmt/user_windows.go
@@ -4,7 +4,7 @@
 
 //go:build windows
 
-package install
+package usermgmt
 
 import (
 	"crypto/rand"

--- a/internal/pkg/agent/install/usermgmt/user_windows_test.go
+++ b/internal/pkg/agent/install/usermgmt/user_windows_test.go
@@ -4,7 +4,7 @@
 
 //go:build windows
 
-package install
+package usermgmt
 
 import (
 	"fmt"

--- a/internal/pkg/agent/perms/opts.go
+++ b/internal/pkg/agent/perms/opts.go
@@ -18,9 +18,16 @@ const (
 type opts struct {
 	mask      os.FileMode
 	ownership utils.FileOwner
+	inherit   bool
 }
 
 type OptFunc func(o *opts)
+
+func WithInherit(inherit bool) OptFunc {
+	return func(o *opts) {
+		o.inherit = inherit
+	}
+}
 
 // WithMask adjusts the default mask used.
 func WithMask(mask os.FileMode) OptFunc {

--- a/internal/pkg/agent/perms/windows.go
+++ b/internal/pkg/agent/perms/windows.go
@@ -84,7 +84,7 @@ func FixPermissions(topPath string, opts ...OptFunc) error {
 				switch {
 				case err == nil:
 					// first level doesn't inherit
-					inherit := topPath != walkPath
+					inherit := o.inherit || topPath != walkPath
 					return applyPermissions(walkPath, true, inherit, userSID, groupSID, grants...)
 				case errors.Is(err, fs.ErrNotExist):
 					return nil

--- a/pkg/component/hooks.go
+++ b/pkg/component/hooks.go
@@ -1,0 +1,261 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package component
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/pkg/component/hooks"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+)
+
+// Hook execution points
+const (
+	HookPreRun = "pre-run"
+)
+
+// Hook types
+const (
+	HookTypeFixPermissions = "fix-permissions"
+)
+
+var supportedHooks = []string{
+	HookTypeFixPermissions,
+}
+
+// HookDefinition defines a single hook with its type and arguments
+type HookDefinition struct {
+	Type string                 `config:"hook_type" yaml:"type" json:"type"`
+	Args map[string]interface{} `config:"args,omitempty" yaml:"args,omitempty" json:"args,omitempty"`
+}
+
+// ComponentHooks defines all hooks for a component organized by execution point
+type ComponentHooks struct {
+	PreRun  []HookDefinition `config:"pre_run,omitempty" yaml:"pre_run,omitempty" json:"pre_run,omitempty"`
+	PostRun []HookDefinition `config:"post_run,omitempty" yaml:"post_run,omitempty" json:"post_run,omitempty"`
+}
+
+// GetHooks returns hooks for a specific execution point
+func (c *ComponentHooks) GetHooks(point string) []HookDefinition {
+	switch point {
+	case HookPreRun:
+		return c.PreRun
+	default:
+		return nil
+	}
+}
+
+// Validate checks that all hooks in ComponentHooks are of known types
+func (c *ComponentHooks) Validate() error {
+	allHooks := []struct {
+		point string
+		hooks []HookDefinition
+	}{
+		{HookPreRun, c.PreRun},
+	}
+
+	var validationErrors []string
+
+	for _, hookGroup := range allHooks {
+		for i, hook := range hookGroup.hooks {
+			if hook.Type == "" {
+				validationErrors = append(validationErrors,
+					fmt.Sprintf("hook at index %d in %s has empty type", i, hookGroup.point))
+				continue
+			}
+
+			if !isValidHookType(hook.Type) {
+				validationErrors = append(validationErrors,
+					fmt.Sprintf("unknown hook type '%s' at index %d in %s. Supported types: %v",
+						hook.Type, i, hookGroup.point, supportedHooks))
+			}
+		}
+	}
+
+	if len(validationErrors) > 0 {
+		return fmt.Errorf("hook validation failed: %s", strings.Join(validationErrors, "; "))
+	}
+
+	return nil
+}
+
+// Run executes the hook with its arguments
+func (hd *HookDefinition) Run() error {
+	switch hd.Type {
+	case HookTypeFixPermissions:
+		return hd.fixPermissions()
+	default:
+		return fmt.Errorf("unknown hook type: %s", hd.Type)
+	}
+}
+
+// GetStringArg safely extracts a string argument
+func (hd *HookDefinition) GetArg(key string) (interface{}, bool) {
+	if val, exists := hd.Args[key]; exists {
+		return val, true
+	}
+	return "", false
+}
+
+// GetStringArg safely extracts a string argument
+func (hd *HookDefinition) GetStringArg(key string) (string, bool) {
+	if val, exists := hd.Args[key]; exists {
+		if str, ok := val.(string); ok {
+			return str, true
+		}
+	}
+	return "", false
+}
+
+// GetIntArg safely extracts a int argument
+func (hd *HookDefinition) GetIntArg(key string) (int, bool) {
+	if val, exists := hd.Args[key]; exists {
+		switch v := val.(type) {
+		case int:
+			return v, true
+		case int32:
+			return int(v), true
+		case int64:
+			return int(v), true
+		case uint64:
+			return int(v), true
+		case uint32:
+			return int(v), true
+		case uint:
+			return int(v), true
+		case float32:
+			// Handle case where YAML/JSON might parse as float.
+			// Make sure we return the value only if it's truly int
+			if v == float32(int(v)) {
+				return int(v), true
+			}
+		case float64:
+			// Handle case where YAML/JSON might parse as float
+			// Make sure we return the value only if it's truly int
+			if v == float64(int(v)) {
+				return int(v), true
+			}
+		}
+	}
+	return 0, false
+}
+
+// GetBoolArg safely extracts a boolean argument
+func (hd *HookDefinition) GetBoolArg(key string) (bool, bool) {
+	if val, exists := hd.Args[key]; exists {
+		if b, ok := val.(bool); ok {
+			return b, true
+		}
+
+	}
+	return false, false
+}
+
+// GetStringSliceArg safely extracts a string slice argument
+func (hd *HookDefinition) GetStringSliceArg(key string) ([]string, bool) {
+	if val, exists := hd.Args[key]; exists {
+		if slice, ok := val.([]interface{}); ok {
+			result := make([]string, len(slice))
+			for i, item := range slice {
+				if str, ok := item.(string); ok {
+					result[i] = str
+				} else {
+					return nil, false
+				}
+			}
+			return result, true
+		}
+	}
+	return nil, false
+}
+
+// ExecuteHooks runs all hooks for a given execution point
+func (c *ComponentHooks) ExecuteHooks(point string, log *logger.Logger) error {
+	hooks := c.GetHooks(point)
+	if len(hooks) == 0 {
+		log.Debug("no hook defined")
+	}
+	for _, hook := range hooks {
+		log.Debug("running %q", hook.Type)
+		if err := hook.Run(); err != nil {
+			return fmt.Errorf("hook %s failed at %s: %w", hook.Type, point, err)
+		}
+		log.Debug("finished running %q", hook.Type)
+	}
+	return nil
+}
+
+// Hook implementations
+func (hd *HookDefinition) fixPermissions() error {
+	// example yaml:
+	//     hooks:
+	//       pre_run:
+	//         - hook_type: "fix-permissions"
+	//           args:
+	//             path: "/opt/elastic/metricbeat" // relative paths will be prefixed with components path
+	//			   target_os: [windows]
+	//             user: root
+	//             group: root
+	//             # windows specific
+	//             inherit_permissions: false
+	//             fail_on_path_not_exist: false
+	//             mask: 0770 # default 0770 if not specified
+
+	targetOs, _ := hd.GetStringSliceArg("target_os")
+	shouldRun := len(targetOs) == 0 // no target specified means all
+	for _, os := range targetOs {
+		if os != "" && runtime.GOOS == os {
+			shouldRun = true
+			break
+		}
+	}
+
+	if !shouldRun {
+		// no need to fail
+		return nil
+	}
+
+	path, ok := hd.GetStringArg("path")
+	if !ok {
+		return fmt.Errorf("required parameter 'path' not found in 'fix_permissions' hook")
+	}
+	path = injectComponentsPath(path)
+	inheritPermissions, _ := hd.GetBoolArg("inherit_permissions")
+	username, _ := hd.GetStringArg("user")
+	groupname, _ := hd.GetStringArg("group")
+	failOnNotExist, _ := hd.GetBoolArg("fail_on_path_not_exist")
+	mask, _ := hd.GetIntArg("mask")
+
+	return hooks.FixPermissions(path, inheritPermissions, username, groupname, failOnNotExist, mask)
+}
+
+// isValidHookType checks if the hook type is supported
+func isValidHookType(hookType string) bool {
+	for _, supported := range supportedHooks {
+		if supported == hookType {
+			return true
+		}
+	}
+
+	return false
+}
+
+func injectComponentsPath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+
+	return filepath.Clean(
+		filepath.Join(
+			paths.VersionedHome(paths.Top()),
+			"components",
+			path,
+		),
+	)
+}

--- a/pkg/component/hooks/fix_permissions_other.go
+++ b/pkg/component/hooks/fix_permissions_other.go
@@ -1,0 +1,54 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build !windows
+
+package hooks
+
+import (
+	"os"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/install/usermgmt"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/perms"
+	"github.com/elastic/elastic-agent/pkg/utils"
+)
+
+func FixPermissions(path string, _ bool, username string, groupname string, failOnNotExist bool, mask int) error {
+	// only valid config is
+	var uid, gid int = -1, -1
+	var err error
+	if len(username) > 0 {
+		uid, err = usermgmt.FindUID(username)
+		if err != nil {
+			return err
+		}
+	}
+
+	// group is also provided
+	if len(groupname) > 0 {
+		gid, err = usermgmt.FindGID(groupname)
+		if err != nil {
+			return err
+		}
+	}
+
+	var opts []perms.OptFunc
+	if uid != -1 || gid != -1 {
+		ownership := utils.FileOwner{}
+		ownership.GID = gid
+		ownership.UID = uid
+		opts = append(opts, perms.WithOwnership(ownership))
+	}
+
+	if mask > 0 {
+		opts = append(opts, perms.WithMask(os.FileMode(mask)))
+	}
+
+	err = perms.FixPermissions(path, opts...)
+	if os.IsNotExist(err) && !failOnNotExist {
+		return nil
+	}
+
+	return err
+}

--- a/pkg/component/hooks/fix_permissions_test.go
+++ b/pkg/component/hooks/fix_permissions_test.go
@@ -2,17 +2,4 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-//go:build !windows
-
-package install
-
-import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-)
-
-func TestEnsureRights(t *testing.T) {
-	// no-op function testing for coverage
-	assert.NoError(t, EnsureRights("custom"))
-}
+package hooks

--- a/pkg/component/hooks/fix_permissions_windows.go
+++ b/pkg/component/hooks/fix_permissions_windows.go
@@ -1,0 +1,65 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build windows
+
+package hooks
+
+import (
+	"os"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/install/usermgmt"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/perms"
+	"github.com/elastic/elastic-agent/pkg/utils"
+)
+
+func FixPermissions(path string, inheritPermissions bool, username string, groupname string, failOnNotExist bool, mask int) error {
+	//         - hook_type: "fix-permissions"
+	//           args:
+	//             path: "/opt/elastic/metricbeat" // relative paths will be prefixed with components path
+	//			   target_os: [windows]
+	//             user: root
+	//             group: root
+	//             # windows specific
+	//             inherit_permissions: false
+
+	// only valid config is
+	var uid, gid string
+	var err error
+	if len(username) > 0 {
+		uid, err = usermgmt.FindUID(username)
+		if err != nil {
+			return err
+		}
+	}
+
+	// group is also provided
+	if len(groupname) > 0 {
+		gid, err = usermgmt.FindGID(groupname)
+		if err != nil {
+			return err
+		}
+	}
+
+	var opts []perms.OptFunc
+	if len(uid) != 0 || len(gid) != 0 {
+		ownership := utils.FileOwner{}
+		ownership.GID = gid
+		ownership.UID = uid
+		opts = append(opts, perms.WithOwnership(ownership))
+	}
+
+	opts = append(opts, perms.WithInherit(inheritPermissions))
+
+	if mask > 0 {
+		opts = append(opts, perms.WithMask(os.FileMode(mask)))
+	}
+
+	err = perms.FixPermissions(path, opts...)
+	if os.IsNotExist(err) && !failOnNotExist {
+		return nil
+	}
+
+	return err
+}

--- a/pkg/component/hooks_test.go
+++ b/pkg/component/hooks_test.go
@@ -1,0 +1,667 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package component
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHookDefinition_GetArg(t *testing.T) {
+	testCases := []struct {
+		name     string
+		args     map[string]interface{}
+		key      string
+		expected interface{}
+		exists   bool
+	}{
+		{
+			name:     "existing string arg",
+			args:     map[string]interface{}{"test": "value"},
+			key:      "test",
+			expected: "value",
+			exists:   true,
+		},
+		{
+			name:     "existing int arg",
+			args:     map[string]interface{}{"count": 42},
+			key:      "count",
+			expected: 42,
+			exists:   true,
+		},
+		{
+			name:     "non-existing arg",
+			args:     map[string]interface{}{"test": "value"},
+			key:      "missing",
+			expected: "",
+			exists:   false,
+		},
+		{
+			name:     "nil args",
+			args:     nil,
+			key:      "test",
+			expected: "",
+			exists:   false,
+		},
+		{
+			name:     "empty args",
+			args:     map[string]interface{}{},
+			key:      "test",
+			expected: "",
+			exists:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hd := &HookDefinition{Args: tc.args}
+			value, exists := hd.GetArg(tc.key)
+			assert.Equal(t, tc.exists, exists)
+			if tc.exists {
+				assert.Equal(t, tc.expected, value)
+			}
+		})
+	}
+}
+
+func TestHookDefinition_GetStringArg(t *testing.T) {
+	testCases := []struct {
+		name     string
+		args     map[string]interface{}
+		key      string
+		expected string
+		exists   bool
+	}{
+		{
+			name:     "valid string",
+			args:     map[string]interface{}{"path": "/opt/elastic"},
+			key:      "path",
+			expected: "/opt/elastic",
+			exists:   true,
+		},
+		{
+			name:     "empty string",
+			args:     map[string]interface{}{"path": ""},
+			key:      "path",
+			expected: "",
+			exists:   true,
+		},
+		{
+			name:     "non-string value",
+			args:     map[string]interface{}{"path": 123},
+			key:      "path",
+			expected: "",
+			exists:   false,
+		},
+		{
+			name:     "non-existing key",
+			args:     map[string]interface{}{"other": "value"},
+			key:      "path",
+			expected: "",
+			exists:   false,
+		},
+		{
+			name:     "nil value",
+			args:     map[string]interface{}{"path": nil},
+			key:      "path",
+			expected: "",
+			exists:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hd := &HookDefinition{Args: tc.args}
+			value, exists := hd.GetStringArg(tc.key)
+			assert.Equal(t, tc.expected, value)
+			assert.Equal(t, tc.exists, exists)
+		})
+	}
+}
+
+func TestHookDefinition_GetIntArg(t *testing.T) {
+	testCases := []struct {
+		name     string
+		args     map[string]interface{}
+		key      string
+		expected int
+		exists   bool
+	}{
+		{
+			name:     "valid int",
+			args:     map[string]interface{}{"mask": 755},
+			key:      "mask",
+			expected: 755,
+			exists:   true,
+		},
+		{
+			name:     "int32",
+			args:     map[string]interface{}{"mask": int32(644)},
+			key:      "mask",
+			expected: 644,
+			exists:   true,
+		},
+		{
+			name:     "int64",
+			args:     map[string]interface{}{"mask": int64(777)},
+			key:      "mask",
+			expected: 777,
+			exists:   true,
+		},
+		{
+			name:     "uint",
+			args:     map[string]interface{}{"mask": uint(600)},
+			key:      "mask",
+			expected: 600,
+			exists:   true,
+		},
+		{
+			name:     "uint32",
+			args:     map[string]interface{}{"mask": uint32(666)},
+			key:      "mask",
+			expected: 666,
+			exists:   true,
+		},
+		{
+			name:     "uint64",
+			args:     map[string]interface{}{"mask": uint64(700)},
+			key:      "mask",
+			expected: 700,
+			exists:   true,
+		},
+		{
+			name:     "float32 whole number",
+			args:     map[string]interface{}{"mask": float32(755.0)},
+			key:      "mask",
+			expected: 755,
+			exists:   true,
+		},
+		{
+			name:     "float64 whole number",
+			args:     map[string]interface{}{"mask": float64(644.0)},
+			key:      "mask",
+			expected: 644,
+			exists:   true,
+		},
+		{
+			name:     "float32 with decimal",
+			args:     map[string]interface{}{"mask": float32(755.5)},
+			key:      "mask",
+			expected: 0,
+			exists:   false,
+		},
+		{
+			name:     "float64 with decimal",
+			args:     map[string]interface{}{"mask": float64(644.7)},
+			key:      "mask",
+			expected: 0,
+			exists:   false,
+		},
+		{
+			name:     "string value",
+			args:     map[string]interface{}{"mask": "755"},
+			key:      "mask",
+			expected: 0,
+			exists:   false,
+		},
+		{
+			name:     "non-existing key",
+			args:     map[string]interface{}{"other": 123},
+			key:      "mask",
+			expected: 0,
+			exists:   false,
+		},
+		{
+			name:     "nil value",
+			args:     map[string]interface{}{"mask": nil},
+			key:      "mask",
+			expected: 0,
+			exists:   false,
+		},
+		{
+			name:     "filemode value",
+			args:     map[string]interface{}{"mask": 0640},
+			key:      "mask",
+			expected: 0640,
+			exists:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hd := &HookDefinition{Args: tc.args}
+			value, exists := hd.GetIntArg(tc.key)
+			assert.Equal(t, tc.expected, value)
+			assert.Equal(t, tc.exists, exists)
+		})
+	}
+}
+
+func TestHookDefinition_GetBoolArg(t *testing.T) {
+	testCases := []struct {
+		name     string
+		args     map[string]interface{}
+		key      string
+		expected bool
+		exists   bool
+	}{
+		{
+			name:     "true value",
+			args:     map[string]interface{}{"inherit": true},
+			key:      "inherit",
+			expected: true,
+			exists:   true,
+		},
+		{
+			name:     "false value",
+			args:     map[string]interface{}{"inherit": false},
+			key:      "inherit",
+			expected: false,
+			exists:   true,
+		},
+		{
+			name:     "string value",
+			args:     map[string]interface{}{"inherit": "true"},
+			key:      "inherit",
+			expected: false,
+			exists:   false,
+		},
+		{
+			name:     "int value",
+			args:     map[string]interface{}{"inherit": 1},
+			key:      "inherit",
+			expected: false,
+			exists:   false,
+		},
+		{
+			name:     "non-existing key",
+			args:     map[string]interface{}{"other": true},
+			key:      "inherit",
+			expected: false,
+			exists:   false,
+		},
+		{
+			name:     "nil value",
+			args:     map[string]interface{}{"inherit": nil},
+			key:      "inherit",
+			expected: false,
+			exists:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hd := &HookDefinition{Args: tc.args}
+			value, exists := hd.GetBoolArg(tc.key)
+			assert.Equal(t, tc.expected, value)
+			assert.Equal(t, tc.exists, exists)
+		})
+	}
+}
+
+func TestHookDefinition_GetStringSliceArg(t *testing.T) {
+	testCases := []struct {
+		name     string
+		args     map[string]interface{}
+		key      string
+		expected []string
+		exists   bool
+	}{
+		{
+			name: "valid string slice",
+			args: map[string]interface{}{
+				"users": []interface{}{"root", "elastic", "agent"},
+			},
+			key:      "users",
+			expected: []string{"root", "elastic", "agent"},
+			exists:   true,
+		},
+		{
+			name: "empty string slice",
+			args: map[string]interface{}{
+				"users": []interface{}{},
+			},
+			key:      "users",
+			expected: []string{},
+			exists:   true,
+		},
+		{
+			name: "single item slice",
+			args: map[string]interface{}{
+				"users": []interface{}{"admin"},
+			},
+			key:      "users",
+			expected: []string{"admin"},
+			exists:   true,
+		},
+		{
+			name: "mixed types in slice",
+			args: map[string]interface{}{
+				"users": []interface{}{"root", 123, "elastic"},
+			},
+			key:      "users",
+			expected: nil,
+			exists:   false,
+		},
+		{
+			name: "non-slice value",
+			args: map[string]interface{}{
+				"users": "single-user",
+			},
+			key:      "users",
+			expected: nil,
+			exists:   false,
+		},
+		{
+			name: "slice with nil elements",
+			args: map[string]interface{}{
+				"users": []interface{}{"root", nil, "elastic"},
+			},
+			key:      "users",
+			expected: nil,
+			exists:   false,
+		},
+		{
+			name:     "non-existing key",
+			args:     map[string]interface{}{"other": []interface{}{"value"}},
+			key:      "users",
+			expected: nil,
+			exists:   false,
+		},
+		{
+			name: "nil value",
+			args: map[string]interface{}{
+				"users": nil,
+			},
+			key:      "users",
+			expected: nil,
+			exists:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hd := &HookDefinition{Args: tc.args}
+			value, exists := hd.GetStringSliceArg(tc.key)
+			assert.Equal(t, tc.expected, value)
+			assert.Equal(t, tc.exists, exists)
+		})
+	}
+}
+
+func TestHookDefinition_GetArgMethods_Integration(t *testing.T) {
+	// Test with realistic hook arguments
+	hd := &HookDefinition{
+		Type: "fix-permissions",
+		Args: map[string]interface{}{
+			"path":                   "/opt/elastic/agent",
+			"mask":                   755,
+			"inherit_permissions":    true,
+			"fail_on_path_not_exist": false,
+			"target_os":              []interface{}{"linux", "darwin"},
+			"timeout":                float64(30.0), // Common YAML parsing result
+			"retries":                int32(3),
+			"debug":                  false,
+		},
+	}
+
+	// Test all methods work together
+	path, ok := hd.GetStringArg("path")
+	assert.True(t, ok)
+	assert.Equal(t, "/opt/elastic/agent", path)
+
+	mask, ok := hd.GetIntArg("mask")
+	assert.True(t, ok)
+	assert.Equal(t, 755, mask)
+
+	inherit, ok := hd.GetBoolArg("inherit_permissions")
+	assert.True(t, ok)
+	assert.True(t, inherit)
+
+	failOnNotExist, ok := hd.GetBoolArg("fail_on_path_not_exist")
+	assert.True(t, ok)
+	assert.False(t, failOnNotExist)
+
+	targetOS, ok := hd.GetStringSliceArg("target_os")
+	assert.True(t, ok)
+	assert.Equal(t, []string{"linux", "darwin"}, targetOS)
+
+	timeout, ok := hd.GetIntArg("timeout")
+	assert.True(t, ok)
+	assert.Equal(t, 30, timeout)
+
+	retries, ok := hd.GetIntArg("retries")
+	assert.True(t, ok)
+	assert.Equal(t, 3, retries)
+
+	debug, ok := hd.GetBoolArg("debug")
+	assert.True(t, ok)
+	assert.False(t, debug)
+
+	// Test non-existing args
+	_, ok = hd.GetStringArg("non_existing")
+	assert.False(t, ok)
+
+	_, ok = hd.GetIntArg("non_existing")
+	assert.False(t, ok)
+
+	_, ok = hd.GetBoolArg("non_existing")
+	assert.False(t, ok)
+
+	_, ok = hd.GetStringSliceArg("non_existing")
+	assert.False(t, ok)
+}
+
+func TestComponentHooks_GetHooks(t *testing.T) {
+	// Setup test hooks
+	preRunHooks := []HookDefinition{
+		{
+			Type: "fix-permissions",
+			Args: map[string]interface{}{
+				"path": "/opt/elastic/pre",
+				"mask": 755,
+			},
+		},
+		{
+			Type: "cleanup",
+			Args: map[string]interface{}{
+				"paths": []interface{}{"/tmp/pre1", "/tmp/pre2"},
+			},
+		},
+	}
+
+	postRunHooks := []HookDefinition{
+		{
+			Type: "backup",
+			Args: map[string]interface{}{
+				"source":      "/data",
+				"destination": "/backup",
+			},
+		},
+	}
+
+	componentHooks := &ComponentHooks{
+		PreRun:  preRunHooks,
+		PostRun: postRunHooks,
+	}
+
+	testCases := []struct {
+		name     string
+		point    string
+		expected []HookDefinition
+	}{
+		{
+			name:     "get pre-run hooks",
+			point:    HookPreRun,
+			expected: preRunHooks,
+		},
+		{
+			name:     "get hooks for unknown point",
+			point:    "unknown-point",
+			expected: nil,
+		},
+		{
+			name:     "get hooks for empty point",
+			point:    "",
+			expected: nil,
+		},
+		{
+			name:     "get hooks with case sensitive point",
+			point:    "PRE-RUN", // Different case
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := componentHooks.GetHooks(tc.point)
+			assert.Equal(t, tc.expected, result)
+
+			// Additional validation: ensure we get a slice even if nil
+			if tc.expected == nil {
+				assert.Len(t, result, 0, "Should return empty slice for unknown points but got %v", result)
+			} else {
+				assert.NotNil(t, result, "Result should not be nil for slice comparison")
+				assert.Len(t, result, len(tc.expected), "Should return correct number of hooks")
+
+				// Verify each hook individually
+				for i, expectedHook := range tc.expected {
+					assert.Equal(t, expectedHook.Type, result[i].Type, "Hook type should match")
+					assert.Equal(t, expectedHook.Args, result[i].Args, "Hook args should match")
+				}
+			}
+		})
+	}
+}
+
+func TestComponentHooks_GetHooks_Integration(t *testing.T) {
+	// Test with realistic hook configuration
+	componentHooks := &ComponentHooks{
+		PreRun: []HookDefinition{
+			{
+				Type: "fix-permissions",
+				Args: map[string]interface{}{
+					"path":                "/opt/elastic/filebeat",
+					"mask":                755,
+					"user":                "elastic",
+					"group":               "elastic",
+					"inherit_permissions": false,
+					"target_os":           []interface{}{"linux", "darwin"},
+				},
+			},
+		},
+	}
+
+	// Test that we can get and validate the returned hooks
+	preRunHooks := componentHooks.GetHooks(HookPreRun)
+	assert.Len(t, preRunHooks, 1)
+
+	hook := preRunHooks[0]
+	assert.Equal(t, "fix-permissions", hook.Type)
+
+	// Verify we can extract arguments correctly
+	path, ok := hook.GetStringArg("path")
+	assert.True(t, ok)
+	assert.Equal(t, "/opt/elastic/filebeat", path)
+
+	mask, ok := hook.GetIntArg("mask")
+	assert.True(t, ok)
+	assert.Equal(t, 755, mask)
+
+	targetOS, ok := hook.GetStringSliceArg("target_os")
+	assert.True(t, ok)
+	assert.Equal(t, []string{"linux", "darwin"}, targetOS)
+}
+
+func TestInjectComponentsPath(t *testing.T) {
+	componentsPrefix := filepath.Join(paths.VersionedHome(paths.Top()), "components")
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "absolute path unchanged",
+			input:    "/opt/elastic/agent",
+			expected: "/opt/elastic/agent",
+		},
+		{
+			name:     "relative path gets components prefix",
+			input:    "filebeat/config",
+			expected: filepath.Clean(filepath.Join(componentsPrefix, "filebeat/config")),
+		},
+		{
+			name:     "single file relative path",
+			input:    "config.yml",
+			expected: filepath.Clean(filepath.Join(componentsPrefix, "config.yml")),
+		},
+		{
+			name:     "nested relative path",
+			input:    "beats/filebeat/data",
+			expected: filepath.Clean(filepath.Join(componentsPrefix, "beats/filebeat/data")),
+		},
+		{
+			name:     "current directory reference",
+			input:    "./config",
+			expected: filepath.Clean(filepath.Join(componentsPrefix, "./config")),
+		},
+		{
+			name:     "parent directory reference",
+			input:    "../shared/config",
+			expected: filepath.Clean(filepath.Join(componentsPrefix, "../shared/config")),
+		},
+		{
+			name:     "empty path",
+			input:    "",
+			expected: filepath.Clean(filepath.Join(componentsPrefix, "")),
+		},
+		{
+			name:     "path with trailing slash",
+			input:    "filebeat/",
+			expected: filepath.Clean(filepath.Join(componentsPrefix, "filebeat/")),
+		},
+		{
+			name:     "path with multiple separators",
+			input:    "filebeat//config//file.yml",
+			expected: filepath.Clean(filepath.Join(componentsPrefix, "filebeat//config//file.yml")),
+		},
+	}
+
+	// Add platform-specific test cases
+	if runtime.GOOS == "windows" {
+		testCases = append(testCases, []struct {
+			name     string
+			input    string
+			expected string
+		}{
+			{
+				name:     "windows absolute path unchanged",
+				input:    "C:\\Program Files\\Elastic\\Agent",
+				expected: "C:\\Program Files\\Elastic\\Agent",
+			},
+			{
+				name:     "windows UNC path unchanged",
+				input:    "\\\\server\\share\\path",
+				expected: "\\\\server\\share\\path",
+			},
+			{
+				name:     "windows relative path with backslashes",
+				input:    "filebeat\\config\\file.yml",
+				expected: filepath.Clean(filepath.Join(componentsPrefix, "filebeat\\config\\file.yml")),
+			},
+		}...)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := injectComponentsPath(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/pkg/component/input_spec.go
+++ b/pkg/component/input_spec.go
@@ -23,6 +23,8 @@ type InputSpec struct {
 	Command      *CommandSpec `config:"command,omitempty" yaml:"command,omitempty"`
 	Service      *ServiceSpec `config:"service,omitempty" yaml:"service,omitempty"`
 	IsolateUnits bool         `config:"isolate_units,omitempty" yaml:"isolate_units,omitempty"`
+
+	Hooks ComponentHooks `config:"hooks,omitempty" yaml:"hooks,omitempty"`
 }
 
 // Validate ensures correctness of input specification.
@@ -56,5 +58,10 @@ func (s *InputSpec) Validate() error {
 			return fmt.Errorf("input '%s' defined 'runtime.preventions.%d.condition' failed to compile: %w", s.Name, idx, err)
 		}
 	}
+
+	if err := s.Hooks.Validate(); err != nil {
+		return fmt.Errorf("input '%s' defines one or more invalid hooks: %w", s.Name, err)
+	}
+
 	return nil
 }

--- a/pkg/component/runtime/command.go
+++ b/pkg/component/runtime/command.go
@@ -360,6 +360,15 @@ func (c *commandRuntime) start(comm Communicator) error {
 		// already running
 		return nil
 	}
+
+	// pre run hook
+	if c.current.InputSpec != nil {
+		c.log.Debugf("running PreRun hooks for %q", c.current.ID)
+		if err := c.current.InputSpec.Spec.Hooks.ExecuteHooks(component.HookPreRun, c.log); err != nil {
+			return fmt.Errorf("failed during pre-run hook execution for %q: %w", c.current.ID, err)
+		}
+	}
+
 	cmdSpec := c.getCommandSpec()
 	env := make([]string, 0, len(cmdSpec.Env)+2)
 	for _, e := range cmdSpec.Env {

--- a/testing/installtest/checks_unix.go
+++ b/testing/installtest/checks_unix.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/install/usermgmt"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 )
 
@@ -30,7 +31,7 @@ func checkPlatform(ctx context.Context, _ *atesting.Fixture, topPath string, opt
 		if opts.Username != "" {
 			username = opts.Username
 		}
-		uid, err := install.FindUID(username)
+		uid, err := usermgmt.FindUID(username)
 		if err != nil {
 			return fmt.Errorf("failed to find %s user: %w", username, err)
 		}
@@ -39,7 +40,7 @@ func checkPlatform(ctx context.Context, _ *atesting.Fixture, topPath string, opt
 		if opts.Username != "" {
 			group = opts.Group
 		}
-		gid, err := install.FindGID(group)
+		gid, err := usermgmt.FindGID(group)
 		if err != nil {
 			return fmt.Errorf("failed to find %s group: %w", group, err)
 		}

--- a/testing/installtest/checks_windows.go
+++ b/testing/installtest/checks_windows.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/sys/windows"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/install/usermgmt"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 )
 
@@ -62,7 +63,7 @@ func checkPlatform(ctx context.Context, f *atesting.Fixture, topPath string, opt
 		}
 
 		// Check that the elastic-agent user/group exist.
-		uid, err := install.FindUID(username)
+		uid, err := usermgmt.FindUID(username)
 		if err != nil {
 			return fmt.Errorf("failed to find %s user: %w", username, err)
 		}
@@ -75,7 +76,7 @@ func checkPlatform(ctx context.Context, f *atesting.Fixture, topPath string, opt
 		if opts.Username != "" {
 			group = opts.Group
 		}
-		gid, err := install.FindGID(group)
+		gid, err := usermgmt.FindGID(group)
 		if err != nil {
 			return fmt.Errorf("failed to find %s group: %w", group, err)
 		}


### PR DESCRIPTION
Added support for user defined hooks - prerun

Spec definition sample
```yaml
version: 2
inputs:
  - name: demo-server
    description: "Demo Server"
    platforms:
      - linux/amd64
    outputs:
      - elasticsearch
    command:
      args:
        - "logging.to_stderr=true"
    hooks:
      pre_run:
        - hook_type: fix-permissions
          args:
            path: "fs/temp"
            user: michal
            group: staff
            mask: 0740
```