### PR TITLE
[otel/kube-stack] Update EDOT SDK k8s auto-instrumentation images to latest versions

### DIFF
--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
@@ -589,12 +589,12 @@ instrumentation:
     type: parentbased_traceidratio # Sampler type
     argument: "1.0" # Sampling rate set to 100% (all traces are sampled).
   java:
-    image: docker.elastic.co/observability/elastic-otel-javaagent:1.5.0
+    image: docker.elastic.co/observability/elastic-otel-javaagent:1.6.0
   nodejs:
-    image: docker.elastic.co/observability/elastic-otel-node:1.3.0
+    image: docker.elastic.co/observability/elastic-otel-node:1.5.0
   dotnet:
     image: docker.elastic.co/observability/elastic-otel-dotnet:1.1.0
   python:
-    image: docker.elastic.co/observability/elastic-otel-python:1.7.0
+    image: docker.elastic.co/observability/elastic-otel-python:1.9.0
   go:
-    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.22.1
+    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.23.0

--- a/deploy/helm/edot-collector/kube-stack/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/values.yaml
@@ -609,12 +609,12 @@ instrumentation:
     type: parentbased_traceidratio # Sampler type
     argument: "1.0" # Sampling rate set to 100% (all traces are sampled).
   java:
-    image: docker.elastic.co/observability/elastic-otel-javaagent:1.5.0
+    image: docker.elastic.co/observability/elastic-otel-javaagent:1.6.0
   nodejs:
-    image: docker.elastic.co/observability/elastic-otel-node:1.3.0
+    image: docker.elastic.co/observability/elastic-otel-node:1.5.0
   dotnet:
     image: docker.elastic.co/observability/elastic-otel-dotnet:1.1.0
   python:
-    image: docker.elastic.co/observability/elastic-otel-python:1.7.0
+    image: docker.elastic.co/observability/elastic-otel-python:1.9.0
   go:
-    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.22.1
+    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.23.0


### PR DESCRIPTION
This also updates the vanilla OTel Go image version to its latest.

---

See https://github.com/elastic/elastic-agent/pull/7327 for an earlier update of the same sort.

/cc @elastic/apm-agent-java @elastic/apm-agent-python because I'm updating your EDOT SDK docker image versions as well.