### PR TITLE
Rewrite the beats receiver log test using common tooling

### DIFF
--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -722,13 +722,13 @@ agent.monitoring.enabled: false
 	require.NoError(t,
 		template.Must(template.New("config").Parse(configTemplate)).Execute(&configBuffer,
 			configOptions{
-				RuntimeExperimental: component.ProcessRuntimeManager.String(),
+				RuntimeExperimental: string(component.ProcessRuntimeManager),
 			}))
 	processConfig := configBuffer.Bytes()
 	require.NoError(t,
 		template.Must(template.New("config").Parse(configTemplate)).Execute(&configBuffer,
 			configOptions{
-				RuntimeExperimental: component.OtelRuntimeManager.String(),
+				RuntimeExperimental: string(component.OtelRuntimeManager),
 			}))
 	receiverConfig := configBuffer.Bytes()
 	// this is the context for the whole test, with a global timeout defined


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Re-enables the integration test for comparing logs between beats processes and beats receivers and rewrites it to use normal integration test tooling, making it simpler and more observable:

- Instead of uninstalling and reinstalling agent with new configuration, we install it once and just let it reload the configuration, verifying that this happened via status.
- Use the normal install process and let agent run as a service instead of running it manually.
- Fetches the logs by running `elastic-agent logs` instead of capturing agent output directly.
- Relax the status check to only verify what we care about. This test sets an ES host that doesn't exist, so the status will eventually be degraded, but the test doesn't really care about this.

## Why is it important?

This test should be enabled and reliable.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] I have added an integration test or an E2E test

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/9890

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
