### PR TITLE
Original ID is used when replace token provided

### DIFF
--- a/internal/pkg/agent/application/enroll/options.go
+++ b/internal/pkg/agent/application/enroll/options.go
@@ -139,18 +139,17 @@ func MergeOptionsWithMigrateAction(action *fleetapi.ActionMigrate, options Enrol
 		return EnrollOptions{}, fmt.Errorf("failed to decode enroll options: %w", err)
 	}
 
-	if len(options.ReplaceToken) == 0 {
-		// do not preserve ID by default
-		delete(configMap, "id")
-		options.ID = ""
-	}
-
 	// overwriting what's needed
 	if len(action.Data.Settings) > 0 {
 		if err := json.Unmarshal(action.Data.Settings, &configMap); err != nil {
 			return EnrollOptions{}, fmt.Errorf("failed to decode migrate setting: %w", err)
 		}
+	}
 
+	if _, ok := configMap["replace_token"]; !ok {
+		// do not preserve ID by default
+		delete(configMap, "id")
+		options.ID = ""
 	}
 
 	cmBytes, err := json.Marshal(configMap)

--- a/internal/pkg/agent/application/enroll/options_test.go
+++ b/internal/pkg/agent/application/enroll/options_test.go
@@ -347,6 +347,28 @@ func TestMergeOptionsWithMigrateAction(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"original id is used when replace token provided",
+			&fleetapi.ActionMigrate{
+				Data: fleetapi.ActionMigrateData{
+					EnrollmentToken: "token",
+					TargetURI:       "uri",
+					Settings:        json.RawMessage(`{"insecure": true, "replace_token": "replace-token", "tags":["a","b"]}`),
+				},
+			},
+			EnrollOptions{
+				ID: "test-id",
+			},
+			EnrollOptions{
+				EnrollAPIKey: "token",
+				ID:           "test-id",
+				Insecure:     true,
+				ReplaceToken: "replace-token",
+				Tags:         []string{"a", "b"},
+				URL:          "uri",
+			},
+			false,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Original implementation was looking at a wrong field.
added test to cover this case