### PR TITLE
[MacOS unit testing] Add version check

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -163,7 +163,7 @@ steps:
       # Runs only on main and release branches
       - label: "Unit tests - macOS 13"
         command: ".buildkite/scripts/steps/unit-tests.sh"
-#        branches: "main 8.* 9.*"
+        branches: "main 8.* 9.*"
         artifact_paths:
           - "build/TEST-*.html"
           - "build/TEST-*.xml"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR checks the version of macOS we're running on to decide if `-ldflags", "-extldflags='-ld_classic'` should be added when building test binaries.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This flag is not supported on macOS versions < 14 Sonoma.

Follow up to https://github.com/elastic/elastic-agent/pull/10234 as we're seeing [CI failures on macOS 13 unit tests](https://buildkite.com/elastic/elastic-agent/builds/29113#019a0d84-ac44-4961-b4e1-8b2cc00c5498/61-263) like so on `main` after that PR was merged:

```
ld: library not found for -ld_classic
```