### PR TITLE
Remove the control plane team as the changelog fragment owners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,11 @@
 # Team responsible for Fleet Server
 * @elastic/elastic-agent-control-plane
 
+# List the changlog fragments without an owner. This will prevent the control plane team from being added
+# as a reviewer every time a change to files they do not own also adds a changelog entry.
+# https://github.community/t/codeowners-file-with-a-not-file-type-condition/1423/9
+changelog/fragments/
+
 # Top-level files ownership
 /catalog-info.yaml @elastic/elastic-agent-control-plane @elastic/observablt-ci
 


### PR DESCRIPTION
The same as https://github.com/elastic/beats/pull/46931 but for elastic-agent.

Stop the control plane team from being requested to review in code they aren't explicit codeowner of when a changelog fragment is also added.