### PR TITLE
Use beat receiver subcomponent status for status translation - with patched upstream

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,6 +61,8 @@ linters:
         - github.com/meraki/dashboard-api-go/v3
         - go.opentelemetry.io/otel/exporters/prometheus
         - github.com/elastic/elastic-agent/internal/edot
+        - github.com/open-telemetry/opentelemetry-collector-contrib/internal/healthcheck
+        - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status
       replace-local: true
     gomodguard:
       blocked:

--- a/go.mod
+++ b/go.mod
@@ -350,4 +350,9 @@ replace (
 // Needed to prevent https://github.com/open-telemetry/opentelemetry-go/issues/7039
 replace go.opentelemetry.io/otel/exporters/prometheus => go.opentelemetry.io/otel/exporters/prometheus v0.58.0
 
+replace (
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/healthcheck => github.com/swiatekm/opentelemetry-collector-contrib/internal/healthcheck v0.0.0-20251215151250-0b5f133ca522
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status => github.com/swiatekm/opentelemetry-collector-contrib/pkg/status v0.0.0-20251215151250-0b5f133ca522
+)
+
 tool golang.org/x/tools/cmd/deadcode

--- a/go.sum
+++ b/go.sum
@@ -440,8 +440,6 @@ github.com/onsi/ginkgo/v2 v2.22.0 h1:Yed107/8DjTr0lKCNt7Dn8yQ6ybuDRQoMGrNFKzMfHg
 github.com/onsi/ginkgo/v2 v2.22.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=
 github.com/onsi/gomega v1.36.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status v0.141.0 h1:bsAO48ojRBMA0dk/RR7LIurkoYZfKTFxnrCQofiFNbI=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status v0.141.0/go.mod h1:eVHnGSqQGxwjlF9svzO1LRRgmMWKLWVKXSCHKRzHfRM=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
@@ -536,6 +534,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/swiatekm/opentelemetry-collector-contrib/pkg/status v0.0.0-20251215151250-0b5f133ca522 h1:m5Zq4qBlseHTI65Yus6V23OEo7PFd9Ngg9f0TEMLFuY=
+github.com/swiatekm/opentelemetry-collector-contrib/pkg/status v0.0.0-20251215151250-0b5f133ca522/go.mod h1:umNY2+bbiGqUGKdsRMvxRT2e+jJE37EP/C5g/WAKsb8=
 github.com/tklauser/go-sysconf v0.3.15 h1:VE89k0criAymJ/Os65CSn1IXaol+1wrsFHEB8Ol49K4=
 github.com/tklauser/go-sysconf v0.3.15/go.mod h1:Dmjwr6tYFIseJw7a3dRLJfsHAMXZ3nEnL/aZY+0IuI4=
 github.com/tklauser/numcpus v0.10.0 h1:18njr6LDBk1zuna922MgdjQuJFjrdppsZG60sHGfjso=

--- a/internal/edot/go.mod
+++ b/internal/edot/go.mod
@@ -740,4 +740,6 @@ replace (
 	github.com/google/gopacket => github.com/elastic/gopacket v1.1.20-0.20241002174017-e8c5fda595e6
 	github.com/insomniacslk/dhcp => github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3 // indirect
 	github.com/meraki/dashboard-api-go/v3 => github.com/tommyers-elastic/dashboard-api-go/v3 v3.0.0-20250616163611-a325b49669a4
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/healthcheck => github.com/swiatekm/opentelemetry-collector-contrib/internal/healthcheck v0.0.0-20251215151250-0b5f133ca522
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status => github.com/swiatekm/opentelemetry-collector-contrib/pkg/status v0.0.0-20251215151250-0b5f133ca522
 )

--- a/internal/edot/go.sum
+++ b/internal/edot/go.sum
@@ -1134,8 +1134,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.141
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.141.0/go.mod h1:QTceC+e3mAclBVDvBUuWvOvzRcIBikDr7jPJ4d/OgHs=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/gopsutilenv v0.141.0 h1:oogTgVI6xpteIjklDRV4qhKu8uhgrBCpdLq+SLgDavw=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/gopsutilenv v0.141.0/go.mod h1:zqz+PDW3woK1SJGzkozF6/158Du5p0VlxGlGHe677QA=
-github.com/open-telemetry/opentelemetry-collector-contrib/internal/healthcheck v0.141.0 h1:Ib8U2EOQq54eRDf33sAK8e2M7aA5UVWfnC5DSEdebk8=
-github.com/open-telemetry/opentelemetry-collector-contrib/internal/healthcheck v0.141.0/go.mod h1:SSQbMNwi8G+rrCMAQxan7lk6nyqLRZ4F7+9sIDXxyDc=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.141.0 h1:23XwDn4lYAIGTKuL5Ex94+KpdLodUdf1sXB02ZUrCQE=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.141.0/go.mod h1:MNTSHMl1wybxq7SMUy/Ew7JYr2cf70+JVCySwA2zBRI=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka v0.141.0 h1:sYXJ024Y/JNUJ6K5LMF/cAYgW580RicjwYvVIJJteFs=
@@ -1174,8 +1172,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.141.0 
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.141.0/go.mod h1:3S0jKFJOdukRxfVUdtR+ymXqB7Rr8kjXLkWK7ESOKqE=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.141.0 h1:VX10o0qIXQiUTkvHtGrpdr6UWJ9yNjgSkL/cVLmdTFY=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.141.0/go.mod h1:KBnG3v77MKoruqf+/o97jyKmZTjKXOb/HIQjVTiaQIc=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status v0.141.0 h1:bsAO48ojRBMA0dk/RR7LIurkoYZfKTFxnrCQofiFNbI=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status v0.141.0/go.mod h1:eVHnGSqQGxwjlF9svzO1LRRgmMWKLWVKXSCHKRzHfRM=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azure v0.141.0 h1:s87GaaCxBAUZRNsuzEc1ytgZENlmO0tCHllRmOqwMgk=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azure v0.141.0/go.mod h1:yz4PL34ed39URi4DBUtvoBAtOZHWI95eMuxW+0/bRIk=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.141.0 h1:G7LQ0plv/NYpPu0Cvym+nwtuiNP6F2vljZEMeUbs6Kk=
@@ -1428,6 +1424,10 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/swiatekm/opentelemetry-collector-contrib/internal/healthcheck v0.0.0-20251215151250-0b5f133ca522 h1:IoVj2Y8BqXetRzhlEqqrtiMMQTpNkMg+dtR1/ieXnoc=
+github.com/swiatekm/opentelemetry-collector-contrib/internal/healthcheck v0.0.0-20251215151250-0b5f133ca522/go.mod h1:tF9H8+S/AmPwrkXpa8Qr3QmUDisnukldx3VYisUMWF8=
+github.com/swiatekm/opentelemetry-collector-contrib/pkg/status v0.0.0-20251215151250-0b5f133ca522 h1:m5Zq4qBlseHTI65Yus6V23OEo7PFd9Ngg9f0TEMLFuY=
+github.com/swiatekm/opentelemetry-collector-contrib/pkg/status v0.0.0-20251215151250-0b5f133ca522/go.mod h1:umNY2+bbiGqUGKdsRMvxRT2e+jJE37EP/C5g/WAKsb8=
 github.com/teambition/rrule-go v1.8.2 h1:lIjpjvWTj9fFUZCmuoVDrKVOtdiyzbzc93qTmRVe/J8=
 github.com/teambition/rrule-go v1.8.2/go.mod h1:Ieq5AbrKGciP1V//Wq8ktsTXwSwJHDD5mD/wLBGl3p4=
 github.com/testcontainers/testcontainers-go v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=

--- a/internal/pkg/otel/manager/healthcheck.go
+++ b/internal/pkg/otel/manager/healthcheck.go
@@ -77,8 +77,9 @@ func injectHealthCheckV2Extension(conf *confmap.Conf, healthCheckExtensionID str
 				"http": map[string]interface{}{
 					"endpoint": fmt.Sprintf("localhost:%d", httpHealthCheckPort),
 					"status": map[string]interface{}{
-						"enabled": healthCheckHealthStatusEnabled,
-						"path":    healthCheckHealthStatusPath,
+						"enabled":            healthCheckHealthStatusEnabled,
+						"path":               healthCheckHealthStatusPath,
+						"include_attributes": true,
 					},
 					"config": map[string]interface{}{
 						"enabled": healthCheckHealthConfigEnabled,

--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -963,7 +963,6 @@ func TestBeatsReceiverSubcomponentStatus(t *testing.T) {
 		},
 		Stack: nil,
 	})
-	t.Skip("Needs otel upstream changes, see https://github.com/elastic/ingest-dev/issues/5742")
 
 	// This configuration contains two system/metrics inputs, each with two identical metricsets:
 	// * one for cpu, always healthy


### PR DESCRIPTION
This is https://github.com/elastic/elastic-agent/pull/11856 with patched otel contrib libraries, showing that enabling the new feature makes the integration test pass.