### PR TITLE
fix(package): use version from .package-version in helm chart packaging

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -4245,8 +4245,11 @@ func (h Helm) Package(ctx context.Context) error {
 	// need to explicitly set SNAPSHOT="false" to produce a production-ready package
 	productionPackage := cfg.Build.SnapshotSet && !cfg.Build.Snapshot
 
-	agentVersion := bversion.GetParsedAgentPackageVersion()
-	agentCoreVersion := agentVersion.CoreVersion()
+	agentCoreVersion := cfg.AgentPackageVersion()
+	agentVersion, err := version.ParseVersion(agentCoreVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse agent version %q: %w", agentCoreVersion, err)
+	}
 	agentImageTag := agentCoreVersion
 	if !productionPackage {
 		// always use the SNAPSHOT version for image tag if not a production package
@@ -4293,7 +4296,7 @@ func (h Helm) Package(ctx context.Context) error {
 	settings := cli.New() // Helm CLI settings
 	actionConfig := &action.Configuration{}
 
-	err := actionConfig.Init(settings.RESTClientGetter(), "default", "",
+	err = actionConfig.Init(settings.RESTClientGetter(), "default", "",
 		func(format string, v ...interface{}) {})
 	if err != nil {
 		return fmt.Errorf("failed to init helm action config: %w", err)


### PR DESCRIPTION
## What does this PR do?

When `USE_PACKAGE_VERSION=true` is set during packaging (the no-manifest-URL PR build path), all other artifacts (debs, rpms, tarballs, docker images) correctly pick up the version from `.package-version` through the mage Settings system. The helm chart was the only artifact that bypassed this and read the version directly from the `version` package, which falls back to `defaultBeatVersion` when no `package.version` file exists next to the running binary.

This caused a version mismatch: for example, the helm chart was packaged as `elastic-agent-helm-chart-9.5.0-SNAPSHOT.tgz` while the DRA publish step expected `elastic-agent-helm-chart-9.4.0-SNAPSHOT.tgz`, causing the release manager `collect` dry-run to fail on PR builds:

- **Failure**: https://buildkite.com/elastic/elastic-agent-package/builds/10484/steps/canvas?jid=019d8c01-6364-434c-9184-df5f66827df4&tab=output#019d8c01-6364-434c-9184-df5f66827df4

## Why is it important?

The `elastic-agent-package` pipeline runs on PRs as a validation check (dry-run). This bug causes it to fail every time `.package-version`'s `core_version` diverges from `version/version.go`'s `defaultBeatVersion`, which happens regularly after version bumps. This blocks PR CI with a false-negative packaging failure.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None. This only affects the internal packaging/CI pipeline, not shipped artifacts or user-facing behavior.

## How to test this PR locally

1. Set `.package-version` `core_version` to a value different from `version/version.go`'s `defaultBeatVersion` (this is the current state on main: `9.4.0` vs `9.5.0`).
2. Run `SNAPSHOT=true USE_PACKAGE_VERSION=true mage helm:package`
3. Verify the produced helm chart tgz in `build/distributions/` uses the version from `.package-version`, not from `version/version.go`.

