### PR TITLE
Add agent_policy_id and policy_revision_idx to checkin requests

### DIFF
--- a/changelog/fragments/1757710842-Add-agent_policy_id-and-policy_revision_idx-to-checkin-requests.yaml
+++ b/changelog/fragments/1757710842-Add-agent_policy_id-and-policy_revision_idx-to-checkin-requests.yaml
@@ -19,7 +19,7 @@ summary: Add agent_policy_id and policy_revision_idx to checkin requests
 description: |
   Add agent_policy_id and policy_revision_idx attributes to checkin requests.
   These attributes are used to inform fleet-server of the policy id and revision that the agent is currently running.
-  Agents that use these policies no longer need to send acks for POLICY_CHANGE actions.
+  Add a feature flag to disable sending acks for POLICY_CHANGE actions on a future release.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component: elastic-agent
@@ -28,7 +28,7 @@ component: elastic-agent
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/elastic-agent/pull/9931
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.

--- a/changelog/fragments/1757710842-Add-agent_policy_id-and-policy_revision_idx-to-checkin-requests.yaml
+++ b/changelog/fragments/1757710842-Add-agent_policy_id-and-policy_revision_idx-to-checkin-requests.yaml
@@ -1,0 +1,35 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add agent_policy_id and policy_revision_idx to checkin requests
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Add agent_policy_id and policy_revision_idx attributes to checkin requests.
+  These attributes are used to inform fleet-server of the policy id and revision that the agent is currently running.
+  Agents that use these policies no longer need to send acks for POLICY_CHANGE actions.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/6446

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
@@ -105,7 +105,7 @@ func TestPolicyAcked(t *testing.T) {
 	agentInfo := &info.AgentInfo{}
 	nullStore := &storage.NullStore{}
 
-	t.Run("Config change should ACK", func(t *testing.T) {
+	t.Run("Config change shouldn't ACK", func(t *testing.T) {
 		ch := make(chan coordinator.ConfigChange, 1)
 		tacker := &testAcker{}
 
@@ -129,8 +129,7 @@ func TestPolicyAcked(t *testing.T) {
 		require.NoError(t, change.Ack())
 
 		actions := tacker.Items()
-		assert.EqualValues(t, 1, len(actions))
-		assert.Equal(t, actionID, actions[0])
+		assert.Empty(t, actions)
 	})
 }
 

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
@@ -105,7 +105,7 @@ func TestPolicyAcked(t *testing.T) {
 	agentInfo := &info.AgentInfo{}
 	nullStore := &storage.NullStore{}
 
-	t.Run("Config change shouldn't ACK", func(t *testing.T) {
+	t.Run("Default: Config changes are ACKed", func(t *testing.T) {
 		ch := make(chan coordinator.ConfigChange, 1)
 		tacker := &testAcker{}
 
@@ -119,6 +119,7 @@ func TestPolicyAcked(t *testing.T) {
 			},
 		}
 
+		// Test default FF value
 		cfg := configuration.DefaultConfiguration()
 		handler := NewPolicyChangeHandler(log, agentInfo, cfg, nullStore, ch, nilLogLevelSet(t), &coordinator.Coordinator{})
 
@@ -129,7 +130,8 @@ func TestPolicyAcked(t *testing.T) {
 		require.NoError(t, change.Ack())
 
 		actions := tacker.Items()
-		assert.Empty(t, actions)
+		assert.Len(t, actions, 1)
+		assert.Equal(t, actionID, actions[0])
 	})
 	t.Run("Config change acks when forced", func(t *testing.T) {
 		ch := make(chan coordinator.ConfigChange, 1)
@@ -147,7 +149,7 @@ func TestPolicyAcked(t *testing.T) {
 
 		cfg := configuration.DefaultConfiguration()
 		handler := NewPolicyChangeHandler(log, agentInfo, cfg, nullStore, ch, nilLogLevelSet(t), &coordinator.Coordinator{})
-		handler.forceAckFn = func() bool { return true }
+		handler.disableAckFn = func() bool { return false }
 
 		err := handler.Handle(context.Background(), action, tacker)
 		require.NoError(t, err)
@@ -158,6 +160,33 @@ func TestPolicyAcked(t *testing.T) {
 		actions := tacker.Items()
 		assert.Len(t, actions, 1)
 		assert.Equal(t, actionID, actions[0])
+	})
+	t.Run("Config change do not ack when disabled", func(t *testing.T) {
+		ch := make(chan coordinator.ConfigChange, 1)
+		tacker := &testAcker{}
+
+		config := map[string]interface{}{"hello": "world"}
+		actionID := "abc123"
+		action := &fleetapi.ActionPolicyChange{
+			ActionID:   actionID,
+			ActionType: "POLICY_CHANGE",
+			Data: fleetapi.ActionPolicyChangeData{
+				Policy: config,
+			},
+		}
+
+		cfg := configuration.DefaultConfiguration()
+		handler := NewPolicyChangeHandler(log, agentInfo, cfg, nullStore, ch, nilLogLevelSet(t), &coordinator.Coordinator{})
+		handler.disableAckFn = func() bool { return true }
+
+		err := handler.Handle(context.Background(), action, tacker)
+		require.NoError(t, err)
+
+		change := <-ch
+		require.NoError(t, change.Ack())
+
+		actions := tacker.Items()
+		assert.Empty(t, actions)
 	})
 }
 

--- a/internal/pkg/agent/application/actions/handlers/handler_action_unenroll.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_unenroll.go
@@ -93,7 +93,7 @@ func (h *Unenroll) handle(ctx context.Context, a fleetapi.Action, acker acker.Ac
 	}
 
 	// Generate empty policy change, this removing all the running components
-	unenrollPolicy := newPolicyChange(ctx, config.New(), a, acker, true)
+	unenrollPolicy := newPolicyChange(ctx, config.New(), a, acker, true, true)
 	h.ch <- unenrollPolicy
 
 	// backup action for future start to avoid starting fleet gateway loop

--- a/internal/pkg/agent/application/actions/handlers/handler_action_unenroll.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_unenroll.go
@@ -93,7 +93,7 @@ func (h *Unenroll) handle(ctx context.Context, a fleetapi.Action, acker acker.Ac
 	}
 
 	// Generate empty policy change, this removing all the running components
-	unenrollPolicy := newPolicyChange(ctx, config.New(), a, acker, true, true)
+	unenrollPolicy := newPolicyChange(ctx, config.New(), a, acker, true, false)
 	h.ch <- unenrollPolicy
 
 	// backup action for future start to avoid starting fleet gateway loop

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -71,6 +71,7 @@ type stateStore interface {
 	AckToken() string
 	SetAckToken(ackToken string)
 	Save() error
+	Action() fleetapi.Action
 }
 
 type FleetGateway struct {
@@ -356,15 +357,21 @@ func (f *FleetGateway) execute(ctx context.Context) (*fleetapi.CheckinResponse, 
 	// Fix loglevel with the current log level used by coordinator
 	ecsMeta.Elastic.Agent.LogLevel = state.LogLevel.String()
 
+	action := f.stateStore.Action()
+	agentPolicyID := getPolicyID(action)
+	policyRevisionIDX := getPolicyRevisionIDX(action)
+
 	// checkin
 	cmd := fleetapi.NewCheckinCmd(f.agentInfo, f.client)
 	req := &fleetapi.CheckinRequest{
-		AckToken:       ackToken,
-		Metadata:       ecsMeta,
-		Status:         agentStateToString(state.State),
-		Message:        state.Message,
-		Components:     components,
-		UpgradeDetails: state.UpgradeDetails,
+		AckToken:          ackToken,
+		Metadata:          ecsMeta,
+		Status:            agentStateToString(state.State),
+		Message:           state.Message,
+		Components:        components,
+		UpgradeDetails:    state.UpgradeDetails,
+		AgentPolicyID:     agentPolicyID,
+		PolicyRevisionIDX: policyRevisionIDX,
 	}
 
 	resp, took, err := cmd.Execute(ctx, req)
@@ -446,4 +453,44 @@ func RequestBackoff(done <-chan struct{}) backoff.Backoff {
 		defaultFleetBackoffSettings.Init,
 		defaultFleetBackoffSettings.Max,
 	)
+}
+
+// getPolicyID will check that the passed action is a POLICY_CHANGE action and return the policy_id attribute of the policy as a string.
+func getPolicyID(action fleetapi.Action) string {
+	policyChange, ok := action.(*fleetapi.ActionPolicyChange)
+	if !ok {
+		return ""
+	}
+	v, ok := policyChange.Data.Policy["policy_id"]
+	if !ok {
+		return ""
+	}
+	vv, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return vv
+}
+
+// getPolicyRevisionIDX will check that the passed action is a POLICY_CHANGE action and return the policy_revision_idx attribute of the policy as an int64.
+// The function will attempt to convert the attribute to int64 if int or float64 is used in order to prevent issues from serialization.
+func getPolicyRevisionIDX(action fleetapi.Action) int64 {
+	policyChange, ok := action.(*fleetapi.ActionPolicyChange)
+	if !ok {
+		return 0
+	}
+	v, ok := policyChange.Data.Policy["policy_revision_idx"]
+	if !ok {
+		return 0
+	}
+	switch vv := v.(type) {
+	case int64:
+		return vv
+	case int:
+		return int64(vv)
+	case float64:
+		return int64(vv)
+	default:
+		return 0
+	}
 }

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -377,6 +377,74 @@ func TestFleetGateway(t *testing.T) {
 		default:
 		}
 	})
+
+	t.Run("sends agent_policy_id and policy_revision_idx", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		scheduler := scheduler.NewStepper()
+		client := newTestingClient()
+
+		log, _ := loggertest.New("fleet_gateway")
+
+		stateStore := newStateStore(t, log)
+		stateStore.SetAction(&fleetapi.ActionPolicyChange{
+			ActionID:   "test-action-id",
+			ActionType: fleetapi.ActionTypePolicyChange,
+			Data: fleetapi.ActionPolicyChangeData{
+				Policy: map[string]interface{}{
+					"policy_id":           "test-policy-id",
+					"policy_revision_idx": 1,
+				},
+			},
+		})
+		err := stateStore.Save()
+		require.NoError(t, err)
+
+		gateway, err := newFleetGatewayWithScheduler(
+			log,
+			settings,
+			agentInfo,
+			client,
+			scheduler,
+			noop.New(),
+			emptyStateFetcher,
+			stateStore,
+		)
+		require.NoError(t, err)
+
+		waitFn := ackSeq(
+			client.Answer(func(headers http.Header, body io.Reader) (*http.Response, error) {
+				data, err := io.ReadAll(body)
+				require.NoError(t, err)
+
+				var checkinRequest fleetapi.CheckinRequest
+				err = json.Unmarshal(data, &checkinRequest)
+				require.NoError(t, err)
+
+				require.Equal(t, "test-policy-id", checkinRequest.AgentPolicyID)
+				require.Equal(t, int64(1), checkinRequest.PolicyRevisionIDX)
+
+				resp := wrapStrToResp(http.StatusOK, `{ "actions": [] }`)
+				return resp, nil
+			}),
+		)
+
+		errCh := runFleetGateway(ctx, gateway)
+
+		// Synchronize scheduler and acking of calls from the worker go routine.
+		scheduler.Next()
+		waitFn()
+
+		cancel()
+		err = <-errCh
+		require.NoError(t, err)
+		select {
+		case actions := <-gateway.Actions():
+			t.Errorf("Expected no actions, got %v", actions)
+		default:
+		}
+	})
 }
 
 func TestRetriesOnFailures(t *testing.T) {

--- a/internal/pkg/fleetapi/checkin_cmd.go
+++ b/internal/pkg/fleetapi/checkin_cmd.go
@@ -41,12 +41,14 @@ type CheckinComponent struct {
 
 // CheckinRequest consists of multiple events reported to fleet ui.
 type CheckinRequest struct {
-	Status         string             `json:"status"`
-	AckToken       string             `json:"ack_token,omitempty"`
-	Metadata       *info.ECSMeta      `json:"local_metadata,omitempty"`
-	Message        string             `json:"message"`    // V2 Agent message
-	Components     []CheckinComponent `json:"components"` // V2 Agent components
-	UpgradeDetails *details.Details   `json:"upgrade_details,omitempty"`
+	Status            string             `json:"status"`
+	AckToken          string             `json:"ack_token,omitempty"`
+	Metadata          *info.ECSMeta      `json:"local_metadata,omitempty"`
+	Message           string             `json:"message"`    // V2 Agent message
+	Components        []CheckinComponent `json:"components"` // V2 Agent components
+	UpgradeDetails    *details.Details   `json:"upgrade_details,omitempty"`
+	AgentPolicyID     string             `json:"agent_policy_id,omitempty"`
+	PolicyRevisionIDX int64              `json:"policy_revision_idx,omitempty"`
 }
 
 // SerializableEvent is a representation of the event to be send to the Fleet Server API via the checkin

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -53,9 +53,9 @@ type cfg struct {
 			TamperProtection *struct {
 				Enabled bool `json:"enabled" yaml:"enabled" config:"enabled"`
 			} `json:"tamper_protection,omitempty" yaml:"tamper_protection,omitempty" config:"tamper_protection,omitempty"`
-			DisablePolicyChangeAcks struct {
+			DisablePolicyChangeAcks *struct {
 				Enabled bool `json:"enabled" yaml:"enabled" config:"enabled"`
-			} `json:"disable_policy_change_acks" toml: "disable_policy_change_acks" config:"disable_policy_change_acks"`
+			} `json:"disable_policy_change_acks" yaml:"disable_policy_change_acks" config:"disable_policy_change_acks"`
 		} `json:"features" yaml:"features" config:"features"`
 	} `json:"agent" yaml:"agent" config:"agent"`
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -36,7 +36,8 @@ type Flags struct {
 	fqdn          bool
 	fqdnCallbacks map[string]BoolValueOnChangeCallback
 
-	tamperProtection bool
+	tamperProtection      bool
+	forcePolicyChangeAcks bool
 }
 
 type cfg struct {
@@ -48,6 +49,9 @@ type cfg struct {
 			TamperProtection *struct {
 				Enabled bool `json:"enabled" yaml:"enabled" config:"enabled"`
 			} `json:"tamper_protection,omitempty" yaml:"tamper_protection,omitempty" config:"tamper_protection,omitempty"`
+			ForcePolicyChangeAcks struct {
+				Enabled bool `json:"enabled" yaml:"enabled" config:"enabled"`
+			} `json:"force_policy_change_acks" toml: "force_policy_change_acks" config:"force_policy_change_acks"`
 		} `json:"features" yaml:"features" config:"features"`
 	} `json:"agent" yaml:"agent" config:"agent"`
 }
@@ -64,6 +68,13 @@ func (f *Flags) TamperProtection() bool {
 	defer f.mu.RUnlock()
 
 	return f.tamperProtection
+}
+
+func (f *Flags) ForcePolicyChangeAcks() bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	return f.forcePolicyChangeAcks
 }
 
 func (f *Flags) AsProto() *proto.Features {
@@ -119,6 +130,13 @@ func (f *Flags) setTamperProtection(newValue bool) {
 	defer f.mu.Unlock()
 
 	f.tamperProtection = newValue
+}
+
+func (f *Flags) setForcePolicyChangeAcks(newValue bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.forcePolicyChangeAcks = newValue
 }
 
 // setSource sets the source from he given cfg.
@@ -208,6 +226,7 @@ func Apply(c *config.Config) error {
 
 	current.setFQDN(parsed.FQDN())
 	current.setTamperProtection(parsed.TamperProtection())
+	current.setForcePolicyChangeAcks(parsed.ForcePolicyChangeAcks())
 	return err
 }
 
@@ -219,4 +238,9 @@ func FQDN() bool {
 // TamperProtection reports if tamper protection feature is enabled
 func TamperProtection() bool {
 	return current.TamperProtection()
+}
+
+// ForcePolicyChangeAcks reports if the agent should force sending an ACK for POLICY_CHANGE actions.
+func ForcePolicyChangeAcks() bool {
+	return current.ForcePolicyChangeAcks()
 }


### PR DESCRIPTION
## What does this PR do?

Add the agent_policy_id and policy_revision_idx attributes to checkin requests.
These attributes are sources from the action stored as a part of the state.
Add a feature flag to disable sending acks for policy change actions; behaviour for policy change acks has not been changed with this addition (they are always sent).

## Why is it important?

The policy information in fleet-server and agent may go out of sync; this may occur in cases where a VM restores from a snapshot.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

N/A

## Related issues

- Closes #6446 