### PR TITLE
Make the otel update script handle the top-level go.mod

### DIFF
--- a/.ci/scripts/update-otel.sh
+++ b/.ci/scripts/update-otel.sh
@@ -18,21 +18,21 @@ next_stable_core=${2:-}
 
 next_contrib=${3:-$next_beta_core}
 
-# Get current versions from internal/edot/go.mod
-current_beta_core=$(grep 'go\.opentelemetry\.io/collector/receiver/otlpreceiver ' internal/edot/go.mod | cut -d' ' -f 2 || true)
-current_stable_core=$(grep 'go\.opentelemetry\.io/collector/confmap/provider/fileprovider ' internal/edot/go.mod | cut -d' ' -f 2 || true)
-current_contrib=$(grep 'github\.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver ' internal/edot/go.mod | cut -d' ' -f 2 || true)
-
-[[ -n "$current_beta_core" ]] || (echo "Error: couldn't find current beta core version." && exit 2)
-[[ -n "$current_stable_core" ]] || (echo "Error: couldn't find current stable core version" && exit 3)
-[[ -n "$current_contrib" ]] || (echo "Error: couldn't find current contrib version" && exit 4)
-
-echo "=> Updating core from $current_beta_core/$current_stable_core to $next_beta_core/$next_stable_core"
-echo "=> Updating contrib from $current_contrib to $next_contrib"
-
 GOMOD_FILES=("internal/edot/go.mod" "go.mod")
 
 for gomod_file in "${GOMOD_FILES[@]}"; do
+  # Get current versions from the go.mod
+  current_beta_core=$(grep 'go\.opentelemetry\.io/collector/component/componentstatus ' "$gomod_file" | cut -d' ' -f 2 || true)
+  current_stable_core=$(grep 'go\.opentelemetry\.io/collector/pdata ' "$gomod_file" | cut -d' ' -f 2 || true)
+  current_contrib=$(grep 'github\.com/open-telemetry/opentelemetry-collector-contrib/pkg/status ' "$gomod_file" | cut -d' ' -f 2 || true)
+
+  [[ -n "$current_beta_core" ]] || (echo "Error: couldn't find current beta core version." && exit 2)
+  [[ -n "$current_stable_core" ]] || (echo "Error: couldn't find current stable core version" && exit 3)
+  [[ -n "$current_contrib" ]] || (echo "Error: couldn't find current contrib version" && exit 4)
+
+  echo "=> Updating core from $current_beta_core/$current_stable_core to $next_beta_core/$next_stable_core in $gomod_file"
+  echo "=> Updating contrib from $current_contrib to $next_contrib in $gomod_file"
+
   sed -i.bak "s/\(go\.opentelemetry\.io\/collector.*\) $current_beta_core/\1 $next_beta_core/" "$gomod_file"
   sed -i.bak "s/\(go\.opentelemetry\.io\/collector.*\) $current_stable_core/\1 $next_stable_core/" "$gomod_file"
   sed -i.bak "s/\(github\.com\/open-telemetry\/opentelemetry\-collector\-contrib\/.*\) $current_contrib/\1 $next_contrib/" "$gomod_file"


### PR DESCRIPTION
Both the EDOT go.mod and the elastic-agent go.mod contain otel dependencies. The otel update script should cover both.