### PR TITLE
fix: restore default packaging behavior when PACKAGES env var is empty

### DIFF
--- a/.buildkite/pipeline.elastic-agent-package.yml
+++ b/.buildkite/pipeline.elastic-agent-package.yml
@@ -66,6 +66,7 @@ steps:
           image: "${IMAGE_UBUNTU_2404_X86_64}"
         env:
           PLATFORMS: "linux/amd64 windows/amd64 darwin/amd64"
+          PACKAGES: "all"
           FIPS: "false"
         command: |
           if [[ -z "$${MANIFEST_URL}" ]]; then
@@ -90,6 +91,7 @@ steps:
           image: "${IMAGE_UBUNTU_2404_X86_64}"
         env:
           PLATFORMS: "linux/amd64"
+          PACKAGES: "all"
           FIPS: "true"
         command: |
           if [[ -z "$${MANIFEST_URL}" ]]; then
@@ -114,7 +116,7 @@ steps:
           diskSizeGb: 400
         env:
           PLATFORMS: "linux/arm64 darwin/arm64 windows/arm64"
-          PACKAGES: "docker,tar.gz,deb,rpm,zip"
+          PACKAGES: "all"
           FIPS: "false"
         command: |
           echo "Add support for multiarch"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Refer to [architecture.md](./docs/architecture.md).
 
 ## Packaging and delivery
 
-Build artifacts (for example tar, deb, rpm, Docker images) are produced via mage packaging targets; see `magefile.go` for environment variables such as `EXTERNAL`, `SNAPSHOT`, `PLATFORMS`, `PACKAGES`, `DEV`, `DOCKER_VARIANTS`. Kubernetes-oriented deployment material lives under `deploy/helm/`.
+Build artifacts (for example tar, deb, rpm, Docker images) are produced via mage packaging targets; see `magefile.go` for environment variables such as `EXTERNAL`, `SNAPSHOT`, `PLATFORMS`, `PACKAGES`, `DEV`, `DOCKER_VARIANTS`. The `PACKAGES` env var is **required** — use `PACKAGES=all` to build all package types, or specify types (for example `PACKAGES=tar.gz,rpm,deb`). Kubernetes-oriented deployment material lives under `deploy/helm/`.
 Produced artifacts will be placed in the `build` directory.
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To build a local version of the agent for development, run the command below. Th
 # EXTERNAL=true downloads the matching version of the binaries that are packaged with agent, not necessary if only using Beats.
 # SNAPSHOT=true indicates that this is a snapshot version and not a release version.
 # PLATFORMS=linux/amd64 builds an agent that will run on 64 bit X86 Linux systems.
