### PR TITLE
[9.3] Remove log line logging unredacted policy change contents

### DIFF
--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -190,7 +190,6 @@ func (f *FleetGateway) Run(ctx context.Context) error {
 			actions := make([]fleetapi.Action, len(resp.Actions))
 			copy(actions, resp.Actions)
 			if len(actions) > 0 {
-				f.log.Infow("received new actions from Fleet checkin", "actions", actions)
 				f.actionCh <- actions
 			}
 		}


### PR DESCRIPTION
- Relates https://github.com/elastic/elastic-agent/pull/11143

https://github.com/elastic/elastic-agent/pull/11143 introduced a log line that logged all actions without redacting the content, meaning it would log all secrets and API keys in every policy change in the logs. Fortunately this is not released yet.