### PR TITLE
[ci] Bump the Win 11 image to `-1774746107`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ env:
   IMAGE_WIN_2016: "platform-ingest-elastic-agent-windows-2016-1772525581"
   IMAGE_WIN_2022: "platform-ingest-elastic-agent-windows-2022-1772525581"
   IMAGE_WIN_10: "platform-ingest-elastic-agent-windows-10-1772525581"
-  IMAGE_WIN_11: "platform-ingest-elastic-agent-windows-11-1772525581"
+  IMAGE_WIN_11: "platform-ingest-elastic-agent-windows-11-1774746107"
 
 steps:
   - label: "check-ci"


### PR DESCRIPTION
Pulled an updated Win11 image build from [ci](https://buildkite.com/elastic/vm-images-platform-ingest/builds/1355#019d371c-83fa-4b5b-bb05-9bfcefb475ff) as a workaround to resolve the currently failing Windows 11 unit tests.

Closes https://github.com/elastic/elastic-agent/issues/13428