### PR TITLE
Fix K8s daemonset for profiling-agent

### DIFF
--- a/changelog/fragments/1777410560-k8s-daemonset-fix.yaml
+++ b/changelog/fragments/1777410560-k8s-daemonset-fix.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: fix profiling agent daemonset for K8s versions v1.33+
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-managed/base/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-managed/base/elastic-agent-managed-daemonset.yaml
@@ -28,9 +28,6 @@ spec:
       # If you are using the Universal Profiling integration, please uncomment the following line before applying.
       # hostPID: true
       hostNetwork: true
-      # The following setting is needed for Universal Profiling to allow to set procMount to "Unmasked".
-      # If you are using the Universal Profiling integration, please uncomment the following line before applying.
-      # hostUsers: false
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: elastic-agent
@@ -86,7 +83,6 @@ spec:
             # The following capabilities are needed for Universal Profiling.
             # More fine graded capabilities are only available for newer Linux kernels.
             # If you are using the Universal Profiling integration, please uncomment these lines before applying.
-            #procMount: "Unmasked"
             #privileged: true
             #capabilities:
             #  add:

--- a/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/default/elastic-agent-standalone/base/elastic-agent-standalone-daemonset.yaml
@@ -28,9 +28,6 @@ spec:
       # If you are using the Universal Profiling integration, please uncomment the following line before applying.
       # hostPID: true
       hostNetwork: true
-      # The following setting is needed for Universal Profiling to allow to set procMount to "Unmasked".
-      # If you are using the Universal Profiling integration, please uncomment the following line before applying.
-      # hostUsers: false
       dnsPolicy: ClusterFirstWithHostNet
       # Uncomment if using hints feature
       #initContainers:
@@ -95,7 +92,6 @@ spec:
             # The following capabilities are needed for Universal Profiling.
             # More fine graded capabilities are only available for newer Linux kernels.
             # If you are using the Universal Profiling integration, please uncomment these lines before applying.
-            #procMount: "Unmasked"
             #privileged: true
             #capabilities:
             #  add:

--- a/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-managed/base/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-managed/base/elastic-agent-managed-daemonset.yaml
@@ -28,9 +28,6 @@ spec:
       # If you are using the Universal Profiling integration, please uncomment the following line before applying.
       # hostPID: true
       hostNetwork: true
-      # The following setting is needed for Universal Profiling to allow to set procMount to "Unmasked".
-      # If you are using the Universal Profiling integration, please uncomment the following line before applying.
-      # hostUsers: false
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: elastic-agent
@@ -86,7 +83,6 @@ spec:
             # The following capabilities are needed for Universal Profiling.
             # More fine graded capabilities are only available for newer Linux kernels.
             # If you are using the Universal Profiling integration, please uncomment these lines before applying.
-            #procMount: "Unmasked"
             #privileged: true
             #capabilities:
             #  add:

--- a/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-managed/extra/elastic-agent-managed-statefulset.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-managed/extra/elastic-agent-managed-statefulset.yaml
@@ -28,9 +28,6 @@ spec:
       # If you are using the Universal Profiling integration, please uncomment the following line before applying.
       # hostPID: true
       hostNetwork: false
-      # The following setting is needed for Universal Profiling to allow to set procMount to "Unmasked".
-      # If you are using the Universal Profiling integration, please uncomment the following line before applying.
-      # hostUsers: false
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: elastic-agent
@@ -86,7 +83,6 @@ spec:
             # The following capabilities are needed for Universal Profiling.
             # More fine graded capabilities are only available for newer Linux kernels.
             # If you are using the Universal Profiling integration, please uncomment these lines before applying.
-            #procMount: "Unmasked"
             #privileged: true
             #capabilities:
             #  add:

--- a/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/base/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/base/elastic-agent-standalone-daemonset.yaml
@@ -28,9 +28,6 @@ spec:
       # If you are using the Universal Profiling integration, please uncomment the following line before applying.
       # hostPID: true
       hostNetwork: true
-      # The following setting is needed for Universal Profiling to allow to set procMount to "Unmasked".
-      # If you are using the Universal Profiling integration, please uncomment the following line before applying.
-      # hostUsers: false
       dnsPolicy: ClusterFirstWithHostNet
       # Uncomment if using hints feature
       #initContainers:
@@ -95,7 +92,6 @@ spec:
             # The following capabilities are needed for Universal Profiling.
             # More fine graded capabilities are only available for newer Linux kernels.
             # If you are using the Universal Profiling integration, please uncomment these lines before applying.
-            #procMount: "Unmasked"
             #privileged: true
             #capabilities:
             #  add:

