### PR TITLE
Add non-fatal exit code 28 to Endpoint check command

### DIFF
--- a/specs/endpoint-security.spec.yml
+++ b/specs/endpoint-security.spec.yml
@@ -36,6 +36,8 @@ inputs:
             - "--log"
             - "stderr"
           timeout: 60s
+          non_fatal_exit_codes:
+            - 28 # tamper protection enabled but could not (re)install
         install:
           args:
             - "install"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

In PR #9320, I forgot to add the non-fatal exit code 28 to the `check` operation in Endpoint's spec.  This PR adds it.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

If Endpoint is tamper protected and the tamper-protection token is not available to Endpoint when the `check` operation is run on the Endpoint binary, the operation will exit with code `28`.  However, Endpoint (the service) keeps running and the host remains protected.   So it is safe to treat this exit code as non-fatal.
