### PR TITLE
Set GOEXPERIMENT=nodwarf5 on Windows dev builds

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -3539,6 +3539,17 @@ func (Otel) GolangCrossBuild(ctx context.Context) error {
 	params.ExtraFlags = append(params.ExtraFlags, "-tags=agentbeat")
 	injectBuildVars(cfg, params.Vars)
 
+	// Workaround for https://github.com/golang/go/issues/75077: the Go PE linker assigns
+	// duplicate virtual addresses to DWARF sections in large binaries, causing Windows to
+	// reject the executable. nodwarf5 avoids this. Only needed for dev builds since
+	// production builds strip debug symbols via -s in DefaultGolangCrossBuildArgs.
+	if cfg.Build.DevBuild && cfg.Build.GOOS == "windows" {
+		if params.Env == nil {
+			params.Env = map[string]string{}
+		}
+		params.Env["GOEXPERIMENT"] = "nodwarf5"
+	}
+
 	// embedded packetbeat is only included in a non-FIPS build
 	if !cfg.Build.FIPSBuild {
 		// requires the NPCAP installer on Windows


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
-->

## What does this PR do?

When building `elastic-otel-collector` for Windows in dev mode (`DEV=true`), the Go PE linker assigns duplicate virtual addresses to DWARF debug sections (`/4`, `/20`, `/36`) in the generated binary. This causes Windows to reject the executable at load time with:

```
{"log.level":"error","@timestamp":"2026-03-18T14:07:33.831Z","log.logger":"otel_manager","log.origin":{"function":"github.com/elastic/elastic-agent/internal/pkg/otel/manager.(*OTelManager).startCollector","file.name":"manager/manager.go","file.line":396},"message":"collector exited with error (will try to recover in 12.050402683s): failed to start supervised collector: failed to start \"C:\\\\Program Files\\\\Elastic\\\\Agent\\\\data\\\\elastic-agent-9.4.0-SNAPSHOT-068d67\\\\components\\\\elastic-otel-collector.exe\": fork/exec C:\\Program Files\\Elastic\\Agent\\data\\elastic-agent-9.4.0-SNAPSHOT-068d67\\components\\elastic-otel-collector.exe: %1 is not a valid Win32 application.","log.source":"elastic-agent","ecs.version":"1.6.0"}
```

This PR sets `GOEXPERIMENT=nodwarf5` in the build environment when `DEV=true` and `GOOS=windows`, which disables DWARF5 generation and avoids the linker bug. Production builds are unaffected since they already strip debug symbols via `-s` in `DefaultGolangCrossBuildArgs`.

## Why is it important?

Without this fix, `elastic-otel-collector.exe` built with `DEV=true` cannot run on Windows at all, breaking local development and testing workflows on Windows machines.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

None. The change is strictly scoped to `DEV=true` + `GOOS=windows` builds. Production releases are not affected.

## How to test this PR locally

Build the `elastic-otel-collector` for Windows in dev mode and verify the binary runs:

```bash
DEV=true mage otel:crossBuild
```

Then copy the resulting `build/golang-crossbuild/elastic-otel-collector-windows-amd64.exe` to a Windows machine and verify it runs:

```powershell
& ".\elastic-otel-collector-windows-amd64.exe" --help
```

Before this fix, the command would fail with "The specified executable is not a valid application for this OS platform."

## Related issues

- Relates https://github.com/golang/go/issues/75077
