### PR TITLE
Fix Ironbank artifact versions in DRA snapshot builds

### DIFF
--- a/.buildkite/scripts/steps/package.sh
+++ b/.buildkite/scripts/steps/package.sh
@@ -41,9 +41,6 @@ if [ "${_UNSET_MANIFEST_URL:-}" = "true" ]; then
   # Unset before calling packageUsingDRA this will have the target
   # use the built agent core packages from above
   unset MANIFEST_URL
-  # SNAPSHOT and USE_PACKAGE_VERSION aren't set in the DRA workflows and we want to be as close to those as possible
-  unset SNAPSHOT
-  unset USE_PACKAGE_VERSION
 fi
 
 MAGE_TARGETS=("packageUsingDRA")


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

It fixes artifact names for ironbank artifacts by adding the SNAPSHOT suffix if the manifest url is provided and the build therein is a snapshot build.

This used to work by accident before https://github.com/elastic/elastic-agent/pull/12128. We'd call `mage packageUsingDRA ironbank`, and packageUsingDRA would set the SNAPSHOT env variable. Both mage targets ran in the same process, so ironbank would pick it up and have the right artifact name by accident in spite of not knowing anything about DRA manifests. After the fix, the ironbank target explicitly looks at the manifest to get the version, just like packageUsingDRA.

Unfortunately, updating `package.sh` in PR checks so this issue isn't masked anymore requires more in-depth changes, so manual tests will have to do for now.

## Why is it important?

elastic-agent-package is currently failing on main for unified release snapshots because the ironbank artifact name is missing the snapshot suffix: https://buildkite.com/elastic/elastic-agent-package/builds?branch=main.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

Run `MANIFEST_URL="$(jq -r .manifest_url .package-version)" mage ironbank`. The produced artifact name should have SNAPSHOT in it.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
