### PR TITLE
chore: fix formatting issues in logp printf-style calls

### DIFF
--- a/pkg/ipc/listener_windows.go
+++ b/pkg/ipc/listener_windows.go
@@ -57,7 +57,7 @@ func securityDescriptor(log *logger.Logger) (string, error) {
 	isAdmin, err := utils.HasRoot()
 	if err != nil {
 		// do not fail, agent would end up in a loop, continue with limited permissions
-		log.Warnf("failed to detect Administrator: %w", err)
+		log.Warnf("failed to detect Administrator: %v", err)
 		isAdmin = false // just in-case to ensure that in error case that its always false
 	}
 	// SYSTEM/Administrators can always talk over the pipe, even when not running as privileged
@@ -73,7 +73,7 @@ func securityDescriptor(log *logger.Logger) (string, error) {
 		gid, err := pathGID(paths.Top())
 		if err != nil {
 			// do not fail, agent would end up in a loop, continue with limited permissions
-			log.Warnf("failed to detect group: %w", err)
+			log.Warnf("failed to detect group: %v", err)
 		} else {
 			descriptor += "(A;;GA;;;" + gid + ")"
 		}


### PR DESCRIPTION
## Proposed commit message

This PR fixes fatal go vet errors on calls to logp functions. Release [v0.22.1](https://github.com/elastic/elastic-agent-libs/releases/tag/v0.22.1) of elastic-agent-libs enabled proper go vet support for printf style calls in logp, and that uncovered many misuses of printing directives.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test

```bash
$ go get -u github.com/elastic/elastic-agent-libs@v0.22.1
$ go vet ./...
```

## Related issues

- Relates https://github.com/elastic/elastic-agent-libs/pull/340.
- Relates https://github.com/elastic/beats/pull/45944