### PR TITLE
chore: fix formatting issues in logp printf-style calls

### DIFF
--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_reassign.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_reassign.go
@@ -29,9 +29,9 @@ func (h *PolicyReassign) Handle(ctx context.Context, a fleetapi.Action, acker ac
 	h.log.Debugf("handlerPolicyReassign: action '%+v' received", a)
 
 	if err := acker.Ack(ctx, a); err != nil {
-		h.log.Errorf("failed to acknowledge POLICY_REASSIGN action with id '%s'", a.ID)
+		h.log.Errorf("failed to acknowledge POLICY_REASSIGN action with id '%s'", a.ID())
 	} else if err := acker.Commit(ctx); err != nil {
-		h.log.Errorf("failed to commit acker after acknowledging action with id '%s'", a.ID)
+		h.log.Errorf("failed to commit acker after acknowledging action with id '%s'", a.ID())
 	}
 
 	return nil

--- a/internal/pkg/agent/application/upgrade/artifact/download/http/verify_backoff_rtt.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/verify_backoff_rtt.go
@@ -63,20 +63,20 @@ func (btr *BackoffRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 		if resettableBody != nil {
 			_, err = resettableBody.Seek(0, io.SeekStart)
 			if err != nil {
-				btr.logger.Errorf("error while resetting request body: %w", err)
+				btr.logger.Errorf("error while resetting request body: %v", err)
 			}
 		}
 
 		attempt++
 		resp, err = btr.next.RoundTrip(req) //nolint:bodyclose // the response body is closed when status code >= 400 or it is closed by the caller
 		if err != nil {
-			btr.logger.Errorf("attempt %d: error round-trip: %w", err)
+			btr.logger.Errorf("attempt %d: error round-trip: %v", attempt, err)
 			return err
 		}
 
 		if resp.StatusCode >= 400 {
 			if err := resp.Body.Close(); err != nil {
-				btr.logger.Errorf("attempt %d: error closing the response body: %w", attempt, err)
+				btr.logger.Errorf("attempt %d: error closing the response body: %v", attempt, err)
 			}
 			btr.logger.Errorf("attempt %d: received response status: %d", attempt, resp.StatusCode)
 			return errors.New(fmt.Sprintf("received response status: %d", resp.StatusCode))

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -269,7 +269,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, sourceURI string
 	// in case of error fallback to keep-all
 	detectedFlavor, err := install.UsedFlavor(paths.Top(), "")
 	if err != nil {
-		u.log.Warnf("error encountered when detecting used flavor with top path %q: %w", paths.Top(), err)
+		u.log.Warnf("error encountered when detecting used flavor with top path %q: %v", paths.Top(), err)
 	}
 	u.log.Debugf("detected used flavor: %q", detectedFlavor)
 	unpackRes, err := u.unpack(version, archivePath, paths.Data(), detectedFlavor)

--- a/internal/pkg/agent/migration/migrate_config.go
+++ b/internal/pkg/agent/migration/migrate_config.go
@@ -32,8 +32,8 @@ func MigrateToEncryptedConfig(ctx context.Context, l *logp.Logger, unencryptedCo
 
 	unencStat, unencFileErr := os.Stat(unencryptedConfigPath)
 
-	l.Debugf(fmt.Sprintf("checking stat of enc config %q: %+v, err: %v", encryptedConfigPath, encStat, encFileErr))
-	l.Debugf(fmt.Sprintf("checking stat of unenc config %q: %+v, err: %v", unencryptedConfigPath, unencStat, unencFileErr))
+	l.Debugf("checking stat of enc config %q: %+v, err: %v", encryptedConfigPath, encStat, encFileErr)
+	l.Debugf("checking stat of unenc config %q: %+v, err: %v", unencryptedConfigPath, unencStat, unencFileErr)
 
 	isEncryptedConfigEmpty := errors.Is(encFileErr, fs.ErrNotExist) || encStat.Size() == 0
 	isUnencryptedConfigPresent := unencFileErr == nil && unencStat.Size() > 0
@@ -54,7 +54,7 @@ func MigrateToEncryptedConfig(ctx context.Context, l *logp.Logger, unencryptedCo
 	defer func() {
 		err = reader.Close()
 		if err != nil {
-			l.Errorf(fmt.Sprintf("Error closing unencrypted store reader for %q: %v", unencryptedConfigPath, err))
+			l.Errorf("Error closing unencrypted store reader for %q: %v", unencryptedConfigPath, err)
 		}
 	}()
 	store, err := storage.NewEncryptedDiskStore(ctx, encryptedConfigPath, storageOpts...)

--- a/internal/pkg/composable/providers/kubernetes/kubernetes.go
+++ b/internal/pkg/composable/providers/kubernetes/kubernetes.go
@@ -124,7 +124,7 @@ func (p *dynamicProvider) watchResource(
 		}
 		p.config.Node, err = kubernetes.DiscoverKubernetesNode(p.logger, nd)
 		if err != nil {
-			p.logger.Debugf("Kubernetes provider skipped, unable to discover node: %w", err)
+			p.logger.Debugf("Kubernetes provider skipped, unable to discover node: %v", err)
 			return nil, nil
 		}
 

--- a/internal/pkg/config/loader.go
+++ b/internal/pkg/config/loader.go
@@ -53,7 +53,7 @@ func (l *Loader) Load(files []string) (*Config, error) {
 				return nil, fmt.Errorf("cannot get configuration from '%s': %w", f, err)
 			}
 			inputsList = append(inputsList, inp...)
-			l.logger.Debugf("Loaded %s input(s) from configuration from %s", len(inp), f)
+			l.logger.Debugf("Loaded %d input(s) from configuration from %s", len(inp), f)
 		} else {
 			if err := merger.Add(cfg.access(), err); err != nil {
 				return nil, fmt.Errorf("failed to merge configuration file '%s' to existing one: %w", f, err)

--- a/internal/pkg/remote/client.go
+++ b/internal/pkg/remote/client.go
@@ -221,7 +221,7 @@ func (c *Client) Send(
 			errs = append(errs, fmt.Errorf("%s: %w", msg, err))
 
 			// Using debug level as the error is only relevant if all clients fail.
-			c.log.With("error", err).Debugf(msg)
+			c.log.With("error", err).Debug(msg)
 			continue
 		}
 		c.checkApiVersionHeaders(req, resp)

--- a/pkg/testing/ess/serverless_provisioner.go
+++ b/pkg/testing/ess/serverless_provisioner.go
@@ -34,7 +34,7 @@ func (log *defaultLogger) Logf(format string, args ...any) {
 	if len(args) == 0 {
 
 	} else {
-		log.wrapped.Infof(format, args)
+		log.wrapped.Infof(format, args...)
 	}
 
 }


### PR DESCRIPTION
## Proposed commit message

This PR fixes fatal go vet errors on calls to logp functions. Release [v0.22.1](https://github.com/elastic/elastic-agent-libs/releases/tag/v0.22.1) of elastic-agent-libs enabled proper go vet support for printf style calls in logp, and that uncovered many misuses of printing directives.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test

```bash
$ go get -u github.com/elastic/elastic-agent-libs@v0.22.1
$ go vet ./...
```

## Related issues

- Relates https://github.com/elastic/elastic-agent-libs/pull/340.
- Relates https://github.com/elastic/beats/pull/45944