### PR TITLE
[9.1][tests] - Fix flaky TestClientWithCertificate

### DIFF
--- a/internal/pkg/remote/client_fips_test.go
+++ b/internal/pkg/remote/client_fips_test.go
@@ -189,7 +189,7 @@ func TestClientWithCertificate(t *testing.T) {
 			require.EventuallyWithT(
 				t,
 				func(collect *assert.CollectT) {
-					return assert.Contains(collect, serverLog.String(), test.expectedServerLog)
+					assert.Contains(collect, serverLog.String(), test.expectedServerLog)
 				},
 				100*time.Millisecond, 10*time.Millisecond,
 			)


### PR DESCRIPTION
Fix TestClientWithCertificate, which is flaky on 9.1. 
This PR updates the test case to match main