--- a/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/extra/elastic-agent-standalone-statefulset.yaml
+++ b/deploy/kubernetes/elastic-agent-kustomize/ksm-autosharding/elastic-agent-standalone/extra/elastic-agent-standalone-statefulset.yaml
@@ -28,9 +28,6 @@ spec:
       # If you are using the Universal Profiling integration, please uncomment the following line before applying.
       # hostPID: true
       hostNetwork: false
-      # The following setting is needed for Universal Profiling to allow to set procMount to "Unmasked".
-      # If you are using the Universal Profiling integration, please uncomment the following line before applying.
-      # hostUsers: false
       dnsPolicy: ClusterFirstWithHostNet
       # Uncomment if using hints feature
       #initContainers:
@@ -95,7 +92,6 @@ spec:
             # The following capabilities are needed for Universal Profiling.
             # More fine graded capabilities are only available for newer Linux kernels.
             # If you are using the Universal Profiling integration, please uncomment these lines before applying.
-            #procMount: "Unmasked"
             #privileged: true
             #capabilities:
             #  add:

--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -28,9 +28,6 @@ spec:
       # If you are using the Universal Profiling integration, please uncomment the following line before applying.
       # hostPID: true
       hostNetwork: true
-      # The following setting is needed for Universal Profiling to allow to set procMount to "Unmasked".
-      # If you are using the Universal Profiling integration, please uncomment the following line before applying.
-      # hostUsers: false
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: elastic-agent
@@ -86,7 +83,6 @@ spec:
             # The following capabilities are needed for Universal Profiling.
             # More fine graded capabilities are only available for newer Linux kernels.
             # If you are using the Universal Profiling integration, please uncomment these lines before applying.
-            #procMount: "Unmasked"
             #privileged: true
             #capabilities:
             #  add:

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -28,9 +28,6 @@ spec:
       # If you are using the Universal Profiling integration, please uncomment the following line before applying.
       # hostPID: true
       hostNetwork: true
-      # The following setting is needed for Universal Profiling to allow to set procMount to "Unmasked".
-      # If you are using the Universal Profiling integration, please uncomment the following line before applying.
-      # hostUsers: false
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: elastic-agent
@@ -86,7 +83,6 @@ spec:
             # The following capabilities are needed for Universal Profiling.
             # More fine graded capabilities are only available for newer Linux kernels.
             # If you are using the Universal Profiling integration, please uncomment these lines before applying.
-            #procMount: "Unmasked"
             #privileged: true
             #capabilities:
             #  add:

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -704,9 +704,6 @@ spec:
       # If you are using the Universal Profiling integration, please uncomment the following line before applying.
       # hostPID: true
       hostNetwork: true
-      # The following setting is needed for Universal Profiling to allow to set procMount to "Unmasked".
-      # If you are using the Universal Profiling integration, please uncomment the following line before applying.
-      # hostUsers: false
       dnsPolicy: ClusterFirstWithHostNet
       # Uncomment if using hints feature
       #initContainers:
@@ -771,7 +768,6 @@ spec:
             # The following capabilities are needed for Universal Profiling.
             # More fine graded capabilities are only available for newer Linux kernels.
             # If you are using the Universal Profiling integration, please uncomment these lines before applying.
-            #procMount: "Unmasked"
             #privileged: true
             #capabilities:
             #  add:

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset.yaml
@@ -28,9 +28,6 @@ spec:
       # If you are using the Universal Profiling integration, please uncomment the following line before applying.
       # hostPID: true
       hostNetwork: true
-      # The following setting is needed for Universal Profiling to allow to set procMount to "Unmasked".
-      # If you are using the Universal Profiling integration, please uncomment the following line before applying.
-      # hostUsers: false
       dnsPolicy: ClusterFirstWithHostNet
       # Uncomment if using hints feature
       #initContainers:
@@ -95,7 +92,6 @@ spec:
             # The following capabilities are needed for Universal Profiling.
             # More fine graded capabilities are only available for newer Linux kernels.
             # If you are using the Universal Profiling integration, please uncomment these lines before applying.
-            #procMount: "Unmasked"
             #privileged: true
             #capabilities:
             #  add:


### PR DESCRIPTION
## What does this PR do?

Updates K8s daemonset to fix deployment for profiling-agent on K8s versions v1.33+.

## Why is it important?

The current daemonset is broken for K8s version v1.33+ as it's using `procMount: Unmasked` which depends on `hostUsers: false` which is incompatible with `hostPID: true` which is a hard requirement for the profiling agent.

## Checklist

- [X] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Related issues

- https://github.com/elastic/prodfiler/issues/6765
- https://github.com/open-telemetry/opentelemetry-ebpf-profiler/issues/923
- https://github.com/elastic/sdh-beats/issues/7043 
