### PR TITLE
Fix multiarch service image push from main to serverless

### DIFF
--- a/.buildkite/scripts/steps/ecp-internal-release.sh
+++ b/.buildkite/scripts/steps/ecp-internal-release.sh
@@ -69,7 +69,7 @@ docker manifest create "$PRIVATE_IMAGE" \
   "$PRIVATE_REPO@$ARM64_DIGEST"
 
 docker login --username "${DOCKER_USERNAME_SECRET}" --password "${DOCKER_PASSWORD_SECRET}" "${DOCKER_REGISTRY}"
-docker push $PRIVATE_IMAGE
+docker manifest push $PRIVATE_IMAGE
 
 # create a new manifest image referencing the source images
 #docker buildx imagetools create -t "$PRIVATE_IMAGE" \

--- a/.buildkite/scripts/steps/ecp-internal-release.sh
+++ b/.buildkite/scripts/steps/ecp-internal-release.sh
@@ -61,19 +61,22 @@ skopeo copy --all "docker-archive:./build/distributions/elastic-agent-service-$D
 
 # attempt to just install docker here
 apt-get update
-apt-get install docker.io
+apt-get install --no-install-recommends -y docker.io
 
 # Create a multi-arch manifest
 docker manifest create "$PRIVATE_IMAGE" \
   "$PRIVATE_REPO@$AMD64_DIGEST" \
   "$PRIVATE_REPO@$ARM64_DIGEST"
 
+docker login --username "${DOCKER_USERNAME_SECRET}" --password "${DOCKER_PASSWORD_SECRET}" "${DOCKER_REGISTRY}"
+docker push $PRIVATE_IMAGE
+
 # create a new manifest image referencing the source images
 #docker buildx imagetools create -t "$PRIVATE_IMAGE" \
 #  "$PRIVATE_REPO@$AMD64_DIGEST" \
 #  "$PRIVATE_REPO@$ARM64_DIGEST"
 
-skopeo copy --all "docker-daemon:$PRIVATE_IMAGE" "docker://$PRIVATE_IMAGE"
+#skopeo copy --all "docker-daemon:$PRIVATE_IMAGE" "docker://$PRIVATE_IMAGE"
 
 annotate "* Image: $PRIVATE_IMAGE"
 annotate "* Short commit: $VERSION"

--- a/.buildkite/scripts/steps/ecp-internal-release.sh
+++ b/.buildkite/scripts/steps/ecp-internal-release.sh
@@ -59,10 +59,20 @@ ARM64_DIGEST=$(skopeo inspect --format "{{.Digest}}" "docker-archive:./build/dis
 skopeo copy --all "docker-archive:./build/distributions/elastic-agent-service-$DOCKER_TAG-$BUILD_VERSION-linux-amd64.docker.tar.gz" "docker://$PRIVATE_REPO@$AMD64_DIGEST"
 skopeo copy --all "docker-archive:./build/distributions/elastic-agent-service-$DOCKER_TAG-$BUILD_VERSION-linux-arm64.docker.tar.gz" "docker://$PRIVATE_REPO@$ARM64_DIGEST"
 
-# create a new manifest image referencing the source images
-docker buildx imagetools create -t "$PRIVATE_IMAGE" \
+# attempt to just install docker here
+apt-get update
+apt-get install docker.io
+
+# Create a multi-arch manifest
+docker manifest create "$PRIVATE_IMAGE" \
   "$PRIVATE_REPO@$AMD64_DIGEST" \
   "$PRIVATE_REPO@$ARM64_DIGEST"
+
+# create a new manifest image referencing the source images
+#docker buildx imagetools create -t "$PRIVATE_IMAGE" \
+#  "$PRIVATE_REPO@$AMD64_DIGEST" \
+#  "$PRIVATE_REPO@$ARM64_DIGEST"
+
 skopeo copy --all "docker-daemon:$PRIVATE_IMAGE" "docker://$PRIVATE_IMAGE"
 
 annotate "* Image: $PRIVATE_IMAGE"

--- a/.buildkite/scripts/steps/ecp-internal-release.sh
+++ b/.buildkite/scripts/steps/ecp-internal-release.sh
@@ -51,9 +51,19 @@ skopeo login --username "${DOCKER_USERNAME_SECRET}" --password "${DOCKER_PASSWOR
 buildkite-agent artifact download "build/distributions/**" . --step "packaging-service-container-amd64"
 buildkite-agent artifact download "build/distributions/**" . --step "packaging-service-container-arm64"
 
-# copy the images into the private image location
-skopeo copy --all "docker-archive:./build/distributions/elastic-agent-service-$DOCKER_TAG-$BUILD_VERSION-linux-amd64.docker.tar.gz" "docker://$PRIVATE_IMAGE"
-skopeo copy --all "docker-archive:./build/distributions/elastic-agent-service-$DOCKER_TAG-$BUILD_VERSION-linux-arm64.docker.tar.gz" "docker://$PRIVATE_IMAGE"
+# get the digest information so the manifest reference the images
+AMD64_DIGEST=$(skopeo inspect --format "{{.Digest}}" "docker-archive:./build/distributions/elastic-agent-service-$DOCKER_TAG-$BUILD_VERSION-linux-amd64.docker.tar.gz")
+ARM64_DIGEST=$(skopeo inspect --format "{{.Digest}}" "docker-archive:./build/distributions/elastic-agent-service-$DOCKER_TAG-$BUILD_VERSION-linux-arm64.docker.tar.gz")
+
+# copy the images into the private image location with digest (not tag)
+skopeo copy --all "docker-archive:./build/distributions/elastic-agent-service-$DOCKER_TAG-$BUILD_VERSION-linux-amd64.docker.tar.gz" "docker://$PRIVATE_REPO@$AMD64_DIGEST"
+skopeo copy --all "docker-archive:./build/distributions/elastic-agent-service-$DOCKER_TAG-$BUILD_VERSION-linux-arm64.docker.tar.gz" "docker://$PRIVATE_REPO@$ARM64_DIGEST"
+
+# create a new manifest image referencing the source images
+docker buildx imagetools create -t "$PRIVATE_IMAGE" \
+  "$PRIVATE_REPO@$AMD64_DIGEST" \
+  "$PRIVATE_REPO@$ARM64_DIGEST"
+skopeo copy --all "docker-daemon:$PRIVATE_IMAGE" "docker://$PRIVATE_IMAGE"
 
 annotate "* Image: $PRIVATE_IMAGE"
 annotate "* Short commit: $VERSION"

--- a/.buildkite/scripts/steps/ecp-internal-release.sh
+++ b/.buildkite/scripts/steps/ecp-internal-release.sh
@@ -109,7 +109,7 @@ echo "Using manifest spec:"
 cat manifest-spec.yaml
 
 # Create and push the multi-arch manifest
-$MANIFEST_TOOL_CMD push from-spec manifest-spec.yaml
+$MANIFEST_TOOL_CMD --username ${DOCKER_USERNAME_SECRET} --password ${DOCKER_PASSWORD_SECRET} push from-spec manifest-spec.yaml
 
 annotate "* Image: $PRIVATE_IMAGE"
 annotate "* Short commit: $VERSION"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes the building and publishing of the service container to serverless from main.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without this change the image is only arm64 and not amd64.
