### PR TITLE
fix: use correct package list for non-sudo test results in Windows ru…

### DIFF
--- a/pkg/testing/windows/windows.go
+++ b/pkg/testing/windows/windows.go
@@ -187,7 +187,7 @@ func (WindowsRunner) Run(ctx context.Context, verbose bool, c ssh.SSHClient, log
 	if len(tests) > 0 {
 		script := toPowershellScript(agentVersion, prefix, verbose, tests, env)
 
-		results, err := runTestsOnWindows(ctx, logger, "non-sudo", prefix, script, c, batch.SudoTests)
+		results, err := runTestsOnWindows(ctx, logger, "non-sudo", prefix, script, c, batch.Tests)
 		if err != nil {
 			return common.OSRunnerResult{}, fmt.Errorf("error running non-sudo tests: %w", err)
 		}


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in `WindowsRunner.Run` (`pkg/testing/windows/windows.go`)
where the non-sudo test path was passing `batch.SudoTests` to `runTestsOnWindows`
instead of `batch.Tests` for result collection.

This one-line change (`batch.SudoTests` -> `batch.Tests`) ensures
non-sudo test results are collected using the correct package list.

## Why is it important?

When `TEST_RUN_UNTIL_FAILURE=true` is used, the framework should stop
as soon as a test fails.  Because non-sudo results were collected from
the wrong package list, failures were masked and the loop never
stopped. This also caused test artifacts from failed runs to be
overwritten by subsequent runs, making debugging harder.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

None. This only affects the integration test framework, not production code.

## How to test this PR locally

Run integration tests on Windows with `TEST_RUN_UNTIL_FAILURE=true`. A
failing non-sudo test should now stop the loop instead of continuing
indefinitely:

```
TEST_RUN_UNTIL_FAILURE=true AGENT_VERSION="9.4.0-SNAPSHOT" TEST_PLATFORMS="windows/amd64" mage -v integration:single TestFilebeatReceiverLogAsFilestream
```

## Related issues

- Closes #13545

## Questions to ask yourself

- How are we going to support this in production? N/A - test framework fix
- How are we going to measure its adoption? N/A
- How are we going to debug this? The fix is a single line; if issues arise, the diff is trivial to review
- What are the metrics I should take care of? N/A
