### PR TITLE
Allow building agent in Docker rootless mode

### DIFF
--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -283,7 +283,10 @@ func (b GolangCrossBuilder) Build() error {
 		args = append(args, "--ulimit", "nofile=262144:262144")
 	}
 
-	if runtime.GOOS != "windows" {
+	// In rootless Docker, container UID 0 maps to the host user's UID, so files
+	// created as root inside the container are already owned by the correct user
+	// on the host.
+	if runtime.GOOS != "windows" && !isRootlessDocker() {
 		args = append(args,
 			"--env", fmt.Sprintf("EXEC_UID=%d", uid),
 			"--env", fmt.Sprintf("EXEC_GID=%d", gid),
@@ -342,6 +345,16 @@ func (b GolangCrossBuilder) Build() error {
 	)
 
 	return dockerRun(args...)
+}
+
+// isRootlessDocker returns true when the Docker daemon is running in rootless
+// mode.
+func isRootlessDocker() bool {
+	out, err := sh.Output("docker", "info", "--format", "{{.SecurityOptions}}")
+	if err != nil {
+		return false
+	}
+	return strings.Contains(out, "rootless")
 }
 
 // DockerChown chowns files generated during build. EXEC_UID and EXEC_GID must


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

When running Docker in [rootless mode](https://docs.docker.com/engine/security/rootless/), passing EXEC_UID and EXEC_GID causes Docker to re-chown files to the host UID and GID inside the container, which maps through the subuid range to a wrong UID on the host (e.g. subuid_start + EXEC_UID - 1 instead of the actual host user UID).

This results in a `permissions denied` error when running `mage package`:

```
Error: multiple failures: failed building elastic-agent type=zip for platform=windows/amd64 fips=false : failed adding file=~/elastic-agent/build/golang-crossbuild/elastic-agent-windows-amd64.exe to zip: lstat ./build/golang-crossbuild/elastic-agent-windows-amd64.exe: permission denied
```

For example, in my case the UID and GID for the `golang-crossbuild` folder is set to `525287` instead of  `1000`:

```
$ ls -al ./build              
...
drwxr-x---. 1 525287 525287       142 mar 18 13:28 golang-crossbuild

$ id   
uid=1000(samuel) gid=1000(samuel) groups=1000(samuel)
```

After the fix:

```
$ ls -al ./build
...
drwxr-x---. 1 samuel samuel       142 mar 18 13:34 golang-crossbuild
```

## Why is it important?

Without this fix, users with Docker in rootless mode cannot build agent locally using the cross-build toolchain.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

1. Configure Docker in [rootless mode](https://docs.docker.com/engine/security/rootless/).
2. Run `mage package`.
3. No issues should appear.

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


