### PR TITLE
fix: cancel ctx on Windows service stop to interrupt enroll retry

### DIFF
--- a/changelog/fragments/1777366905-fix-windows-service-stop-hang-during-enroll-retry.yaml
+++ b/changelog/fragments/1777366905-fix-windows-service-stop-hang-during-enroll-retry.yaml
@@ -1,0 +1,48 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user's deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Stop Windows service promptly while the agent is retrying enrollment
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  Stopping the Elastic Agent Windows service while it was retrying
+  enrollment could hang for several minutes and cause MSI uninstall to
+  fail. The service now stops promptly.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -139,6 +139,9 @@ func run(override application.CfgOverrider, testingMode bool, fleetInitTimeout t
 	stop := make(chan bool)
 	ctx, cancel := context.WithCancel(context.Background())
 	stopBeat := func() {
+		// Cancel ctx so any ctx-aware work running before the main select
+		// loop on `stop` is reached returns promptly.
+		cancel()
 		close(stop)
 	}
 

--- a/internal/pkg/agent/cmd/run_test.go
+++ b/internal/pkg/agent/cmd/run_test.go
@@ -5,19 +5,27 @@
 package cmd
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/enroll"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	monitoringCfg "github.com/elastic/elastic-agent/internal/pkg/core/monitoring/config"
+	"github.com/elastic/elastic-agent/internal/pkg/testutils"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
 var (
@@ -152,5 +160,60 @@ func TestRunLoadConfig(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.expect(), cfg)
 		})
+	}
+}
+
+func TestTryDelayEnroll_ExitsOnCtxCancel(t *testing.T) {
+	testutils.InitStorage(t)
+
+	origCfgDir := paths.Config()
+	t.Cleanup(func() { paths.SetConfig(origCfgDir) })
+	paths.SetConfig(t.TempDir())
+
+	// Reply with 503 on every request so the agent keeps retrying enrollment.
+	gotRequest := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case gotRequest <- struct{}{}:
+		default:
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	enrollContents, err := yaml.Marshal(&enroll.EnrollOptions{
+		URL:          server.URL,
+		EnrollAPIKey: "fake-token",
+		Insecure:     true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(paths.AgentEnrollFile(), enrollContents, 0o600))
+
+	log := logger.NewWithoutConfig("")
+	cfg := configuration.DefaultConfiguration()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := tryDelayEnroll(ctx, log, cfg, nil)
+		errCh <- err
+	}()
+
+	// Wait until the agent has actually started trying to enroll before
+	// cancelling, so we know the retry loop is running.
+	select {
+	case <-gotRequest:
+	case <-time.After(10 * time.Second):
+		t.Fatal("server never received an enrollment request")
+	}
+	cancel()
+
+	// After cancel, tryDelayEnroll should return promptly with context.Canceled.
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("tryDelayEnroll did not exit after ctx cancel")
 	}
 }


### PR DESCRIPTION
## What does this PR do?

When the Elastic Agent Windows service was asked to stop while it was still retrying enrollment against an unreachable Fleet Server the service did not stop until the enrollment retry timed out (~10 min).

The agent now interrupts the enrollment retry as soon as the service receives a stop request, so the service stops promptly.

## Why is it important?

Once this ships in a snapshot, the `ForceStop-ElasticAgent` workaround in `elastic-stack-installers/src/agent-qa/msi.tests.ps1` can be removed:

https://github.com/elastic/elastic-stack-installers/blob/main/src/agent-qa/msi.tests.ps1#L141-L146

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

None.

## How to test this PR locally

Covered by an automated unit test:

```
go test -run TestTryDelayEnroll_ExitsOnCtxCancel ./internal/pkg/agent/cmd/ -v
```
