### PR TITLE
docs: use vale-paths for vale linting path filter

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -13,6 +13,6 @@ jobs:
     uses: elastic/docs-actions/.github/workflows/docs-build.yml@v1
     with:
       enable-vale-linting: true
-      include-paths: |
+      vale-paths: |
         docs/release-notes/**
         docs/reference/**

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -14,3 +14,6 @@ jobs:
     uses: elastic/docs-actions/.github/workflows/docs-deploy.yml@v1
     with:
       enable-vale-linting: true
+      vale-paths: |
+        docs/release-notes/**
+        docs/reference/**


### PR DESCRIPTION
## Summary

Renames `include-paths` → `vale-paths` in `docs-build.yml` and adds the matching `vale-paths` to `docs-deploy.yml`.

The new `vale-paths` input was added in [elastic/docs-actions#50](https://github.com/elastic/docs-actions/pull/50) (released in v1.6.5) to fix a bug where `vale-report` in the deploy workflow would fail with **"no artifacts found"** when a PR only touched files excluded from vale linting. With `vale-paths` set in `docs-deploy`, the `preflight` job now skips `vale-report` entirely when no changed files match the filter.

## Changes

- `docs-build.yml`: `include-paths` → `vale-paths` (old name kept as deprecated alias in docs-actions)
- `docs-deploy.yml`: adds `vale-paths` matching the build filter

Refs: elastic/docs-actions#50, elastic/docs-eng-team#474