### PR TITLE
Add retries to the test Kibana client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/elastic/cloud-on-k8s/v2 v2.0.0-20250327073047-b624240832ae
 	github.com/elastic/elastic-agent-autodiscover v0.10.2
 	github.com/elastic/elastic-agent-client/v7 v7.18.1
-	github.com/elastic/elastic-agent-libs v0.37.0
+	github.com/elastic/elastic-agent-libs v0.39.0
 	github.com/elastic/elastic-agent-system-metrics v0.14.3
 	github.com/elastic/elastic-transport-go/v8 v8.11.0
 	github.com/elastic/go-elasticsearch/v8 v8.19.3

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/elastic/elastic-agent-autodiscover v0.10.2 h1:fzi+CIcK7FKUQlQHfKP+3Ix
 github.com/elastic/elastic-agent-autodiscover v0.10.2/go.mod h1:qBoYxp3lX3qFRYjEgsOaROC+xL4ItG63GSvOg1SjjsQ=
 github.com/elastic/elastic-agent-client/v7 v7.18.1 h1:WnM53JjaukeysrAuiTyrhDPmFxJG07ZAByc2TrkcKcs=
 github.com/elastic/elastic-agent-client/v7 v7.18.1/go.mod h1:uDpSGZ+YCKgqgtkwCA0qjwX0gU/wmixDsVbPjY3GkPs=
-github.com/elastic/elastic-agent-libs v0.37.0 h1:BJmBYqjtVq6dIrkq8pF88QnfdtFuq6l2gZmmt0EQc5w=
-github.com/elastic/elastic-agent-libs v0.37.0/go.mod h1:axkpqDCCzAky6G4D/cklgtZQa3jTNGAMVHVkU0u6YbU=
+github.com/elastic/elastic-agent-libs v0.39.0 h1:AFarqtG405/oucG/goLcMXrLjc+sSEQqVpNedIH8Qyg=
+github.com/elastic/elastic-agent-libs v0.39.0/go.mod h1:axkpqDCCzAky6G4D/cklgtZQa3jTNGAMVHVkU0u6YbU=
 github.com/elastic/elastic-agent-system-metrics v0.14.3 h1:v867kcgCVguOX3AYIHEVn2RNracdH40FqqXiZq71pDU=
 github.com/elastic/elastic-agent-system-metrics v0.14.3/go.mod h1:JNfnZrC0viAjlJRUzQKKuMpDlXgjXBn4WdWEXQF7jcA=
 github.com/elastic/elastic-transport-go/v8 v8.11.0 h1:taYmqC2M6+fZt/+W+ENYh/W5L9+KrlJGOSbEJs8egWc=

--- a/internal/edot/go.mod
+++ b/internal/edot/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20260423145443-78957d7ea901
 	github.com/elastic/elastic-agent v0.0.0-00010101000000-000000000000
-	github.com/elastic/elastic-agent-libs v0.37.0
+	github.com/elastic/elastic-agent-libs v0.39.0
 	github.com/elastic/mock-es v0.0.0-20250530054253-8c3b6053f9b6
 	github.com/elastic/opentelemetry-collector-components/connector/elasticapmconnector v0.46.0
 	github.com/elastic/opentelemetry-collector-components/connector/profilingmetricsconnector v0.46.0

--- a/internal/edot/go.sum
+++ b/internal/edot/go.sum
@@ -484,8 +484,8 @@ github.com/elastic/elastic-agent-autodiscover v0.10.2 h1:fzi+CIcK7FKUQlQHfKP+3Ix
 github.com/elastic/elastic-agent-autodiscover v0.10.2/go.mod h1:qBoYxp3lX3qFRYjEgsOaROC+xL4ItG63GSvOg1SjjsQ=
 github.com/elastic/elastic-agent-client/v7 v7.18.1 h1:WnM53JjaukeysrAuiTyrhDPmFxJG07ZAByc2TrkcKcs=
 github.com/elastic/elastic-agent-client/v7 v7.18.1/go.mod h1:uDpSGZ+YCKgqgtkwCA0qjwX0gU/wmixDsVbPjY3GkPs=
