### PR TITLE
Fix Windows archive root path in the package spec

### DIFF
--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -855,7 +855,7 @@ specs:
         <<: *elastic_license_for_binaries
         files:
           '{{.BeatName}}{{.BinaryExt}}':
-            source: ./build/windows-{{.Platform.Arch}}-archive-root-binary/elastic-agent-archive-root.exe
+            source: '{{ repo.RootDir }}/build/core/extracted/{{.GOOS}}-{{.Platform.Arch}}/elastic-agent-archive-root.exe'
           'package.version':
             content: >
               {{ agent_package_version }}


### PR DESCRIPTION
https://github.com/elastic/elastic-agent/pull/11924 missed this while making changes to the package spec.