### PR TITLE
Prevent migration of agents on Docker 

### DIFF
--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -62,6 +62,8 @@ const (
 
 var ErrNotManaged = errors.New("unmanaged agent")
 
+var ErrContainerNotSupported = errors.New("unsupported action: agent runs in a container")
+
 var ErrFleetServer = errors.New("unsupported action: agent runs Fleet server")
 
 // ErrNotUpgradable error is returned when upgrade cannot be performed.
@@ -609,6 +611,9 @@ func (c *Coordinator) Migrate(
 	backoffFactory func(done <-chan struct{}) backoff.Backoff,
 	notifyFn func(context.Context, *fleetapi.ActionMigrate) error,
 ) error {
+	if c.specs.Platform().OS == component.Container {
+		return ErrContainerNotSupported
+	}
 	if !c.isManaged {
 		return ErrNotManaged
 	}

--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -1639,6 +1639,54 @@ func TestCoordinator_UnmanagedAgent_SkipsMigrate(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotManaged)
 }
 
+func TestCoordinator_ContainerAgent_SkipsMigrate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// overrideStateChan has buffer 2 so we can run on a single goroutine,
+	// since a successful upgrade sets the override state twice.
+	overrideStateChan := make(chan *coordinatorOverrideState, 2)
+
+	// similarly, upgradeDetailsChan is a buffered channel as well.
+	upgradeDetailsChan := make(chan *details.Details, 2)
+
+	// Create a manager that will allow upgrade attempts but return a failure
+	// from Upgrade itself (success requires testing ReExec and we aren't
+	// quite ready to do that yet).
+	upgradeMgr := &fakeUpgradeManager{
+		upgradeable: true,
+		upgradeErr:  errors.New("failed upgrade"),
+	}
+
+	platformSpecs, _ := component.NewRuntimeSpecs(component.PlatformDetail{
+		Platform:                     component.Platform{OS: component.Container},
+		NativeArch:                   "",
+		Family:                       "",
+		Major:                        0,
+		Minor:                        0,
+		IsInstalledViaExternalPkgMgr: false,
+		User:                         component.UserDetail{},
+	}, nil)
+	coord := &Coordinator{
+		stateBroadcaster:   broadcaster.New(State{}, 0, 0),
+		overrideStateChan:  overrideStateChan,
+		upgradeDetailsChan: upgradeDetailsChan,
+		upgradeMgr:         upgradeMgr,
+		logger:             logp.NewLogger("testing"),
+		isManaged:          false,
+		specs:              platformSpecs,
+	}
+
+	action := &fleetapi.ActionMigrate{}
+
+	backoffFactory := func(done <-chan struct{}) backoff.Backoff {
+		return backoff.NewExpBackoff(done, 30*time.Millisecond, 2*time.Second)
+	}
+
+	err := coord.Migrate(ctx, action, backoffFactory, nil)
+	require.ErrorIs(t, err, ErrContainerNotSupported)
+}
+
 func TestCoordinator_FleetServer_SkipsMigration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/pkg/component/load.go
+++ b/pkg/component/load.go
@@ -232,6 +232,11 @@ func NewRuntimeSpecs(platform PlatformDetail, inputSpecs []InputRuntimeSpec) (Ru
 	}, nil
 }
 
+// Platform return PlatformDetail being used.
+func (r *RuntimeSpecs) Platform() PlatformDetail {
+	return r.platform
+}
+
 // Inputs returns the list of supported inputs for this platform.
 func (r *RuntimeSpecs) Inputs() []string {
 	inputs := make([]string, 0, len(r.inputSpecs))


### PR DESCRIPTION
Just exposing platform used in component specs for check to happen, other option would be to inject it from the top

this seems less disruptive. 

Related https://github.com/elastic/kibana/issues/231151