### PR TITLE
github-actions: support label after being merged

### DIFF
--- a/.github/workflows/backport-active.yml
+++ b/.github/workflows/backport-active.yml
@@ -13,9 +13,13 @@ permissions:
 jobs:
   backport:
     # Only run if the PR was merged (not just closed) and has one of the backport labels
+    # or has been added afterwards.
     if: |
       github.event.pull_request.merged == true && 
-      ( contains(toJSON(github.event.pull_request.labels.*.name), 'backport-active-') || startsWith(github.event.label.name, 'backport-active-') )
+      ( 
+        (github.event.action == 'closed' && contains(toJSON(github.event.pull_request.labels.*.name), 'backport-active-')) || 
+        (github.event.action == 'labeled' && startsWith(github.event.label.name, 'backport-active-'))
+      )
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/backport-active.yml
+++ b/.github/workflows/backport-active.yml
@@ -2,7 +2,7 @@ name: Backport to active branches
 
 on:
   pull_request_target:
-    types: [closed]
+    types: [closed, labeled]
     branches:
       - main
 
@@ -15,7 +15,7 @@ jobs:
     # Only run if the PR was merged (not just closed) and has one of the backport labels
     if: |
       github.event.pull_request.merged == true && 
-      contains(toJSON(github.event.pull_request.labels.*.name), 'backport-active-')
+      ( contains(toJSON(github.event.pull_request.labels.*.name), 'backport-active-') || startsWith(github.event.label.name, 'backport-active-') )
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Support backports after a PR has been merged and labelled with `backport-active-*`.

## Why is it important?

Fixes a corner case when the PRs have been labeled after being merged with the supported list of active branches.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
