### PR TITLE
[9.2][backport] Temporarily redirect FIPS integration tests to Production CFT (#13537)

### DIFF
--- a/.buildkite/bk.integration-fips.pipeline.yml
+++ b/.buildkite/bk.integration-fips.pipeline.yml
@@ -60,9 +60,9 @@ steps:
           - packaging-amd64-fips # Reuse artifacts produced in .buildkite/integration.pipeline.yml
         env:
           FIPS: "true"
-          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
-          ESS_REGION: "us-gov-east-1"
-          TF_VAR_deployment_template_id: "aws-general-purpose"
+#          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
+#          ESS_REGION: "us-gov-east-1"
+#          TF_VAR_deployment_template_id: "aws-general-purpose"
           TF_VAR_integration_server_docker_image: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips:git-${BUILDKITE_COMMIT:0:12}"
           TF_VAR_docker_images_name_suffix: "-fips"
           TEST_PACKAGE: "github.com/elastic/elastic-agent/testing/integration/ess"
@@ -94,9 +94,9 @@ steps:
           - packaging-arm64-fips
         env:
           FIPS: "true"
-          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
-          ESS_REGION: "us-gov-east-1"
-          TF_VAR_deployment_template_id: "aws-general-purpose"
+#          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
+#          ESS_REGION: "us-gov-east-1"
+#          TF_VAR_deployment_template_id: "aws-general-purpose"
           TF_VAR_integration_server_docker_image: "docker.elastic.co/beats-ci/elastic-agent-cloud-fips:git-${BUILDKITE_COMMIT:0:12}"
           TF_VAR_docker_images_name_suffix: "-fips"
           TEST_PACKAGE: "github.com/elastic/elastic-agent/testing/integration/ess"
@@ -127,8 +127,8 @@ steps:
         if: build.env("BUILDKITE_PULL_REQUEST") != "false" &&  build.env("GITHUB_PR_LABELS") =~ /.*(Testing:run:TestUpgradeIntegrationsServer).*/
         env:
           FIPS: "true"
-          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
-          ESS_REGION: "us-gov-east-1"
+#          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
+#          ESS_REGION: "us-gov-east-1"
           TEST_PACKAGE: "github.com/elastic/elastic-agent/testing/integration/ess"
         command: |
           .buildkite/scripts/buildkite-integration-tests.sh ech-deployment false


### PR DESCRIPTION
Backport of https://github.com/elastic/elastic-agent/pull/13537.