### PR TITLE
[AutoOps] Add Bundled Support for SSL CAs

### DIFF
--- a/internal/edot/samples/darwin/autoops_es_ssl.yml
+++ b/internal/edot/samples/darwin/autoops_es_ssl.yml
@@ -1,0 +1,65 @@
+receivers:
+  metricbeatreceiver:
+    metricbeat:
+      modules:
+        # Metrics
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 10s
+          metricsets:
+            - cat_shards
+            - node_stats
+            - tasks_management
+          ssl.certificate_authorities:
+            - ${env:AUTOOPS_ES_CA}
+        # Less Frequent Metrics
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 1m
+          metricsets:
+            - cluster_health
+            - cluster_settings
+          ssl.certificate_authorities:
+            - ${env:AUTOOPS_ES_CA}
+        # Templates and License Details
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 1d
+          metricsets:
+            - cat_template
+            - component_template
+            - index_template
+            - license
+          ssl.certificate_authorities:
+            - ${env:AUTOOPS_ES_CA}
+    processors:
+      - add_fields:
+          target: autoops_es
+          fields:
+            temp_resource_id: ${env:AUTOOPS_TEMP_RESOURCE_ID}
+            token: ${env:AUTOOPS_TOKEN}
+    telemetry_types: ["logs"]
+
+exporters:
+  otlphttp:
+    headers:
+      Authorization: "AutoOpsToken ${env:AUTOOPS_TOKEN}"
+    endpoint: ${env:AUTOOPS_OTEL_URL}
+    sending_queue:
+      batch:
+        flush_timeout: 1s
+        min_size: 1048576 # 1 MiB uncompressed
+        max_size: 4194304 # 4 MiB uncompressed
+      block_on_overflow: true
+      enabled: true
+      queue_size: 52428800 # 50 MiB uncompressed
+      sizer: bytes
+
+service:
+  pipelines:
+    logs:
+      receivers: [metricbeatreceiver]
+      exporters: [otlphttp]
+  telemetry:
+    logs:
+      encoding: json

--- a/internal/edot/samples/linux/autoops_es_ssl.yml
+++ b/internal/edot/samples/linux/autoops_es_ssl.yml
@@ -1,0 +1,65 @@
+receivers:
+  metricbeatreceiver:
+    metricbeat:
+      modules:
+        # Metrics
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 10s
+          metricsets:
+            - cat_shards
+            - node_stats
+            - tasks_management
+          ssl.certificate_authorities:
+            - ${env:AUTOOPS_ES_CA}
+        # Less Frequent Metrics
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 1m
+          metricsets:
+            - cluster_health
+            - cluster_settings
+          ssl.certificate_authorities:
+            - ${env:AUTOOPS_ES_CA}
+        # Templates and License Details
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 1d
+          metricsets:
+            - cat_template
+            - component_template
+            - index_template
+            - license
+          ssl.certificate_authorities:
+            - ${env:AUTOOPS_ES_CA}
+    processors:
+      - add_fields:
+          target: autoops_es
+          fields:
+            temp_resource_id: ${env:AUTOOPS_TEMP_RESOURCE_ID}
+            token: ${env:AUTOOPS_TOKEN}
+    telemetry_types: ["logs"]
+
+exporters:
+  otlphttp:
+    headers:
+      Authorization: "AutoOpsToken ${env:AUTOOPS_TOKEN}"
+    endpoint: ${env:AUTOOPS_OTEL_URL}
+    sending_queue:
+      batch:
+        flush_timeout: 1s
+        min_size: 1048576 # 1 MiB uncompressed
+        max_size: 4194304 # 4 MiB uncompressed
+      block_on_overflow: true
+      enabled: true
+      queue_size: 52428800 # 50 MiB uncompressed
+      sizer: bytes
+
+service:
+  pipelines:
+    logs:
+      receivers: [metricbeatreceiver]
+      exporters: [otlphttp]
+  telemetry:
+    logs:
+      encoding: json

--- a/internal/edot/samples/windows/autoops_es_ssl.yml
+++ b/internal/edot/samples/windows/autoops_es_ssl.yml
@@ -1,0 +1,65 @@
+receivers:
+  metricbeatreceiver:
+    metricbeat:
+      modules:
+        # Metrics
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 10s
+          metricsets:
+            - cat_shards
+            - node_stats
+            - tasks_management
+          ssl.certificate_authorities:
+            - ${env:AUTOOPS_ES_CA}
+        # Less Frequent Metrics
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 1m
+          metricsets:
+            - cluster_health
+            - cluster_settings
+          ssl.certificate_authorities:
+            - ${env:AUTOOPS_ES_CA}
+        # Templates and License Details
+        - module: autoops_es
+          hosts: ${env:AUTOOPS_ES_URL}
+          period: 1d
+          metricsets:
+            - cat_template
+            - component_template
+            - index_template
+            - license
+          ssl.certificate_authorities:
+            - ${env:AUTOOPS_ES_CA}
+    processors:
+      - add_fields:
+          target: autoops_es
+          fields:
+            temp_resource_id: ${env:AUTOOPS_TEMP_RESOURCE_ID}
+            token: ${env:AUTOOPS_TOKEN}
+    telemetry_types: ["logs"]
+
+exporters:
+  otlphttp:
+    headers:
+      Authorization: "AutoOpsToken ${env:AUTOOPS_TOKEN}"
+    endpoint: ${env:AUTOOPS_OTEL_URL}
+    sending_queue:
+      batch:
+        flush_timeout: 1s
+        min_size: 1048576 # 1 MiB uncompressed
+        max_size: 4194304 # 4 MiB uncompressed
+      block_on_overflow: true
+      enabled: true
+      queue_size: 52428800 # 50 MiB uncompressed
+      sizer: bytes
+
+service:
+  pipelines:
+    logs:
+      receivers: [metricbeatreceiver]
+      exporters: [otlphttp]
+  telemetry:
+    logs:
+      encoding: json


### PR DESCRIPTION
This adds a new, bundled config option for AutoOps to simplify using it with SSL.

## What does this PR do?

Adds an extra configuration option to simplify end user setup of using AutoOps with SSL.

## Why is it important?

Custom certificate authorities (and SSL in general)

## Disruptive User Impact

None. This simply adds a new optional configuration to use.

## How to test this PR locally

Use the configuration to run against a SSL/TLS-enabled cluster that requires a custom certificate authority -- and add its path (or the value inline) as the environment variable value for `AUTOOPS_ES_CA`.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
