### PR TITLE
Consider timestamps when comparing otel statuses

### DIFF
--- a/internal/pkg/otel/status/serializable.go
+++ b/internal/pkg/otel/status/serializable.go
@@ -118,13 +118,17 @@ func CompareStatuses(s1, s2 *status.AggregateStatus) bool {
 		// one of them is nil
 		return false
 	}
+
+	// We do compare timestamps, because we want to emit a new status if something changed in the collector
+	// even if the same components are running, with the same status values.
+	if s1.Timestamp() != s2.Timestamp() {
+		return false
+	}
+
 	if s1.Status() != s2.Status() {
 		// status doesn't match
 		return false
 	}
-
-	// NOTE: we don't check the timestamp
-	// as we care only about the event and component statuses/error differences
 
 	if (s1.Err() == nil && s2.Err() != nil) || (s1.Err() != nil && s2.Err() == nil) {
 		return false

--- a/internal/pkg/otel/status/serializable_test.go
+++ b/internal/pkg/otel/status/serializable_test.go
@@ -48,6 +48,26 @@ func TestCompareAggregateStatuses(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "unequal timestamps",
+			s1: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:     componentstatus.StatusOK,
+					timestamp:  timestamp,
+					attributes: pcommon.NewMap(),
+					err:        nil,
+				},
+			},
+			s2: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:     componentstatus.StatusOK,
+					timestamp:  timestamp.Add(time.Second),
+					attributes: pcommon.NewMap(),
+					err:        nil,
+				},
+			},
+			expected: false,
+		},
+		{
 			name: "unequal statuses",
 			s1: &status.AggregateStatus{
 				Event: &healthCheckEvent{


### PR DESCRIPTION
## What does this PR do?

Makes timestamps matter when comparing otel statuses. Until now, timestamps were ignored - if the status was identical to the one emitted previously, it wasn't reported to the otel manager. Now, it will be reported.

## Why is it important?

The timestamp is set on status event emission, not per request to the healthcheck extension. It changing can signify a change to the collector that doesn't involve components. For example, if we only change the log level and the collector restarts quickly enough to start all the components between healthcheck requests from agent, then it won't see any difference and won't emit any status update to the coordinator. We should emit the update even if it doesn't change component statuses, if only to demonstrate that something changed.

It also makes testing easier.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/12366

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
