### PR TITLE
Add verbosity to debug exporter

### DIFF
--- a/changelog/fragments/1772011539-debugexporter_verbosity.yaml
+++ b/changelog/fragments/1772011539-debugexporter_verbosity.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: set debugexporter verbosity to basic in gateway collector
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+# description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/12878

--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/logs-values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/logs-values.yaml
@@ -240,6 +240,7 @@ collectors:
       processors: {}
       exporters:
         debug:
+          verbosity: basic
         otlp/ingest:
           endpoint: ${env:ELASTIC_OTLP_ENDPOINT}
           headers:

--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
@@ -545,6 +545,7 @@ collectors:
       processors: {}
       exporters:
         debug:
+          verbosity: basic
         otlp/ingest_logs:
           endpoint: ${env:ELASTIC_OTLP_ENDPOINT}
           headers:


### PR DESCRIPTION
## What does this PR do?

Verbosity for debug exporter is explicitly set to basic for gateway collector. This matches with the default extension config, but also with the configured value for the other collectors configured in the same deployment (daemon, cluster-stats). 

## Why is it important?

- Closes https://github.com/elastic/elastic-agent/issues/12878
- Makes the configuration consistent across all the collectors in the same deployment

**NOTE:** Whilst I have not been able to reproduce the issue raised in ttps://github.com/elastic/elastic-agent/issues/12878, I still believe the change should be made. It makes the configuration more explicit, has no functional impact (when things work), since the extension defaults to the same value. Finally, it also seems it might prevents crashes under certain conditions. (Also why marked this both as bug and enhancement, due to the fact that so far I was not able to see the collector crash because of this value)


## Checklist


- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

No user impact

## How to test this PR locally

```sh
helm upgrade --install opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack \
  --namespace opentelemetry-operator-system \
  --values ./values.yaml \ 
  --version '0.12.4
```

This assumes namespace and required secrets already present.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/12878

