### PR TITLE
[chore] add changelog entry for otel subcommand flag issue

### DIFF
--- a/changelog/fragments/1767937335-remove-cli-flags-otel-subcommand.yaml
+++ b/changelog/fragments/1767937335-remove-cli-flags-otel-subcommand.yaml
@@ -19,10 +19,10 @@ summary: Remove Elastic Agent global CLI flags from `otel` subcommand.
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
 description: |
-  The elastic-agent otel subcommand no longer accepts global CLI flags such as `-c`, `--path.home`, `--path.config`, `--path.data`, and `--path.logs`. 
+  The `elastic-agent otel` subcommand no longer accepts global CLI flags that had no effect: `-c`, `--path.home`, `--path.home.unversioned`, `--path.config`, `--path.logs`, `--path.socket` and `--path.downloads`.
 
 # REQUIRED for breaking-change, deprecation, known-issue
-impact: Removal of these flags can result in otel subcommand failure, if they being are used.
+impact: Removal of these flags can result in otel subcommand failure, if they being are used. These flags had no effect on the otel subcommand behavior.
 
 # REQUIRED for breaking-change, deprecation, known-issue
 # action:


### PR DESCRIPTION
## What does this PR do?

After Blake's [changes](https://github.com/elastic/elastic-agent/pull/11821/files#diff-b3370f597162d8c7ab3afb07c9f9b5c50957d1f551a4a463ac49a2a536ad7a77), the otel subcommand is no longer embedded and it doesn't support the elastic-agent specific flags. As a result, it errors out if any of the agent-specific flags are used.

This PR adds a change log entry for the same.

## Why is it important?

Because this is a breaking change.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

Following command will fail in 9.3 and subsequent releases:

```
./elastic-agent -c ./otel.yml otel
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/12070