### PR TITLE
[AutoOps] 1d needs to be 24h

### DIFF
--- a/internal/edot/samples/darwin/autoops_es.yml
+++ b/internal/edot/samples/darwin/autoops_es.yml
@@ -20,7 +20,7 @@ receivers:
         # Templates and License Details
         - module: autoops_es
           hosts: ${env:AUTOOPS_ES_URL}
-          period: 1d
+          period: 24h
           metricsets:
             - cat_template
             - component_template

--- a/internal/edot/samples/darwin/autoops_es_debug.yml
+++ b/internal/edot/samples/darwin/autoops_es_debug.yml
@@ -20,7 +20,7 @@ receivers:
         # Templates and License Details
         - module: autoops_es
           hosts: ${env:AUTOOPS_ES_URL}
-          period: 1d
+          period: 24h
           metricsets:
             - cat_template
             - component_template

--- a/internal/edot/samples/darwin/autoops_es_ssl.yml
+++ b/internal/edot/samples/darwin/autoops_es_ssl.yml
@@ -24,7 +24,7 @@ receivers:
         # Templates and License Details
         - module: autoops_es
           hosts: ${env:AUTOOPS_ES_URL}
-          period: 1d
+          period: 24h
           metricsets:
             - cat_template
             - component_template

--- a/internal/edot/samples/linux/autoops_es.yml
+++ b/internal/edot/samples/linux/autoops_es.yml
@@ -20,7 +20,7 @@ receivers:
         # Templates and License Details
         - module: autoops_es
           hosts: ${env:AUTOOPS_ES_URL}
-          period: 1d
+          period: 24h
           metricsets:
             - cat_template
             - component_template

--- a/internal/edot/samples/linux/autoops_es_debug.yml
+++ b/internal/edot/samples/linux/autoops_es_debug.yml
@@ -20,7 +20,7 @@ receivers:
         # Templates and License Details
         - module: autoops_es
           hosts: ${env:AUTOOPS_ES_URL}
-          period: 1d
+          period: 24h
           metricsets:
             - cat_template
             - component_template

--- a/internal/edot/samples/linux/autoops_es_ssl.yml
+++ b/internal/edot/samples/linux/autoops_es_ssl.yml
@@ -24,7 +24,7 @@ receivers:
         # Templates and License Details
         - module: autoops_es
           hosts: ${env:AUTOOPS_ES_URL}
-          period: 1d
+          period: 24h
           metricsets:
             - cat_template
             - component_template

--- a/internal/edot/samples/windows/autoops_es.yml
+++ b/internal/edot/samples/windows/autoops_es.yml
@@ -20,7 +20,7 @@ receivers:
         # Templates and License Details
         - module: autoops_es
           hosts: ${env:AUTOOPS_ES_URL}
-          period: 1d
+          period: 24h
           metricsets:
             - cat_template
             - component_template

--- a/internal/edot/samples/windows/autoops_es_debug.yml
+++ b/internal/edot/samples/windows/autoops_es_debug.yml
@@ -20,7 +20,7 @@ receivers:
         # Templates and License Details
         - module: autoops_es
           hosts: ${env:AUTOOPS_ES_URL}
-          period: 1d
+          period: 24h
           metricsets:
             - cat_template
             - component_template

--- a/internal/edot/samples/windows/autoops_es_ssl.yml
+++ b/internal/edot/samples/windows/autoops_es_ssl.yml
@@ -24,7 +24,7 @@ receivers:
         # Templates and License Details
         - module: autoops_es
           hosts: ${env:AUTOOPS_ES_URL}
-          period: 1d
+          period: 24h
           metricsets:
             - cat_template
             - component_template


### PR DESCRIPTION
A last minute change to the config (`1d` from `24h`) to align with the other values is incompatible with the config reader. It does not recognize `d` as a valid unit.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
