### PR TITLE
Use agent version from .package-version in unified release packaging step test

### DIFF
--- a/.buildkite/scripts/steps/package.sh
+++ b/.buildkite/scripts/steps/package.sh
@@ -14,6 +14,12 @@ if test -z "${MANIFEST_URL:-}"; then
   # building in SNAPSHOT mode.
   export SNAPSHOT=true
 
+  # We want to use the version from .package-version.
+  # If the version defined in version/version.go is different,
+  # the packaging step will expect artifacts with different names
+  # than what the manifest contains
+  export USE_PACKAGE_VERSION=true
+
   # No manifest URL build the the core packages.
   mage packageAgentCore
 


### PR DESCRIPTION
## What does this PR do?

When we test the unified release packaging workflow in a PR, we build agent with the version from `.package-version` instead of the one specified in `version/version.go`.

## Why is it important?

If we don't do this, this step can fail if the version in version.go was updated, but a snapshot build isn't yet available in the DRA. This can happen for various reasons, and is in fact the case right now. It's the reason https://github.com/elastic/elastic-agent/pull/12590 is failing, for example.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
