### PR TITLE
Fix `applies_to` in the "Profiles collection" doc

### DIFF
--- a/docs/reference/edot-collector/config/configure-profiles-collection.md
+++ b/docs/reference/edot-collector/config/configure-profiles-collection.md
@@ -2,11 +2,11 @@
 navigation_title: Profiles collection
 description: Learn how to configure and customize profiles collection through the Elastic Distribution of OpenTelemetry Collector.
 applies_to:
-  stack: preview 9.3+
+  stack: preview 9.2+
   serverless:
     observability:
   product:
-    edot_collector: preview 9.3+
+    edot_collector: preview 9.2+
 products:
   - id: observability
   - id: edot-collector
@@ -44,6 +44,32 @@ You can configure the components to generate and report metrics exclusively from
 
 The following example generates profiling metrics by frame, frame type, and classification:
 
+::::{applies-switch}
+
+:::{applies-item} stack: preview =9.2
+```yaml
+connectors:
+  profilingmetrics:
+    by_frame: true
+    by_frametype: true
+    by_classification: true
+
+receivers:
+  profiling:
+    SamplesPerSecond: 19
+
+service:
+  pipelines:
+    profiles:
+      receivers: [ profiling ]
+      exporters: [ profilingmetrics ]
+    metrics:
+      receivers: [ profilingmetrics ]
+      exporters: [ elasticsearch ]
+```
+:::
+
+:::{applies-item} stack: preview 9.3+
 ```yaml
 connectors:
   profilingmetrics:
@@ -60,6 +86,9 @@ service:
       receivers: [ profilingmetrics ]
       exporters: [ elasticsearch ]
 ```
+:::
+
+::::
 
 ## Kubernetes deployments
 


### PR DESCRIPTION
Docs

## What does this PR do?

This PR:
- Fixes the page-level `applies_to` in the "Profiles collection" doc as the configuration was available in preview from 9.2 which should be reflected at the page-level.
- Updates the doc to use an applies-switch to show the difference in configuration between versions 9.2 and 9.3.

Reference PRs: 
- https://github.com/elastic/elastic-agent/pull/10146
- https://github.com/elastic/elastic-agent/pull/11846

## Preview

- Page-level:
<img width="669" height="143" alt="Screenshot 2026-01-09 at 12 37 33" src="https://github.com/user-attachments/assets/16fdb91f-a6f7-48a4-8d19-6412b13c7278" />

- Configuration for 9.3+
<img width="918" height="625" alt="Screenshot 2026-01-09 at 12 36 27" src="https://github.com/user-attachments/assets/a81ef5e0-a956-45ca-89a2-287b3749e06b" />

- Configuration for 9.2
<img width="906" height="700" alt="Screenshot 2026-01-09 at 12 36 20" src="https://github.com/user-attachments/assets/8509535c-7de1-4729-8a5e-d0bcea028281" />


## Checklist

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test