### PR TITLE
[fast checkin]: Work around the config limitations

### DIFF
--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -100,7 +100,7 @@ func New(
 	acker acker.Acker,
 	stateStore stateStore,
 	stateFetcher StateFetcher,
-	cfg configuration.FleetCheckin,
+	cfg *configuration.FleetCheckin,
 ) (*FleetGateway, error) {
 	scheduler := scheduler.NewPeriodicJitter(defaultGatewaySettings.Duration, defaultGatewaySettings.Jitter)
 	st := defaultGatewaySettings
@@ -615,8 +615,12 @@ func (s *CheckinStateFetcher) FetchState(ctx context.Context) (coordinator.State
 func (s *CheckinStateFetcher) Done()                                     {}
 func (s *CheckinStateFetcher) StartStateWatch(ctx context.Context) error { return nil }
 
-func getBackoffSettings(cfg configuration.FleetCheckin) *backoffSettings {
+func getBackoffSettings(cfg *configuration.FleetCheckin) *backoffSettings {
 	bo := defaultFleetBackoffSettings
+
+	if cfg == nil {
+		return &defaultFleetBackoffSettings
+	}
 
 	if cfg.RequestBackoffInit > 0 {
 		bo.Init = cfg.RequestBackoffInit

--- a/internal/pkg/agent/application/managed_mode.go
+++ b/internal/pkg/agent/application/managed_mode.go
@@ -175,7 +175,7 @@ func (m *managedConfigManager) Run(ctx context.Context) error {
 	} else {
 		stateFetcher = fleetgateway.NewCheckinStateFetcher(m.coord.State)
 	}
-	m.log.Infof("running managed config manager with checkin mode: %s", m.cfg.Fleet.Checkin.Mode)
+	m.log.Infof("running managed config manager with checkin mode: %s", m.cfg.Fleet.Checkin.GetMode())
 
 	gateway, err := fleetgateway.New(
 		m.log,

--- a/internal/pkg/agent/configuration/fleet.go
+++ b/internal/pkg/agent/configuration/fleet.go
@@ -21,7 +21,7 @@ type FleetAgentConfig struct {
 	Client              remote.Config      `config:",inline" yaml:",inline"`
 	Info                *AgentInfo         `config:"agent" yaml:"agent"`
 	Server              *FleetServerConfig `config:"server" yaml:"server,omitempty"`
-	Checkin             FleetCheckin       `config:"checkin" yaml:"checkin,omitempty"`
+	Checkin             *FleetCheckin      `config:"checkin" yaml:"checkin,omitempty"`
 }
 
 // Valid validates the required fields for accessing the API.
@@ -54,13 +54,7 @@ func DefaultFleetAgentConfig() *FleetAgentConfig {
 		Enabled: false,
 		Client:  remote.DefaultClientConfig(),
 		Info:    &AgentInfo{},
-		Checkin: DefaultFleetCheckin(),
-	}
-}
-
-func DefaultFleetCheckin() FleetCheckin {
-	return FleetCheckin{
-		Mode: fleetCheckinModeStandard,
+		Checkin: nil,
 	}
 }
 
@@ -71,10 +65,22 @@ type FleetCheckin struct {
 }
 
 func (f *FleetCheckin) IsModeOnStateChanged() bool {
-	return f.Mode == fleetCheckinModeOnStateChanged
+	return f != nil && f.Mode == fleetCheckinModeOnStateChanged
+}
+
+func (f *FleetCheckin) GetMode() string {
+	if f == nil || f.Mode == "" {
+		return fleetCheckinModeStandard
+	}
+
+	return f.Mode
 }
 
 func (f *FleetCheckin) Validate() error {
+	if f == nil {
+		return nil
+	}
+
 	if f.Mode != "" && f.Mode != fleetCheckinModeStandard && f.Mode != fleetCheckinModeOnStateChanged {
 		return errors.New("checkin.mode must be either 'standard' or 'on_state_change'")
 	}

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -131,7 +131,7 @@ func TestCommaParsing(t *testing.T) {
 func dumpToYAML(t *testing.T, out string, in interface{}) {
 	b, err := yaml.Marshal(in)
 	require.NoError(t, err)
-	err = os.WriteFile(out, b, 0600)
+	err = os.WriteFile(out, b, 0o600)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
Because of this [bug](https://github.com/elastic/elastic-agent/issues/10729) we are unable to enable the fast checkin in agentless. Here is a workaround that can be backported to 9.2, to overcome the original root cause. 

The already implemented tests cover this change. 

## Why is it important?
Due to the config [bug](https://github.com/elastic/elastic-agent/issues/10729) we cannot enable to fast check-in in agentless through the configuration file. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
