### PR TITLE
Restore cloudbeat executable permission in container images

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -37,6 +37,7 @@ RUN true && \
     ln -s {{ $beatHome }}/data/elastic-agent-{{ commit_short }}/elastic-agent {{ $beatBinary }} && \
     chmod 0755 {{ $beatHome }}/data/elastic-agent-*/elastic-agent && \
     chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/elastic-otel-collector && \
+    (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/cloudbeat || true) && \
     (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/osquery* || true) && \
     (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/apm-server || true) && \
     (chmod 0755 {{ $beatHome }}/data/elastic-agent-*/components/cloud-defend || true) && \


### PR DESCRIPTION
## What does this PR do?

Ensures the cloudbeat binary has the executable bit set in container images.

## Why is it important?

https://github.com/elastic/elastic-agent/pull/11821 removed the line adding this bit to all beats binaries on the assumption that agentbeat is now part of the otel collector binary. However, this is not true for cloudbeat.

## How to test this PR locally

Build the container image and check the cloudbeat binary permissions.

```
$ docker run --interactive --tty --rm --entrypoint bash docker.elastic.co/elastic-agent/elastic-agent-complete:9.3.0-SNAPSHOT -c 'ls -lah /usr/share/elastic-agent/data/elastic-agent-*/components/*' | grep cloudbeat
-rwxr-xr-x 1 elastic-agent elastic-agent 396M Dec 22 13:12 /usr/share/elastic-agent/data/elastic-agent-0c8b8f/components/cloudbeat
-rw-r--r-- 1 elastic-agent elastic-agent 2.6K Dec 22 13:12 /usr/share/elastic-agent/data/elastic-agent-0c8b8f/components/cloudbeat.spec.yml
-rw-r--r-- 1 elastic-agent elastic-agent 6.8K Dec 22 13:12 /usr/share/elastic-agent/data/elastic-agent-0c8b8f/components/cloudbeat.yml

```

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
