### PR TITLE
Increase timeout in TestCISKeepsRunningOnNonFatalExitCodeFromStart

### DIFF
--- a/pkg/component/runtime/service_test.go
+++ b/pkg/component/runtime/service_test.go
@@ -368,7 +368,7 @@ func TestCISKeepsRunningOnNonFatalExitCodeFromStart(t *testing.T) {
 		}
 
 		return false
-	}, 2*time.Second, 200*time.Millisecond)
+	}, 30*time.Second, 1*time.Second)
 }
 
 // TestServiceStartRetry tests that the service runtime will


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Increases the timeout we wait for the condition in TestCISKeepsRunningOnNonFatalExitCodeFromStart to 30s.

## Why is it important?

This test is a bit flaky on Windows, and I suspect it's because the npipe dial can time out. The default timeout in winio is 2 seconds, which was also how long we waited.


Resolves https://github.com/elastic/elastic-agent/issues/11590.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
