### PR TITLE
Fix defer misfire when ConfigureRegistryPermissions fails in SwitchExecutingMode

### DIFF
--- a/internal/pkg/agent/install/switch.go
+++ b/internal/pkg/agent/install/switch.go
@@ -92,9 +92,8 @@ func SwitchExecutingMode(topPath string, pt ProgressDescriber, username string, 
 
 	// update the registry ACL so the new service user can update the entry on future upgrades
 	pt.Describe("Configuring registry permissions")
-	err = ConfigureRegistryPermissions(ownership)
-	if err != nil {
-		pt.Describe(fmt.Sprintf("Failed to configure registry permissions: %s", err.Error()))
+	if regErr := ConfigureRegistryPermissions(ownership); regErr != nil {
+		pt.Describe(fmt.Sprintf("Failed to configure registry permissions: %s", regErr.Error()))
 	}
 
 	return nil


### PR DESCRIPTION
Issue caught during 9.4 backport: https://github.com/elastic/elastic-agent/pull/13676#discussion_r3098804991