### PR TITLE
Add elasticapmprocessor to core components metadata

### DIFF
--- a/internal/pkg/otel/core-components.yaml
+++ b/internal/pkg/otel/core-components.yaml
@@ -23,7 +23,7 @@ components:
   - attributesprocessor
   - batchprocessor
   - elasticinframetricsprocessor
-  - elastictraceprocessor
+  - elasticapmprocessor
   - k8sattributesprocessor
   - resourcedetectionprocessor
   - resourceprocessor


### PR DESCRIPTION
This adds `elasticapmprocessor` to the Core components metadata file used to generate the docs.

The change will happen in 9.2