### PR TITLE
Fix error logging for provider failures

### DIFF
--- a/changelog/fragments/1759334752-fix-error-logging-for-provider-failures.yaml
+++ b/changelog/fragments/1759334752-fix-error-logging-for-provider-failures.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix an incorrectly formatted log message when a provider fails
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/composable/controller.go
+++ b/internal/pkg/composable/controller.go
@@ -469,11 +469,11 @@ func (c *controller) startContextProvider(ctx context.Context, wg *sync.WaitGrou
 				return
 			}
 			// all other exits are bad, even a nil error
-			cause := "exited unexpectedly with nil error"
+			cause := ""
 			if err != nil {
-				cause = err.Error()
+				cause = fmt.Sprintf(": %v", err)
 			}
-			l.Errorf("provider %q failed to run (will retry in %s): %s", name, c.restartInterval.String(), cause)
+			l.Errorf("provider %q failed to run (will retry in %s)%s", name, c.restartInterval.String(), cause)
 			if fpok {
 				// turn off fetch provider
 				sendFetchProvider(ctx, fetchCh, name, nil)
@@ -531,11 +531,11 @@ func (c *controller) startDynamicProvider(ctx context.Context, wg *sync.WaitGrou
 				return
 			}
 			// all other exits are bad, even a nil error
-			cause := "exited unexpectedly with nil error"
+			cause := ""
 			if err != nil {
-				cause = err.Error()
+				cause = fmt.Sprintf(": %v", err)
 			}
-			l.Errorf("provider %q failed to run (will restart in %s): %s", name, c.restartInterval.String(), cause)
+			l.Errorf("provider %q failed to run (will restart in %s)%s", name, c.restartInterval.String(), cause)
 			select {
 			case <-ctx.Done():
 				return

--- a/internal/pkg/composable/controller.go
+++ b/internal/pkg/composable/controller.go
@@ -469,7 +469,11 @@ func (c *controller) startContextProvider(ctx context.Context, wg *sync.WaitGrou
 				return
 			}
 			// all other exits are bad, even a nil error
-			l.Errorf("provider %q failed to run (will retry in %s): %s", name, c.restartInterval.String(), err)
+			cause := "exited unexpectedly with nil error"
+			if err != nil {
+				cause = err.Error()
+			}
+			l.Errorf("provider %q failed to run (will retry in %s): %s", name, c.restartInterval.String(), cause)
 			if fpok {
 				// turn off fetch provider
 				sendFetchProvider(ctx, fetchCh, name, nil)
@@ -527,7 +531,11 @@ func (c *controller) startDynamicProvider(ctx context.Context, wg *sync.WaitGrou
 				return
 			}
 			// all other exits are bad, even a nil error
-			l.Errorf("provider %q failed to run (will restart in %s): %s", name, c.restartInterval.String(), err)
+			cause := "exited unexpectedly with nil error"
+			if err != nil {
+				cause = err.Error()
+			}
+			l.Errorf("provider %q failed to run (will restart in %s): %s", name, c.restartInterval.String(), cause)
 			select {
 			case <-ctx.Done():
 				return


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Avoid logging a nil error for provider exits.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Some providers intentionally stop and return a nil error; they already log the exit reason internally. The previous log formatted a nil error into "%!s()", which can be confusing (e.g. `provider "env" failed to run (will retry in 30s): %!s()`). This change removes the incorrect formatting and only includes the error text when non-nil.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

None.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #9284