### PR TITLE
fix: clean up leftover artifacts when install fails

### DIFF
--- a/changelog/fragments/1776765594-clean-up-after-failed-install.yaml
+++ b/changelog/fragments/1776765594-clean-up-after-failed-install.yaml
@@ -1,0 +1,49 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user's deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Clean up leftover artifacts when `elastic-agent install` fails
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  When `elastic-agent install` failed, some artifacts could be left on the
+  system. On Windows, the agent could also still show up in "Add or Remove
+  Programs" even though it was not installed. These leftovers are now
+  removed when the install fails.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -256,7 +257,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		// Uninstall the agent
 		progBar.Describe(fmt.Sprintf("Uninstalling current %s", paths.ServiceDisplayName()))
 		if !runUninstallBinary {
-			err := execUninstall(streams, topPath, paths.BinaryName)
+			err := execUninstall(cmd.Context(), streams, topPath, paths.BinaryName)
 			if err != nil {
 				progBar.Describe("Uninstall failed")
 				return err
@@ -284,11 +285,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 			flavor = install.FlavorServers
 		}
 
-		ownership, err = install.Install(cfgFile, topPath, unprivileged, log, progBar, streams, customUser, customGroup, customPass, flavor)
-		if err != nil {
-			return fmt.Errorf("error installing package: %w", err)
-		}
-
+		// Registered before install.Install so partial-install failures are also rolled back.
 		defer func() {
 			if err != nil {
 				progBar.Describe("Uninstalling")
@@ -300,6 +297,11 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 				}
 			}
 		}()
+
+		ownership, err = install.Install(cfgFile, topPath, unprivileged, log, progBar, streams, customUser, customGroup, customPass, flavor)
+		if err != nil {
+			return fmt.Errorf("error installing package: %w", err)
+		}
 
 		if !delayEnroll {
 			progBar.Describe("Starting Service")
@@ -330,7 +332,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 	if enroll {
 		enrollArgs := []string{"enroll", "--from-install"}
 		enrollArgs = append(enrollArgs, buildEnrollmentFlags(cmd, url, token)...)
-		enrollCmd := exec.Command(install.ExecutablePath(topPath), enrollArgs...) //nolint:gosec // it's not tainted
+		enrollCmd := exec.CommandContext(cmd.Context(), install.ExecutablePath(topPath), enrollArgs...) //nolint:gosec // it's not tainted
 		enrollCmd.Stdin = os.Stdin
 		enrollCmd.Stdout = os.Stdout
 		enrollCmd.Stderr = os.Stderr
@@ -385,7 +387,7 @@ func isFleetServerFlagProvided(cmd *cobra.Command) bool {
 }
 
 // execUninstall execs "elastic-agent uninstall --force" from the elastic agent installed on the system (found in PATH)
-func execUninstall(streams *cli.IOStreams, topPath string, binName string) error {
+func execUninstall(ctx context.Context, streams *cli.IOStreams, topPath string, binName string) error {
 	args := []string{
 		"uninstall",
 		"--force",
@@ -404,7 +406,7 @@ func execUninstall(streams *cli.IOStreams, topPath string, binName string) error
 		return fmt.Errorf("expected file, found a directory at %s", binPath)
 	}
 
-	uninstall := exec.Command(binPath, args...)
+	uninstall := exec.CommandContext(ctx, binPath, args...)
 	uninstall.Stdout = streams.Out
 	uninstall.Stderr = streams.Err
 	if err := uninstall.Start(); err != nil {

--- a/internal/pkg/agent/cmd/install_test.go
+++ b/internal/pkg/agent/cmd/install_test.go
@@ -86,7 +86,7 @@ func TestExecUninstall(t *testing.T) {
 			Err: &stderr,
 		}
 
-		err = execUninstall(streams, tmpDir, "elastic-agent")
+		err = execUninstall(t.Context(), streams, tmpDir, "elastic-agent")
 		assert.NoError(t, err)
 	})
 
@@ -96,7 +96,7 @@ func TestExecUninstall(t *testing.T) {
 			Err: &bytes.Buffer{},
 		}
 
-		err := execUninstall(streams, tmpDir, "non-existent-binary")
+		err := execUninstall(t.Context(), streams, tmpDir, "non-existent-binary")
 		assert.Error(t, err)
 		assert.True(t, errors.Is(err, fs.ErrNotExist))
 	})
@@ -111,7 +111,7 @@ func TestExecUninstall(t *testing.T) {
 			Err: &bytes.Buffer{},
 		}
 
-		err = execUninstall(streams, tmpDir, "elastic-agent-dir")
+		err = execUninstall(t.Context(), streams, tmpDir, "elastic-agent-dir")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "expected file, found a directory")
 	})
