### PR TITLE
[OTel] Fix CLI example to use proper syntax

### DIFF
--- a/internal/pkg/agent/cmd/otel_flags.go
+++ b/internal/pkg/agent/cmd/otel_flags.go
@@ -27,7 +27,7 @@ func setupOtelFlags(flags *pflag.FlagSet) {
 		" single location can be set per flag entry e.g. `--config=file:/path/to/first --config=file:path/to/second`.")
 
 	flags.StringArray(otelSetFlagName, []string{}, "Set arbitrary component config property. The component has to be defined in the config file and the flag"+
-		" has a higher precedence. Array config properties are overridden and maps are joined. Example --set=processors.batch.timeout=2s")
+		" has a higher precedence. Array config properties are overridden and maps are joined. Example --set \"processors::batch::timeout=2s\"")
 
 	flags.Bool(manager.OtelSetSupervisedFlagName, false, "Set that this collector is supervised.")
 	// the only error we can get here is that the flag does not exist

--- a/internal/pkg/agent/cmd/validate_test.go
+++ b/internal/pkg/agent/cmd/validate_test.go
@@ -24,6 +24,26 @@ func TestValidateCommand(t *testing.T) {
 			false,
 		},
 		{
+			"otel config with set",
+			[]string{filepath.Join("testdata", "otel", "otel.yml"), "yaml:processors::resource::attributes: [{ key: service.name, action: insert, value: elastic-otel-test1 }]"},
+			false,
+		},
+		{
+			"otel config with set missing action field",
+			[]string{filepath.Join("testdata", "otel", "otel.yml"), "yaml:processors::resource::attributes: [{ key: service.name, value: elastic-otel-test2 }]"},
+			true,
+		},
+		{
+			"otel config with set missing key field",
+			[]string{filepath.Join("testdata", "otel", "otel.yml"), "yaml:processors::resource::attributes: [{ action: insert, value: elastic-otel-test3 }]"},
+			true,
+		},
+		{
+			"otel config with set missing key and action fields",
+			[]string{filepath.Join("testdata", "otel", "otel.yml"), "yaml:processors::resource::attributes: [{ value: elastic-otel-test4 }]"},
+			true,
+		},
+		{
 			"agent config",
 			[]string{filepath.Join("testdata", "otel", "elastic-agent.yml")},
 			true,
@@ -33,7 +53,12 @@ func TestValidateCommand(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
 			err := validateOtelConfig(context.Background(), tc.ConfigPaths)
-			require.Equal(t, tc.ExpectingErr, err != nil)
+
+			if tc.ExpectingErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This uses the expected `::` syntax instead of `.` for the `--set` argument.

## What does this PR do?

Fixes the example text for showing users how to use the `--set` argument.

## Why is it important?

The documentation shows the correct format.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
