### PR TITLE
Add code owners for otel sample configs and core components metadata files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,8 @@
 /.github/workflows/update-docs.yml @elastic/ingest-docs
 /docs/reference/edot-collector @elastic/ingest-docs
 /docs/scripts/update-docs @elastic/ingest-docs
+/internal/pkg/otel/samples @elastic/ingest-otel-data @elastic/ingest-docs
+/internal/pkg/otel/core-components.yaml @elastic/ingest-otel-data @elastic/ingest-docs
 /internal/pkg/composable/providers/kubernetes @elastic/elastic-agent-control-plane
 /internal/pkg/otel/samples/darwin/autoops_es.yml @elastic/opex
 /internal/pkg/otel/samples/linux/autoops_es.yml @elastic/opex


### PR DESCRIPTION
As suggested in https://github.com/elastic/elastic-agent/pull/10022#issuecomment-3306586282

This will allow the @elastic/ingest-otel-data and @elastic/ingest-docs teams to edit sample configuration files and core components metadata (used only for docs generation) more easily.

+CC @pchila @swiatekm @AlexanderWert 