### PR TITLE
Add support for variable parser to handle `:` as default constant .

### DIFF
--- a/changelog/fragments/1755544412-Fix-default-constant-support-in-output-configuration.yaml
+++ b/changelog/fragments/1755544412-Fix-default-constant-support-in-output-configuration.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix default constant support in output configuration
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/9451
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/pull/9451

--- a/changelog/fragments/1755544412-Fix-default-constant-support-in-output-configuration.yaml
+++ b/changelog/fragments/1755544412-Fix-default-constant-support-in-output-configuration.yaml
@@ -29,4 +29,4 @@ pr: https://github.com/elastic/elastic-agent/pull/9451
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.
-issue: https://github.com/elastic/elastic-agent/pull/9451
+issue: https://github.com/elastic/elastic-agent/issues/9328

--- a/changelog/fragments/1755544412-Fix-default-constant-support-in-output-configuration.yaml
+++ b/changelog/fragments/1755544412-Fix-default-constant-support-in-output-configuration.yaml
@@ -11,7 +11,7 @@
 kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
-summary: Fix default constant support in output configuration
+summary: Fix Docker container failing to start with no matching vars: ${env.ELASTICSEARCH_API_KEY:} and similar errors by restoring support for `:` to set default values.
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.

--- a/changelog/fragments/1755544412-Fix-default-constant-support-in-output-configuration.yaml
+++ b/changelog/fragments/1755544412-Fix-default-constant-support-in-output-configuration.yaml
@@ -11,7 +11,7 @@
 kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
-summary: Fix Docker container failing to start with no matching vars: ${env.ELASTICSEARCH_API_KEY:} and similar errors by restoring support for `:` to set default values.
+summary: "Fix Docker container failing to start with no matching vars: ${env.ELASTICSEARCH_API_KEY:} and similar errors by restoring support for `:` to set default values."
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.

--- a/elastic-agent.yml
+++ b/elastic-agent.yml
@@ -11,10 +11,10 @@ outputs:
   default:
     type: elasticsearch
     hosts: [127.0.0.1:9200]
-    api_key: "example-key"
-    #username: "elastic"
-    #password: "changeme"
     preset: balanced
+    username: ${ELASTICSEARCH_USERNAME:}
+    password: ${ELASTICSEARCH_PASSWORD:}
+    api_key: ${ELASTICSEARCH_API_KEY:}
 
 
 
@@ -49,10 +49,10 @@ inputs:
 #       data_stream.dataset: system.process
 #       # While running in unprivileged mode, process/process_summary metricsets can emit
 #       # partial metrics. Some metrics that require privileged access can be missing.
-#       # On Windows, non-administrator users may not be able to access protected processes, leading 
-#       # to missing details like command line and arguments. On Unix, non-root users can't access 
-#       # procfs without the right permissions. 
-#       # Errors like ERROR_ACCESS_DENIED, EPERM, and EACCESS may result in partial metrics. 
+#       # On Windows, non-administrator users may not be able to access protected processes, leading
+#       # to missing details like command line and arguments. On Unix, non-root users can't access
+#       # procfs without the right permissions.
+#       # Errors like ERROR_ACCESS_DENIED, EPERM, and EACCESS may result in partial metrics.
 #       # Enabling the config below will mark the metricset as degraded when this occurs.
 #       # You may want to enable it to identify potential permission-related issues.
 #       # If you're unable to provide the necessary access, you can disable this config to keep
@@ -201,11 +201,11 @@ inputs:
 #   # is force killed
 #   stop_timeout: 30s
 
-# agent.grpc:
+agent.grpc:
 #   # listen address for the GRPC server that spawned processes connect back to.
 #   address: localhost
 #   # port for the GRPC server that spawned processes connect back to.
-#   port: 6789
+  port: 6790
 #   # max_message_size limits the message size in agent internal communication
 #   # default is 100MB
 #   max_message_size: 104857600

--- a/elastic-agent.yml
+++ b/elastic-agent.yml
@@ -11,10 +11,10 @@ outputs:
   default:
     type: elasticsearch
     hosts: [127.0.0.1:9200]
+    api_key: "example-key"
+    #username: "elastic"
+    #password: "changeme"
     preset: balanced
-    username: ${ELASTICSEARCH_USERNAME:}
-    password: ${ELASTICSEARCH_PASSWORD:}
-    api_key: ${ELASTICSEARCH_API_KEY:}
 
 
 
@@ -49,10 +49,10 @@ inputs:
 #       data_stream.dataset: system.process
 #       # While running in unprivileged mode, process/process_summary metricsets can emit
 #       # partial metrics. Some metrics that require privileged access can be missing.
-#       # On Windows, non-administrator users may not be able to access protected processes, leading
-#       # to missing details like command line and arguments. On Unix, non-root users can't access
-#       # procfs without the right permissions.
-#       # Errors like ERROR_ACCESS_DENIED, EPERM, and EACCESS may result in partial metrics.
+#       # On Windows, non-administrator users may not be able to access protected processes, leading 
+#       # to missing details like command line and arguments. On Unix, non-root users can't access 
+#       # procfs without the right permissions. 
+#       # Errors like ERROR_ACCESS_DENIED, EPERM, and EACCESS may result in partial metrics. 
 #       # Enabling the config below will mark the metricset as degraded when this occurs.
 #       # You may want to enable it to identify potential permission-related issues.
 #       # If you're unable to provide the necessary access, you can disable this config to keep
@@ -201,11 +201,11 @@ inputs:
 #   # is force killed
 #   stop_timeout: 30s
 
