### PR TITLE
Exclude otel components from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
       - dependency-name: "helm.sh/helm/*"
     ignore:
       - dependency-name: "github.com/elastic/beats/*"
+      # Otel dependency updates are done in lock-step with Otel core framework updates
+      - dependency-name: "github.com/elastic/opentelemetry-collector-components/*"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## What does this PR do?

Excludes elastic's otel components from dependabot updates.

## Why is it important?

These should be updated in lock-step with the otel core upgrades for now.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
