### PR TITLE
Conditionally check for `ms_tls13kdf` build tag

### DIFF
--- a/dev-tools/packaging/testing/package_test.go
+++ b/dev-tools/packaging/testing/package_test.go
@@ -844,13 +844,12 @@ func checkFIPS(t *testing.T, agentPackageRootDir string) {
 				case "-tags":
 					foundTags = true
 					require.Contains(t, setting.Value, "requirefips")
-					// the check on ms_tls13kdf is no longer needed for go >= 1.25
-					// It should probably be conditioned to the output of `go version <binary>`
-					// for example:
-					// go version elastic-agent-9.2.0-SNAPSHOT-linux-x86_64/data/elastic-agent-7b3817/components/apm-server
-					// elastic-agent-9.2.0-SNAPSHOT-linux-x86_64/data/elastic-agent-7b3817/components/apm-server: go1.25.1
-					//
-					// require.Contains(t, setting.Value, "ms_tls13kdf")
+
+					// Check if the ms_tls13kdf build tag is set only if the binary was built
+					// with go1.24.x (see https://github.com/microsoft/go/pull/1662).
+					if strings.HasPrefix(info.GoVersion, "go1.24") {
+						require.Contains(t, setting.Value, "ms_tls13kdf")
+					}
 					continue
 				case "GOEXPERIMENT":
 					foundExperiment = true


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR restores the check for the `ms_tls13kdf` Go build tag on the packaged FIPS-capable `elastic-agent` binary and component binaries.  However, it only checks for this build tag if the binary was built with Go 1.24.x, which is where this tag was supported and required to ensure FIPS compliance.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To ensure FIPS compliance of binaries built with Go 1.24.x.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None; this is a change to a Go test that gets executed when Elastic Agent is packaged.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Create a FIPS-capable Elastic Agent package.  Make sure a Go version other than 1.24.x is being used.

```
cat .go-version
FIPS=true SNAPSHOT=true EXTERNAL=true PLATFORMS="linux/arm64" PACKAGES="tar.gz" mage -v package
```

Make sure the package builds without any errors.
