### PR TITLE
[mage] Centralize MANIFEST_URL handling

### DIFF
--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -25,7 +25,9 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-agent/dev-tools/mage/gotool"
+	"github.com/elastic/elastic-agent/dev-tools/mage/manifest"
 	v1 "github.com/elastic/elastic-agent/pkg/api/v1"
+	"github.com/elastic/elastic-agent/pkg/version"
 )
 
 const (
@@ -42,6 +44,8 @@ const (
 
 	// ManifestUrlEnvVar is the name of the environment variable containing the Manifest URL used for packaging agent
 	ManifestUrlEnvVar = "MANIFEST_URL"
+	// AgentCoreProjectName is the project name for elastic-agent-core in the build manifest.
+	AgentCoreProjectName = "elastic-agent-core"
 	// AgentCommitHashEnvVar allows to override agent commit hash string during packaging
 
 	// Mapped functions
@@ -859,6 +863,38 @@ func (s *Settings) WithAgentCommitHashOverride(hash string) *Settings {
 	return clone
 }
 
+// WithManifestInfo downloads the manifest at ManifestURL and applies version information to a copy of
+// the settings. It sets Build.Snapshot, Build.BeatVersion, Build.AgentCommitHashOverride,
+// Build.DependenciesVersion, and Packaging.Manifest. It is a no-op if ManifestURL is empty.
+func (s *Settings) WithManifestInfo(ctx context.Context) (*Settings, error) {
+	if s.Packaging.ManifestURL == "" {
+		return s, nil
+	}
+
+	resp, err := manifest.DownloadManifest(ctx, s.Packaging.ManifestURL)
+	if err != nil {
+		return nil, fmt.Errorf("downloading manifest: %w", err)
+	}
+
+	parsedVersion, err := version.ParseVersion(resp.Version)
+	if err != nil {
+		return nil, fmt.Errorf("parsing manifest version %s: %w", resp.Version, err)
+	}
+
+	agentCoreProject, ok := resp.Projects[AgentCoreProjectName]
+	if !ok {
+		return nil, fmt.Errorf("%q project not found in manifest %q", AgentCoreProjectName, s.Packaging.ManifestURL)
+	}
+
+	clone := s.Clone()
+	clone.Packaging.Manifest = &resp
+	clone.Build.Snapshot = parsedVersion.IsSnapshot()
+	clone.Build.BeatVersion = parsedVersion.CoreVersion()
+	clone.Build.AgentCommitHashOverride = agentCoreProject.CommitHash
+	clone.Build.DependenciesVersion = parsedVersion.VersionWithPrerelease()
+	return clone, nil
+}
+
 // WithAgentDropPath returns a copy of the settings with the specified agent drop path.
 func (s *Settings) WithAgentDropPath(path string) *Settings {
 	clone := s.Clone()
@@ -946,6 +982,10 @@ type BuildSettings struct {
 
 	// AgentCommitHashOverride overrides the commit hash for packaging (from AGENT_COMMIT_HASH_OVERRIDE or set programmatically)
 	AgentCommitHashOverride string
+
+	// DependenciesVersion is the version string used when resolving manifest dependency packages (VersionWithPrerelease).
+	// Populated by WithManifestInfo when ManifestURL is set.
+	DependenciesVersion string
 
 	// commitHash is the commit hash of the current build. Can be overridden via the AGENT_COMMIT_HASH_OVERRIDE env var.
 	// We lazy load this value, because inside crossbuild containers, fetching it can fail.
@@ -1059,6 +1099,9 @@ type PackagingSettings struct {
 
 	// ManifestURL is the location of manifest file for packaging (from MANIFEST_URL env var)
 	ManifestURL string
+
+	// Manifest is the downloaded manifest response. Populated by WithManifestInfo when ManifestURL is set.
+	Manifest *manifest.Build
 
 	// UsePackageVersion enables reading version from .package-version file (from USE_PACKAGE_VERSION env var)
 	UsePackageVersion bool

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -1060,9 +1060,6 @@ type PackagingSettings struct {
 	// ManifestURL is the location of manifest file for packaging (from MANIFEST_URL env var)
 	ManifestURL string
 
-	// PackagingFromManifest indicates whether to use manifest for packaging (derived from ManifestURL)
-	PackagingFromManifest bool
-
 	// UsePackageVersion enables reading version from .package-version file (from USE_PACKAGE_VERSION env var)
 	UsePackageVersion bool
 
@@ -1420,7 +1417,6 @@ func (s *Settings) loadPackagingSettingsFromEnv() {
 	}
 	if v := os.Getenv("MANIFEST_URL"); v != "" {
 		s.Packaging.ManifestURL = v
-		s.Packaging.PackagingFromManifest = true
 	}
 	if os.Getenv("USE_PACKAGE_VERSION") == "true" {
 		s.Packaging.UsePackageVersion = true
@@ -1434,7 +1430,7 @@ func (s *Settings) loadPackagingSettingsFromEnv() {
 
 	// Apply .package-version overrides when USE_PACKAGE_VERSION is set.
 	// This mirrors the old initPackageVersion() behavior: read the file,
-	// set ManifestURL / PackagingFromManifest / AgentDropPath so the
+	// set ManifestURL / AgentDropPath so the
 	// packaging path downloads components from the manifest instead of
 	// fetching them individually. Values from the .package-version file
 	// take precedence over environment variables.
@@ -1444,7 +1440,6 @@ func (s *Settings) loadPackagingSettingsFromEnv() {
 			log.Printf("Warning: failed to get package version info: %v", err)
 		}
 		if pv != nil {
-			s.Packaging.PackagingFromManifest = true
 			s.Packaging.ManifestURL = pv.ManifestURL
 			s.Packaging.AgentPackageVersion = pv.CoreVersion
 			s.Build.BeatVersion = pv.CoreVersion

--- a/dev-tools/mage/settings_test.go
+++ b/dev-tools/mage/settings_test.go
@@ -755,7 +755,6 @@ func TestLoadSettings(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "2.0.0", settings.Packaging.AgentPackageVersion)
 		assert.Equal(t, "https://manifest.url", settings.Packaging.ManifestURL)
-		assert.True(t, settings.Packaging.PackagingFromManifest)
 		assert.Equal(t, "/drop/path", settings.Packaging.AgentDropPath)
 		assert.True(t, settings.Packaging.KeepArchive)
 	})
@@ -771,7 +770,6 @@ func TestLoadSettings(t *testing.T) {
 		require.NoError(t, err)
 
 		isSnapshot := strings.HasSuffix(pv.Version, SnapshotSuffix)
-		assert.True(t, settings.Packaging.PackagingFromManifest)
 		assert.Equal(t, pv.ManifestURL, settings.Packaging.ManifestURL)
 		assert.Equal(t, pv.CoreVersion, settings.Packaging.AgentPackageVersion)
 		assert.Equal(t, pv.CoreVersion, settings.Build.BeatVersion)

--- a/magefile.go
+++ b/magefile.go
@@ -604,7 +604,7 @@ func Package(ctx context.Context) error {
 		return err
 	}
 
-	if cfg.Packaging.PackagingFromManifest {
+	if cfg.Packaging.ManifestURL != "" {
 		// manifest is not passed into packageAgent below because we want packageAgent to go through the
 		// flow using the elastic-agent-core that was built above. if it was passed in, it would download
 		// elastic-agent-core from the manifest and it would not be the code from this repository in the package
@@ -645,7 +645,7 @@ func downloadManifest(ctx context.Context, cfg *mage.Settings, pkgSpecs []mage.O
 		return errNoAgentDropPath
 	}
 
-	if !cfg.Packaging.PackagingFromManifest {
+	if cfg.Packaging.ManifestURL == "" {
 		return errNoManifest
 	}
 

--- a/magefile.go
+++ b/magefile.go
@@ -106,7 +106,6 @@ const (
 	cloudImageTmpl = "docker.elastic.co/observability-ci/elastic-agent:%s"
 
 	baseURLForSnapshotDRA = "https://snapshots.elastic.co/"
-	agentCoreProjectName  = "elastic-agent-core"
 
 	helmChartPath      = "./deploy/helm/elastic-agent"
 	helmOtelChartPath  = "./deploy/helm/edot-collector/kube-stack"
@@ -604,19 +603,16 @@ func Package(ctx context.Context) error {
 		return err
 	}
 
+	// manifest is not passed into packageAgent below because we want packageAgent to go through the
+	// flow using the elastic-agent-core that was built above. if it was passed in, it would download
+	// elastic-agent-core from the manifest and it would not be the code from this repository in the package
+	cfg, err = cfg.WithManifestInfo(ctx)
+	if err != nil {
+		return fmt.Errorf("failed downloading manifest: %w", err)
+	}
 	if cfg.Packaging.ManifestURL != "" {
-		// manifest is not passed into packageAgent below because we want packageAgent to go through the
-		// flow using the elastic-agent-core that was built above. if it was passed in, it would download
-		// elastic-agent-core from the manifest and it would not be the code from this repository in the package
-		_, parsedVersion, err := downloadManifestAndParseVersion(ctx, cfg.Packaging.ManifestURL)
-		if err != nil {
-			return fmt.Errorf("failed downloading manifest: %w", err)
-		}
-		// Apply manifest version info to config
-		cfg = cfg.WithSnapshot(parsedVersion.IsSnapshot()).WithBeatVersion(parsedVersion.CoreVersion())
-
 		// don't download the elastic-agent-core components; built above
-		if err := downloadManifest(ctx, cfg, pkgSpec, packaging.WithoutProjectName(agentCoreProjectName)); err != nil {
+		if err := downloadManifest(ctx, cfg, pkgSpec, packaging.WithoutProjectName(mage.AgentCoreProjectName)); err != nil {
 			return fmt.Errorf("failed downloading manifest components: %w", err)
 		}
 	}
@@ -1433,12 +1429,12 @@ func FetchLatestAgentCoreStagingDRA(ctx context.Context, branch string) error {
 	if err != nil {
 		return fmt.Errorf("retrieving defined components: %w", err)
 	}
-	elasticAgentCoreComponents := packaging.FilterComponents(components, packaging.WithProjectName(agentCoreProjectName), packaging.WithFIPS(cfg.Build.FIPSBuild))
+	elasticAgentCoreComponents := packaging.FilterComponents(components, packaging.WithProjectName(mage.AgentCoreProjectName), packaging.WithFIPS(cfg.Build.FIPSBuild))
 
 	if len(elasticAgentCoreComponents) != 1 {
 		return fmt.Errorf(
 			"found an unexpected number of elastic-agent-core components (should be 1) [projectName: %q, fips: %v]: %v",
-			agentCoreProjectName,
+			mage.AgentCoreProjectName,
 			cfg.Build.FIPSBuild,
 			elasticAgentCoreComponents,
 		)
@@ -1494,50 +1490,16 @@ func PackageUsingDRA(ctx context.Context) error {
 
 	// When MANIFEST_URL is not provided in the environment elastic-agent-core packages from build/distributions
 	// will be used instead of pulling from the manifest.
-	var manifestResponse *manifest.Build
-	var dependenciesVersion string
-	manifestURL := cfg.Packaging.ManifestURL
-	if manifestURL == "" {
+	if cfg.Packaging.ManifestURL == "" {
 		fmt.Println("NOTICE: No MANIFEST_URL was provided, using elastic-agent-core packages from build/distributions.")
-	} else {
-		var parsedVersion *version.ParsedSemVer
-		manifestResponse, parsedVersion, err = downloadManifestAndParseVersion(ctx, cfg.Packaging.ManifestURL)
-		if err != nil {
-			return fmt.Errorf("failed downloading manifest: %w", err)
-		}
-		dependenciesVersion = parsedVersion.VersionWithPrerelease()
-
-		// fix the commit hash independently of the current commit hash on the branch
-		agentCoreProject, ok := manifestResponse.Projects[agentCoreProjectName]
-		if !ok {
-			return fmt.Errorf("%q project not found in manifest %q", agentCoreProjectName, cfg.Packaging.ManifestURL)
-		}
-		cfg = cfg.WithAgentCommitHashOverride(agentCoreProject.CommitHash)
-
-		// Apply manifest version to config
-		cfg = cfg.WithSnapshot(parsedVersion.IsSnapshot()).WithBeatVersion(parsedVersion.CoreVersion())
-		ctx = devtools.ContextWithSettings(ctx, cfg)
 	}
-
-	return packageAgent(ctx, cfg, pkgSpec, dependenciesVersion, manifestResponse)
-}
-
-// downloadManifestAndParseVersion downloads the manifest and returns the build info and parsed version.
-// The caller is responsible for applying the version information to the config using:
-//
-//	cfg = cfg.WithSnapshot(parsedVersion.IsSnapshot()).WithBeatVersion(parsedVersion.CoreVersion())
-func downloadManifestAndParseVersion(ctx context.Context, url string) (*manifest.Build, *version.ParsedSemVer, error) {
-	resp, err := manifest.DownloadManifest(ctx, url)
+	cfg, err = cfg.WithManifestInfo(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("downloading manifest: %w", err)
+		return fmt.Errorf("failed downloading manifest: %w", err)
 	}
+	ctx = devtools.ContextWithSettings(ctx, cfg)
 
-	parsedVersion, err := version.ParseVersion(resp.Version)
-	if err != nil {
-		return nil, nil, fmt.Errorf("parsing manifest version %s: %w", resp.Version, err)
-	}
-
-	return &resp, parsedVersion, nil
+	return packageAgent(ctx, cfg, pkgSpec, cfg.Build.DependenciesVersion, cfg.Packaging.Manifest)
 }
 
 func findLatestBuildForBranch(ctx context.Context, baseURL string, branch string) (*branchInfo, error) {
@@ -1660,11 +1622,11 @@ func extractAgentCoreForPackage(ctx context.Context, cfg *mage.Settings, manifes
 	if err != nil {
 		return fmt.Errorf("retrieving defined components: %w", err)
 	}
-	elasticAgentCoreComponents := packaging.FilterComponents(components, packaging.WithProjectName(agentCoreProjectName), packaging.WithFIPS(cfg.Build.FIPSBuild))
+	elasticAgentCoreComponents := packaging.FilterComponents(components, packaging.WithProjectName(mage.AgentCoreProjectName), packaging.WithFIPS(cfg.Build.FIPSBuild))
 	if len(elasticAgentCoreComponents) != 1 {
 		return fmt.Errorf(
 			"found an unexpected number of elastic-agent-core components (should be 1) [projectName: %q, fips: %v]: %v",
-			agentCoreProjectName,
+			mage.AgentCoreProjectName,
 			cfg.Build.FIPSBuild,
 			elasticAgentCoreComponents,
 		)
@@ -1974,23 +1936,9 @@ func Ironbank(ctx context.Context) error {
 		return nil
 	}
 	cfg := devtools.SettingsFromContext(ctx)
-	// TODO: centralize the manifest loading logic
-	if cfg.Packaging.ManifestURL != "" { // get the version from the manifest
-		var parsedVersion *version.ParsedSemVer
-		manifestResponse, parsedVersion, err := downloadManifestAndParseVersion(ctx, cfg.Packaging.ManifestURL)
-		if err != nil {
-			return fmt.Errorf("failed downloading manifest: %w", err)
-		}
-
-		// fix the commit hash independently of the current commit hash on the branch
-		agentCoreProject, ok := manifestResponse.Projects[agentCoreProjectName]
-		if !ok {
-			return fmt.Errorf("%q project not found in manifest %q", agentCoreProjectName, cfg.Packaging.ManifestURL)
-		}
-		cfg = cfg.WithAgentCommitHashOverride(agentCoreProject.CommitHash)
-
-		// Apply manifest version to config
-		cfg = cfg.WithSnapshot(parsedVersion.IsSnapshot()).WithBeatVersion(parsedVersion.CoreVersion())
+	cfg, err := cfg.WithManifestInfo(ctx)
+	if err != nil {
+		return fmt.Errorf("failed downloading manifest: %w", err)
 	}
 	if err := prepareIronbankBuild(cfg); err != nil {
 		return fmt.Errorf("failed to prepare the IronBank context: %w", err)

--- a/magefile.go
+++ b/magefile.go
@@ -606,10 +606,13 @@ func Package(ctx context.Context) error {
 	// manifest is not passed into packageAgent below because we want packageAgent to go through the
 	// flow using the elastic-agent-core that was built above. if it was passed in, it would download
 	// elastic-agent-core from the manifest and it would not be the code from this repository in the package
-	cfg, err = cfg.WithManifestInfo(ctx)
+	cfgWithManifest, err := cfg.WithManifestInfo(ctx)
 	if err != nil {
 		return fmt.Errorf("failed downloading manifest: %w", err)
 	}
+	// only take the snapshot and version from the manifest, we don't want the commit hash or dependency version
+	cfg = cfg.WithSnapshot(cfgWithManifest.Build.Snapshot).WithBeatVersion(cfgWithManifest.BeatVersion())
+
 	if cfg.Packaging.ManifestURL != "" {
 		// don't download the elastic-agent-core components; built above
 		if err := downloadManifest(ctx, cfg, pkgSpec, packaging.WithoutProjectName(mage.AgentCoreProjectName)); err != nil {

--- a/magefile.go
+++ b/magefile.go
@@ -4193,22 +4193,17 @@ func (h Helm) Package(ctx context.Context) error {
 	// need to explicitly set SNAPSHOT="false" to produce a production-ready package
 	productionPackage := cfg.Build.SnapshotSet && !cfg.Build.Snapshot
 
-	agentVersion := bversion.GetParsedAgentPackageVersion()
-	agentCoreVersion := agentVersion.CoreVersion()
+	cfg, err := cfg.WithManifestInfo(ctx)
+	if err != nil {
+		return fmt.Errorf("failed downloading manifest: %w", err)
+	}
+	agentCoreVersion := cfg.BeatVersion()
 	agentImageTag := agentCoreVersion
+	agentChartVersion := agentCoreVersion
 	if !productionPackage {
 		// always use the SNAPSHOT version for image tag if not a production package
-		agentImageTag = agentImageTag + "-SNAPSHOT"
-	}
-
-	agentChartVersion := agentCoreVersion + "-SNAPSHOT"
-	switch {
-	case productionPackage && agentVersion.Major() >= 9:
-		// for 9.0.0 and later versions, elastic-agent Helm chart is GA
-		agentChartVersion = agentCoreVersion
-	case productionPackage && agentVersion.Major() >= 8 && agentVersion.Minor() >= 18:
-		// for 8.18.0 and later versions, elastic-agent Helm chart is GA
-		agentChartVersion = agentCoreVersion
+		agentImageTag = agentImageTag + mage.SnapshotSuffix
+		agentChartVersion = agentChartVersion + mage.SnapshotSuffix
 	}
 
 	for yamlFile, keyVals := range map[string][]struct {
@@ -4241,7 +4236,7 @@ func (h Helm) Package(ctx context.Context) error {
 	settings := cli.New() // Helm CLI settings
 	actionConfig := &action.Configuration{}
 
-	err := actionConfig.Init(settings.RESTClientGetter(), "default", "",
+	err = actionConfig.Init(settings.RESTClientGetter(), "default", "",
 		func(format string, v ...interface{}) {})
 	if err != nil {
 		return fmt.Errorf("failed to init helm action config: %w", err)


### PR DESCRIPTION
## What does this PR do?

It moves the logic of obtaining and parsing the manifest into a single method on the Settings struct, which can then be reused by every target where it's relevant. It also fixes a bug where the `helm:package` target wasn't using the manifest version, but rather the one from `version/version.go`.

This logic can likely become unconditional, but that can happen in a follow-up. There's also some awkwardness involved with the `USE_PACKAGE_VERSION` option, that needs to be resolved later.

## Why is it important?

Currently this is done separately in each target that needs it, for no reason other than technical debt.

## How to test this PR locally

You can try running `MANIFEST_URL="$(jq -r .manifest_url .package-version)" mage helm:package` to verify that the bug fix is effective. No other behavior should change.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
