### PR TITLE
Make post-dependabot job update EDOT dependencies

### DIFF
--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -23,10 +23,10 @@ jobs:
           go-version-file: .go-version
 
       - name: set up git user
-        run: |
-          git config --global user.name 'dependabot[bot]'
-          git config --global user.email 'dependabot[bot]@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+        uses: elastic/oblt-actions/git/setup@v1
+        with:
+          username: 'dependabot[bot]'
+          email: 'dependabot[bot]@users.noreply.github.com'
 
       - name: Install mage
         uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b # v3.1.0


### PR DESCRIPTION
## What does this PR do?

Makes dependabot PRs contain changes to the EDOT go.mod.

## Why is it important?

We need to do this, otherwise dependabot PRs can fail CI, complaining about `go mod tidy` not being a noop. See: https://github.com/elastic/elastic-agent/pull/11153.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
