### PR TITLE
Fix binary build time returned by `version` command

### DIFF
--- a/changelog/fragments/1773392178-fix-agent-buildtime.yaml
+++ b/changelog/fragments/1773392178-fix-agent-buildtime.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug_fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix the elastic-agent build time as reported by the version command
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/magefile/mage/sh"
 	"golang.org/x/text/cases"
@@ -75,7 +76,7 @@ func FuncMap(cfg *Settings) map[string]interface{} {
 		"beat_version":                   func() string { return cfg.BeatQualifiedVersion() },
 		"commit":                         func() (string, error) { return cfg.Build.CommitHash() },
 		"commit_short":                   func() (string, error) { return cfg.Build.CommitHashShort() },
-		"date":                           func() string { return cfg.BuildDate },
+		"date":                           func() string { return cfg.BuildDateString() },
 		"elastic_beats_dir":              func() string { return cfg.ElasticBeatsDir },
 		"go_version":                     func() string { return cfg.GoVersion() },
 		"repo":                           func() *ProjectRepoInfo { return cfg.RepoInfo },
@@ -650,7 +651,7 @@ type Settings struct {
 
 	// BuildDate is the timestamp when settings were loaded (build started).
 	// Initialized during LoadSettings().
-	BuildDate string
+	BuildDate time.Time
 }
 
 // DefaultSettings returns a new Settings instance with all default values.
@@ -682,6 +683,7 @@ func (s *Settings) setBuildDefaults() {
 	s.Build.GOOS = build.Default.GOOS
 	s.Build.GOARCH = build.Default.GOARCH
 	s.Build.MaxParallel = runtime.NumCPU()
+	s.BuildDate = time.Now().UTC()
 }
 
 // setBeatDefaults sets default values for BeatSettings.
@@ -1735,6 +1737,11 @@ func (s *Settings) BeatVersion() string {
 		return s.Build.BeatVersion
 	}
 	return s.beatVersion
+}
+
+// BuildDateString returns a formatted build date.
+func (s *Settings) BuildDateString() string {
+	return s.BuildDate.Format(time.RFC3339)
 }
 
 // GetPlatforms returns the parsed platform list from PLATFORMS env var.

--- a/dev-tools/mage/settings_test.go
+++ b/dev-tools/mage/settings_test.go
@@ -602,6 +602,7 @@ func TestDefaultSettings(t *testing.T) {
 		assert.False(t, settings.Build.Snapshot)
 		assert.False(t, settings.Build.DevBuild)
 		assert.Greater(t, settings.Build.MaxParallel, 0)
+		assert.NotZero(t, settings.BuildDate)
 
 		// Dev machine defaults
 		assert.Equal(t, DefaultDevMachineImage, settings.DevMachine.MachineImage)

--- a/testing/integration/ess/pkgversion_common_test.go
+++ b/testing/integration/ess/pkgversion_common_test.go
@@ -20,9 +20,15 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
+	"github.com/elastic/elastic-agent/internal/pkg/release"
 	integrationtest "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/version"
 )
+
+type VersionOutput struct {
+	Binary *release.VersionInfo `yaml:"binary"`
+	Daemon *release.VersionInfo `yaml:"daemon,omitempty"`
+}
 
 // testAgentPackageVersion returns a func that can be used with t.Run() to execute the version check as a subtest
 func testAgentPackageVersion(ctx context.Context, f *integrationtest.Fixture, binaryOnly bool) func(*testing.T) {
@@ -98,11 +104,24 @@ func getAgentVersionOutput(t *testing.T, f *integrationtest.Fixture, ctx context
 
 // unmarshalVersionOutput retrieves the version string for binary or daemon from "version" subcommand yaml output
 func unmarshalVersionOutput(t *testing.T, cmdOutput []byte, binaryOrDaemonKey string) string {
-	versionCmdOutput := map[string]any{}
+	t.Helper()
+	versionCmdOutput := &VersionOutput{}
 	err := yaml.Unmarshal(cmdOutput, &versionCmdOutput)
 	require.NoError(t, err, "error parsing 'version' command output")
-	require.Contains(t, versionCmdOutput, binaryOrDaemonKey)
-	return versionCmdOutput[binaryOrDaemonKey].(map[any]any)["version"].(string)
+	var versionInfo *release.VersionInfo
+	switch binaryOrDaemonKey {
+	case "binary":
+		versionInfo = versionCmdOutput.Binary
+	case "daemon":
+		versionInfo = versionCmdOutput.Daemon
+	default:
+		t.Errorf("expected either 'binary' or 'daemon', got: %s", binaryOrDaemonKey)
+	}
+	require.NotNil(t, versionInfo)
+	require.NotZero(t, versionInfo.BuildTime)
+	require.NotZero(t, versionInfo.Commit)
+	require.NotZero(t, versionInfo.Version)
+	return versionInfo.Version
 }
 
 // findPkgVersionFiles scans recursively a root directory and returns all the package version files encountered


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the build time reported by the agent binary is the zero value. This was accidentally broken by https://github.com/elastic/elastic-agent/pull/12856, where the global containing this value was moved to the Settings struct, but was never actually populated.

I've also added unit tests and verified that the output of `version` is correct in an existing integration test.

## Why is it important?

The reported build time should be accurate.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## How to test this PR locally

Build the agent and run `elastic-agent version --binary-only`. Packaging isn't necessary.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
