### PR TITLE
Improve Integration test documentation

### DIFF
--- a/testing/integration/k8s/kubernetes_agent_standalone_test.go
+++ b/testing/integration/k8s/kubernetes_agent_standalone_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/elastic-agent-libs/kibana"
 
@@ -1047,33 +1046,8 @@ func k8sStepDeployKustomize(containerName string, overrides k8sKustomizeOverride
 			}
 		})
 
-		defer func() {
-			if t.Failed() {
-				dumpK8sObjectsToTempDir(t, objects)
-			}
-		}()
-
 		err = k8sCreateObjects(ctx, kCtx.client, k8sCreateOpts{wait: true, namespace: namespace}, objects...)
 		require.NoError(t, err, "failed to create objects")
-	}
-}
-
-func dumpK8sObjectsToTempDir(t *testing.T, objects []k8s.Object) {
-	f, err := os.CreateTemp("", t.Name()+"-*")
-	if err != nil {
-		t.Logf("cannot create temp dir to dump K8s manifest: %s", err)
-	}
-
-	defer f.Close()
-	defer t.Logf("K8s manifest saved to: ", f.Name())
-
-	for _, obj := range objects {
-		yamlData, err := yaml.Marshal(obj)
-		if err != nil {
-			fmt.Printf("Error marshaling object to YAML: %v\n", err)
-			continue
-		}
-		fmt.Fprintf(f, "---\n%s\n", string(yamlData))
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

It improves the integration tests framework docs

## Why is it important?

See above

## Checklist

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

~~## Disruptive User Impact~~
~~## How to test this PR locally~~
~~## Related issues~~

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
