### PR TITLE
[8.19] Move otel status serialization to a separate package

### DIFF
--- a/internal/pkg/otel/manager/healthcheck.go
+++ b/internal/pkg/otel/manager/healthcheck.go
@@ -15,8 +15,9 @@ import (
 
 	"go.opentelemetry.io/collector/confmap"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status"
-	"go.opentelemetry.io/collector/component/componentstatus"
+	"github.com/elastic/elastic-agent/internal/pkg/otel/status"
+
+	otelstatus "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status"
 )
 
 const (
@@ -32,46 +33,8 @@ const (
 	healthCheckHealthConfigEnabled      = false
 )
 
-// SerializableStatus is exported for json.Unmarshal
-type SerializableStatus struct {
-	StartTimestamp *time.Time `json:"start_time,omitempty"`
-	*SerializableEvent
-	ComponentStatuses map[string]*SerializableStatus `json:"components,omitempty"`
-}
-
-// SerializableEvent is exported for json.Unmarshal
-type SerializableEvent struct {
-	Healthy      bool      `json:"healthy"`
-	StatusString string    `json:"status"`
-	Error        string    `json:"error,omitempty"`
-	Timestamp    time.Time `json:"status_time"`
-}
-
-// stringToStatusMap is a map from string representation of status to componentstatus.Status.
-var stringToStatusMap = map[string]componentstatus.Status{
-	"StatusNone":             componentstatus.StatusNone,
-	"StatusStarting":         componentstatus.StatusStarting,
-	"StatusOK":               componentstatus.StatusOK,
-	"StatusRecoverableError": componentstatus.StatusRecoverableError,
-	"StatusPermanentError":   componentstatus.StatusPermanentError,
-	"StatusFatalError":       componentstatus.StatusFatalError,
-	"StatusStopping":         componentstatus.StatusStopping,
-	"StatusStopped":          componentstatus.StatusStopped,
-}
-
-// healthCheckEvent implements status.Event interface for health check events.
-type healthCheckEvent struct {
-	status    componentstatus.Status
-	timestamp time.Time
-	err       error
-}
-
-func (e *healthCheckEvent) Status() componentstatus.Status { return e.status }
-func (e *healthCheckEvent) Timestamp() time.Time           { return e.timestamp }
-func (e *healthCheckEvent) Err() error                     { return e.err }
-
 // AllComponentsStatuses retrieves the status of all components from the health check endpoint.
-func AllComponentsStatuses(ctx context.Context, client http.Client, httpHealthCheckPort int) (*status.AggregateStatus, error) {
+func AllComponentsStatuses(ctx context.Context, client http.Client, httpHealthCheckPort int) (*otelstatus.AggregateStatus, error) {
 	var err error
 
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
@@ -98,106 +61,13 @@ func AllComponentsStatuses(ctx context.Context, client http.Client, httpHealthCh
 		return nil, fmt.Errorf("failed to read body: %w", err)
 	}
 
-	serStatus := &SerializableStatus{}
+	serStatus := &status.SerializableStatus{}
 	err = json.Unmarshal(body, serStatus)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal serializable status: %w", err)
 	}
 
-	return fromSerializableStatus(serStatus), nil
-}
-
-// fromSerializableStatus reconstructs an AggregateStatus from serializableStatus.
-func fromSerializableStatus(ss *SerializableStatus) *status.AggregateStatus {
-	ev := fromSerializableEvent(ss.SerializableEvent)
-
-	as := &status.AggregateStatus{
-		Event:              ev,
-		ComponentStatusMap: make(map[string]*status.AggregateStatus),
-	}
-
-	for k, cs := range ss.ComponentStatuses {
-		as.ComponentStatusMap[k] = fromSerializableStatus(cs)
-	}
-
-	return as
-}
-
-// fromSerializableEvent reconstructs a status.Event from SerializableEvent.
-func fromSerializableEvent(se *SerializableEvent) status.Event {
-	if se == nil {
-		return nil
-	}
-
-	var err error
-	if se.Error != "" {
-		err = errors.New(se.Error)
-	}
-
-	statusVal, ok := stringToStatusMap[se.StatusString]
-	if !ok {
-		statusVal = componentstatus.StatusNone
-	}
-
-	return &healthCheckEvent{
-		status:    statusVal,
-		timestamp: se.Timestamp,
-		err:       err,
-	}
-}
-
-// compareStatuses checks if two AggregateStatuses are equal, excluding timestamp.
-func compareStatuses(s1, s2 *status.AggregateStatus) bool {
-	if s1 == nil && s2 == nil {
-		// both nil
-		return true
-	}
-	if s1 == nil || s2 == nil {
-		// one of them is nil
-		return false
-	}
-	if s1.Status() != s2.Status() {
-		// status doesn't match
-		return false
-	}
-
-	// NOTE: we don't check the timestamp
-	// as we care only about the event and component statuses/error differences
-
-	if (s1.Err() == nil && s2.Err() != nil) || (s1.Err() != nil && s2.Err() == nil) {
-		return false
-	}
-	if s1.Err() != nil && s2.Err() != nil {
-		if s1.Err().Error() != s2.Err().Error() {
-			return false
-		}
-	}
-
-	if len(s1.ComponentStatusMap) != len(s2.ComponentStatusMap) {
-		return false
-	}
-	for k, v1 := range s1.ComponentStatusMap {
-		v2, ok := s2.ComponentStatusMap[k]
-		if !ok {
-			return false
-		}
-		if !compareStatuses(v1, v2) {
-			return false
-		}
-	}
-	return true
-}
-
-// aggregateStatus creates a new AggregateStatus with the provided component status and error.
-func aggregateStatus(sts componentstatus.Status, err error) *status.AggregateStatus {
-	return &status.AggregateStatus{
-		Event: &healthCheckEvent{
-			status:    sts,
-			timestamp: time.Now(),
-			err:       err,
-		},
-		ComponentStatusMap: make(map[string]*status.AggregateStatus),
-	}
+	return status.FromSerializableStatus(serStatus), nil
 }
 
 // injectHealthCheckV2Extension injects the healthcheckv2 extension into the provided configuration.

--- a/internal/pkg/otel/status/serializable.go
+++ b/internal/pkg/otel/status/serializable.go
@@ -1,0 +1,144 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package status
+
+import (
+	"errors"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status"
+	"go.opentelemetry.io/collector/component/componentstatus"
+)
+
+// SerializableStatus is exported for json.Unmarshal
+type SerializableStatus struct {
+	StartTimestamp *time.Time `json:"start_time,omitempty"`
+	*SerializableEvent
+	ComponentStatuses map[string]*SerializableStatus `json:"components,omitempty"`
+}
+
+// SerializableEvent is exported for json.Unmarshal
+type SerializableEvent struct {
+	Healthy      bool      `json:"healthy"`
+	StatusString string    `json:"status"`
+	Error        string    `json:"error,omitempty"`
+	Timestamp    time.Time `json:"status_time"`
+}
+
+// stringToStatusMap is a map from string representation of status to componentstatus.Status.
+var stringToStatusMap = map[string]componentstatus.Status{
+	"StatusNone":             componentstatus.StatusNone,
+	"StatusStarting":         componentstatus.StatusStarting,
+	"StatusOK":               componentstatus.StatusOK,
+	"StatusRecoverableError": componentstatus.StatusRecoverableError,
+	"StatusPermanentError":   componentstatus.StatusPermanentError,
+	"StatusFatalError":       componentstatus.StatusFatalError,
+	"StatusStopping":         componentstatus.StatusStopping,
+	"StatusStopped":          componentstatus.StatusStopped,
+}
+
+// healthCheckEvent implements status.Event interface for health check events.
+type healthCheckEvent struct {
+	status    componentstatus.Status
+	timestamp time.Time
+	err       error
+}
+
+func (e *healthCheckEvent) Status() componentstatus.Status { return e.status }
+func (e *healthCheckEvent) Timestamp() time.Time           { return e.timestamp }
+func (e *healthCheckEvent) Err() error                     { return e.err }
+
+// FromSerializableStatus reconstructs an AggregateStatus from serializableStatus.
+func FromSerializableStatus(ss *SerializableStatus) *status.AggregateStatus {
+	ev := FromSerializableEvent(ss.SerializableEvent)
+
+	as := &status.AggregateStatus{
+		Event:              ev,
+		ComponentStatusMap: make(map[string]*status.AggregateStatus),
+	}
+
+	for k, cs := range ss.ComponentStatuses {
+		as.ComponentStatusMap[k] = FromSerializableStatus(cs)
+	}
+
+	return as
+}
+
+// FromSerializableEvent reconstructs a status.Event from SerializableEvent.
+func FromSerializableEvent(se *SerializableEvent) status.Event {
+	if se == nil {
+		return nil
+	}
+
+	var err error
+	if se.Error != "" {
+		err = errors.New(se.Error)
+	}
+
+	statusVal, ok := stringToStatusMap[se.StatusString]
+	if !ok {
+		statusVal = componentstatus.StatusNone
+	}
+
+	return &healthCheckEvent{
+		status:    statusVal,
+		timestamp: se.Timestamp,
+		err:       err,
+	}
+}
+
+// CompareStatuses checks if two AggregateStatuses are equal, excluding timestamp.
+func CompareStatuses(s1, s2 *status.AggregateStatus) bool {
+	if s1 == nil && s2 == nil {
+		// both nil
+		return true
+	}
+	if s1 == nil || s2 == nil {
+		// one of them is nil
+		return false
+	}
+	if s1.Status() != s2.Status() {
+		// status doesn't match
+		return false
+	}
+
+	// NOTE: we don't check the timestamp
+	// as we care only about the event and component statuses/error differences
+
+	if (s1.Err() == nil && s2.Err() != nil) || (s1.Err() != nil && s2.Err() == nil) {
+		return false
+	}
+	if s1.Err() != nil && s2.Err() != nil {
+		if s1.Err().Error() != s2.Err().Error() {
+			return false
+		}
+	}
+
+	if len(s1.ComponentStatusMap) != len(s2.ComponentStatusMap) {
+		return false
+	}
+	for k, v1 := range s1.ComponentStatusMap {
+		v2, ok := s2.ComponentStatusMap[k]
+		if !ok {
+			return false
+		}
+		if !CompareStatuses(v1, v2) {
+			return false
+		}
+	}
+	return true
+}
+
+// AggregateStatus creates a new AggregateStatus with the provided component status and error.
+func AggregateStatus(sts componentstatus.Status, err error) *status.AggregateStatus {
+	return &status.AggregateStatus{
+		Event: &healthCheckEvent{
+			status:    sts,
+			timestamp: time.Now(),
+			err:       err,
+		},
+		ComponentStatusMap: make(map[string]*status.AggregateStatus),
+	}
+}

--- a/internal/pkg/otel/status/serializable_test.go
+++ b/internal/pkg/otel/status/serializable_test.go
@@ -1,0 +1,254 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package status
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status"
+	"go.opentelemetry.io/collector/component/componentstatus"
+)
+
+func TestCompareAggregateStatuses(t *testing.T) {
+	timestamp := time.Now()
+	for _, tc := range []struct {
+		name     string
+		s1, s2   *status.AggregateStatus
+		expected bool
+	}{
+		{
+			name: "equal statuses",
+			s1: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:    componentstatus.StatusOK,
+					timestamp: timestamp,
+					err:       nil,
+				},
+			},
+			s2: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:    componentstatus.StatusOK,
+					timestamp: timestamp,
+					err:       nil,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "unequal statuses",
+			s1: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:    componentstatus.StatusOK,
+					timestamp: timestamp,
+					err:       nil,
+				},
+			},
+			s2: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:    componentstatus.StatusPermanentError,
+					timestamp: timestamp,
+					err:       nil,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "unequal errors",
+			s1: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:    componentstatus.StatusOK,
+					timestamp: timestamp,
+					err:       nil,
+				},
+			},
+			s2: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:    componentstatus.StatusOK,
+					timestamp: timestamp,
+					err:       errors.New("error"),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "unequal component statuses",
+			s1: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:    componentstatus.StatusOK,
+					timestamp: timestamp,
+					err:       nil,
+				},
+				ComponentStatusMap: map[string]*status.AggregateStatus{
+					"component1": {
+						Event: &healthCheckEvent{
+							status:    componentstatus.StatusOK,
+							timestamp: timestamp,
+							err:       nil,
+						},
+					},
+				},
+			},
+			s2: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:    componentstatus.StatusOK,
+					timestamp: timestamp,
+					err:       nil,
+				},
+				ComponentStatusMap: map[string]*status.AggregateStatus{
+					"component1": {
+						Event: &healthCheckEvent{
+							status:    componentstatus.StatusStopped,
+							timestamp: timestamp,
+							err:       nil,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "more components",
+			s1: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:    componentstatus.StatusOK,
+					timestamp: timestamp,
+					err:       nil,
+				},
+				ComponentStatusMap: map[string]*status.AggregateStatus{
+					"component1": {
+						Event: &healthCheckEvent{
+							status:    componentstatus.StatusOK,
+							timestamp: timestamp,
+							err:       nil,
+						},
+					},
+					"component2": {
+						Event: &healthCheckEvent{
+							status:    componentstatus.StatusOK,
+							timestamp: timestamp,
+							err:       nil,
+						},
+					},
+				},
+			},
+			s2: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:    componentstatus.StatusOK,
+					timestamp: timestamp,
+					err:       nil,
+				},
+				ComponentStatusMap: map[string]*status.AggregateStatus{
+					"component1": {
+						Event: &healthCheckEvent{
+							status:    componentstatus.StatusOK,
+							timestamp: timestamp,
+							err:       nil,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "completely different components",
+			s1: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:    componentstatus.StatusOK,
+					timestamp: timestamp,
+					err:       nil,
+				},
+				ComponentStatusMap: map[string]*status.AggregateStatus{
+					"component1": {
+						Event: &healthCheckEvent{
+							status:    componentstatus.StatusOK,
+							timestamp: timestamp,
+							err:       nil,
+						},
+					},
+				},
+			},
+			s2: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:    componentstatus.StatusOK,
+					timestamp: timestamp,
+					err:       nil,
+				},
+				ComponentStatusMap: map[string]*status.AggregateStatus{
+					"component3": {
+						Event: &healthCheckEvent{
+							status:    componentstatus.StatusOK,
+							timestamp: timestamp,
+							err:       nil,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "unequal component errors",
+			s1: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:    componentstatus.StatusOK,
+					timestamp: timestamp,
+					err:       nil,
+				},
+				ComponentStatusMap: map[string]*status.AggregateStatus{
+					"component1": {
+						Event: &healthCheckEvent{
+							status:    componentstatus.StatusOK,
+							timestamp: timestamp,
+							err:       errors.New("error1"),
+						},
+					},
+				},
+			},
+			s2: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:    componentstatus.StatusOK,
+					timestamp: timestamp,
+					err:       nil,
+				},
+				ComponentStatusMap: map[string]*status.AggregateStatus{
+					"component1": {
+						Event: &healthCheckEvent{
+							status:    componentstatus.StatusOK,
+							timestamp: timestamp,
+							err:       errors.New("error2"),
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "both nil",
+			s1:       nil,
+			s2:       nil,
+			expected: true,
+		},
+		{
+			name: "one nil",
+			s1: &status.AggregateStatus{
+				Event: &healthCheckEvent{
+					status:    componentstatus.StatusOK,
+					timestamp: timestamp,
+					err:       nil,
+				},
+			},
+			s2:       nil,
+			expected: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := CompareStatuses(tc.s1, tc.s2)
+			if actual != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Backport of the serialization refactoring from https://github.com/elastic/elastic-agent/pull/11856. Moves SerializableStatus, SerializableEvent, and related types and functions from the manager package to internal/pkg/otel/status, making them reusable by other packages.

## Related issues

- Will make https://github.com/elastic/elastic-agent/pull/12882 easier to merge.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
