### PR TITLE
fix: pass all necessary env vars so retried fips steps provision ESS

### DIFF
--- a/.buildkite/bk.integration-fips.pipeline.yml
+++ b/.buildkite/bk.integration-fips.pipeline.yml
@@ -52,6 +52,8 @@ steps:
           - packaging-amd64-fips # Reuse artifacts produced in .buildkite/integration.pipeline.yml
         env:
           FIPS: "true"
+          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
+          ESS_REGION: "us-gov-east-1"
           TF_VAR_integration_server_docker_image: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips:git-${BUILDKITE_COMMIT:0:12}"
           TEST_PACKAGE: "github.com/elastic/elastic-agent/testing/integration/ess"
         command: |
@@ -82,6 +84,8 @@ steps:
           - packaging-arm64-fips
         env:
           FIPS: "true"
+          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
+          ESS_REGION: "us-gov-east-1"
           TF_VAR_integration_server_docker_image: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips:git-${BUILDKITE_COMMIT:0:12}"
           TEST_PACKAGE: "github.com/elastic/elastic-agent/testing/integration/ess"
         command: |
@@ -111,6 +115,8 @@ steps:
         if: build.env("BUILDKITE_PULL_REQUEST") != "false" &&  build.env("GITHUB_PR_LABELS") =~ /.*(Testing:run:TestUpgradeIntegrationsServer).*/
         env:
           FIPS: "true"
+          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
+          ESS_REGION: "us-gov-east-1"
           TEST_PACKAGE: "github.com/elastic/elastic-agent/testing/integration/ess"
         command: |
           .buildkite/scripts/buildkite-integration-tests.sh ech-deployment false


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR adds the required environment variables (`EC_ENDPOINT` and `ESS_REGION`) to all FIPS integration test steps in the Buildkite pipeline to ensure proper ESS (Elastic Stack Service) stack provisioning during test retrying.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without these environment variables, retried FIPS integration test steps fail to provision ESS stacks correctly, causing test failures. This issue was discovered when investigating [this failed build](https://buildkite.com/elastic/elastic-agent/builds/29729#019a3981-4f12-4f52-9ebf-c1f22ae2c1de/291-331), where every retried FIPS step failed ESS stack provisioning due to the missing `EC_ENDPOINT` configuration (at least this is my working theory).

Interestingly, retried `fips:x86_64:sudo-false:fleet` CI steps appeared successful, but further investigation revealed they [don't actually run any tests](https://buildkite.com/organizations/elastic/pipelines/elastic-agent/builds/29729/jobs/019a395d-6976-4d01-809a-a2f499573af9/artifacts/019a3979-ac98-472e-ad4f-ab612afd6e60), which masked the underlying issue.

This fix ensures that all FIPS integration tests have the correct environment configuration regardless of whether they are initial runs or retried steps.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

No disruptive user impact. This change only affects the CI pipeline configuration and does not modify any user-facing functionality.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

This change affects the Buildkite CI pipeline configuration.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
N/A