### PR TITLE
Fix license issue for spdx/tools-golang

### DIFF
--- a/dev-tools/notice/overrides.json
+++ b/dev-tools/notice/overrides.json
@@ -22,3 +22,4 @@
 {"name": "github.com/elastic/cloud-on-k8s/v2", "licenceType": "Elastic"}
 {"name": "github.com/elastic/elastic-agent/internal/edot", "licenceType": "Elastic"}
 {"name": "github.com/elastic/ebpfevents", "licenceType": "Apache-2.0"}
+{"name": "github.com/spdx/tools-golang", "licenceFile": "LICENSE.code"}

--- a/dev-tools/notice/overrides.json
+++ b/dev-tools/notice/overrides.json
@@ -22,4 +22,4 @@
 {"name": "github.com/elastic/cloud-on-k8s/v2", "licenceType": "Elastic"}
 {"name": "github.com/elastic/elastic-agent/internal/edot", "licenceType": "Elastic"}
 {"name": "github.com/elastic/ebpfevents", "licenceType": "Apache-2.0"}
-{"name": "github.com/spdx/tools-golang", "licenceFile": "LICENSE.code"}
+{"name": "github.com/spdx/tools-golang", "licenceFile": "LICENSE.code", "licenceType": "Apache-2.0"}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
The DRA is failing after this PR went in [github.com/elastic/elastic-agent/pull/13313.](https://github.com/elastic/elastic-agent/pull/13313)
The error is 
```
+ go run go.elastic.co/go-licence-detector -includeIndirect -rules /opt/buildkite-agent/builds/bk-agent-prod-gcp-1776302717266580963/elastic/elastic-agent-binary-dra/dev-tools/notice/rules.json -overrides /opt/buildkite-agent/builds/bk-agent-prod-gcp-1776302717266580963/elastic/elastic-agent-binary-dra/dev-tools/notice/overrides.json -noticeTemplate /opt/buildkite-agent/builds/bk-agent-prod-gcp-1776302717266580963/elastic/elastic-agent-binary-dra/dev-tools/notice/dependencies.csv.tmpl -noticeOut dependencies.csv -depsOut
2026/04/16 01:41:46 Failed to detect licences: no licence file found for github.com/spdx/tools-golang. Add an override entry with licence type to continue.
```

This PR overrides license for spdx/tools-golang

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
It is required to correctly pull in license of the dependencies we use

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Disruptive User Impact
None

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally
`sh dev-tools/dependencies-report --csv /tmp/dependencies.csv`

