### PR TITLE
Enhancement/5235 handle insufficient disk space errors in artifact unpack

### DIFF
--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -88,7 +88,7 @@ type packageMetadata struct {
 	hash     string
 }
 
-func (u *Upgrader) getPackageMetadata(archivePath string) (packageMetadata, error) {
+func (u *unpacker) getPackageMetadata(archivePath string) (packageMetadata, error) {
 	ext := filepath.Ext(archivePath)
 	if ext == ".gz" {
 		// if we got gzip extension we need another extension before last

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -424,7 +424,7 @@ func untar(log *logger.Logger, archivePath, dataDir string, flavor string) (Unpa
 			// Using common.MkdirAll instead of os.MkdirAll so that we can
 			// mock it in tests.
 			if err = common.MkdirAll(filepath.Dir(abs), 0750); err != nil {
-				return UnpackResult{}, errors.New(err, "TarInstaller: creating directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
+				return UnpackResult{}, goerrors.Join(err, errors.New("TarInstaller: creating directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs)))
 			}
 
 			// remove any world permissions from the file
@@ -432,7 +432,7 @@ func untar(log *logger.Logger, archivePath, dataDir string, flavor string) (Unpa
 			// mock it in tests.
 			wf, err := common.OpenFile(abs, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode.Perm()&0770)
 			if err != nil {
-				return UnpackResult{}, errors.New(err, "TarInstaller: creating file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
+				return UnpackResult{}, goerrors.Join(err, errors.New("TarInstaller: creating file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs)))
 			}
 
 			// Using common.Copy instead of io.Copy so that we can
@@ -454,7 +454,7 @@ func untar(log *logger.Logger, archivePath, dataDir string, flavor string) (Unpa
 				// Using common.MkdirAll instead of os.MkdirAll so that we can
 				// mock it in tests.
 				if err := common.MkdirAll(abs, mode.Perm()&0770); err != nil {
-					return UnpackResult{}, errors.New(err, "TarInstaller: creating directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
+					return UnpackResult{}, goerrors.Join(err, errors.New("TarInstaller: creating directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs)))
 				}
 			} else if err != nil {
 				return UnpackResult{}, errors.New(err, "TarInstaller: stat() directory for file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
@@ -462,7 +462,7 @@ func untar(log *logger.Logger, archivePath, dataDir string, flavor string) (Unpa
 				// directory already exists, set the appropriate permissions
 				err = os.Chmod(abs, mode.Perm()&0770)
 				if err != nil {
-					return UnpackResult{}, errors.New(err, fmt.Sprintf("TarInstaller: setting permissions %O for directory %q", mode.Perm()&0770, abs), errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
+					return UnpackResult{}, goerrors.Join(err, errors.New("TarInstaller: setting permissions %O for directory %q", mode.Perm()&0770, abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs)))
 				}
 			}
 		default:

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -186,7 +186,7 @@ func unzip(log *logger.Logger, archivePath, dataDir string, flavor string) (Unpa
 
 			// Using common.Copy instead of io.Copy so that we can
 			// mock it in tests.
-			if _, err = common.Copy(f, rc); err != nil { //nolint:gosec // legacy
+			if _, err = common.Copy(f, rc); err != nil {
 				return err
 			}
 		}
@@ -437,7 +437,7 @@ func untar(log *logger.Logger, archivePath, dataDir string, flavor string) (Unpa
 
 			// Using common.Copy instead of io.Copy so that we can
 			// mock it in tests.
-			_, err = common.Copy(wf, tr) //nolint:gosec // legacy
+			_, err = common.Copy(wf, tr)
 			if closeErr := wf.Close(); closeErr != nil && err == nil {
 				err = closeErr
 			}

--- a/internal/pkg/agent/application/upgrade/step_unpack_test.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack_test.go
@@ -390,10 +390,10 @@ func TestUpgrader_unpackTarGz(t *testing.T) {
 
 			got, err := untar(log, archiveFile, testDataDir, tt.flavor, tt.copy, tt.mkdirAll, tt.openFile)
 			if tt.expectedError != nil {
-				assert.ErrorIs(t, err, tt.expectedError, fmt.Sprintf("untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir))
+				assert.ErrorIsf(t, err, tt.expectedError, "untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)
 				return
 			}
-			assert.NoError(t, err, fmt.Sprintf("untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir))
+			assert.NoErrorf(t, err, "untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)
 			assert.Equalf(t, tt.want, got, "untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)
 			if tt.checkFiles != nil {
 				tt.checkFiles(t, testDataDir)
@@ -583,7 +583,7 @@ func TestUpgrader_unpackZip(t *testing.T) {
 				assert.ErrorIs(t, err, tt.expectedError, "error mismatch")
 				return
 			}
-			assert.NoError(t, err, fmt.Sprintf("unzip(%v, %v)", archiveFile, testDataDir))
+			assert.NoErrorf(t, err, "unzip(%v, %v)", archiveFile, testDataDir)
 			assert.Equalf(t, tt.want, got, "unzip(%v, %v)", archiveFile, testDataDir)
 			if tt.checkFiles != nil {
 				tt.checkFiles(t, testDataDir)

--- a/internal/pkg/agent/application/upgrade/step_unpack_test.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack_test.go
@@ -8,6 +8,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -23,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	v1 "github.com/elastic/elastic-agent/pkg/api/v1"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
 	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
 )
 
@@ -205,6 +207,7 @@ type createArchiveFunc func(t *testing.T, archiveFiles []files) (string, error)
 type checkExtractedPath func(t *testing.T, testDataDir string)
 
 func TestUpgrader_unpackTarGz(t *testing.T) {
+	testError := errors.New("test error")
 	type args struct {
 		version          string
 		archiveGenerator createArchiveFunc
@@ -217,12 +220,15 @@ func TestUpgrader_unpackTarGz(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		args       args
-		want       UnpackResult
-		wantErr    assert.ErrorAssertionFunc
-		checkFiles checkExtractedPath
-		flavor     string
+		name          string
+		args          args
+		want          UnpackResult
+		expectedError error
+		checkFiles    checkExtractedPath
+		flavor        string
+		copy          copyFunc
+		mkdirAll      mkdirAllFunc
+		openFile      openFileFunc
 	}{
 		{
 			name: "file before containing folder",
@@ -237,11 +243,14 @@ func TestUpgrader_unpackTarGz(t *testing.T) {
 				Hash:          "abcdef",
 				VersionedHome: filepath.Join("data", "elastic-agent-abcdef"),
 			},
-			wantErr: assert.NoError,
+			expectedError: nil,
 			checkFiles: func(t *testing.T, testDataDir string) {
 				versionedHome := filepath.Join(testDataDir, "elastic-agent-abcdef")
 				checkExtractedFilesOutOfOrder(t, versionedHome)
 			},
+			copy:     io.Copy,
+			mkdirAll: os.MkdirAll,
+			openFile: os.OpenFile,
 		},
 		{
 			name: "package with manifest file",
@@ -256,8 +265,11 @@ func TestUpgrader_unpackTarGz(t *testing.T) {
 				Hash:          "abcdef",
 				VersionedHome: filepath.Join("data", "elastic-agent-1.2.3-SNAPSHOT-abcdef"),
 			},
-			wantErr:    assert.NoError,
-			checkFiles: checkExtractedFilesWithManifest,
+			expectedError: nil,
+			checkFiles:    checkExtractedFilesWithManifest,
+			copy:          io.Copy,
+			mkdirAll:      os.MkdirAll,
+			openFile:      os.OpenFile,
 		},
 		{
 			name: "package with basic flavor",
@@ -272,8 +284,8 @@ func TestUpgrader_unpackTarGz(t *testing.T) {
 				Hash:          "abcdef",
 				VersionedHome: filepath.Join("data", "elastic-agent-1.2.3-SNAPSHOT-abcdef"),
 			},
-			wantErr: assert.NoError,
-			flavor:  "basic",
+			expectedError: nil,
+			flavor:        "basic",
 			checkFiles: func(t *testing.T, testDataDir string) {
 				checkFilesPresence(t, testDataDir,
 					[]string{
@@ -283,6 +295,9 @@ func TestUpgrader_unpackTarGz(t *testing.T) {
 					},
 					[]string{filepath.Join("components", "comp3"), filepath.Join("components", "comp3.spec.yml"), filepath.Join("components", "component.zip")})
 			},
+			copy:     io.Copy,
+			mkdirAll: os.MkdirAll,
+			openFile: os.OpenFile,
 		},
 		{
 			name: "package with servers flavor",
@@ -297,8 +312,8 @@ func TestUpgrader_unpackTarGz(t *testing.T) {
 				Hash:          "abcdef",
 				VersionedHome: filepath.Join("data", "elastic-agent-1.2.3-SNAPSHOT-abcdef"),
 			},
-			wantErr: assert.NoError,
-			flavor:  "servers",
+			expectedError: nil,
+			flavor:        "servers",
 			checkFiles: func(t *testing.T, testDataDir string) {
 				checkFilesPresence(t, testDataDir,
 					[]string{
@@ -309,6 +324,57 @@ func TestUpgrader_unpackTarGz(t *testing.T) {
 					},
 					[]string{})
 			},
+			copy:     io.Copy,
+			mkdirAll: os.MkdirAll,
+			openFile: os.OpenFile,
+		},
+		{
+			name: "copying file fails",
+			args: args{
+				version:      "1.2.3",
+				archiveFiles: append(archiveFilesWithMoreComponents, agentArchiveSymLink),
+				archiveGenerator: func(t *testing.T, i []files) (string, error) {
+					return createTarArchive(t, "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64.tar.gz", i)
+				},
+			},
+			expectedError: testError,
+			copy: func(dst io.Writer, src io.Reader) (written int64, err error) {
+				return 0, testError
+			},
+			mkdirAll: os.MkdirAll,
+			openFile: os.OpenFile,
+		},
+		{
+			name: "opening file fails",
+			args: args{
+				version:      "1.2.3",
+				archiveFiles: append(archiveFilesWithMoreComponents, agentArchiveSymLink),
+				archiveGenerator: func(t *testing.T, i []files) (string, error) {
+					return createTarArchive(t, "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64.tar.gz", i)
+				},
+			},
+			expectedError: testError,
+			openFile: func(name string, flag int, perm os.FileMode) (*os.File, error) {
+				return nil, testError
+			},
+			mkdirAll: os.MkdirAll,
+			copy:     io.Copy,
+		},
+		{
+			name: "creating directory fails",
+			args: args{
+				version:      "1.2.3",
+				archiveFiles: append(archiveFilesWithMoreComponents, agentArchiveSymLink),
+				archiveGenerator: func(t *testing.T, i []files) (string, error) {
+					return createTarArchive(t, "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64.tar.gz", i)
+				},
+			},
+			expectedError: testError,
+			mkdirAll: func(name string, perm os.FileMode) error {
+				return testError
+			},
+			openFile: os.OpenFile,
+			copy:     io.Copy,
 		},
 	}
 	for _, tt := range tests {
@@ -322,10 +388,12 @@ func TestUpgrader_unpackTarGz(t *testing.T) {
 			archiveFile, err := tt.args.archiveGenerator(t, tt.args.archiveFiles)
 			require.NoError(t, err, "creation of test archive file failed")
 
-			got, err := untar(log, archiveFile, testDataDir, tt.flavor)
-			if !tt.wantErr(t, err, fmt.Sprintf("untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)) {
+			got, err := untar(log, archiveFile, testDataDir, tt.flavor, tt.copy, tt.mkdirAll, tt.openFile)
+			if tt.expectedError != nil {
+				assert.ErrorIs(t, err, tt.expectedError, fmt.Sprintf("untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir))
 				return
 			}
+			assert.NoError(t, err, fmt.Sprintf("untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir))
 			assert.Equalf(t, tt.want, got, "untar(%v, %v, %v)", tt.args.version, archiveFile, testDataDir)
 			if tt.checkFiles != nil {
 				tt.checkFiles(t, testDataDir)
@@ -335,6 +403,7 @@ func TestUpgrader_unpackTarGz(t *testing.T) {
 }
 
 func TestUpgrader_unpackZip(t *testing.T) {
+	testError := errors.New("test error")
 	type args struct {
 		archiveGenerator createArchiveFunc
 		archiveFiles     []files
@@ -346,12 +415,15 @@ func TestUpgrader_unpackZip(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		args       args
-		want       UnpackResult
-		wantErr    assert.ErrorAssertionFunc
-		checkFiles checkExtractedPath
-		flavor     string
+		name          string
+		args          args
+		want          UnpackResult
+		expectedError error
+		checkFiles    checkExtractedPath
+		flavor        string
+		copy          copyFunc
+		mkdirAll      mkdirAllFunc
+		openFile      openFileFunc
 	}{
 		{
 			name: "file before containing folder",
@@ -365,11 +437,14 @@ func TestUpgrader_unpackZip(t *testing.T) {
 				Hash:          "abcdef",
 				VersionedHome: filepath.Join("data", "elastic-agent-abcdef"),
 			},
-			wantErr: assert.NoError,
+			expectedError: nil,
 			checkFiles: func(t *testing.T, testDataDir string) {
 				versionedHome := filepath.Join(testDataDir, "elastic-agent-abcdef")
 				checkExtractedFilesOutOfOrder(t, versionedHome)
 			},
+			copy:     io.Copy,
+			mkdirAll: os.MkdirAll,
+			openFile: os.OpenFile,
 		},
 		{
 			name: "package with manifest file",
@@ -383,8 +458,11 @@ func TestUpgrader_unpackZip(t *testing.T) {
 				Hash:          "abcdef",
 				VersionedHome: filepath.Join("data", "elastic-agent-1.2.3-SNAPSHOT-abcdef"),
 			},
-			wantErr:    assert.NoError,
-			checkFiles: checkExtractedFilesWithManifest,
+			expectedError: nil,
+			checkFiles:    checkExtractedFilesWithManifest,
+			copy:          io.Copy,
+			mkdirAll:      os.MkdirAll,
+			openFile:      os.OpenFile,
 		},
 
 		{
@@ -399,8 +477,8 @@ func TestUpgrader_unpackZip(t *testing.T) {
 				Hash:          "abcdef",
 				VersionedHome: filepath.Join("data", "elastic-agent-1.2.3-SNAPSHOT-abcdef"),
 			},
-			wantErr: assert.NoError,
-			flavor:  "basic",
+			expectedError: nil,
+			flavor:        "basic",
 			checkFiles: func(t *testing.T, testDataDir string) {
 				checkFilesPresence(t, testDataDir,
 					[]string{
@@ -410,6 +488,9 @@ func TestUpgrader_unpackZip(t *testing.T) {
 					},
 					[]string{filepath.Join("components", "comp3"+binarySuffix), filepath.Join("components", "comp3.spec.yml"), filepath.Join("components", "component.zip")})
 			},
+			copy:     io.Copy,
+			mkdirAll: os.MkdirAll,
+			openFile: os.OpenFile,
 		},
 		{
 			name: "package with servers flavor",
@@ -423,8 +504,8 @@ func TestUpgrader_unpackZip(t *testing.T) {
 				Hash:          "abcdef",
 				VersionedHome: filepath.Join("data", "elastic-agent-1.2.3-SNAPSHOT-abcdef"),
 			},
-			wantErr: assert.NoError,
-			flavor:  "servers",
+			expectedError: nil,
+			flavor:        "servers",
 			checkFiles: func(t *testing.T, testDataDir string) {
 				checkFilesPresence(t, testDataDir,
 					[]string{
@@ -435,6 +516,54 @@ func TestUpgrader_unpackZip(t *testing.T) {
 					},
 					[]string{})
 			},
+			copy:     io.Copy,
+			mkdirAll: os.MkdirAll,
+			openFile: os.OpenFile,
+		},
+		{
+			name: "copying file fails",
+			args: args{
+				archiveFiles: archiveFilesWithMoreComponents,
+				archiveGenerator: func(t *testing.T, i []files) (string, error) {
+					return createZipArchive(t, "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64.zip", i)
+				},
+			},
+			expectedError: testError,
+			copy: func(dst io.Writer, src io.Reader) (written int64, err error) {
+				return 0, testError
+			},
+			mkdirAll: os.MkdirAll,
+			openFile: os.OpenFile,
+		},
+		{
+			name: "opening file fails",
+			args: args{
+				archiveFiles: archiveFilesWithMoreComponents,
+				archiveGenerator: func(t *testing.T, i []files) (string, error) {
+					return createZipArchive(t, "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64.zip", i)
+				},
+			},
+			expectedError: testError,
+			openFile: func(name string, flag int, perm os.FileMode) (*os.File, error) {
+				return nil, testError
+			},
+			mkdirAll: os.MkdirAll,
+			copy:     io.Copy,
+		},
+		{
+			name: "creating directory fails",
+			args: args{
+				archiveFiles: archiveFilesWithMoreComponents,
+				archiveGenerator: func(t *testing.T, i []files) (string, error) {
+					return createZipArchive(t, "elastic-agent-1.2.3-SNAPSHOT-someos-x86_64.zip", i)
+				},
+			},
+			expectedError: testError,
+			mkdirAll: func(name string, perm os.FileMode) error {
+				return testError
+			},
+			openFile: os.OpenFile,
+			copy:     io.Copy,
 		},
 	}
 	for _, tt := range tests {
@@ -449,10 +578,12 @@ func TestUpgrader_unpackZip(t *testing.T) {
 			archiveFile, err := tt.args.archiveGenerator(t, tt.args.archiveFiles)
 			require.NoError(t, err, "creation of test archive file failed")
 
-			got, err := unzip(log, archiveFile, testDataDir, tt.flavor)
-			if !tt.wantErr(t, err, fmt.Sprintf("unzip(%v, %v)", archiveFile, testDataDir)) {
+			got, err := unzip(log, archiveFile, testDataDir, tt.flavor, tt.copy, tt.mkdirAll, tt.openFile)
+			if tt.expectedError != nil {
+				assert.ErrorIs(t, err, tt.expectedError, "error mismatch")
 				return
 			}
+			assert.NoError(t, err, fmt.Sprintf("unzip(%v, %v)", archiveFile, testDataDir))
 			assert.Equalf(t, tt.want, got, "unzip(%v, %v)", archiveFile, testDataDir)
 			if tt.checkFiles != nil {
 				tt.checkFiles(t, testDataDir)
@@ -648,4 +779,50 @@ func TestGetFileNamePrefix(t *testing.T) {
 		})
 	}
 
+}
+
+func TestUnpack(t *testing.T) {
+	log, _ := loggertest.New("TestUnpack")
+
+	unarchiveSetup := func(unpackResult UnpackResult, err error) unarchiveFunc {
+		return func(log *logger.Logger, archivePath, dataDir string, flavor string, copy copyFunc, mkdirAll mkdirAllFunc, openFile openFileFunc) (UnpackResult, error) {
+			return unpackResult, err
+		}
+	}
+
+	type testCase struct {
+		expectedUnpackResult UnpackResult
+		expectedErr          error
+		unarchiveFunc        unarchiveFunc
+	}
+
+	testCases := map[string]testCase{
+		"when unarchiving succeeds it should return the unpack result": {
+			expectedUnpackResult: UnpackResult{
+				Hash:          "abcdef",
+				VersionedHome: filepath.Join("data", "elastic-agent-abcdef"),
+			},
+			expectedErr: nil,
+			unarchiveFunc: unarchiveSetup(UnpackResult{
+				Hash:          "abcdef",
+				VersionedHome: filepath.Join("data", "elastic-agent-abcdef"),
+			}, nil),
+		},
+		"when unarchiving fails it should return an error": {
+			expectedUnpackResult: UnpackResult{},
+			expectedErr:          errors.New("unarchiving failed"),
+			unarchiveFunc:        unarchiveSetup(UnpackResult{}, errors.New("unarchiving failed")),
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			unpacker := newUnpacker(log)
+			unpacker.untar = test.unarchiveFunc
+			unpacker.unzip = test.unarchiveFunc
+			unpackResult, unpackErr := unpacker.unpack("mockVersion", "mockArchivePath", "mockDataDir", "mockFlavor")
+			assert.Equal(t, test.expectedUnpackResult, unpackResult)
+			assert.Equal(t, test.expectedErr, unpackErr)
+		})
+	}
 }

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -75,6 +75,7 @@ type artifactDownloadHandler interface {
 }
 type unpackHandler interface {
 	unpack(version, archivePath, dataDir string, flavor string) (UnpackResult, error)
+	getPackageMetadata(archivePath string) (packageMetadata, error)
 }
 
 // Upgrader performs an upgrade

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -91,6 +91,7 @@ type Upgrader struct {
 	artifactDownloader   artifactDownloadHandler
 	unpacker             unpackHandler
 	isDiskSpaceErrorFunc func(err error) bool
+	extractAgentVersion  func(metadata packageMetadata, upgradeVersion string) agentVersion
 }
 
 // IsUpgradeable when agent is installed and running as a service or flag was provided.
@@ -111,6 +112,7 @@ func NewUpgrader(log *logger.Logger, settings *artifact.Config, agentInfo info.A
 		artifactDownloader:   newArtifactDownloader(settings, log),
 		unpacker:             newUnpacker(log),
 		isDiskSpaceErrorFunc: upgradeErrors.IsDiskSpaceError,
+		extractAgentVersion:  extractAgentVersion,
 	}, nil
 }
 
@@ -285,7 +287,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 		return nil, fmt.Errorf("reading metadata for elastic agent version %s package %q: %w", version, archivePath, err)
 	}
 
-	newVersion := extractAgentVersion(metadata, version)
+	newVersion := u.extractAgentVersion(metadata, version)
 	if err := checkUpgrade(u.log, currentVersion, newVersion, metadata); err != nil {
 		return nil, fmt.Errorf("cannot upgrade the agent: %w", err)
 	}

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -280,7 +280,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 
 	det.SetState(details.StateExtracting)
 
-	metadata, err := u.getPackageMetadata(archivePath)
+	metadata, err := u.unpacker.getPackageMetadata(archivePath)
 	if err != nil {
 		return nil, fmt.Errorf("reading metadata for elastic agent version %s package %q: %w", version, archivePath, err)
 	}

--- a/internal/pkg/agent/application/upgrade/upgrade_test.go
+++ b/internal/pkg/agent/application/upgrade/upgrade_test.go
@@ -1311,38 +1311,94 @@ func (m *mockArtifactDownloader) withFleetServerURI(fleetServerURI string) {
 	m.fleetServerURI = fleetServerURI
 }
 
+type mockUnpacker struct {
+	returnPackageMetadata      packageMetadata
+	returnPackageMetadataError error
+	returnUnpackResult         UnpackResult
+	returnUnpackError          error
+}
+
+func (m *mockUnpacker) getPackageMetadata(archivePath string) (packageMetadata, error) {
+	return m.returnPackageMetadata, m.returnPackageMetadataError
+}
+
+func (m *mockUnpacker) unpack(version, archivePath, dataDir string, flavor string) (UnpackResult, error) {
+	return m.returnUnpackResult, m.returnUnpackError
+}
+
 func TestUpgradeErrorHandling(t *testing.T) {
 	log, _ := loggertest.New("test")
 	testError := errors.New("test error")
+	type upgraderMocker func(upgrader *Upgrader)
 
 	type testCase struct {
 		isDiskSpaceErrorResult bool
 		expectedError          error
+		upgraderMocker         upgraderMocker
 	}
 
 	testCases := map[string]testCase{
 		"should return error if downloadArtifact fails": {
 			isDiskSpaceErrorResult: false,
 			expectedError:          testError,
+			upgraderMocker: func(upgrader *Upgrader) {
+				upgrader.artifactDownloader = &mockArtifactDownloader{
+					returnError: testError,
+				}
+			},
+		},
+		"should return error if getPackageMetadata fails": {
+			isDiskSpaceErrorResult: false,
+			expectedError:          testError,
+			upgraderMocker: func(upgrader *Upgrader) {
+				upgrader.artifactDownloader = &mockArtifactDownloader{}
+				upgrader.unpacker = &mockUnpacker{
+					returnPackageMetadataError: testError,
+				}
+			},
+		},
+		"should return error if unpack fails": {
+			isDiskSpaceErrorResult: false,
+			expectedError:          testError,
+			upgraderMocker: func(upgrader *Upgrader) {
+				upgrader.artifactDownloader = &mockArtifactDownloader{}
+				upgrader.extractAgentVersion = func(metadata packageMetadata, upgradeVersion string) agentVersion {
+					return agentVersion{
+						version:  upgradeVersion,
+						snapshot: false,
+						hash:     metadata.hash,
+					}
+				}
+				upgrader.unpacker = &mockUnpacker{
+					returnPackageMetadata: packageMetadata{
+						manifest: &v1.PackageManifest{},
+						hash:     "hash",
+					},
+					returnUnpackError: testError,
+				}
+			},
 		},
 		"should add disk space error to the error chain if downloadArtifact fails with disk space error": {
 			isDiskSpaceErrorResult: true,
 			expectedError:          upgradeErrors.ErrInsufficientDiskSpace,
+			upgraderMocker: func(upgrader *Upgrader) {
+				upgrader.artifactDownloader = &mockArtifactDownloader{
+					returnError: upgradeErrors.ErrInsufficientDiskSpace,
+				}
+			},
 		},
 	}
 
 	mockAgentInfo := info.NewAgent(t)
 	mockAgentInfo.On("Version").Return("9.0.0")
 
-	upgrader, err := NewUpgrader(log, &artifact.Config{}, mockAgentInfo)
-	require.NoError(t, err)
-
-	upgrader.artifactDownloader = &mockArtifactDownloader{
-		returnError: testError,
-	}
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			upgrader, err := NewUpgrader(log, &artifact.Config{}, mockAgentInfo)
+			require.NoError(t, err)
+
+			tc.upgraderMocker(upgrader)
+
 			upgrader.isDiskSpaceErrorFunc = func(err error) bool {
 				return tc.isDiskSpaceErrorResult
 			}
@@ -1362,7 +1418,6 @@ func (m *mockSender) Send(ctx context.Context, method, path string, params url.V
 func (m *mockSender) URI() string {
 	return "mockURI"
 }
-
 func TestSetClient(t *testing.T) {
 	log, _ := loggertest.New("test")
 	upgrader := &Upgrader{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

**PR 2/6**

- Enhancement


## What does this PR do?

- This is a follow up on https://github.com/elastic/elastic-agent/pull/9122. 
- Introduces disk space error type and relevant functions
- Modifies the upgrader unpack step to wrap errors so that the errors are propagated correctly.
- Adds relevant tests, asserts that errors, specifically the disk space error, get propagated up the call chain.

## Why is it important?

Non-wrapped errors mask the underlying disk space error when using errors.Is. This is need to address the original issue.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

If the agent runs into disk space errors when it is unpacking the downloaded agent archive, the status and fleet ui will show "insufficient disk space" as the error message

## How to test this PR locally

- Build for windows, mac, linux
- Install agent (managed and standalone)
- Fill up disk until there is  approximately 500mb left
- Trigger upgrade
  - From fleet
  - Cli with remote url and file
- Validate the upgrade detail error message shows insufficient disk error message both in the status output and on fleet ui.

- Run the upgrade, step_unpack tests

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #5235 
- Requires #9347
- Requires #9122 
- Prerequisite for #9349 


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
