### PR TITLE
Report collector telemetry via the existing agent datastream

### DIFF
--- a/internal/pkg/agent/application/monitoring/component/testdata/monitoring_config_full.yaml
+++ b/internal/pkg/agent/application/monitoring/component/testdata/monitoring_config_full.yaml
@@ -871,14 +871,14 @@ inputs:
   name: metrics-monitoring-collector
   streams:
   - data_stream:
-      dataset: elastic_agent.collector
+      dataset: elastic_agent.elastic_agent
       namespace: default
       type: metrics
     failure_threshold: 5
     hosts:
     - placeholder
     id: metrics-monitoring-collector
-    index: metrics-elastic_agent.collector-default
+    index: metrics-elastic_agent.elastic_agent-default
     metrics_path: /metrics
     metricsets:
     - collector
@@ -887,13 +887,13 @@ inputs:
     processors:
     - add_fields:
         fields:
-          dataset: elastic_agent.collector
+          dataset: elastic_agent.elastic_agent
           namespace: default
           type: metrics
         target: data_stream
     - add_fields:
         fields:
-          dataset: elastic_agent.collector
+          dataset: elastic_agent.elastic_agent
         target: event
     - add_fields:
         fields:

--- a/internal/pkg/agent/application/monitoring/component/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/component/v1_monitor.go
@@ -840,7 +840,7 @@ func (b *BeatsMonitor) getPrometheusStream(
 	// Send these metrics through the metricbeat monitoring datastream, since
 	// the processors will convert any usable metrics into ECS equivalents
 	// so they're visible in Agent dashboards.
-	dataset := fmt.Sprintf("elastic_agent.%s", collectorName)
+	dataset := "elastic_agent.elastic_agent"
 	indexName := fmt.Sprintf("metrics-%s-%s", dataset, monitoringNamespace)
 
 	prometheusHost := b.getCollectorTelemetryEndpoint()


### PR DESCRIPTION
Fix the issue in https://github.com/elastic/elastic-agent/issues/10277 caused when collector telemetry was sent to a new (unconfigured) `elastic_agent.collector` datastream (which is expected to be used by future followup work) rather than the existing `elastic_agent.elastic_agent` one (which will allow incomplete but backwards-compatible collector metrics in existing Agent dashboards).

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

(skip-changelog because this is a fix for an unreleased change.)

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/10277
