### PR TITLE
Wait for ESS stack in CI

### DIFF
--- a/.buildkite/scripts/steps/ess.sh
+++ b/.buildkite/scripts/steps/ess.sh
@@ -39,6 +39,45 @@ function ess_up() {
   popd
 }
 
+function wait_for_stack() {
+  local max_attempts=${1:-60}
+  local sleep_seconds=${2:-10}
+
+  echo "~~~ Waiting for ESS Stack to be reachable"
+
+  local attempt=0
+  while [ $attempt -lt $max_attempts ]; do
+    attempt=$((attempt + 1))
+    echo "Attempt $attempt/$max_attempts: checking stack connectivity..."
+
+    local es_ok=false
+    local kibana_ok=false
+
+    if curl -sf -u "${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD}" \
+        --max-time 10 \
+        "${ELASTICSEARCH_HOST}" > /dev/null 2>&1; then
+      es_ok=true
+    fi
+
+    if curl -sf -u "${KIBANA_USERNAME}:${KIBANA_PASSWORD}" \
+        --max-time 10 \
+        "${KIBANA_HOST}/api/status" > /dev/null 2>&1; then
+      kibana_ok=true
+    fi
+
+    if $es_ok && $kibana_ok; then
+      echo "Stack is reachable (Elasticsearch: OK, Kibana: OK)"
+      return 0
+    fi
+
+    echo "Not ready yet (Elasticsearch: $es_ok, Kibana: $kibana_ok). Retrying in ${sleep_seconds}s..."
+    sleep "$sleep_seconds"
+  done
+
+  echo "Error: Stack did not become reachable after $((max_attempts * sleep_seconds))s" >&2
+  return 1
+}
+
 function ess_down() {
   echo "~~~ Tearing down the ESS Stack"
   local ESS_REGION=${1:-"gcp-us-west2"}

--- a/.buildkite/scripts/steps/ess_start.sh
+++ b/.buildkite/scripts/steps/ess_start.sh
@@ -15,6 +15,8 @@ ESS_REGION="${ESS_REGION:-gcp-us-west2}"
 
 ess_up "$STACK_VERSION" "$STACK_BUILD_ID" "$ESS_REGION"
 
+wait_for_stack
+
 preinstall_fleet_packages
 
 echo "ES_HOST: ${ELASTICSEARCH_HOST}"


### PR DESCRIPTION
Explicitly wait for the stack to be available by hitting the respective ES and Kibana status endpoints. We're seeing more stack instability right after provisioning. This should at least tell us if the problem is intermittent.