### PR TITLE
ci(packaging): use pinned versions

### DIFF
--- a/.buildkite/pipeline.elastic-agent-binary-dra.yml
+++ b/.buildkite/pipeline.elastic-agent-binary-dra.yml
@@ -7,6 +7,11 @@ env:
   DRA_PROJECT_ID: "elastic-agent-core"
   DRA_PROJECT_ARTIFACT_ID: "agent-core"
 
+  # The following images are defined here and their values will be updated by updatecli
+  # Please do not change them manually.
+  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-elastic-agent-ubuntu-2404-1760144464"
+  IMAGE_UBUNTU_2404_ARM_64: "platform-ingest-elastic-agent-ubuntu-2404-aarch64-1760144464"
+
 # This section is used to define the plugins that will be used in the pipeline.
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
@@ -29,6 +34,7 @@ steps:
       agents:
         provider: "gcp"
         machineType: "c2-standard-16"
+        image: "${IMAGE_UBUNTU_2404_X86_64}"
       env:
         DRA_WORKFLOW: "snapshot"
         PLATFORMS: "linux/amd64 windows/amd64 darwin/amd64"
@@ -42,6 +48,7 @@ steps:
       agents:
         provider: "gcp"
         machineType: "c2-standard-16"
+        image: "${IMAGE_UBUNTU_2404_X86_64}"
       env:
         DRA_WORKFLOW: "snapshot"
         PLATFORMS: "linux/amd64"
@@ -56,7 +63,7 @@ steps:
       agents:
         provider: "aws"
         instanceType: "c6g.4xlarge"
-        imagePrefix: "core-ubuntu-2204-aarch64"
+        image: "${IMAGE_UBUNTU_2404_ARM_64}"
       env:
         DRA_WORKFLOW: "snapshot"
         PLATFORMS: "linux/arm64 darwin/arm64 windows/arm64"
@@ -70,7 +77,7 @@ steps:
       agents:
         provider: "aws"
         instanceType: "c6g.4xlarge"
-        imagePrefix: "core-ubuntu-2204-aarch64"
+        image: "${IMAGE_UBUNTU_2404_ARM_64}"
       env:
         DRA_WORKFLOW: "snapshot"
         PLATFORMS: "linux/arm64"
@@ -89,6 +96,7 @@ steps:
       agents:
         provider: "gcp"
         machineType: "c2-standard-16"
+        image: "${IMAGE_UBUNTU_2404_X86_64}"
       env:
         DRA_WORKFLOW: "snapshot"
       plugins:
@@ -119,6 +127,7 @@ steps:
       agents:
         provider: "gcp"
         machineType: "c2-standard-16"
+        image: "${IMAGE_UBUNTU_2404_X86_64}"
       env:
         DRA_WORKFLOW: "staging"
         PLATFORMS: "linux/amd64 windows/amd64 darwin/amd64"
@@ -133,6 +142,7 @@ steps:
       agents:
         provider: "gcp"
         machineType: "c2-standard-16"
+        image: "${IMAGE_UBUNTU_2404_X86_64}"
       env:
         DRA_WORKFLOW: "staging"
         PLATFORMS: "linux/amd64"
@@ -148,7 +158,7 @@ steps:
       agents:
         provider: "aws"
         instanceType: "c6g.4xlarge"
-        imagePrefix: "core-ubuntu-2204-aarch64"
+        image: "${IMAGE_UBUNTU_2404_ARM_64}"
       env:
         DRA_WORKFLOW: "dra-core-staging"
         PLATFORMS: "linux/arm64 darwin/arm64 windows/arm64"
@@ -163,7 +173,7 @@ steps:
       agents:
         provider: "aws"
         instanceType: "c6g.4xlarge"
-        imagePrefix: "core-ubuntu-2204-aarch64"
+        image: "${IMAGE_UBUNTU_2404_ARM_64}"
       env:
         DRA_WORKFLOW: "dra-core-staging"
         PLATFORMS: "linux/arm64"
@@ -184,6 +194,7 @@ steps:
       agents:
         provider: "gcp"
         machineType: "c2-standard-16"
+        image: "${IMAGE_UBUNTU_2404_X86_64}"
       env:
         DRA_WORKFLOW: "staging"
       plugins:

--- a/.buildkite/pipeline.elastic-agent-package.yml
+++ b/.buildkite/pipeline.elastic-agent-package.yml
@@ -5,6 +5,11 @@ env:
   # after moving elastic-agent out of beats, we should update the URL of the packaging.
   BEAT_URL: "https://www.elastic.co/elastic-agent"
 
