### PR TITLE
Add documentation for `filelogreceiver` component of the EDOT Collector

### DIFF
--- a/docs/reference/edot-collector/components/filelogreceiver.md
+++ b/docs/reference/edot-collector/components/filelogreceiver.md
@@ -3,7 +3,6 @@ title: File log receiver
 description: The File log receiver is an OpenTelemetry Collector component that ingests logs from files.
 products:
   - id: elastic-agent
-  - id: cloud
   - id: observability
   - id: edot-collector
 ---
@@ -17,7 +16,7 @@ The receiver supports multiline parsing, filtering, persistent tracking of file 
 
 ## Default usage in EDOT
 
-The `filelog` receiver is included by default in the EDOT Collector's Kubernetes Helm chart. It is preconfigured to collect logs from pod log files such as `/var/log/pods/*/*/*.log`, and uses the [`file_storage`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage) extension to track read positions and avoid duplicate ingestion after restarts.
+The `filelogreceiver` is included by default in the EDOT Collector's Kubernetes Helm chart. It is preconfigured to collect logs from pod log files such as `/var/log/pods/*/*/*.log`, and uses the [`file_storage`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage) extension to track read positions and avoid duplicate ingestion after restarts.
 
 To view or customize the default configuration, refer to:
 
@@ -27,7 +26,7 @@ To view or customize the default configuration, refer to:
 
 ## Example configuration
 
-This example shows how to ingest Kubernetes container logs with routing logic based on log format:
+The following example shows how to ingest Kubernetes container logs with routing logic based on log format:
 
 ```yaml
 receivers:
@@ -66,9 +65,9 @@ receivers:
 ```
 
 
-## **Key configuration options**
+## Key configuration options
 
-The following are some of the most commonly used settings when working with the `filelog` receiver. These options help control what files are read, how logs are parsed, and how file positions are tracked between restarts:
+The following are some of the most commonly used settings when working with the file log receiver. These options help control what files are read, how logs are parsed, and how file positions are tracked between restarts:
 
 | Option | Description |
 |---------|-------------|
@@ -80,7 +79,7 @@ The following are some of the most commonly used settings when working with the 
 | `max_log_size` | Maximum size of individual log entries (in bytes) |
 | `fingerprint_size`| Size (in bytes) used to identify and deduplicate files |
 
-For the full list of options, refer to the[ upstream `filelogreceiver` docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/filelogreceiver/README.md).
+For the full list of options, refer to the [upstream `filelogreceiver` documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/filelogreceiver/README.md).
 
 
 ## Best practices
@@ -97,7 +96,7 @@ These tips can help you get the most out of the file log receiver:
   Multiline log support is not enabled by default. To handle multi-line messages such as stack traces, define a `regex_parser`, `combine_logs`, or `multiline` operator in your Helm chart configuration.
 
 - **Route different log formats using conditional parsing**  
-  If your environment produces logs in multiple formats (e.g. containerd and CRI-O), use the `router` operator to apply appropriate parsers based on the log structure.
+  If your environment produces logs in multiple formats (for example containerd and CRI-O), use the `router` operator to apply appropriate parsers based on the log structure.
 
 - **Avoid using `start_at: beginning` without storage**  
   Using `start_at: beginning` without a storage extension will re-read all files from the start after each restart, which might lead to duplicate log entries.
@@ -105,19 +104,19 @@ These tips can help you get the most out of the file log receiver:
 
 ## Limitations
 
-Like any component, `filelogreceiver` has some trade-offs and behaviors to be aware of, especially in Kubernetes environments:
+Like any component, file log receiver has some trade-offs and behaviors to be aware of, especially in Kubernetes environments:
 
 * Persistent log tracking requires explicit `storage:` configuration and persistent volume support in Kubernetes.
 
-* Multiline logs are not parsed by default — you must customize the configuration to parse them.
+* Multiline logs are not parsed by default. You must customize the configuration to parse them.
 
 * Incorrect include/exclude globs can result in missing rotated logs or unintended ingestion.
 
-* High-volume directories may require tuning of `max_concurrent_files`.
+* High-volume directories might require tuning of `max_concurrent_files`.
 
 
 ## Resources
 
 * [Upstream component: filelogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/filelogreceiver/README.md)
