### PR TITLE
Fix assertion in otel shutdown test

### DIFF
--- a/testing/integration/ess/otel_test.go
+++ b/testing/integration/ess/otel_test.go
@@ -140,7 +140,9 @@ service:
 
 	// stop the collector and check that it emitted logs indicating a graceful shutdown
 	require.NoError(t, cmd.Process.Signal(os.Interrupt))
-	require.NoError(t, cmd.Wait())
+	if waitErr := cmd.Wait(); waitErr != nil {
+		assert.ErrorContains(t, waitErr, "signal: interrupt")
+	}
 	assert.Contains(t, output.String(), "Shutdown complete")
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes an assertion in an integration test.

## Why is it important?

This makes the test less flaky. There's been some problems with it, see https://buildkite.com/elastic/elastic-agent/builds/29862#019a4b3e-776e-4c68-a2b6-c67253f68fc2 for example.


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
