### PR TITLE
docs(otel): document delivery guarantees for OTel mode

### DIFF
--- a/docs/hybrid-agent-beats-receivers.md
+++ b/docs/hybrid-agent-beats-receivers.md
@@ -221,7 +221,7 @@ exporters:
             enabled: true
             initial_interval: 1s
             max_interval: 1m0s
-            max_retries: 5
+            max_retries: 3
 
         sending_queue:
             enabled: true
@@ -261,8 +261,8 @@ To achieve the intended delivery guarantee, the exporter that receives events fr
 - `enabled: true`: The queue must be active.  
 - `wait_for_result: true`: The pipeline must wait for the exporter response before removing events.  
 - `block_on_overflow: true`: Prevents event drops when the queue is full.  
-- A bounded queue with enough capacity and batch configured with explicit limits.
+- The `batch` configuration must include explicit `max_size`, `min_size`, and `flush_timeout` values to ensure events are grouped and flushed in predictable, controlled batches.
 
-Additionally, the `retry` seetings must be enabled on the exporter, with a backoff policy that retries until success.
+Additionally, the retry settings must be enabled on the exporter, using a backoff policy that retries until the operation succeeds. By default, `max_retries` is set to 3, which is how most Beats behave. Standalone Filebeat, however, retries indefinitely. Beats receivers don't support unlimited retries yet, and this is being tracked at https://github.com/elastic/beats/issues/47892.
 
-Beat receivers also require the Beat-internal memory queue to work in synchronous mode, which is achieved by setting `queue.mem.flush.timeout: 0s` in each receiver configuration, as shown in the example above.
+Beat receivers also require the Beat-internal memory queue to run in synchronous mode for delivery guarantees. This is enabled by setting `queue.mem.flush.timeout: 0s` in each receiver configuration, as shown in the example above.


### PR DESCRIPTION
## What does this PR do?

When running in OTel mode, delivery guarantees for Beats receivers are only possible with a specific combination of retry settings, the sending queue, and Beats queue options, so document that.

## Checklist

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Related issues

- Closes https://github.com/elastic/beats/issues/41529.