### PR TITLE
Persist ID only when provided in action

### DIFF
--- a/internal/pkg/agent/application/enroll/options.go
+++ b/internal/pkg/agent/application/enroll/options.go
@@ -138,6 +138,10 @@ func MergeOptionsWithMigrateAction(action *fleetapi.ActionMigrate, options Enrol
 		return EnrollOptions{}, fmt.Errorf("failed to decode enroll options: %w", err)
 	}
 
+	// do not preserve ID by default
+	delete(configMap, "id")
+	options.ID = ""
+
 	// overwriting what's needed
 	if len(action.Data.Settings) > 0 {
 		if err := json.Unmarshal(action.Data.Settings, &configMap); err != nil {

--- a/internal/pkg/agent/application/enroll/options_test.go
+++ b/internal/pkg/agent/application/enroll/options_test.go
@@ -305,6 +305,48 @@ func TestMergeOptionsWithMigrateAction(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"id is not persisted by default",
+			&fleetapi.ActionMigrate{
+				Data: fleetapi.ActionMigrateData{
+					EnrollmentToken: "token",
+					TargetURI:       "uri",
+					Settings:        json.RawMessage(`{"insecure": true, "tags":["a","b"]}`),
+				},
+			},
+			EnrollOptions{
+				ID: "test-id",
+			},
+			EnrollOptions{
+				EnrollAPIKey: "token",
+				URL:          "uri",
+				Insecure:     true,
+				Tags:         []string{"a", "b"},
+			},
+			false,
+		},
+		{
+			"id from action is used when provided",
+			&fleetapi.ActionMigrate{
+				Data: fleetapi.ActionMigrateData{
+					EnrollmentToken: "token",
+					TargetURI:       "uri",
+					Settings:        json.RawMessage(`{"insecure": true, "id": "new-id", "replace_token": "replace-token", "tags":["a","b"]}`),
+				},
+			},
+			EnrollOptions{
+				ID: "test-id",
+			},
+			EnrollOptions{
+				EnrollAPIKey: "token",
+				ID:           "new-id",
+				Insecure:     true,
+				ReplaceToken: "replace-token",
+				Tags:         []string{"a", "b"},
+				URL:          "uri",
+			},
+			false,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
At this stage we always try to persist agent id, when agent with same id already exists in target cluster migrate actions fails

