### PR TITLE
mergify: remove duplicated configuration and rebase action

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -41,17 +41,6 @@ pull_request_rules:
     actions:
       queue:
         name: default
-  - name: rebase pull requests for the VM autobump and ESS version pinning
-    conditions:
-      - author=github-actions[bot]
-      - or:
-        - files~=^.buildkite/(pipeline.yml|bk.integration.pipeline.yml)$
-      - head~=^updatecli_.*
-      - "#check-failure>0"
-      - schedule=Mon-Fri 04:00-06:00[Europe/Paris]
-    actions:
-      rebase:
-
   - name: self-assign PRs
     conditions:
       - -merged
@@ -67,13 +56,8 @@ pull_request_rules:
       - label=forwardport-main
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "main"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: ask to resolve conflict
     conditions:
       - -merged
@@ -184,234 +168,144 @@ pull_request_rules:
       - label~=^(backport-v7.17.0|backport-7.17)$
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "7.17"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.2 branch
     conditions:
       - merged
       - label=backport-v8.2.0
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.2"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.3 branch
     conditions:
       - merged
       - label=backport-v8.3.0
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.3"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.4 branch
     conditions:
       - merged
       - label=backport-v8.4.0
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.4"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.5 branch
     conditions:
       - merged
       - label=backport-v8.5.0
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.5"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.6 branch
     conditions:
       - merged
       - label=backport-v8.6.0
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.6"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.7 branch
     conditions:
       - merged
       - label=backport-v8.7.0
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.7"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.8 branch
     conditions:
       - merged
       - label=backport-v8.8.0
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.8"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.9 branch
     conditions:
       - merged
       - label=backport-v8.9.0
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.9"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.10 branch
     conditions:
       - merged
       - label=backport-v8.10.0
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.10"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.11 branch
     conditions:
       - merged
       - label=backport-v8.11.0
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.11"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.12 branch
     conditions:
       - merged
       - label=backport-v8.12.0
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.12"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.13 branch
     conditions:
       - merged
       - label=backport-v8.13.0
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.13"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.14 branch
     conditions:
       - merged
       - label=backport-v8.14.0
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.14"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.15 branch
     conditions:
       - merged
       - label~=^(backport-v8.15.0|backport-8.15)$
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.15"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.16 branch
     conditions:
       - merged
       - label~=^(backport-v8.16.0|backport-8.16)$
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.16"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.17 branch
     conditions:
       - merged
       - label=backport-8.17
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.17"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.18 branch
     conditions:
       - merged
       - label=backport-8.18
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "8.18"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.19 branch
     conditions:
       - merged
@@ -426,13 +320,8 @@ pull_request_rules:
       - label=backport-9.0
     actions:
       backport:
-        assignees:
-          - "{{ author }}"
         branches:
           - "9.0"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 9.1 branch
     conditions:
       - merged


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

* Remove Rebase
* Remove duplicated backport configuration

## Why is it important?

Duplicated configuration is unrequired for the backports; there are top-level default settings now. https://github.com/elastic/elastic-agent/pull/7814 enabled the defaults but never removed duplication

Rebase never worked, but it's misleading with some [errors](https://github.com/elastic/elastic-agent/pull/11458/checks?check_run_id=56528599351) in some other places

<img width="1706" height="420" alt="image" src="https://github.com/user-attachments/assets/6be506ca-2478-4355-aea9-5a82f5f2ab88" />


Rebase requires a GH user called bot:

> To rebase, Mergify needs to impersonate a GitHub user. You can specify the account to use with this option. If no bot_account is set, Mergify picks the pull request author. The user account must have already been logged in Mergify dashboard once.
Warning: Due to security on GitHub side, rebase cannot be performed on pull requests created by bot accounts without explicitly setting the bot_account impersonation option.


since it never worked let's remove this configuration for now - https://github.com/elastic/elastic-agent/pull/8470 is the original implementation

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
