### PR TITLE
ci: fix update-otel action

### DIFF
--- a/.ci/updatecli/update-otel.yml
+++ b/.ci/updatecli/update-otel.yml
@@ -19,6 +19,7 @@ sources:
     kind: golang/gomod
     name: Get current OTel Collector core beta version in go.mod
     spec:
+      file: internal/edot/go.mod
       module: go.opentelemetry.io/collector/receiver/otlpreceiver
   latest_core_beta:
     kind: golang/module
@@ -34,6 +35,7 @@ sources:
     kind: golang/gomod
     name: Get current OTel Collector contrib version in go.mod
     spec:
+      file: internal/edot/go.mod
       module: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
   latest_contrib:
     kind: golang/module


### PR DESCRIPTION
This [action](https://github.com/elastic/elastic-agent/actions/workflows/bump-otel-version.yml) has been [broken](https://github.com/elastic/elastic-agent/actions/runs/19221702838) since the EDOT Collector's go.mod file reorg https://github.com/elastic/elastic-agent/pull/10922.