### PR TITLE
fix: always clear the coordinator overridden state on err inside upgrade of coordinator

### DIFF
--- a/changelog/fragments/1758045690-clear-coordinator-state.yaml
+++ b/changelog/fragments/1758045690-clear-coordinator-state.yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+summary: Fix stuck upgrade state by clearing coordinator overridden state after failed upgrade
+component: elastic-agent
+pr: https://github.com/elastic/elastic-agent/pull/9992
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -765,6 +765,7 @@ func (c *Coordinator) Upgrade(ctx context.Context, version string, sourceURI str
 
 	// early check outside of upgrader before overriding the state
 	if !c.upgradeMgr.Upgradeable() {
+		c.ClearOverrideState()
 		det.Fail(ErrNotUpgradable)
 		return ErrNotUpgradable
 	}
@@ -772,6 +773,7 @@ func (c *Coordinator) Upgrade(ctx context.Context, version string, sourceURI str
 	// early check capabilities to ensure this upgrade actions is allowed
 	if c.caps != nil {
 		if !c.caps.AllowUpgrade(version, sourceURI) {
+			c.ClearOverrideState()
 			det.Fail(ErrNotUpgradable)
 			return ErrNotUpgradable
 		}
@@ -780,6 +782,7 @@ func (c *Coordinator) Upgrade(ctx context.Context, version string, sourceURI str
 	// run any pre upgrade callback
 	if uOpts.preUpgradeCallback != nil {
 		if err := uOpts.preUpgradeCallback(ctx, c.logger, action); err != nil {
+			c.ClearOverrideState()
 			det.Fail(err)
 			return err
 		}

--- a/internal/pkg/agent/application/coordinator/coordinator_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_test.go
@@ -579,6 +579,7 @@ func TestPreUpgradeCallback(t *testing.T) {
 		}))
 
 	assert.ErrorIs(t, preUpgradeCallbackErr, upgradeErr)
+	assert.Nil(t, coord.overrideState)
 	assert.Equal(t, preUpgradeCallbackErr, upgradeErr, "expected pre upgrade callback error")
 	assert.Eventually(t, func() bool {
 		return coord.State().UpgradeDetails.State == details.StateFailed


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR fixes a regression introduced by [#9634](https://github.com/elastic/elastic-agent/pull/9634) where the coordinator’s `overrideState` could remain set if an upgrade attempt failed early (e.g. agent not upgradeable, capability check denied, or pre-upgrade callback returned an error).  

Specifically, this PR:
- Adds calls to `ClearOverrideState()` before returning from all early failure branches inside `Coordinator.Upgrade`.
- Extends the coordinator test suite to assert that `overrideState` is reset to `nil` after a failing `preUpgradeCallback`, preventing stale state from leaking into subsequent upgrade attempts.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without this change, failed upgrades could leave the coordinator in a state that incorrectly reflects an ongoing upgrade. This blocks future upgrade attempts until the Elastic Agent is restarted, which is disruptive and operationally undesirable.  

By clearing the override state on failure, we ensure the coordinator always returns to a clean state, enabling subsequent upgrade attempts to proceed without requiring a restart.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

Previously, users would need to manually restart the Elastic Agent after a failed upgrade attempt in order to retry an upgrade.  
With this fix, the agent automatically clears the override state, removing the need for manual intervention.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

 Run `mage unitTest` and confirm that all tests pass, including the updated coordinator tests.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/pull/9634
