### PR TITLE
feat: make EDOT subprocess the default execution mode

### DIFF
--- a/internal/pkg/otel/config/config.go
+++ b/internal/pkg/otel/config/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/otel/manager"
 )
 
-const defaultExecMode = manager.EmbeddedExecutionMode
+const defaultExecMode = manager.SubprocessExecutionMode
 
 type execModeConfig struct {
 	Agent struct {

--- a/internal/pkg/otel/manager/manager_test.go
+++ b/internal/pkg/otel/manager/manager_test.go
@@ -746,41 +746,74 @@ func TestOTelManager_Run(t *testing.T) {
 }
 
 func TestOTelManager_Logging(t *testing.T) {
+	wd, erWd := os.Getwd()
+	require.NoError(t, erWd, "cannot get working directory")
+
+	testBinary := filepath.Join(wd, "testing", "testing")
+	require.FileExists(t, testBinary, "testing binary not found")
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	const waitTimeForStop = 30 * time.Second
 
 	base, obs := loggertest.New("otel")
 	l, _ := loggertest.New("otel-manager")
-	m, err := NewOTelManager(l, logp.DebugLevel, base, EmbeddedExecutionMode, nil, nil, waitTimeForStop)
-	require.NoError(t, err, "could not create otel manager")
 
-	go func() {
-		err := m.Run(ctx)
-		assert.ErrorIs(t, err, context.Canceled, "otel manager should be cancelled")
-	}()
+	for _, tc := range []struct {
+		name       string
+		execModeFn func(collectorRunErr chan error) (collectorExecution, error)
+	}{
+		{
+			name: "in-process execution",
+			execModeFn: func(collectorRunErr chan error) (collectorExecution, error) {
+				return newExecutionEmbedded(), nil
+			},
+		},
+		{
+			name: "subprocess execution",
+			execModeFn: func(collectorRunErr chan error) (collectorExecution, error) {
+				return newSubprocessExecution(logp.DebugLevel, testBinary)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// the execution mode passed here is overridden below so it is irrelevant
+			m, err := NewOTelManager(l, logp.DebugLevel, base, EmbeddedExecutionMode, nil, nil, waitTimeForStop)
+			require.NoError(t, err, "could not create otel manager")
 
-	// watch is synchronous, so we need to read from it to avoid blocking the manager
-	go func() {
-		for {
-			select {
-			case <-m.WatchCollector():
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
+			executionMode, err := tc.execModeFn(m.collectorRunErr)
+			require.NoError(t, err, "failed to create execution mode")
+			testExecutionMode := &testExecution{exec: executionMode}
+			m.execution = testExecutionMode
 
-	cfg := confmap.NewFromStringMap(testConfig)
-	m.Update(cfg, nil)
+			go func() {
+				err := m.Run(ctx)
+				assert.ErrorIs(t, err, context.Canceled, "otel manager should be cancelled")
+			}()
 
-	// the collector should log to the base logger
-	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		logs := obs.All()
-		require.NotEmpty(collect, logs, "Logs should not be empty")
-		firstMessage := logs[0].Message
-		assert.Equal(collect, "Internal metrics telemetry disabled", firstMessage)
-	}, time.Second*10, time.Second)
+			// watch is synchronous, so we need to read from it to avoid blocking the manager
+			go func() {
+				for {
+					select {
+					case <-m.WatchCollector():
+					case <-ctx.Done():
+						return
+					}
+				}
+			}()
+
+			cfg := confmap.NewFromStringMap(testConfig)
+			m.Update(cfg, nil)
+
+			// the collector should log to the base logger
+			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+				logs := obs.All()
+				require.NotEmpty(collect, logs, "Logs should not be empty")
+				firstMessage := logs[0].Message
+				assert.Equal(collect, "Internal metrics telemetry disabled", firstMessage)
+			}, time.Second*10, time.Second)
+		})
+	}
 }
 
 // statusToYaml converts the status.AggregateStatus to a YAML string representation.

--- a/testing/integration/ess/metrics_monitoring_test.go
+++ b/testing/integration/ess/metrics_monitoring_test.go
@@ -7,9 +7,12 @@
 package ess
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httputil"
 	"testing"
 	"time"
 
@@ -19,6 +22,7 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/kibana"
 	"github.com/elastic/elastic-agent-libs/testing/estools"
+	otelMonitoring "github.com/elastic/elastic-agent/internal/pkg/otel/monitoring"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
@@ -29,8 +33,9 @@ type MetricsRunner struct {
 	suite.Suite
 	info         *define.Info
 	agentFixture *atesting.Fixture
-
-	ESHost string
+	policyID     string
+	policyName   string
+	ESHost       string
 }
 
 func TestMetricsMonitoringCorrectBinaries(t *testing.T) {
@@ -76,10 +81,54 @@ func (runner *MetricsRunner) SetupSuite() {
 	policyResp, _, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
 
+	runner.policyName = policyResp.Name
+	runner.policyID = policyResp.ID
+
 	_, err = tools.InstallPackageFromDefaultFile(ctx, runner.info.KibanaClient, "system",
 		integration.PreinstalledPackages["system"], "testdata/system_integration_setup.json", uuid.Must(uuid.NewV4()).String(), policyResp.ID)
 	require.NoError(runner.T(), err)
 
+}
+
+func (runner *MetricsRunner) addMonitoringToOtelRuntimeOverwrite() {
+	addMonitoringOverwriteBody := fmt.Sprintf(`
+{
+  "name": "%s",
+  "namespace": "default",
+  "overrides": {
+    "agent": {
+      "monitoring": {
+        "_runtime_experimental": "otel"
+      }
+    }
+  }
+}
+`, runner.policyName)
+	resp, err := runner.info.KibanaClient.Send(
+		http.MethodPut,
+		fmt.Sprintf("/api/fleet/agent_policies/%s", runner.policyID),
+		nil,
+		nil,
+		bytes.NewBufferString(addMonitoringOverwriteBody),
+	)
+	if err != nil {
+		runner.T().Fatalf("could not execute request to Kibana/Fleet: %s", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		// On error dump the whole request response so we can easily spot
+		// what went wrong.
+		runner.T().Errorf("received a non 200-OK when adding overwrite to policy. "+
+			"Status code: %d", resp.StatusCode)
+		respDump, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			runner.T().Fatalf("could not dump error response from Kibana: %s", err)
+		}
+		// Make debugging as easy as possible
+		runner.T().Log("================================================================================")
+		runner.T().Log("Kibana error response:")
+		runner.T().Log(string(respDump))
+		runner.T().FailNow()
+	}
 }
 
 func (runner *MetricsRunner) TestBeatsMetrics() {
@@ -133,6 +182,30 @@ func (runner *MetricsRunner) TestBeatsMetrics() {
 			if res.Hits.Total.Value < 1 {
 				return false
 			}
+		}
+		return true
+	}, time.Minute*10, time.Second*10, "could not fetch metrics for all known components in default install: %v", componentIds)
+
+	// Add a policy overwrite to change the agent monitoring to use Otel runtime
+	runner.addMonitoringToOtelRuntimeOverwrite()
+
+	// since the default execution mode of Otel runtime is sub-process we should see resource
+	// metrics for elastic-agent/collector component.
+	edotCollectorComponentID := otelMonitoring.EDOTComponentID
+	query = genESQuery(agentStatus.Info.ID,
+		[][]string{
+			{"match", "component.id", edotCollectorComponentID},
+			{"exists", "field", "system.process.cpu.total.value"},
+			{"exists", "field", "system.process.memory.size"},
+		})
+
+	require.Eventually(t, func() bool {
+		now = time.Now()
+		res, err := estools.PerformQueryForRawQuery(ctx, query, "metrics-elastic_agent*", runner.info.ESClient)
+		require.NoError(t, err)
+		t.Logf("Fetched metrics for %s, got %d hits", edotCollectorComponentID, res.Hits.Total.Value)
+		if res.Hits.Total.Value < 1 {
+			return false
 		}
 		return true
 	}, time.Minute*10, time.Second*10, "could not fetch metrics for all known components in default install: %v", componentIds)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR makes the **EDOT collector subprocess execution mode the default** and extends our integration test coverage to ensure its resource metrics are visible under Fleet-managed setups.  

Key changes:
- **Default execution mode:** Switches the OTel collector from in-process (`EmbeddedExecutionMode`) to subprocess (`SubprocessExecutionMode`), insulating the Elastic Agent control plane from collector panics, segmentation faults, or memory leaks.
- **Enhanced integration test:** Extends `TestMetricsMonitoringCorrectBinaries/TestBeatsMetrics` in `testing/integration/ess/metrics_monitoring_test.go` to:
  - Programmatically add an `_runtime_experimental: otel` agent monitoring policy overwrite.
  - Query Elasticsearch for `elastic-agent/collector` resource metrics (`system.process.cpu.total.value`, `system.process.memory.size`) to confirm that the subprocess is running and reporting telemetry.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Running the collector as a subprocess improves **resilience** by preventing collector failures from taking down the entire Elastic Agent. This aligns with the design goal of **control plane/data plane separation**.

The updated integration test provides an end-to-end verification that resource metrics for the EDOT subprocess are ingested into `metrics-elastic_agent*`, ensuring observability does not regress when subprocess mode becomes the default.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

With this change, a **new subprocess will now appear** alongside the `elastic-agent` process.  
This subprocess is responsible for running the EDOT collector and will have its own resource metrics (CPU, memory) visible in the **existing Elastic Agent dashboards** under the `elastic-agent/collector` component.  

No user action is required: the new process and its metrics integrate seamlessly with current Fleet monitoring.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Build Elastic Agent from this branch.
2. Enable the otel runtime for monitoring (or any other input you prefer) in your `elastic-agent.yml`:
   ```yaml
   agent:
     monitoring:
       otel:
         _runtime_experimental: otel
   ```
3. Install elastic-agent.
4. Verify in Kibana’s Agent Metrics dashboard that a separate metrics stream for `elastic-agent/collector` appears. PS: you might have to install the elastic-agent integration if it's not already installed

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
N/A
