### PR TITLE
Comment out check for ms_tls13kdf tag for FIPS-capable binaries

### DIFF
--- a/dev-tools/packaging/testing/package_test.go
+++ b/dev-tools/packaging/testing/package_test.go
@@ -844,7 +844,13 @@ func checkFIPS(t *testing.T, agentPackageRootDir string) {
 				case "-tags":
 					foundTags = true
 					require.Contains(t, setting.Value, "requirefips")
-					require.Contains(t, setting.Value, "ms_tls13kdf")
+					// the check on ms_tls13kdf is no longer needed for go >= 1.25
+					// It should probably be conditioned to the output of `go version <binary>`
+					// for example:
+					// go version elastic-agent-9.2.0-SNAPSHOT-linux-x86_64/data/elastic-agent-7b3817/components/apm-server
+					// elastic-agent-9.2.0-SNAPSHOT-linux-x86_64/data/elastic-agent-7b3817/components/apm-server: go1.25.1
+					//
+					// require.Contains(t, setting.Value, "ms_tls13kdf")
 					continue
 				case "GOEXPERIMENT":
 					foundExperiment = true


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
Removes a check for tag `ms_tls13kdf` for binaries included in FIPS capable packages. This tag is no longer used for binaries built with Go >= 1.25

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
This allows unblocking the unified release, should a more precise check be needed, it can be introduced in a follow-up PR

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
