### PR TITLE
Skip the Auditd integration test on Debian

### DIFF
--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -40,7 +40,9 @@ func TestAuditdCorrectBinaries(t *testing.T) {
 		Local: false, // requires Agent installation
 		Sudo:  true,  // requires Agent installation
 		OS: []define.OS{
-			{Type: define.Linux},
+			// Skipped on Debian, see https://github.com/elastic/elastic-agent/issues/7813
+			{Type: define.Linux, Distro: "ubuntu"},
+			{Type: define.Linux, Distro: "rhel"},
 		},
 	})
 


### PR DESCRIPTION
## What does this PR do?

Skips the auditd integration test. It appears that the VM update from https://github.com/elastic/elastic-agent/pull/10806 is what causes the test to fail, but the root cause is not yet known.

## Why is it important?

Our CI shouldn't be blocked by what is likely a problem in auditbeat.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Mitigates https://github.com/elastic/elastic-agent/issues/7813


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