-github.com/elastic/elastic-agent-libs v0.37.0 h1:BJmBYqjtVq6dIrkq8pF88QnfdtFuq6l2gZmmt0EQc5w=
-github.com/elastic/elastic-agent-libs v0.37.0/go.mod h1:axkpqDCCzAky6G4D/cklgtZQa3jTNGAMVHVkU0u6YbU=
+github.com/elastic/elastic-agent-libs v0.39.0 h1:AFarqtG405/oucG/goLcMXrLjc+sSEQqVpNedIH8Qyg=
+github.com/elastic/elastic-agent-libs v0.39.0/go.mod h1:axkpqDCCzAky6G4D/cklgtZQa3jTNGAMVHVkU0u6YbU=
 github.com/elastic/elastic-agent-system-metrics v0.14.3 h1:v867kcgCVguOX3AYIHEVn2RNracdH40FqqXiZq71pDU=
 github.com/elastic/elastic-agent-system-metrics v0.14.3/go.mod h1:JNfnZrC0viAjlJRUzQKKuMpDlXgjXBn4WdWEXQF7jcA=
 github.com/elastic/elastic-transport-go/v8 v8.11.0 h1:taYmqC2M6+fZt/+W+ENYh/W5L9+KrlJGOSbEJs8egWc=

--- a/pkg/testing/define/define.go
+++ b/pkg/testing/define/define.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -309,6 +310,16 @@ func getKibanaClient() (*kibana.Client, error) {
 		Username:      kibanaUser,
 		Password:      kibanaPass,
 		IgnoreVersion: false,
+		Retry: kibana.RetryConfig{
+			MaxRetries:    5,
+			RetryOnStatus: []int{429, 500, 502, 503, 504},
+			RetryBackoff: func(attempt int) time.Duration {
+				base := time.Second
+				maxWait := 10 * time.Second
+				wait := (1 << (attempt - 1)) * base
+				return min(wait, maxWait)
+			},
+		},
 	}, 0, "Elastic-Agent-Test-Define", version.GetDefaultVersion(), version.Commit(), version.BuildTime().String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kibana client: %w", err)

--- a/test_infra/ess/deployment.tf
+++ b/test_infra/ess/deployment.tf
@@ -119,7 +119,7 @@ resource "ec_deployment" "integration-testing" {
     }
   }
   kibana = {
-    size                      = "1g"
+    size                      = "2g"
     zone_count                = 1
     config = {
       user_settings_json = jsonencode({

--- a/test_infra/ess/deployment.tf
+++ b/test_infra/ess/deployment.tf
@@ -119,6 +119,7 @@ resource "ec_deployment" "integration-testing" {
     }
   }
   kibana = {
+    size                      = "8g" # we've got enough memory on the host
     zone_count                = 1
     config = {
       user_settings_json = jsonencode({

--- a/test_infra/ess/deployment.tf
+++ b/test_infra/ess/deployment.tf
@@ -119,7 +119,6 @@ resource "ec_deployment" "integration-testing" {
     }
   }
   kibana = {
-    size                      = "2g"
     zone_count                = 1
     config = {
       user_settings_json = jsonencode({

--- a/test_infra/ess/deployment.tf
+++ b/test_infra/ess/deployment.tf
@@ -141,6 +141,10 @@ resource "ec_deployment" "integration-testing" {
     }
   }
 
+  observability = {
+    deployment_id = "self"
+  }
+
   tags = {
     "provisioner"  = "elastic-agent-integration-tests"
     "creator"      = var.creator


### PR DESCRIPTION
Add retries to the integration test Kibana client. We also upgrade to the latest version of elastic-agent-libs which allows us to configure these.