### PR TITLE
[OTel Docs] Indent `batch` config

### DIFF
--- a/docs/reference/edot-collector/config/default-config-standalone.md
+++ b/docs/reference/edot-collector/config/default-config-standalone.md
@@ -116,10 +116,10 @@ otlp/ingest:
     sizer: bytes
     queue_size: 50000000 # 50MB uncompressed
     block_on_overflow: true
-  batch:
-    flush_interval: 1s
-    min_size: 1_000_000 # 1MB uncompressed
-    max_size: 4_000_000 # 4MB uncompressed
+    batch:
+      flush_interval: 1s
+      min_size: 1_000_000 # 1MB uncompressed
+      max_size: 4_000_000 # 4MB uncompressed
 ```
 
 The previous configuration leverages an in-memory queue and optimized batching defaults to improve throughput, minimize data loss, and maintain low end-to-end latency.


### PR DESCRIPTION
This updates the `batch` config to match the nesting in https://github.com/elastic/elastic-agent/pull/10569.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
