### PR TITLE
[docs] Fix applies_to tags in EDOT Collector component pages

### DIFF
--- a/docs/reference/edot-collector/components/apmconfigextension.md
+++ b/docs/reference/edot-collector/components/apmconfigextension.md
@@ -2,11 +2,9 @@
 navigation_title: APM Config extension
 description: The APM Config extension is an OpenTelemetry Collector component that enables central configuration delivery for EDOT SDKs using the Open Agent Management Protocol (OpAMP).
 applies_to:
-  stack:
+  stack: ga
   serverless:
-  observability:
-  product:
-    edot_collector:
+    observability: ga
 products:
   - id: elastic-agent
   - id: observability

--- a/docs/reference/edot-collector/components/attributesprocessor.md
+++ b/docs/reference/edot-collector/components/attributesprocessor.md
@@ -2,11 +2,9 @@
 navigation_title: Attributes processor
 description: The attributes processor is an OpenTelemetry Collector component that modifies resource attributes and span, metric, or log attributes before they are exported.
 applies_to:
-  stack:
+  stack: ga
   serverless:
-  observability:
-  product:
-    edot_collector:
+    observability: ga
 products:
   - id: elastic-agent
   - id: observability

--- a/docs/reference/edot-collector/components/elasticapmconnector.md
+++ b/docs/reference/edot-collector/components/elasticapmconnector.md
@@ -2,11 +2,9 @@
 navigation_title: Elastic {{product.apm}} connector
 description: The Elastic {{product.apm}} connector is an OpenTelemetry Collector component that generates pre-aggregated APM metrics from trace data.
 applies_to:
-  stack:
+  stack: ga
   serverless:
-    observability:
-  product:
-    edot_collector:
+    observability: ga
 products:
   - id: elastic-agent
   - id: observability

--- a/docs/reference/edot-collector/components/elasticapmintakereceiver.md
+++ b/docs/reference/edot-collector/components/elasticapmintakereceiver.md
@@ -4,9 +4,7 @@ description: The Elastic APM intake receiver is an OpenTelemetry Collector compo
 applies_to:
   stack: ga 9.2
   serverless:
-    observability:
-  product:
-    edot_collector: ga 9.2
+    observability: ga
 products:
   - id: cloud-serverless
   - id: observability

--- a/docs/reference/edot-collector/components/elasticapmprocessor.md
+++ b/docs/reference/edot-collector/components/elasticapmprocessor.md
@@ -2,11 +2,9 @@
 navigation_title: Elastic APM processor
 description: The Elastic APM processor is an OpenTelemetry Collector component that enriches OTel data for optimal use with Elastic APM.
 applies_to:
-  stack: ga 9.2+
+  stack: ga 9.2
   serverless:
-    observability:
-  product:
-    edot_collector: ga 9.2+
+    observability: ga
 products:
   - id: elastic-agent
   - id: observability

--- a/docs/reference/edot-collector/components/elasticsearchexporter.md
+++ b/docs/reference/edot-collector/components/elasticsearchexporter.md
@@ -2,11 +2,9 @@
 navigation_title: Elasticsearch exporter
 description: The Elasticsearch exporter is an OpenTelemetry Collector component that sends telemetry data to Elasticsearch.
 applies_to:
-  stack:
+  stack: ga
   serverless:
-    observability:
-  product:
-    edot_collector:
+    observability: ga
 products:
   - id: cloud-serverless
   - id: observability
@@ -146,7 +144,7 @@ exporters:
 ### Deprecated batcher configuration
 
 ```{applies_to}
-stack: ga 9.0-9.1, deprecated =9.2, removed 9.3+
+stack: ga 9.0-9.1, deprecated =9.2, removed 9.3
 ```
 
 :::{warning}

--- a/docs/reference/edot-collector/components/filelogreceiver.md
+++ b/docs/reference/edot-collector/components/filelogreceiver.md
@@ -2,11 +2,9 @@
 navigation_title: File log receiver
 description: The file log receiver is an OpenTelemetry Collector component that ingests logs from files.
 applies_to:
-  stack:
+  stack: ga
   serverless:
