### PR TITLE
Update code ownership of core-components.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@
 /docs/reference/edot-collector @elastic/ingest-docs
 /docs/scripts/update-docs @elastic/ingest-docs
 /internal/pkg/otel/samples @elastic/ingest-otel-data @elastic/ingest-docs
-/internal/pkg/otel/core-components.yaml @ingest-otel-leads
+/internal/pkg/otel/core-components.yaml @elastic/ingest-otel-leads
 /internal/pkg/composable/providers/kubernetes @elastic/elastic-agent-control-plane
 /internal/pkg/otel/samples/darwin/autoops_es.yml @elastic/opex
 /internal/pkg/otel/samples/linux/autoops_es.yml @elastic/opex

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@
 /docs/reference/edot-collector @elastic/ingest-docs
 /docs/scripts/update-docs @elastic/ingest-docs
 /internal/pkg/otel/samples @elastic/ingest-otel-data @elastic/ingest-docs
-/internal/pkg/otel/core-components.yaml @mlunadia @AlexanderWert
+/internal/pkg/otel/core-components.yaml @ingest-otel-leads
 /internal/pkg/composable/providers/kubernetes @elastic/elastic-agent-control-plane
 /internal/pkg/otel/samples/darwin/autoops_es.yml @elastic/opex
 /internal/pkg/otel/samples/linux/autoops_es.yml @elastic/opex

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@
 /docs/reference/edot-collector @elastic/ingest-docs
 /docs/scripts/update-docs @elastic/ingest-docs
 /internal/pkg/otel/samples @elastic/ingest-otel-data @elastic/ingest-docs
-/internal/pkg/otel/core-components.yaml @elastic/ingest-otel-data @elastic/ingest-docs
+/internal/pkg/otel/core-components.yaml @mlunadia @AlexanderWert
 /internal/pkg/composable/providers/kubernetes @elastic/elastic-agent-control-plane
 /internal/pkg/otel/samples/darwin/autoops_es.yml @elastic/opex
 /internal/pkg/otel/samples/linux/autoops_es.yml @elastic/opex


### PR DESCRIPTION
With increased components' movement, the role of `core-components.yml` is becoming critical. The ingest docs team is not qualified to decide on the content of that file.

This PR suggests adding the PM and EM for these file decisions as exclusive owners of the file. That also means they would be gating components updates and changes in each Collector release.

Case in point: the status of some new receivers in https://github.com/elastic/elastic-agent/pull/9344

+CC @mlunadia @AlexanderWert @colleenmcginnis 
