### PR TITLE
Update run command to have a critical section to ensure errors are always logged

### DIFF
--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"context"
+	goerrors "errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -88,7 +89,6 @@ func newRunCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
 			testingMode, _ := cmd.Flags().GetBool("testing-mode")
 			if err := run(nil, testingMode, fleetInitTimeout); err != nil && !errors.Is(err, context.Canceled) {
 				fmt.Fprintf(streams.Err, "Error: %v\n%s\n", err, troubleshootMessage())
-				logExternal(fmt.Sprintf("%s run failed: %s", paths.BinaryName, err))
 				return err
 			}
 			return nil
@@ -141,56 +141,81 @@ func run(override application.CfgOverrider, testingMode bool, fleetInitTimeout t
 	defer cancel()
 	go service.ProcessWindowsControlEvents(stopBeat)
 
-	upgradeDetailsFromMarker, err := handleUpgrade()
-	if err != nil {
-		return fmt.Errorf("error checking for and handling upgrade: %w", err)
-	}
-
-	locker := filelock.NewAppLocker(paths.Data(), paths.AgentLockFileName)
-	if err := locker.TryLock(); err != nil {
-		return err
-	}
-	defer func() {
-		_ = locker.Unlock()
-	}()
-
-	return runElasticAgent(ctx, cancel, override, stop, testingMode, fleetInitTimeout, upgradeDetailsFromMarker, modifiers...)
+	return runElasticAgentCritical(ctx, cancel, override, stop, testingMode, fleetInitTimeout, modifiers...)
 }
 
 func logReturn(l *logger.Logger, err error) error {
 	if err != nil && !errors.Is(err, context.Canceled) {
 		l.Errorf("%s", err)
+		logExternal(fmt.Sprintf("%s run failed: %s", paths.BinaryName, err))
 	}
 	return err
 }
 
