### PR TITLE
Enroll options contains parsable URI after FromFleetConfig call

### DIFF
--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -1892,7 +1892,7 @@ func TestComputeEnrollOptions(t *testing.T) {
 	assert.NotNil(t, options)
 
 	assert.Equal(t, "123", options.EnrollAPIKey, "EnrollAPIKey mismatch")
-	assert.Equal(t, "localhost:1234", options.URL, "URL mismatch")
+	assert.Equal(t, "http://localhost:1234", options.URL, "URL mismatch")
 
 	assert.Equal(t, []string{"sha1", "sha2"}, options.CASha256, "CASha256 mismatch")
 	assert.Equal(t, true, options.Insecure, "Insecure mismatch")

--- a/internal/pkg/agent/application/enroll/options.go
+++ b/internal/pkg/agent/application/enroll/options.go
@@ -7,6 +7,7 @@ package enroll
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
@@ -175,6 +176,12 @@ func FromFleetConfig(cfg *configuration.FleetAgentConfig) EnrollOptions {
 
 	if len(cfg.Client.Hosts) > 0 {
 		options.URL = cfg.Client.Hosts[0]
+	}
+
+	// URL at this point may not be parsable by url.Parse (missing protocol)
+	if host := options.URL; len(host) > 0 && !strings.HasPrefix(host, string(remote.ProtocolHTTPS)+"://") &&
+		!strings.HasPrefix(host, string(remote.ProtocolHTTP)+"://") {
+		options.URL = string(cfg.Client.Protocol) + "://" + host
 	}
 
 	if cfg.Client.Transport.TLS != nil {

--- a/internal/pkg/agent/application/enroll/options_test.go
+++ b/internal/pkg/agent/application/enroll/options_test.go
@@ -380,7 +380,7 @@ func TestFromFleetConfig(t *testing.T) {
 			"default config",
 			defaultFleetAgentCfg,
 			EnrollOptions{
-				URL:          defaultFleetAgentCfg.Client.Host,
+				URL:          string(defaultFleetAgentCfg.Client.Protocol) + "://" + defaultFleetAgentCfg.Client.Host,
 				EnrollAPIKey: defaultFleetAgentCfg.AccessAPIKey,
 				ProxyHeaders: make(map[string]string),
 			},


### PR DESCRIPTION
when we use enroll options in migrate flow constructed by FromFleetConfig we can fail on url.Parse as URL is preset from Host that omits protocol information. 

Prolematic is  subsequent call of
```
options := FromFleetConfig()
options.RemoteConfig()
```
where RemoteConfig parses URI 

Logic is the same as we use in [client URI function](https://github.com/elastic/elastic-agent/blob/392fc972241caf6043f477f5f4c08377b5588e54/internal/pkg/remote/client.go#L255).

This PR changes construction of EnrollOptions.URL in a way that Protocol information is not lost

Related: https://github.com/elastic/elastic-agent/issues/9574