### PR TITLE
Add 9.2.1 known issue for host as string in monitoring Elasticsearch output

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -23,16 +23,16 @@ Known issues are significant defects or limitations that may impact your impleme
 % Workaround description.
 % :::
 
-:::{dropdown} Elastic Agent becomes unhealthy when an Elasticsearch output used for monitoring specifies the hosts parameter as a string instead of a list.
+:::{dropdown} Elastic Agent becomes unhealthy when an Elasticsearch output used for monitoring specifies the hosts parameter as a string
 **Applies to: {{agent}} 9.2.1**
 
-On November 12st 2025, a known issue was discovered that causes Elastic Agent to become unhealthy with the error:
+On November 21st 2025, a known issue was discovered that causes Elastic Agent to become unhealthy with the error:
 
 `Otel manager failed: failed to generate otel config: error translating config for output: monitoring, unit: http/metrics-monitoring, error: failed decoding config. decoding failed due to the following error(s): 'hosts' source data must be an array or slice, got string`
 
 This occurs when the `hosts` parameter of an Elasticsearch output that is set as the monitoring output is defined as a string instead of a list:
 
-```yaml
+```yaml callouts=false
 output.elasticsearch:
   hosts: "https://myEShost:9200" # string instead of list
 ```
@@ -41,14 +41,14 @@ For more information, check [#11352](https://github.com/elastic/elastic-agent/is
 
 **Workaround**
 
-Affected users can change the `hosts` configuration from a string to list:
+Affected users can change the `hosts` configuration from a string to a list:
 
-```yaml
+```yaml callouts=false
 output.elasticsearch:
   hosts: ["https://myEShost:9200"] # list/array instead of string
 ```
 
-The fix will be included in version 9.2.2 which will allow both the string and list formats as was previously the case.
+The fix will be included in version 9.2.2, which restores support for both the string and list formats of the `hosts` parameter.
 :::
 
 :::{dropdown} Elastic Agent becomes unhealthy with a host URL parsing error related to the Prometheus collector metricset


### PR DESCRIPTION
Create a known issue for https://github.com/elastic/elastic-agent/issues/11352