### PR TITLE
fix: disable spinner auto-refresh on Windows to prevent blank lines

### DIFF
--- a/changelog/fragments/1775487826-issue-11228.yaml
+++ b/changelog/fragments/1775487826-issue-11228.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix blank lines appearing in Windows Server 2022 PowerShell during installation with --unprivileged flag.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/11228

--- a/internal/pkg/agent/install/progress.go
+++ b/internal/pkg/agent/install/progress.go
@@ -7,6 +7,7 @@ package install
 import (
 	"io"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/schollz/progressbar/v3"
@@ -24,7 +25,9 @@ func CreateAndStartNewSpinner(stream io.Writer, initialMessage string) *progress
 	)
 
 	// don't bother with the spinner refresh if we're not connected to stdout
-	if term.IsTerminal(int(os.Stdout.Fd())) {
+	// Skip auto-refresh on Windows to avoid blank lines issue on Windows Server 2022 PowerShell
+	// See: https://github.com/elastic/elastic-agent/issues/11228
+	if term.IsTerminal(int(os.Stdout.Fd())) && runtime.GOOS != "windows" {
 		// This keeps the progress spinner running while we're idling
 		// Otherwise, the spinner would freeze until it got an update
 		go func() {


### PR DESCRIPTION
## What does this PR do?

Disables the progress bar auto-refresh goroutine on Windows to prevent
blank lines appearing in PowerShell output during installation with
the `--unprivileged` flag.

The spinner's `RenderBlank()` method was generating control characters
every 40ms that Windows Server 2022 PowerShell interprets as line
breaks.

The fix adds a runtime OS check (`runtime.GOOS != "windows"`) to skip
the continuous spinner animation (40ms refresh rate) on Windows
platforms. Progress messages still appear when there are actual
updates via `Describe()` calls.

## Why is it important?

This fixes a user-facing bug reported in #11228 where installation
output on Windows Server 2022 is cluttered with numerous blank lines,
making it difficult to read progress messages and diagnose issues
during installation.

The issue affects Windows Server 2022 specifically (not Windows Server
2025), suggesting a platform-specific handling of terminal control
sequences. The blank lines create a poor user experience and make the
installation appear broken.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation *(not applicable - internal behavior change)*
- [ ] I have made corresponding change to the default configuration files *(not applicable)*
- [ ] I have added tests that prove my fix is effective or that my feature works *(existing tests pass, manual testing performed on Windows Server 2022)*
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test *(manual testing performed, automated testing would require Windows Server 2022 CI environment)*

## Disruptive User Impact

**No disruptive impact.** This is a visual-only change that improves user experience on Windows.

- Users on **Windows** will see a static spinner during installation instead of an animated one, but progress messages will continue to appear as normal
- Users on **Linux/macOS** experience no change
- No functional behavior changes
- No configuration changes required
- Fully backwards compatible

## How to test this PR locally

### What I tested:

I verified this fix by building both the buggy version (`main` branch) and the fixed version (this PR), then comparing their installation output side-by-side on Windows Server 2022.

## Related issues

- Closes #11228

## Questions to ask yourself

- **How are we going to support this in production?**
  - This is a cosmetic fix with no functional impact. If issues arise, users can report via standard channels.
  - The change is platform-specific (Windows only) and low-risk.

- **How are we going to measure its adoption?**
  - Not applicable - this is a bug fix automatically included in future releases.
  - Users on Windows Server 2022 will automatically benefit.

- **How are we going to debug this?**
  - If the spinner behavior needs adjustment, the code is isolated to `progress.go` and easy to modify.
  - Progress messages are logged normally, debugging remains unchanged.

- **What are the metrics I should take care of?**
  - No new metrics needed.
  - Existing installation success/failure metrics remain unchanged.
