### PR TITLE
fix(flake): clean up prefix install data dirs in RPM test fixture

### DIFF
--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -34,6 +34,8 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/process"
 )
 
+var errMultipleAgentVersionDirs = errors.New("multiple agent data directories found for the same version")
+
 // Fixture handles the setup and management of the Elastic Agent.
 type Fixture struct {
 	t       *testing.T
@@ -1455,8 +1457,10 @@ func findAgentDataVersionDir(dir, version string) (string, error) {
 				// directories, we don't want first found
 				continue
 			}
+			if versionDir != "" {
+				return filepath.Join(dataDir, versionDir), errMultipleAgentVersionDirs
+			}
 			versionDir = filename
-			break
 		}
 	}
 	if versionDir == "" {
@@ -1469,7 +1473,11 @@ func findAgentDataVersionDir(dir, version string) (string, error) {
 func FindComponentsDir(dir, version string) (string, error) {
 	versionDir, err := findAgentDataVersionDir(dir, version)
 	if err != nil {
-		return "", err
+		if errors.Is(err, errMultipleAgentVersionDirs) {
+			fmt.Fprintf(os.Stderr, "WARNING: %s for version %q; stale directories from a previous test run should be cleaned up\n", err, version)
+		} else {
+			return "", err
+		}
 	}
 	componentsDir := filepath.Join(versionDir, "components")
 	fi, err := os.Stat(componentsDir)
@@ -1486,7 +1494,11 @@ func FindRunDir(fixture *Fixture) (string, error) {
 	version := fixture.Version()
 	versionDir, err := findAgentDataVersionDir(agentWorkDir, version)
 	if err != nil {
-		return "", err
+		if errors.Is(err, errMultipleAgentVersionDirs) {
+			fixture.t.Logf("WARNING: %s for version %q; stale directories from a previous test run should be cleaned up", err, version)
+		} else {
+			return "", err
+		}
 	}
 	runDir := filepath.Join(versionDir, "run")
 	fi, err := os.Stat(runDir)

--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -34,8 +34,6 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/process"
 )
 
-var errMultipleAgentVersionDirs = errors.New("multiple agent data directories found for the same version")
-
 // Fixture handles the setup and management of the Elastic Agent.
 type Fixture struct {
 	t       *testing.T
@@ -1447,7 +1445,10 @@ func findAgentDataVersionDir(dir, version string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to read contents of the data directory %s: %w", dataDir, err)
 	}
-	var versionDir string
+	var (
+		versionDir        string
+		versionDirModTime time.Time
+	)
 	for _, fi := range agentVersions {
 		filename := fi.Name()
 		if strings.HasPrefix(filename, "elastic-agent-") && fi.IsDir() {
@@ -1457,10 +1458,17 @@ func findAgentDataVersionDir(dir, version string) (string, error) {
 				// directories, we don't want first found
 				continue
 			}
-			if versionDir != "" {
-				return filepath.Join(dataDir, versionDir), errMultipleAgentVersionDirs
+			info, err := fi.Info()
+			if err != nil {
+				continue
 			}
-			versionDir = filename
+			// After an upgrade within the same version, two directories with
+			// different build hashes will exist. Use the most recently modified
+			// one because that is the active install.
+			if versionDir == "" || info.ModTime().After(versionDirModTime) {
+				versionDir = filename
+				versionDirModTime = info.ModTime()
+			}
 		}
 	}
 	if versionDir == "" {
@@ -1473,11 +1481,7 @@ func findAgentDataVersionDir(dir, version string) (string, error) {
 func FindComponentsDir(dir, version string) (string, error) {
 	versionDir, err := findAgentDataVersionDir(dir, version)
 	if err != nil {
-		if errors.Is(err, errMultipleAgentVersionDirs) {
-			fmt.Fprintf(os.Stderr, "WARNING: %s for version %q; stale directories from a previous test run should be cleaned up\n", err, version)
-		} else {
-			return "", err
-		}
+		return "", err
 	}
 	componentsDir := filepath.Join(versionDir, "components")
 	fi, err := os.Stat(componentsDir)
@@ -1494,11 +1498,7 @@ func FindRunDir(fixture *Fixture) (string, error) {
 	version := fixture.Version()
 	versionDir, err := findAgentDataVersionDir(agentWorkDir, version)
 	if err != nil {
-		if errors.Is(err, errMultipleAgentVersionDirs) {
-			fixture.t.Logf("WARNING: %s for version %q; stale directories from a previous test run should be cleaned up", err, version)
-		} else {
-			return "", err
-		}
+		return "", err
 	}
 	runDir := filepath.Join(versionDir, "run")
 	fi, err := os.Stat(runDir)

--- a/pkg/testing/fixture_install.go
+++ b/pkg/testing/fixture_install.go
@@ -628,10 +628,19 @@ func (f *Fixture) installRpm(ctx context.Context, installOpts *InstallOpts, shou
 		}
 
 		f.t.Logf("removing installed agent files")
-		out, err = exec.CommandContext(uninstallCtx, "sudo", "rm", "-rf", "/var/lib/elastic-agent", "/var/log/elastic-agent", "/etc/elastic-agent").CombinedOutput()
+		basePath := "/"
+		if installOpts.BasePath != "" {
+			basePath = installOpts.BasePath
+		}
+		rmArgs := []string{"rm", "-rf",
+			filepath.Join(basePath, "var/lib/elastic-agent"),
+			filepath.Join(basePath, "var/log/elastic-agent"),
+			filepath.Join(basePath, "etc/elastic-agent"),
+		}
+		out, err = exec.CommandContext(uninstallCtx, "sudo", rmArgs...).CombinedOutput()
 		if err != nil {
 			f.t.Log(string(out))
-			f.t.Logf("failed to 'sudo rm -rf /var/lib/elastic-agent /var/log/elastic-agent/ /etc/elastic-agent'")
+			f.t.Logf("failed to remove installed agent files: %v", rmArgs)
 			f.t.FailNow()
 		}
 	})


### PR DESCRIPTION
## What does this PR do?

Fixes flaky `TestRpmWithPrefixUpgrade` failures caused by stale agent data directories accumulating on long-running CI agents:

- Failure 1: https://buildkite.com/elastic/elastic-agent/builds/36955/steps/canvas?jid=019d7246-cb90-42e4-911c-a7543d4badb6&tab=output#019d7246-cb90-42e4-911c-a7543d4badb6
- Failure 2: https://buildkite.com/elastic/elastic-agent/builds/36949/steps/canvas?jid=019d717e-a075-49d2-9fd8-3691e9b47ea7&tab=output#019d717e-a075-49d2-9fd8-3691e9b47ea7

When the agent is installed with a custom prefix (e.g. `--prefix /opt/elastic-agent`), the test cleanup was only removing `/var/lib/elastic-agent` (the default path), leaving versioned data directories behind under `/opt/elastic-agent/var/lib/elastic-agent/`. On subsequent runs those stale directories would be picked up instead of the current one causing test assertions to fail.

The fix makes the cleanup remove the correct paths under the install prefix and pick the most recent version if multiple directories are found (could happen during upgrades).

## Why is it important?

The tests were producing intermittent false failures on long-lived CI agents due to incomplete cleanup between runs unrelated to the actual behavior being tested.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~I have added an integration test or an E2E test~~

## How to test this PR locally

Run the RPM prefix upgrade integration test twice back-to-back on a Linux host with RPM support and verify the second run passes:

```
SNAPSHOT=true TEST_PLATFORMS="linux/amd64" TEST_INTEG_CLEAN_ON_EXIT="false" \
  mage -v integration:single TestRpmWithPrefixUpgrade
```
