### PR TITLE
[9.2] Don't build unnecessary artifacts for agent core

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -779,16 +779,9 @@ func PackageAgentCore(ctx context.Context) error {
 
 	cfg := devtools.SettingsFromContext(ctx)
 
-	// If Docker is selected but TarGz isn't, add TarGz since it's required for docker images
-	if cfg.IsPackageTypeSelected(devtools.Docker) && !cfg.IsPackageTypeSelected(devtools.TarGz) {
-		cfg = cfg.WithAddedPackageType(devtools.TarGz)
-		ctx = devtools.ContextWithSettings(ctx, cfg)
-	}
-
 	fmt.Println("--- Build elastic-agent-core")
-	mg.CtxDeps(ctx, Update, Otel.CrossBuild, CrossBuild, Build.WindowsArchiveRootBinary)
+	mg.CtxDeps(ctx, CrossBuild)
 
-	fmt.Println("--- Package elastic-agent-core")
 	devtools.UseElasticAgentCorePackaging(cfg)
 
 	// ran directly as we don't want mage to cache that it already called devtools.Package


### PR DESCRIPTION
## What does this PR do?

Fixes the `mage packageAgentCore` target to not build unnecessary (on 9.2) artifacts like the otel collector. This was unintentionally introduced by https://github.com/elastic/elastic-agent/pull/12835.

Tested these changes in https://buildkite.com/elastic/elastic-agent-binary-dra/builds/7662/steps/canvas?sid=019d0af1-7be2-4709-86de-4939f78eb1bd&tab=output, and they fix the problem.

## Why is it important?

The [binary dra workflow](https://buildkite.com/elastic/elastic-agent-binary-dra/builds?branch=9.2) has been failing due to running OOM recently because of the unnecessary builds.

## How to test this PR locally

Run `mage packageAgentCore` and see it only build the agent binary.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
