### PR TITLE
Ensure we don't report output status in tests where it's irrelevant

### DIFF
--- a/testing/integration/ess/monitoring_probe_preserve_text_cfg_test.go
+++ b/testing/integration/ess/monitoring_probe_preserve_text_cfg_test.go
@@ -33,6 +33,8 @@ outputs:
     api_key: "example-key"
     preset: balanced
     allow_older_versions: true
+    status_reporting:
+      enabled: false
 
 inputs:
   - type: system/metrics

--- a/testing/integration/ess/upgrade_rollback_test.go
+++ b/testing/integration/ess/upgrade_rollback_test.go
@@ -97,6 +97,8 @@ outputs:
   default:
     type: elasticsearch
     hosts: [127.0.0.1:9200]
+    status_reporting:
+      enabled: false
 
 inputs:
   - condition: '${agent.version.version} == "%s"'


### PR DESCRIPTION
## What does this PR do?

In some tests, we use a nonexistent ES host to avoid needing to use a remote. Output health reporting actually works for beats receivers, so this can lead to flakiness due to components reporting a degraded state. Disable the status reporting where it's irrelevant to the test.

## Why is it important?

Tests shouldn't randomly fail because the output correctly reports a degraded status.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Fixes part of https://github.com/elastic/elastic-agent/issues/5437

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
