### PR TITLE
Use unique index for TestKubernetesJournaldInputOtel

### DIFF
--- a/testing/integration/k8s/journald_test.go
+++ b/testing/integration/k8s/journald_test.go
@@ -186,8 +186,8 @@ func TestKubernetesJournaldInputOtel(t *testing.T) {
 		info.ESClient,
 		kCtx,
 		steps,
-		fmt.Sprintf("logs-generic.otel-%s", namespace),
-		"body.structured.input.type",
+		namespace,
+		"Body.input.type",
 		"journald")
 }
 

--- a/testing/integration/k8s/testdata/journald-otel.yml
+++ b/testing/integration/k8s/testdata/journald-otel.yml
@@ -24,8 +24,11 @@ processors:
 
 exporters:
   elasticsearch:
+    logs_index: "${EA_POLICY_NAMESPACE}"
     endpoint: "${ES_HOST}"
     api_key: "${ES_API_KEY_ENCODED}"
+    mapping:
+      mode: none
 
 service:
   pipelines:


### PR DESCRIPTION

## What does this PR do?

Use unique index for TestKubernetesJournaldInputOtel

## Why is it important?

Closes https://github.com/elastic/elastic-agent/issues/11220 

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~

~~## Disruptive User Impact~~

## How to test this PR locally


```
# Package DEV=true SNAPSHOT=true EXTERNAL=true DOCKER_VARIANTS="elastic-otel-collector" PACKAGES="docker" PLATFORMS=linux/amd64 mage -v package

# Run the tests
SNAPSHOT=true INSTANCE_PROVISIONER=kind mage -v integration:testKubernetesSingle TestKubernetesJournaldInputOtel
```

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/11220 

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
