### PR TITLE
Fix Incorrect conversion between integer types

### DIFF
--- a/internal/pkg/agent/install/user_linux.go
+++ b/internal/pkg/agent/install/user_linux.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"math"
 )
 
 // FindGID returns the group's GID on the machine.
@@ -89,6 +90,9 @@ func getentGetID(database string, key string) (int, error) {
 	val, err := strconv.Atoi(split[2])
 	if err != nil {
 		return -1, fmt.Errorf("failed to convert %s to int: %w", split[2], err)
+	}
+	if val < 0 || val > int(math.MaxUint32) {
+		return -1, fmt.Errorf("ID value %d out of range [0, %d]", val, uint32(math.MaxUint32))
 	}
 	return val, nil
 }


### PR DESCRIPTION
To address the incorrect conversion, we should ensure that only valid, positive, in-range user and group IDs are allowed to flow to the place they are cast to `uint32`. The best fix is to add explicit range checks where the conversion from int (parsed from string) to the UID/GID storage location happens—specifically in the return statements of `getentGetID`, `FindUID`, and `FindGID` in `internal/pkg/agent/install/user_linux.go`. These must only return an id if it is within `[0, math.MaxUint32]`, otherwise return an error. This prevents any "out of range" id from ever being used to populate the `ownership` struct or to reach the cast in the credential setup.

To implement this:

- In `internal/pkg/agent/install/user_linux.go`:  
  - At the end of `getentGetID`, after parsing the id, check that 0 <= val <= math.MaxUint32. If not, return error.
  - Update imports to include `"math"` for `math.MaxUint32`.

This patch does not change the user-facing functionality; it only ensures that the code safely handles ids from the OS and will fail fast if there are anomalies.


#### References
[Integer overflow](https://en.wikipedia.org/wiki/Integer_overflow)
Go language specification [Integer overflow](https://golang.org/ref/spec#Integer_overflow)
[strconv.Atoi](https://golang.org/pkg/strconv/#Atoi)
[strconv.ParseInt](https://golang.org/pkg/strconv/#ParseInt)
[strconv.ParseUint](https://golang.org/pkg/strconv/#ParseUint)

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

