### PR TITLE
[docs] Add stub page for Markdown release notes

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -1,0 +1,9 @@
+project: Elastic Agent docs
+products:
+  - id: elastic-agent
+exclude:
+  - "*.md"
+  - "manifests/kustomize-autosharding/README.md"
+toc:
+  - toc: release-notes
+

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,0 +1,3 @@
+# Elastic Agent release notes
+
+_Work in progress_

--- a/docs/release-notes/toc.yml
+++ b/docs/release-notes/toc.yml
@@ -1,0 +1,2 @@
+toc:
+  - file: index.md


### PR DESCRIPTION
Related to https://github.com/elastic/elastic-agent/pull/9440

Adds a stub page for the Elastic Agent Markdown release notes to prevent failing docs checks on `main` while we wait for https://github.com/elastic/elastic-agent/pull/9440 to be reviewed/merged. 