### PR TITLE
Added version round tripper

### DIFF
--- a/internal/pkg/fleetapi/client/client.go
+++ b/internal/pkg/fleetapi/client/client.go
@@ -43,8 +43,9 @@ type Sender interface {
 const defaultFleetApiVersion = "2023-06-01"
 
 var baseRoundTrippers = func(rt http.RoundTripper) (http.RoundTripper, error) {
-	rt = NewFleetUserAgentRoundTripper(rt, release.Version())
-
+	ver := release.Version()
+	rt = NewFleetUserAgentRoundTripper(rt, ver)
+	rt = NewElasticAgentVersionRoundTripper(rt, ver)
 	rt = NewElasticApiVersionRoundTripper(rt, defaultFleetApiVersion)
 
 	return rt, nil

--- a/internal/pkg/fleetapi/client/client_test.go
+++ b/internal/pkg/fleetapi/client/client_test.go
@@ -111,6 +111,36 @@ func TestHTTPClient(t *testing.T) {
 		},
 	))
 
+	t.Run("Elastic Agent Version header", withServer(
+		func(t *testing.T) *http.ServeMux {
+			msg := `{ message: "hello" }`
+			mux := http.NewServeMux()
+			mux.HandleFunc("/echo-hello", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, msg)
+				require.Equal(t, r.Header.Get("Elastic-Agent-Version"), "v8.0.0")
+			})
+			return mux
+		}, func(t *testing.T, host string) {
+			cfg := config.MustNewConfigFrom(map[string]interface{}{
+				"host": host,
+			})
+
+			client, err := remote.NewWithRawConfig(nil, cfg, func(wrapped http.RoundTripper) (http.RoundTripper, error) {
+				return NewElasticAgentVersionRoundTripper(wrapped, "8.0.0"), nil
+			})
+
+			require.NoError(t, err)
+			resp, err := client.Send(ctx, "GET", "/echo-hello", nil, nil, nil)
+			require.NoError(t, err)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, `{ message: "hello" }`, string(body))
+		},
+	))
+
 	t.Run("Fleet endpoint is not responding", func(t *testing.T) {
 		cfg := config.MustNewConfigFrom(map[string]interface{}{
 			"host": "127.0.0.0:7278",

--- a/internal/pkg/fleetapi/client/round_trippers.go
+++ b/internal/pkg/fleetapi/client/round_trippers.go
@@ -7,6 +7,7 @@ package client
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/elastic/elastic-agent/internal/pkg/remote"
 )
@@ -87,4 +88,27 @@ func (r *ElasticApiVersionRoundTripper) RoundTrip(req *http.Request) (*http.Resp
 
 func NewElasticApiVersionRoundTripper(inner http.RoundTripper, elasticApiVersion string) http.RoundTripper {
 	return &ElasticApiVersionRoundTripper{elasticApiVersion: elasticApiVersion, rt: inner}
+}
+
+// ElasticAgentVersionRoundTripper adds an Elastic-Agent-Version header on every request.
+type ElasticAgentVersionRoundTripper struct {
+	rt      http.RoundTripper
+	version string
+}
+
+const elasticAgentVersionHeaderKey = "Elastic-Agent-Version"
+
+// RoundTrip adds an Elastic-Agent-Version header on every request.
+func (r *ElasticAgentVersionRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set(elasticAgentVersionHeaderKey, r.version)
+
+	return r.rt.RoundTrip(req)
+}
+
+// NewElasticAgentVersionRoundTripper returns a RoundTripper that sets Elastic-Agent-Version on each request.
+func NewElasticAgentVersionRoundTripper(inner http.RoundTripper, version string) http.RoundTripper {
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+	return &ElasticAgentVersionRoundTripper{rt: inner, version: version}
 }


### PR DESCRIPTION
In order to use custom header for agentless deployments, we need to provide some way for fleet server to detect agent version

at this point server parser User agent header and expects `Elastic Agent v1.2.3` this is no longer true.
Adding `Elastic-Agent-Version` header that can use as a fallback for cases when version is not included in User Agent