### PR TITLE
Revert "[9.0][Automation] Bump VM Image version to 1755306060"

### DIFF
--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -6,12 +6,12 @@ env:
 
   # The following images are defined here and their values will be updated by updatecli
   # Please do not change them manually.
-  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-elastic-agent-ubuntu-2404-1755306060"
-  IMAGE_UBUNTU_2404_ARM_64: "platform-ingest-elastic-agent-ubuntu-2404-aarch64-1755306060"
-  IMAGE_RHEL_8: "platform-ingest-elastic-agent-rhel-8-1755306060"
-  IMAGE_DEBIAN_12: "platform-ingest-elastic-agent-debian-12-1755306060"
-  IMAGE_WIN_2022: "platform-ingest-elastic-agent-windows-2022-1755306060"
-  IMAGE_WIN_2025: "platform-ingest-elastic-agent-windows-2025-1755306060"
+  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-elastic-agent-ubuntu-2404-1753491662"
+  IMAGE_UBUNTU_2404_ARM_64: "platform-ingest-elastic-agent-ubuntu-2404-aarch64-1753491662"
+  IMAGE_RHEL_8: "platform-ingest-elastic-agent-rhel-8-1753491662"
+  IMAGE_DEBIAN_12: "platform-ingest-elastic-agent-debian-12-1753491662"
+  IMAGE_WIN_2022: "platform-ingest-elastic-agent-windows-2022-1753491662"
+  IMAGE_WIN_2025: "platform-ingest-elastic-agent-windows-2025-1753491662"
 
 # This section is used to define the plugins that will be used in the pipeline.
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins

--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -6,8 +6,8 @@ env:
 
   # The following images are defined here and their values will be updated by updatecli
   # Please do not change them manually.
-  IMAGE_UBUNTU_2204_X86_64: "platform-ingest-elastic-agent-ubuntu-2204-1755306060"
-  IMAGE_UBUNTU_2204_ARM_64: "platform-ingest-elastic-agent-ubuntu-2204-aarch64-1755306060"
+  IMAGE_UBUNTU_2204_X86_64: "platform-ingest-elastic-agent-ubuntu-2204-1753491662"
+  IMAGE_UBUNTU_2204_ARM_64: "platform-ingest-elastic-agent-ubuntu-2204-aarch64-1753491662"
 
 steps:
   - group: "Integration tests: packaging"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,12 +5,12 @@ env:
 
   # The following images are defined here and their values will be updated by updatecli
   # Please do not change them manually.
-  IMAGE_UBUNTU_2204_X86_64: "platform-ingest-elastic-agent-ubuntu-2204-1755306060"
-  IMAGE_UBUNTU_2204_ARM_64: "platform-ingest-elastic-agent-ubuntu-2204-aarch64-1755306060"
-  IMAGE_WIN_2016: "platform-ingest-elastic-agent-windows-2016-1755306060"
-  IMAGE_WIN_2022: "platform-ingest-elastic-agent-windows-2022-1755306060"
-  IMAGE_WIN_10: "platform-ingest-elastic-agent-windows-10-1755306060"
-  IMAGE_WIN_11: "platform-ingest-elastic-agent-windows-11-1755306060"
+  IMAGE_UBUNTU_2204_X86_64: "platform-ingest-elastic-agent-ubuntu-2204-1753491662"
+  IMAGE_UBUNTU_2204_ARM_64: "platform-ingest-elastic-agent-ubuntu-2204-aarch64-1753491662"
+  IMAGE_WIN_2016: "platform-ingest-elastic-agent-windows-2016-1753491662"
+  IMAGE_WIN_2022: "platform-ingest-elastic-agent-windows-2022-1753491662"
+  IMAGE_WIN_10: "platform-ingest-elastic-agent-windows-10-1753491662"
+  IMAGE_WIN_11: "platform-ingest-elastic-agent-windows-11-1753491662"
 
 steps:
   - label: "check-ci"


### PR DESCRIPTION
Reverts elastic/elastic-agent#9403

As per https://github.com/elastic/elastic-agent/issues/9433#issuecomment-3197240477, we need to revert it as it causes packaging problems due to git vcs errors.