### PR TITLE
Avoid using setenv in the embedded collector execution

### DIFF
--- a/internal/pkg/otel/manager/execution_embedded.go
+++ b/internal/pkg/otel/manager/execution_embedded.go
@@ -6,12 +6,18 @@ package manager
 
 import (
 	"context"
-	"os"
+	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status"
 	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/confmap/provider/envprovider"
+	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
+	"go.opentelemetry.io/collector/confmap/provider/httpprovider"
+	"go.opentelemetry.io/collector/confmap/provider/httpsprovider"
+	"go.opentelemetry.io/collector/confmap/provider/yamlprovider"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -52,11 +58,13 @@ func (r *embeddedExecution) startCollector(ctx context.Context, logger *logger.L
 	if err != nil {
 		return nil, err
 	}
+	collectorEnvMap := map[string]string{
+		componentmonitoring.OtelCollectorMetricsPortEnvVarName: strconv.Itoa(collectorMetricsPort),
+	}
 	// NewForceExtensionConverterFactory is used to ensure that the agent_status extension is always enabled.
 	// It is required for the Elastic Agent to extract the status out of the OTel collector.
 	settings := otel.NewSettings(
 		release.Version(), []string{ap.URI()},
-		otel.WithConfigProviderFactory(ap.NewFactory()),
 		otel.WithConfigConvertorFactory(NewForceExtensionConverterFactory(AgentStatusExtensionType.String(), nil)),
 		otel.WithConfigConvertorFactory(NewForceExtensionConverterFactory(elasticdiagnostics.DiagnosticsExtensionID.String(), extConf)),
 		otel.WithExtensionFactory(NewAgentStatusFactory(statusCh)))
@@ -64,24 +72,21 @@ func (r *embeddedExecution) startCollector(ctx context.Context, logger *logger.L
 	settings.LoggingOptions = []zap.Option{zap.WrapCore(func(zapcore.Core) zapcore.Core {
 		return logger.Core() // use same zap as agent
 	})}
+	// we need to explicitly specify the provider list because we replace the env provider
+	settings.ConfigProviderSettings.ResolverSettings.ProviderFactories = []confmap.ProviderFactory{
+		fileprovider.NewFactory(),
+		NewFactoryWithEnvMap(collectorEnvMap), // replace the env provider with our wrapper
+		yamlprovider.NewFactory(),
+		httpprovider.NewFactory(),
+		httpsprovider.NewFactory(),
+		ap.NewFactory(),
+	}
 	svc, err := otelcol.NewCollector(*settings)
 	if err != nil {
 		collectorCancel()
 		return nil, err
 	}
 	go func() {
-		// Set the environment variable for the collector metrics port. See comment at the constant definition for more information.
-		setErr := os.Setenv(componentmonitoring.OtelCollectorMetricsPortEnvVarName, strconv.Itoa(collectorMetricsPort))
-		defer func() {
-			unsetErr := os.Unsetenv(componentmonitoring.OtelCollectorMetricsPortEnvVarName)
-			if unsetErr != nil {
-				logger.Errorf("couldn't unset environment variable %s: %v", componentmonitoring.OtelCollectorMetricsPortEnvVarName, unsetErr)
-			}
-		}()
-		if setErr != nil {
-			reportErr(ctx, errCh, setErr)
-			return
-		}
 		runErr := svc.Run(collectorCtx)
 		close(ctl.collectorDoneCh)
 		// after the collector exits, we need to report the error and a nil status
@@ -125,4 +130,61 @@ func (s *ctxHandle) Stop(waitTime time.Duration) {
 		return
 	case <-s.collectorDoneCh:
 	}
+}
+
+// Define a provider that wraps the env provider and returns values from a static map first, deferring to the env provider
+// if the env variable doesn't exist in the map.
+// This is a hacky workaround for the problem where we pass some values into the configuration through env variables,
+// but SetEnv causes various confusing race conditions. Considering we're probably going to get rid of this execution
+// sooner rather than later, this should be fine.
+const (
+	schemeName = "env"
+)
+
+type provider struct {
+	envProvider confmap.Provider
+	envMap      map[string]string
+}
+
+func NewFactoryWithEnvMap(envMap map[string]string) confmap.ProviderFactory {
+	return confmap.NewProviderFactory(func(s confmap.ProviderSettings) confmap.Provider {
+		return newProviderWithEnvMap(s, envMap)
+	})
+}
+
+func newProviderWithEnvMap(ps confmap.ProviderSettings, envMap map[string]string) confmap.Provider {
+	envProvider := envprovider.NewFactory().Create(ps)
+	return &provider{envProvider: envProvider, envMap: envMap}
+}
+
+func (emp *provider) Retrieve(ctx context.Context, uri string, watcherFunc confmap.WatcherFunc) (*confmap.Retrieved, error) {
+	if !strings.HasPrefix(uri, schemeName+":") {
+		return nil, fmt.Errorf("%q uri is not supported by %q provider", uri, schemeName)
+	}
+
+	// check if we have the variable in our static map, if not go to the actual environment
+	envVarName, _ := parseEnvVarURI(uri[len(schemeName)+1:])
+	if val, ok := emp.envMap[envVarName]; ok {
+		return confmap.NewRetrievedFromYAML([]byte(val))
+	}
+
+	return emp.envProvider.Retrieve(ctx, uri, watcherFunc)
+}
+
+func (*provider) Scheme() string {
+	return schemeName
+}
+
+func (*provider) Shutdown(context.Context) error {
+	return nil
+}
+
+// returns (var name, default value)
+func parseEnvVarURI(uri string) (string, *string) {
+	const defaultSuffix = ":-"
+	name, defaultValue, hasDefault := strings.Cut(uri, defaultSuffix)
+	if hasDefault {
+		return name, &defaultValue
+	}
+	return uri, nil
 }


### PR DESCRIPTION
## What does this PR do?

When running the otel collector in-process, it passes env variables via a config provider wrapper instead of using `setenv`. The solution is a bit hacky, but this mode isn't the default and is likely to be removed shortly.

## Why is it important?

The latter is not thread-safe and leads to race conditions. In particular, we have some peculiar flaky test failures on MacOS in unit tests that do this.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

Running existing unit tests is enough.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/10636

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
