### PR TITLE
Give the integration test stack Kibana more resources

### DIFF
--- a/test_infra/ess/deployment.tf
+++ b/test_infra/ess/deployment.tf
@@ -119,7 +119,7 @@ resource "ec_deployment" "integration-testing" {
     }
   }
   kibana = {
-    size                      = "1g"
+    size                      = "4g" # our integration tests open a lot of connections
     zone_count                = 1
     config = {
       user_settings_json = jsonencode({

--- a/test_infra/ess/deployment.tf
+++ b/test_infra/ess/deployment.tf
@@ -141,6 +141,10 @@ resource "ec_deployment" "integration-testing" {
     }
   }
 
+  observability = {
+    deployment_id = "self"
+  }
+
   tags = {
     "provisioner"  = "elastic-agent-integration-tests"
     "creator"      = var.creator


### PR DESCRIPTION
We've been seeing Kibana unavailability in integration tests, which appears to be caused by increased memory consumption leading to an OOMKill. Increase it to be above the ECH default, just to be sure.

This PR also enables Stack Monitoring in the integration test stack to make future investigation easier. 