### PR TITLE
chore: trust repo paths inside container to prevent git ownership errors

### DIFF
--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/josephspurrier/goversioninfo"
 	"github.com/magefile/mage/mg"
-	"github.com/magefile/mage/sh"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
@@ -175,11 +174,6 @@ func GolangCrossBuild(ctx context.Context, cfg *Settings, params BuildArgs) erro
 
 	defer DockerChown(filepath.Join(params.OutputDir, params.Name+binaryExtension(cfg.Build.GOOS)))
 	defer DockerChown(filepath.Join(params.OutputDir))
-
-	mountPoint := cfg.ElasticBeatsDir
-	if err := sh.Run("git", "config", "--global", "--add", "safe.directory", mountPoint); err != nil {
-		return err
-	}
 
 	return Build(ctx, cfg, params)
 }

--- a/dev-tools/mage/container-gitconfig
+++ b/dev-tools/mage/container-gitconfig
@@ -1,0 +1,9 @@
+# Mounted into /etc/gitconfig inside the golang-crossbuild container by
+# crossbuild.go. Marks the mounted repo path as trusted so git can operate
+# on it regardless of ownership mismatches between the container process and
+# files within the repository tree. Without this, git's dubious-ownership
+# check can fire and break build-time git calls (e.g. `git rev-parse HEAD`
+# during ldflags template expansion).
+[safe]
+	directory = /go/src/github.com/elastic/elastic-agent
+	directory = /go/src/github.com/elastic/elastic-agent/beats

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -317,6 +317,11 @@ func (b GolangCrossBuilder) Build() error {
 		"-v", repoInfo.RootDir+":"+mountPoint,
 	)
 
+	// Trust the mounted repo path so git works despite the host/container UID
+	// mismatch under rootful Docker.
+	containerGitConfig := filepath.Join(repoInfo.RootDir, "dev-tools", "mage", "container-gitconfig")
+	args = append(args, "-v", containerGitConfig+":/etc/gitconfig:ro")
+
 	// If in a git worktree, mount the main repo's .git directory into the
 	// container so git can resolve the worktree reference.
 	if commonDir, err := sh.Output("git", "-C", repoInfo.RootDir, "rev-parse", "--git-common-dir"); err == nil {


### PR DESCRIPTION
## What does this PR do?

Prevents `fatal: detected dubious ownership` errors from aborting the cross-build by mounting a committed `container-gitconfig` into `/etc/gitconfig` inside the `golang-crossbuild` Docker container. The mounted config marks both the main repo path and the beats submodule path as trusted, so git operations invoked during the build (e.g. `git rev-parse HEAD` during ldflags template expansion) succeed regardless of ownership mismatches between the container process (UID 0 under rootful Docker) and files within the repository tree.

Example failure this fixes:

```
>> build: Building elastic-agent
fatal: detected dubious ownership in repository at '/go/src/github.com/elastic/elastic-agent'
To add an exception for this directory, call:

        git config --global --add safe.directory /go/src/github.com/elastic/elastic-agent
Error: failed to expand template '-s -X github.com/elastic/elastic-agent/internal/pkg/release.snapshot=true -X github.com/elastic/elastic-agent/version.buildTime={{ date }} -X github.com/elastic/elastic-agent/version.commit={{ commit }}': template: inline:1:193: executing "inline" at <commit>: error calling commit: failed to get commit hash: running "git rev-parse HEAD" failed with exit code 128
Error: failed building for linux/amd64: exit status 1
failed building for linux/amd64: exit status 1
```

The exact trigger is not fully reproducible on demand. The leading theory is that prior container runs occasionally leave root-owned files inside the repository tree (e.g. under `beats/` or `.git/modules/beats/`), which causes git's ownership check to fire on subsequent builds. `mage clean` and `git reset --hard` on beats submodule  tend to clear the symptom, but the mount-based fix removes the dependency on filesystem state altogether.

## Why is it important?

The error blocks `mage package` / `mage crossBuild` entirely, with a non-obvious root cause and a workaround (`git config --global --add safe.directory ...`) that cannot be applied from outside the container. This change makes the container resilient to ownership mismatches so local builds no longer fail based on the cleanliness of the working tree.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

N/A

## How to test this PR locally

Working on that

## Related issues

- https://github.com/elastic/elastic-agent/pull/2093

## Questions to ask yourself

- How are we going to support this in production? N/A
- How are we going to measure its adoption? N/A
- How are we going to debug this? N/A
- What are the metrics I should take care of? N/A
