### PR TITLE
Add IT for helm template

### DIFF
--- a/testing/integration/k8s/kubernetes_agent_standalone_test.go
+++ b/testing/integration/k8s/kubernetes_agent_standalone_test.go
@@ -1277,7 +1277,6 @@ func k8sStepHelmTemplateApply(chartPath string, releaseName string, values map[s
 		release, err := installAction.Run(helmChart, values)
 		require.NoError(t, err, "failed to render helm chart")
 
-		// Use kubectl apply -f to apply the manifest.
 		manifestFile, err := os.CreateTemp("", "helm-template-*.yaml")
 		require.NoError(t, err, "failed to create temp manifest file")
 		manifestPath := manifestFile.Name()
@@ -1303,7 +1302,7 @@ func k8sStepHelmTemplateApply(chartPath string, releaseName string, values map[s
 			delCmd := exec.CommandContext(ctx, "kubectl", "delete", "-f", manifestPath, "--ignore-not-found", "--wait", "--timeout=120s")
 			_ = delCmd.Run()
 		})
-
+		// Use kubectl apply -f to apply the manifest.
 		applyCmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", manifestPath)
 		applyOut, applyErr := applyCmd.CombinedOutput()
 		require.NoError(t, applyErr, "kubectl apply failed: %s", string(applyOut))

--- a/testing/integration/k8s/otel_helm_test.go
+++ b/testing/integration/k8s/otel_helm_test.go
@@ -154,7 +154,7 @@ func TestOtelKubeStackHelm(t *testing.T) {
 		// Catches config issues (e.g. missing/invalid debug exporter per #12878) that would
 		// cause collector pods to crash at startup.
 		{
-			name: "mOTel logs only helm template apply kube-stack on cluster",
+			name: "mOTel with helm template apply kube-stack on cluster",
 			steps: []k8sTestStep{
 				k8sStepCreateNamespace(),
 				k8sStepHelmTemplateApplyWithValueOptions(KubeStackChartPath, "kube-stack-otel",


### PR DESCRIPTION
## What does this PR do?

Adds a new IT case to validate if helm template followed by `kubectl apply -f` of the manifest works when deploying edot as a otel collector. 

## Why is it important?

Issue #12878 showed that `helm template` followed by `kubectl apply` of the generated manifest can lead to a different outcome than using `helm install`. In particular,  the Otel collector config can be rendered slightly differently with the `help template` approach which can potentially  cause the collector to crash on boot-up.

This new IT cases adds an additional IT case that checks for this scenario, ensuring that the config is also veted for this scenario.  

## Disruptive User Impact

- No impact, only a test added to the rep

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates #12878

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
