### PR TITLE
Exclude deprecated components from generated OCB config

### DIFF
--- a/docs/reference/edot-collector/custom-collector.md
+++ b/docs/reference/edot-collector/custom-collector.md
@@ -108,8 +108,6 @@ processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.141.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.141.0
   - gomod: github.com/elastic/opentelemetry-collector-components/processor/elasticapmprocessor v0.24.0
-  - gomod: github.com/elastic/opentelemetry-collector-components/processor/elasticinframetricsprocessor v0.24.0
-  - gomod: github.com/elastic/opentelemetry-collector-components/processor/elastictraceprocessor v0.24.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.141.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor v0.141.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.141.0

--- a/docs/scripts/update-docs/templates/ocb.jinja2
+++ b/docs/scripts/update-docs/templates/ocb.jinja2
@@ -21,34 +21,46 @@ dist:
 
 receivers:
 {%- for comp in grouped_components.get('Receivers', []) %}
+{%- if comp.support_status != 'Deprecated' %}
   - gomod: {{ comp.dep }}
 {%- if comp.get('special_import') %}
     import: {{ comp.special_import }}
+{%- endif %}
 {%- endif %}
 {%- endfor %}
 
 processors:
 {%- for comp in grouped_components.get('Processors', []) %}
+{%- if comp.support_status != 'Deprecated' %}
   - gomod: {{ comp.dep }}
+{%- endif %}
 {%- endfor %}
 
 exporters:
 {%- for comp in grouped_components.get('Exporters', []) %}
+{%- if comp.support_status != 'Deprecated' %}
   - gomod: {{ comp.dep }}
+{%- endif %}
 {%- endfor %}
 
 connectors:
 {%- for comp in grouped_components.get('Connectors', []) %}
+{%- if comp.support_status != 'Deprecated' %}
   - gomod: {{ comp.dep }}
+{%- endif %}
 {%- endfor %}
 
 extensions:
 {%- for comp in grouped_components.get('Extensions', []) %}
+{%- if comp.support_status != 'Deprecated' %}
   - gomod: {{ comp.dep }}
+{%- endif %}
 {%- endfor %}
 
 providers:
 {%- for comp in grouped_components.get('Providers', []) %}
+{%- if comp.support_status != 'Deprecated' %}
   - gomod: {{ comp.dep }}
+{%- endif %}
 {%- endfor %}
 ```


### PR DESCRIPTION
## Summary

- Updates the OCB Jinja2 template (`docs/scripts/update-docs/templates/ocb.jinja2`) to filter out components marked as `Deprecated` in `components.yml`.
- Regenerates the OCB builder configuration in `custom-collector.md`, removing `elasticinframetricsprocessor` and `elastictraceprocessor` from the output.

## Motivation

The generated OCB configuration is meant to help users build a custom collector with the same components as EDOT. Deprecated components are slated for removal and should not be recommended to users as part of a new custom build. The components table already marks them appropriately; this change makes the OCB config consistent.

Fixes https://github.com/elastic/opentelemetry-dev/issues/1227

Made with [Cursor](https://cursor.com) and Claude Opus 4.6