### PR TITLE
fix: retry delayed enrollment on invalid token

### DIFF
--- a/changelog/fragments/1777354971-drosiek-fix-delay-enrollment.yaml
+++ b/changelog/fragments/1777354971-drosiek-fix-delay-enrollment.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Retry delayed enrollment on invalid token instead of failing fast
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/enroll/enroll.go
+++ b/internal/pkg/agent/application/enroll/enroll.go
@@ -97,12 +97,12 @@ func EnrollWithBackoff(
 	enrollFn := func() error {
 		return enroll(ctx, log, persistentConfig, client, options, configStore)
 	}
-	err = retryEnroll(ctx, err, maxAttempts, log, enrollFn, client.URI(), backExp)
+	err = retryEnroll(ctx, err, maxAttempts, log, enrollFn, client.URI(), backExp, options.RetryOnInvalidToken)
 
 	return err
 }
 
-func retryEnroll(ctx context.Context, err error, maxAttempts int, log *logger.Logger, enrollFn func() error, clientURI string, backExp backoff.Backoff) error {
+func retryEnroll(ctx context.Context, err error, maxAttempts int, log *logger.Logger, enrollFn func() error, clientURI string, backExp backoff.Backoff, retryOnInvalidToken bool) error {
 	attemptNo := 1
 
 RETRYLOOP:
@@ -115,7 +115,7 @@ RETRYLOOP:
 			log.Warn("Remote server is not ready to accept connections(Connection Refused), will retry in a moment.")
 		case errors.Is(err, fleetapi.ErrTemporaryServerError):
 			log.Warnf("Remote server failed to handle the request(%s), will retry in a moment.", err.Error())
-		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded), errors.Is(err, fleetapi.ErrInvalidToken), err == nil, (maxAttempts != EnrollInfiniteAttempts && attemptNo > maxAttempts):
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded), errors.Is(err, fleetapi.ErrInvalidToken) && !retryOnInvalidToken, err == nil, (maxAttempts != EnrollInfiniteAttempts && attemptNo > maxAttempts):
 			break RETRYLOOP
 		case err != nil:
 			log.Warnf("Error detected: %s, will retry in a moment.", err.Error())

--- a/internal/pkg/agent/application/enroll/enroll_test.go
+++ b/internal/pkg/agent/application/enroll/enroll_test.go
@@ -58,7 +58,7 @@ func TestRetryEnroll_SucceedsAfterOneRetry(t *testing.T) {
 
 	l := logger.NewWithoutConfig("")
 
-	err := retryEnroll(t.Context(), initialErr, 5, l, enrollFn, "http://localhost", fb)
+	err := retryEnroll(t.Context(), initialErr, 5, l, enrollFn, "http://localhost", fb, false)
 	require.NoError(t, err)
 	require.Equal(t, 1, called)
 }
@@ -76,7 +76,7 @@ func TestRetryEnroll_StopsAfterMaxAttempts(t *testing.T) {
 
 	l := logger.NewWithoutConfig("")
 
-	err := retryEnroll(t.Context(), initialErr, maxAttempts, l, enrollFn, "http://localhost", fb)
+	err := retryEnroll(t.Context(), initialErr, maxAttempts, l, enrollFn, "http://localhost", fb, false)
 	require.Equal(t, maxAttempts-1, called)
 	require.Error(t, err)                  // error is expected
 	require.NotErrorIs(t, err, initialErr) // subsequent failures are different
@@ -94,7 +94,7 @@ func TestRetryEnroll_ExitsOnBackoffStop(t *testing.T) {
 
 	l := logger.NewWithoutConfig("")
 
-	err := retryEnroll(t.Context(), initialErr, -1, l, enrollFn, "http://localhost", fb)
+	err := retryEnroll(t.Context(), initialErr, -1, l, enrollFn, "http://localhost", fb, false)
 	require.Equal(t, 0, called)
 	require.ErrorIs(t, err, initialErr) // error is expected
 }
@@ -119,11 +119,31 @@ func TestRetryEnroll_ExitsOnTerminalEnrollError(t *testing.T) {
 			fb := &fakeBackoff{}
 			l := logger.NewWithoutConfig("")
 
-			err := retryEnroll(t.Context(), tc.err, 5, l, enrollFn, "http://localhost", fb)
+			err := retryEnroll(t.Context(), tc.err, 5, l, enrollFn, "http://localhost", fb, false)
 			require.ErrorIs(t, err, tc.err)
 			require.Equal(t, 0, called)
 		})
 	}
