### PR TITLE
ci: make CI paths co-owned by Elastic Agent team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 # Sub-directories/files ownership. Remember that order matters; the last matching pattern takes the most precedence.
 /.buildkite @elastic/elastic-agent-control-plane @elastic/observablt-ci
 /.ci @elastic/elastic-agent-control-plane @elastic/observablt-ci
+/.ci/scripts/update-otel.sh @elastic/elastic-agent-control-plane
 /.github @elastic/elastic-agent-control-plane @elastic/observablt-ci
 /.github/CODEOWNERS @elastic/ingest-tech-lead
 /deploy/helm @elastic/elastic-agent-control-plane

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,12 +2,12 @@
 * @elastic/elastic-agent-control-plane
 
 # Top-level files ownership
-/catalog-info.yaml @elastic/observablt-ci
+/catalog-info.yaml @elastic/elastic-agent-control-plane @elastic/observablt-ci
 
 # Sub-directories/files ownership. Remember that order matters; the last matching pattern takes the most precedence.
-/.buildkite @elastic/observablt-ci
-/.ci @elastic/observablt-ci
-/.github @elastic/observablt-ci
+/.buildkite @elastic/elastic-agent-control-plane @elastic/observablt-ci
+/.ci @elastic/elastic-agent-control-plane @elastic/observablt-ci
+/.github @elastic/elastic-agent-control-plane @elastic/observablt-ci
 /.github/CODEOWNERS @elastic/ingest-tech-lead
 /deploy/helm @elastic/elastic-agent-control-plane
 /deploy/helm/edot-collector @elastic/ingest-otel-data


### PR DESCRIPTION
Adds the Elastic Agent Control Plane team as a code owner of CI directories like `.ci/` and `.buildkite` beside the ObservaBLT CI team.

This should prevent pull requests that touch files in those directories from being blocked on the ObservaBLT CI team ([example](https://github.com/elastic/elastic-agent/pull/9858#discussion_r2360852379)). The ObservaBLT CI team's help in reviewing these pull requests is still valuable and sometimes indispensable. Ultimately though, in my view the responsibility on the CI in this repository falls on the Elastic Agent Control Plane team, so it should be owned by them.

Happy to hear other's opinions on this and close this PR if the discussion results in another approach being more desirable.