### PR TITLE
Improve docs automation for Gateway configs and deprecated components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,7 @@ changelog/fragments/
 /docs/scripts/update-docs @elastic/ingest-docs
 /internal/pkg/otel/samples @elastic/ingest-otel-data @elastic/ingest-docs
 /internal/pkg/otel/core-components.yaml @elastic/ingest-otel-leads
+/internal/pkg/otel/deprecated-components.yaml @elastic/ingest-otel-leads
 /internal/pkg/composable/providers/kubernetes @elastic/elastic-agent-control-plane
 /internal/pkg/otel/samples/darwin/autoops_es*.yml @elastic/opex
 /internal/pkg/otel/samples/linux/autoops_es*.yml @elastic/opex

--- a/docs/reference/edot-collector/config/default-config-standalone.md
+++ b/docs/reference/edot-collector/config/default-config-standalone.md
@@ -113,18 +113,22 @@ The following example configuration files are available for the Gateway mode:
 :::::{tab-set}
 
 ::::{tab-item} 9.x
+% start:edot-gateway-9x-table
 | Version | Configuration  |
 |---------|----------------|
-| 9.1     | [Gateway mode](https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v9.1.0/internal/pkg/otel/samples/linux/gateway.yml) |
-| 9.0     | [Gateway mode](https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v9.0.4/internal/pkg/otel/samples/linux/gateway.yml) |
+| 9.1     | [Gateway mode](https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v9.1.5/internal/pkg/otel/samples/linux/gateway.yml) |
+| 9.0     | [Gateway mode](https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v9.0.8/internal/pkg/otel/samples/linux/gateway.yml) |
+% end:edot-gateway-9x-table
 ::::
 
 ::::{tab-item} 8.x
+% start:edot-gateway-8x-table
 | Version | Configuration  |
 |---------|----------------|
-| 8.19    | [Gateway mode](https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v8.19.0/internal/pkg/otel/samples/linux/gateway.yml) |
-| 8.18    | [Gateway mode](https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v9.0.4/internal/pkg/otel/samples/linux/gateway.yml) |
-| 8.17    | [Gateway mode](https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v9.0.4/internal/pkg/otel/samples/linux/gateway.yml) |
+| 8.19    | [Gateway mode](https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v8.19.5/internal/pkg/otel/samples/linux/gateway.yml) |
+| 8.18    | [Gateway mode](https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v8.18.8/internal/pkg/otel/samples/linux/gateway.yml) |
+| 8.17    | [Gateway mode](https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v8.17.10/internal/pkg/otel/samples/linux/gateway.yml) |
+% end:edot-gateway-8x-table
 ::::
 :::::
 

--- a/docs/scripts/update-docs/templates/gateway-table.jinja2
+++ b/docs/scripts/update-docs/templates/gateway-table.jinja2
@@ -1,0 +1,5 @@
+| Version | Configuration  |
+|---------|----------------|
+{%- for version in versions %}
+| {{ "%-7s"|format(version.version) }} | [Gateway mode](https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/{{ version.tag }}/internal/pkg/otel/samples/linux/gateway.yml) |
+{%- endfor %}

--- a/docs/scripts/update-docs/update-components-docs.py
+++ b/docs/scripts/update-docs/update-components-docs.py
@@ -106,7 +106,9 @@ def get_deprecated_components(version='main'):
         
     try:
         data = yaml.safe_load(content)
-        return data.get('deprecated', [])
+        deprecated = data.get('deprecated', [])
+        # Handle case where 'deprecated:' exists but has no items (returns None)
+        return deprecated if deprecated is not None else []
     except yaml.YAMLError as e:
         print(f"Warning: Error parsing deprecated-components.yaml from tag {version_tag}: {e}")
         return []

--- a/docs/scripts/update-docs/update-components-docs.py
+++ b/docs/scripts/update-docs/update-components-docs.py
@@ -22,11 +22,15 @@ import tempfile
 
 TABLE_TAG = 'edot-collector-components-table'
 DEPS_TAG = 'edot-collector-components-ocb'
