### PR TITLE
[ci] skip TestStandaloneUpgradeRollback

### DIFF
--- a/testing/integration/ess/upgrade_rollback_test.go
+++ b/testing/integration/ess/upgrade_rollback_test.go
@@ -60,6 +60,8 @@ func TestStandaloneUpgradeRollback(t *testing.T) {
 		Sudo:  true,  // requires Agent installation
 	})
 
+	t.Skip("Skipping due to flakiness, see https://github.com/elastic/elastic-agent/issues/11267")
+
 	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
 	defer cancel()
 


### PR DESCRIPTION
Skipping this test to unblock CI until https://github.com/elastic/elastic-agent/issues/10917 is properly resolved.