### PR TITLE
Add ingest-docs team as CODEOWNERS for release notes and docset.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,8 @@
 /deploy/helm/edot-collector @elastic/ingest-otel-data
 /deploy/kubernetes @elastic/elastic-agent-control-plane
 /dev-tools/kubernetes @elastic/elastic-agent-control-plane
+/docs/release-notes @elastic/ingest-docs
+/docs/docset.yml @elastic/ingest-docs
 /internal/pkg/composable/providers/kubernetes @elastic/elastic-agent-control-plane
 /internal/pkg/otel/samples/darwin/autoops_es.yml @elastic/opex
 /internal/pkg/otel/samples/linux/autoops_es.yml @elastic/opex


### PR DESCRIPTION
Related to #9440

Adds ingest-docs team as CODEOWNERS for `docs/release-notes` and `docset.yml`. 

In my experience, someone with admin rights in this repo will need to add the `@elastic/ingest-docs` team with write permissions even if all of elastic already has write access. 

>When the code owner is a team, that team must be visible and it must have write permissions, even if all the individual members of the team already have write permissions directly, through organization membership, or through another team membership.

From: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners