### PR TITLE
updatecli: automate EDOT SDK k8s auto-instrumentation images to their latest version

### DIFF
--- a/.ci/updatecli/README.md
+++ b/.ci/updatecli/README.md
@@ -1,0 +1,79 @@
+# Overview
+
+This is how we manage adhoc dependency updates using `updatecli`.
+
+## EDOT SDK Dependencies Update Automation
+
+This directory contains updatecli configuration to automatically update EDOT SDK docker image versions in the elastic-agent repository.
+
+### Overview
+
+The automation tracks latest releases from the following repositories and updates corresponding docker image references in elastic-agent:
+
+- **elastic/elastic-otel-dotnet** → `docker.elastic.co/observability/elastic-otel-dotnet`
+- **elastic/elastic-otel-java** → `docker.elastic.co/observability/elastic-otel-javaagent`
+- **elastic/elastic-otel-node** → `docker.elastic.co/observability/elastic-otel-node`
+- **elastic/elastic-otel-python** → `docker.elastic.co/observability/elastic-otel-python`
+- **open-telemetry/opentelemetry-go-instrumentation** → `ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go`
+
+### Files Updated
+
+The automation updates these files in the elastic-agent repository:
+- `deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml`
+- `deploy/helm/edot-collector/kube-stack/values.yaml`
+
+Specifically, it updates the `instrumentation` section with the latest versions:
+
+```yaml
+instrumentation:
+  java:
+    image: docker.elastic.co/observability/elastic-otel-javaagent:X.Y.Z
+  nodejs:
+    image: docker.elastic.co/observability/elastic-otel-node:X.Y.Z
+  dotnet:
+    image: docker.elastic.co/observability/elastic-otel-dotnet:X.Y.Z
+  python:
+    image: docker.elastic.co/observability/elastic-otel-python:X.Y.Z
+  go:
+    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:vX.Y.Z
+```
+
+### Configuration Files
+
+- **`bump-edot-images.yml`**: Main updatecli configuration that defines sources and targets
+- **`values.d/scm.yml`**: Contains SCM configuration values for GitHub authentication
+
+### GitHub Workflow
+
+The automation runs via GitHub workflow `.github/workflows/bump-edot-images.yml` which:
+- Runs Monday to Friday at 3 PM UTC
+- Can be triggered manually via workflow_dispatch
+- Uses the OBS_AUTOMATION_APP credentials for creating PRs
+- Creates pull requests with `dependencies`, `skip-changelog`, and backport labels.
+
+### Example Output
+
+When new versions are detected, the automation will create a pull request similar to [elastic-agent#7327](https://github.com/elastic/elastic-agent/pull/7327) that was manually created previously.
+
+### Version Handling
+
+The configuration handles different version formatting:
+- Some repositories use `v` prefix in their tags (like `v1.2.0`)
+- The automation strips the `v` prefix where needed to match the expected docker tag format
+- Go instrumentation keeps the `v` prefix as that's the expected format
+
+### Manual Testing
+
+To test the configuration locally:
+
+```bash
+export GITHUB_TOKEN=$(gh auth token)
+export GITHUB_ACTOR=v1v
+updatecli diff \
+    --config .ci/updatecli/bump-edot-images.yml \
+    --values .ci/updatecli/values.d/scm.yml
+# Apply changes (requires write access to elastic-agent repo)
+updatecli apply \
+    --config .ci/updatecli/bump-edot-images.yml \
+    --values .ci/updatecli/values.d/scm.yml
+```

--- a/.ci/updatecli/updatecli-bump-edot.yml
+++ b/.ci/updatecli/updatecli-bump-edot.yml
@@ -96,7 +96,7 @@ targets:
       files:
         - "deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml"
         - "deploy/helm/edot-collector/kube-stack/values.yaml"
-      key: "instrumentation.dotnet.image"
+      key: "$.instrumentation.dotnet.image"
     transformers:
       - addprefix: "docker.elastic.co/observability/elastic-otel-dotnet:"
 
@@ -110,7 +110,7 @@ targets:
       files:
         - "deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml"
         - "deploy/helm/edot-collector/kube-stack/values.yaml"
-      key: "instrumentation.java.image"
+      key: "$.instrumentation.java.image"
     transformers:
       - trimprefix: "v"
       - addprefix: "docker.elastic.co/observability/elastic-otel-javaagent:"
@@ -124,7 +124,7 @@ targets:
       files:
         - "deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml"
         - "deploy/helm/edot-collector/kube-stack/values.yaml"
-      key: "instrumentation.nodejs.image"
+      key: "$.instrumentation.nodejs.image"
     transformers:
       - trimprefix: "v"
       - addprefix: "docker.elastic.co/observability/elastic-otel-node:"
@@ -138,7 +138,7 @@ targets:
       files:
         - "deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml"
         - "deploy/helm/edot-collector/kube-stack/values.yaml"
-      key: "instrumentation.python.image"
+      key: "$.instrumentation.python.image"
     transformers:
       - trimprefix: "v"
       - addprefix: "docker.elastic.co/observability/elastic-otel-python:"
@@ -152,6 +152,6 @@ targets:
       files:
         - "deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml"
         - "deploy/helm/edot-collector/kube-stack/values.yaml"
-      key: "instrumentation.go.image"
+      key: "$.instrumentation.go.image"
     transformers:
       - addprefix: "ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:"

--- a/.ci/updatecli/updatecli-bump-edot.yml
+++ b/.ci/updatecli/updatecli-bump-edot.yml
@@ -1,5 +1,5 @@
 ---
-name: Bump golang-version to latest version
+name: Bump EDOT SDKs to latest versions
 
 scms:
   elastic-agent:

--- a/.ci/updatecli/updatecli-bump-edot.yml
+++ b/.ci/updatecli/updatecli-bump-edot.yml
@@ -1,0 +1,157 @@
+---
+name: Bump golang-version to latest version
+
+scms:
+  elastic-agent:
+    kind: github
+    spec:
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      owner: '{{ .scm.owner }}'
+      repository: '{{ .scm.repository }}'
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      commitusingapi: true
+      branch: '{{ .scm.branch }}'
+      force: false
+
+actions:
+  elastic-agent:
+    kind: github/pullrequest
+    scmid: elastic-agent
+    spec:
+      automerge: false
+      labels:
+        - backport-active-8
+        - backport-active-9
+        - dependencies
+        - skip-changelog
+        - Team:Elastic-Agent-Control-Plane
+      title: '[otel/kube-stack] Update EDOT SDK k8s auto-instrumentation images to their latest versions'
+      description: |
+        Update the versions of the EDOT language SDK images being used with the OTel Operator.
+
+sources:
+  elastic-otel-dotnet:
+    name: "Get latest Elastic OTEL .NET release"
+    kind: githubrelease
+    spec:
+      owner: "elastic"
+      repository: "elastic-otel-dotnet"
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: semver
+
+  elastic-otel-java:
+    name: "Get latest Elastic OTEL Java release"
+    kind: githubrelease
+    spec:
+      owner: "elastic"
+      repository: "elastic-otel-java"
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: semver
+
+  elastic-otel-node:
+    name: "Get latest Elastic OTEL Node.js release"
+    kind: githubrelease
+    spec:
+      owner: "elastic"
+      repository: "elastic-otel-node"
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: semver
+
+  elastic-otel-python:
+    name: "Get latest Elastic OTEL Python release"
+    kind: githubrelease
+    spec:
+      owner: "elastic"
+      repository: "elastic-otel-python"
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: semver
+
+  otel-go-instrumentation:
+    name: "Get latest OpenTelemetry Go Instrumentation release"
+    kind: githubrelease
+    spec:
+      owner: "open-telemetry"
+      repository: "opentelemetry-go-instrumentation"
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: semver
+
+targets:
+  update-dotnet-managed-otlp:
+    name: "Update Elastic OTEL .NET image in values.yaml"
+    kind: yaml
+    scmid: elastic-agent
+    sourceid: elastic-otel-dotnet
+    spec:
+      files:
+        - "deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml"
+        - "deploy/helm/edot-collector/kube-stack/values.yaml"
+      key: "instrumentation.dotnet.image"
+    transformers:
+      - addprefix: "docker.elastic.co/observability/elastic-otel-dotnet:"
+
+  # Update Java image in managed_otlp/values.yaml
+  update-java-managed-otlp:
+    name: "Update Elastic OTEL Java image in values.yaml"
+    kind: yaml
+    scmid: elastic-agent
+    sourceid: elastic-otel-java
+    spec:
+      files:
+        - "deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml"
+        - "deploy/helm/edot-collector/kube-stack/values.yaml"
+      key: "instrumentation.java.image"
+    transformers:
+      - trimprefix: "v"
+      - addprefix: "docker.elastic.co/observability/elastic-otel-javaagent:"
+
+  update-nodejs-managed-otlp:
+    name: "Update Elastic OTEL Node.js image in values.yaml"
+    kind: yaml
+    scmid: elastic-agent
+    sourceid: elastic-otel-node
+    spec:
+      files:
+        - "deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml"
+        - "deploy/helm/edot-collector/kube-stack/values.yaml"
+      key: "instrumentation.nodejs.image"
+    transformers:
+      - trimprefix: "v"
+      - addprefix: "docker.elastic.co/observability/elastic-otel-node:"
+
+  update-python-managed-otlp:
+    name: "Update Elastic OTEL Python image in managed_otlp/values.yaml"
+    kind: yaml
+    scmid: elastic-agent
+    sourceid: elastic-otel-python
+    spec:
+      files:
+        - "deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml"
+        - "deploy/helm/edot-collector/kube-stack/values.yaml"
+      key: "instrumentation.python.image"
+    transformers:
+      - trimprefix: "v"
+      - addprefix: "docker.elastic.co/observability/elastic-otel-python:"
+
+  update-go-main:
+    name: "Update OpenTelemetry Go Instrumentation image in values.yaml"
+    kind: yaml
+    scmid: elastic-agent
+    sourceid: otel-go-instrumentation
+    spec:
+      files:
+        - "deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml"
+        - "deploy/helm/edot-collector/kube-stack/values.yaml"
+      key: "instrumentation.go.image"
+    transformers:
+      - addprefix: "ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:"

--- a/.github/workflows/bump-edot-images.yml
+++ b/.github/workflows/bump-edot-images.yml
@@ -1,0 +1,36 @@
+---
+name: bump-edot-images
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 20 * * 1-6"
+
+permissions:
+  contents: read
+
+env:
+  JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+jobs:
+  bump:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: elastic/oblt-actions/updatecli/run@v1
+        with:
+          command: apply --config .ci/updatecli/updatecli-bump-edot.yml --values .ci/updatecli/values.d/scm.yml
+          version-file: .updatecli-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: ${{ failure()  }}
+        uses: elastic/oblt-actions/slack/send@v1
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#ingest-notifications"
+          message: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, `@agent-team` please look what's going on <${{ env.JOB_URL }}|here>"


### PR DESCRIPTION
## What does this PR do?

automated dependency management for EDOT SDK docker images in the elastic-agent repository using updatecli. The automation tracks latest releases from EDOT SDK repositories and creates pull requests to update image versions in Helm chart configurations.

## Why is it important?

Previously, EDOT SDK image versions in elastic-agent had to be updated manually, as shown in https://github.com/elastic/elastic-agent/pull/7327. This manual process was time-consuming and could lead to outdated dependencies.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

```bash
$ GITHUB_TOKEN=$(gh auth token) \
   GITHUB_ACTOR=v1v \
   updatecli diff --config .ci/updatecli/updatecli-bump-edot.yml --values .ci/updatecli/values.d/scm.yml
```

and

```diff
--- a/.ci/updatecli/values.d/scm.yml
+++ b/.ci/updatecli/values.d/scm.yml
@@ -1,8 +1,8 @@
 scm:
   enabled: true
-  owner: elastic
+  owner: v1v
   repository: elastic-agent
-  branch: main
+  branch: test/updatecli-branch
   commitusingapi: true
   # begin updatecli-compose policy values
   user: 'github-actions[bot]'
```

produced

```
SUMMARY:

⚠ Bump golang-version to latest version:
	Source:
		✔ [elastic-otel-dotnet] Get latest Elastic OTEL .NET release
		✔ [elastic-otel-java] Get latest Elastic OTEL Java release
		✔ [elastic-otel-node] Get latest Elastic OTEL Node.js release
		✔ [elastic-otel-python] Get latest Elastic OTEL Python release
		✔ [otel-go-instrumentation] Get latest OpenTelemetry Go Instrumentation release
	Target:
		⚠ [update-dotnet-managed-otlp] Update Elastic OTEL .NET image in values.yaml
		⚠ [update-go-main] Update OpenTelemetry Go Instrumentation image in values.yaml
		⚠ [update-java-managed-otlp] Update Elastic OTEL Java image in values.yaml
		⚠ [update-nodejs-managed-otlp] Update Elastic OTEL Node.js image in values.yaml
		⚠ [update-python-managed-otlp] Update Elastic OTEL Python image in managed_otlp/values.yaml


Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	0
  * Total:	1
```


then if I applied the changes

```bash
$ GITHUB_TOKEN=$(gh auth token) \
   GITHUB_ACTOR=v1v \
   updatecli apply --config .ci/updatecli/updatecli-bump-edot.yml --values .ci/updatecli/values.d/scm.yml

SUMMARY:

⚠ Bump golang-version to latest version:
	Source:
		✔ [elastic-otel-dotnet] Get latest Elastic OTEL .NET release
		✔ [elastic-otel-java] Get latest Elastic OTEL Java release
		✔ [elastic-otel-node] Get latest Elastic OTEL Node.js release
		✔ [elastic-otel-python] Get latest Elastic OTEL Python release
		✔ [otel-go-instrumentation] Get latest OpenTelemetry Go Instrumentation release
	Target:
		⚠ [update-dotnet-managed-otlp] Update Elastic OTEL .NET image in values.yaml
		⚠ [update-go-main] Update OpenTelemetry Go Instrumentation image in values.yaml
		⚠ [update-java-managed-otlp] Update Elastic OTEL Java image in values.yaml
		⚠ [update-nodejs-managed-otlp] Update Elastic OTEL Node.js image in values.yaml
		⚠ [update-python-managed-otlp] Update Elastic OTEL Python image in managed_otlp/values.yaml


Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	0
  * Total:	1

One action to follow up:
  * https://github.com/v1v/elastic-agent/pull/11

```

## Caveats

It removes the inline comments:

<img width="1188" height="710" alt="image" src="https://github.com/user-attachments/assets/dbdd140a-ab84-4dd2-991a-059c17567042" />


Shall we remove them? Or move them one line above so they are not removed by the updatecli automation?

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