+GATEWAY_9X_TAG = 'edot-gateway-9x-table'
+GATEWAY_8X_TAG = 'edot-gateway-8x-table'
 
 EDOT_COLLECTOR_DIR = '../../../docs/reference/edot-collector'
 TEMPLATE_COLLECTOR_COMPONENTS_TABLE = 'templates/components-table.jinja2'
 TEMPLATE_COLLECTOR_OCB_FILE = 'templates/ocb.jinja2'
 COMPONENT_DOCS_YAML = '../../../docs/reference/edot-collector/component-docs.yml'
+DEFAULT_CONFIG_FILE = '../../../docs/reference/edot-collector/config/default-config-standalone.md'
+DEPRECATED_COMPONENTS_YAML = '../../../internal/pkg/otel/deprecated-components.yaml'
 
 
 def read_file_from_git_tag(file_path, tag):
@@ -85,6 +89,26 @@ def get_core_components(version='main'):
         return data.get('components', [])
     except yaml.YAMLError as e:
         raise ValueError(f"Error parsing core-components.yaml from tag {version_tag}: {e}")
+
+def get_deprecated_components(version='main'):
+    """Read and parse the deprecated-components.yaml file to determine deprecated status"""
+    latest_version = get_latest_version()
+    version_tag = f"v{latest_version}"
+    
+    # Always read from Git tag
+    deprecated_components_path = 'internal/pkg/otel/deprecated-components.yaml'
+    print(f"Reading deprecated components from tag {version_tag}: {deprecated_components_path}")
+    content = read_file_from_git_tag(deprecated_components_path, version_tag)
+    if content is None:
+        print(f"Warning: Could not read deprecated components file from tag {version_tag}. Assuming no deprecated components.")
+        return []
+        
+    try:
+        data = yaml.safe_load(content)
+        return data.get('deprecated', [])
+    except yaml.YAMLError as e:
+        print(f"Warning: Error parsing deprecated-components.yaml from tag {version_tag}: {e}")
+        return []
 
 def dep_to_component(dep):
     url = dep[:dep.rfind(' v')].strip()
@@ -151,6 +175,10 @@ def get_otel_components(version='main', component_docs_mapping=None):
     # Get the list of core components
     core_components = get_core_components(version)
     print(f"Found {len(core_components)} core components")
+    
+    # Get the list of deprecated components
+    deprecated_components = get_deprecated_components(version)
+    print(f"Found {len(deprecated_components)} deprecated components")
 
     lines = elastic_agent_go_mod.splitlines()
     components_type = ['receiver', 'connector', 'processor', 'exporter', 'extension', 'provider']
@@ -161,11 +189,18 @@ def get_otel_components(version='main', component_docs_mapping=None):
     for comp in otel_components:
         # Extract the component name without the suffix (e.g., 'filelogreceiver' from 'filelogreceiver ')
         comp_name = comp['name'].strip()
+        
+        # Check if this component is deprecated (takes precedence)
+        if comp_name in deprecated_components:
+            comp['support_status'] = 'Deprecated'
+            comp['is_deprecated'] = True
         # Check if this component is in the core components list
-        if comp_name in core_components:
+        elif comp_name in core_components:
             comp['support_status'] = '[Core]'
+            comp['is_deprecated'] = False
         else:
             comp['support_status'] = '[Extended]'
+            comp['is_deprecated'] = False
             
         # Add documentation link if available
         if component_docs_mapping and comp_name in component_docs_mapping:
@@ -269,6 +304,194 @@ def get_component_docs_mapping(source_file):
         print(f"Error reading component docs YAML file: {exc}")
         return {}
 
