### PR TITLE
Fix flaky TestDocker variant size ordering assertion

### DIFF
--- a/dev-tools/packaging/testing/package_test.go
+++ b/dev-tools/packaging/testing/package_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"maps"
 	"os"
 	"path"
 	"path/filepath"
@@ -168,7 +167,7 @@ func TestDocker(t *testing.T) {
 		}
 
 		// sort the built variants by size
-		variantOrderBySize := slices.Collect(maps.Keys(builtVariantSizes))
+		variantOrderBySize := slices.Clone(builtVariantsExpectedOrder)
 		sort.SliceStable(variantOrderBySize, func(i, j int) bool {
 			return builtVariantSizes[variantOrderBySize[i]] < builtVariantSizes[variantOrderBySize[j]]
 		})


### PR DESCRIPTION
## Summary
- `maps.Keys` returns keys in non-deterministic order, so when two docker variants have the same size, `sort.SliceStable` preserves that random order rather than the expected order
- Fix by using `slices.Clone` of the already-ordered `builtVariantsExpectedOrder` as the input to the stable sort, so equal-sized variants retain their expected relative order

See https://buildkite.com/elastic/elastic-agent/builds/34668#019c57eb-9074-4fa6-b4f1-8ce37475b31a/L372 for example of resulting flakiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)