### PR TITLE
Refactoring: Make the linter happy

### DIFF
--- a/pkg/component/runtime/service.go
+++ b/pkg/component/runtime/service.go
@@ -612,9 +612,10 @@ func (s *serviceRuntime) sendObserved() {
 func (s *serviceRuntime) compState(state client.UnitState, missedCheckins int) {
 	name := s.name()
 	msg := stateUnknownMessage
-	if state == client.UnitStateHealthy {
+	switch state {
+	case client.UnitStateHealthy:
 		msg = fmt.Sprintf("Healthy: communicating with %s service", name)
-	} else if state == client.UnitStateDegraded {
+	case client.UnitStateDegraded:
 		if missedCheckins == 1 {
 			msg = fmt.Sprintf("Degraded: %s service missed 1 check-in", name)
 		} else {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR switches an `if-else` to a `switch`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To make the linter happy.  Specifically to avoid it reporting the following linter failure:
```
QF1003: could use tagged switch on state (staticcheck)
```
