### PR TITLE
Improve Collector docs automation script

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -17,6 +17,25 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Fetch all history including tags
+      
+      - name: Add upstream remote and fetch tags
+        run: |
+          git remote add upstream https://github.com/elastic/elastic-agent.git || true
+          git fetch upstream --tags
+      
+      - name: Find latest semantic version
+        id: get_version
+        run: |
+          # Get the latest semantic version tag (excluding pre-release versions)
+          LATEST_VERSION=$(git tag --list | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -1)
+          echo "Latest version: $LATEST_VERSION"
+          echo "version=$LATEST_VERSION" >> $GITHUB_OUTPUT
+      
+      - name: Pass version to script
+        run: |
+          echo "LATEST_VERSION=${{ steps.get_version.outputs.version }}" >> $GITHUB_ENV
       
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -38,14 +57,20 @@ jobs:
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "docs: update generated documentation"
-          title: "Update generated documentation"
+          commit-message: "docs: update generated documentation for ${{ steps.get_version.outputs.version }}"
+          title: "Update generated documentation for ${{ steps.get_version.outputs.version }}"
           body: |
-            This PR updates the generated documentation based on the latest local repository data.
+            This PR updates the generated documentation based on the latest released version **${{ steps.get_version.outputs.version }}**.
             
+            ## Changes
             - Updates EDOT Collector component tables
             - Updates OpenTelemetry Collector Builder (OCB) configuration
-            - Uses local version from version.go file
+            - Uses data from the latest released version tag: `${{ steps.get_version.outputs.version }}`
+            
+            ## References
+            - **Source go.mod**: https://github.com/elastic/elastic-agent/blob/${{ steps.get_version.outputs.version }}/go.mod
+            - **Source core-components.yaml**: https://github.com/elastic/elastic-agent/blob/${{ steps.get_version.outputs.version }}/internal/pkg/otel/core-components.yaml
+            - **Release tag**: https://github.com/elastic/elastic-agent/tree/${{ steps.get_version.outputs.version }}
             
             This is an automated PR created by the documentation update workflow.
           branch: update-docs

--- a/docs/reference/edot-collector/components.md
+++ b/docs/reference/edot-collector/components.md
@@ -21,6 +21,10 @@ The {{edot}} (EDOT) Collector includes embedded Collector components from the [O
 The components included in the EDOT Collector are categorized into **[Core]** and **[Extended]** components. The following table describes the current components included in the EDOT Collector, their source, and support status.
 
 % start:edot-collector-components-table
+## List of components
+
+These components are included in EDOT Collector version 9.1.4.
+
 | Component | GitHub Repo | Support status | Version |
 |:---|:---|:---|:---|
 |***Receivers***||||

--- a/docs/reference/edot-collector/components.md
+++ b/docs/reference/edot-collector/components.md
@@ -25,7 +25,6 @@ The components included in the EDOT Collector are categorized into **[Core]** an
 |:---|:---|:---|:---|
 |***Receivers***||||
 | [dockerstatsreceiver ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dockerstatsreceiver) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Extended] | v0.130.0 |
-| [elasticapmintakereceiver ](/reference/edot-collector/components/elasticapmintakereceiver.md) | [Elastic Repo](https://github.com/elastic/opentelemetry-collector-components) | [Core] | v0.2.1 |
 | [filelogreceiver ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Core] | v0.130.0 |
 | [hostmetricsreceiver ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Core] | v0.130.0 |
 | [httpcheckreceiver ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/httpcheckreceiver) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Extended] | v0.130.0 |
@@ -43,8 +42,8 @@ The components included in the EDOT Collector are categorized into **[Core]** an
 | [redisreceiver ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/redisreceiver) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Extended] | v0.130.0 |
 | [zipkinreceiver ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/zipkinreceiver) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Extended] | v0.130.0 |
 |***Exporters***||||
-| [debugexporter ](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter) | [OTel Core Repo](https://github.com/open-telemetry/opentelemetry-collector) | [Extended] | v0.132.0 |
-| [elasticsearchexporter ](/reference/edot-collector/components/elasticsearchexporter.md) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Core] | v0.132.0 |
+| [debugexporter ](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter) | [OTel Core Repo](https://github.com/open-telemetry/opentelemetry-collector) | [Extended] | v0.130.0 |
+| [elasticsearchexporter ](/reference/edot-collector/components/elasticsearchexporter.md) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Core] | v0.130.0 |
 | [fileexporter ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/fileexporter) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Extended] | v0.130.0 |
 | [kafkaexporter ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kafkaexporter) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Extended] | v0.130.0 |
 | [loadbalancingexporter ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Extended] | v0.130.0 |
