### PR TITLE
Switch to SerialDeps in packageAgent.

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -1241,7 +1241,7 @@ func packageAgent(ctx context.Context, platforms devtools.BuildPlatformList, dep
 	// package agent
 	log.Println("--- Running post packaging ")
 	mg.Deps(Update)
-	mg.Deps(agentBinaryTargets...)
+	mg.SerialDeps(agentBinaryTargets...)
 
 	// compile the elastic-agent.exe proxy binary for the windows archive
 	for _, p := range platforms {


### PR DESCRIPTION
Fix issue where building with `OTEL_COMPONENT=true` can cause fail to build in CI because it builds the Elastic Agent and the EDOT collector at the same time.

I already used this commit in the backport to 9.2, because it keep failing without. This just needs to go into main and 8.19 to be consistent. - https://github.com/elastic/elastic-agent/pull/11417/commits/ce0c0c46c7c781814da23f07b4e5d01d2fe23c69

Without it build would fail in 9.2 - https://buildkite.com/elastic/elastic-agent/builds/31033#_

With it build passes - https://buildkite.com/elastic/elastic-agent/builds/31100#019ac10f-31e0-432d-886e-a79d6a50c8d0
