### PR TITLE
fix: change source for Noto-CJK font

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -260,9 +260,9 @@ RUN for iter in {1..10}; do \
         libX11-xcb libxcb libXcomposite libXdamage libXext libXfixes libXrandr libxkbcommon libxshmfence glib2 \
         dbus-glib libicu mesa-libGL unzip iptables && \
         mkdir -p /usr/share/fonts/google-noto && \
-        curl -LO https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip && \
-        unzip NotoSansCJKjp-hinted.zip -d /usr/share/fonts/google-noto && \
-        rm -f NotoSansCJKjp-hinted.zip && \
+        curl -L -o NotoSansCJKjp.zip https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/06_NotoSansCJKjp.zip && \
+        unzip NotoSansCJKjp.zip -d /usr/share/fonts/google-noto && \
+        rm -f NotoSansCJKjp.zip && \
         microdnf -y remove unzip && \
         curl -LO https://github.com/googlefonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-Regular.ttf && \
         mv NotoSans-Regular.ttf /usr/share/fonts/google-noto && \


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

The source we were using to download the Noto CJK font stopped working.
Switch to the github's repository releases to find the required font.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

CI fails because the Noto CJK can't be installed on ubi9 docker images

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Build elastic-agent locally

> DEV=true SNAPSHOT=true PLATFORMS=linux/amd64 PACKAGES=docker EXTERNAL=true mage package


2. Create a fleet agent policy

Go to fleet > Agent policies > Create agent policies

3. Add an agent to the agent policy

Policy options > add agent

Follow steps to run elastic-agent locally. Example:

> docker run --name elastic-agent --rm --env FLEET_ENROLL=1 --env FLEET_URL=<url> --env FLEET_ENROLLMENT_TOKEN="<token>" local/elastic-agent:latest

4. Create a synthetics private location

Go to Synthetics > Settings > Private Locations > Create location

Assign the agent policy to the location

5. Create a browser monitor that uses the private location.

> step("first", async () => {
>     await page.goto('https://zh.wikipedia.org/wiki/%E7%BB%B4%E5%9F%BA%E7%99%BE%E7%A7%91', { waitUntil: 'networkidle' });
> });


Result is correct:

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/a293f167-ce29-4cd9-92f4-2edd05d2be35" />


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