+}
+
+func TestRetryEnroll_RetriesOnInvalidTokenWhenEnabled(t *testing.T) {
+	called := 0
+	enrollFn := func() error {
+		called++
+		return fleetapi.ErrInvalidToken
+	}
+	// Allow two waits, then stop the loop so the test terminates.
+	fb := &fakeBackoff{results: []bool{true, true, false}}
+	l := logger.NewWithoutConfig("")
+
+	err := retryEnroll(
+		t.Context(), fleetapi.ErrInvalidToken, -1, l, enrollFn, "http://localhost", fb,
+		true,
+	)
+	// With RetryOnInvalidToken=true, ErrInvalidToken must not short-circuit the loop;
+	// we should see retries happen until the backoff itself signals stop.
+	require.Equal(t, 2, called)
+	require.ErrorIs(t, err, fleetapi.ErrInvalidToken)
 }
 
 func TestRetryEnroll_InterruptsBackoffWaitOnCtxCancel(t *testing.T) {
@@ -140,7 +160,7 @@ func TestRetryEnroll_InterruptsBackoffWaitOnCtxCancel(t *testing.T) {
 
 		errCh := make(chan error, 1)
 		go func() {
-			errCh <- retryEnroll(ctx, errors.New("initial"), -1, l, enrollFn, "http://localhost", fb)
+			errCh <- retryEnroll(ctx, errors.New("initial"), -1, l, enrollFn, "http://localhost", fb, false)
 		}()
 
 		// retryEnroll should return when the caller's context is canceled, even if the retry

--- a/internal/pkg/agent/application/enroll/options.go
+++ b/internal/pkg/agent/application/enroll/options.go
@@ -40,6 +40,7 @@ type EnrollOptions struct {
 	UserProvidedMetadata map[string]interface{}     `yaml:"-" json:"-"`
 	FixPermissions       *utils.FileOwner           `yaml:"-" json:"-"`
 	DelayEnroll          bool                       `yaml:"-" json:"-"`
+	RetryOnInvalidToken  bool                       `yaml:"-" json:"-"`
 	FleetServer          EnrollCmdFleetServerOption `yaml:"-" json:"-"`
 	SkipCreateSecret     bool                       `yaml:"-" json:"-"`
 	SkipDaemonRestart    bool                       `yaml:"-" json:"-"`

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -669,6 +669,10 @@ func tryDelayEnroll(ctx context.Context, logger *logger.Logger, cfg *configurati
 	}
 	options.DelayEnroll = false
 	options.FleetServer.SpawnAgent = false
+	// Daemon mode: the enrollment token may be fixed externally (e.g. rotated
+	// secret) without restarting the agent, so we keep retrying instead of
+	// failing fast like the interactive `enroll` CLI does.
+	options.RetryOnInvalidToken = true
 	// enrollCmd daemonReloadWithBackoff is broken
 	// see https://github.com/elastic/elastic-agent/issues/4043
 	// SkipDaemonRestart to true avoids running that code.
@@ -693,19 +697,20 @@ func tryDelayEnroll(ctx context.Context, logger *logger.Logger, cfg *configurati
 	if err != nil {
 		return nil, err
 	}
-	// perform the enrollment in a loop, it should keep trying to enroll no matter what
-	// the enrollCmd has built in backoff so no need to wrap this in its own backoff as well
-	for {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		err = c.Execute(ctx, cli.NewIOStreams())
-		if err == nil {
-			// enrollment was successful
-			break
-		}
-		logger.Error(fmt.Errorf("failed to perform delayed enrollment (will try again): %w", err))
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
+
+	err = c.Execute(ctx, cli.NewIOStreams())
+	if err != nil {
+		return nil, errors.New(
+			err,
+			"failed to execute delayed enrollment",
+			errors.TypeApplication,
+			errors.M("path", enrollPath))
+	}
+
 	err = os.Remove(enrollPath)
 	if err != nil {
 		logger.Warn(errors.New(


### PR DESCRIPTION
## What does this PR do?

Add EnrollOptions.RetryOnInvalidToken; the CLI keeps the safe default (fail fast), the delayed-enroll path opts in to retrying instead of breaking out the retry loop

Fixes #13549

Logs after change:

```
./elastic-agent run -e                            
{"log.level":"info","@timestamp":"2026-04-27T16:36:53.028+0200","log.origin":{"function":"github.com/elastic/elastic-agent/internal/pkg/agent/cmd.runElasticAgent","file.name":"cmd/run.go","file.line":315},"message":"Elastic Agent started","log.source":"elastic-agent","process.pid":1744082,"agent.version":"9.5.0","agent.unprivileged":true,"ecs.version":"1.6.0"}
{"log.level":"warn","@timestamp":"2026-04-27T16:36:53.106+0200","log.logger":"tls","log.origin":{"function":"github.com/elastic/elastic-agent-libs/transport/tlscommon.(*TLSConfig).ToConfig","file.name":"tlscommon/tls_config.go","file.line":129},"message":"SSL/TLS verifications disabled.","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2026-04-27T16:36:53.106+0200","log.origin":{"function":"github.com/elastic/elastic-agent/internal/pkg/agent/application/enroll.EnrollWithBackoff","file.name":"enroll/enroll.go","file.line":86},"message":"Starting enrollment to URL: https://fleet-server:8220/","log.source":"elastic-agent","ecs.version":"1.6.0"}
{"log.level":"warn","@timestamp":"2026-04-27T16:36:53.310+0200","log.logger":"tls","log.origin":{"function":"github.com/elastic/elastic-agent-libs/transport/tlscommon.(*TLSConfig).ToConfig","file.name":"tlscommon/tls_config.go","file.line":129},"message":"SSL/TLS verifications disabled.","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2026-04-27T16:36:53.347+0200","log.origin":{"function":"github.com/elastic/elastic-agent/internal/pkg/agent/application/enroll.EnrollWithBackoff","file.name":"enroll/enroll.go","file.line":92},"message":"1st enrollment attempt failed, retrying enrolling to URL: https://fleet-server:8220/ with exponential backoff (init 5s, max 10m0s)","log.source":"elastic-agent","ecs.version":"1.6.0"}
{"log.level":"warn","@timestamp":"2026-04-27T16:36:53.347+0200","log.origin":{"function":"github.com/elastic/elastic-agent/internal/pkg/agent/application/enroll.retryEnroll","file.name":"enroll/enroll.go","file.line":121},"message":"Error detected: fail to execute request to fleet-server: invalid enrollment token, will retry in a moment.","log.source":"elastic-agent","ecs.version":"1.6.0"}

{"log.level":"info","@timestamp":"2026-04-27T16:37:54.754+0200","log.origin":{"function":"github.com/elastic/elastic-agent/internal/pkg/agent/application/enroll.retryEnroll","file.name":"enroll/enroll.go","file.line":135},"message":"Retrying enrollment to URL: https://fleet-server:8220/","log.source":"elastic-agent","ecs.version":"1.6.0"}
{"log.level":"warn","@timestamp":"2026-04-27T16:37:54.994+0200","log.origin":{"function":"github.com/elastic/elastic-agent/internal/pkg/agent/application/enroll.retryEnroll","file.name":"enroll/enroll.go","file.line":121},"message":"Error detected: fail to execute request to fleet-server: invalid enrollment token, will retry in a moment.","log.source":"elastic-agent","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2026-04-27T16:41:50.530+0200","log.origin":{"function":"github.com/elastic/elastic-agent/internal/pkg/agent/application/enroll.retryEnroll","file.name":"enroll/enroll.go","file.line":135},"message":"Retrying enrollment to URL: https://fleet-server:8220/","log.source":"elastic-agent","ecs.version":"1.6.0"}
{"log.level":"warn","@timestamp":"2026-04-27T16:41:50.745+0200","log.origin":{"function":"github.com/elastic/elastic-agent/internal/pkg/agent/application/enroll.retryEnroll","file.name":"enroll/enroll.go","file.line":121},"message":"Error detected: fail to execute request to fleet-server: invalid enrollment token, will retry in a moment.","log.source":"elastic-agent","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2026-04-27T16:47:44.847+0200","log.origin":{"function":"github.com/elastic/elastic-agent/internal/pkg/agent/application/enroll.retryEnroll","file.name":"enroll/enroll.go","file.line":135},"message":"Retrying enrollment to URL: https://fleet-server:8220/","log.source":"elastic-agent","ecs.version":"1.6.0"}
{"log.level":"warn","@timestamp":"2026-04-27T16:47:45.071+0200","log.origin":{"function":"github.com/elastic/elastic-agent/internal/pkg/agent/application/enroll.retryEnroll","file.name":"enroll/enroll.go","file.line":121},"message":"Error detected: fail to execute request to fleet-server: invalid enrollment token, will retry in a moment.","log.source":"elastic-agent","ecs.version":"1.6.0"}
```

## Why is it important?

Delayed enrollment (daemon picking up enroll.json on startup) used to break out of the retry loop immediately on ErrInvalidToken, the same way the interactive `enroll` CLI does. For a long-lived agent that's wrong: the operator may rotate the enrollment token externally (e.g. updated secret) and the daemon should keep waiting.

## Checklist

- [X] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

N/A

## How to test this PR locally

1. Run elastic stack: `elastic-package stack up -v -d --version=9.5.0-SNAPSHOT`
2. Configure agent: `./elastic-agent enroll --url=https://fleet-server:8220 --enrollment-token=X3Q2VnpaMEJPYmlla01PUDBGNU86SWN0bEhveXF2MFkxQ1RpRXYyOGpMQQ== --insecure --delay-enroll`
3. Run agent: `./elastic-agent run -e`
4. Observe logs

## Related issues

- Closes #13549

## Questions to ask yourself

- How are we going to support this in production? N/A
- How are we going to measure its adoption? N/A
- How are we going to debug this? N/A
- What are the metrics I should take care of? N/A
