### PR TITLE
Fix go install of junit2html

### DIFF
--- a/.buildkite/scripts/buildkite-integration-tests.ps1
+++ b/.buildkite/scripts/buildkite-integration-tests.ps1
@@ -90,7 +90,7 @@ finally
     if (Test-Path $outputXML)
     {
         # Install junit2html if not installed
-        go install github.com/alexec/junit2html@latest
+        go install github.com/kitproj/junit2html@latest
         Get-Content $outputXML | junit2html > "build/TEST-report.html"
     }
     else

--- a/.buildkite/scripts/buildkite-integration-tests.sh
+++ b/.buildkite/scripts/buildkite-integration-tests.sh
@@ -84,7 +84,7 @@ if [[ $TESTS_EXIT_STATUS -ne 0 ]]; then
 fi
 
 if [ -f "$outputXML" ]; then
-  go install github.com/alexec/junit2html@latest
+  go install github.com/kitproj/junit2html@latest
   junit2html < "$outputXML" > build/TEST-report.html
 else
     echo "Cannot generate HTML test report: $outputXML not found"

--- a/.buildkite/scripts/steps/integration_tests.sh
+++ b/.buildkite/scripts/steps/integration_tests.sh
@@ -17,7 +17,7 @@ set -e
 outputXML="build/TEST-go-integration.xml"
 
 if [ -f "$outputXML" ]; then
-  go install github.com/alexec/junit2html@latest
+  go install github.com/kitproj/junit2html@latest
   junit2html < "$outputXML" > build/TEST-report.html
 else
     echo "Cannot generate HTML test report: $outputXML not found"

--- a/.buildkite/scripts/steps/k8s-extended-tests.sh
+++ b/.buildkite/scripts/steps/k8s-extended-tests.sh
@@ -34,7 +34,7 @@ set -e
 outputXML="build/TEST-go-integration.xml"
 
 if [ -f "$outputXML" ]; then
-  go install github.com/alexec/junit2html@latest
+  go install github.com/kitproj/junit2html@latest
   junit2html < "$outputXML" > build/TEST-report.html
 else
     echo "Cannot generate HTML test report: $outputXML not found"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Updates all the go installs of `github.com/alexec/junit2html@latest` to `github.com/kitproj/junit2html@latest`. The repository now redirects to that new name and go fails to install of it with:

```

go: downloading github.com/alexec/junit2html v1.0.0
go: github.com/alexec/junit2html@latest: version constraints conflict:
      github.com/alexec/junit2html@v1.0.0: parsing go.mod:
      module declares its path as: github.com/kitproj/junit2html
                      but was required as: github.com/alexec/junit2html
```

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Fixes the integration tests.
