### PR TITLE
[ci][dependabot] include `internal/edot/go.mod` in dep bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,9 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/"
+    directories:
+      - "/"
+      - "/internal/edot"
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
Avoid `check-ci` failures when dependabot doesn't update `internal/edot/go.mod` alongside top-level `go.mod`.

Example build failure: https://buildkite.com/elastic/elastic-agent/builds/30598#019a9df3-76dd-4e26-8021-0443bae1c7da