### PR TITLE
[9.1] Skip flaky TestSensitiveLogsESExporter

### DIFF
--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -909,6 +909,9 @@ func TestSensitiveLogsESExporter(t *testing.T) {
 		},
 		Stack: &define.Stack{},
 	})
+
+	t.Skip("Flaky test, see https://github.com/elastic/elastic-agent/issues/11023#issuecomment-3596964850")
+
 	tmpDir := t.TempDir()
 	numEvents := 50
 	// Create the data file to ingest


### PR DESCRIPTION
This test is flaky due to a race condition involving paths in filebeat. The fix for this race condition wasn't backported to 9.1, so this test periodically fails.

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/11023

