### PR TITLE
[ci] Handling of `-SNAPSHOT` in ESS testing infra

### DIFF
--- a/test_infra/ess/deployment.tf
+++ b/test_infra/ess/deployment.tf
@@ -93,7 +93,7 @@ locals {
 
 # If we have defined a stack version, validate that this version exists on that region and return it.
 data "ec_stack" "latest" {
-  version_regex = var.stack_version
+  version_regex = split("-", var.stack_version)[0] # Remove -SNAPSHOT suffix in the stack filter.
   region        = local.ess_region
 }
 


### PR DESCRIPTION
Accounting for ESS cluster setup when a `-SNAPSHOT` version of what's defined in `.package-version` isn't available between release the next version's snapshot.

**Example Scenario:** `9.2.4` has released, but `9.2.5-SNAPSHOT` not yet available in ESS. `9.2.4-SNAPSHOT` is no longer a valid version to select from on ESS and integration testing steps will fail.

Not recommending as a long term approach, but this change will strip the `-SNAPSHOT` suffix from the [version_regex](https://registry.terraform.io/providers/elastic/ec/latest/docs/data-sources/stack#version_regex-1) parameter, if present.

With `-SNAPSHOT` version [present](https://buildkite.com/elastic/elastic-agent/builds/33405#019bc479-8afe-4808-a7e9-195c77f635c0):

```terraform

data.ec_stack.latest: Reading...
--
data.ec_stack.latest: Read complete after 0s [id=9.4.0-SNAPSHOT]

```
Without `-SNAPSHOT` version [present](https://buildkite.com/elastic/elastic-agent/builds/33389#019bc3d5-0439-463f-ac89-4bcb0fe210b2)

```terraform

data.ec_stack.latest: Reading...
--
data.ec_stack.latest: Read complete after 1s [id=9.2.4]

```