### PR TITLE
remove non used default kube-stack debug pipelines

### DIFF
--- a/changelog/fragments/1755774149-disable_default_kube_stack_pipelines.yaml
+++ b/changelog/fragments/1755774149-disable_default_kube_stack_pipelines.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Disable default non used kube-stack debug pipelines
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
@@ -469,6 +469,10 @@ collectors:
       # [Service Section](https://opentelemetry.io/docs/collector/configuration/#service)
       service:
         pipelines:
+          # Disable default non used kube-stack Helm Chart pipelines
+          logs: null
+          metrics: null
+          traces: null
           logs/node:
             receivers:
               - filelog

--- a/deploy/helm/edot-collector/kube-stack/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/values.yaml
@@ -428,6 +428,10 @@ collectors:
       # [Service Section](https://opentelemetry.io/docs/collector/configuration/#service)
       service:
         pipelines:
+          # Disable default non used kube-stack Helm Chart pipelines
+          logs: null
+          metrics: null
+          traces: null
           logs/node:
             receivers:
               - filelog


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Disables the `daemon` collector default debug pipelines created by the Kube-stack Helm Chart. These are the created pipelines without these changes:

```yaml
service:
  extensions:
    - file_storage
  pipelines:
    logs:
      exporters:
        - debug
      processors:
        - k8sattributes
        - resourcedetection/env
        - batch
      receivers:
        - otlp
        - filelog
    logs/apm:
      exporters:
        - otlp/gateway
      processors:
        - batch
        - resource/hostname
      receivers:
        - otlp
    logs/node:
      exporters:
        - otlp/gateway
      processors:
        - batch
        - k8sattributes
        - resourcedetection/system
        - resourcedetection/eks
        - resourcedetection/gcp
        - resourcedetection/aks
        - resource/hostname
        - resource/cloud
      receivers:
        - filelog
    metrics:
      exporters:
        - debug
      processors:
        - k8sattributes
        - resourcedetection/env
        - batch
      receivers:
        - otlp
        - hostmetrics
        - kubeletstats
    metrics/node/otel:
      exporters:
        - otlp/gateway
      processors:
        - batch/metrics
        - k8sattributes
        - resourcedetection/system
        - resourcedetection/eks
        - resourcedetection/gcp
        - resourcedetection/aks
        - resource/hostname
        - resource/cloud
      receivers:
        - kubeletstats
        - hostmetrics
    metrics/otel-apm:
      exporters:
        - otlp/gateway
      processors:
        - batch/metrics
        - resource/hostname
      receivers:
        - otlp
    traces:
      exporters:
        - debug
      processors:
        - k8sattributes
        - resourcedetection/env
        - batch
      receivers:
        - otlp
    traces/apm:
      exporters:
        - otlp/gateway
      processors:
        - batch
        - resource/hostname
      receivers:
        - otlp
```

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The Chart's `traces/metrics/logs` pipelines just exports to the `debug` exporter, which is already done by our predefined pipelines. That would prevent having duplicated components being initialized (hostmetrics, filelog, etc), thus the collector using less resources. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
