### PR TITLE
enhancement(5235): moved gosec:nolint comment to

### DIFF
--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -178,8 +178,7 @@ func unzip(log *logger.Logger, archivePath, dataDir string, flavor string) (Unpa
 				}
 			}()
 
-			//nolint:gosec // legacy
-			if _, err = io.Copy(f, rc); err != nil {
+			if _, err = io.Copy(f, rc); err != nil { //nolint:gosec // legacy
 				return err
 			}
 		}
@@ -424,8 +423,7 @@ func untar(log *logger.Logger, archivePath, dataDir string, flavor string) (Unpa
 				return UnpackResult{}, errors.New(err, "TarInstaller: creating file "+abs, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, abs))
 			}
 
-			//nolint:gosec // legacy
-			_, err = io.Copy(wf, tr)
+			_, err = io.Copy(wf, tr) //nolint:gosec // legacy
 			if closeErr := wf.Close(); closeErr != nil && err == nil {
 				err = closeErr
 			}


### PR DESCRIPTION
the correct line

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->
- Cleanup

## What does this PR do?

Fixes where nolint comments are in step_unpack.go
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Currently the nolint comments are causing linting errors
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

none
<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

not necessary
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #5235 
- Superseds #9322

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
