### PR TITLE
Skip TestFleetManagedUpgradeRollbackOnRestarts to unblock CI

### DIFF
--- a/testing/integration/ess/upgrade_rollback_test.go
+++ b/testing/integration/ess/upgrade_rollback_test.go
@@ -298,6 +298,8 @@ func TestFleetManagedUpgradeRollbackOnRestarts(t *testing.T) {
 		Stack: &define.Stack{},
 	})
 
+	t.Skip("Skipping due to flakiness, see https://github.com/elastic/elastic-agent/issues/10917")
+
 	type fixturesSetupFunc func(t *testing.T) (from *atesting.Fixture, to *atesting.Fixture)
 	testcases := []struct {
 		name          string


### PR DESCRIPTION
Since we have a fix underway, skipping this test to unblock CI in the meantime, until https://github.com/elastic/elastic-agent/issues/10917 is properly resolved.