-* [Configure logs collection in EDOT](opentelemetry://reference/edot-collector/config/configure-logs-collection.md)
+* [Configure logs collection in EDOT](../config/configure-logs-collection.md)
 * [Helm chart default values](https://github.com/elastic/elastic-agent/blob/v9.1.4/deploy/helm/edot-collector/kube-stack/values.yaml)

--- a/docs/reference/edot-collector/components/filelogreceiver.md
+++ b/docs/reference/edot-collector/components/filelogreceiver.md
@@ -1,0 +1,95 @@
+---
+title: File log receiver
+description: The File log receiver is an OpenTelemetry Collector component that ingests logs from files.
+products:
+  - id: elastic-agent
+  - id: cloud
+  - id: observability
+  - id: edot-collector
+---
+
+# File log receiver
+
+The File log receiver ingests logs from local files and forwards them for processing and exporting. It is a versatile and widely-used component for collecting logs in file-based formats, such as container logs, system logs, or custom application logs.
+
+The receiver supports multiline parsing, filtering, persistent tracking of file offsets, and routing based on file metadata or log content.
+
+
+## Example configuration
+
+This example shows how to ingest Kubernetes container logs with routing logic based on log format:
+
+```yaml
+receivers:
+  filelog:
+    include:
+      - /var/log/pods/*/*/*.log
+    exclude:
+      - /var/log/pods/*/*/*.gz
+    start_at: beginning
+    include_file_name: true
+    include_file_path: true
+    fingerprint_size: 100
+    max_log_size: 102_400
+    storage: file_storage
+    operators:
+      - type: router
+        routes:
+          - output: parser_containerd
+            expr: 'body matches "^\\d{4}-\\d{2}-\\d{2}T"'
+          - output: parser_crio
+            expr: 'body matches "^[A-Z][a-z]{2} [0-9]{1,2} "'
+
+      - id: parser_containerd
+        type: json_parser
+        timestamp:
+          parse_from: attributes.time
+          layout_type: gotime
+          layout: 2006-01-02T15:04:05.000000000Z07:00
+
+      - id: parser_crio
+        type: regex_parser
+        regex: '^(?P<time>[^ ]+ [^ ]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<body>.*)'
+        timestamp:
+          parse_from: attributes.time
+          layout: '%b %d %H:%M:%S'
+```
+
+
+## **Key configuration options**
+
+| Option | Description |
+|---------|-------------|
+| `include` | List of glob patterns for files to include |
+| `exclude` | Optional glob patterns for files to exclude |
+| `start_at` | `beginning` or `end`. Controls where to start reading |
+| `operators` | Parsing and routing logic for logs |
+| `storage` | Enables persistent state to avoid duplications on restarts |
+| `max_log_size` | Maximum size of individual log entries (in bytes) |
+
+For the full list of options, refer to the[ upstream `filelogreceiver` docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/filelogreceiver/README.md).
+
+
+## **Best practices**
+
+* Use [persistent storage](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/design.md#storage-extension) to avoid duplicate log entries after restarts.
+
+* Leverage `operators` to normalize log formats (for example parse JSON, regex fields).
+* Use the `router` operator when handling multiple formats (for example containerd and CRI-O). 
+* Avoid using the `start_at: end` setting in ephemeral containers (risk of missing logs).
+* Use `exclude` for rotated or compressed logs you don’t want ingested.
+
+
+## Limitations
+
+* The `filelogreceiver` does not support dynamic file discovery inside containers.
+
+* High-volume directories (for example `/var/log/containers`) may require tuning `max_concurrent_files`.
+
+* File renaming or rotation may cause skipped or duplicated lines without fingerprinting.
+
+
+## Resources
+
+* [Upstream component: filelogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/filelogreceiver/README.md)
+* [Configure logs collection in EDOT](https://www.elastic.co/docs/reference/edot-collector/config/configure-logs-collection)

--- a/docs/reference/edot-collector/toc.yml
+++ b/docs/reference/edot-collector/toc.yml
@@ -15,6 +15,7 @@ toc:
     children:
       - file: components/elasticsearchexporter.md
       - file: components/elasticapmintakereceiver.md
+      - file: components/filelogreceiver.md
   - file: customization.md
     children:
       - file: custom-collector.md


### PR DESCRIPTION
## What does this PR do?

This PR adds a new EDOT Collector component reference page for the `filelogreceiver`.

The page includes:
- An overview of the component’s role in log ingestion
- A sample configuration block
- Key configuration options explained
- Best practices for Kubernetes environments

The file is located at:
`docs/reference/edot-collector/components/filelogreceiver.md`

## Why is it important?

File log receiver is a part of the default config, and as such should be documented.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

No

## How to test this PR locally

Follow the [Contribute locally](https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/contribute/locally) guide.

## Related issues

- Closes [#1025](https://github.com/elastic/opentelemetry-dev/issues/1025)

