### PR TITLE
Fix goroutine leak in TestFilebeatReceiverLogAsFilestream

### DIFF
--- a/testing/integration/ess/otel_log_as_filestream_test.go
+++ b/testing/integration/ess/otel_log_as_filestream_test.go
@@ -113,6 +113,11 @@ func TestFilebeatReceiverLogAsFilestream(t *testing.T) {
 
 	// Start Elastic Agent/Filebeat receiver running the Log input
 	wg.Add(1)
+	// Guarantee the goroutine joins before the test returns even if a later
+	// require.X triggers t.Fatal. Otherwise the goroutine outlives the test
+	// and its require.NoError(t, ...) panics with "Fail in goroutine after
+	// TestFilebeatReceiverLogAsFilestream has completed".
+	t.Cleanup(wg.Wait)
 	go func() {
 		defer wg.Done()
 		ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(3*time.Minute))
@@ -152,6 +157,7 @@ func TestFilebeatReceiverLogAsFilestream(t *testing.T) {
 	require.NoError(t, fixture.ConfigureOtel(t.Context(), yamlCfg), "cannot configure Otel")
 
 	wg.Add(1)
+	t.Cleanup(wg.Wait)
 	go func() {
 		defer wg.Done()
 		ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
@@ -197,6 +203,7 @@ func TestFilebeatReceiverLogAsFilestream(t *testing.T) {
 	wg.Wait()
 
 	wg.Add(1)
+	t.Cleanup(wg.Wait)
 	go func() {
 		defer wg.Done()
 		ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(3*


### PR DESCRIPTION
<!-- Type of change: Bug -->

## What does this PR do?

Adds `t.Cleanup(wg.Wait)` immediately after each `wg.Add(1)` in `TestFilebeatReceiverLogAsFilestream` so the three goroutines spawned by the test always join before `tRunner` returns. The existing inline `wg.Wait()` calls remain (they become idempotent on completed groups).

## Why is it important?

The test spawns three goroutines that run `fixture.RunOtelWithClient(ctx)` and assert via `require.NoError(t, ...)`. The wait/join only happens after a series of `agentLogFile.WaitLogsContains(t, ...)` and `waitEventsInES` calls in the main body. Each of those can `t.Fatal` (`runtime.Goexit`), in which case the test exits before reaching `fixture.Stop()` + `wg.Wait()`. The orphaned goroutine then runs until its 3-5 minute context deadline, returns from `RunOtelWithClient` (often with an error because the fixture was never stopped cleanly), and calls `require.NoError(t, err)` on a test that has already completed - producing:

```
panic: Fail in goroutine after TestFilebeatReceiverLogAsFilestream has completed
goroutine N [running]:
testing.(*common).Fail(...)
require.NoError(...)
TestFilebeatReceiverLogAsFilestream.func4()
    otel_log_as_filestream_test.go:159
created by ... in goroutine M
    otel_log_as_filestream_test.go:155
```

Test cleanups run while `tRunner` is still active, so any `t.*` call from the goroutine fires while the testing framework still considers the test in progress and no panic results.

Same class of bug as #13806 (TestProcessMarker goroutine leak) - a goroutine that calls `t.Errorf`/`t.Fatal` after its parent test has returned. The bug is pre-existing (introduced when the test landed in #11155).

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in ./changelog/fragments~~ (test-only change)
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

None. Test-only change.

## How to test this PR locally

Run the existing integration test:

```
mage integration:single TestFilebeatReceiverLogAsFilestream
```

The test should pass on Linux/Darwin/Windows. Behavior on the success path is unchanged; the fix only prevents a panic on the failure path where a `require.X` in the main body terminates the test before the inline `wg.Wait()`.