### PR TITLE
[8.19] Fix Windows Archive root binary

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -245,9 +245,9 @@ func (Build) GenerateConfig() error {
 // WindowsArchiveRootBinary compiles a binary to be placed at the root of the windows elastic-agent archive. This binary
 // is a thin proxy to the actual elastic-agent binary that resides in the data/elastic-agent-{commit-short-sha}
 // directory of the archive.
-func (Build) WindowsArchiveRootBinary() error {
+func (Build) WindowsArchiveRootBinary(ctx context.Context) error {
 	fmt.Println("--- Compiling root binary for windows archive")
-	cfg := devtools.MustLoadSettings()
+	cfg := devtools.SettingsFromContext(ctx)
 	hashShort, err := cfg.Build.CommitHashShort()
 	if err != nil {
 		return fmt.Errorf("error getting commit hash: %w", err)
@@ -289,7 +289,7 @@ func (Build) WindowsArchiveRootBinary() error {
 		args.CGO = true
 	}
 
-	return devtools.Build(context.Background(), cfg, args)
+	return devtools.Build(ctx, cfg, args)
 }
 
 // GolangCrossBuildOSS build the Beat binary inside of the golang-builder.


### PR DESCRIPTION
## What does this PR do?

Fixes an issue introduced by https://github.com/elastic/elastic-agent/pull/12836, where the DRA build uses the wrong commit hash to build the Windows archive proxy binary. This worked by accident since that change, as we don't have a high rate of change in 8.19 and the commits happened to line up.

## Why is it important?

It's broken for https://snapshots.elastic.co/8.19.13-2c3676d4/downloads/beats/elastic-agent/elastic-agent-8.19.13-SNAPSHOT-windows-x86_64.zip, which is currently causing CI failures in upgrade tests. For example https://buildkite.com/elastic/elastic-agent/builds/35743/steps/table?jid=019ce208-c48c-4799-bd5a-74fc89dd7223&tab=output.

## How to test this PR locally

```bash
export AGENT_DROP_PATH=build/elastic-agent-drop MANIFEST_URL=$(jq -r .manifest_url .package-version)
mage downloadManifest
PLATFORMS="windows/amd64" mage packageUsingDRA
```

Extract the package on a windows machine and run `.\elastic-agent.exe version --binary-only`.


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
