### PR TITLE
Add "backport-active-all" label to Dependabot-created PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
       - automation
       - skip-changelog
       - Team:Elastic-Agent-Control-Plane
+      - backport-active-all
     allow:
       # Only update internal dependencies for now while we evaluate this workflow.
       - dependency-name: "github.com/elastic/*"
@@ -29,4 +30,5 @@ updates:
       - automation
       - skip-changelog
       - Team:Elastic-Agent-Control-Plane
+      - backport-active-all
     open-pull-requests-limit: 10


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR makes it so that all future Dependabot-created PRs will have the `backport-active-all` label on them.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To ensure that dependencies are updated in all active branches.
