### PR TITLE
Allow crossbuilding in a git worktree

### DIFF
--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -365,6 +365,17 @@ func (b GolangCrossBuilder) Build() error {
 		"--env", fmt.Sprintf("DEV=%v", DevBuild),
 		"--env", fmt.Sprintf("FIPS=%v", FIPSBuild),
 		"-v", repoInfo.RootDir+":"+mountPoint,
+	)
+
+	// If in a git worktree, mount the main repo's .git directory into the
+	// container so git can resolve the worktree reference.
+	if commonDir, err := sh.Output("git", "-C", repoInfo.RootDir, "rev-parse", "--git-common-dir"); err == nil {
+		if filepath.IsAbs(commonDir) && !strings.HasPrefix(commonDir, repoInfo.RootDir) {
+			args = append(args, "-v", commonDir+":"+commonDir+":ro")
+		}
+	}
+
+	args = append(args,
 		"-w", workDir,
 		image,
 


### PR DESCRIPTION
## What does this PR do?

Allows building binaries in a crossbuild container in a git worktree, rather than a full repository. In a worktree, `.git` is a symlink, and running git commands with that symlink pointing to an invalid path - as it is if we only mount the worktree directory in a container - results in errors. This change fixes the issue by checking what the actual root is, and mounting it if need be. It does not affect non-worktree repositories at all.

## Why is it important?

Worktrees are a convenient way to work on multiple changes in parallel without needing to have multiple full clones of the agent repo.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
