### PR TITLE
Revert "[8.19][Automation] Bump VM Image version to 1764775167"

### DIFF
--- a/.buildkite/bk.integration-fips.pipeline.yml
+++ b/.buildkite/bk.integration-fips.pipeline.yml
@@ -4,9 +4,9 @@ env:
   ASDF_MAGE_VERSION: 1.14.0
   MS_GOTOOLCHAIN_TELEMETRY_ENABLED: "0"
 
-  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-elastic-agent-ubuntu-2404-1764775167"
-  IMAGE_UBUNTU_X86_64_FIPS: "platform-ingest-elastic-agent-ubuntu-2204-fips-1764775167"
-  IMAGE_UBUNTU_ARM64_FIPS: "platform-ingest-elastic-agent-ubuntu-2204-fips-aarch64-1764775167"
+  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-elastic-agent-ubuntu-2404-1762801856"
+  IMAGE_UBUNTU_X86_64_FIPS: "platform-ingest-elastic-agent-ubuntu-2204-fips-1762801856"
+  IMAGE_UBUNTU_ARM64_FIPS: "platform-ingest-elastic-agent-ubuntu-2204-fips-aarch64-1762801856"
   ASDF_TERRAFORM_VERSION: 1.9.2
 
 # This section is used to define the plugins that will be used in the pipeline.

--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -6,14 +6,14 @@ env:
 
   # The following images are defined here and their values will be updated by updatecli
   # Please do not change them manually.
-  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-elastic-agent-ubuntu-2404-1764775167"
-  IMAGE_UBUNTU_2404_ARM_64: "platform-ingest-elastic-agent-ubuntu-2404-aarch64-1764775167"
-  IMAGE_RHEL_8: "platform-ingest-elastic-agent-rhel-8-1764775167"
-  IMAGE_RHEL_10: "platform-ingest-elastic-agent-rhel-10-1764775167"
-  IMAGE_DEBIAN_11: "platform-ingest-elastic-agent-debian-11-1764775167"
-  IMAGE_DEBIAN_13: "platform-ingest-elastic-agent-debian-13-1764775167"
-  IMAGE_WIN_2022: "platform-ingest-elastic-agent-windows-2022-1764775167"
-  IMAGE_WIN_2025: "platform-ingest-elastic-agent-windows-2025-1764775167"
+  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-elastic-agent-ubuntu-2404-1762801856"
+  IMAGE_UBUNTU_2404_ARM_64: "platform-ingest-elastic-agent-ubuntu-2404-aarch64-1762801856"
+  IMAGE_RHEL_8: "platform-ingest-elastic-agent-rhel-8-1762801856"
+  IMAGE_RHEL_10: "platform-ingest-elastic-agent-rhel-10-1762801856"
+  IMAGE_DEBIAN_11: "platform-ingest-elastic-agent-debian-11-1762801856"
+  IMAGE_DEBIAN_13: "platform-ingest-elastic-agent-debian-13-1762801856"
+  IMAGE_WIN_2022: "platform-ingest-elastic-agent-windows-2022-1762801856"
+  IMAGE_WIN_2025: "platform-ingest-elastic-agent-windows-2025-1762801856"
   ASDF_TERRAFORM_VERSION: 1.9.2
 
 # This section is used to define the plugins that will be used in the pipeline.

--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -6,8 +6,8 @@ env:
 
   # The following images are defined here and their values will be updated by updatecli
   # Please do not change them manually.
-  IMAGE_UBUNTU_2204_X86_64: "platform-ingest-elastic-agent-ubuntu-2204-1764775167"
-  IMAGE_UBUNTU_2204_ARM_64: "platform-ingest-elastic-agent-ubuntu-2204-aarch64-1764775167"
+  IMAGE_UBUNTU_2204_X86_64: "platform-ingest-elastic-agent-ubuntu-2204-1762801856"
+  IMAGE_UBUNTU_2204_ARM_64: "platform-ingest-elastic-agent-ubuntu-2204-aarch64-1762801856"
 
 common:
   - vault_docker_login: &vault_docker_login

--- a/.buildkite/pipeline.elastic-agent-binary-dra.yml
+++ b/.buildkite/pipeline.elastic-agent-binary-dra.yml
@@ -9,8 +9,8 @@ env:
 
   # The following images are defined here and their values will be updated by updatecli
   # Please do not change them manually.
-  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-elastic-agent-ubuntu-2404-1764775167"
-  IMAGE_UBUNTU_2404_ARM_64: "platform-ingest-elastic-agent-ubuntu-2404-aarch64-1764775167"
+  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-elastic-agent-ubuntu-2404-1762801856"
+  IMAGE_UBUNTU_2404_ARM_64: "platform-ingest-elastic-agent-ubuntu-2404-aarch64-1762801856"
 
 # This section is used to define the plugins that will be used in the pipeline.
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins

--- a/.buildkite/pipeline.elastic-agent-package.yml
+++ b/.buildkite/pipeline.elastic-agent-package.yml
@@ -7,8 +7,8 @@ env:
 
   # The following images are defined here and their values will be updated by updatecli
   # Please do not change them manually.
-  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-elastic-agent-ubuntu-2404-1764775167"
-  IMAGE_UBUNTU_2404_ARM_64: "platform-ingest-elastic-agent-ubuntu-2404-aarch64-1764775167"
+  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-elastic-agent-ubuntu-2404-1762801856"
+  IMAGE_UBUNTU_2404_ARM_64: "platform-ingest-elastic-agent-ubuntu-2404-aarch64-1762801856"
 
 steps:
   - input: "Build parameters"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,12 +5,12 @@ env:
 
   # The following images are defined here and their values will be updated by updatecli
   # Please do not change them manually.
-  IMAGE_UBUNTU_2204_X86_64: "platform-ingest-elastic-agent-ubuntu-2204-1764775167"
-  IMAGE_UBUNTU_2204_ARM_64: "platform-ingest-elastic-agent-ubuntu-2204-aarch64-1764775167"
-  IMAGE_WIN_2016: "platform-ingest-elastic-agent-windows-2016-1764775167"
-  IMAGE_WIN_2022: "platform-ingest-elastic-agent-windows-2022-1764775167"
-  IMAGE_WIN_10: "platform-ingest-elastic-agent-windows-10-1764775167"
-  IMAGE_WIN_11: "platform-ingest-elastic-agent-windows-11-1764775167"
+  IMAGE_UBUNTU_2204_X86_64: "platform-ingest-elastic-agent-ubuntu-2204-1762801856"
+  IMAGE_UBUNTU_2204_ARM_64: "platform-ingest-elastic-agent-ubuntu-2204-aarch64-1762801856"
+  IMAGE_WIN_2016: "platform-ingest-elastic-agent-windows-2016-1762801856"
+  IMAGE_WIN_2022: "platform-ingest-elastic-agent-windows-2022-1762801856"
+  IMAGE_WIN_10: "platform-ingest-elastic-agent-windows-10-1762801856"
+  IMAGE_WIN_11: "platform-ingest-elastic-agent-windows-11-1762801856"
 
 steps:
   - label: "check-ci"


### PR DESCRIPTION
Reverts elastic/elastic-agent#11573

Relates https://github.com/elastic/elastic-agent/issues/11604