### PR TITLE
Update Elasticsearch exporter version recommendation to 0.124.0

### DIFF
--- a/docs/reference/edot-collector/components/elasticsearchexporter.md
+++ b/docs/reference/edot-collector/components/elasticsearchexporter.md
@@ -253,7 +253,7 @@ The following are the main known issues with the {{es}} exporter:
 
 | Issue | Cause | Solution |
 |-------|-------|----------|
-| **version_conflict_engine_exception** | TSDB data streams require unique documents per timestamp. Occurs with OTel mapping mode on {{es}} 8.16+ or ECS mode with system integration streams. | Update to {{es}} version 8.17.6 or higher and the {{es}} exporter version 0.121.0 or higher, or install a custom component template. Remove batch processors to prevent metric splitting. |
+| **version_conflict_engine_exception** | TSDB data streams require unique documents per timestamp. Occurs with OTel mapping mode on {{es}} 8.16+ or ECS mode with system integration streams. | Update to {{es}} version 8.17.6 or later and the {{es}} exporter version 0.124.0 or later, or install a custom component template. Remove batch processors to prevent metric splitting. |
 | **flush failed (400) illegal_argument_exception** | OTel mapping mode, which is default from version 0.122.0, requires {{es}} 8.12 or higher. | Upgrade {{es}} to 8.12 or higher or use alternative mapping modes. |
 
 ## Troubleshooting


### PR DESCRIPTION
## What does this PR do?

Updates the recommended Elasticsearch exporter version from 0.121.0 to 0.124.0 in the Elasticsearch exporter documentation.

## Why is it important?

Version 0.124.0 or later is required due to fixes in the OpenTelemetry Collector Contrib repository (see open-telemetry/opentelemetry-collector-contrib#38083).

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

No disruptive impact

## Related issues

- Closes [#3135](https://github.com/elastic/docs-content/issues/3135)

- Relates to open-telemetry/opentelemetry-collector-contrib#38083