-agent.grpc:
+# agent.grpc:
 #   # listen address for the GRPC server that spawned processes connect back to.
 #   address: localhost
 #   # port for the GRPC server that spawned processes connect back to.
-  port: 6790
+#   port: 6789
 #   # max_message_size limits the message size in agent internal communication
 #   # default is 100MB
 #   max_message_size: 104857600

--- a/internal/pkg/agent/transpiler/vars.go
+++ b/internal/pkg/agent/transpiler/vars.go
@@ -256,7 +256,7 @@ func extractVars(i string, defaultProvider string) ([]varI, error) {
 					res = append(res, &varString{maybeAddDefaultProvider(string(is), defaultProvider)})
 				}
 				is = is[:0]         // slice to zero length; to keep allocated memory
-				constant = r == ':' // not a constant when ':'
+				constant = r == ':' // not a constant when '|'
 			} else {
 				is = append(is, r)
 			}

--- a/internal/pkg/agent/transpiler/vars.go
+++ b/internal/pkg/agent/transpiler/vars.go
@@ -239,9 +239,12 @@ func extractVars(i string, defaultProvider string) ([]varI, error) {
 	is := make([]rune, 0, len(i))
 	res := make([]varI, 0)
 	for _, r := range i {
-		if r == '|' {
+		if r == '|' || r == ':' {
 			if escape {
-				return nil, fmt.Errorf(`variable pipe cannot be escaped; remove \ before |`)
+				if r == '|' {
+					return nil, fmt.Errorf(`variable pipe cannot be escaped; remove \ before |`)
+				}
+				return nil, fmt.Errorf(`default pipe cannot be escaped; remove \ before :`)
 			}
 			if quote == out {
 				if constant {
@@ -252,8 +255,8 @@ func extractVars(i string, defaultProvider string) ([]varI, error) {
 					}
 					res = append(res, &varString{maybeAddDefaultProvider(string(is), defaultProvider)})
 				}
-				is = is[:0] // slice to zero length; to keep allocated memory
-				constant = false
+				is = is[:0]         // slice to zero length; to keep allocated memory
+				constant = r == ':' // not a constant when ':'
 			} else {
 				is = append(is, r)
 			}

--- a/internal/pkg/agent/transpiler/vars.go
+++ b/internal/pkg/agent/transpiler/vars.go
@@ -242,9 +242,9 @@ func extractVars(i string, defaultProvider string) ([]varI, error) {
 		if r == '|' || r == ':' {
 			if escape {
 				if r == '|' {
-					return nil, fmt.Errorf(`variable pipe cannot be escaped; remove \ before |`)
+					return nil, fmt.Errorf(`variable pipe cannot be escaped; remove '\' before '|'`)
 				}
-				return nil, fmt.Errorf(`default pipe cannot be escaped; remove \ before :`)
+				return nil, fmt.Errorf(`default pipe cannot be escaped; remove '\' before ':'`)
 			}
 			if quote == out {
 				if constant {
@@ -263,14 +263,15 @@ func extractVars(i string, defaultProvider string) ([]varI, error) {
 			continue
 		}
 		if !escape && (r == '"' || r == '\'') {
-			if quote == out {
+			switch quote {
+			case out:
 				// start of unescaped quote
 				quote = r
 				constant = true
-			} else if quote == r {
+			case r:
 				// end of unescaped quote
 				quote = out
-			} else {
+			default:
 				is = append(is, r)
 			}
 			continue

--- a/internal/pkg/agent/transpiler/vars_test.go
+++ b/internal/pkg/agent/transpiler/vars_test.go
@@ -255,6 +255,30 @@ func TestVars_Replace(t *testing.T) {
 			false,
 			false,
 		},
+		{
+			"${missing.key:}",
+			NewStrVal(""),
+			false,
+			false,
+		},
+		{
+			"${missing.key:constant_string}",
+			NewStrVal("constant_string"),
+			false,
+			false,
+		},
+		{
+			"${missing.key|missing.key2:constant_string}",
+			NewStrVal("constant_string"),
+			false,
+			false,
+		},
+		{
+			"${un-der_score.with-dash:not_used}",
+			NewStrVal("dash-value"),
+			false,
+			false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.Input, func(t *testing.T) {

--- a/internal/pkg/agent/transpiler/vars_test.go
+++ b/internal/pkg/agent/transpiler/vars_test.go
@@ -88,6 +88,12 @@ func TestVars_Replace(t *testing.T) {
 			false,
 		},
 		{
+			`${un-der_score.missing\|'fallback'}`,
+			NewStrVal(""),
+			true,
+			false,
+		},
+		{
 			"${un-der_score.missing|'fallback'}",
 			NewStrVal("fallback"),
 			false,
@@ -259,6 +265,12 @@ func TestVars_Replace(t *testing.T) {
 			"${missing.key:}",
 			NewStrVal(""),
 			false,
+			false,
+		},
+		{
+			`${missing.key\:constant_string}`,
+			NewStrVal(""),
+			true,
 			false,
 		},
 		{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds backwards compatibility for the `:` that comes from `go-ucfg` that was originally used in outputs before https://github.com/elastic/elastic-agent/commit/b59d51af881397da24efde53b33750be9132a1d0 was merged.

The `:` allows the following characters to be considered a constant where the `|` considers the following characters as a variable unless wrapped in quotes. This allows `${ELASTICSEARCH_USERNAME:}` to be used in outputs and work originally as it used to before variables provider was switch for output replacement.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This ensures that configurations that used the `go-ucfg` syntax in output configuration works as it always did, but continues to allow the composable providers in outputs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~ (covered in unit tests)

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #9451
