### PR TITLE
Use sparse checkout for steps where we only upload buildkite pipelines

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -52,6 +52,12 @@ if [[ "${pull_request}" == "false" ]]; then
     exit 0
 fi
 
+if ! git symbolic-ref -q HEAD; then
+    echo "Detached HEAD, skipping"
+    exit 0
+fi
+
+
 TARGET_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
 PR_COMMIT="${BUILDKITE_COMMIT}"
 PR_ID=${BUILDKITE_PULL_REQUEST}

--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -166,6 +166,8 @@ steps:
     - sparse-checkout#v1.3.1:
         paths:
         - .buildkite
+        - .go-version
+        - version/version.go
 
   ## PRs
   - label: "Triggering custom FIPS integration tests"
@@ -176,6 +178,8 @@ steps:
     - sparse-checkout#v1.3.1:
         paths:
         - .buildkite
+        - .go-version
+        - version/version.go
     if_changed:
       include:
         - .buildkite/**
@@ -192,6 +196,8 @@ steps:
     - sparse-checkout#v1.3.1:
         paths:
         - .buildkite
+        - .go-version
+        - version/version.go
 
   - label: "Test packages"
     depends_on:

--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -15,6 +15,12 @@ common:
   - vault_docker_login: &vault_docker_login
       elastic/vault-docker-login#v0.5.2:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
+  - sparse_checkout_plugin: &sparse_checkout_plugin
+      sparse-checkout#v1.3.1:
+        paths:
+        - .buildkite
+        - .go-version
+        - version/version.go
 
 steps:
   - group: "Integration tests: packaging"
@@ -163,11 +169,7 @@ steps:
   - label: "Triggering Integration tests"
     command: "buildkite-agent pipeline upload .buildkite/bk.integration.pipeline.yml"
     plugins:
-    - sparse-checkout#v1.3.1:
-        paths:
-        - .buildkite
-        - .go-version
-        - version/version.go
+    - *sparse_checkout_plugin
 
   ## PRs
   - label: "Triggering custom FIPS integration tests"
@@ -175,11 +177,7 @@ steps:
     key: "fips-its-prs"
     command: "buildkite-agent pipeline upload .buildkite/bk.integration-fips.pipeline.yml"
     plugins:
-    - sparse-checkout#v1.3.1:
-        paths:
-        - .buildkite
-        - .go-version
-        - version/version.go
+    - *sparse_checkout_plugin
     if_changed:
       include:
         - .buildkite/**
@@ -193,11 +191,7 @@ steps:
     key: "fips-its-branches"
     command: "buildkite-agent pipeline upload .buildkite/bk.integration-fips.pipeline.yml"
     plugins:
-    - sparse-checkout#v1.3.1:
-        paths:
-        - .buildkite
-        - .go-version
-        - version/version.go
+    - *sparse_checkout_plugin
 
   - label: "Test packages"
     depends_on:

--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -162,12 +162,20 @@ steps:
 
   - label: "Triggering Integration tests"
     command: "buildkite-agent pipeline upload .buildkite/bk.integration.pipeline.yml"
+    plugins:
+    - sparse-checkout#v1.3.1:
+        paths:
+        - .buildkite
 
   ## PRs
   - label: "Triggering custom FIPS integration tests"
     if: build.pull_request.id != null
     key: "fips-its-prs"
     command: "buildkite-agent pipeline upload .buildkite/bk.integration-fips.pipeline.yml"
+    plugins:
+    - sparse-checkout#v1.3.1:
+        paths:
+        - .buildkite
     if_changed:
       include:
         - .buildkite/**
@@ -180,6 +188,10 @@ steps:
     if: build.pull_request.id == null
     key: "fips-its-branches"
     command: "buildkite-agent pipeline upload .buildkite/bk.integration-fips.pipeline.yml"
+    plugins:
+    - sparse-checkout#v1.3.1:
+        paths:
+        - .buildkite
 
   - label: "Test packages"
     depends_on:

--- a/.buildkite/integration.pipeline.yml
+++ b/.buildkite/integration.pipeline.yml
@@ -16,7 +16,7 @@ common:
       elastic/vault-docker-login#v0.5.2:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
   - sparse_checkout_plugin: &sparse_checkout_plugin
-      sparse-checkout#v1.3.1:
+      sparse-checkout#v1.6.0:
         paths:
         - .buildkite
         - .go-version

--- a/.buildkite/pipeline.agentless-app-release.yaml
+++ b/.buildkite/pipeline.agentless-app-release.yaml
@@ -89,5 +89,9 @@ steps:
                 SYNTHETICS_TAG: "agentless-ci"
       YAML
       fi
+    plugins:
+    - sparse-checkout#v1.3.1:
+        paths:
+        - .buildkite
     agents:
       image: docker.elastic.co/ci-agent-images/serverless-helm-builder:0.0.2@sha256:d00e8a7a0ab3618cfaacb0a7b1e1b06ee29728eb2b44de602374bd8f6b9b92ac

--- a/.buildkite/pipeline.agentless-app-release.yaml
+++ b/.buildkite/pipeline.agentless-app-release.yaml
@@ -93,5 +93,7 @@ steps:
     - sparse-checkout#v1.3.1:
         paths:
         - .buildkite
+        - .go-version
+        - version/version.go
     agents:
       image: docker.elastic.co/ci-agent-images/serverless-helm-builder:0.0.2@sha256:d00e8a7a0ab3618cfaacb0a7b1e1b06ee29728eb2b44de602374bd8f6b9b92ac

--- a/.buildkite/pipeline.agentless-app-release.yaml
+++ b/.buildkite/pipeline.agentless-app-release.yaml
@@ -90,7 +90,7 @@ steps:
       YAML
       fi
     plugins:
-    - sparse-checkout#v1.3.1:
+    - sparse-checkout#v1.6.0:
         paths:
         - .buildkite
         - .go-version

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
+# This section is used to define the plugins that will be used in the pipeline.
+# See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
+common:
+  - sparse_checkout_plugin: &sparse_checkout_plugin
+      sparse-checkout#v1.3.1:
+        paths:
+        - .buildkite
+        - .go-version
+        - version/version.go
+
 env:
   # The following images are defined here and their values will be updated by updatecli
   # Please do not change them manually.
@@ -326,11 +336,7 @@ steps:
       build.env("GITHUB_PR_TRIGGER_COMMENT") =~ /.*extended.*/
     command: "buildkite-agent pipeline upload .buildkite/integration.pipeline.yml"
     plugins:
