### PR TITLE
ci: remove non-existent unused env var

### DIFF
--- a/.buildkite/scripts/steps/validate-agentless-docker-image.sh
+++ b/.buildkite/scripts/steps/validate-agentless-docker-image.sh
@@ -24,14 +24,13 @@ _SELF=$(dirname "$0")
 source "${_SELF}/../common.sh"
 
 if [ -z "$SERVICE_VERSION" ]; then
-    echo "No SHA found for environment: $ENVIRONMENT"
+    echo "SERVICE_VERSION environment variable is not set"
     exit 1
 fi
 
 DOCKER_TAG="git-${SERVICE_VERSION}"
 PRIVATE_IMAGE="${PRIVATE_REPO}:${DOCKER_TAG}"
 
-echo "Environment: ${ENVIRONMENT}"
 echo "Commit SHA: ${SERVICE_VERSION}"
 echo "Validating image: ${PRIVATE_IMAGE}"
 


### PR DESCRIPTION
This PR fixes the validation of the Image for agentless. The environment variable `$ENVIRONMENT` is not present just after the image creation. It can be removed as it was not actually used.