### PR TITLE
Always run the otel collector self-monitoring input in the otel runtime

### DIFF
--- a/internal/pkg/agent/application/monitoring/component/testdata/monitoring_config_full_process.yaml
+++ b/internal/pkg/agent/application/monitoring/component/testdata/monitoring_config_full_process.yaml
@@ -865,7 +865,8 @@ inputs:
         target: component
   type: http/metrics
   use_output: monitoring
-- data_stream:
+- _runtime_experimental: otel
+  data_stream:
     namespace: default
   id: metrics-monitoring-collector
   name: metrics-monitoring-collector

--- a/internal/pkg/agent/application/monitoring/component/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/component/v1_monitor.go
@@ -578,6 +578,9 @@ func (b *BeatsMonitor) injectMetricsInput(
 				"namespace": monitoringNamespace,
 			},
 			"streams": []any{prometheusStream},
+			// hardcode this to run in the otel runtime
+			// it won't work in a beat process because we don't set the required environment variable there
+			"_runtime_experimental": monitoringCfg.OtelRuntimeManager,
 		})
 	}
 
@@ -585,7 +588,9 @@ func (b *BeatsMonitor) injectMetricsInput(
 	if b.config.C.RuntimeManager != monitoringCfg.DefaultRuntimeManager {
 		for _, input := range inputs {
 			inputMap := input.(map[string]interface{})
-			inputMap["_runtime_experimental"] = b.config.C.RuntimeManager
+			if _, found := inputMap["_runtime_experimental"]; !found {
+				inputMap["_runtime_experimental"] = b.config.C.RuntimeManager
+			}
 		}
 	}
 


### PR DESCRIPTION
## What does this PR do?

Makes the prometheus metrics input we use to collect otel collector metrics always run inside said otel collector, even if the user configures self-monitoring to run in beats processes.

## Why is it important?

This input can't run in a beats process because it requires an environment variable which we only set for the otel collector. Fixing this properly would require significant additional work, and we're planning to collect these metrics in a much more robust way in 9.3.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
~~- [ ] I have added an integration test or an E2E test~~

## How to test this PR locally

Build the agent locally and run it with self-monitoring in process mode and an input in otel mode. For example:

```yaml
agent:
  logging:
    to_stderr: true
    level: debug
  monitoring:
    _runtime_experimental: process
inputs:
- data_stream:
    namespace: default
  id: unique-system-metrics-input
  streams:
  - data_stream:
      dataset: system.cpu
    metricsets:
    - cpu
  type: system/metrics
  use_output: default
  _runtime_experimental: otel
outputs:
  default:
    username: elastic
    password: xxxxx
    hosts:
    - 127.0.0.1:9200
    type: elasticsearch
```

Then check status. There should be a prometheus/metrics-monitoring component running as a beat receiver:

```json
{
    "id": "prometheus/metrics-monitoring",
    "name": "prometheus/metrics",
    "state": 2,
    "message": "HEALTHY",
    "units": [
        {
            "unit_id": "prometheus/metrics-monitoring",
            "unit_type": 1,
            "state": 2,
            "message": "Healthy"
        },
        {
            "unit_id": "prometheus/metrics-monitoring-metrics-monitoring-collector",
            "unit_type": 0,
            "state": 2,
            "message": "Healthy",
            "payload": {
                "streams": {
                    "metrics-monitoring-collector": {
                        "error": "",
                        "status": "HEALTHY"
                    }
                }
            }
        }
    ],
    "version_info": {
        "name": "beats-receiver",
        "meta": {
            "build_time": "2025-10-24 17:36:57 +0000 UTC",
            "commit": "66155e4093dcf38ab0e446f83f40ca449c73eb10"
        }
    }
}
```

## Related issues

- Closes https://github.com/elastic/ingest-dev/issues/6295

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
