### PR TITLE
Speed up execution of the default Fleet test group by 10m by improving installation tests.

### DIFF
--- a/testing/integration/ess/install_test.go
+++ b/testing/integration/ess/install_test.go
@@ -163,12 +163,9 @@ func TestInstallWithBasePath(t *testing.T) {
 	require.NoError(t, installtest.CheckSuccess(ctx, fixture, topPath, &installtest.CheckOpts{Privileged: opts.Privileged}))
 
 	t.Run("check agent package version", testAgentPackageVersion(ctx, fixture, true))
-	t.Run("check second agent installs with --namespace", testSecondAgentCanInstall(ctx, fixture, basePath, false, opts))
-	t.Run("check second agent can be installed again with --namespace --force", testSecondAgentCanInstallWithForce(ctx, fixture, basePath, false, opts))
 	t.Run("check the initial agent is still installed and healthy", func(t *testing.T) {
 		require.NoError(t, installtest.CheckSuccess(ctx, fixture, topPath, &installtest.CheckOpts{Privileged: opts.Privileged}))
 	})
-
 	t.Run("check components set",
 		testComponentsPresence(ctx, fixture,
 			[]componentPresenceDefinition{
@@ -261,7 +258,6 @@ func TestInstallServersWithBasePath(t *testing.T) {
 	require.NoError(t, installtest.CheckSuccess(ctx, fixture, topPath, &installtest.CheckOpts{Privileged: opts.Privileged}))
 
 	t.Run("check agent package version", testAgentPackageVersion(ctx, fixture, true))
-	t.Run("check second agent installs with --namespace", testSecondAgentCanInstall(ctx, fixture, basePath, false, opts))
 
 	t.Run("check components set",
 		testComponentsPresence(ctx, fixture,
@@ -328,8 +324,6 @@ func TestInstallPrivilegedWithoutBasePath(t *testing.T) {
 	require.NoError(t, installtest.CheckSuccess(ctx, fixture, opts.BasePath, &installtest.CheckOpts{Privileged: opts.Privileged}))
 
 	t.Run("check agent package version", testAgentPackageVersion(ctx, fixture, true))
-	t.Run("check second agent installs with --namespace", testSecondAgentCanInstall(ctx, fixture, "", false, opts))
-	t.Run("check second agent can be installed again with --namespace --force", testSecondAgentCanInstallWithForce(ctx, fixture, "", false, opts))
 	t.Run("check the initial agent is still installed and healthy", func(t *testing.T) {
 		require.NoError(t, installtest.CheckSuccess(ctx, fixture, opts.BasePath, &installtest.CheckOpts{Privileged: opts.Privileged}))
 	})
@@ -380,11 +374,75 @@ func TestInstallPrivilegedWithBasePath(t *testing.T) {
 	topPath := filepath.Join(randomBasePath, "Elastic", "Agent")
 	require.NoError(t, installtest.CheckSuccess(ctx, fixture, topPath, &installtest.CheckOpts{Privileged: opts.Privileged}))
 	t.Run("check agent package version", testAgentPackageVersion(ctx, fixture, true))
-	t.Run("check second agent installs with --develop", testSecondAgentCanInstall(ctx, fixture, randomBasePath, true, opts))
-	t.Run("check second agent can be installed again with --develop --force", testSecondAgentCanInstallWithForce(ctx, fixture, randomBasePath, true, opts))
 	t.Run("check the initial agent is still installed and healthy", func(t *testing.T) {
 		require.NoError(t, installtest.CheckSuccess(ctx, fixture, topPath, &installtest.CheckOpts{Privileged: opts.Privileged}))
 	})
+}
+
+// Isolate the tests of --develop (which uses --namespace in it's implementation) into it's own test
+// to minimize overall test execution time. These tests were previously sub-tests of every other
+// installation mode which significantly increased the testing time, as installing and uninstalling agent
+// is currently somewhat expensive. The --develop/--namespace options are mostly isolated to changing the
+// installation directory and do not interact with other installation options, and also are for internal use only.
+func TestInstallSecondAgentInDevelopmentNamespace(t *testing.T) {
+	define.Require(t, define.Requirements{
+		Group: integration.Default,
+		// We require sudo for this test to run
+		// `elastic-agent install` (even though it will
+		// be installed as non-root).
+		Sudo: true,
+
+		// It's not safe to run this test locally as it
+		// installs Elastic Agent.
+		Local: false,
+	})
+
+	// Get path to Elastic Agent executable
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
+	require.NoError(t, err)
+
+	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	defer cancel()
+
+	// Prepare the Elastic Agent so the binary is extracted and ready to use.
+	err = fixture.Prepare(ctx)
+	require.NoError(t, err)
+
+	opts := atesting.InstallOpts{Force: true, Privileged: false}
+	out, err := fixture.Install(ctx, &opts)
+	if err != nil {
+		t.Logf("install output: %s", out)
+		require.NoError(t, err)
+	}
+
+	// Check that Agent was installed in default base path
+	topPath := installtest.DefaultTopPath()
+	checks := &installtest.CheckOpts{
+		Privileged: opts.Privileged,
+	}
+	require.NoError(t, installtest.CheckSuccess(ctx, fixture, topPath, checks))
+
+	t.Run("check agent package version", testAgentPackageVersion(ctx, fixture, true))
+	t.Run("check second agent installs with --develop", testSecondAgentCanInstall(ctx, fixture, "", true, opts))
+	// Regression test for https://github.com/elastic/elastic-agent/issues/5595
+	t.Run("check second agent can be installed again with --develop --force", testSecondAgentCanInstall(ctx, fixture, "", true, opts))
+	t.Run("check the initial agent is still installed and healthy", func(t *testing.T) {
+		require.NoError(t, installtest.CheckSuccess(ctx, fixture, topPath, checks))
+	})
+
+	// Make sure uninstall from within the topPath fails on Windows
+	if runtime.GOOS == "windows" {
+		cwd, err := os.Getwd()
+		require.NoErrorf(t, err, "GetWd failed: %s", err)
+		err = os.Chdir(topPath)
+		require.NoErrorf(t, err, "Chdir to topPath failed: %s", err)
+		t.Cleanup(func() {
+			_ = os.Chdir(cwd)
+		})
+		out, err = fixture.Uninstall(ctx, &atesting.UninstallOpts{Force: true})
+		require.Error(t, err, "uninstall should have failed")
+		require.Containsf(t, string(out), "uninstall must be run from outside the installed path", "expected error string not found in: %s err: %s", out, err)
+	}
 }
 
 func testInstallWithoutBasePathWithCustomUser(ctx context.Context, t *testing.T, fixture *atesting.Fixture, customUsername, customGroup string) {
@@ -414,12 +472,6 @@ func testInstallWithoutBasePathWithCustomUser(ctx context.Context, t *testing.T,
 	require.NoError(t, installtest.CheckSuccess(ctx, fixture, topPath, checks))
 
 	t.Run("check agent package version", testAgentPackageVersion(ctx, fixture, true))
-	t.Run("check second agent installs with --develop", testSecondAgentCanInstall(ctx, fixture, "", true, opts))
-
-	t.Run("check second agent can be installed again with --develop --force", testSecondAgentCanInstallWithForce(ctx, fixture, "", true, opts))
-	t.Run("check the initial agent is still installed and healthy", func(t *testing.T) {
-		require.NoError(t, installtest.CheckSuccess(ctx, fixture, topPath, checks))
-	})
 
 	// Make sure uninstall from within the topPath fails on Windows
 	if runtime.GOOS == "windows" {
@@ -475,11 +527,6 @@ func testComponentsPresence(ctx context.Context, fixture *atesting.Fixture, requ
 			}
 		}
 	}
-}
-
-func testSecondAgentCanInstallWithForce(ctx context.Context, fixture *atesting.Fixture, basePath string, develop bool, installOpts atesting.InstallOpts) func(*testing.T) {
-	installOpts.Force = true
-	return testSecondAgentCanInstall(ctx, fixture, basePath, develop, installOpts)
 }
 
 // Tests that a second agent can be installed in an isolated namespace, using either --develop or --namespace.


### PR DESCRIPTION
Isolate --develop tests into a single test for speed, installing agent currently takes +1 minute and this test does that a lot. At this point the --develop and --namespace features don't interact with any other installation features, and it's an internal only feature, so there's no point to the exhaustive test coverage given the cost of it.

This saves ~10m per test run as this was the longest running test.

* 1h42m with this change https://buildkite.com/elastic/elastic-agent/builds/34248/waterfall
* 1h52m without this change https://buildkite.com/elastic/elastic-agent/builds/34143/waterfall