### PR TITLE
Add default option to allow merging multiple agent config keys

### DIFF
--- a/changelog/fragments/1764873750-Merge-multiple-agent-keys-when-loading-config.yaml
+++ b/changelog/fragments/1764873750-Merge-multiple-agent-keys-when-loading-config.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Merge multiple agent keys when loading config
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/3717

--- a/internal/pkg/agent/cmd/testdata/run/singlelogging.yaml
+++ b/internal/pkg/agent/cmd/testdata/run/singlelogging.yaml
@@ -1,0 +1,5 @@
+agent:
+  logging:
+    level: debug
+    to_files: true
+    to_stderr: false

--- a/internal/pkg/agent/cmd/testdata/run/splitlogging.yaml
+++ b/internal/pkg/agent/cmd/testdata/run/splitlogging.yaml
@@ -1,0 +1,5 @@
+agent.logging.level: debug
+agent.logging.to_files: true
+agent:
+  logging:
+    to_stderr: false

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -56,6 +56,7 @@ var DefaultOptions = []interface{}{
 	ucfg.IgnoreCommas,
 	ucfg.ResolveEnv,
 	ucfg.VarExp,
+	ucfg.FieldMergeValues("agent"),
 	VarSkipKeys("inputs", "outputs"),
 	OTelKeys("connectors", "receivers", "processors", "exporters", "extensions", "service"),
 }


### PR DESCRIPTION
## What does this PR do?

Merge multiple `agent.*` keys when handling config.

## Why is it important?

Multiple keys were getting silently ignored, leading to configs that contain:
```yaml
agent.logging.level: error
agent.logging.to_files: true
```

not working as expected.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

Standalone agent configs will no longer silently ignore multiple `agent.*` attributes.

## How to test this PR locally

Create a stand-alone config with multiple `agent.*` entries such as:

```
agent.logging.level: debug
agent.logging.to_stderr: true
agent:
  download:
    sourceURI: https://artifacts.elastic.co/downloads/
  monitoring:
    enabled: true
    use_output: default
    logs: false
    metrics: false
    traces: true
    namespace: default
```

and observe that the logging entries are configured correctly.

## Related issues

- Closes #3717