### PR TITLE
Allow overriding AGENT_PACKAGE_VERSION and MANIFEST_URL when USE_PACKAGE_VERSION=true

### DIFF
--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -162,17 +162,18 @@ func initGlobals() {
 
 	versionQualifier, versionQualified = os.LookupEnv("VERSION_QUALIFIER")
 
-	agentPackageVersion = EnvOr(agentPackageVersionEnvVar, "")
-
-	ManifestURL = EnvOr(ManifestUrlEnvVar, "")
-	PackagingFromManifest = ManifestURL != ""
-
 	// order matters this must be called last as it will override some of the
 	// values above
 	err = initPackageVersion()
 	if err != nil {
 		panic(fmt.Errorf("failed to init package version: %w", err))
 	}
+
+	agentPackageVersion = EnvOr(agentPackageVersionEnvVar, agentPackageVersion)
+
+	ManifestURL = EnvOr(ManifestUrlEnvVar, ManifestURL)
+	PackagingFromManifest = ManifestURL != ""
+
 }
 
 // ProjectType specifies the type of project (OSS vs X-Pack).


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This PR allows overriding `AGENT_PACKAGE_VERSION` and `MANIFEST_URL` when packaging using the information in `package.version` file. This is achieved by loading the package.version data before looking up the relevant env vars and using the values assigned from package version as fallbacks if the env vars are not defined.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
This allows for easy repackaging elastic-agent from a working directory, in order to have 2 "different" versions for the elastic-agent package: this is useful mostly when testing some upgrade scenarios.
Most of the time `USER_PACKAGE_VERSION=true` by itself will do a fine job for packaging so the usage of this change should be limited to some very specific testing.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
