### PR TITLE
Set self-monitoring runtime in agent metrics integration test

### DIFF
--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -435,8 +435,12 @@ func TestAgentMetricsInput(t *testing.T) {
 		RuntimeExperimental string
 		Metricsets          []string
 	}
-	configTemplate := `agent.logging.level: info
-agent.logging.to_stderr: true
+	configTemplate := `agent:
+  logging:
+    level: debug
+    to_stderr: true
+  monitoring:
+    _runtime_experimental: {{.RuntimeExperimental}}
 inputs:
   # Collecting system metrics
   - type: system/metrics
@@ -472,7 +476,7 @@ outputs:
 		name                string
 		runtimeExperimental string
 	}{
-		{name: "agent"},
+		{name: "agent", runtimeExperimental: "process"},
 		{name: "otel", runtimeExperimental: "otel"},
 	}
 


### PR DESCRIPTION
## What does this PR do?

Explicitly sets the self-monitoring runtime in the integration test checking if metrics collected using the process and otel runtimes are identical.

## Why is it important?

We have a [bug](https://github.com/elastic/ingest-dev/issues/6295) which causes self-monitoring using the process runtime to fail if one of the inputs uses the otel runtime. Until that's fixed, this PR unblocks CI by making this test pass.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/8486
- Closes https://github.com/elastic/elastic-agent/issues/10713

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
