### PR TITLE
Revert "Temporarily have FIPS integration tests spin up deployments in Production CFT environment"

### DIFF
--- a/.buildkite/bk.integration-fips.pipeline.yml
+++ b/.buildkite/bk.integration-fips.pipeline.yml
@@ -12,28 +12,20 @@ env:
 # This section is used to define the plugins that will be used in the pipeline.
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
-#  We are temporarily using the Production CFT environment API key instead of the
-#  Staging GovCloud one.  This is being done until issues with creating deployments in
-#  Staging GovCloud are fixed.  Once those are fixed, uncomment the `vault_ec_key_staging_frh_gov`
-#  section and delete the `vault_ec_key_prod` section below.
-#  - vault_ec_key_staging_frh_gov: &vault_ec_key_staging_frh_gov
-#      elastic/vault-secrets#v0.1.0:
-#        path: "kv/ci-shared/platform-ingest/platform-ingest-ec-staging-gov"
-#        field: "apiKey"
-#        env_var: "EC_API_KEY"
-  - vault_ec_key_prod: &vault_ec_key_prod
+  - vault_ec_key_staging_frh_gov: &vault_ec_key_staging_frh_gov
       elastic/vault-secrets#v0.1.0:
-        path: "kv/ci-shared/platform-ingest/platform-ingest-ec-prod"
+        path: "kv/ci-shared/platform-ingest/platform-ingest-ec-staging-gov"
         field: "apiKey"
         env_var: "EC_API_KEY"
+
 steps:
   - label: Start ESS stack for FIPS integration tests
     key: integration-fips-ess
     env:
       FIPS: "true"
-#      EC_ENDPOINT: "https://api.staging.elastic-gov.com"
-#      ESS_REGION: "us-gov-east-1"
-#      TF_VAR_deployment_template_id: "aws-general-purpose"
+      EC_ENDPOINT: "https://api.staging.elastic-gov.com"
+      ESS_REGION: "us-gov-east-1"
+      TF_VAR_deployment_template_id: "aws-general-purpose"
       TF_VAR_integration_server_docker_image: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips:git-${BUILDKITE_COMMIT:0:12}"
       TF_VAR_docker_images_name_suffix: "-fips"
     command: |
@@ -45,7 +37,7 @@ steps:
       image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:0.5"
       useCustomGlobalHooks: true
     plugins:
-      - *vault_ec_key_prod
+      - *vault_ec_key_staging_frh_gov
 
   - group: "fips:Stateful:Ubuntu"
     key: integration-tests-ubuntu-fips
@@ -73,7 +65,7 @@ steps:
           image: "${IMAGE_UBUNTU_X86_64_FIPS}"
           instanceType: "m5.2xlarge"
         plugins:
-          - *vault_ec_key_prod
+          - *vault_ec_key_staging_frh_gov
         matrix:
           setup:
             sudo:
@@ -103,7 +95,7 @@ steps:
           image: "${IMAGE_UBUNTU_ARM64_FIPS}"
           instanceType: "m6g.2xlarge"
         plugins:
-          - *vault_ec_key_prod
+          - *vault_ec_key_staging_frh_gov
         matrix:
           setup:
             sudo:
@@ -130,16 +122,16 @@ steps:
           image: "${IMAGE_UBUNTU_X86_64_FIPS}"
           instanceType: "m5.2xlarge"
         plugins:
-          - *vault_ec_key_prod
+          - *vault_ec_key_staging_frh_gov
 
   - label: ESS FIPS stack cleanup
     depends_on:
       - integration-tests-ubuntu-fips
     env:
       FIPS: "true"
-#      EC_ENDPOINT: "https://api.staging.elastic-gov.com"
-#      ESS_REGION: "us-gov-east-1"
-#      TF_VAR_deployment_template_id: "aws-general-purpose"
+      EC_ENDPOINT: "https://api.staging.elastic-gov.com"
+      ESS_REGION: "us-gov-east-1"
+      TF_VAR_deployment_template_id: "aws-general-purpose"
       TF_VAR_integration_server_docker_image: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips:git-${BUILDKITE_COMMIT:0:12}"
       TF_VAR_docker_images_name_suffix: "-fips"
     allow_dependency_failure: true
@@ -151,7 +143,7 @@ steps:
       image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:0.5"
       useCustomGlobalHooks: true
     plugins:
-      - *vault_ec_key_prod
+      - *vault_ec_key_staging_frh_gov
 
   - label: Aggregate test reports
     depends_on:


### PR DESCRIPTION
Reverts elastic/elastic-agent#10007

I was able to successfully create a `9.2.0-SNAPSHOT` deployment in the GovCloud Staging region so I'm putting up this PR to direct FIPS integration tests back to that environment.  Let's make sure it passes CI a few times (at least 3?) before we merge it.