### PR TITLE
[testing] fix flaky TestClassicAndReceiverAgentMonitoring

### DIFF
--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -245,9 +245,9 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 	err = classicFixture.Configure(ctx, updatedPolicyBytes)
 	require.NoError(t, err, "error configuring fixture")
 
+	timestamp := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	output, err := classicFixture.InstallWithoutEnroll(ctx, &installOpts)
 	require.NoErrorf(t, err, "error install withouth enroll: %s\ncombinedoutput:\n%s", err, string(output))
-	timestamp := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		var statusErr error


### PR DESCRIPTION
## What does this PR do?

If the log has arrived on elasticsearch before we set the timestamp, we would never be able to query it.
This PR updates the initialization order to ensure the timestamp is set first.

Fixes https://github.com/elastic/elastic-agent/issues/11036
