### PR TITLE
[ci] Revert "include internal/edot/go.mod in dep bumps (#11272)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,7 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directories:
-      - "/"
-      - "/internal/edot"
+    directory: "/"
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
This reverts commit 2b2dff737441ba5c931b91ebe91f0b0586767433.

Need to update top-level `go.mod` and `internal/edot/go.mod` in lockstep and not separate PRs. Will approach this with a different solution.