### PR TITLE
Fix arbitrary file write extracting an archive containing symbolic links

### DIFF
--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -490,6 +490,14 @@ func untar(sourceFile, destinationDir string) error {
 			if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 				return err
 			}
+			// Check that creating a symlink at 'path' pointing to 'header.Linkname' is safe (stays in destinationDir)
+			safe, err := isSafeSymlink(path, header.Linkname, destinationDir)
+			if err != nil {
+				return fmt.Errorf("error evaluating symlink %s -> %s: %w", path, header.Linkname, err)
+			}
+			if !safe {
+				return fmt.Errorf("refusing to create unsafe symlink %s -> %s (outside extraction dir)", path, header.Linkname)
+			}
 			if err := os.Symlink(header.Linkname, path); err != nil {
 				return fmt.Errorf("error creating symlink %s pointing to %s: %w", path, header.Linkname, err)
 			}


### PR DESCRIPTION

To properly fix this issue:
- When extracting symlinks, you must ensure the symlink `path` created will, when resolved, not point outside the intended extraction directory.
- This requires, before creating the symlink at `path` pointing to `header.Linkname`, that you:
  1. Ensure that (a) `path` is in `destinationDir`, and (b) the link target (when resolved as if the symlink would exist) would still be within `destinationDir`.
  2. This involves simulating (or after creation, confirming) that resolving the symlink as placed would not escape.
  3. Additionally, all writes (not just symlink creation) should, before writing, resolve their final location with `filepath.EvalSymlinks`, starting from `destinationDir` and the archive entry, to confirm it's "in jail".

For minimal safe fix (without refactoring to check every write):  
- For the symlink case, do *not* create the symlink if:
    - Its path is not in `destinationDir`
    - Its resolved destination (as would be followed by a process in `destinationDir`) does not remain under `destinationDir`.
- This requires a helper: a function that, for a desired symlink at `path` pointing to `header.Linkname`, simulates following the resulting symlink and checks if it is inside `destinationDir`.

**Changes to implement:**
- Add a helper function, e.g., `isSafeSymlink(linkPath, linkTarget, destinationDir string) (bool, error)` that:  
    - Joins the linkPath's parent and linkTarget to get the symlink destination as seen from the filesystem.
    - Resolves the result using `filepath.EvalSymlinks`.
    - Checks if the resulting path is still under `destinationDir`.
- In the `tar.TypeSymlink` case, conditionally create the symlink only if this check passes, else error.

**What is needed:**
- A new helper function.
- Possibly import `"path/filepath"` if not already present (already imported here).
- Minimal code changes inside the `case tar.TypeSymlink` block of `untar`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

