### PR TITLE
dra(iar): support helmcharts workaround

### DIFF
--- a/.buildkite/pipeline.elastic-agent-package.yml
+++ b/.buildkite/pipeline.elastic-agent-package.yml
@@ -227,6 +227,8 @@ steps:
       ls -alR build
       echo "--- Copy workaround for ironbank container filename"
       .buildkite/scripts/steps/ironbank-cp-workaround.sh
+      echo "--- Copy workaround for helmchart filename"
+      .buildkite/scripts/steps/helmchart-cp-workaround.sh
       echo "--- File listing after workaround"
       ls -alR build
       echo "+++ Checking artifact validity with release-manager collect dry run"

--- a/.buildkite/scripts/steps/helmchart-cp-workaround.sh
+++ b/.buildkite/scripts/steps/helmchart-cp-workaround.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This file is a temporary workaround for the Independent Agent Release
+# workflow. The helmchart does not currently handle the
+# AGENT_PACKAGE_VERSION env var override. This renames that file
+# to use that new version.
+#
+# We will not (at first) be using the helmchart in the 
+# Independent Agent releases; however, we want to use the release-manager
+# container dry-run as a check that all the expected images exist.
+#
+# This workaround allows the check to proceed without erroring on the file
+# that we know won't be named correctly.
+#
+
+PACKAGE_VERSION="${AGENT_PACKAGE_VERSION:=""}"
+
+if [[ -z "${PACKAGE_VERSION}" ]]; then 
+    echo "AGENT_PACKAGE_VERSION is not set, exiting"
+    exit 1
+fi
+
+HELMCHART_DOCKER_BLOB_PREFIX="elastic-agent-helm-chart"
+HELMCHART_DOCKER_BLOB_SUFFIX=".tgz"
+OUTPUT_DIRNAME="build/distributions"
+
+echo "--- ls ${OUTPUT_DIRNAME}"
+ls -al "${OUTPUT_DIRNAME}"
+echo "--- helmchart expected path"
+echo "${OUTPUT_DIRNAME}"/"${HELMCHART_DOCKER_BLOB_PREFIX}"*"${HELMCHART_DOCKER_BLOB_SUFFIX}"
+ls -al "${OUTPUT_DIRNAME}"/"${HELMCHART_DOCKER_BLOB_PREFIX}"*"${HELMCHART_DOCKER_BLOB_SUFFIX}" || true
+
+echo "--- looking for helmchart file to copy to new name"
+if ls "${OUTPUT_DIRNAME}"/"${HELMCHART_DOCKER_BLOB_PREFIX}"*"${HELMCHART_DOCKER_BLOB_SUFFIX}" 2>/dev/null; then 
+    echo "Found the helmchart file"
+    NEW_HELMCHART_NAME="elastic-agent-helm-chart-${PACKAGE_VERSION}.tgz"
+    echo "Copying to new path: ${OUTPUT_DIRNAME}/${NEW_HELMCHART_NAME}"
+    cp "${OUTPUT_DIRNAME}"/"${HELMCHART_DOCKER_BLOB_PREFIX}"*"${HELMCHART_DOCKER_BLOB_SUFFIX}" "${OUTPUT_DIRNAME}/${NEW_HELMCHART_NAME}"
+else
+    echo "Error: could not find helmchart file"
+    exit 1
+fi


### PR DESCRIPTION
## What does this PR do?

Workaround the DRA for IAR for helmcharts

## Why is it important?

As long as Helmcharts are not distributed in the IAR we can remove this requirement of honouring `AGENT_PACKAGE_VERSION` when packaging the HelmChart.

This should unblock the IAR failures

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- https://github.com/elastic/elastic-agent/pull/4222

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
