### PR TITLE
ci: fix commit env var for image verification

### DIFF
--- a/.buildkite/pipeline.agentless-app-release.yaml
+++ b/.buildkite/pipeline.agentless-app-release.yaml
@@ -57,6 +57,8 @@ steps:
 
   - label: ":docker: Validate docker image is built for all architectures"
     command: ".buildkite/scripts/steps/validate-agentless-docker-image.sh"
+    env:
+      SERVICE_VERSION: "${VERSION}"
     agents:
       image: "docker.elastic.co/ci-agent-images/observability/oci-image-tools-agent:latest@sha256:a4ababd1347111759babc05c9ad5a680f4af48892784951358488b7e7fc94af9"
     plugins:


### PR DESCRIPTION
This PR fixes the image validation step after the image creation.

`SERVICE_VERSION` env var is not present in this pipeline as it is in the other pipeline where this script is executed.

agentless-tests pipeline:
```
SERVICE="agentless"
SERVICE_VERSION="24d365bcaf73"
```

release:
```
VERSION="538ccd087506"
```

