### PR TITLE
Allow different beats versions in integration tests

### DIFF
--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -376,7 +376,7 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 			"agent.ephemeral_id",
 			// agent.id is different because it's the id of the underlying beat
 			"agent.id",
-			// agent.version is different because we force version 9.0.0 in CI
+			// for short periods of time, the beats binary version can be out of sync with the beat receiver version
 			"agent.version",
 			"data_stream.namespace",
 			"elastic_agent.id",
@@ -589,6 +589,9 @@ outputs:
 			"data_stream.namespace",
 			"event.ingested",
 			"event.duration",
+
+			// for short periods of time, the beats binary version can be out of sync with the beat receiver version
+			"agent.version",
 
 			// only in receiver doc
 			"agent.otelcol.component.id",

--- a/testing/integration/ess/otel_test.go
+++ b/testing/integration/ess/otel_test.go
@@ -1634,6 +1634,8 @@ service:
 		"@timestamp",
 		"agent.ephemeral_id",
 		"agent.id",
+
+		// for short periods of time, the beats binary version can be out of sync with the beat receiver version
 		"agent.version",
 
 		// Missing from fbreceiver doc
@@ -1994,7 +1996,7 @@ receivers:
             - cpu
     output:
       otelconsumer:
-    queue.mem.flush.timeout: 0s	  
+    queue.mem.flush.timeout: 0s
 exporters:
   elasticsearch/log:
     endpoints:
@@ -2140,7 +2142,7 @@ receivers:
             - cpu
     output:
       otelconsumer:
-    queue.mem.flush.timeout: 0s	  
+    queue.mem.flush.timeout: 0s
 exporters:
   elasticsearch/log:
     endpoints:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Makes tests which compare data emitted by beats processes and beats receivers to ignore differences in the agent version.

## Why is it important?

These values can be different when the version has been bumped in beats, but the respective commit hasn't been pulled in as a dependency. We shouldn't block CI in that case.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
