### PR TITLE
Default inputs using dynamic providers to the process runtime

### DIFF
--- a/changelog/fragments/1771503155-dynamic-inputs-process.yaml
+++ b/changelog/fragments/1771503155-dynamic-inputs-process.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Default inputs using dynamic providers to the process runtime
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -51,7 +51,7 @@ type BeatRuntimeConfig struct {
 func DefaultRuntimeConfig() *RuntimeConfig {
 	return &RuntimeConfig{
 		Default:       string(DefaultRuntimeManager),
-		DynamicInputs: "",
+		DynamicInputs: string(ProcessRuntimeManager),
 		Metricbeat: BeatRuntimeConfig{
 			InputType: map[string]string{
 				"activemq/metrics":      string(OtelRuntimeManager),

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -3824,6 +3824,7 @@ func TestDefaultRuntimeConfig(t *testing.T) {
 	config := DefaultRuntimeConfig()
 	require.NotNil(t, config)
 	assert.Equal(t, string(DefaultRuntimeManager), config.Default)
+	assert.Equal(t, string(ProcessRuntimeManager), config.DynamicInputs)
 	assert.Equal(t, "", config.Filebeat.Default)
 	assert.Empty(t, config.Filebeat.InputType)
 	assert.Equal(t, "", config.Metricbeat.Default)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Default inputs using dynamic providers to the process runtime.

I've also refactored the runtime override tests for this feature a bit.

## Why is it important?

The otel runtime isn't efficient at reloading configuration right now. Nonetheless, we want to enable it by default for inputs which are often used in highly dynamic environments, like filestream in Kubernetes. This change allows us to do that without impacting those use cases.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

Build agent and try running an input with a local dynamic provider:

```yaml
inputs:
- id: "${local_dynamic.id}"
  type: filestream
  prospector.scanner.fingerprint.enabled: false
  file_identity.native: ~
  use_output: default
  paths: [...]

outputs:
  default:
    type: elasticsearch
    hosts: [http://localhost:9200]
    username: elastic
    password: elastic
agent:
  monitoring:
    enabled: false
  internal.runtime.filebeat.filestream: otel
  internal.runtime.dynamic_inputs: process
agent.logging.level: debug
providers:
  local_dynamic:
    items:
    - vars:
        id: filestream-1
```

Filestream should run in the process runtime.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/12750

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
