### PR TITLE
fix: mount /opt/git-mirrors in golang-crossbuild container for VCS stamping

### DIFF
--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -328,6 +328,11 @@ func (b GolangCrossBuilder) Build() error {
 		args = append(args, "-v", hostDir+":/go/pkg/mod:ro")
 	}
 
+	// Mount /opt/git-mirrors (if present) to resolve git alternates in CI
+	if _, err := os.Stat("/opt/git-mirrors"); err == nil {
+		args = append(args, "-v", "/opt/git-mirrors:/opt/git-mirrors:ro")
+	}
+
 	if !ExternalBuild {
 		beatsPath, err := filepath.Abs(filepath.Join("../beats"))
 		if err != nil {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR updates the golangCrossBuild logic to conditionally mount `/opt/git-mirrors` into the container if it exists.  
This ensures that git alternates created by Buildkite PR checkouts can be resolved correctly when running `go build`.

In Buildkite, PRs are checked out using a local git mirror reference:

```bash
git clone -v --reference /opt/git-mirrors/git-github-com-elastic-elastic-agent-git -- git@github.com:elastic/elastic-agent.git .
git clean -ffxdq
git fetch -v --prune -- origin refs/pull/<PR>/head
git checkout -f <commit-sha>
git clean -ffxdq
```

This creates a `.git/objects/info/alternates` file pointing to `/opt/git-mirrors/....`
If this path is missing inside the container, any git invocation might fail because it cannot find the referenced object database.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without this mount, VCS stamping invoked by go build fails with:

```
# cd /go/src/github.com/elastic/elastic-agent; git -c log.showsignature=false log -1 --format=%H:%ct
error: object directory /opt/git-mirrors/git-github-com-elastic-elastic-agent-git/objects does not exist; check .git/objects/info/alternates
fatal: Failed to traverse parents of commit <sha>
error obtaining VCS status: exit status 128
        Use -buildvcs=false to disable VCS stamping.
```

This blocks builds that rely on commit metadata being embedded in the binary.
By mounting /opt/git-mirrors read-only, we restore access to the object store and allow go build to complete successfully.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None. The change only affects CI. 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

You can replicate the same checkout logic above and then run:
```
USE_PACKAGE_VERSION="true" SNAPSHOT="true" EXTERNAL="true" PLATFORMS="linux/arm64" PACKAGES="tar.gz" mage package
```

However [here](https://buildkite.com/elastic/elastic-agent/builds/26392) is a CI run of a PR without this fix and failing packaging steps. And [here](https://buildkite.com/elastic/elastic-agent/builds/26409#_) is a CI run of a PR with this fix and passing packaging steps 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/9433
