### PR TITLE
Generalize existing known issue on using strings for list parameters making agent unhealthy

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -40,7 +40,6 @@ output.elasticsearch:
   ssl.certificate_authorities: "/tmp/ca.pem" # string instead of list
 ```
 
-For more information, check [#11352](https://github.com/elastic/elastic-agent/issues/11352).
 
 **Workaround**
 


### PR DESCRIPTION
We have discovered this is a more general issue affecting any list parameter, and not isolated to just the `hosts` parameter.

Rather than a known issue per parameter I have generalized the existing known issue.