-# PACKAGES=tar.gz produces a tar.gz package
+# PACKAGES is required. Use PACKAGES=all to build all package types, or specify types (e.g. tar.gz,rpm,deb,zip,docker).
 EXTERNAL=true SNAPSHOT=true PLATFORMS=linux/amd64 PACKAGES=tar.gz mage -v package
 ```
 

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -80,6 +80,9 @@ var (
 	Docker             = PackageType(pkgcommon.Docker)
 )
 
+// AllPackageTypes contains all available package types.
+var AllPackageTypes = []PackageType{RPM, Deb, Zip, TarGz, Docker}
+
 // OSPackageArgs define a set of package types to build for an operating
 // system using the contained PackageSpec.
 type OSPackageArgs struct {

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -1815,7 +1815,8 @@ func (s *Settings) GetPlatforms() BuildPlatformList {
 // GetPackageTypes returns the package types to use.
 // If SelectedPackageTypes is set in the settings, returns that.
 // Otherwise parses from PACKAGES env var.
-// If PACKAGES is empty, returns nil (meaning all package types are selected).
+// If PACKAGES is "all", returns all available package types.
+// If PACKAGES is empty, returns nil.
 func (s *Settings) GetPackageTypes() []PackageType {
 	// Check settings override first
 	if s.SelectedPackageTypes != nil {
@@ -1824,6 +1825,9 @@ func (s *Settings) GetPackageTypes() []PackageType {
 	// Fall back to env var
 	if s.CrossBuild.Packages == "" {
 		return nil
+	}
+	if strings.ToLower(s.CrossBuild.Packages) == "all" {
+		return []PackageType{RPM, Deb, Zip, TarGz, Docker}
 	}
 	var types []PackageType
 	for _, pkgtype := range strings.Split(s.CrossBuild.Packages, ",") {

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -1827,7 +1827,7 @@ func (s *Settings) GetPackageTypes() []PackageType {
 		return nil
 	}
 	if strings.ToLower(s.CrossBuild.Packages) == "all" {
-		return []PackageType{RPM, Deb, Zip, TarGz, Docker}
+		return AllPackageTypes
 	}
 	var types []PackageType
 	for _, pkgtype := range strings.Split(s.CrossBuild.Packages, ",") {

--- a/dev-tools/mage/settings_test.go
+++ b/dev-tools/mage/settings_test.go
@@ -358,6 +358,24 @@ func TestSettingsGetPackageTypes(t *testing.T) {
 
 		assert.Nil(t, types)
 	})
+
+	t.Run("returns all package types when PACKAGES is all", func(t *testing.T) {
+		s := DefaultSettings()
+		s.CrossBuild.Packages = "all"
+
+		types := s.GetPackageTypes()
+
+		assert.Equal(t, []PackageType{RPM, Deb, Zip, TarGz, Docker}, types)
+	})
+
+	t.Run("returns all package types when PACKAGES is ALL (case-insensitive)", func(t *testing.T) {
+		s := DefaultSettings()
+		s.CrossBuild.Packages = "ALL"
+
+		types := s.GetPackageTypes()
+
+		assert.Equal(t, []PackageType{RPM, Deb, Zip, TarGz, Docker}, types)
+	})
 }
 
 func TestSettingsGetDockerVariants(t *testing.T) {

--- a/dev-tools/mage/settings_test.go
+++ b/dev-tools/mage/settings_test.go
@@ -365,7 +365,7 @@ func TestSettingsGetPackageTypes(t *testing.T) {
 
 		types := s.GetPackageTypes()
 
-		assert.Equal(t, []PackageType{RPM, Deb, Zip, TarGz, Docker}, types)
+		assert.Equal(t, AllPackageTypes, types)
 	})
 
 	t.Run("returns all package types when PACKAGES is ALL (case-insensitive)", func(t *testing.T) {
@@ -374,7 +374,7 @@ func TestSettingsGetPackageTypes(t *testing.T) {
 
 		types := s.GetPackageTypes()
 
-		assert.Equal(t, []PackageType{RPM, Deb, Zip, TarGz, Docker}, types)
+		assert.Equal(t, AllPackageTypes, types)
 	})
 }
 

--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -93,10 +93,9 @@ The packaging process has many leavers that need to be correctly set:
   not set, it defaults to **ALL** platforms. [Selecting specific
   platform](#selecting-specific-platform) contains a list of common
   values. For a full list look at [`elastic-agent/dev-tools/mage/platforms.go`](https://github.com/elastic/elastic-agent/blob/main/dev-tools/mage/platforms.go#L15).
- - `PACKAGES`: Comma separated list of packages you want to build. If
-  not set, it defaults to **ALL** packages, which takes a long time,
-  so make sure to *always* set it correctly. The packages are defined
-  on
+ - `PACKAGES`: **Required.** Comma separated list of packages you want
+  to build. Use `PACKAGES=all` to build all package types.
+  The packages are defined in
   [`elastic-agent/dev-tools/mage/pkgtypes.go`](https://github.com/elastic/elastic-agent/blob/main/dev-tools/mage/pkgtypes.go#L72).
   To run Linux tests you need to package `tar.gz` ,`deb` and `rpm`.
 The possible options are:

--- a/magefile.go
+++ b/magefile.go
@@ -589,6 +589,10 @@ func Package(ctx context.Context) error {
 	start := time.Now()
 	defer func() { fmt.Println("package ran for", time.Since(start)) }()
 
+	if len(cfg.GetPackageTypes()) == 0 {
+		return fmt.Errorf("PACKAGES env var is required. Set PACKAGES=all to build all package types, or specify types (e.g. PACKAGES=tar.gz,rpm,deb,zip,docker)")
+	}
+
 	if len(cfg.GetPlatforms()) == 0 {
 		panic("elastic-agent package is expected to build at least one platform package")
 	}
@@ -1479,6 +1483,10 @@ func PackageUsingDRA(ctx context.Context) error {
 	cfg := devtools.SettingsFromContext(ctx)
 	start := time.Now()
 	defer func() { fmt.Println("package ran for", time.Since(start)) }()
+
+	if len(cfg.GetPackageTypes()) == 0 {
+		return fmt.Errorf("PACKAGES env var is required. Set PACKAGES=all to build all package types, or specify types (e.g. PACKAGES=tar.gz,rpm,deb,zip,docker)")
+	}
 
 	if len(cfg.GetPlatforms()) == 0 {
 		return fmt.Errorf("elastic-agent package is expected to build at least one platform package")


### PR DESCRIPTION
## What does this PR do?

This PR addresses the regression introduced in PR #6016 where running `mage package` without setting the `PACKAGES` environment variable would fail with a confusing "No packages were successfully downloaded" error.

Based on reviewer feedback from @swiatekm and @blakerouse, instead of restoring the old implicit "build all" default, this PR takes a safer approach:

**Changes:**
- `Package()` and `PackageUsingDRA()` in `magefile.go` now reject an empty `PACKAGES` env var with a clear, actionable error message
- `GetPackageTypes()` in `dev-tools/mage/settings.go` now supports `PACKAGES=all` (case-insensitive) to explicitly build all package types
- Added unit tests for the `PACKAGES=all` behavior
- Set `PACKAGES=all` in `.buildkite/pipeline.elastic-agent-package.yml` crossbuild jobs that previously had no `PACKAGES` set

**Root cause:** 
PR #6016 (commit e09d2d3ee5) added package type filtering logic that broke the default behavior. When `packageTypes` is empty, the filtering loop doesn't execute, causing components to be incorrectly excluded.

## Why is it important?
This bug breaks the basic packaging workflow for developers and CI/CD pipelines that don't set the `PACKAGES` environment variable. The error message is confusing and doesn't indicate the root cause.

With this fix:
- Users get a clear error: `PACKAGES env var is required. Set PACKAGES=all to build all package types, or specify types (e.g. PACKAGES=tar.gz,rpm,deb,zip,docker)`
- `PACKAGES=all` explicitly builds all package types, preventing accidental full builds
- Specific types can still be selected: `PACKAGES=tar.gz,rpm`

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact
Users who previously ran `mage package` without `PACKAGES` set will now get a clear error instead of a confusing failure. They need to set `PACKAGES=all` to build all types, or specify the desired types explicitly.

## How to test this PR locally

1. Checkout this branch
2. Unset the PACKAGES environment variable: `unset PACKAGES`
3. Run `mage package` -> should fail with a clear error message about PACKAGES being required
4. Run `PACKAGES=all mage package` -> should build all package types
5. Run `PACKAGES=tar.gz mage package` -> should build only tar.gz
6. Run the unit tests: `go test ./dev-tools/mage/... -run TestSettingsGetPackageTypes -v`

## Related issues

- Closes #6584

## Questions to ask yourself

- How are we going to support this in production? N/A - build tooling fix
- How are we going to measure its adoption? Developers will no longer encounter the confusing packaging failure
- How are we going to debug this? Unit tests ensure the fix continues working
- What are the metrics I should take care of? N/A - build tooling
