### PR TITLE
ci: add unit tests for internal/edot nested module

### DIFF
--- a/.buildkite/scripts/steps/unit-tests.ps1
+++ b/.buildkite/scripts/steps/unit-tests.ps1
@@ -23,8 +23,12 @@ Write-Host "--- Prepare artifacts"
 $buildkiteJobId = $env:BUILDKITE_JOB_ID
 Move-Item -Path "build/TEST-go-unit.cov" -Destination "coverage-$buildkiteJobId.out"
 Move-Item -Path "build/TEST-go-unit.xml" -Destination "build/TEST-$buildkiteJobId.xml"
+if (Test-Path "build/TEST-edot.cov") {
+  Move-Item -Path "build/TEST-edot.cov" -Destination "coverage-edot-$buildkiteJobId.out"
+}
+if (Test-Path "build/TEST-edot.xml") {
+  Move-Item -Path "build/TEST-edot.xml" -Destination "build/TEST-edot-$buildkiteJobId.xml"
+}
 if ($LASTEXITCODE -ne 0) {
   exit 1
 }
-
-

--- a/.buildkite/scripts/steps/unit-tests.sh
+++ b/.buildkite/scripts/steps/unit-tests.sh
@@ -9,4 +9,6 @@ echo "--- Prepare artifacts"
 # Copy coverage file to build directory so it can be downloaded as an artifact
 mv build/TEST-go-unit.cov "coverage-${BUILDKITE_JOB_ID:go-unit}.out"
 mv build/TEST-go-unit.xml build/"TEST-${BUILDKITE_JOB_ID:go-unit}.xml"
+mv build/TEST-edot.cov "coverage-edot-${BUILDKITE_JOB_ID}.out" 2>/dev/null || true
+mv build/TEST-edot.xml build/"TEST-edot-${BUILDKITE_JOB_ID}.xml" 2>/dev/null || true
 exit $TESTS_EXIT_STATUS

--- a/internal/edot/go.mod
+++ b/internal/edot/go.mod
@@ -92,10 +92,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/basgys/goxml2json v1.1.1-0.20231018121955-e66ee54ceaad // indirect
+	github.com/bitfield/gotestdox v0.2.2 // indirect
 	github.com/bluekeyes/go-gitdiff v0.7.1 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/coder/websocket v1.8.14 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
+	github.com/dnephin/pflag v1.0.7 // indirect
 	github.com/elastic/ebpfevents v0.8.0 // indirect
 	github.com/elastic/go-libaudit/v2 v2.6.2 // indirect
 	github.com/elastic/go-licenser v0.4.2 // indirect
