### PR TITLE
[8.19][backport] Temporarily redirect FIPS integration tests to Production CFT (#13537)

### DIFF
--- a/.buildkite/bk.integration-fips.pipeline.yml
+++ b/.buildkite/bk.integration-fips.pipeline.yml
@@ -12,9 +12,18 @@ env:
 # This section is used to define the plugins that will be used in the pipeline.
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
-  - vault_ec_key_staging_frh_gov: &vault_ec_key_staging_frh_gov
+  #  We are temporarily using the Production CFT environment API key instead of the
+  #  Staging GovCloud one.  This is being done until issues with creating deployments in
+  #  Staging GovCloud are fixed.  Once those are fixed, uncomment the `vault_ec_key_staging_frh_gov`
+  #  section and delete the `vault_ec_key_prod` section below.
+#  - vault_ec_key_staging_frh_gov: &vault_ec_key_staging_frh_gov
+#      elastic/vault-secrets#v0.1.0:
+#        path: "kv/ci-shared/platform-ingest/platform-ingest-ec-staging-gov"
+#        field: "apiKey"
+#        env_var: "EC_API_KEY"
+  - vault_ec_key_prod: &vault_ec_key_prod
       elastic/vault-secrets#v0.1.0:
-        path: "kv/ci-shared/platform-ingest/platform-ingest-ec-staging-gov"
+        path: "kv/ci-shared/platform-ingest/platform-ingest-ec-prod"
         field: "apiKey"
         env_var: "EC_API_KEY"
 
@@ -26,9 +35,9 @@ steps:
     key: integration-fips-ess
     env:
       FIPS: "true"
-      EC_ENDPOINT: "https://api.staging.elastic-gov.com"
-      ESS_REGION: "us-gov-east-1"
-      TF_VAR_deployment_template_id: "aws-general-purpose"
+#      EC_ENDPOINT: "https://api.staging.elastic-gov.com"
+#      ESS_REGION: "us-gov-east-1"
+#      TF_VAR_deployment_template_id: "aws-general-purpose"
       TF_VAR_integration_server_docker_image: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips:git-${BUILDKITE_COMMIT:0:12}"
       TF_VAR_docker_images_name_suffix: "-fips"
     command: |
@@ -40,7 +49,7 @@ steps:
       image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:0.5"
       useCustomGlobalHooks: true
     plugins:
-      - *vault_ec_key_staging_frh_gov
+      - *vault_ec_key_prod
 
   - group: "fips:Stateful:Ubuntu"
     key: integration-tests-ubuntu-fips
@@ -52,9 +61,9 @@ steps:
           - packaging-amd64-fips # Reuse artifacts produced in .buildkite/integration.pipeline.yml
         env:
           FIPS: "true"
-          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
-          ESS_REGION: "us-gov-east-1"
-          TF_VAR_deployment_template_id: "aws-general-purpose"
+#          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
+#          ESS_REGION: "us-gov-east-1"
+#          TF_VAR_deployment_template_id: "aws-general-purpose"
           TF_VAR_integration_server_docker_image: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips:git-${BUILDKITE_COMMIT:0:12}"
           TF_VAR_docker_images_name_suffix: "-fips"
           TEST_PACKAGE: "github.com/elastic/elastic-agent/testing/integration/ess"
@@ -72,7 +81,7 @@ steps:
           image: "${IMAGE_UBUNTU_X86_64_FIPS}"
           instanceType: "m5.2xlarge"
         plugins:
-          - *vault_ec_key_staging_frh_gov
+          - *vault_ec_key_prod
         matrix:
           setup:
             sudo:
@@ -86,9 +95,9 @@ steps:
           - packaging-arm64-fips
         env:
           FIPS: "true"
-          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
-          ESS_REGION: "us-gov-east-1"
-          TF_VAR_deployment_template_id: "aws-general-purpose"
+#          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
+#          ESS_REGION: "us-gov-east-1"
+#          TF_VAR_deployment_template_id: "aws-general-purpose"
           TF_VAR_integration_server_docker_image: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips:git-${BUILDKITE_COMMIT:0:12}"
           TF_VAR_docker_images_name_suffix: "-fips"
           TEST_PACKAGE: "github.com/elastic/elastic-agent/testing/integration/ess"
@@ -106,7 +115,7 @@ steps:
           image: "${IMAGE_UBUNTU_ARM64_FIPS}"
           instanceType: "m6g.2xlarge"
         plugins:
-          - *vault_ec_key_staging_frh_gov
+          - *vault_ec_key_prod
         matrix:
           setup:
             sudo:
@@ -119,8 +128,8 @@ steps:
         if: build.env("BUILDKITE_PULL_REQUEST") != "false" &&  build.env("GITHUB_PR_LABELS") =~ /.*(Testing:run:TestUpgradeIntegrationsServer).*/
         env:
           FIPS: "true"
-          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
-          ESS_REGION: "us-gov-east-1"
+#          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
+#          ESS_REGION: "us-gov-east-1"
           TEST_PACKAGE: "github.com/elastic/elastic-agent/testing/integration/ess"
         command: |
           .buildkite/scripts/buildkite-integration-tests.sh ech-deployment false
@@ -135,16 +144,16 @@ steps:
           image: "${IMAGE_UBUNTU_X86_64_FIPS}"
           instanceType: "m5.2xlarge"
         plugins:
-          - *vault_ec_key_staging_frh_gov
+          - *vault_ec_key_prod
 
   - label: ESS FIPS stack cleanup
     depends_on:
       - integration-tests-ubuntu-fips
     env:
       FIPS: "true"
-      EC_ENDPOINT: "https://api.staging.elastic-gov.com"
-      ESS_REGION: "us-gov-east-1"
-      TF_VAR_deployment_template_id: "aws-general-purpose"
+#      EC_ENDPOINT: "https://api.staging.elastic-gov.com"
+#      ESS_REGION: "us-gov-east-1"
+#      TF_VAR_deployment_template_id: "aws-general-purpose"
       TF_VAR_integration_server_docker_image: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips:git-${BUILDKITE_COMMIT:0:12}"
       TF_VAR_docker_images_name_suffix: "-fips"
     allow_dependency_failure: true
@@ -156,7 +165,7 @@ steps:
       image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:0.5"
       useCustomGlobalHooks: true
     plugins:
-      - *vault_ec_key_staging_frh_gov
+      - *vault_ec_key_prod
 
   - label: Aggregate test reports
     depends_on:


### PR DESCRIPTION
Backport of https://github.com/elastic/elastic-agent/pull/13537.