### PR TITLE
[AutoOps] Provide Sample Configuration to Debug Data

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,6 @@
 /internal/pkg/otel/samples @elastic/ingest-otel-data @elastic/ingest-docs
 /internal/pkg/otel/core-components.yaml @elastic/ingest-otel-leads
 /internal/pkg/composable/providers/kubernetes @elastic/elastic-agent-control-plane
-/internal/pkg/otel/samples/darwin/autoops_es.yml @elastic/opex
-/internal/pkg/otel/samples/linux/autoops_es.yml @elastic/opex
-/internal/pkg/otel/samples/windows/autoops_es.yml @elastic/opex
+/internal/pkg/otel/samples/darwin/autoops_es*.yml @elastic/opex
+/internal/pkg/otel/samples/linux/autoops_es*.yml @elastic/opex
+/internal/pkg/otel/samples/windows/autoops_es*.yml @elastic/opex

--- a/changelog/fragments/1759359160-autoops-debug-output.yaml
+++ b/changelog/fragments/1759359160-autoops-debug-output.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Add debug exporter to AutoOps OTel config sample
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/otel/samples/darwin/autoops_es_debug.yml
+++ b/internal/pkg/otel/samples/darwin/autoops_es_debug.yml
@@ -1,0 +1,48 @@
+receivers:
+  metricbeatreceiver:
+    metricbeat:
+      modules:
+        # Metrics
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 10s
+          metricsets:
+            - cat_shards
+            - cluster_health
+            - cluster_settings
+            - license
+            - node_stats
+            - tasks_management
+        # Templates
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 24h
+          metricsets:
+            - cat_template
+            - component_template
+            - index_template
+    processors:
+      - add_fields:
+          target: autoops_es
+          fields:
+            temp_resource_id: ${env:AUTOOPS_TEMP_RESOURCE_ID}
+            token: ${env:AUTOOPS_TOKEN}
+    output:
+      otelconsumer:
+    telemetry_types: ["logs"]
+
+exporters:
+  # Exporter to print the first 5 logs/metrics and then every 1000th
+  debug:
+    verbosity: detailed
+    sampling_initial: 5
+    sampling_thereafter: 1000
+
+service:
+  pipelines:
+    logs:
+      receivers: [metricbeatreceiver]
+      exporters: [debug]
+  telemetry:
+    logs:
+      encoding: json

--- a/internal/pkg/otel/samples/linux/autoops_es_debug.yml
+++ b/internal/pkg/otel/samples/linux/autoops_es_debug.yml
@@ -1,0 +1,48 @@
+receivers:
+  metricbeatreceiver:
+    metricbeat:
+      modules:
+        # Metrics
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 10s
+          metricsets:
+            - cat_shards
+            - cluster_health
+            - cluster_settings
+            - license
+            - node_stats
+            - tasks_management
+        # Templates
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 24h
+          metricsets:
+            - cat_template
+            - component_template
+            - index_template
+    processors:
+      - add_fields:
+          target: autoops_es
+          fields:
+            temp_resource_id: ${env:AUTOOPS_TEMP_RESOURCE_ID}
+            token: ${env:AUTOOPS_TOKEN}
+    output:
+      otelconsumer:
+    telemetry_types: ["logs"]
+
+exporters:
+  # Exporter to print the first 5 logs/metrics and then every 1000th
+  debug:
+    verbosity: detailed
+    sampling_initial: 5
+    sampling_thereafter: 1000
+
+service:
+  pipelines:
+    logs:
+      receivers: [metricbeatreceiver]
+      exporters: [debug]
+  telemetry:
+    logs:
+      encoding: json

--- a/internal/pkg/otel/samples/windows/autoops_es_debug.yml
+++ b/internal/pkg/otel/samples/windows/autoops_es_debug.yml
@@ -1,0 +1,48 @@
+receivers:
+  metricbeatreceiver:
+    metricbeat:
+      modules:
+        # Metrics
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 10s
+          metricsets:
+            - cat_shards
+            - cluster_health
+            - cluster_settings
+            - license
+            - node_stats
+            - tasks_management
+        # Templates
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 24h
+          metricsets:
+            - cat_template
+            - component_template
+            - index_template
+    processors:
+      - add_fields:
+          target: autoops_es
+          fields:
+            temp_resource_id: ${env:AUTOOPS_TEMP_RESOURCE_ID}
+            token: ${env:AUTOOPS_TOKEN}
+    output:
+      otelconsumer:
+    telemetry_types: ["logs"]
+
+exporters:
+  # Exporter to print the first 5 logs/metrics and then every 1000th
+  debug:
+    verbosity: detailed
+    sampling_initial: 5
+    sampling_thereafter: 1000
+
+service:
+  pipelines:
+    logs:
+      receivers: [metricbeatreceiver]
+      exporters: [debug]
+  telemetry:
+    logs:
+      encoding: json


### PR DESCRIPTION
This provides a separate OTel configuration to allow users to better understand what data they are shipping with the AutoOps ES module.

## What does this PR do?

This adds a new OTel configuration available for every OS that helps users to understand what data the AutoOps ES module exports.

## Why is it important?

Many users have asked what data is collected by AutoOps and this helps them to explore it locally before shipping it anywhree.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Disruptive User Impact

None. This adds a new, optional configuration that the user can run to better understand AutoOps.

## How to test this PR locally

Run the Elastic Agent against an Elasticsearch cluster.

```bash
./elastic-agent --config otel_samples/autoops_es_debug.yml
```

You will want to supply these environment variables (with values filled in relevant to your environment):

```bash
# Values are examples and have no effect other than to appear in output unchanged
AUTOOPS_TEMP_RESOURCE_ID=example-id
AUTOOPS_TOKEN=example_token

# Values must work:
AUTOOPS_ES_URL=https://localhost:9200

# Username / Password _OR_ API Key
AUTOOPS_ES_USERNAME=my-username
AUTOOPS_ES_PASSWORD=my-secure-password

AUTOOPS_ES_API_KEY=myapikey==
```

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
