### PR TITLE
fix: lower log level for process runtime fallback warning

### DIFF
--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -2233,7 +2233,7 @@ func maybeOverrideRuntimeForComponent(logger *logger.Logger, runtimeCfg *compone
 		// check if the component is actually supported
 		err := translate.VerifyComponentIsOtelSupported(comp)
 		if err != nil {
-			logger.Warnf("otel runtime is not supported for component %s, switching to process runtime, reason: %v", comp.ID, err)
+			logger.Infof("otel runtime is not supported for component %s, switching to process runtime, reason: %v", comp.ID, err)
 			comp.RuntimeManager = component.ProcessRuntimeManager
 		}
 

--- a/internal/pkg/agent/application/monitoring/component/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/component/v1_monitor.go
@@ -177,7 +177,7 @@ func (b *BeatsMonitor) MonitoringConfig(
 	outputOtelSupportedErr := verifyOutputOtelSupported(outputCfg)
 	monitoringRuntime := component.RuntimeManager(b.config.C.RuntimeManager)
 	if outputOtelSupportedErr != nil {
-		b.logger.Warnf("otel runtime is not supported for monitoring output, switching to process runtime, reason: %v", outputOtelSupportedErr)
+		b.logger.Infof("otel runtime is not supported for monitoring output, switching to process runtime, reason: %v", outputOtelSupportedErr)
 		monitoringRuntime = monitoringCfg.ProcessRuntimeManager
 	}
 	outputOtelSupported := outputOtelSupportedErr == nil

--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -941,7 +941,7 @@ outputs:
 	logsBytes, err := fixture.Exec(ctx, []string{"logs", "-n", "1000", "--exclude-events"})
 	require.NoError(t, err)
 
-	// verify we've logged a warning about using the process runtime
+	// verify we've logged a message about using the process runtime
 	var unsupportedLogRecords []map[string]any
 	var monitoringOutputUnsupportedLogRecord map[string]any
 	for _, line := range strings.Split(string(logsBytes), "\n") {


### PR DESCRIPTION
There was a report from a user "getting thousands" of these warnings. I think they don't need to be warnings.