### PR TITLE
Set max_shards_per_node to 2000 for the integration test cluster

### DIFF
--- a/test_infra/ess/deployment.tf
+++ b/test_infra/ess/deployment.tf
@@ -113,6 +113,9 @@ resource "ec_deployment" "integration-testing" {
     }
     config = {
       docker_image = local.elasticsearch_docker_image
+      user_settings_json = jsonencode({
+        "cluster.max_shards_per_node" = 2000
+      })
     }
   }
   kibana = {


### PR DESCRIPTION
Our integration tests create a lot of indices due to each test running in its own namespace. Recently, we've been hitting the per-node cluster wide limit of 1000 shards, causing some tests to randomly be flaky - see https://github.com/elastic/elastic-agent/issues/11325 for example.

I've looked into this in https://github.com/elastic/elastic-agent/pull/11329, and it does look like we create almost 500 indicies, each of which gets an inactive replica shard that counts towards the limit. I tried to disable replication at first, but doing so for managed indices turns out to be a huge pain. Instead, I decided to just increase the limit, as the replica shards aren't really doing much anyway.

