### PR TITLE
Move available rollbacks under upgrade.rollbacks in checkin request

### DIFF
--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -430,15 +430,17 @@ func (f *FleetGateway) execute(ctx context.Context) (*fleetapi.CheckinResponse, 
 	// checkin
 	cmd := fleetapi.NewCheckinCmd(f.agentInfo, f.client)
 	req := &fleetapi.CheckinRequest{
-		AckToken:           ackToken,
-		Metadata:           ecsMeta,
-		Status:             agentStateToString(state.State),
-		Message:            state.Message,
-		Components:         components,
-		UpgradeDetails:     state.UpgradeDetails,
-		AgentPolicyID:      agentPolicyID,
-		PolicyRevisionIDX:  policyRevisionIDX,
-		AvailableRollbacks: validRollbacks,
+		AckToken:          ackToken,
+		Metadata:          ecsMeta,
+		Status:            agentStateToString(state.State),
+		Message:           state.Message,
+		Components:        components,
+		UpgradeDetails:    state.UpgradeDetails,
+		AgentPolicyID:     agentPolicyID,
+		PolicyRevisionIDX: policyRevisionIDX,
+	}
+	if len(validRollbacks) > 0 {
+		req.Upgrade.Rollbacks = validRollbacks
 	}
 
 	resp, took, err := cmd.Execute(stateCtx, req)

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -1155,17 +1155,17 @@ func TestAvailableRollbacks(t *testing.T) {
 					unmarshaled := map[string]json.RawMessage{}
 					err := json.NewDecoder(body).Decode(&unmarshaled)
 					assert.NoError(t, err, "error decoding checkin body")
-					if assert.Contains(t, unmarshaled, "available_rollbacks") {
+					if assert.Contains(t, unmarshaled, "upgrade") {
 						// verify that we got the correct data
-						var actual []fleetapi.CheckinRollback
-						err = json.Unmarshal(unmarshaled["available_rollbacks"], &actual)
-						require.NoError(t, err, "error decoding available rollbacks from checkin body")
+						var actualUpgrade fleetapi.CheckinUpgrade
+						err = json.Unmarshal(unmarshaled["upgrade"], &actualUpgrade)
+						require.NoError(t, err, "error decoding upgrade info from checkin body")
 
 						expected := []fleetapi.CheckinRollback{{
 							Version:    "1.2.3",
 							ValidUntil: validUntil,
 						}}
-						assert.Equal(t, expected, actual)
+						assert.Equal(t, expected, actualUpgrade.Rollbacks)
 					}
 
 					return &http.Response{

--- a/internal/pkg/fleetapi/checkin_cmd.go
+++ b/internal/pkg/fleetapi/checkin_cmd.go
@@ -44,17 +44,21 @@ type CheckinRollback struct {
 	ValidUntil time.Time `json:"valid_until"`
 }
 
+type CheckinUpgrade struct {
+	Rollbacks []CheckinRollback `json:"rollbacks,omitempty"`
+}
+
 // CheckinRequest consists of multiple events reported to fleet ui.
 type CheckinRequest struct {
-	Status             string             `json:"status"`
-	AckToken           string             `json:"ack_token,omitempty"`
-	Metadata           *info.ECSMeta      `json:"local_metadata,omitempty"`
-	Message            string             `json:"message"`    // V2 Agent message
-	Components         []CheckinComponent `json:"components"` // V2 Agent components
-	UpgradeDetails     *details.Details   `json:"upgrade_details,omitempty"`
-	AgentPolicyID      string             `json:"agent_policy_id,omitempty"`
-	PolicyRevisionIDX  int64              `json:"policy_revision_idx,omitempty"`
-	AvailableRollbacks []CheckinRollback  `json:"available_rollbacks,omitempty"`
+	Status            string             `json:"status"`
+	AckToken          string             `json:"ack_token,omitempty"`
+	Metadata          *info.ECSMeta      `json:"local_metadata,omitempty"`
+	Message           string             `json:"message"`    // V2 Agent message
+	Components        []CheckinComponent `json:"components"` // V2 Agent components
+	UpgradeDetails    *details.Details   `json:"upgrade_details,omitempty"`
+	AgentPolicyID     string             `json:"agent_policy_id,omitempty"`
+	PolicyRevisionIDX int64              `json:"policy_revision_idx,omitempty"`
+	Upgrade           CheckinUpgrade     `json:"upgrade,omitempty"`
 }
 
 // SerializableEvent is a representation of the event to be send to the Fleet Server API via the checkin


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This is a follow-up to PR https://github.com/elastic/elastic-agent/pull/11143 moving available rollbacks information under `upgrade.rollbacks` in the elastic-agent checkin request body.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
To align the structure with the Elasticsearch structure implemented in https://github.com/elastic/fleet-server/pull/5975
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