@@ -122,6 +124,7 @@ require (
 	github.com/gofrs/uuid/v5 v5.4.0 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20260202012954-cb029daf43ef // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75 // indirect
 	github.com/gosnmp/gosnmp v1.43.2 // indirect
 	github.com/grobie/gomemcache v0.0.0-20230213081705-239240bbc445 // indirect
@@ -173,6 +176,7 @@ require (
 	go.opentelemetry.io/collector/processor/processorhelper v0.149.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
+	gotest.tools/gotestsum v1.13.0 // indirect
 	mvdan.cc/garble v0.12.1 // indirect
 	sigs.k8s.io/e2e-framework v0.4.0 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
@@ -414,7 +418,7 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
 	github.com/expr-lang/expr v1.17.8 // indirect
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb // indirect
-	github.com/fatih/color v1.18.0 // indirect
+	github.com/fatih/color v1.19.0 // indirect
 	github.com/fearful-symmetry/gomsr v0.0.1 // indirect
 	github.com/fearful-symmetry/gorapl v0.0.4 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/internal/edot/go.sum
+++ b/internal/edot/go.sum
@@ -328,6 +328,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bitfield/gotestdox v0.2.2 h1:x6RcPAbBbErKLnapz1QeAlf3ospg8efBsedU93CDsnE=
+github.com/bitfield/gotestdox v0.2.2/go.mod h1:D+gwtS0urjBrzguAkTM2wodsTQYFHdpx8eqRJ3N+9pY=
 github.com/bitly/go-simplejson v0.5.1 h1:xgwPbetQScXt1gh9BmoJ6j9JMr3TElvuIyjR8pgdoow=
 github.com/bitly/go-simplejson v0.5.1/go.mod h1:YOPVLzCfwK14b4Sff3oP1AmGhI9T9Vsg84etUnlyp+Q=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
@@ -441,6 +443,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dnephin/pflag v1.0.7 h1:oxONGlWxhmUct0YzKTgrpQv9AUA1wtPBn7zuSjJqptk=
+github.com/dnephin/pflag v1.0.7/go.mod h1:uxE91IoWURlOiTUIA8Mq5ZZkAv3dPUfZNaT80Zm7OQE=
 github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
 github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
@@ -601,6 +605,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
+github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
+github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/fearful-symmetry/gomsr v0.0.1 h1:m208RzdTApWVbv8a9kf78rdPLQe+BY9AxRb/nSbHxSA=
 github.com/fearful-symmetry/gomsr v0.0.1/go.mod h1:Qb/0Y7zwobP7v8Sji+M5mlL4N7Voyz5WaKXXRFPnLio=
 github.com/fearful-symmetry/gorapl v0.0.4 h1:TMn4fhhtIAd+C3NrAl638oaYlX1vgcKNVVdad53oyiE=
@@ -811,6 +817,8 @@ github.com/google/pprof v0.0.0-20260202012954-cb029daf43ef h1:xpF9fUHpoIrrjX24DU
 github.com/google/pprof v0.0.0-20260202012954-cb029daf43ef/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -2270,6 +2278,8 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/gotestsum v1.13.0 h1:+Lh454O9mu9AMG1APV4o0y7oDYKyik/3kBOiCqiEpRo=
+gotest.tools/gotestsum v1.13.0/go.mod h1:7f0NS5hFb0dWr4NtcsAsF0y1kzjEFfAil0HiBQJE03Q=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
 gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=

--- a/magefile.go
+++ b/magefile.go
@@ -536,7 +536,7 @@ func (Check) Changes() error {
 
 // All runs all the tests.
 func (Test) All() {
-	mg.SerialDeps(Test.Unit)
+	mg.SerialDeps(Test.Unit, Otel.UnitTest)
 }
 
 // Unit runs all the unit tests.
@@ -3851,6 +3851,42 @@ func (Otel) Prepare(ctx context.Context) {
 		deps = append(deps, Otel.OsquerybeatFetchOsqueryDistros, Otel.OsquerybeatCrossBuildExt)
 	}
 	mg.Deps(deps...)
+}
+
+// UnitTest runs unit tests for the internal/edot module.
+func (Otel) UnitTest(ctx context.Context) (err error) {
+	mg.Deps(Prepare.Env, Build.TestBinaries)
+
+	// Save current directory
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	// Change to internal/edot directory
+	edotDir := filepath.Join(wd, "internal", "edot")
+	if err := os.Chdir(edotDir); err != nil {
+		return fmt.Errorf("failed to change to edot directory: %w", err)
+	}
+
+	// Restore original directory
+	defer func() {
+		if chdirErr := os.Chdir(wd); chdirErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to restore working directory: %w", chdirErr))
+		}
+	}()
+
+	// Configure test parameters similar to Test.Unit
+	cfg := devtools.SettingsFromContext(ctx)
+	params := devtools.DefaultGoTestUnitArgs(cfg)
+
+	// Adjust output file paths to be relative to the root build directory
+	params.OutputFile = filepath.Join(wd, "build", "TEST-edot.out")
+	params.JUnitReportFile = filepath.Join(wd, "build", "TEST-edot.xml")
+	params.CoverageProfileFile = filepath.Join(wd, "build", "TEST-edot.cov")
+
+	// Run tests using devtools.GoTest (same as Test.Unit)
+	return devtools.GoTest(ctx, params)
 }
 
 type Helm mg.Namespace


### PR DESCRIPTION
## What does this PR do?

This PR extends CI unit test coverage to include the `internal/edot` nested Go module, which was previously not being tested in CI.

**Changes:**
- Add `Otel.UnitTest()` mage target in `magefile.go` that cd's into `internal/edot`, runs tests via `devtools.GoTest`, and generates JUnit XML reports
- Wire `Otel.UnitTest` into `Test.All()` so `mage unitTest` covers both root and edot modules in a single invocation
- Update `unit-tests.sh` and `unit-tests.ps1` to collect edot test artifacts (coverage, JUnit XML)
- Add `gotestsum` to `internal/edot/go.mod` (required by `devtools.GoTest`)

## Why is it important?

The `internal/edot` module contains the EDOT (Elastic Distribution of OpenTelemetry) collector implementation, which is a critical component. Without CI test coverage, regressions in this module could go undetected. This change ensures that:

1. Tests for the nested Go module run automatically in CI
2. Coverage data is collected and can be tracked over time
3. Both root and nested modules are properly tested in the same pipeline

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog) (Not required - CI-only change, use `skip-changelog` label)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

None. This is a CI-only change that does not affect user-facing functionality.

## How to test this PR locally

1. Run the mage target directly:
   ```bash
   mage unitTest
   ```
   This now runs both root module and `internal/edot` module tests.

2. Or run the edot tests in isolation:
   ```bash
   mage otel:unitTest
   ```

3. Verify that coverage files are generated: `build/TEST-go-unit.cov` and `build/TEST-edot.cov`

## Related issues

- Closes #13352

## Questions to ask yourself

- How are we going to support this in production? N/A - CI-only change
- How are we going to measure its adoption? Coverage metrics will now include the edot module
- How are we going to debug this? Standard CI logs and test output
- What are the metrics I should take care of? Test coverage percentage for the edot module
