### PR TITLE
fix: take into account units state on liveness

### DIFF
--- a/changelog/fragments/1758287649-fix-liveness_units.yaml
+++ b/changelog/fragments/1758287649-fix-liveness_units.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Include components units status in HTTP liveness checks
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/8047

--- a/internal/pkg/agent/application/monitoring/liveness.go
+++ b/internal/pkg/agent/application/monitoring/liveness.go
@@ -84,9 +84,17 @@ func livenessHandler(coord CoordinatorState) func(http.ResponseWriter, *http.Req
 		}
 
 		unhealthyComponent := false
+	componentsLoop:
 		for _, comp := range state.Components {
 			if (failConfig.Failed && comp.State.State == client.UnitStateFailed) || (failConfig.Degraded && comp.State.State == client.UnitStateDegraded) {
 				unhealthyComponent = true
+				break componentsLoop
+			}
+			for _, unit := range comp.State.Units {
+				if (failConfig.Failed && unit.State == client.UnitStateFailed) || (failConfig.Degraded && unit.State == client.UnitStateDegraded) {
+					unhealthyComponent = true
+					break componentsLoop
+				}
 			}
 		}
 		if state.Collector != nil {

--- a/internal/pkg/agent/application/monitoring/liveness_test.go
+++ b/internal/pkg/agent/application/monitoring/liveness_test.go
@@ -383,6 +383,102 @@ func TestLivenessProcessHTTPHandler(t *testing.T) {
 			expectedCode: 500,
 			failon:       "degraded",
 		},
+		{
+			name: "component healthy and unit degraded",
+			coord: mockCoordinator{
+				isUp: true,
+				state: coordinator.State{
+					Components: []runtime.ComponentComponentState{
+						{
+							LegacyPID: "2",
+							State: runtime.ComponentState{
+								State: client.UnitStateHealthy,
+								Units: map[runtime.ComponentUnitKey]runtime.ComponentUnitState{
+									{
+										UnitType: client.UnitTypeInput,
+										UnitID:   "some-input-unit",
+									}: {
+										State: client.UnitStateDegraded,
+									},
+								},
+							},
+							Component: component.Component{
+								ID: "test-component",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCode: 500,
+			failon:       "degraded",
+		},
+		{
+			name: "component healthy and unit failed",
+			coord: mockCoordinator{
+				isUp: true,
+				state: coordinator.State{
+					Components: []runtime.ComponentComponentState{
+						{
+							LegacyPID: "2",
+							State: runtime.ComponentState{
+								State: client.UnitStateHealthy,
+								Units: map[runtime.ComponentUnitKey]runtime.ComponentUnitState{
+									{
+										UnitType: client.UnitTypeInput,
+										UnitID:   "some-input-unit",
+									}: {
+										State: client.UnitStateFailed,
+									},
+								},
+							},
+							Component: component.Component{
+								ID: "test-component",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCode: 500,
+			failon:       "failed",
+		},
+		{
+			name: "component healthy and unit healty",
+			coord: mockCoordinator{
+				isUp: true,
+				state: coordinator.State{
+					Components: []runtime.ComponentComponentState{
+						{
+							LegacyPID: "2",
+							State: runtime.ComponentState{
+								State: client.UnitStateHealthy,
+								Units: map[runtime.ComponentUnitKey]runtime.ComponentUnitState{
+									{
+										UnitType: client.UnitTypeInput,
+										UnitID:   "some-input-unit",
+									}: {
+										State: client.UnitStateHealthy,
+									},
+								},
+							},
+							Component: component.Component{
+								ID: "test-component",
+								InputSpec: &component.InputRuntimeSpec{
+									BinaryName: "testbeat",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCode: 200,
+			failon:       "failed",
+		},
 	}
 
 	// test with processesHandler


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR adds the check of the component's unit's state on liveness endpoint. If a component state is healthy, but a unit state is degraded or failed, the liveness endpoint will return a 500.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact
Liveness probes will now fail if a component state is healthy but any of the units is failed or degraded, likely causing the container to be restarted (see https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/#liveness-probe).

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/8047

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->



<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