@@ -126,7 +126,7 @@ func TestExecUninstall(t *testing.T) {
 			Err: &bytes.Buffer{},
 		}
 
-		err = execUninstall(streams, tmpDir, "failing-agent")
+		err = execUninstall(t.Context(), streams, tmpDir, "failing-agent")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to uninstall elastic-agent")
 	})

--- a/testing/installtest/checks.go
+++ b/testing/installtest/checks.go
@@ -50,6 +50,8 @@ type CheckOpts struct {
 	TargetVersion string
 	// StartVersion is the version the agent was upgraded from.
 	StartVersion string
+	// TopPath is the agent install directory.
+	TopPath string
 }
 
 func CheckSuccess(ctx context.Context, f *atesting.Fixture, topPath string, opts *CheckOpts) error {
@@ -86,6 +88,15 @@ func CheckSuccess(ctx context.Context, f *atesting.Fixture, topPath string, opts
 }
 
 func CheckUninstallSuccess(opts *CheckOpts) error {
+	if opts.TopPath != "" {
+		if _, err := os.Stat(opts.TopPath); !os.IsNotExist(err) {
+			if err == nil {
+				return fmt.Errorf("%s still exists after uninstall", opts.TopPath)
+			}
+			return fmt.Errorf("unexpected error checking %s: %w", opts.TopPath, err)
+		}
+	}
+
 	return checkUninstallPlatform(opts)
 }
 

--- a/testing/integration/ess/install_test.go
+++ b/testing/integration/ess/install_test.go
@@ -431,13 +431,13 @@ func TestInstallFailureCleanup(t *testing.T) {
 	err = fixture.Prepare(ctx)
 	require.NoError(t, err)
 
-	// Force enrollment to fail by pointing at an unreachable URL.
+	// Force enrollment to fail instantly by pointing to a malformed URL, triggering an install failure.
 	opts := atesting.InstallOpts{
 		Force:      true,
 		Privileged: true,
 		Insecure:   true,
 		EnrollOpts: atesting.EnrollOpts{
-			URL:             "https://127.0.0.1:1",
+			URL:             "http://invalid-url-%",
 			EnrollmentToken: "bogus-enrollment-token",
 		},
 	}
@@ -450,7 +450,8 @@ func TestInstallFailureCleanup(t *testing.T) {
 		Privileged: opts.Privileged,
 		TopPath:    installtest.DefaultTopPath(),
 	}
-	require.NoError(t, installtest.CheckUninstallSuccess(checks))
+	err = installtest.CheckUninstallSuccess(checks)
+	require.NoError(t, err)
 }
 
 // Isolate the tests of --develop (which uses --namespace in it's implementation) into it's own test

--- a/testing/integration/ess/install_test.go
+++ b/testing/integration/ess/install_test.go
@@ -156,6 +156,7 @@ func TestInstallWithBasePath(t *testing.T) {
 	checks := &installtest.CheckOpts{
 		Privileged:    opts.Privileged,
 		TargetVersion: fixture.Version(),
+		TopPath:       topPath,
 	}
 	require.NoError(t, installtest.CheckSuccess(ctx, fixture, topPath, checks))
 
@@ -259,6 +260,7 @@ func TestInstallServersWithBasePath(t *testing.T) {
 	checks := &installtest.CheckOpts{
 		Privileged:    opts.Privileged,
 		TargetVersion: fixture.Version(),
+		TopPath:       topPath,
 	}
 	require.NoError(t, installtest.CheckSuccess(ctx, fixture, topPath, checks))
 
@@ -333,6 +335,7 @@ func TestInstallPrivilegedWithoutBasePath(t *testing.T) {
 	checks := &installtest.CheckOpts{
 		Privileged:    opts.Privileged,
 		TargetVersion: fixture.Version(),
+		TopPath:       installtest.DefaultTopPath(),
 	}
 	require.NoError(t, installtest.CheckSuccess(ctx, fixture, opts.BasePath, checks))
 
@@ -392,6 +395,7 @@ func TestInstallPrivilegedWithBasePath(t *testing.T) {
 	checks := &installtest.CheckOpts{
 		Privileged:    opts.Privileged,
 		TargetVersion: fixture.Version(),
+		TopPath:       topPath,
 	}
 	require.NoError(t, installtest.CheckSuccess(ctx, fixture, topPath, checks))
 	t.Run("check agent package version", testAgentPackageVersion(ctx, fixture, true))
@@ -402,6 +406,51 @@ func TestInstallPrivilegedWithBasePath(t *testing.T) {
 	fixture.PostUninstallHook(func(t *testing.T) {
 		require.NoError(t, installtest.CheckUninstallSuccess(checks))
 	})
+}
+
+func TestInstallFailureCleanup(t *testing.T) {
+	define.Require(t, define.Requirements{
+		Group: integration.Default,
+		// We require sudo for this test to run
+		// `elastic-agent install`.
+		Sudo: true,
+
+		// It's not safe to run this test locally as it
+		// installs Elastic Agent.
+		Local: false,
+	})
+
+	// Get path to Elastic Agent executable
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
+	require.NoError(t, err)
+
+	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	defer cancel()
+
+	// Prepare the Elastic Agent so the binary is extracted and ready to use.
+	err = fixture.Prepare(ctx)
+	require.NoError(t, err)
+
+	// Force enrollment to fail by pointing at an unreachable URL.
+	opts := atesting.InstallOpts{
+		Force:      true,
+		Privileged: true,
+		Insecure:   true,
+		EnrollOpts: atesting.EnrollOpts{
+			URL:             "https://127.0.0.1:1",
+			EnrollmentToken: "bogus-enrollment-token",
+		},
+	}
+
+	out, err := fixture.Install(ctx, &opts)
+	require.Errorf(t, err, "install should have failed; output: %s", out)
+
+	// Verify the install directory and any platform-specific state was cleaned up.
+	checks := &installtest.CheckOpts{
+		Privileged: opts.Privileged,
+		TopPath:    installtest.DefaultTopPath(),
+	}
+	require.NoError(t, installtest.CheckUninstallSuccess(checks))
 }
 
 // Isolate the tests of --develop (which uses --namespace in it's implementation) into it's own test
@@ -445,6 +494,7 @@ func TestInstallSecondAgentInDevelopmentNamespace(t *testing.T) {
 	checks := &installtest.CheckOpts{
 		Privileged:    opts.Privileged,
 		TargetVersion: fixture.Version(),
+		TopPath:       topPath,
 	}
 	require.NoError(t, installtest.CheckSuccess(ctx, fixture, topPath, checks))
 
@@ -499,6 +549,7 @@ func testInstallWithoutBasePathWithCustomUser(ctx context.Context, t *testing.T,
 		Username:      customUsername,
 		Group:         customGroup,
 		TargetVersion: fixture.Version(),
+		TopPath:       topPath,
 	}
 	require.NoError(t, installtest.CheckSuccess(ctx, fixture, topPath, checks))
 
@@ -594,6 +645,7 @@ func testSecondAgentCanInstall(ctx context.Context, fixture *atesting.Fixture, b
 			Username:      installOpts.Username,
 			Group:         installOpts.Group,
 			TargetVersion: devFixture.Version(),
+			TopPath:       topPath,
 		}
 
 		require.NoError(t, installtest.CheckSuccess(ctx, devFixture, topPath, checks))


### PR DESCRIPTION
## What does this PR do?

When `elastic-agent install` fails the installer now removes any artifacts it created before the failure.

On Windows this also removes the entry that was added to "Add or Remove Programs", so the agent no longer shows up there after a failed install.

## Why is it important?

Before this change, a failed install could leave the agent listed in "Add or Remove Programs" on Windows even though the agent was not actually installed.

Users then had to clean that up by hand before they could try to install again, failed install now leaves the machine in the same state as before the install was attempted.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

None.

## How to test this PR locally

Run the new integration test:

```
SNAPSHOT=true TEST_PLATFORMS="windows/amd64/2022" mage -v integration:single TestInstallWithoutBasePathWithCustomUser
```

