### PR TITLE
Replace elastic-agent/collector name with elastic-otel-collector in self-monitoring metrics

### DIFF
--- a/changelog/fragments/1769021076-replace-elastic-agent-collector-with-elastic-otel-collector-in-self-monitoring.yaml
+++ b/changelog/fragments/1769021076-replace-elastic-agent-collector-with-elastic-otel-collector-in-self-monitoring.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Replace elastic-agent/collector component name with elastic-otel-collector in self-monitoring.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: Make self-monitoring metrics consistently use the name of the new elastic-otel-collector binary executing the EDOT collector and beats receivers.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/monitoring/component/testdata/monitoring_config_full_otel.yaml
+++ b/internal/pkg/agent/application/monitoring/component/testdata/monitoring_config_full_otel.yaml
@@ -437,7 +437,7 @@ inputs:
     - add_fields:
         fields:
           id: ""
-          process: elastic-agent/collector
+          process: elastic-otel-collector
           snapshot: false
           version: placeholder
         target: elastic_agent
@@ -468,7 +468,7 @@ inputs:
     - add_fields:
         fields:
           binary: elastic-agent
-          id: elastic-agent/collector
+          id: elastic-otel-collector
         target: component
   - data_stream:
       dataset: elastic_agent.elastic_agent

--- a/internal/pkg/agent/application/monitoring/component/testdata/monitoring_config_full_process.yaml
+++ b/internal/pkg/agent/application/monitoring/component/testdata/monitoring_config_full_process.yaml
@@ -413,7 +413,7 @@ inputs:
     - add_fields:
         fields:
           id: ""
-          process: elastic-agent/collector
+          process: elastic-otel-collector
           snapshot: false
           version: placeholder
         target: elastic_agent
@@ -444,7 +444,7 @@ inputs:
     - add_fields:
         fields:
           binary: elastic-agent
-          id: elastic-agent/collector
+          id: elastic-otel-collector
         target: component
   - data_stream:
       dataset: elastic_agent.elastic_agent

--- a/internal/pkg/otel/manager/manager.go
+++ b/internal/pkg/otel/manager/manager.go
@@ -478,7 +478,7 @@ func monitoringEventTemplate(monitoring *monitoringCfg.MonitoringConfig, agentIn
 		},
 		"elastic_agent": map[string]any{
 			"id":       agentInfo.AgentID(),
-			"process":  "elastic-agent",
+			"process":  "elastic-otel-collector",
 			"snapshot": agentInfo.Snapshot(),
 			"version":  agentInfo.Version(),
 		},
@@ -486,8 +486,8 @@ func monitoringEventTemplate(monitoring *monitoringCfg.MonitoringConfig, agentIn
 			"id": agentInfo.AgentID(),
 		},
 		"component": mapstr.M{
-			"binary": "elastic-agent",
-			"id":     "elastic-agent/collector",
+			"binary": "elastic-otel-collector",
+			"id":     "elastic-otel-collector",
 		},
 		"metricset": mapstr.M{
 			"name": "stats",

--- a/internal/pkg/otel/monitoring/monitoring.go
+++ b/internal/pkg/otel/monitoring/monitoring.go
@@ -27,7 +27,7 @@ import (
 )
 
 // EDOTComponentID is the component ID for the EDOT collector.
-const EDOTComponentID = "elastic-agent/collector"
+const EDOTComponentID = "elastic-otel-collector"
 
 // EDOTMonitoringEndpoint returns the monitoring endpoint for the EDOT collector.
 func EDOTMonitoringEndpoint() string {


### PR DESCRIPTION
Now that we are executing a dedicated elastic-otel-collector binary, use it's name instead of the `elastic-agent/collector` name that was used when we were executing `elastic-agent otel` instead.

<img width="1224" height="604" alt="Screenshot 2026-01-21 at 1 43 52 PM" src="https://github.com/user-attachments/assets/118bc444-c12c-41f0-8fb1-c1d63cfc6036" />
