### PR TITLE
fix: interrupt retry backoff on ctx cancellation for fleet enroll

### DIFF
--- a/changelog/fragments/1776702953-fix-enroll-retry-blocks-uninstall.yaml
+++ b/changelog/fragments/1776702953-fix-enroll-retry-blocks-uninstall.yaml
@@ -1,0 +1,51 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user's deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Make enrollment retry backoff respect context cancellation
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  The enrollment retry loop's backoff wait was not context-aware, so a
+  canceled context could not interrupt the current sleep. This caused
+  `elastic-agent uninstall` and graceful shutdown to block for up to
+  EnrollBackoffMax (10 minutes) while the agent was retrying enrollment
+  against an unreachable Fleet Server. The retry loop now exits
+  immediately when the caller's context is canceled.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/enroll/enroll.go
+++ b/internal/pkg/agent/application/enroll/enroll.go
@@ -120,6 +120,8 @@ RETRYLOOP:
 		case err != nil:
 			log.Warnf("Error detected: %s, will retry in a moment.", err.Error())
 		}
+		// Context cancellation should be able to interrupt the exponential backoff wait,
+		// otherwise the loop keeps sleeping after context is canceled
 		waitCh := make(chan bool, 1)
 		go func() { waitCh <- backExp.Wait() }()
 		select {

--- a/internal/pkg/agent/application/enroll/enroll.go
+++ b/internal/pkg/agent/application/enroll/enroll.go
@@ -97,12 +97,12 @@ func EnrollWithBackoff(
 	enrollFn := func() error {
 		return enroll(ctx, log, persistentConfig, client, options, configStore)
 	}
-	err = retryEnroll(err, maxAttempts, log, enrollFn, client.URI(), backExp)
+	err = retryEnroll(ctx, err, maxAttempts, log, enrollFn, client.URI(), backExp)
 
 	return err
 }
 
-func retryEnroll(err error, maxAttempts int, log *logger.Logger, enrollFn func() error, clientURI string, backExp backoff.Backoff) error {
+func retryEnroll(ctx context.Context, err error, maxAttempts int, log *logger.Logger, enrollFn func() error, clientURI string, backExp backoff.Backoff) error {
 	attemptNo := 1
 
 RETRYLOOP:
@@ -120,8 +120,15 @@ RETRYLOOP:
 		case err != nil:
 			log.Warnf("Error detected: %s, will retry in a moment.", err.Error())
 		}
-		if !backExp.Wait() {
-			break RETRYLOOP
+		waitCh := make(chan bool, 1)
+		go func() { waitCh <- backExp.Wait() }()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ok := <-waitCh:
+			if !ok {
+				break RETRYLOOP
+			}
 		}
 		log.Infof("Retrying enrollment to URL: %s", clientURI)
 		err = enrollFn()

--- a/internal/pkg/agent/application/enroll/enroll_test.go
+++ b/internal/pkg/agent/application/enroll/enroll_test.go
@@ -10,20 +10,33 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
+	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
 // fakeBackoff allows controlling the sequence of Wait() return values for tests.
 type fakeBackoff struct {
 	results []bool
+	block   chan struct{}
 }
 
+// Wait returns values from results (FIFO), or true when results is empty.
+// If block is non-nil, it simulates an infinite backoff.
 func (f *fakeBackoff) Wait() bool {
+	if f.block != nil {
+		<-f.block
+	}
+	if len(f.results) > 0 {
+		r := f.results[0]
+		f.results = f.results[1:]
+		return r
+	}
 	return true
 }
 
@@ -41,19 +54,37 @@ func TestRetryEnroll_SucceedsAfterOneRetry(t *testing.T) {
 		return nil
 	}
 
-	fb := &fakeBackoff{results: []bool{true}}
+	fb := &fakeBackoff{}
 
 	l := logger.NewWithoutConfig("")
 
-	err := retryEnroll(initialErr, 5, l, enrollFn, "http://localhost", fb)
+	err := retryEnroll(t.Context(), initialErr, 5, l, enrollFn, "http://localhost", fb)
 	require.NoError(t, err)
 	require.Equal(t, 1, called)
 }
 
-func TestRetryEnroll_BackoffStopsImmediately(t *testing.T) {
+func TestRetryEnroll_StopsAfterMaxAttempts(t *testing.T) {
 	initialErr := fmt.Errorf("network")
 	called := 0
-	expectedAttempts := 5
+	maxAttempts := 5
+	enrollFn := func() error {
+		called++
+		return errors.New("still failing")
+	}
+
+	fb := &fakeBackoff{}
+
+	l := logger.NewWithoutConfig("")
+
+	err := retryEnroll(t.Context(), initialErr, maxAttempts, l, enrollFn, "http://localhost", fb)
+	require.Equal(t, maxAttempts-1, called)
+	require.Error(t, err)                  // error is expected
+	require.NotErrorIs(t, err, initialErr) // subsequent failures are different
+}
+
+func TestRetryEnroll_ExitsOnBackoffStop(t *testing.T) {
+	initialErr := fmt.Errorf("initial")
+	called := 0
 	enrollFn := func() error {
 		called++
 		return errors.New("still failing")
@@ -63,27 +94,63 @@ func TestRetryEnroll_BackoffStopsImmediately(t *testing.T) {
 
 	l := logger.NewWithoutConfig("")
 
-	err := retryEnroll(initialErr, expectedAttempts, l, enrollFn, "http://localhost", fb)
-	require.Equal(t, expectedAttempts-1, called)
-	require.Error(t, err)                  // error is expected
-	require.NotErrorIs(t, err, initialErr) // subsequent failures are different
+	err := retryEnroll(t.Context(), initialErr, -1, l, enrollFn, "http://localhost", fb)
+	require.Equal(t, 0, called)
+	require.ErrorIs(t, err, initialErr) // error is expected
 }
 
-func TestRetryEnroll_BreaksOnContextCanceled(t *testing.T) {
-	// When err is context.Canceled, retryEnroll should return immediately
-	cancelErr := context.Canceled
-	called := 0
-	enrollFn := func() error {
-		called++
-		return nil
+func TestRetryEnroll_ExitsOnTerminalEnrollError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"context canceled", context.Canceled},
+		{"deadline exceeded", context.DeadlineExceeded},
+		{"invalid token", fleetapi.ErrInvalidToken},
 	}
-	fb := &fakeBackoff{results: []bool{true}}
 
-	l := logger.NewWithoutConfig("")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			called := 0
+			enrollFn := func() error {
+				called++
+				return nil
+			}
+			fb := &fakeBackoff{}
+			l := logger.NewWithoutConfig("")
 
-	err := retryEnroll(cancelErr, 5, l, enrollFn, "http://localhost", fb)
-	require.ErrorIs(t, err, context.Canceled)
-	require.Equal(t, called, 0)
+			err := retryEnroll(t.Context(), tc.err, 5, l, enrollFn, "http://localhost", fb)
+			require.ErrorIs(t, err, tc.err)
+			require.Equal(t, 0, called)
+		})
+	}
+}
+
+func TestRetryEnroll_InterruptsBackoffWaitOnCtxCancel(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		fb := &fakeBackoff{block: make(chan struct{})}
+		defer close(fb.block)
+
+		enrollFn := func() error { return errors.New("still failing") }
+
+		l := logger.NewWithoutConfig("")
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- retryEnroll(ctx, errors.New("initial"), -1, l, enrollFn, "http://localhost", fb)
+		}()
+
+		// retryEnroll should return when the caller's context is canceled, even if the retry
+		// loop is currently blocked in backoff.Wait()
+		synctest.Wait()
+		cancel()
+
+		err := <-errCh
+		require.ErrorIs(t, err, context.Canceled)
+	})
 }
 
 func TestLoadPersistentConfig_FleetCheckin(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `elastic-agent uninstall -f` (and graceful shutdown generally) could block for up to 10 minutes when the agent was in its enrollment retry loop with an unreachable Fleet Server.

The backoff wait is now wrapped in a ctx-aware select, so canceling the caller's context interrupts the loop immediately.

## Why is it important?

`elastic-agent uninstall` waits for the running agent to stop before the service can exit, while the enrollment retry was sleeping the service was unresponsive. 

This was discovered while fixing MSI uninstall tests in https://github.com/elastic/elastic-stack-installers, the Fleet-mode MSI uninstall was hitting its 10-minute timeout because the backoff sleep was blocking shutdown.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~I have added an integration test or an E2E test~~ (MSI uninstall IT in elastic-stack-installers covers the user-visible scenario)

## Disruptive User Impact

None. Reduces uninstall/shutdown latency when the agent is in the enrollment retry loop; no API, config, or observable-behavior changes otherwise.

## How to test this PR locally

```
go test ./internal/pkg/agent/application/enroll/ -v
```

Manual reproduction:
1. Start an elastic-agent configured to enroll against an unreachable Fleet URL.
2. After the first enrollment attempt fails and the retry loop enters backoff, run `elastic-agent uninstall -f`.
3. Before the fix: uninstall blocks until the current backoff sleep ends (up to 10 min).
4. After the fix: uninstall returns promptly.
