### PR TITLE
skip TestKubernetesAgentHelmRotatedLogs

### DIFF
--- a/testing/integration/k8s/agent_helm_test.go
+++ b/testing/integration/k8s/agent_helm_test.go
@@ -32,6 +32,7 @@ func TestKubernetesAgentHelmRotatedLogs(t *testing.T) {
 		},
 		Group: define.Kubernetes,
 	})
+	t.Skip("skipping until https://github.com/elastic/beats/pull/47893 and https://github.com/elastic/elastic-agent/pull/11783 are merged and make to the SNAPSHOT build")
 
 	containerRegex, err := regexp.Compile(`^/var/log/containers/.*flog.*\.log$`)
 	require.NoError(t, err, "failed to compile container log regex")


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
skip TestKubernetesAgentHelmRotatedLogs

TestKubernetesAgentHelmRotatedLogs needs to be skipped until https://github.com/elastic/beats/pull/47893 and
https://github.com/elastic/elastic-agent/pull/11783 are both merged make to the SNAPSHOT build.


## Why is it important?

beats#47893 introduced a new config for ingesting GZIP-compressed logs. elastic-agent#11783 updates the helm chart to use the new configuration. Therefore, TestKubernetesAgentHelmRotatedLogs will fail while beats#47893 is merged and elastic-agent#11783 isn't yet.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

None

## How to test this PR locally

Run the test TestKubernetesAgentHelmRotatedLogs and observe it's skipped.

## Related issues

- Relates https://github.com/elastic/beats/pull/47893
- Relates #11783

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
