### PR TITLE
Fix index template conflict between integration tests

### DIFF
--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -1517,9 +1517,8 @@ func setStrictMapping(client *elasticsearch.Client, index string) error {
 	defer cancel()
 
 	// Build request
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
-		esEndpoint+"/_index_template/no-dynamic-template",
-		bytes.NewReader(jsonData))
+	url := fmt.Sprintf("%s/_index_template/%s", esEndpoint, index)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(jsonData))
 	if err != nil {
 		return fmt.Errorf("could not create http request to ES server: %v", err)
 	}
@@ -1531,8 +1530,15 @@ func setStrictMapping(client *elasticsearch.Client, index string) error {
 	if err != nil {
 		return fmt.Errorf("error performing request: %v", err)
 	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("incorrect response code: %v", err)
+		responseBody, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("unexpected status code: %d, error reading response body: %w", resp.StatusCode, readErr)
+		}
+		return fmt.Errorf("unexpected status code: %d, response body: %s", resp.StatusCode, responseBody)
 	}
 	return nil
 }


### PR DESCRIPTION
We have two integration tests which need to cause Elasticsearch to return mapping conflict errors. To achieve this, they intentionally add an incorrect mapping by creating an index template. However, this index template had the same name in both tests, causing them to be flaky. This PR fixes the problem.

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/11023