### PR TITLE
set path.home for beat receivers to be components dir

### DIFF
--- a/changelog/fragments/1765388410-set-path.home-for-beat-receivers.yaml
+++ b/changelog/fragments/1765388410-set-path.home-for-beat-receivers.yaml
@@ -1,0 +1,47 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: set path.home for beat receivers to components directory
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/elastic-agent/pull/11726
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234
+issue: https://github.com/elastic/beats/issues/48010

--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -299,6 +299,7 @@ func getReceiversConfigForComponent(
 	receiverConfig := map[string]any{
 		// just like we do for beats processes, each receiver needs its own data path
 		"path": map[string]any{
+			"home": paths.Components(),
 			"data": BeatDataPath(comp.ID),
 		},
 		// adds additional context on logs emitted by beatreceivers to uniquely identify per component logs
@@ -641,7 +642,6 @@ func BeatDataPath(componentId string) string {
 // getBeatsAuthExtensionConfig sets http transport settings on beatsauth
 // currently this is only supported for elasticsearch output
 func getBeatsAuthExtensionConfig(outputCfg *config.C) (map[string]any, error) {
-
 	authSettings := beatsauthextension.BeatsAuthConfig{
 		Transport: elasticsearch.ESDefaultTransportSettings(),
 	}

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -408,6 +408,7 @@ func TestGetOtelConfig(t *testing.T) {
 				},
 			},
 			"path": map[string]any{
+				"home": paths.Components(),
 				"data": filepath.Join(paths.Run(), id),
 			},
 			"queue": map[string]any{
@@ -741,6 +742,7 @@ func TestGetOtelConfig(t *testing.T) {
 							},
 						},
 						"path": map[string]any{
+							"home": paths.Components(),
 							"data": filepath.Join(paths.Run(), "beat-metrics-monitoring"),
 						},
 						"queue": map[string]any{
@@ -849,6 +851,7 @@ func TestGetOtelConfig(t *testing.T) {
 							},
 						},
 						"path": map[string]any{
+							"home": paths.Components(),
 							"data": filepath.Join(paths.Run(), "system-metrics"),
 						},
 						"queue": map[string]any{


### PR DESCRIPTION
## What does this PR do?

sets `path.home` for beat receivers to be the components dir.  

## Why is it important?

This is necessary so metricbeat receiver gets the correct directory to
find light modules

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

### Unit test

```
cd internal/pkg/otel/translate
go test .
```

### By hand
1. build agent
2. enroll with policy that has activemq metrics
3. override so all metrics are collected with metricbeat receiver
```
PUT kbn:/api/fleet/agent_policies/<policy_id>
{
    "name": "test",
    "namespace": "default",
    "overrides": {
        "agent": {
            "internal": {
                "runtime": {
                    "metricbeat": {
                        "default": "otel"
                    }
                }
            }
        }
    }
}
4. verify activemq metrics starts

```

## Related issues

- Closes elastic/beats#48010

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
