### PR TITLE
[ci] Handling `-SNAPSHOT` in ESS stack versions

### DIFF
--- a/test_infra/ess/deployment.tf
+++ b/test_infra/ess/deployment.tf
@@ -93,7 +93,7 @@ locals {
 
 # If we have defined a stack version, validate that this version exists on that region and return it.
 data "ec_stack" "latest" {
-  version_regex = var.stack_version
+  version_regex = split("-", var.stack_version)[0] # Remove -SNAPSHOT suffix in the stack filter.
   region        = local.ess_region
 }
 


### PR DESCRIPTION
Experimenting with handling of ESS cluster provisioning for integration testing when a `-SNAPSHOT` version isn't available between release the next version's snapshot.

Not recommending as a long term approach, but the only failure from referencing `9.2.4-SNAPSHOT` vs. `9.2.4` is coming from the ESS stack provisioning version filter. This change would strip the `-SNAPSHOT` suffix.

Still need to validate if passing the version without the `-SNAPSHOT` [version_regex](https://registry.terraform.io/providers/elastic/ec/latest/docs/data-sources/stack#version_regex-1) still returns a valid version match when Terraform provisions.