### PR TITLE
Fix flaky coordinator test

### DIFF
--- a/internal/pkg/agent/application/coordinator/coordinator_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"go.uber.org/zap/zapcore"
@@ -579,64 +580,62 @@ func TestUpgradeSameErrorAcked(t *testing.T) {
 }
 
 func TestReplayedRollbackActionAcked(t *testing.T) {
-	coordCh := make(chan error, 1)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	synctest.Test(t, func(t *testing.T) {
+		coordCh := make(chan error, 1)
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
 
-	upgradeManager := &fakeUpgradeManager{
-		upgradeable: true,
-	}
-
-	acker := &fakeActionAcker{}
-	coord, _, _ := createCoordinator(t, ctx,
-		ManagedCoordinator(true),
-		WithUpgradeManager(upgradeManager),
-		WithActionAcker(acker))
-
-	var coordWait sync.WaitGroup
-	coordWait.Add(1)
-	go func() {
-		coordWait.Done()
-		err := coord.Run(ctx)
-		if errors.Is(err, context.Canceled) {
-			// allowed error
-			err = nil
+		upgradeManager := &fakeUpgradeManager{
+			upgradeable: true,
 		}
-		coordCh <- err
-	}()
 
-	coordWait.Wait()
+		acker := &fakeActionAcker{}
+		coord, _, _ := createCoordinator(t, ctx,
+			ManagedCoordinator(true),
+			WithUpgradeManager(upgradeManager),
+			WithActionAcker(acker),
+			WithRuntimeManager(&fakeRuntimeManager{}))
 
-	action := fleetapi.NewAction(fleetapi.ActionTypeUpgrade)
-	actionUpgrade, ok := action.(*fleetapi.ActionUpgrade)
-	require.True(t, ok)
-	actionUpgrade.Data.Rollback = true
-	actionUpgrade.Data.Version = release.VersionWithSnapshot()
+		go func() {
+			err := coord.Run(ctx)
+			if errors.Is(err, context.Canceled) {
+				// allowed error
+				err = nil
+			}
+			coordCh <- err
+		}()
 
-	acker.On("Ack", mock.Anything, actionUpgrade).Return(nil)
-	acker.On("Commit", mock.Anything).Return(nil)
+		// Wait for the coordinator goroutine to be durably blocked in its run loop.
+		synctest.Wait()
 
-	// A rollback targeting the current version should be detected as replayed and acked without processing
-	require.NoError(t, coord.Upgrade(t.Context(), release.VersionWithSnapshot(), "", actionUpgrade, WithRollback(true)))
+		action := fleetapi.NewAction(fleetapi.ActionTypeUpgrade)
+		actionUpgrade, ok := action.(*fleetapi.ActionUpgrade)
+		require.True(t, ok)
+		actionUpgrade.Data.Rollback = true
+		actionUpgrade.Data.Version = release.VersionWithSnapshot()
 
-	acker.AssertCalled(t, "Ack", mock.Anything, actionUpgrade)
-	acker.AssertCalled(t, "Commit", mock.Anything)
-	assert.False(t, upgradeManager.upgradeCalled, "upgrade should not have been called for a replayed rollback action")
+		acker.On("Ack", mock.Anything, actionUpgrade).Return(nil)
+		acker.On("Commit", mock.Anything).Return(nil)
 
-	// Replayed rollback should report UpgradeDetails with StateRollback so that
-	// Fleet knows the agent completed the rollback (not empty/nil details).
-	// State propagation from Upgrade() to the stateBroadcaster happens on the
-	// coordinator goroutine, so poll until the update is visible.
-	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		// A rollback targeting the current version should be detected as replayed and acked without processing
+		require.NoError(t, coord.Upgrade(t.Context(), release.VersionWithSnapshot(), "", actionUpgrade, WithRollback(true)))
+
+		acker.AssertCalled(t, "Ack", mock.Anything, actionUpgrade)
+		acker.AssertCalled(t, "Commit", mock.Anything)
+		assert.False(t, upgradeManager.upgradeCalled, "upgrade should not have been called for a replayed rollback action")
+
+		// Replayed rollback should report UpgradeDetails with StateRollback so that
+		// Fleet knows the agent completed the rollback (not empty/nil details).
+		// State propagation from Upgrade() to the stateBroadcaster happens on the
+		// coordinator goroutine; synctest.Wait blocks until that propagation is done.
+		synctest.Wait()
 		state := coord.State()
-		if !assert.NotNil(ct, state.UpgradeDetails, "upgrade details should be present after replayed rollback is handled") {
-			return
-		}
-		assert.Equal(ct, details.StateRollback, state.UpgradeDetails.State, "upgrade details state should be rollback")
-	}, 3*time.Second, 10*time.Millisecond)
+		require.NotNil(t, state.UpgradeDetails, "upgrade details should be present after replayed rollback is handled")
+		assert.Equal(t, details.StateRollback, state.UpgradeDetails.State, "upgrade details state should be rollback")
 
-	cancel()
-	require.NoError(t, <-coordCh)
+		cancel()
+		require.NoError(t, <-coordCh)
+	})
 }
 
 func TestPreUpgradeCallback(t *testing.T) {
@@ -1445,6 +1444,7 @@ type createCoordinatorOpts struct {
 	upgradeManager UpgradeManager
 	compInputSpec  component.InputSpec
 	acker          acker.Acker
+	runtimeManager RuntimeManager
 }
 
 type CoordinatorOpt func(o *createCoordinatorOpts)
@@ -1470,6 +1470,12 @@ func WithActionAcker(acker acker.Acker) CoordinatorOpt {
 func WithComponentInputSpec(spec component.InputSpec) CoordinatorOpt {
 	return func(o *createCoordinatorOpts) {
 		o.compInputSpec = spec
+	}
+}
+
+func WithRuntimeManager(rm RuntimeManager) CoordinatorOpt {
+	return func(o *createCoordinatorOpts) {
+		o.runtimeManager = rm
 	}
 }
 
@@ -1505,10 +1511,16 @@ func createCoordinator(t testing.TB, ctx context.Context, opts ...CoordinatorOpt
 
 	monitoringMgr := newTestMonitoringMgr()
 	cfg := configuration.DefaultConfiguration()
-	grpcCfg := cfg.Settings.GRPC
-	grpcCfg.Port = 0
-	rm, err := runtime.NewManager(l, l, ai, apmtest.DiscardTracer, monitoringMgr, grpcCfg)
-	require.NoError(t, err)
+	var rm RuntimeManager
+	if o.runtimeManager != nil {
+		rm = o.runtimeManager
+	} else {
+		grpcCfg := cfg.Settings.GRPC
+		grpcCfg.Port = 0
+		realRM, err := runtime.NewManager(l, l, ai, apmtest.DiscardTracer, monitoringMgr, grpcCfg)
+		require.NoError(t, err)
+		rm = realRM
+	}
 	otelMgr := &fakeOTelManager{}
 	caps, err := capabilities.LoadFile(paths.AgentCapabilitiesPath(), l)
 	require.NoError(t, err)
@@ -1875,8 +1887,8 @@ func (r *fakeRuntimeManager) PerformAction(_ context.Context, _ component.Compon
 }
 
 // SubscribeAll provides an interface to watch for changes in all components.
-func (r *fakeRuntimeManager) SubscribeAll(context.Context) *runtime.SubscriptionAll {
-	return nil
+func (r *fakeRuntimeManager) SubscribeAll(ctx context.Context) *runtime.SubscriptionAll {
+	return runtime.NewSubscriptionAll(ctx)
 }
 
 // PerformDiagnostics executes the diagnostic action for the provided units. If no units are provided then

--- a/internal/pkg/agent/application/coordinator/coordinator_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_test.go
@@ -625,9 +625,15 @@ func TestReplayedRollbackActionAcked(t *testing.T) {
 
 	// Replayed rollback should report UpgradeDetails with StateRollback so that
 	// Fleet knows the agent completed the rollback (not empty/nil details).
-	state := coord.State()
-	require.NotNil(t, state.UpgradeDetails, "upgrade details should be present after replayed rollback is handled")
-	assert.Equal(t, details.StateRollback, state.UpgradeDetails.State, "upgrade details state should be rollback")
+	// State propagation from Upgrade() to the stateBroadcaster happens on the
+	// coordinator goroutine, so poll until the update is visible.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		state := coord.State()
+		if !assert.NotNil(ct, state.UpgradeDetails, "upgrade details should be present after replayed rollback is handled") {
+			return
+		}
+		assert.Equal(ct, details.StateRollback, state.UpgradeDetails.State, "upgrade details state should be rollback")
+	}, 3*time.Second, 10*time.Millisecond)
 
 	cancel()
 	require.NoError(t, <-coordCh)

--- a/pkg/component/runtime/subscription.go
+++ b/pkg/component/runtime/subscription.go
@@ -39,6 +39,12 @@ func newSubscriptionAll(ctx context.Context) *SubscriptionAll {
 	}
 }
 
+// NewSubscriptionAll returns a SubscriptionAll whose channel is never written to.
+// Intended for use in tests that provide a fake runtime manager.
+func NewSubscriptionAll(ctx context.Context) *SubscriptionAll {
+	return newSubscriptionAll(ctx)
+}
+
 // Ch provides the channel to get state changes.
 func (s *SubscriptionAll) Ch() <-chan ComponentComponentState {
 	return s.ch


### PR DESCRIPTION
## What does this PR do?

Change `TestReplayedRollbackActionAcked` to retry state verification with `require.Eventually` instead of doing a single read.

## Why is it important?

Fixes flaky tests