### PR TITLE
[AutoOps] Configure OTel Exporter to Send Maximum-sized Batches

### DIFF
--- a/internal/pkg/otel/samples/darwin/autoops_es.yml
+++ b/internal/pkg/otel/samples/darwin/autoops_es.yml
@@ -36,6 +36,11 @@ exporters:
     headers:
       Authorization: "AutoOpsToken ${env:AUTOOPS_TOKEN}"
     endpoint: ${env:AUTOOPS_OTEL_URL}
+    sending_queue:
+      batch:
+        max_size: 4194304 # 4 MiB
+        sizer: bytes
+      enabled: true
 
 service:
   pipelines:

--- a/internal/pkg/otel/samples/linux/autoops_es.yml
+++ b/internal/pkg/otel/samples/linux/autoops_es.yml
@@ -36,6 +36,11 @@ exporters:
     headers:
       Authorization: "AutoOpsToken ${env:AUTOOPS_TOKEN}"
     endpoint: ${env:AUTOOPS_OTEL_URL}
+    sending_queue:
+      batch:
+        max_size: 4194304 # 4 MiB
+        sizer: bytes
+      enabled: true
 
 service:
   pipelines:

--- a/internal/pkg/otel/samples/windows/autoops_es.yml
+++ b/internal/pkg/otel/samples/windows/autoops_es.yml
@@ -36,6 +36,11 @@ exporters:
     headers:
       Authorization: "AutoOpsToken ${env:AUTOOPS_TOKEN}"
     endpoint: ${env:AUTOOPS_OTEL_URL}
+    sending_queue:
+      batch:
+        max_size: 4194304 # 4 MiB
+        sizer: bytes
+      enabled: true
 
 service:
   pipelines:


### PR DESCRIPTION
This configures the standard `sending_queue` to batch-process and limit the maximum size of payloads being sent over the wire to avoid proxy and other rejections.

Note: `max_size` is uncompressed bytes and `enabled` defaults to `true`, but it's unused if no settings are set. I want to ensure a future release doesn't flip the default to `false`.

## What does this PR do?

It limits the size of requests being sent over the wire to a more reasonable size.

## Why is it important?

Sending large payloads can trigger security issues as well as rejections at many levels.
