### PR TITLE
Drop 7.17.30-SNAPSHOT from testVersions

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -2314,17 +2314,12 @@ func (Integration) UpdateVersions(ctx context.Context) error {
 
 	// limit the number of snapshot branches to the maxSnapshots
 	targetSnapshotBranches := branches[:maxSnapshots]
-
-	// we also want to always include the latest snapshot from lts release branches
-	ltsBranches := []string{
-		// 7.17 is an LTS branch so we need to include it always
-		"7.17",
-	}
+	var ltsBranches []string
 
 	// if we have a newer version of the agent, we want to include the latest snapshot from 8.19 LTS branch
 	if agentVersion.Major() > 8 || agentVersion.Major() == 8 && agentVersion.Minor() > 19 {
 		// order is important
-		ltsBranches = append([]string{"8.19"}, ltsBranches...)
+		ltsBranches = []string{"8.19"}
 	}
 
 	// need to include the LTS branches, sort them and remove duplicates
@@ -2339,7 +2334,7 @@ func (Integration) UpdateVersions(ctx context.Context) error {
 		UpgradeToVersion: bversion.Agent,
 		CurrentMajors:    1,
 		PreviousMinors:   2,
-		PreviousMajors:   1,
+		PreviousMajors:   2,
 		SnapshotBranches: targetSnapshotBranches,
 	}
 	b, _ := json.MarshalIndent(reqs, "", "  ")

--- a/testing/integration/testdata/.upgrade-test-agent-versions.yml
+++ b/testing/integration/testdata/.upgrade-test-agent-versions.yml
@@ -5,9 +5,10 @@
 # upgrade integration tests.
 
 testVersions:
-  - 9.2.3-SNAPSHOT
-  - 9.2.2
-  - 9.1.8
-  - 8.19.9-SNAPSHOT
-  - 8.19.8
-  - 7.17.30-SNAPSHOT
+  - 9.3.0-SNAPSHOT
+  - 9.2.4-SNAPSHOT
+  - 9.2.3
+  - 9.1.9
+  - 8.19.10-SNAPSHOT
+  - 8.19.9
+  - 7.17.29


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

It changes the upgrade tests to use 7.17.29, the final release for the 7.17 branch, instead of 7.17.30-SNAPSHOT. 

## Why is it important?

The 7.17 branch is being decommissioned on January 15th, at which point no more snapshot builds will be produced for it. Even now, `curl -i https://snapshots.elastic.co/latest/7.17.30-SNAPSHOT.json` gives a 404. Instead of investigating why that is, it's simpler to just drop this version from tests.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