@@ -63,7 +62,6 @@ The components included in the EDOT Collector are categorized into **[Core]** an
 | [memorylimiterprocessor ](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor) | [OTel Core Repo](https://github.com/open-telemetry/opentelemetry-collector) | [Extended] | v0.130.0 |
 | [resourcedetectionprocessor ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Core] | v0.130.0 |
 | [resourceprocessor ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Core] | v0.130.0 |
-| [tailsamplingprocessor ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Extended] | v0.130.0 |
 | [transformprocessor ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Core] | v0.130.0 |
 |***Connectors***||||
 | [elasticapmconnector ](https://github.com/elastic/opentelemetry-collector-components/tree/main/connector/elasticapmconnector) | [Elastic Repo](https://github.com/elastic/opentelemetry-collector-components) | [Core] | v0.6.0 |
@@ -76,17 +74,16 @@ The components included in the EDOT Collector are categorized into **[Core]** an
 | [bearertokenauthextension ](/reference/edot-collector/config/authentication-methods.md) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Extended] | v0.130.0 |
 | [filestorage ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Core] | v0.130.0 |
 | [healthcheckextension ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Extended] | v0.130.0 |
-| [healthcheckv2extension ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckv2extension) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Extended] | v0.130.0 |
 | [k8sleaderelector ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/k8sleaderelector) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Extended] | v0.130.0 |
 | [k8sobserver ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/k8sobserver) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Extended] | v0.130.0 |
 | [memorylimiterextension ](https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/memorylimiterextension) | [OTel Core Repo](https://github.com/open-telemetry/opentelemetry-collector) | [Extended] | v0.130.0 |
 | [pprofextension ](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/pprofextension) | [OTel Contrib Repo](https://github.com/open-telemetry/opentelemetry-collector-contrib) | [Extended] | v0.130.0 |
 |***Providers***||||
 | [envprovider ](https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider/envprovider) | [OTel Core Repo](https://github.com/open-telemetry/opentelemetry-collector) | [Core] | v1.36.0 |
-| [fileprovider ](https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider/fileprovider) | [OTel Core Repo](https://github.com/open-telemetry/opentelemetry-collector) | [Core] | v1.38.0 |
+| [fileprovider ](https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider/fileprovider) | [OTel Core Repo](https://github.com/open-telemetry/opentelemetry-collector) | [Core] | v1.36.0 |
 | [httpprovider ](https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider/httpprovider) | [OTel Core Repo](https://github.com/open-telemetry/opentelemetry-collector) | [Core] | v1.36.0 |
-| [httpsprovider ](https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider/httpsprovider) | [OTel Core Repo](https://github.com/open-telemetry/opentelemetry-collector) | [Core] | v1.35.0 |
-| [yamlprovider ](https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider/yamlprovider) | [OTel Core Repo](https://github.com/open-telemetry/opentelemetry-collector) | [Core] | v1.38.0 |
+| [httpsprovider ](https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider/httpsprovider) | [OTel Core Repo](https://github.com/open-telemetry/opentelemetry-collector) | [Core] | v1.36.0 |
+| [yamlprovider ](https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider/yamlprovider) | [OTel Core Repo](https://github.com/open-telemetry/opentelemetry-collector) | [Core] | v1.36.0 |
 
 % end:edot-collector-components-table
 

--- a/docs/reference/edot-collector/custom-collector.md
+++ b/docs/reference/edot-collector/custom-collector.md
@@ -66,8 +66,6 @@ dist:
 receivers:
   dockerstatsreceiver :
     gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.130.0
-  elasticapmintakereceiver :
-    gomod: github.com/elastic/opentelemetry-collector-components/receiver/elasticapmintakereceiver v0.2.1
   filelogreceiver :
     gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.130.0
   hostmetricsreceiver :
@@ -124,16 +122,14 @@ processors:
     gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.130.0
   resourceprocessor :
     gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.130.0
-  tailsamplingprocessor :
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.130.0
   transformprocessor :
     gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.130.0
 
 exporters:
   debugexporter :
-    gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.132.0
+    gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.130.0
   elasticsearchexporter :
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.132.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.130.0
   fileexporter :
     gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.130.0
   kafkaexporter :
@@ -168,8 +164,6 @@ extensions:
     gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.130.0
   healthcheckextension :
     gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.130.0
-  healthcheckv2extension :
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension v0.130.0
   k8sleaderelector :
     gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector v0.130.0
   k8sobserver :
@@ -183,13 +177,13 @@ providers:
   envprovider :
     gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.36.0
   fileprovider :
-    gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.38.0
+    gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.36.0
   httpprovider :
     gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.36.0
   httpsprovider :
-    gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.35.0
+    gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.36.0
   yamlprovider :
-    gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.38.0
+    gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.36.0
 ```
 % end:edot-collector-components-ocb
 

--- a/docs/reference/edot-collector/custom-collector.md
+++ b/docs/reference/edot-collector/custom-collector.md
@@ -44,6 +44,8 @@ Create a builder configuration file,`builder-config.yml`, to define the custom C
 The following example, `builder-config.yml`, contains the components needed to send your telemetry data to Elastic Observability. For more information on these components, refer to the [components](/reference/edot-collector/components.md) documentation. Keep or remove components from the example configuration file to fit your needs.
 
 % start:edot-collector-components-ocb
+This OCB configuration is for EDOT Collector version 9.1.4.
+
 ```yaml
 dist:
   otelcol_edot:

--- a/docs/reference/edot-collector/download.md
+++ b/docs/reference/edot-collector/download.md
@@ -38,3 +38,7 @@ sudo ./otelcol --config otel.yml
 ```
 
 For specific configuration, refer to the [Quickstart guides](docs-content://solutions/observability/get-started/opentelemetry/quickstart/index.md) or refer to [Configuration](/reference/edot-collector/config/index.md).
+
+:::{tip}
+To download a specific version of the EDOT Collector, replace {{version.edot_collector}} with the version you want to download.
+:::

--- a/docs/scripts/update-docs/templates/components-table.jinja2
+++ b/docs/scripts/update-docs/templates/components-table.jinja2
@@ -1,3 +1,7 @@
+## List of components
+
+These components are included in EDOT Collector version {{version.edot_collector}}.
+
 | Component | GitHub Repo | Support status | Version |
 |:---|:---|:---|:---|
 {%if grouped_components['Receivers'] -%}

--- a/docs/scripts/update-docs/templates/ocb.jinja2
+++ b/docs/scripts/update-docs/templates/ocb.jinja2
@@ -1,3 +1,5 @@
+This OCB configuration is for EDOT Collector version {{version.edot_collector}}.
+
 ```yaml
 dist:
   otelcol_edot:

--- a/docs/scripts/update-docs/update-components-docs.py
+++ b/docs/scripts/update-docs/update-components-docs.py
@@ -287,7 +287,10 @@ def check_markdown():
     otel_col_version = get_otel_col_upstream_version()
     data = {
         'grouped_components': components,
-        'otel_col_version': otel_col_version
+        'otel_col_version': otel_col_version,
+        'version': {
+            'edot_collector': col_version
+        }
     }
     tables = check_markdown_generation(EDOT_COLLECTOR_DIR, data, TEMPLATE_COLLECTOR_COMPONENTS_TABLE, TABLE_TAG) 
     ocb = check_markdown_generation(EDOT_COLLECTOR_DIR, data, TEMPLATE_COLLECTOR_OCB_FILE, DEPS_TAG)
@@ -312,7 +315,10 @@ def generate_markdown():
     otel_col_version = get_otel_col_upstream_version()
     data = {
         'grouped_components': components,
-        'otel_col_version': otel_col_version
+        'otel_col_version': otel_col_version,
+        'version': {
+            'edot_collector': col_version
+        }
     }
     render_components_into_file(EDOT_COLLECTOR_DIR, data, TEMPLATE_COLLECTOR_COMPONENTS_TABLE, TABLE_TAG)
     render_components_into_file(EDOT_COLLECTOR_DIR, data, TEMPLATE_COLLECTOR_OCB_FILE, DEPS_TAG)


### PR DESCRIPTION
This PR improves our Collector docs automation to avoid creating PRs for current docs from the changes in `main`, as the Collector reference docs always describe the latest version.

### GitHub Workflow (.github/workflows/update-docs.yml):

- Added logic to discover latest semantic version tag from Git repository
- Set LATEST_VERSION environment variable to pass version to Python script
- Updated PR title to include version: "Update generated documentation for {version}"
- Enhanced PR description with version information and source file references
- Added links to versioned source files (go.mod, core-components.yaml, release tag)

### Python Script (docs/scripts/update-docs/update-components-docs.py)

- Added read_file_from_git_tag() function to read files from specific Git tags
- Modified all data-reading functions to use git show {tag}:{file} commands:
- get_core_components() - reads from v{version}:internal/pkg/otel/core-components.yaml
- get_otel_components() - reads from v{version}:go.mod
- get_otel_col_upstream_version() - reads from v{version}:go.mod
- Added auto-discovery of latest version when no environment variable is set