### PR TITLE
Remove accidentally committed debugging change.

### DIFF
--- a/pkg/testing/define/define.go
+++ b/pkg/testing/define/define.go
@@ -283,7 +283,7 @@ func getESClient() (*elasticsearch.Client, error) {
 	esUser := os.Getenv("ELASTICSEARCH_USERNAME")
 	esPass := os.Getenv("ELASTICSEARCH_PASSWORD")
 	if esHost == "" || esUser == "" || esPass == "" {
-		return nil, fmt.Errorf("ELASTICSEARCH_* must be defined by the test runner: %s %s %s", esHost, esUser, esPass)
+		return nil, errors.New("ELASTICSEARCH_* must be defined by the test runner")
 	}
 	c, err := elasticsearch.NewClient(elasticsearch.Config{
 		Addresses: []string{esHost},


### PR DESCRIPTION
Remove local debugging change accidentally comitted in https://github.com/elastic/elastic-agent/pull/13713. I am likely going to force merge this since this can leak the ES cluster secrets in tests logs.