### PR TITLE
Re-enable serverless tests

### DIFF
--- a/testing/integration/serverless/logs_ingestion_test.go
+++ b/testing/integration/serverless/logs_ingestion_test.go
@@ -20,6 +20,5 @@ func TestLogIngestionFleetManaged(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
-	t.Skip("Skip serverless tests until we can enroll an agent with 9.3.0-SNAPSHOT.")
 	integration.LogIngestionFleetManaged(t, info)
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR re-enabled serverless tests that were disabled in #10401 because `fleet-service` 9.3.0-SNAPSHOT had not been promoted to Serverless at the time.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To have Serverless tests again.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #10419
