### PR TITLE
Temporarily skip MacOS unit tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -150,6 +150,7 @@ steps:
 
   - group: "macOS tests"
     key: "macos-unit-tests"
+    skip: "Incident 2968, Orka 3 upgrade. Unskip after it's resolved."
     steps:
       - label: "Unit tests - macOS 15 ARM"
         command: ".buildkite/scripts/steps/unit-tests.sh"


### PR DESCRIPTION
Skip unit tests on MacOS until the incident affecting buildkite MacOS runners is resolved.