-    - sparse-checkout#v1.3.1:
-        paths:
-        - .buildkite
-        - .go-version
-        - version/version.go
+    - *sparse_checkout_plugin
     env:
       BUILDKITE_PULL_REQUEST: ${BUILDKITE_PULL_REQUEST}
       BUILDKITE_PULL_REQUEST_BASE_BRANCH: ${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
@@ -392,11 +398,7 @@ steps:
       - .buildkite/scripts/steps/trigger-elastic-agent-package.sh
       - .buildkite/scripts/steps/trigger-elastic-agent-package.sh | buildkite-agent pipeline upload
     plugins:
-    - sparse-checkout#v1.3.1:
-        paths:
-        - .buildkite
-        - .go-version
-        - version/version.go
+    - *sparse_checkout_plugin
     if_changed:
       include:
         - .buildkite/pipeline.elastic-agent-package.yml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -325,6 +325,10 @@ steps:
       (build.pull_request.id != null && !build.env("GITHUB_PR_LABELS") =~ /skip-it/) ||
       build.env("GITHUB_PR_TRIGGER_COMMENT") =~ /.*extended.*/
     command: "buildkite-agent pipeline upload .buildkite/integration.pipeline.yml"
+    plugins:
+    - sparse-checkout#v1.3.1:
+        paths:
+        - .buildkite
     env:
       BUILDKITE_PULL_REQUEST: ${BUILDKITE_PULL_REQUEST}
       BUILDKITE_PULL_REQUEST_BASE_BRANCH: ${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
@@ -385,6 +389,10 @@ steps:
     commands:
       - .buildkite/scripts/steps/trigger-elastic-agent-package.sh
       - .buildkite/scripts/steps/trigger-elastic-agent-package.sh | buildkite-agent pipeline upload
+    plugins:
+    - sparse-checkout#v1.3.1:
+        paths:
+        - .buildkite
     if_changed:
       include:
         - .buildkite/pipeline.elastic-agent-package.yml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -329,6 +329,8 @@ steps:
     - sparse-checkout#v1.3.1:
         paths:
         - .buildkite
+        - .go-version
+        - version/version.go
     env:
       BUILDKITE_PULL_REQUEST: ${BUILDKITE_PULL_REQUEST}
       BUILDKITE_PULL_REQUEST_BASE_BRANCH: ${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
@@ -393,6 +395,8 @@ steps:
     - sparse-checkout#v1.3.1:
         paths:
         - .buildkite
+        - .go-version
+        - version/version.go
     if_changed:
       include:
         - .buildkite/pipeline.elastic-agent-package.yml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
   - sparse_checkout_plugin: &sparse_checkout_plugin
-      sparse-checkout#v1.3.1:
+      sparse-checkout#v1.6.0:
         paths:
         - .buildkite
         - .go-version

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -38,6 +38,12 @@ spec:
       branch_configuration: "main 7.* 8.* 9.*"
       repository: elastic/elastic-agent
       pipeline_file: ".buildkite/pipeline.yml"
+      initial_step_plugins:
+      - sparse-checkout#v1.6.0:
+          paths:
+          - .buildkite
+          - .go-version
+          - version/version.go
       provider_settings:
         build_pull_request_forks: false
         build_pull_requests: true


### PR DESCRIPTION
The agent repo is quite big, and it also pulls in the beats repo as a submodule. For pipeline trigger jobs, we only really need .buildkite and some files referenced in the common scripts. Use the sparse checkout plugin to only check out those.

This takes the pipeline trigger jobs from ~75 seconds to ~5 seconds.