### PR TITLE
[ipc/;listener][windows] Implement retry mechanism for listener creation

### DIFF
--- a/pkg/ipc/listener_windows.go
+++ b/pkg/ipc/listener_windows.go
@@ -9,8 +9,10 @@ package ipc
 import (
 	"fmt"
 	"net"
+	"os"
 	"os/user"
 	"strings"
+	"time"
 
 	"golang.org/x/sys/windows"
 
@@ -43,7 +45,13 @@ func CreateListener(log *logger.Logger, address string) (net.Listener, error) {
 }
 
 func CleanupListener(log *logger.Logger, address string) {
-	// nothing to do on windows
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		_, err := os.Stat(npipe.TransformString(address))
+		if os.IsNotExist(err) {
+			break
+		}
+	}
 }
 
 func securityDescriptor(log *logger.Logger) (string, error) {

--- a/pkg/ipc/listener_windows_test.go
+++ b/pkg/ipc/listener_windows_test.go
@@ -7,6 +7,7 @@
 package ipc
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -16,11 +17,15 @@ import (
 func TestCreateListener(t *testing.T) {
 	name := "npipe:///testpipe"
 
-	// try creating and closing listeners with same name multiple times
+	// try creating and closing servers with same name multiple times
 	for range 1000 {
 		lis, err := CreateListener(logp.NewNopLogger(), name)
 		require.NoError(t, err)
 		require.NotNil(t, lis)
-		require.NotNil(t, lis.Close())
+		s := &http.Server{}
+		go func() {
+			s.Serve(lis)
+		}()
+		require.NoError(t, s.Close())
 	}
 }

--- a/pkg/ipc/listener_windows_test.go
+++ b/pkg/ipc/listener_windows_test.go
@@ -1,0 +1,26 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build windows
+
+package ipc
+
+import (
+	"testing"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateListener(t *testing.T) {
+	name := "npipe:///testpipe"
+
+	// try creating and closing listeners with same name multiple times
+	for range 1000 {
+		lis, err := CreateListener(logp.NewNopLogger(), name)
+		require.NoError(t, err)
+		require.NotNil(t, lis)
+		require.NotNil(t, lis.Close())
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds a retry mechanism when creating a named pipe listener on Windows.
Instead of failing immediately if listener creation fails, it now retries for up to 5 seconds with a short delay between attempts.

## Why is it important?

Sometimes the named pipe might not be immediately available. This was observed when using monitoring with beat receivers.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test
