### PR TITLE
Disable otel collector metrics in integration tests

### DIFF
--- a/testing/integration/ess/otel_test.go
+++ b/testing/integration/ess/otel_test.go
@@ -81,6 +81,9 @@ exporters:
         insecure: true
 
 service:
+  telemetry:
+    metrics:
+      level: none
   pipelines:
     logs:
       receivers: [filelog]
@@ -104,6 +107,9 @@ func TestOtelStartShutdown(t *testing.T) {
 exporters:
   nop:
 service:
+  telemetry:
+    metrics:
+      level: none
   pipelines:
     logs:
       receivers:
@@ -209,6 +215,9 @@ exporters:
   file:
     path: {{.OutputPath}}
 service:
+  telemetry:
+    metrics:
+      level: none
   pipelines:
     logs:
       receivers:
@@ -511,6 +520,8 @@ service:
       receivers:
         - filelog
   telemetry:
+    metrics:
+      level: none
     logs:
       level: DEBUG
       encoding: json
@@ -1488,6 +1499,8 @@ service:
         - elasticsearch/log
         #- debug
   telemetry:
+    metrics:
+      level: none
     logs:
       level: DEBUG
       encoding: json

--- a/testing/integration/ess/testdata/filebeat_receiver_log_as_filestream.yml
+++ b/testing/integration/ess/testdata/filebeat_receiver_log_as_filestream.yml
@@ -36,6 +36,8 @@ service:
       receivers: [filebeatreceiver]
       exporters: [elasticsearch]
   telemetry:
+    metrics:
+      level: none
     logs:
       level: DEBUG
       encoding: json


### PR DESCRIPTION
The tests don't need the metrics. When running as a plain collector, we bind to port 8888 by default, which can cause conflicts.

See https://buildkite.com/elastic/elastic-agent-extended-testing/builds/12537/steps/canvas?sid=019c6567-4a9c-4fd8-b00e-bd01659e80f7 for example.
