### PR TITLE
Deduplicate extensions when generating otel config

### DIFF
--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -509,11 +509,11 @@ func TestGetOtelConfig(t *testing.T) {
 					"filebeatreceiver/_agent-component/filestream-default": expectedFilestreamConfig("filestream-default"),
 				},
 				"service": map[string]any{
-					"extensions": []interface{}{"beatsauth/_agent-component/default"},
+					"extensions": []any{"beatsauth/_agent-component/default"},
 					"pipelines": map[string]any{
 						"logs/_agent-component/filestream-default": map[string][]string{
-							"exporters": []string{"elasticsearch/_agent-component/default"},
-							"receivers": []string{"filebeatreceiver/_agent-component/filestream-default"},
+							"exporters": {"elasticsearch/_agent-component/default"},
+							"receivers": {"filebeatreceiver/_agent-component/filestream-default"},
 						},
 					},
 				},
@@ -589,15 +589,97 @@ func TestGetOtelConfig(t *testing.T) {
 					"filebeatreceiver/_agent-component/filestream-secondaryOutput": expectedFilestreamConfig("filestream-secondaryOutput"),
 				},
 				"service": map[string]any{
-					"extensions": []interface{}{"beatsauth/_agent-component/primaryOutput", "beatsauth/_agent-component/secondaryOutput"},
+					"extensions": []any{"beatsauth/_agent-component/primaryOutput", "beatsauth/_agent-component/secondaryOutput"},
 					"pipelines": map[string]any{
 						"logs/_agent-component/filestream-primaryOutput": map[string][]string{
-							"exporters": []string{"elasticsearch/_agent-component/primaryOutput"},
-							"receivers": []string{"filebeatreceiver/_agent-component/filestream-primaryOutput"},
+							"exporters": {"elasticsearch/_agent-component/primaryOutput"},
+							"receivers": {"filebeatreceiver/_agent-component/filestream-primaryOutput"},
 						},
 						"logs/_agent-component/filestream-secondaryOutput": map[string][]string{
-							"exporters": []string{"elasticsearch/_agent-component/secondaryOutput"},
-							"receivers": []string{"filebeatreceiver/_agent-component/filestream-secondaryOutput"},
+							"exporters": {"elasticsearch/_agent-component/secondaryOutput"},
+							"receivers": {"filebeatreceiver/_agent-component/filestream-secondaryOutput"},
+						},
+					},
+				},
+			}),
+		},
+		{
+			name: "multiple filestream inputs and one output",
+			model: &component.Model{
+				Components: []component.Component{
+					{
+						ID:         "filestream1-default",
+						InputType:  "filestream",
+						OutputType: "elasticsearch",
+						InputSpec: &component.InputRuntimeSpec{
+							BinaryName: "agentbeat",
+							Spec: component.InputSpec{
+								Command: &component.CommandSpec{
+									Args: []string{"filebeat"},
+								},
+							},
+						},
+						Units: []component.Unit{
+							{
+								ID:     "filestream-unit",
+								Type:   client.UnitTypeInput,
+								Config: component.MustExpectedConfig(fileStreamConfig),
+							},
+							{
+								ID:     "filestream-default",
+								Type:   client.UnitTypeOutput,
+								Config: component.MustExpectedConfig(esOutputConfig()),
+							},
+						},
+					},
+					{
+						ID:         "filestream2-default",
+						InputType:  "filestream",
+						OutputType: "elasticsearch",
+						InputSpec: &component.InputRuntimeSpec{
+							BinaryName: "agentbeat",
+							Spec: component.InputSpec{
+								Command: &component.CommandSpec{
+									Args: []string{"filebeat"},
+								},
+							},
+						},
+						Units: []component.Unit{
+							{
+								ID:     "filestream-unit",
+								Type:   client.UnitTypeInput,
+								Config: component.MustExpectedConfig(fileStreamConfig),
+							},
+							{
+								ID:     "filestream-default",
+								Type:   client.UnitTypeOutput,
+								Config: component.MustExpectedConfig(esOutputConfig()),
+							},
+						},
+					},
+				},
+			},
+			expectedConfig: confmap.NewFromStringMap(map[string]any{
+				"exporters": map[string]any{
+					"elasticsearch/_agent-component/default": expectedESConfig("default"),
+				},
+				"extensions": map[string]any{
+					"beatsauth/_agent-component/default": expectedExtensionConfig(),
+				},
+				"receivers": map[string]any{
+					"filebeatreceiver/_agent-component/filestream1-default": expectedFilestreamConfig("filestream1-default"),
+					"filebeatreceiver/_agent-component/filestream2-default": expectedFilestreamConfig("filestream2-default"),
+				},
+				"service": map[string]any{
+					"extensions": []any{"beatsauth/_agent-component/default"},
+					"pipelines": map[string]any{
+						"logs/_agent-component/filestream1-default": map[string][]string{
+							"exporters": {"elasticsearch/_agent-component/default"},
+							"receivers": {"filebeatreceiver/_agent-component/filestream1-default"},
+						},
+						"logs/_agent-component/filestream2-default": map[string][]string{
+							"exporters": {"elasticsearch/_agent-component/default"},
+							"receivers": {"filebeatreceiver/_agent-component/filestream2-default"},
 						},
 					},
 				},
@@ -692,11 +774,11 @@ func TestGetOtelConfig(t *testing.T) {
 					},
 				},
 				"service": map[string]any{
-					"extensions": []interface{}{"beatsauth/_agent-component/default"},
+					"extensions": []any{"beatsauth/_agent-component/default"},
 					"pipelines": map[string]any{
 						"logs/_agent-component/beat-metrics-monitoring": map[string][]string{
-							"exporters": []string{"elasticsearch/_agent-component/default"},
-							"receivers": []string{"metricbeatreceiver/_agent-component/beat-metrics-monitoring"},
+							"exporters": {"elasticsearch/_agent-component/default"},
+							"receivers": {"metricbeatreceiver/_agent-component/beat-metrics-monitoring"},
 						},
 					},
 				},
@@ -802,11 +884,11 @@ func TestGetOtelConfig(t *testing.T) {
 					},
 				},
 				"service": map[string]any{
-					"extensions": []interface{}{"beatsauth/_agent-component/default"},
+					"extensions": []any{"beatsauth/_agent-component/default"},
 					"pipelines": map[string]any{
 						"logs/_agent-component/system-metrics": map[string][]string{
-							"exporters": []string{"elasticsearch/_agent-component/default"},
-							"receivers": []string{"metricbeatreceiver/_agent-component/system-metrics"},
+							"exporters": {"elasticsearch/_agent-component/default"},
+							"receivers": {"metricbeatreceiver/_agent-component/system-metrics"},
 						},
 					},
 				},


### PR DESCRIPTION
## What does this PR do?

Ensures the extension list in the otel config we generate for components always has only one instance of each extension. Currently, we get the same beatsauth extension multiple times, which only works due to a quirk of otel's config processing.

## Why is it important?

The config we currently generate for the otel collector is invalid, and is only accepted and works correctly due to implementation details.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/10154

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
