### PR TITLE
Temporarily skip MacOS 13 unit tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -170,6 +170,7 @@ steps:
       # Runs only on main and release branches
       - label: "Unit tests - macOS 13"
         command: ".buildkite/scripts/steps/unit-tests.sh"
+        skip: "Ongoing issues with MacOS 13 CI runners. Unskip after resolved."
         branches: "main 8.* 9.*"
         artifact_paths:
           - "build/TEST-*.html"


### PR DESCRIPTION
Skip unit tests on MacOS 13 until the performance issues affecting buildkite MacOS 13 runners are resolved.