### PR TITLE
Temporarily disable FIPS integration tests

### DIFF
--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -179,7 +179,10 @@ steps:
       - int-packaging
     command: "buildkite-agent pipeline upload .buildkite/bk.integration.pipeline.yml"
 
-  - label: "Triggering custom FIPS integration tests"
-    depends_on:
-      - int-packaging
-    command: "buildkite-agent pipeline upload .buildkite/bk.integration-fips.pipeline.yml"
+# Temporarily disabled FIPS integration tests while we're encountering deployment creation
+# issues in the FRH GovCloud Staging environment.
+# Example: https://buildkite.com/elastic/elastic-agent-extended-testing/builds/10211#01995752-0966-4c21-874c-0894305ac091
+#  - label: "Triggering custom FIPS integration tests"
+#    depends_on:
+#      - int-packaging
+#    command: "buildkite-agent pipeline upload .buildkite/bk.integration-fips.pipeline.yml"

--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -182,7 +182,7 @@ steps:
 # Temporarily disabled FIPS integration tests while we're encountering deployment creation
 # issues in the FRH GovCloud Staging environment.
 # Example: https://buildkite.com/elastic/elastic-agent-extended-testing/builds/10211#01995752-0966-4c21-874c-0894305ac091
-  - if: false
+  - if: false != false
     label: "Triggering custom FIPS integration tests"
     depends_on:
       - int-packaging

--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -182,7 +182,8 @@ steps:
 # Temporarily disabled FIPS integration tests while we're encountering deployment creation
 # issues in the FRH GovCloud Staging environment.
 # Example: https://buildkite.com/elastic/elastic-agent-extended-testing/builds/10211#01995752-0966-4c21-874c-0894305ac091
-#  - label: "Triggering custom FIPS integration tests"
-#    depends_on:
-#      - int-packaging
-#    command: "buildkite-agent pipeline upload .buildkite/bk.integration-fips.pipeline.yml"
+  - if: false
+    label: "Triggering custom FIPS integration tests"
+    depends_on:
+      - int-packaging
+    command: "buildkite-agent pipeline upload .buildkite/bk.integration-fips.pipeline.yml"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR temporarily disables the FIPS integration testing Buildkite pipeline.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The FIPS integration tests pipeline is currently failing because the step where it provisions deployments in GovCloud Staging is consistently failing.  So we are disabling the FIPS integration tests pipeline until the underlying issues in the GovCloud Staging environment are resolved.
