### PR TITLE
Make CI docker builds less verbose

### DIFF
--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -4,6 +4,9 @@ env:
   VAULT_PATH: "kv/ci-shared/observability-ingest/cloud/gcp"
   ASDF_MAGE_VERSION: 1.14.0
 
+  # Make Docker builds less verbose
+  BUILDKIT_PROGRESS: plain
+
   # The following images are defined here and their values will be updated by updatecli
   # Please do not change them manually.
   IMAGE_UBUNTU_2204_X86_64: "platform-ingest-elastic-agent-ubuntu-2204-1762801856"


### PR DESCRIPTION
We produce 100Mb+ of logs for each container build currently, because buildkit believes it's running in an interactive tty. Switch the progress reporting mode to plain to avoid doing this.

Before: https://buildkite.com/elastic/elastic-agent-extended-testing/builds/11459/steps/waterfall?jid=019ae3a1-e6c3-4a3f-8f66-d89542fe58a6
After: https://buildkite.com/elastic/elastic-agent/builds/31378/steps/canvas?sid=019ae50b-6bba-411c-83b1-039441341104