-    observability:
-  product:
-    edot_collector:
+    observability: ga
 products:
   - id: elastic-agent
   - id: observability

--- a/docs/reference/edot-collector/components/hostmetricsreceiver.md
+++ b/docs/reference/edot-collector/components/hostmetricsreceiver.md
@@ -2,11 +2,9 @@
 navigation_title: Host metrics receiver
 description: The host metrics receiver is an OpenTelemetry Collector component that collects system-level metrics from the host machine.
 applies_to:
-  stack:
+  stack: ga
   serverless:
-    observability:
-  product:
-    edot_collector:
+    observability: ga
 products:
   - id: elastic-agent
   - id: observability

--- a/docs/reference/edot-collector/components/k8sclusterreceiver.md
+++ b/docs/reference/edot-collector/components/k8sclusterreceiver.md
@@ -2,11 +2,9 @@
 navigation_title: Kubernetes cluster receiver
 description: The Kubernetes cluster receiver is an OpenTelemetry Collector component that collects Kubernetes cluster-level metrics and entity events for Elastic Observability through the EDOT Collector.
 applies_to:
-  stack:
+  stack: ga
   serverless:
-    observability:
-  product:
-    edot_collector:
+    observability: ga
 products:
   - id: cloud-serverless
   - id: observability

--- a/docs/reference/edot-collector/components/k8sobjectsreceiver.md
+++ b/docs/reference/edot-collector/components/k8sobjectsreceiver.md
@@ -2,11 +2,9 @@
 navigation_title: Kubernetes objects receiver
 description: The Kubernetes objects receiver is an OpenTelemetry Collector component that collects Kubernetes API objects and events for Elastic Observability through the EDOT Collector.
 applies_to:
-  stack:
+  stack: ga
   serverless:
-    observability:
-  product:
-    edot_collector:
+    observability: ga
 products:
   - id: cloud-serverless
   - id: observability

--- a/docs/reference/edot-collector/components/kubeletstatsreceiver.md
+++ b/docs/reference/edot-collector/components/kubeletstatsreceiver.md
@@ -2,11 +2,9 @@
 navigation_title: Kubelet stats receiver
 description: The Kubelet stats receiver is an OpenTelemetry Collector component that collects node, pod, container, and volume resource metrics from the Kubernetes Kubelet.
 applies_to:
-  stack:
+  stack: ga
   serverless:
-    observability:
-  product:
-    edot_collector:
+    observability: ga
 products:
   - id: cloud-serverless
   - id: observability

--- a/docs/reference/edot-collector/components/migrate-components.md
+++ b/docs/reference/edot-collector/components/migrate-components.md
@@ -2,11 +2,9 @@
 navigation_title: Migrate components
 description: How to migrate from deprecated EDOT Collector components to their replacements.
 applies_to:
-  stack:
+  stack: ga
   serverless:
-    observability:
-  product:
-    edot_collector: ga
+    observability: ga
 type: how-to
 products:
   - id: cloud-serverless

--- a/docs/reference/edot-collector/components/prometheusremotewritereceiver.md
+++ b/docs/reference/edot-collector/components/prometheusremotewritereceiver.md
@@ -4,9 +4,7 @@ description: The Prometheus remote write receiver is an OpenTelemetry Collector 
 applies_to:
   stack: ga 9.3
   serverless:
-    observability:
-  product:
-    edot_collector: ga 9.3
+    observability: ga
 products:
   - id: elastic-agent
   - id: observability


### PR DESCRIPTION
## Summary

- Remove mixed `applies_to` dimensions (stack/serverless + product) from all 13 EDOT Collector component pages, keeping only the stack/serverless dimension.
- Add explicit `ga` lifecycle values where they were previously empty/null.
- Fix `observability` key nesting in `attributesprocessor.md` and `apmconfigextension.md` (was a sibling of `serverless` instead of a subkey).
- Remove redundant `+` suffixes from final lifecycle entries in `elasticapmprocessor.md` and `elasticsearchexporter.md`.

## Test plan

- [ ] Verify docs build passes with no errors.
- [ ] Confirm `applies_to` badges render correctly on affected pages.

Made with [Cursor](https://cursor.com)