### PR TITLE
Disable scheduled otel dependency updates

### DIFF
--- a/.github/workflows/bump-otel-version.yml
+++ b/.github/workflows/bump-otel-version.yml
@@ -2,8 +2,9 @@ name: bump-otel-version
 
 on:
   workflow_dispatch:
-  schedule:
-  - cron: '24 5 * * 1-5'
+  # Disabled because we do the updates manually, due to upstream dependencies like beats and elastic components
+  #schedule:
+  #- cron: '24 5 * * 1-5'
 
 permissions:
   contents: read


### PR DESCRIPTION
We currently orchestrate these updates manually, as they need to be done in a specific order between multiple repositories.