+  # The following images are defined here and their values will be updated by updatecli
+  # Please do not change them manually.
+  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-elastic-agent-ubuntu-2404-1760144464"
+  IMAGE_UBUNTU_2404_ARM_64: "platform-ingest-elastic-agent-ubuntu-2404-aarch64-1760144464"
+
 steps:
   - input: "Build parameters"
     if: build.env("MANIFEST_URL") == null
@@ -59,6 +64,7 @@ steps:
           provider: "gcp"
           machineType: "c2-standard-16"
           diskSizeGb: 400
+          image: "${IMAGE_UBUNTU_2404_X86_64}"
         env:
           PLATFORMS: "linux/amd64 windows/amd64 darwin/amd64"
           FIPS: "{{matrix.fips}}"
@@ -90,7 +96,7 @@ steps:
         agents:
           provider: "aws"
           instanceType: "t4g.2xlarge"
-          imagePrefix: "core-ubuntu-2204-aarch64"
+          image: "${IMAGE_UBUNTU_2404_ARM_64}"
           diskSizeGb: 400
         env:
           PLATFORMS: "linux/arm64 darwin/arm64 windows/arm64"
@@ -126,6 +132,7 @@ steps:
     depends_on: package
     agents:
       provider: "gcp"
+      image: "${IMAGE_UBUNTU_2404_X86_64}"
     env:
       DRA_PROJECT_ID: "elastic-agent-package"
       DRA_PROJECT_ARTIFACT_ID: "agent-package"
@@ -164,6 +171,7 @@ steps:
       provider: "gcp"
       machineType: "n2-standard-8"
       diskSizeGb: 400
+      image: "${IMAGE_UBUNTU_2404_X86_64}"
     env:
       DRA_PROJECT_ID: "elastic-agent-package"
       DRA_PROJECT_ARTIFACT_ID: "agent-package"

--- a/.ci/updatecli/updatecli-bump-vm-images.yml
+++ b/.ci/updatecli/updatecli-bump-vm-images.yml
@@ -87,3 +87,23 @@ targets:
       file: .buildkite/bk.integration-fips.pipeline.yml
       matchpattern: '(IMAGE_.+): "platform-ingest-elastic-agent-(.+)-(.+)"'
       replacepattern: '$1: "platform-ingest-elastic-agent-$2-{{ source "latestVersion" }}"'
+
+  update-buildkite-pipeline.elastic-agent-binary-dra:
+    name: "Update .buildkite/pipeline.elastic-agent-binary-dra.yml"
+    sourceid: latestVersion
+    scmid: githubConfig
+    kind: file
+    spec:
+      file: .buildkite/pipeline.elastic-agent-binary-dra.yml
+      matchpattern: '(IMAGE_.+): "platform-ingest-elastic-agent-(.+)-(.+)"'
+      replacepattern: '$1: "platform-ingest-elastic-agent-$2-{{ source "latestVersion" }}"'
+
+  update-buildkite-pipeline.elastic-agent-package:
+    name: "Update .buildkite/pipeline.elastic-agent-package.yml"
+    sourceid: latestVersion
+    scmid: githubConfig
+    kind: file
+    spec:
+      file: .buildkite/pipeline.elastic-agent-package.yml
+      matchpattern: '(IMAGE_.+): "platform-ingest-elastic-agent-(.+)-(.+)"'
+      replacepattern: '$1: "platform-ingest-elastic-agent-$2-{{ source "latestVersion" }}"'


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Use pinned versions for the packaging pipelines

## Why is it important?

we should rely on the specialised VM images

in addition, there were some quota limits when accessing docker

Our VMs support docker out of the box


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally
`NA`

## CI

- See https://buildkite.com/elastic/elastic-agent-package/builds/8297 worked as expected, just failed with the DRA itself, this pipeline does not support feature branches
 
```
2025-10-23 19:01:59 UTC | Starting a Gradle Daemon, 1 incompatible Daemon could not be reused, use --status for details
-- | --
  | 2025-10-23 19:02:00 UTC |  
  | 2025-10-23 19:02:00 UTC | FAILURE: Build failed with an exception.
  | 2025-10-23 19:02:00 UTC |  
  | 2025-10-23 19:02:00 UTC | * What went wrong:
  | 2025-10-23 19:02:00 UTC | The specified project directory '/release/project-configs/feature/use-pinned-versions-packaging-too' does not exist.
```

Probably something to improve in the future, but not here

- See https://buildkite.com/elastic/elastic-agent-binary-dra/builds/5520


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
