### PR TITLE
[9.2] Fix DRA version set in the CI elastic-agent-package step

### DIFF
--- a/.buildkite/scripts/steps/trigger-elastic-agent-package.sh
+++ b/.buildkite/scripts/steps/trigger-elastic-agent-package.sh
@@ -15,7 +15,7 @@ if [ ! -f .package-version ]; then
 fi
 
 # No need for the snapshot but the three digits version is required
-BEAT_VERSION=$(jq -r .version .core_version)
+BEAT_VERSION=$(jq -r .core_version .package-version)
 MANIFEST_URL=$(jq -r .manifest_url .package-version)
 
 cat << EOF


### PR DESCRIPTION
Fix the DRA version used to test the elastic-agent-package pipeline. This should be using the DRA manifest from `.package-version`, as it does on 9.3 and main. Instead, it looks for a file that doesn't exist, and the `DRA_VERSION` variable passed to the triggered pipeline is empty. In that case, the pipeline uses the version defined in `version/version.go`, which is normally the same. However, immediately after new releases, when a snapshot for the new version is not yet published to the DRA, these values are different and the pipeline fails when trying to to a DRA publishing dry run. See https://buildkite.com/elastic/elastic-agent-package/builds/9296/steps/canvas?sid=019bd543-0b62-4e0f-b402-dc3ed4611b3e for example.

This PR fixes the problem and makes the logic identical to `9.3` and `main`. It also unblocks other PRs, like the VM image updates.