### PR TITLE
Add Elastic Agent 9.3.0+IAR release notes

### DIFF
--- a/docs/release-notes/_snippets/9.3.0+build202602051825/breaking-changes.md
+++ b/docs/release-notes/_snippets/9.3.0+build202602051825/breaking-changes.md
@@ -1,0 +1,3 @@
+## 9.3.0&#43;build202602051825 [elastic-agent-9.3.0&#43;build202602051825-breaking-changes]
+
+_No breaking changes._

--- a/docs/release-notes/_snippets/9.3.0+build202602051825/deprecations.md
+++ b/docs/release-notes/_snippets/9.3.0+build202602051825/deprecations.md
@@ -1,0 +1,3 @@
+## 9.3.0&#43;build202602051825 [elastic-agent-9.3.0&#43;build202602051825-deprecations]
+
+_No deprecations._

--- a/docs/release-notes/_snippets/9.3.0+build202602051825/index.md
+++ b/docs/release-notes/_snippets/9.3.0+build202602051825/index.md
@@ -1,0 +1,11 @@
+## 9.3.0&#43;build202602051825 [elastic-agent-release-notes-9.3.0&#43;build202602051825]
+
+:::{note}
+This is an independent Elastic Agent release. Independent Elastic Agent releases deliver critical fixes and updates for Elastic Agent and Elastic Defend independently of a full Elastic Stack release. Read more in [Elastic Agent release process](docs-content://reference/fleet/fleet-agent-release-process.md).
+:::
+
+
+### Fixes [elastic-agent-9.3.0&#43;build202602051825-fixes]
+
+* Fixes a bug in version 9.3.0 of Elastic Defend that resulted in the Windows Security Center status page showing an error.
+* Fixes a DNS parsing bug in Linux versions of Elastic Defend.

--- a/docs/release-notes/_snippets/index/9.3.md
+++ b/docs/release-notes/_snippets/index/9.3.md
@@ -1,3 +1,5 @@
-:::{include} /release-notes/_snippets/9.3.0/index.md
+:::{include} /release-notes/_snippets/9.3.0+build202602051825/index.md
 :::
 
+:::{include} /release-notes/_snippets/9.3.0/index.md
+:::


### PR DESCRIPTION
Adds Elastic Agent 9.3.0+build202602051825 release notes
Fixes: https://github.com/elastic/docs-content/issues/5173

**PREVIEW:** https://docs-v3-preview.elastic.dev/elastic/elastic-agent/pull/12911/release-notes