### PR TITLE
[OTEL Collector] Expand docs on auth between exporter and ES

### DIFF
--- a/docs/reference/edot-collector/components/elasticsearchexporter.md
+++ b/docs/reference/edot-collector/components/elasticsearchexporter.md
@@ -38,7 +38,16 @@ If none of the previous settings are specified, the exporter relies on the `ELAS
 The exporter supports standard OpenTelemetry [authentication configuration](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configauth/README.md#authentication-configuration). You can also use these simplified authentication options:
 
 - `user` and `password`: For HTTP Basic Authentication
-- `api_key`: For [{{es}} API key authentication](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key)
+- `api_key`: For [Elasticsearch API key authentication](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key) 
+
+:::{admonition} Authentication to and from the EDOT Collector
+
+{{es}} exporter authentication settings (as covered in this section) enable _outbound_ communication from the EDOT Collector to {{es}} for bulk indexing.
+
+This is different from the _`apikeyauth`_ used to authenticate _incoming_ OTLP/SDK traffic to the EDOT Collector as covered in [Authentication methods for the EDOT Collector](/reference/edot-collector/config/authentication-methods.md).
+
+Using the same key for both inbound and outbound authentication is possible with additional configuration, but is _not_ recommended from a security perspective. 
+:::
 
 ### TLS and security settings
 


### PR DESCRIPTION
## What does this PR do?

Closes: https://github.com/elastic/docs-content/issues/5295
Page: https://www.elastic.co/docs/reference/edot-collector/components/elasticsearchexporter


## Why is it important?
[Paraphrased from issue] The onboarding flows in Kibana walk users through setting up a secured connection between the Elasticsearch Exporter and Elasticsearch. We should document the setup so that users don't have to spin up an instance of Kibana to generate the correct API key. 



### Requests in issue 
- [ ] Explain and provide examples for:
    - [ ] Generating the API key with the correct permissions
    - [ ] Eventually provide the set of settings to provide custom CA for self-signed certificates
- [ ] Clarify:
   - [ ] It is also unclear from the doc if the EDOT SDK ApiKey is used also to authenticate to Elasticsearch (so EDOT SDK is granted access to the endpoint but the same api key is used as passthrough auth for ES).

### Additional info
We have a glimpse of it at https://www.elastic.co/docs/solutions/observability/get-started/quickstart-monitor-your-application-performance but it purely deflects on Kibana wizard.