-func runElasticAgent(
+// runElasticAgentCritical provides a critical path to running runElasticAgent, it exhausts all efforts to log any
+// errors to ensure that any issues are captured in the logs.
+func runElasticAgentCritical(
 	ctx context.Context,
 	cancel context.CancelFunc,
 	override application.CfgOverrider,
 	stop chan bool,
 	testingMode bool,
 	fleetInitTimeout time.Duration,
-	upgradeDetailsFromMarker *details.Details,
 	modifiers ...component.PlatformModifier,
 ) error {
-	err := coordinator.RestoreConfig()
+	var errs []error
+
+	// early handleUpgrade, but don't error yet
+	upgradeDetailsFromMarker, err := handleUpgrade()
 	if err != nil {
-		return err
+		errs = append(errs, err)
 	}
 
+	// single run, but don't error yet
+	locker := filelock.NewAppLocker(paths.Data(), paths.AgentLockFileName)
+	lockErr := locker.TryLock()
+	if lockErr != nil {
+		errs = append(errs, lockErr)
+	}
+	defer func() {
+		_ = locker.Unlock()
+	}()
+
+	// try restore (if app locker didn't fail), but don't error yet
+	if lockErr == nil {
+		err = coordinator.RestoreConfig()
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// try load config, but don't error yet
 	cfg, err := loadConfig(ctx, override)
 	if err != nil {
-		return err
+		// failed to load configuration, just load the default to create the logger
+		cfg = configuration.DefaultConfiguration()
 	}
 
-	logLvl := logger.DefaultLogLevel
-	if cfg.Settings.LoggingConfig != nil {
-		logLvl = cfg.Settings.LoggingConfig.Level
-	}
 	baseLogger, err := logger.NewFromConfig("", cfg.Settings.LoggingConfig, cfg.Settings.EventLoggingConfig, true)
 	if err != nil {
-		return err
+		errs = append(errs, err)
+
+		// failed to create the baseLogger, this comes from the configuration being possibly invalid
+		// switch to a default config and try again
+		cfg = configuration.DefaultConfiguration()
+		baseLogger, err = logger.NewFromConfig("", cfg.Settings.LoggingConfig, cfg.Settings.EventLoggingConfig, true)
+		if err != nil {
+			errs = append(errs, err)
+
+			// this really should not happen, but this whole critical function is very defensive
+			baseLogger, err = logger.New("", true)
+			if err != nil {
+				errs = append(errs, err)
+
+				// again? no way, but you never know
+				baseLogger = logger.NewWithoutConfig("")
+			}
+		}
 	}
 
 	// Make sure to flush any buffered logs before we're done.
@@ -200,10 +225,42 @@ func runElasticAgent(
 		"source": agentName,
 	})
 
+	// at this point the logger is working, so any errors that we hit can now be logged and returned
+	if len(errs) > 0 {
+		return logReturn(l, goerrors.Join(errs...))
+	}
+
+	// actually run the agent now
+	err = runElasticAgent(ctx, cancel, baseLogger, l, cfg, override, stop, testingMode, fleetInitTimeout, upgradeDetailsFromMarker, modifiers...)
+	if err != nil {
+		return logReturn(l, err)
+	}
+	return nil
+}
+
+// runElasticAgent runs the actual Elastic Agent.
+func runElasticAgent(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	baseLogger *logger.Logger,
+	l *logger.Logger,
+	cfg *configuration.Configuration,
+	override application.CfgOverrider,
+	stop chan bool,
+	testingMode bool,
+	fleetInitTimeout time.Duration,
+	upgradeDetailsFromMarker *details.Details,
+	modifiers ...component.PlatformModifier,
+) error {
+	logLvl := logger.DefaultLogLevel
+	if cfg.Settings.LoggingConfig != nil {
+		logLvl = cfg.Settings.LoggingConfig.Level
+	}
+
 	// try early to check if running as root
 	isRoot, err := utils.HasRoot()
 	if err != nil {
-		return logReturn(l, fmt.Errorf("failed to check for root/Administrator privileges: %w", err))
+		return fmt.Errorf("failed to check for root/Administrator privileges: %w", err)
 	}
 
 	l.Infow("Elastic Agent started",
@@ -213,7 +270,7 @@ func runElasticAgent(
 
 	cfg, err = tryDelayEnroll(ctx, l, cfg, override)
 	if err != nil {
-		return logReturn(l, errors.New(err, "failed to perform delayed enrollment"))
+		return errors.New(err, "failed to perform delayed enrollment")
 	}
 
 	// agent ID needs to stay empty in bootstrap mode
@@ -225,7 +282,7 @@ func runElasticAgent(
 	// that writes the agentID into fleet.enc (encrypted fleet.yml) before even loading the configuration.
 	err = secret.CreateAgentSecret(ctx, vault.WithUnprivileged(!isRoot))
 	if err != nil {
-		return logReturn(l, fmt.Errorf("failed to read/write secrets: %w", err))
+		return fmt.Errorf("failed to read/write secrets: %w", err)
 	}
 
 	// Migrate .yml files if the corresponding .enc does not exist
@@ -233,7 +290,7 @@ func runElasticAgent(
 	// the encrypted config does not exist but the unencrypted file does
 	err = migration.MigrateToEncryptedConfig(ctx, l, paths.AgentConfigYmlFile(), paths.AgentConfigFile())
 	if err != nil {
-		return logReturn(l, errors.New(err, "error migrating fleet config"))
+		return errors.New(err, "error migrating fleet config")
 	}
 
 	// the encrypted state does not exist but the unencrypted file does
@@ -241,15 +298,15 @@ func runElasticAgent(
 		paths.AgentStateStoreYmlFile(),
 		paths.AgentStateStoreFile())
 	if err != nil {
-		return logReturn(l, errors.New(err, "error migrating agent state"))
+		return errors.New(err, "error migrating agent state")
 	}
 
 	agentInfo, err := info.NewAgentInfoWithLog(ctx, defaultLogLevel(cfg, logLvl.String()), createAgentID)
 	if err != nil {
-		return logReturn(l, errors.New(err,
+		return errors.New(err,
 			"could not load agent info",
 			errors.TypeFilesystem,
-			errors.M(errors.MetaKeyPath, paths.AgentConfigFile())))
+			errors.M(errors.MetaKeyPath, paths.AgentConfigFile()))
 	}
 
 	// Ensure that the log level now matches what is configured in the agentInfo.
@@ -275,14 +332,14 @@ func runElasticAgent(
 
 	execPath, err := reexecPath()
 	if err != nil {
-		return logReturn(l, fmt.Errorf("failed to get reexec path: %w", err))
+		return fmt.Errorf("failed to get reexec path: %w", err)
 	}
 	rexLogger := l.Named("reexec")
 	rex := reexec.NewManager(rexLogger, execPath)
 
 	tracer, err := initTracer(agentName, release.Version(), cfg.Settings.MonitoringConfig)
 	if err != nil {
-		return logReturn(l, fmt.Errorf("could not initiate APM tracer: %w", err))
+		return fmt.Errorf("could not initiate APM tracer: %w", err)
 	}
 	if tracer != nil {
 		l.Info("APM instrumentation enabled")
@@ -298,12 +355,12 @@ func runElasticAgent(
 	coord, configMgr, _, err := application.New(ctx, l, baseLogger, logLvl, agentInfo, rex, tracer, testingMode,
 		fleetInitTimeout, isBootstrap, override, upgradeDetailsFromMarker, modifiers...)
 	if err != nil {
-		return logReturn(l, err)
+		return err
 	}
 
 	monitoringServer, err := setupMetrics(l, cfg.Settings.DownloadConfig.OS(), cfg.Settings.MonitoringConfig, tracer, coord)
 	if err != nil {
-		return logReturn(l, err)
+		return err
 	}
 	coord.RegisterMonitoringServer(monitoringServer)
 	defer func() {
@@ -327,7 +384,7 @@ func runElasticAgent(
 
 	// start the control listener
 	if err := control.Start(); err != nil {
-		return logReturn(l, err)
+		return err
 	}
 	defer control.Stop()
 
@@ -410,7 +467,7 @@ LOOP:
 	if isRex {
 		rex.ShutdownComplete()
 	}
-	return logReturn(l, err)
+	return err
 }
 
 func loadConfig(ctx context.Context, override application.CfgOverrider) (*configuration.Configuration, error) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Updates the `run` subcommand to always log any errors to the logger.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

There where still some cases where the Elastic Agent can fail to run but the reason is not written to the log.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test`~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #9099
