### PR TITLE
Skip flaky test TestFleetDownloadProxyURL

### DIFF
--- a/testing/integration/ess/proxy_url_test.go
+++ b/testing/integration/ess/proxy_url_test.go
@@ -823,6 +823,9 @@ func TestFleetDownloadProxyURL(t *testing.T) {
 		Local: false,
 		Sudo:  true,
 	})
+
+	t.Skip("Flaky test, see https://github.com/elastic/elastic-agent/issues/11796#issuecomment-3667342065")
+
 	ctx := t.Context()
 	kibClient := info.KibanaClient
 	fleetServerURL, err := fleettools.DefaultURL(ctx, kibClient)


### PR DESCRIPTION
Temporary skip `TestFleetDownloadProxyURL` test until resolved. See discussion in https://github.com/elastic/elastic-agent/issues/11796.