### PR TITLE
Trigger agent packaging test for PRs if dev tools were modified

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -360,6 +360,8 @@ steps:
         - .buildkite/pipeline.elastic-agent-package.yml
         - .buildkite/scripts/steps/package.sh
         - .buildkite/scripts/steps/trigger-elastic-agent-package.sh
+        - magefile.go
+        - dev-tools/**/*
 
   # NOTE: This should help detecting issues earlier in the development cycle
   # See https://github.com/elastic/elastic-agent/pull/11725


### PR DESCRIPTION
The magefile and dev tools are involved in the DRA packaging step as well, so any changes to them should trigger the dry run. This bit us in https://github.com/elastic/elastic-agent/pull/11450, which broke the packaging in a subtle way.