### PR TITLE
[8.19] Remove accidentally committed merge conflict in the update beats GH action definition

### DIFF
--- a/.github/workflows/bump-beats-version.yml
+++ b/.github/workflows/bump-beats-version.yml
@@ -61,36 +61,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH_NAME: ${{ matrix.branch }}
 
-<<<<<<< HEAD
     - if: ${{ failure()  }}
-=======
-    - name: Export beats versions to environment variables
-      run: |
-        echo BEATS_PREVIOUS_VERSION=$(cat /tmp/.beats-previous-version) >> "$GITHUB_ENV"
-        echo BEATS_NEW_VERSION=$(cat /tmp/.beats-new-version) >> "$GITHUB_ENV"
-
-    - name: Create Pull Request
-      uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: "[${{ matrix.branch }}][Automation] Update elastic/beats to ${{ env.BEATS_NEW_VERSION }}"
-        title: "[${{ matrix.branch }}][Automation] Update elastic/beats to ${{ env.BEATS_NEW_VERSION }}"
-        body: |
-          ### What
-          Update `elastic/beats` to the latest version on branch `${{ matrix.branch }}`.
-
-          *Changeset*
-          * https://github.com/elastic/beats/compare/${{ env.BEATS_PREVIOUS_VERSION }}...${{ env.BEATS_NEW_VERSION }}
-        branch: update-beats-${{ matrix.branch }}
-        base: ${{ matrix.branch }}
-        delete-branch: true
-        labels: |
-          automation
-          skip-changelog
-          Team:Elastic-Agent-Control-Plane
-
-    - if: ${{ failure() }}
->>>>>>> 16b2e4c27 (build(deps): bump peter-evans/create-pull-request from 7.0.11 to 8.0.0 (#11805))
       uses: elastic/oblt-actions/slack/send@v1
       with:
         bot-token: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Removes the accidentally committed merge conflict introduced in https://github.com/elastic/elastic-agent/pull/12008