### PR TITLE
feat: add reconnect jitter to Fleet gateway to prevent thundering herd

### DIFF
--- a/changelog/fragments/1777359345-reconnect-jitter.yaml
+++ b/changelog/fragments/1777359345-reconnect-jitter.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Add reconnect jitter to Fleet gateway to prevent thundering herd on mass reconnection
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -7,6 +7,7 @@ package fleet
 import (
 	"context"
 	stderrors "errors"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -93,6 +94,7 @@ type FleetGateway struct {
 	acker              acker.Acker
 	unauthCounter      int
 	checkinFailCounter int
+	wasConnected       bool
 	stateStore         stateStore
 	stateFetcher       StateFetcher
 	errCh              chan error
@@ -192,6 +194,7 @@ func (f *FleetGateway) Run(ctx context.Context) error {
 			if err != nil {
 				continue
 			}
+			f.wasConnected = true
 
 			actions := make([]fleetapi.Action, len(resp.Actions))
 			copy(actions, resp.Actions)
@@ -216,6 +219,20 @@ func (f *FleetGateway) doExecute(ctx context.Context, bo backoff.Backoff) (*flee
 		f.log.Debugf("Checking started")
 		resp, took, err := f.execute(ctx)
 		if err != nil {
+			// On first failure after being connected, apply random jitter to prevent
+			// thundering herd on mass reconnection.
+			if f.wasConnected {
+				f.wasConnected = false
+				jitter := rand.N(2 * time.Minute)
+				f.log.Infow("First reconnect attempt after connection loss, applying jitter",
+					"jitter_ns", jitter, "error.message", err)
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(jitter):
+				}
+			}
+
 			becauseOfStateChanged := errors.Is(err, errComponentStateChanged)
 
 			// don't count that as failed attempt


### PR DESCRIPTION
## What does this PR do?

Adds a random 0-2 minute jitter on the first reconnection attempt after a connection loss in the Fleet gateway checkin loop. A `wasConnected` field on `FleetGateway` tracks whether the agent was previously connected. On the first failure after being connected, a random sleep (0-120s) is applied before entering the normal exponential backoff retry loop.

## Why is it important?

The existing `EqualJitterBackoff` already provides jitter, but `bo.Reset()` is called at the top of every `doExecute` invocation, so the first retry after reset always lands in a `init/2 + rand(0, init)` = 30-90s window. When all agents lose their connections simultaneously (e.g. new Fleet Server version deployment — which happens frequently in Serverless — or network partition), they all hit that same 60s window — creating a thundering herd that overwhelms Fleet Server.

This PR adds an additional 0-120s delay *before* the backoff loop starts, only on the connected → disconnected transition. This widens the initial reconnection window from ~60s to ~210s. On subsequent failures the normal exponential backoff handles spreading naturally.

Companion PR for Horde: https://github.com/elastic/horde/pull/287

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None. This only adds a delay on the first retry after a connection loss, which is already a failure scenario. The delay is bounded at 2 minutes and only applies once per disconnection event.

## How to test this PR locally

1. Run an agent connected to a fleet server
2. Kill the fleet server to simulate a connection loss
3. Observe the agent logs — should see "First reconnect attempt after connection loss, applying jitter" with a random jitter value
4. Verify the agent reconnects after the jitter + normal backoff

## Related issues

- Relates https://github.com/elastic/horde/pull/287

🤖 Generated with [Claude Code](https://claude.ai/code)