### PR TITLE
Add build failure notifications for elastic-agent-package on release branches

### DIFF
--- a/.buildkite/pipeline.elastic-agent-package.yml
+++ b/.buildkite/pipeline.elastic-agent-package.yml
@@ -257,5 +257,6 @@ notify:
 - slack:
     channels:
       - "#ingest-notifications"
-    message: "Testing build notifications for elastic-agent-package <!subteam^S030QSX59PH>"
+    message: ":traffic_cone: elastic-agent-package failed! <!subteam^S030QSX59PH> please investigate."
+  if: build.state == "failed" && (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/)
 


### PR DESCRIPTION
## What does this PR do?

Adds a Slack notification for failing builds of the elastic-agent-package workflow on release branches. The notification pings the whole team in the same way as updatecli failures do.

I tested the notification, it pinged us correctly.

## Why is it important?

elastic-agent-package failing on a release branch almost always means it was triggered by unified-release. Those failures need to be addressed asap.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