+def get_all_version_tags():
+    """Get all version tags from the repository"""
+    try:
+        result = subprocess.run(
+            ['git', 'tag', '--list', 'v*'],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return [tag.strip() for tag in result.stdout.strip().split('\n') if tag.strip()]
+    except subprocess.CalledProcessError as e:
+        print(f"Error getting version tags: {e}")
+        return []
+
+def parse_version(tag):
+    """Parse a version tag into (major, minor, patch) tuple"""
+    match = re.match(r'^v(\d+)\.(\d+)\.(\d+)$', tag)
+    if match:
+        return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+    return None
+
+def get_latest_minor_versions(major_version):
+    """Get the latest patch version for each minor version of a major version"""
+    all_tags = get_all_version_tags()
+    versions = {}
+    
+    for tag in all_tags:
+        parsed = parse_version(tag)
+        if parsed and parsed[0] == major_version:
+            major, minor, patch = parsed
+            minor_key = f"{major}.{minor}"
+            
+            # Keep only the latest patch for each minor version
+            if minor_key not in versions or parsed[2] > versions[minor_key]['patch']:
+                versions[minor_key] = {
+                    'minor': minor,
+                    'patch': patch,
+                    'tag': tag
+                }
+    
+    # Sort by minor version (descending)
+    return sorted(versions.values(), key=lambda x: x['minor'], reverse=True)
+
+def parse_gateway_table(content, tag):
+    """Parse existing gateway table to extract current versions and their tags
+    
+    Returns:
+        List of dicts with 'version' (e.g., '9.1') and 'current_tag' (e.g., 'v9.1.4')
+    """
+    start_tag = f'% start:{tag}'
+    end_tag = f'% end:{tag}'
+    
+    pattern = start_tag + r'(.*?)' + end_tag
+    matches = re.findall(pattern, content, re.DOTALL)
+    
+    if not matches:
+        return []
+    
+    table_content = matches[0]
+    # Extract version and tag from each row
+    # Pattern matches: | 9.1     | [Gateway mode](https://...v9.1.4/...) |
+    row_pattern = r'\|\s*(\d+\.\d+)\s*\|[^|]*\(https://[^/]+/[^/]+/[^/]+/refs/tags/(v[\d.]+)/[^)]+\)'
+    rows = re.findall(row_pattern, table_content)
+    
+    return [{'version': version, 'current_tag': tag} for version, tag in rows]
+
+def check_file_exists_at_tag(file_path, tag):
+    """Check if a file exists at a specific Git tag"""
+    try:
+        subprocess.run(
+            ['git', 'cat-file', '-e', f'{tag}:{file_path}'],
+            capture_output=True,
+            check=True
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+def update_gateway_table(content, tag, major_version):
+    """Update gateway configuration table with new versions and updated patch releases
+    
+    Args:
+        content: The file content to update
+        tag: The marker tag for the table section
+        major_version: The major version number (8 or 9)
+    
+    Returns:
+        Updated file content
+    """
+    # Parse existing rows in the table (with their current tags)
+    existing_rows = parse_gateway_table(content, tag)
+    existing_versions = {row['version'] for row in existing_rows}
+    
+    print(f"Existing versions for {major_version}.x: {[row['version'] for row in existing_rows]}")
+    
+    # Get all available minor versions for this major version (with latest patches)
+    available_versions = get_latest_minor_versions(major_version)
+    available_map = {f"{major_version}.{v['minor']}": v for v in available_versions}
+    
+    # Track updates and new versions
+    updated_rows = []
+    new_rows = []
+    
+    # Check existing rows for patch updates
+    for existing_row in existing_rows:
+        version = existing_row['version']
+        current_tag = existing_row['current_tag']
+        
+        if version in available_map:
+            latest_tag = available_map[version]['tag']
+            if latest_tag != current_tag:
+                updated_rows.append({
+                    'version': version,
+                    'old_tag': current_tag,
+                    'new_tag': latest_tag
+                })
+                print(f"  Updating {version}: {current_tag} → {latest_tag}")
+            else:
+                print(f"  {version} is up to date ({current_tag})")
+    
+    # Find new minor versions that need to be added
+    for version_str, version_info in available_map.items():
+        if version_str not in existing_versions:
+            # Check if the gateway.yml file exists at this tag
+            gateway_file = 'internal/pkg/otel/samples/linux/gateway.yml'
+            if check_file_exists_at_tag(gateway_file, version_info['tag']):
+                new_rows.append({
+                    'version': version_str,
+                    'tag': version_info['tag']
+                })
+                print(f"  New version found: {version_str} (tag: {version_info['tag']})")
+            else:
+                print(f"  Skipping {version_str}: gateway.yml not found at {version_info['tag']}")
+    
+    if not new_rows and not updated_rows:
+        print(f"  No updates needed for {major_version}.x")
+        return content
+    
+    # Update the table content
+    start_tag_str = f'% start:{tag}'
+    end_tag_str = f'% end:{tag}'
+    pattern = start_tag_str + r'(.*?)' + end_tag_str
+    
+    def replace_table(match):
+        old_table = match.group(1)
+        lines = old_table.split('\n')
+        
+        # Find where the table content starts (after the header)
+        header_end_idx = 0
+        for i, line in enumerate(lines):
+            if '|---------|' in line or '|---|' in line:
+                header_end_idx = i + 1
+                break
+        
+        # Generate new rows for additions
+        new_table_rows = []
+        for row in new_rows:
+            new_table_rows.append(
+                f"| {row['version']:<7} | [Gateway mode](https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/{row['tag']}/internal/pkg/otel/samples/linux/gateway.yml) |"
+            )
+        
+        # Process existing rows (update tags where needed)
+        existing_table_rows = []
+        for i in range(header_end_idx, len(lines)):
+            line = lines[i]
+            if line.strip() and '|' in line:
+                # Check if this row needs updating
+                # Match both the version AND the old tag to avoid cross-contamination
+                for update_info in updated_rows:
+                    version = update_info['version']
+                    old_tag = update_info['old_tag']
+                    new_tag = update_info['new_tag']
+                    # Match pattern: | version | ... old_tag ...
+                    version_pattern = rf'\|\s*{re.escape(version)}\s*\|'
+                    if re.search(version_pattern, line) and old_tag in line:
+                        line = line.replace(old_tag, new_tag)
+                        break
+                existing_table_rows.append(line)
+        
+        # Reconstruct: header + new rows + updated existing rows
+        new_content_lines = lines[:header_end_idx] + new_table_rows + existing_table_rows
+        
+        return start_tag_str + '\n'.join(new_content_lines) + '\n' + end_tag_str
+    
+    updated_content = re.sub(pattern, replace_table, content, flags=re.DOTALL)
+    
+    return updated_content
+
 def check_markdown():
     col_version = get_collector_version()
     print(f"Collector version: {col_version}")
@@ -322,6 +545,25 @@ def generate_markdown():
     }
     render_components_into_file(EDOT_COLLECTOR_DIR, data, TEMPLATE_COLLECTOR_COMPONENTS_TABLE, TABLE_TAG)
     render_components_into_file(EDOT_COLLECTOR_DIR, data, TEMPLATE_COLLECTOR_OCB_FILE, DEPS_TAG)
+    
+    # Update gateway configuration tables
+    print("\nUpdating gateway configuration tables...")
+    
+    # Read the current file
+    with open(DEFAULT_CONFIG_FILE, 'r', encoding='utf-8') as file:
+        content = file.read()
+    
+    print("Checking for new 9.x versions...")
+    content = update_gateway_table(content, GATEWAY_9X_TAG, 9)
+    
+    print("\nChecking for new 8.x versions...")
+    content = update_gateway_table(content, GATEWAY_8X_TAG, 8)
+    
+    # Write the updated content back to the file
+    with open(DEFAULT_CONFIG_FILE, 'w', encoding='utf-8') as file:
+        file.write(content)
+    
+    print("\nGateway configuration tables updated successfully!")
 
 if __name__ == "__main__":
     import sys

--- a/internal/pkg/otel/deprecated-components.yaml
+++ b/internal/pkg/otel/deprecated-components.yaml
@@ -1,0 +1,20 @@
+# Deprecated components registry
+#
+# Components listed here are marked as deprecated in the EDOT Collector documentation.
+# Deprecated components may be removed in future versions.
+#
+# Format:
+#   deprecated:
+#     - componentname1
+#     - componentname2
+
+deprecated:
+  # Add deprecated component names here
+  # Component names should match exactly as they appear in go.mod (without trailing spaces)
+  # Example:
+  # - elastictraceprocessor  # Replaced by elasticapmprocessor in 9.2.0
+  
+  # When a component is deprecated, it will be marked as "Deprecated" in the components table
+  # instead of [Core] or [Extended]. The component name will still link to its documentation
+  # or source repository, but the status column will clearly show it's deprecated.
+


### PR DESCRIPTION
This improves the existing docs automation to:

- Update the Gateway Collector configs tables automatically with new feature versions rows when detected, and updating the patch versions for existing feature versions.
- It adds a "deprecated" metadata file, owned by Ingest leads, to mark deprecated Collector components and update the table.

Fixes https://github.com/elastic/opentelemetry-dev/issues/1102