### PR TITLE
move FIPS related env vars inline for FIPS unit tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -67,8 +67,8 @@ steps:
       - label: "Unit tests - fips140=only Ubuntu 22.04"
         key: "unit-tests-2204-fips140-only"
         # Note: The GODEBUG=fips140=only environment variable must be set in the command itself (as opposed to
-        # in the env) so that it is applied *only* to the 'go' command invoked by the script, and
-        # not to any other 'go' code executed as part of Buildkite itself.
+        # in the env block) so that it is applied *only* to the 'go' command invoked by the script, and
+        # not to any other Go code executed as part of the Buildkite agent itself.
         command: 'GODEBUG="fips140=only" .buildkite/scripts/steps/unit-tests.sh'
         env:
           FIPS: "true"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR moves the `GODEBUG=fips140=only` env var in the Buildkite `unit-tests-2204-fips140-only` step from the `env` block to the `command`. 

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

[Buildkite's artifact uploader](https://github.com/buildkite/agent/blame/main/internal/artifact/uploader.go#L360), also written in Go, uses non-FIPS-compliant algorithms, so setting the `GODEBUG=fips140=only` environment variable for the entire `unit-tests-2204-fips140-only` step causes the artifact uploading part of the step to fail like so:

```
buildkite-agent: fatal: failed to upload artifacts: collecting artifacts: building artifact: reading contents of /opt/buildkite-agent/builds/bk-agent-prod-gcp-1761918947504095287/elastic/elastic-agent/build/TEST-go-unit.html: crypto/sha1: use of SHA-1 is not allowed in FIPS 140-only mode
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~
- [ ] ~I have added an integration test or an E2E test~
