### PR TITLE
fix(upgrade): prevent live install deletion from stale markers

### DIFF
--- a/changelog/fragments/1777453119-drosiek-marker-state.yaml
+++ b/changelog/fragments/1777453119-drosiek-marker-state.yaml
@@ -13,7 +13,7 @@ kind: bug-fix
 
 # REQUIRED for all kinds
 # Change summary; a 80ish characters long description of the change.
-summary: Reconcile stale upgrade markers on startup and report failed upgrades to Fleet
+summary: Prevent live install deletion from stale upgrade markers and report failures to Fleet
 
 # REQUIRED for breaking-change, deprecation, known-issue
 # Long description; in case the summary is not enough to describe the change

--- a/changelog/fragments/1777453119-drosiek-marker-state.yaml
+++ b/changelog/fragments/1777453119-drosiek-marker-state.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Reconcile stale upgrade markers on startup and report failed upgrades to Fleet
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -133,6 +133,69 @@ The new process looks like this:
   - we invoke the new agent binary if the new version > 8.13.0
 - Shutdown current agent and its command components, copy components state once again and restart
 
+### Marker reconciliation on startup
+
+In addition to the in-flight upgrade flow shown above, the agent reconciles
+any on-disk upgrade marker against the running version when it starts up
+([`cmd.handleUpgrade`](../internal/pkg/agent/cmd/run.go)). This handles
+cases where an upgrade was interrupted before reaching re-exec, leaving a
+stale marker behind, or where a previous boot wrote a terminal-state marker
+that needs to be cleaned up.
+
+The classifier compares the running agent's commit hash
+([`release.Commit`](../internal/pkg/release/version.go)) against
+`marker.Hash` and `marker.PrevHash` (truncated to `HashLen = 6`; see
+[`UpdateMarker.IsTarget` / `IsPrevious`](../internal/pkg/agent/application/upgrade/step_mark.go)).
+Five outcomes:
+
+1. **No marker on disk** — nothing to do.
+2. **Marker is terminal (`Completed`/`Rollback`/`Failed`) and `Acked`** —
+   leftover bookkeeping; remove it.
+3. **Running agent matches `marker.Hash`** — we are the upgrade target. Run
+   normal post-upgrade housekeeping (install marker, service config,
+   Windows uninstall registry entry).
+4. **Running agent matches `marker.PrevHash`** — two sub-cases:
+   - **Marker already terminal** (e.g. set to `Rollback` by the watcher on
+     a previous boot, or `Failed` by a prior reconcile pass): return the
+     marker so the coordinator can finish reporting to Fleet; no physical
+     work to redo.
+   - **Marker not yet terminal**: the on-disk state is inconsistent with
+     the running agent.
+     [`ReconcileMismatchedUpgrade`](../internal/pkg/agent/application/upgrade/reconcile.go)
+     aligns the symlink and `active.commit` to the running install, removes
+     the partial new versioned home referenced by the marker, and rewrites
+     the marker as `state=Failed` so the failure is reportable to Fleet via
+     the normal upgrade-details path. The marker is removed on a subsequent
+     boot once Fleet acks it.
+5. **Running agent matches neither** — discard the marker as stale; do
+   not touch any versioned homes.
+
+The reconcile path also runs synchronously inside `Upgrade()`'s rollback
+paths ([`(Upgrader).abortUpgrade`](../internal/pkg/agent/application/upgrade/reconcile.go))
+so that an aborted upgrade transitions to `state=Failed` immediately rather
+than waiting for the next agent restart. The on-startup classifier is the
+safety net for cases where the synchronous path didn't run (process killed,
+cleanup itself failed, marker from an older agent version that didn't have
+this logic).
+
+### Cleanup safety guarantee
+
+[`upgrade.cleanup`](../internal/pkg/agent/application/upgrade/rollback.go)
+always preserves the versioned home that the top-level agent symlink
+resolves to, regardless of what keep list the caller provides. This is a
+structural backstop on top of the TTL-based rollback retention
+(`marker.RollbacksAvailable`): the symlink is the single source of truth
+for "the binary the daemon will launch on next start," and that directory
+must always survive cleanup. See
+[`liveVersionedHome`](../internal/pkg/agent/application/upgrade/step_relink.go)
+and the guard at the top of the cleanup loop in
+[`rollback.go`](../internal/pkg/agent/application/upgrade/rollback.go).
+
+This protects the live install against a caller-supplied keep list that
+references directories no longer on disk — the failure mode that could
+otherwise have caused cleanup to delete every versioned home except a
+missing one.
+
 ### Windows Add/Remove Programs registry entry
 
 Starting from version 9.4.0, Elastic Agent creates an entry in the Windows

--- a/internal/pkg/agent/application/upgrade/manual_rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/manual_rollback_test.go
@@ -354,7 +354,7 @@ func TestManualRollback(t *testing.T) {
 
 				expectedUpdateMarker := &UpdateMarker{
 					Version:           release.VersionWithSnapshot(),
-					Hash:              release.Commit(),
+					Hash:              release.ShortCommit(),
 					VersionedHome:     filepath.Join("data", fmt.Sprintf("elastic-agent-%s", release.ShortCommit())),
 					UpdatedOn:         aMomentInTime,
 					PrevVersion:       "1.2.3",

--- a/internal/pkg/agent/application/upgrade/reconcile.go
+++ b/internal/pkg/agent/application/upgrade/reconcile.go
@@ -84,10 +84,17 @@ func ReconcileMismatchedUpgrade(
 	// Rewrite the marker as state=Failed so the coordinator reports the
 	// failure to Fleet. The marker is removed on a subsequent boot once
 	// Fleet acks it.
+	//
+	// Use Fail() rather than SetStateWithReason(StateFailed, ...): the latter
+	// is documented as an anti-pattern because it doesn't populate
+	// FailedState (the state we were in when failing) or ErrorMsg. If
+	// Details is nil we initialize with StateReplacing as a placeholder for
+	// "an upgrade was in progress" — Fail() then records that as the
+	// failed-from state.
 	if marker.Details == nil {
-		marker.Details = details.NewDetails(marker.Version, details.StateFailed, marker.GetActionID())
+		marker.Details = details.NewDetails(marker.Version, details.StateReplacing, marker.GetActionID())
 	}
-	marker.Details.SetStateWithReason(details.StateFailed, "running agent does not match upgrade marker target")
+	marker.Details.Fail(goerrors.New("running agent does not match upgrade marker target"))
 	if err := SaveMarker(paths.DataFrom(topDir), marker, true); err != nil {
 		errs = append(errs, fmt.Errorf("saving failed-state marker: %w", err))
 	}

--- a/internal/pkg/agent/application/upgrade/reconcile.go
+++ b/internal/pkg/agent/application/upgrade/reconcile.go
@@ -1,0 +1,85 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package upgrade
+
+import (
+	"context"
+	goerrors "errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/details"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+)
+
+// ReconcileMismatchedUpgrade reconciles on-disk upgrade state when the running
+// agent matches marker.PrevHash rather than marker.Hash. It mirrors the shape
+// of RollbackWithOpts: take over the watcher, align the active install,
+// remove the versioned home referenced by the marker, then rewrite the marker
+// as state=Failed so the failure is reported to Fleet via the normal
+// upgrade-details path.
+//
+// homeRelPath is the running agent's versioned home, relative to topDir.
+// runningHash is the running agent's commit (truncated or full). The marker
+// is mutated in place and saved to disk.
+//
+// Operations are idempotent and best-effort: errors are accumulated and
+// returned via errors.Join so the caller can continue startup.
+func ReconcileMismatchedUpgrade(
+	ctx context.Context,
+	log *logger.Logger,
+	helper WatcherHelper,
+	topDir, homeRelPath, runningHash string,
+	marker *UpdateMarker,
+) error {
+	// Take over (terminate + lock) any running watcher so it doesn't act on
+	// the marker we're about to rewrite. If takeover fails, an orphan watcher
+	// may still operate on its in-memory snapshot of the marker — including
+	// running Cleanup against marker.VersionedHome, which can delete the
+	// active install. There is no defense from the daemon side once the
+	// watcher is past its terminal-state check; the structural fix is in the
+	// watcher's cleanup path (see https://github.com/elastic/elastic-agent/issues/13505).
+	if lock, err := helper.TakeOverWatcher(ctx, log, topDir); err == nil {
+		defer func() {
+			if unlockErr := lock.Unlock(); unlockErr != nil {
+				log.Warnw("failed releasing watcher lock", "error.message", unlockErr.Error())
+			}
+		}()
+	} else {
+		log.Warnw("could not take over watcher; proceeding best-effort",
+			"error.message", err.Error())
+	}
+
+	var errs []error
+
+	// Point the symlink at the running install and write our hash to
+	// active.commit. Same primitive rollback uses, with target = us.
+	if err := AlignActiveInstall(log, topDir, homeRelPath, runningHash); err != nil {
+		errs = append(errs, fmt.Errorf("aligning active install: %w", err))
+	}
+
+	// Remove the versioned home the marker points at, if it still exists.
+	if marker.VersionedHome != "" {
+		markerHome := filepath.Join(topDir, marker.VersionedHome)
+		if err := os.RemoveAll(markerHome); err != nil {
+			errs = append(errs, fmt.Errorf("removing marker versioned home %q: %w", markerHome, err))
+		}
+	}
+
+	// Rewrite the marker as state=Failed so the coordinator reports the
+	// failure to Fleet. The marker is removed on a subsequent boot once
+	// Fleet acks it.
+	if marker.Details == nil {
+		marker.Details = details.NewDetails(marker.Version, details.StateFailed, marker.GetActionID())
+	}
+	marker.Details.SetStateWithReason(details.StateFailed, "running agent does not match upgrade marker target")
+	if err := SaveMarker(paths.DataFrom(topDir), marker, true); err != nil {
+		errs = append(errs, fmt.Errorf("saving failed-state marker: %w", err))
+	}
+
+	return goerrors.Join(errs...)
+}

--- a/internal/pkg/agent/application/upgrade/reconcile.go
+++ b/internal/pkg/agent/application/upgrade/reconcile.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/details"
+	"github.com/elastic/elastic-agent/internal/pkg/release"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
 
@@ -83,4 +84,68 @@ func ReconcileMismatchedUpgrade(
 	}
 
 	return goerrors.Join(errs...)
+}
+
+// DiscardStaleMarker removes an upgrade marker that doesn't describe the
+// running agent or any version we recognize. Conservative: takes the watcher
+// lock so an orphan can't act on the marker, but doesn't touch versioned
+// homes since we don't know what they refer to. Just removes the misleading
+// metadata so it doesn't keep tripping startup logic.
+func DiscardStaleMarker(ctx context.Context, log *logger.Logger, helper WatcherHelper, topDir string) error {
+	if lock, err := helper.TakeOverWatcher(ctx, log, topDir); err == nil {
+		defer func() { _ = lock.Unlock() }()
+	} else {
+		log.Warnw("could not take over watcher when discarding stale marker",
+			"error.message", err.Error())
+	}
+
+	if err := CleanMarker(log, paths.DataFrom(topDir)); err != nil {
+		return fmt.Errorf("clearing stale marker: %w", err)
+	}
+	return nil
+}
+
+// abortUpgrade undoes an in-progress upgrade and reconciles any on-disk
+// marker so the failure is reportable to Fleet. Combines the physical undo
+// (rollbackInstall: symlink revert, new home removal, TTL clear) with the
+// marker reconcile (rewrite as state=Failed, align active.commit). Returns
+// the physical-undo error; reconcile failures are logged best-effort and
+// don't shadow the original failure.
+//
+// Used by every error path in Upgrade() that occurs after the symlink has
+// been flipped, so callers don't need to remember to combine the two steps.
+func (u *Upgrader) abortUpgrade(ctx context.Context, newVersionedHome, currentVersionedHome string) error {
+	rollbackErr := u.rollbackInstall(ctx, u.log, paths.Top(), newVersionedHome, currentVersionedHome, u.availableRollbacksSource)
+	u.reconcileFailedUpgrade(ctx, currentVersionedHome)
+	return rollbackErr
+}
+
+// reconcileFailedUpgrade reconciles any on-disk upgrade marker after an
+// aborted upgrade. If a marker is present, it is rewritten as state=Failed
+// and the on-disk state (symlink, active.commit) is realigned with the
+// running agent so the failure is reportable to Fleet via the existing
+// upgrade-details path. Best-effort: errors are logged, never returned.
+//
+// Called from Upgrade()'s rollback paths after rollbackInstall has done the
+// physical undo. Composes with the next-boot reconcile in handleUpgrade so
+// that residual cases (SIGKILL between marker write and this call,
+// LoadMarker failures, etc.) still get caught later.
+func (u *Upgrader) reconcileFailedUpgrade(ctx context.Context, currentVersionedHome string) {
+	marker, err := LoadMarker(paths.Data())
+	if err != nil {
+		u.log.Warnw("could not load marker after upgrade failure; reconcile deferred to next boot",
+			"error.message", err.Error())
+		return
+	}
+	if marker == nil {
+		return
+	}
+	if reconcileErr := ReconcileMismatchedUpgrade(
+		ctx, u.log, u.watcherHelper,
+		paths.Top(), currentVersionedHome, release.Commit(),
+		marker,
+	); reconcileErr != nil {
+		u.log.Warnw("failed to reconcile upgrade marker after failure",
+			"error.message", reconcileErr.Error())
+	}
 }

--- a/internal/pkg/agent/application/upgrade/reconcile.go
+++ b/internal/pkg/agent/application/upgrade/reconcile.go
@@ -37,12 +37,13 @@ func ReconcileMismatchedUpgrade(
 	marker *UpdateMarker,
 ) error {
 	// Take over (terminate + lock) any running watcher so it doesn't act on
-	// the marker we're about to rewrite. If takeover fails, an orphan watcher
-	// may still operate on its in-memory snapshot of the marker — including
-	// running Cleanup against marker.VersionedHome, which can delete the
-	// active install. There is no defense from the daemon side once the
-	// watcher is past its terminal-state check; the structural fix is in the
-	// watcher's cleanup path (see https://github.com/elastic/elastic-agent/issues/13505).
+	// the marker we're about to rewrite. The data-loss hazard if takeover
+	// fails (orphan watcher running Cleanup against a stale
+	// marker.VersionedHome) is covered structurally by the keep-list guard
+	// in upgrade.cleanup, which always preserves the directory backing the
+	// live agent symlink. Takeover here is still preferable so the orphan
+	// doesn't observe the in-flight reconcile and report misleading state
+	// to Fleet — but it is best-effort, not load-bearing.
 	if lock, err := helper.TakeOverWatcher(ctx, log, topDir); err == nil {
 		defer func() {
 			if unlockErr := lock.Unlock(); unlockErr != nil {

--- a/internal/pkg/agent/application/upgrade/reconcile.go
+++ b/internal/pkg/agent/application/upgrade/reconcile.go
@@ -2,6 +2,15 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
+// This file consolidates upgrade-marker reconciliation logic — both the
+// standalone functions (ReconcileMismatchedUpgrade, DiscardStaleMarker) used
+// from cmd.handleUpgrade on the next-boot path, and the (Upgrader)-method
+// helpers (abortUpgrade, reconcileFailedUpgrade) used from upgrade.Upgrade()'s
+// error paths. The methods on Upgrader live here rather than in upgrade.go
+// because they are exclusively about reconciliation; cohesion of the
+// reconciliation surface in one file is preferred over having all methods
+// of a type in the file where the type is declared.
+
 package upgrade
 
 import (
@@ -112,11 +121,15 @@ func DiscardStaleMarker(ctx context.Context, log *logger.Logger, helper WatcherH
 // the physical-undo error; reconcile failures are logged best-effort and
 // don't shadow the original failure.
 //
+// newHomeRelPath is the partial new install (relative to topDir) being undone.
+// currentHomeRelPath is the running agent's home (relative to topDir) — i.e.
+// the install we want to keep.
+//
 // Used by every error path in Upgrade() that occurs after the symlink has
 // been flipped, so callers don't need to remember to combine the two steps.
-func (u *Upgrader) abortUpgrade(ctx context.Context, newVersionedHome, currentVersionedHome string) error {
-	rollbackErr := u.rollbackInstall(ctx, u.log, paths.Top(), newVersionedHome, currentVersionedHome, u.availableRollbacksSource)
-	u.reconcileFailedUpgrade(ctx, currentVersionedHome)
+func (u *Upgrader) abortUpgrade(ctx context.Context, newHomeRelPath, currentHomeRelPath string) error {
+	rollbackErr := u.rollbackInstall(ctx, u.log, paths.Top(), newHomeRelPath, currentHomeRelPath, u.availableRollbacksSource)
+	u.reconcileFailedUpgrade(ctx, currentHomeRelPath)
 	return rollbackErr
 }
 
@@ -126,11 +139,13 @@ func (u *Upgrader) abortUpgrade(ctx context.Context, newVersionedHome, currentVe
 // running agent so the failure is reportable to Fleet via the existing
 // upgrade-details path. Best-effort: errors are logged, never returned.
 //
+// currentHomeRelPath is the running agent's home (relative to topDir).
+//
 // Called from Upgrade()'s rollback paths after rollbackInstall has done the
 // physical undo. Composes with the next-boot reconcile in handleUpgrade so
 // that residual cases (SIGKILL between marker write and this call,
 // LoadMarker failures, etc.) still get caught later.
-func (u *Upgrader) reconcileFailedUpgrade(ctx context.Context, currentVersionedHome string) {
+func (u *Upgrader) reconcileFailedUpgrade(ctx context.Context, currentHomeRelPath string) {
 	marker, err := LoadMarker(paths.Data())
 	if err != nil {
 		u.log.Warnw("could not load marker after upgrade failure; reconcile deferred to next boot",
@@ -142,7 +157,7 @@ func (u *Upgrader) reconcileFailedUpgrade(ctx context.Context, currentVersionedH
 	}
 	if reconcileErr := ReconcileMismatchedUpgrade(
 		ctx, u.log, u.watcherHelper,
-		paths.Top(), currentVersionedHome, release.Commit(),
+		paths.Top(), currentHomeRelPath, release.Commit(),
 		marker,
 	); reconcileErr != nil {
 		u.log.Warnw("failed to reconcile upgrade marker after failure",

--- a/internal/pkg/agent/application/upgrade/reconcile_test.go
+++ b/internal/pkg/agent/application/upgrade/reconcile_test.go
@@ -92,6 +92,12 @@ func TestReconcileMismatchedUpgrade(t *testing.T) {
 	assert.Equal(t, details.StateFailed, saved.Details.State)
 	assert.Equal(t, otherHash, saved.Hash, "current hash unchanged so the action keeps describing the original target")
 	assert.Equal(t, myHash, saved.PrevHash, "prev hash unchanged")
+	// Failure metadata is populated by Fail() — guards against regressing to
+	// the SetStateWithReason(StateFailed, ...) anti-pattern.
+	assert.Equal(t, details.StateReplacing, saved.Details.Metadata.FailedState,
+		"FailedState should record the state we were in when failing")
+	assert.NotEmpty(t, saved.Details.Metadata.ErrorMsg,
+		"ErrorMsg should describe the failure")
 }
 
 // TestReconcileMismatchedUpgrade_NoMarkerVersionedHome covers the marker.VersionedHome=""

--- a/internal/pkg/agent/application/upgrade/reconcile_test.go
+++ b/internal/pkg/agent/application/upgrade/reconcile_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/filelock"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/details"
 	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
 )
@@ -245,4 +246,93 @@ func TestReconcileMismatchedUpgrade_TakeoverFailureProceeds(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, saved.Details)
 	assert.Equal(t, details.StateFailed, saved.Details.State)
+}
+
+// TestUpgrader_reconcileFailedUpgrade exercises the source-side wrapper used
+// by Upgrade()'s error paths after rollbackInstall. Confirms that a marker
+// left on disk in a non-terminal state by an aborted upgrade ends up
+// rewritten as state=Failed so the failure is reportable to Fleet without
+// waiting for the next-boot reconcile.
+func TestUpgrader_reconcileFailedUpgrade(t *testing.T) {
+	const (
+		liveHash   = "aaaaaa"
+		failedHash = "bbbbbb"
+	)
+
+	topDir := t.TempDir()
+	dataDir := filepath.Join(topDir, "data")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+
+	// Set the global top path so paths.Top() / paths.Data() return our temp dir.
+	originalTop := paths.Top()
+	paths.SetTop(topDir)
+	t.Cleanup(func() { paths.SetTop(originalTop) })
+
+	// Live install — backs the symlink.
+	liveHomeRel := filepath.Join("data", "elastic-agent-"+liveHash)
+	liveHomeAbs := filepath.Join(topDir, liveHomeRel)
+	require.NoError(t, os.MkdirAll(liveHomeAbs, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(liveHomeAbs, AgentName), []byte("live"), 0o755))
+	require.NoError(t, os.Symlink(filepath.Join(liveHomeAbs, AgentName), filepath.Join(topDir, AgentName)))
+
+	// Marker left on disk by an aborted Upgrade(): non-terminal state.
+	marker := &UpdateMarker{
+		Version:           "9.9.9",
+		Hash:              failedHash,
+		VersionedHome:     filepath.Join("data", "elastic-agent-"+failedHash),
+		PrevVersion:       "9.0.0",
+		PrevHash:          liveHash,
+		PrevVersionedHome: liveHomeRel,
+		Details:           details.NewDetails("9.9.9", details.StateReplacing, "test-action"),
+	}
+	require.NoError(t, SaveMarker(dataDir, marker, true))
+
+	helper := NewMockWatcherHelper(t)
+	locker := filelock.NewAppLocker(topDir, watcherApplockerFileName)
+	helper.EXPECT().TakeOverWatcher(mock.Anything, mock.Anything, topDir).Return(locker, nil)
+
+	log, _ := loggertest.New(t.Name())
+	u := &Upgrader{
+		log:           log,
+		watcherHelper: helper,
+	}
+
+	u.reconcileFailedUpgrade(t.Context(), liveHomeRel)
+
+	// Marker on disk is now terminal.
+	saved, err := LoadMarker(dataDir)
+	require.NoError(t, err)
+	require.NotNil(t, saved.Details)
+	assert.Equal(t, details.StateFailed, saved.Details.State)
+	// Original action is preserved so it can still be acked.
+	assert.Equal(t, "test-action", saved.Details.ActionID)
+}
+
+// TestUpgrader_reconcileFailedUpgrade_NoMarker confirms the wrapper is a
+// no-op when no marker is on disk — covers the changeSymlink/Set-TTL error
+// paths in Upgrade() that fail before markUpgrade has had a chance to write.
+func TestUpgrader_reconcileFailedUpgrade_NoMarker(t *testing.T) {
+	topDir := t.TempDir()
+	dataDir := filepath.Join(topDir, "data")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+
+	originalTop := paths.Top()
+	paths.SetTop(topDir)
+	t.Cleanup(func() { paths.SetTop(originalTop) })
+
+	// No marker on disk; the helper must not be invoked.
+	helper := NewMockWatcherHelper(t)
+
+	log, _ := loggertest.New(t.Name())
+	u := &Upgrader{
+		log:           log,
+		watcherHelper: helper,
+	}
+
+	// Should be a silent no-op.
+	u.reconcileFailedUpgrade(t.Context(), filepath.Join("data", "elastic-agent-aaaaaa"))
+
+	// And no marker should magically appear.
+	_, err := os.Stat(filepath.Join(dataDir, markerFilename))
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/internal/pkg/agent/application/upgrade/reconcile_test.go
+++ b/internal/pkg/agent/application/upgrade/reconcile_test.go
@@ -136,22 +136,21 @@ func TestReconcileMismatchedUpgrade_NoMarkerVersionedHome(t *testing.T) {
 	assert.Equal(t, details.StateFailed, saved.Details.State)
 }
 
-// TestCleanup_DeletesLiveInstallWhenKeepTargetIsMissing demonstrates the
-// hazard described in https://github.com/elastic/elastic-agent/issues/13505.
+// TestCleanup_PreservesLiveInstallEvenWithStaleKeep is the regression test
+// for the structural fix described in
+// https://github.com/elastic/elastic-agent/issues/13505.
 //
-// When a watcher (or any other caller) builds the cleanup keep list from
-// marker.VersionedHome and that path has already been removed from disk
-// (for example by an aborted upgrade's rollbackInstall), cleanup happily
-// "keeps" the missing directory and deletes every other versioned home —
-// including the one backing the live symlink. The result is that the running
-// install is wiped from disk while still in memory; on the next service
-// restart there is no binary to launch.
+// Without the cleanup guard, when a watcher (or any other caller) builds the
+// cleanup keep list from marker.VersionedHome and that path has already been
+// removed from disk (for example by an aborted upgrade's rollbackInstall),
+// cleanup "kept" the missing directory and deleted every other versioned
+// home — including the one backing the live symlink, wiping the running
+// install from disk while still in memory.
 //
-// This test crafts that exact situation against the cleanup function
-// directly. It is the failure mode that ReconcileMismatchedUpgrade prevents
-// by transitioning the marker to a terminal state and pointing the symlink
-// at the running install before any future cleanup runs.
-func TestCleanup_DeletesLiveInstallWhenKeepTargetIsMissing(t *testing.T) {
+// The cleanup guard now resolves the live symlink and unconditionally adds
+// its versioned home to the keep list, so a stale caller-supplied keep list
+// can no longer cause data loss.
+func TestCleanup_PreservesLiveInstallEvenWithStaleKeep(t *testing.T) {
 	const (
 		liveHash = "aaaaaa"
 		// staleHash names a versioned home that was already removed from
@@ -171,41 +170,39 @@ func TestCleanup_DeletesLiveInstallWhenKeepTargetIsMissing(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(liveHomeAbs, AgentName), []byte("live-binary"), 0o755))
 	require.NoError(t, os.Symlink(filepath.Join(liveHomeAbs, AgentName), filepath.Join(topDir, AgentName)))
 
-	// A second versioned home that survived from some prior boot; presence
-	// is irrelevant to the bug, only included to show the deletion sweeps
-	// everything that isn't in the keep list.
+	// A second versioned home that survived from some prior boot; not in
+	// the keep list, so the guard should NOT preserve it. Only the live
+	// symlink target is unconditionally protected.
 	otherHomeRel := filepath.Join("data", "elastic-agent-cccccc")
 	require.NoError(t, os.MkdirAll(filepath.Join(topDir, otherHomeRel), 0o755))
 
-	// The keep list points at staleHash, which was never created (or was
-	// already deleted). This is what marker.VersionedHome would say after
-	// an aborted upgrade left the marker behind.
+	// The caller-supplied keep list points at staleHash, which was never
+	// created (or was already deleted). Without the guard, cleanup would
+	// trust this and delete everything else.
 	staleKeep := filepath.Join("data", "elastic-agent-"+staleHash)
 
 	log, _ := loggertest.New(t.Name())
-	// keepLogs=false so RemoveBut treats the whole versioned home as removable
-	// and we observe the dir disappearing rather than just being emptied.
 	require.NoError(t, cleanup(log, topDir, false, false, 0, staleKeep))
 
-	// The smoking gun: the directory backing the live symlink is gone,
-	// because cleanup trusted the keep list and treated liveHomeRel as
-	// "not in keep, delete it."
-	_, err := os.Stat(liveHomeAbs)
-	assert.ErrorIs(t, err, os.ErrNotExist, "live install should have been deleted by stale-keep cleanup (the #13505 hazard)")
+	// Guard kicked in: the live install survives even though it wasn't in
+	// the caller's keep list.
+	_, err := os.Stat(filepath.Join(liveHomeAbs, AgentName))
+	require.NoError(t, err, "live install must survive cleanup with stale keep list (#13505 guard)")
 
-	// The symlink still points at a now-missing target; on the next service
-	// restart there is no binary to launch.
-	target, _ := os.Readlink(filepath.Join(topDir, AgentName))
+	// Symlink still resolves.
+	target, err := os.Readlink(filepath.Join(topDir, AgentName))
+	require.NoError(t, err)
 	_, err = os.Stat(target)
-	assert.ErrorIs(t, err, os.ErrNotExist, "symlink target gone — agent cannot restart")
+	assert.NoError(t, err, "symlink target must still exist")
 
 	// The "kept" directory was missing to begin with and is still missing.
 	_, err = os.Stat(filepath.Join(topDir, staleKeep))
 	assert.ErrorIs(t, err, os.ErrNotExist)
 
-	// Any other versioned home is also gone.
+	// The unrelated versioned home was correctly cleaned up — only the
+	// live install gets the guard's protection.
 	_, err = os.Stat(filepath.Join(topDir, otherHomeRel))
-	assert.ErrorIs(t, err, os.ErrNotExist)
+	assert.ErrorIs(t, err, os.ErrNotExist, "non-live, non-keep home should be cleaned")
 }
 
 // TestReconcileMismatchedUpgrade_TakeoverFailureProceeds confirms that a

--- a/internal/pkg/agent/application/upgrade/reconcile_test.go
+++ b/internal/pkg/agent/application/upgrade/reconcile_test.go
@@ -1,0 +1,251 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/filelock"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/details"
+	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
+)
+
+// TestReconcileMismatchedUpgrade exercises the reconcile path end-to-end against
+// a temp top dir that mimics a real install: a "running" home, a "partial new"
+// home referenced by the marker, and a symlink pointing at the wrong target.
+// After reconcile, the symlink, active.commit, and marker should all describe
+// the running install, and the partial new home should be gone.
+func TestReconcileMismatchedUpgrade(t *testing.T) {
+	const (
+		myHash    = "aaaaaa"
+		otherHash = "bbbbbb"
+	)
+
+	topDir := t.TempDir()
+	dataDir := filepath.Join(topDir, "data")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+
+	// Running install ("we are this one").
+	myHomeRel := filepath.Join("data", "elastic-agent-"+myHash)
+	myHomeAbs := filepath.Join(topDir, myHomeRel)
+	require.NoError(t, os.MkdirAll(myHomeAbs, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(myHomeAbs, AgentName), []byte("fake-binary"), 0o755))
+
+	// Partial "new" install referenced by the marker.
+	otherHomeRel := filepath.Join("data", "elastic-agent-"+otherHash)
+	otherHomeAbs := filepath.Join(topDir, otherHomeRel)
+	require.NoError(t, os.MkdirAll(otherHomeAbs, 0o755))
+
+	// Symlink currently points at the failed-target install.
+	symlinkPath := filepath.Join(topDir, AgentName)
+	require.NoError(t, os.Symlink(filepath.Join(otherHomeAbs, AgentName), symlinkPath))
+
+	// Marker says current=other, prev=us, with a non-terminal state.
+	marker := &UpdateMarker{
+		Version:           "9.9.9",
+		Hash:              otherHash,
+		VersionedHome:     otherHomeRel,
+		PrevVersion:       "9.0.0",
+		PrevHash:          myHash,
+		PrevVersionedHome: myHomeRel,
+		Details:           details.NewDetails("9.9.9", details.StateReplacing, "test-action"),
+	}
+	require.NoError(t, SaveMarker(dataDir, marker, true))
+
+	// Mock watcher takeover: hand back a real locker so the deferred Unlock
+	// in reconcile is exercised.
+	helper := NewMockWatcherHelper(t)
+	locker := filelock.NewAppLocker(topDir, watcherApplockerFileName)
+	helper.EXPECT().TakeOverWatcher(mock.Anything, mock.Anything, topDir).Return(locker, nil)
+
+	log, _ := loggertest.New(t.Name())
+
+	require.NoError(t, ReconcileMismatchedUpgrade(t.Context(), log, helper, topDir, myHomeRel, myHash, marker))
+
+	// Symlink now points at our binary.
+	target, err := os.Readlink(symlinkPath)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(myHomeAbs, AgentName), target)
+
+	// Partial "other" home is gone.
+	_, err = os.Stat(otherHomeAbs)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	// active.commit reflects us.
+	commitBytes, err := os.ReadFile(filepath.Join(topDir, agentCommitFile))
+	require.NoError(t, err)
+	assert.Equal(t, myHash, string(commitBytes))
+
+	// Marker is rewritten as Failed and the action is preserved for ack.
+	saved, err := LoadMarker(dataDir)
+	require.NoError(t, err)
+	require.NotNil(t, saved.Details)
+	assert.Equal(t, details.StateFailed, saved.Details.State)
+	assert.Equal(t, otherHash, saved.Hash, "current hash unchanged so the action keeps describing the original target")
+	assert.Equal(t, myHash, saved.PrevHash, "prev hash unchanged")
+}
+
+// TestReconcileMismatchedUpgrade_NoMarkerVersionedHome covers the marker.VersionedHome=""
+// fallback so we don't try to RemoveAll(topDir).
+func TestReconcileMismatchedUpgrade_NoMarkerVersionedHome(t *testing.T) {
+	const myHash = "aaaaaa"
+
+	topDir := t.TempDir()
+	dataDir := filepath.Join(topDir, "data")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+
+	myHomeRel := filepath.Join("data", "elastic-agent-"+myHash)
+	myHomeAbs := filepath.Join(topDir, myHomeRel)
+	require.NoError(t, os.MkdirAll(myHomeAbs, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(myHomeAbs, AgentName), []byte("fake-binary"), 0o755))
+
+	require.NoError(t, os.Symlink(filepath.Join(myHomeAbs, AgentName), filepath.Join(topDir, AgentName)))
+
+	marker := &UpdateMarker{
+		Version:       "9.9.9",
+		Hash:          "bbbbbb",
+		VersionedHome: "", // legacy / partial marker with no path recorded
+		PrevVersion:   "9.0.0",
+		PrevHash:      myHash,
+	}
+	require.NoError(t, SaveMarker(dataDir, marker, true))
+
+	helper := NewMockWatcherHelper(t)
+	locker := filelock.NewAppLocker(topDir, watcherApplockerFileName)
+	helper.EXPECT().TakeOverWatcher(mock.Anything, mock.Anything, topDir).Return(locker, nil)
+
+	log, _ := loggertest.New(t.Name())
+
+	require.NoError(t, ReconcileMismatchedUpgrade(t.Context(), log, helper, topDir, myHomeRel, myHash, marker))
+
+	// Top dir still exists — no aggressive deletion when VersionedHome is empty.
+	_, err := os.Stat(topDir)
+	assert.NoError(t, err)
+
+	saved, err := LoadMarker(dataDir)
+	require.NoError(t, err)
+	require.NotNil(t, saved.Details)
+	assert.Equal(t, details.StateFailed, saved.Details.State)
+}
+
+// TestCleanup_DeletesLiveInstallWhenKeepTargetIsMissing demonstrates the
+// hazard described in https://github.com/elastic/elastic-agent/issues/13505.
+//
+// When a watcher (or any other caller) builds the cleanup keep list from
+// marker.VersionedHome and that path has already been removed from disk
+// (for example by an aborted upgrade's rollbackInstall), cleanup happily
+// "keeps" the missing directory and deletes every other versioned home —
+// including the one backing the live symlink. The result is that the running
+// install is wiped from disk while still in memory; on the next service
+// restart there is no binary to launch.
+//
+// This test crafts that exact situation against the cleanup function
+// directly. It is the failure mode that ReconcileMismatchedUpgrade prevents
+// by transitioning the marker to a terminal state and pointing the symlink
+// at the running install before any future cleanup runs.
+func TestCleanup_DeletesLiveInstallWhenKeepTargetIsMissing(t *testing.T) {
+	const (
+		liveHash = "aaaaaa"
+		// staleHash names a versioned home that was already removed from
+		// disk — typical aftermath of rollbackInstall on a failed upgrade.
+		staleHash = "bbbbbb"
+	)
+
+	topDir := t.TempDir()
+	dataDir := filepath.Join(topDir, "data")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+
+	// The live install. This directory backs the running symlink; cleanup
+	// must not delete it.
+	liveHomeRel := filepath.Join("data", "elastic-agent-"+liveHash)
+	liveHomeAbs := filepath.Join(topDir, liveHomeRel)
+	require.NoError(t, os.MkdirAll(liveHomeAbs, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(liveHomeAbs, AgentName), []byte("live-binary"), 0o755))
+	require.NoError(t, os.Symlink(filepath.Join(liveHomeAbs, AgentName), filepath.Join(topDir, AgentName)))
+
+	// A second versioned home that survived from some prior boot; presence
+	// is irrelevant to the bug, only included to show the deletion sweeps
+	// everything that isn't in the keep list.
+	otherHomeRel := filepath.Join("data", "elastic-agent-cccccc")
+	require.NoError(t, os.MkdirAll(filepath.Join(topDir, otherHomeRel), 0o755))
+
+	// The keep list points at staleHash, which was never created (or was
+	// already deleted). This is what marker.VersionedHome would say after
+	// an aborted upgrade left the marker behind.
+	staleKeep := filepath.Join("data", "elastic-agent-"+staleHash)
+
+	log, _ := loggertest.New(t.Name())
+	// keepLogs=false so RemoveBut treats the whole versioned home as removable
+	// and we observe the dir disappearing rather than just being emptied.
+	require.NoError(t, cleanup(log, topDir, false, false, 0, staleKeep))
+
+	// The smoking gun: the directory backing the live symlink is gone,
+	// because cleanup trusted the keep list and treated liveHomeRel as
+	// "not in keep, delete it."
+	_, err := os.Stat(liveHomeAbs)
+	assert.ErrorIs(t, err, os.ErrNotExist, "live install should have been deleted by stale-keep cleanup (the #13505 hazard)")
+
+	// The symlink still points at a now-missing target; on the next service
+	// restart there is no binary to launch.
+	target, _ := os.Readlink(filepath.Join(topDir, AgentName))
+	_, err = os.Stat(target)
+	assert.ErrorIs(t, err, os.ErrNotExist, "symlink target gone — agent cannot restart")
+
+	// The "kept" directory was missing to begin with and is still missing.
+	_, err = os.Stat(filepath.Join(topDir, staleKeep))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	// Any other versioned home is also gone.
+	_, err = os.Stat(filepath.Join(topDir, otherHomeRel))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+// TestReconcileMismatchedUpgrade_TakeoverFailureProceeds confirms that a
+// failing watcher takeover is best-effort: reconcile logs the failure and
+// continues so the marker still ends up in a consistent terminal state.
+func TestReconcileMismatchedUpgrade_TakeoverFailureProceeds(t *testing.T) {
+	const (
+		myHash    = "aaaaaa"
+		otherHash = "bbbbbb"
+	)
+
+	topDir := t.TempDir()
+	dataDir := filepath.Join(topDir, "data")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+
+	myHomeRel := filepath.Join("data", "elastic-agent-"+myHash)
+	myHomeAbs := filepath.Join(topDir, myHomeRel)
+	require.NoError(t, os.MkdirAll(myHomeAbs, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(myHomeAbs, AgentName), []byte("fake-binary"), 0o755))
+
+	require.NoError(t, os.Symlink(filepath.Join(myHomeAbs, AgentName), filepath.Join(topDir, AgentName)))
+
+	marker := &UpdateMarker{
+		Version:       "9.9.9",
+		Hash:          otherHash,
+		VersionedHome: filepath.Join("data", "elastic-agent-"+otherHash),
+		PrevVersion:   "9.0.0",
+		PrevHash:      myHash,
+	}
+	require.NoError(t, SaveMarker(dataDir, marker, true))
+
+	helper := NewMockWatcherHelper(t)
+	helper.EXPECT().TakeOverWatcher(mock.Anything, mock.Anything, topDir).Return(nil, assert.AnError)
+
+	log, _ := loggertest.New(t.Name())
+
+	require.NoError(t, ReconcileMismatchedUpgrade(t.Context(), log, helper, topDir, myHomeRel, myHash, marker))
+
+	saved, err := LoadMarker(dataDir)
+	require.NoError(t, err)
+	require.NotNil(t, saved.Details)
+	assert.Equal(t, details.StateFailed, saved.Details.State)
+}

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -78,24 +78,13 @@ func RollbackWithOpts(ctx context.Context, log *logger.Logger, c client.Client, 
 
 	settings := NewRollbackSettings(opts...)
 
-	symlinkPath := filepath.Join(topDirPath, AgentName)
-
 	if prevVersionedHome == "" {
 		// fallback for upgrades that didn't use the manifest and path remapping
 		hashedDir := fmt.Sprintf("%s-%s", AgentName, prevHash)
 		prevVersionedHome = filepath.Join("data", hashedDir)
 	}
 
-	// paths.BinaryPath properly derives the binary directory depending on the platform. The path to the binary for macOS is inside of the app bundle.
-	symlinkTarget := paths.BinaryPath(filepath.Join(topDirPath, prevVersionedHome), AgentName)
-
-	// change symlink
-	if err := changeSymlink(log, topDirPath, symlinkPath, symlinkTarget); err != nil {
-		return err
-	}
-
-	// revert active commit
-	if err := UpdateActiveCommit(log, topDirPath, prevHash, os.WriteFile); err != nil {
+	if err := AlignActiveInstall(log, topDirPath, prevVersionedHome, prevHash); err != nil {
 		return err
 	}
 

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -84,6 +84,8 @@ func RollbackWithOpts(ctx context.Context, log *logger.Logger, c client.Client, 
 		prevVersionedHome = filepath.Join("data", hashedDir)
 	}
 
+	// Repoint the top-level symlink at the previous install and revert
+	// active.commit to its hash.
 	if err := AlignActiveInstall(log, topDirPath, prevVersionedHome, prevHash); err != nil {
 		return err
 	}

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -177,6 +177,33 @@ func cleanup(log *logger.Logger, topDirPath string, removeMarker, keepLogs bool,
 		relativeHomePaths = append(relativeHomePaths, relHomePath)
 	}
 
+	// Always preserve the versioned home that the top-level agent symlink
+	// resolves to, regardless of what the caller passed in
+	// versionedHomesToKeep. This closes the data-loss hazard described in
+	// https://github.com/elastic/elastic-agent/issues/13505: if a caller's
+	// keep list is built from a stale marker.VersionedHome that no longer
+	// exists on disk, cleanup would otherwise treat the live install as
+	// "not in keep" and delete it.
+	//
+	// The TTL-based rollback retention (marker.RollbacksAvailable) covers
+	// the homes operators explicitly want to keep across an upgrade. This
+	// guard is the structural backstop on top of that — the symlink is the
+	// single source of truth for "the binary the daemon will launch on
+	// next start," and that directory must always survive cleanup.
+	if liveHome, err := liveVersionedHome(topDirPath); err == nil {
+		liveBasename, basenameErr := filepath.Rel(dataDirPath, filepath.Join(topDirPath, liveHome))
+		if basenameErr != nil {
+			log.Warnw("could not compute live versioned home basename; cleanup proceeds without protection",
+				"error.message", basenameErr.Error())
+		} else if !slices.Contains(relativeHomePaths, liveBasename) {
+			log.Infof("adding live versioned home %q to keep list", liveBasename)
+			relativeHomePaths = append(relativeHomePaths, liveBasename)
+		}
+	} else {
+		log.Warnw("could not derive live versioned home; cleanup proceeds without protection",
+			"error.message", err.Error())
+	}
+
 	log.Infof("Starting cleanup of versioned homes. Keeping: %v", relativeHomePaths)
 
 	for _, dir := range subdirs {

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -137,17 +137,13 @@ type updateActiveCommitFunc func(log *logger.Logger, topDirPath, hash string, wr
 func markUpgradeProvider(updateActiveCommit updateActiveCommitFunc, writeFile writeFileFunc) markUpgradeFunc {
 	return func(log *logger.Logger, dataDirPath string, updatedOn time.Time, agent, previousAgent agentInstall, action *fleetapi.ActionUpgrade, upgradeDetails *details.Details, availableRollbacks map[string]ttl.TTLMarker) error {
 
-		if len(previousAgent.hash) > HashLen {
-			previousAgent.hash = previousAgent.hash[:HashLen]
-		}
-
 		marker := &UpdateMarker{
 			Version:            agent.version,
-			Hash:               agent.hash,
+			Hash:               truncateHash(agent.hash),
 			VersionedHome:      agent.versionedHome,
 			UpdatedOn:          updatedOn,
 			PrevVersion:        previousAgent.version,
-			PrevHash:           previousAgent.hash,
+			PrevHash:           truncateHash(previousAgent.hash),
 			PrevVersionedHome:  previousAgent.versionedHome,
 			Action:             action,
 			Details:            upgradeDetails,
@@ -280,4 +276,29 @@ func IsTerminalState(marker *UpdateMarker) bool {
 	default:
 		return false
 	}
+}
+
+// IsTarget reports whether runningHash matches the upgrade target recorded in
+// the marker (the version the upgrade was advancing to). runningHash is
+// truncated to HashLen because marker.Hash is stored truncated (see
+// markUpgradeProvider).
+func (um *UpdateMarker) IsTarget(runningHash string) bool {
+	return um.Hash != "" && truncateHash(runningHash) == um.Hash
+}
+
+// IsPrevious reports whether runningHash matches the previous version recorded
+// in the marker (the version the upgrade was advancing from). runningHash is
+// truncated to HashLen because marker.Hash is stored truncated (see
+// markUpgradeProvider).
+func (um *UpdateMarker) IsPrevious(runningHash string) bool {
+	return um.PrevHash != "" && truncateHash(runningHash) == um.PrevHash
+}
+
+// truncateHash truncates hash to HashLen, matching the format the upgrade
+// marker stores commit hashes in.
+func truncateHash(hash string) string {
+	if len(hash) > HashLen {
+		return hash[:HashLen]
+	}
+	return hash
 }

--- a/internal/pkg/agent/application/upgrade/step_mark_test.go
+++ b/internal/pkg/agent/application/upgrade/step_mark_test.go
@@ -265,3 +265,64 @@ func TestMarkUpgrade(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateMarker_IsTarget_IsPrevious(t *testing.T) {
+	const (
+		targetHash = "aaaaaa"
+		prevHash   = "bbbbbb"
+	)
+	marker := &UpdateMarker{Hash: targetHash, PrevHash: prevHash}
+
+	tests := []struct {
+		name        string
+		runningHash string
+		wantTarget  bool
+		wantPrev    bool
+	}{
+		{
+			name:        "matches target",
+			runningHash: targetHash,
+			wantTarget:  true,
+		},
+		{
+			name:        "matches previous",
+			runningHash: prevHash,
+			wantPrev:    true,
+		},
+		{
+			name:        "matches neither",
+			runningHash: "cccccc",
+		},
+		{
+			name:        "long running hash truncated to target",
+			runningHash: targetHash + "0123456789abcdef",
+			wantTarget:  true,
+		},
+		{
+			name:        "long running hash truncated to prev",
+			runningHash: prevHash + "0123456789abcdef",
+			wantPrev:    true,
+		},
+		{
+			name:        "empty running hash matches nothing",
+			runningHash: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.wantTarget, marker.IsTarget(tc.runningHash))
+			assert.Equal(t, tc.wantPrev, marker.IsPrevious(tc.runningHash))
+		})
+	}
+}
+
+func TestUpdateMarker_IsTarget_IsPrevious_EmptyMarkerHashes(t *testing.T) {
+	// A marker with empty hashes must never match anything, including an
+	// empty runningHash. Without this guard, "" == um.Hash would be true.
+	marker := &UpdateMarker{}
+	assert.False(t, marker.IsTarget(""))
+	assert.False(t, marker.IsPrevious(""))
+	assert.False(t, marker.IsTarget("aaaaaa"))
+	assert.False(t, marker.IsPrevious("aaaaaa"))
+}

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 
 	"github.com/elastic/elastic-agent-libs/file"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
@@ -52,4 +53,17 @@ func prevSymlinkPath(topDirPath string) string {
 	}
 
 	return filepath.Join(topDirPath, agentPrevName)
+}
+
+// AlignActiveInstall points the top-level agent symlink at the binary inside
+// versionedHome (relative to topDir) and writes hash to active.commit. Used
+// by both the rollback path (target = previous install) and reconcile
+// (target = current install).
+func AlignActiveInstall(log *logger.Logger, topDir, versionedHome, hash string) error {
+	symlinkPath := filepath.Join(topDir, AgentName)
+	target := paths.BinaryPath(filepath.Join(topDir, versionedHome), AgentName)
+	if err := changeSymlink(log, topDir, symlinkPath, target); err != nil {
+		return err
+	}
+	return UpdateActiveCommit(log, topDir, hash, os.WriteFile)
 }

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -61,9 +61,15 @@ func prevSymlinkPath(topDirPath string) string {
 // (target = current install).
 func AlignActiveInstall(log *logger.Logger, topDir, versionedHome, hash string) error {
 	symlinkPath := filepath.Join(topDir, AgentName)
+
+	// paths.BinaryPath properly derives the binary directory depending on the platform. The path to the binary for macOS is inside of the app bundle.
 	target := paths.BinaryPath(filepath.Join(topDir, versionedHome), AgentName)
+	
+	// change symlink
 	if err := changeSymlink(log, topDir, symlinkPath, target); err != nil {
 		return err
 	}
+
+	// revert active commit
 	return UpdateActiveCommit(log, topDir, hash, os.WriteFile)
 }

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -5,6 +5,7 @@
 package upgrade
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -53,6 +54,38 @@ func prevSymlinkPath(topDirPath string) string {
 	}
 
 	return filepath.Join(topDirPath, agentPrevName)
+}
+
+// liveVersionedHome resolves the versioned home that the top-level agent
+// symlink points at, returned as a path relative to topDirPath. Used by
+// cleanup as a defense against stale keep lists deleting the live install.
+//
+// Returns the empty string and a non-nil error if the symlink can't be read
+// or doesn't point at a path under topDirPath.
+func liveVersionedHome(topDirPath string) (string, error) {
+	symlinkPath := filepath.Join(topDirPath, AgentName)
+	if runtime.GOOS == windowsOSName {
+		symlinkPath += exe
+	}
+	target, err := os.Readlink(symlinkPath)
+	if err != nil {
+		return "", fmt.Errorf("reading symlink %q: %w", symlinkPath, err)
+	}
+	// Resolve a relative symlink target against the symlink's directory.
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(symlinkPath), target)
+	}
+	// target is the binary path; strip down to the versioned home.
+	home := filepath.Dir(target)
+	if runtime.GOOS == "darwin" {
+		// macOS BinaryPath: <versionedHome>/elastic-agent.app/Contents/MacOS/elastic-agent
+		home = filepath.Dir(filepath.Dir(filepath.Dir(home)))
+	}
+	rel, err := filepath.Rel(topDirPath, home)
+	if err != nil {
+		return "", fmt.Errorf("computing %q relative to %q: %w", home, topDirPath, err)
+	}
+	return rel, nil
 }
 
 // AlignActiveInstall points the top-level agent symlink at the binary inside

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	windowsOSName = "windows"
+	darwinOSName  = "darwin"
 	exe           = ".exe"
 )
 
@@ -77,7 +78,7 @@ func liveVersionedHome(topDirPath string) (string, error) {
 	}
 	// target is the binary path; strip down to the versioned home.
 	home := filepath.Dir(target)
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == darwinOSName {
 		// macOS BinaryPath: <versionedHome>/elastic-agent.app/Contents/MacOS/elastic-agent
 		home = filepath.Dir(filepath.Dir(filepath.Dir(home)))
 	}

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -98,7 +98,7 @@ func AlignActiveInstall(log *logger.Logger, topDir, versionedHome, hash string) 
 
 	// paths.BinaryPath properly derives the binary directory depending on the platform. The path to the binary for macOS is inside of the app bundle.
 	target := paths.BinaryPath(filepath.Join(topDir, versionedHome), AgentName)
-	
+
 	// change symlink
 	if err := changeSymlink(log, topDir, symlinkPath, target); err != nil {
 		return err

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -502,8 +502,8 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, rollback bool, s
 		previous, // old agent version data
 		action, det, availableRollbacks); err != nil {
 		u.log.Errorw("Rolling back: marking upgrade failed", "error.message", err)
-		rollbackErr := u.rollbackInstall(ctx, u.log, paths.Top(), hashedDir, currentVersionedHome, u.availableRollbacksSource)
-		return nil, goerrors.Join(err, rollbackErr)
+		abortErr := u.abortUpgrade(ctx, hashedDir, currentVersionedHome)
+		return nil, goerrors.Join(err, abortErr)
 	}
 
 	watcherExecutable := u.watcherHelper.SelectWatcherExecutable(paths.Top(), previous, current)
@@ -511,15 +511,15 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, rollback bool, s
 	var watcherCmd *exec.Cmd
 	if watcherCmd, err = u.watcherHelper.InvokeWatcher(u.log, watcherExecutable); err != nil {
 		u.log.Errorw("Rolling back: starting watcher failed", "error.message", err)
-		rollbackErr := u.rollbackInstall(ctx, u.log, paths.Top(), hashedDir, currentVersionedHome, u.availableRollbacksSource)
-		return nil, goerrors.Join(err, rollbackErr)
+		abortErr := u.abortUpgrade(ctx, hashedDir, currentVersionedHome)
+		return nil, goerrors.Join(err, abortErr)
 	}
 
 	watcherWaitErr := u.watcherHelper.WaitForWatcher(ctx, u.log, markerFilePath(paths.Data()), watcherMaxWaitTime)
 	if watcherWaitErr != nil {
 		killWatcherErr := watcherCmd.Process.Kill()
-		rollbackErr := u.rollbackInstall(ctx, u.log, paths.Top(), hashedDir, currentVersionedHome, u.availableRollbacksSource)
-		return nil, goerrors.Join(watcherWaitErr, killWatcherErr, rollbackErr)
+		abortErr := u.abortUpgrade(ctx, hashedDir, currentVersionedHome)
+		return nil, goerrors.Join(watcherWaitErr, killWatcherErr, abortErr)
 	}
 
 	cb := shutdownCallback(u.log, paths.Home(), release.Version(), version, filepath.Join(paths.Top(), unpackRes.VersionedHome))
@@ -609,6 +609,51 @@ func extractAgentVersion(metadata packageMetadata, upgradeVersion string) agentV
 func isSameVersion(log *logger.Logger, current agentVersion, newVersion agentVersion) bool {
 	log.Debugw("Comparing current and new agent version", "current_version", current, "new_version", newVersion)
 	return current == newVersion
+}
+
+// abortUpgrade undoes an in-progress upgrade and reconciles any on-disk
+// marker so the failure is reportable to Fleet. Combines the physical undo
+// (rollbackInstall: symlink revert, new home removal, TTL clear) with the
+// marker reconcile (rewrite as state=Failed, align active.commit). Returns
+// the physical-undo error; reconcile failures are logged best-effort and
+// don't shadow the original failure.
+//
+// Used by every error path in Upgrade() that occurs after the symlink has
+// been flipped, so callers don't need to remember to combine the two steps.
+func (u *Upgrader) abortUpgrade(ctx context.Context, newVersionedHome, currentVersionedHome string) error {
+	rollbackErr := u.rollbackInstall(ctx, u.log, paths.Top(), newVersionedHome, currentVersionedHome, u.availableRollbacksSource)
+	u.reconcileFailedUpgrade(ctx, currentVersionedHome)
+	return rollbackErr
+}
+
+// reconcileFailedUpgrade reconciles any on-disk upgrade marker after an
+// aborted upgrade. If a marker is present, it is rewritten as state=Failed
+// and the on-disk state (symlink, active.commit) is realigned with the
+// running agent so the failure is reportable to Fleet via the existing
+// upgrade-details path. Best-effort: errors are logged, never returned.
+//
+// Called from Upgrade()'s rollback paths after rollbackInstall has done the
+// physical undo. Composes with the next-boot reconcile in handleUpgrade so
+// that residual cases (SIGKILL between marker write and this call,
+// LoadMarker failures, etc.) still get caught later.
+func (u *Upgrader) reconcileFailedUpgrade(ctx context.Context, currentVersionedHome string) {
+	marker, err := LoadMarker(paths.Data())
+	if err != nil {
+		u.log.Warnw("could not load marker after upgrade failure; reconcile deferred to next boot",
+			"error.message", err.Error())
+		return
+	}
+	if marker == nil {
+		return
+	}
+	if reconcileErr := ReconcileMismatchedUpgrade(
+		ctx, u.log, u.watcherHelper,
+		paths.Top(), currentVersionedHome, release.Commit(),
+		marker,
+	); reconcileErr != nil {
+		u.log.Warnw("failed to reconcile upgrade marker after failure",
+			"error.message", reconcileErr.Error())
+	}
 }
 
 func rollbackInstall(ctx context.Context, log *logger.Logger, topDirPath, versionedHome, oldVersionedHome string, rollbackSource availableRollbacksSource) error {

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -611,51 +611,6 @@ func isSameVersion(log *logger.Logger, current agentVersion, newVersion agentVer
 	return current == newVersion
 }
 
-// abortUpgrade undoes an in-progress upgrade and reconciles any on-disk
-// marker so the failure is reportable to Fleet. Combines the physical undo
-// (rollbackInstall: symlink revert, new home removal, TTL clear) with the
-// marker reconcile (rewrite as state=Failed, align active.commit). Returns
-// the physical-undo error; reconcile failures are logged best-effort and
-// don't shadow the original failure.
-//
-// Used by every error path in Upgrade() that occurs after the symlink has
-// been flipped, so callers don't need to remember to combine the two steps.
-func (u *Upgrader) abortUpgrade(ctx context.Context, newVersionedHome, currentVersionedHome string) error {
-	rollbackErr := u.rollbackInstall(ctx, u.log, paths.Top(), newVersionedHome, currentVersionedHome, u.availableRollbacksSource)
-	u.reconcileFailedUpgrade(ctx, currentVersionedHome)
-	return rollbackErr
-}
-
-// reconcileFailedUpgrade reconciles any on-disk upgrade marker after an
-// aborted upgrade. If a marker is present, it is rewritten as state=Failed
-// and the on-disk state (symlink, active.commit) is realigned with the
-// running agent so the failure is reportable to Fleet via the existing
-// upgrade-details path. Best-effort: errors are logged, never returned.
-//
-// Called from Upgrade()'s rollback paths after rollbackInstall has done the
-// physical undo. Composes with the next-boot reconcile in handleUpgrade so
-// that residual cases (SIGKILL between marker write and this call,
-// LoadMarker failures, etc.) still get caught later.
-func (u *Upgrader) reconcileFailedUpgrade(ctx context.Context, currentVersionedHome string) {
-	marker, err := LoadMarker(paths.Data())
-	if err != nil {
-		u.log.Warnw("could not load marker after upgrade failure; reconcile deferred to next boot",
-			"error.message", err.Error())
-		return
-	}
-	if marker == nil {
-		return
-	}
-	if reconcileErr := ReconcileMismatchedUpgrade(
-		ctx, u.log, u.watcherHelper,
-		paths.Top(), currentVersionedHome, release.Commit(),
-		marker,
-	); reconcileErr != nil {
-		u.log.Warnw("failed to reconcile upgrade marker after failure",
-			"error.message", reconcileErr.Error())
-	}
-}
-
 func rollbackInstall(ctx context.Context, log *logger.Logger, topDirPath, versionedHome, oldVersionedHome string, rollbackSource availableRollbacksSource) error {
 	oldAgentPath := paths.BinaryPath(filepath.Join(topDirPath, oldVersionedHome), AgentName)
 	err := changeSymlink(log, topDirPath, filepath.Join(topDirPath, AgentName), oldAgentPath)

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -815,10 +815,10 @@ func setupMetrics(
 //     housekeeping.
 //  3. Running agent matches marker.PrevHash:
 //     a. Marker in terminal state: return it so the coordinator can finish
-//        reporting; no physical work to do.
+//     reporting; no physical work to do.
 //     b. Marker not yet terminal: on-disk state is inconsistent with the
-//        running agent; reconcile it and rewrite the marker with
-//        state=Failed so the mismatch is reported to Fleet.
+//     running agent; reconcile it and rewrite the marker with
+//     state=Failed so the mismatch is reported to Fleet.
 //  4. Running agent matches neither: discard the marker.
 func handleUpgrade(ctx context.Context, log *logger.Logger) (*upgrade.UpdateMarker, error) {
 	upgradeMarker, err := upgrade.LoadMarker(paths.Data())

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -45,6 +45,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/reexec"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/secret"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/details"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
@@ -227,7 +228,7 @@ func runElasticAgentCritical(
 	l := baseLogger.With("log.source", agentName)
 
 	// handleUpgrade, but don't error yet
-	initialUpdateMarker, err = handleUpgrade(l)
+	initialUpdateMarker, err = handleUpgrade(ctx, l)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to handle upgrade: %w", err))
 	}
@@ -804,10 +805,23 @@ func setupMetrics(
 	return s, nil
 }
 
-// handleUpgrade checks if agent is being run as part of an
-// ongoing upgrade operation, i.e. being re-exec'd and performs
-// any upgrade-specific work, if needed.
-func handleUpgrade(log *logger.Logger) (*upgrade.UpdateMarker, error) {
+// handleUpgrade reconciles any on-disk upgrade marker with the version of the
+// agent that is actually running, and performs the appropriate cleanup or
+// post-upgrade work before the daemon proceeds.
+//
+// If there is no marker on disk, returns (nil, nil). Otherwise:
+//
+//  1. Marker in terminal state and acked: leftover bookkeeping; remove it.
+//  2. Running agent matches marker.Hash (the upgrade target): run post-upgrade
+//     housekeeping.
+//  3. Running agent matches marker.PrevHash:
+//     a. Marker in terminal state: return it so the coordinator can finish
+//        reporting; no physical work to do.
+//     b. Marker not yet terminal: on-disk state is inconsistent with the
+//        running agent; reconcile it and rewrite the marker with
+//        state=Failed so the mismatch is reported to Fleet.
+//  4. Running agent matches neither: discard the marker.
+func handleUpgrade(ctx context.Context, log *logger.Logger) (*upgrade.UpdateMarker, error) {
 	upgradeMarker, err := upgrade.LoadMarker(paths.Data())
 	if err != nil {
 		return nil, fmt.Errorf("unable to load upgrade marker to check if Agent is being upgraded: %w", err)
@@ -818,12 +832,53 @@ func handleUpgrade(log *logger.Logger) (*upgrade.UpdateMarker, error) {
 		return nil, nil
 	}
 
+	if upgrade.IsTerminalState(upgradeMarker) && upgradeMarker.Acked {
+		log.Infow("removing acked terminal-state upgrade marker")
+		return nil, upgrade.CleanMarker(log, paths.Data())
+	}
+
+	runningHash := release.Commit()
+	switch {
+	// We are the upgrade target; post-upgrade housekeeping is needed
+	case upgradeMarker.IsTarget(runningHash):
+		return upgradeMarker, postUpgradeHousekeeping(log, upgradeMarker)
+
+	// Running agent matches marker.PrevHash. Either the marker is already in a
+	// terminal state from an earlier pass (waiting for coordinator ack), or the
+	// on-disk state is inconsistent with the running agent and needs to be
+	// reconciled.
+	case upgradeMarker.IsPrevious(runningHash):
+		if upgrade.IsTerminalState(upgradeMarker) {
+			// Marker is already terminal; coordinator hasn't acked yet. Return
+			// it so reporting can complete; nothing physical to redo.
+			return upgradeMarker, nil
+		}
+		log.Warnw("running agent matches marker.PrevHash; reconciling on-disk state",
+			"marker.hash", upgradeMarker.Hash, "marker.prev_hash", upgradeMarker.PrevHash,
+			"marker.version", upgradeMarker.Version, "marker.prev_version", upgradeMarker.PrevVersion,
+			"running.hash", runningHash)
+
+		return upgradeMarker, reconcileMismatchedUpgrade(ctx, log, upgradeMarker)
+
+	default:
+		log.Errorw("upgrade marker references neither the running agent nor a known previous version; discarding",
+			"marker.hash", upgradeMarker.Hash, "marker.prev_hash", upgradeMarker.PrevHash,
+			"running.hash", runningHash)
+		return nil, discardStaleMarker(ctx, log)
+	}
+}
+
+// postUpgradeHousekeeping performs the install-marker / service-config /
+// registry updates expected after a successful re-exec into the upgrade
+// target. Idempotent — safe to call again on a subsequent boot if the marker
+// is still around.
+func postUpgradeHousekeeping(log *logger.Logger, upgradeMarker *upgrade.UpdateMarker) error {
 	if err := ensureInstallMarkerPresent(); err != nil {
-		return nil, err
+		return err
 	}
 
 	if err := upgrade.EnsureServiceConfigUpToDate(); err != nil {
-		return nil, err
+		return err
 	}
 
 	// Update the Add/Remove Programs registry entry with the running version.
@@ -847,7 +902,101 @@ func handleUpgrade(log *logger.Logger) (*upgrade.UpdateMarker, error) {
 		}
 	}
 
-	return upgradeMarker, nil
+	return nil
+}
+
+// reconcileMismatchedUpgrade brings on-disk state in line with the running
+// agent when the marker says the running agent should be the upgrade target
+// but it isn't. Operations are idempotent and best-effort: take over any
+// orphan watcher, point the symlink at the running install, drop the
+// versioned home referenced by the marker, write our hash to active.commit,
+// and rewrite the marker as state=Failed.
+//
+// The marker is rewritten (not deleted) so the coordinator can report the
+// failure to Fleet via the normal upgrade-details path. It will be removed
+// on a subsequent boot once Fleet acks it (see the IsTerminalState && Acked
+// branch in handleUpgrade).
+func reconcileMismatchedUpgrade(ctx context.Context, log *logger.Logger, marker *upgrade.UpdateMarker) error {
+	// Take over (terminate + lock) any running watcher so it doesn't act on
+	// the marker we're about to rewrite. If takeover fails, an orphan watcher
+	// may still operate on its in-memory snapshot of the marker — including
+	// running Cleanup against marker.VersionedHome, which can delete the
+	// active install. There is no defense from the daemon side once the
+	// watcher is past its terminal-state check; the structural fix is in the
+	// watcher's cleanup path (see https://github.com/elastic/elastic-agent/issues/13505).
+	helper := upgrade.AgentWatcherHelper{}
+	if lock, err := helper.TakeOverWatcher(ctx, log, paths.Top()); err == nil {
+		defer func() {
+			if unlockErr := lock.Unlock(); unlockErr != nil {
+				log.Warnw("failed releasing watcher lock", "error.message", unlockErr.Error())
+			}
+		}()
+	} else {
+		log.Warnw("could not take over watcher; proceeding best-effort",
+			"error.message", err.Error())
+	}
+
+	var errs []error
+
+	// 1. Point the symlink at the running install.
+	symlinkPath := filepath.Join(paths.Top(), agentName)
+	target := paths.BinaryPath(paths.Home(), agentName)
+	if err := restoreSymlink(symlinkPath, target); err != nil {
+		errs = append(errs, fmt.Errorf("restoring symlink: %w", err))
+	}
+
+	// 2. Remove the versioned home referenced by the marker if it still exists.
+	if marker.VersionedHome != "" {
+		markerHome := filepath.Join(paths.Top(), marker.VersionedHome)
+		if err := os.RemoveAll(markerHome); err != nil {
+			errs = append(errs, fmt.Errorf("removing versioned home %q: %w", markerHome, err))
+		}
+	}
+
+	// 3. Write our hash to active.commit so it agrees with the running binary.
+	if err := upgrade.UpdateActiveCommit(log, paths.Top(), release.Commit(), os.WriteFile); err != nil {
+		errs = append(errs, fmt.Errorf("writing active commit: %w", err))
+	}
+
+	// 4. Mark the upgrade as failed so the coordinator reports it to Fleet.
+	if marker.Details == nil {
+		marker.Details = details.NewDetails(marker.Version, details.StateFailed, marker.GetActionID())
+	}
+	marker.Details.SetStateWithReason(details.StateFailed, "running agent does not match upgrade marker target")
+	if err := upgrade.SaveMarker(paths.Data(), marker, true); err != nil {
+		errs = append(errs, fmt.Errorf("saving failed-state marker: %w", err))
+	}
+
+	return goerrors.Join(errs...)
+}
+
+// discardStaleMarker handles a marker that references neither the running
+// version nor the previous one. Be conservative: don't touch versioned homes
+// we don't understand, just remove the misleading metadata so we don't keep
+// tripping over it on reboots.
+func discardStaleMarker(ctx context.Context, log *logger.Logger) error {
+	helper := upgrade.AgentWatcherHelper{}
+	if lock, err := helper.TakeOverWatcher(ctx, log, paths.Top()); err == nil {
+		defer func() { _ = lock.Unlock() }()
+	} else {
+		log.Warnw("could not take over watcher when discarding stale marker",
+			"error.message", err.Error())
+	}
+
+	if err := upgrade.CleanMarker(log, paths.Data()); err != nil {
+		return fmt.Errorf("clearing stale marker: %w", err)
+	}
+	return nil
+}
+
+// restoreSymlink atomically points symlinkPath at target.
+func restoreSymlink(symlinkPath, target string) error {
+	tmp := symlinkPath + ".tmp"
+	_ = os.Remove(tmp)
+	if err := os.Symlink(target, tmp); err != nil {
+		return err
+	}
+	return os.Rename(tmp, symlinkPath)
 }
 
 func ensureInstallMarkerPresent() error {

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -45,7 +45,6 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/reexec"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/secret"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade"
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/details"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
@@ -858,7 +857,13 @@ func handleUpgrade(ctx context.Context, log *logger.Logger) (*upgrade.UpdateMark
 			"marker.version", upgradeMarker.Version, "marker.prev_version", upgradeMarker.PrevVersion,
 			"running.hash", runningHash)
 
-		return upgradeMarker, reconcileMismatchedUpgrade(ctx, log, upgradeMarker)
+		homeRelPath, relErr := filepath.Rel(paths.Top(), paths.Home())
+		if relErr != nil {
+			return upgradeMarker, fmt.Errorf("computing relative home path: %w", relErr)
+		}
+		return upgradeMarker, upgrade.ReconcileMismatchedUpgrade(
+			ctx, log, &upgrade.AgentWatcherHelper{},
+			paths.Top(), homeRelPath, runningHash, upgradeMarker)
 
 	default:
 		log.Errorw("upgrade marker references neither the running agent nor a known previous version; discarding",
@@ -905,71 +910,6 @@ func postUpgradeHousekeeping(log *logger.Logger, upgradeMarker *upgrade.UpdateMa
 	return nil
 }
 
-// reconcileMismatchedUpgrade brings on-disk state in line with the running
-// agent when the marker says the running agent should be the upgrade target
-// but it isn't. Operations are idempotent and best-effort: take over any
-// orphan watcher, point the symlink at the running install, drop the
-// versioned home referenced by the marker, write our hash to active.commit,
-// and rewrite the marker as state=Failed.
-//
-// The marker is rewritten (not deleted) so the coordinator can report the
-// failure to Fleet via the normal upgrade-details path. It will be removed
-// on a subsequent boot once Fleet acks it (see the IsTerminalState && Acked
-// branch in handleUpgrade).
-func reconcileMismatchedUpgrade(ctx context.Context, log *logger.Logger, marker *upgrade.UpdateMarker) error {
-	// Take over (terminate + lock) any running watcher so it doesn't act on
-	// the marker we're about to rewrite. If takeover fails, an orphan watcher
-	// may still operate on its in-memory snapshot of the marker — including
-	// running Cleanup against marker.VersionedHome, which can delete the
-	// active install. There is no defense from the daemon side once the
-	// watcher is past its terminal-state check; the structural fix is in the
-	// watcher's cleanup path (see https://github.com/elastic/elastic-agent/issues/13505).
-	helper := upgrade.AgentWatcherHelper{}
-	if lock, err := helper.TakeOverWatcher(ctx, log, paths.Top()); err == nil {
-		defer func() {
-			if unlockErr := lock.Unlock(); unlockErr != nil {
-				log.Warnw("failed releasing watcher lock", "error.message", unlockErr.Error())
-			}
-		}()
-	} else {
-		log.Warnw("could not take over watcher; proceeding best-effort",
-			"error.message", err.Error())
-	}
-
-	var errs []error
-
-	// 1. Point the symlink at the running install.
-	symlinkPath := filepath.Join(paths.Top(), agentName)
-	target := paths.BinaryPath(paths.Home(), agentName)
-	if err := restoreSymlink(symlinkPath, target); err != nil {
-		errs = append(errs, fmt.Errorf("restoring symlink: %w", err))
-	}
-
-	// 2. Remove the versioned home referenced by the marker if it still exists.
-	if marker.VersionedHome != "" {
-		markerHome := filepath.Join(paths.Top(), marker.VersionedHome)
-		if err := os.RemoveAll(markerHome); err != nil {
-			errs = append(errs, fmt.Errorf("removing versioned home %q: %w", markerHome, err))
-		}
-	}
-
-	// 3. Write our hash to active.commit so it agrees with the running binary.
-	if err := upgrade.UpdateActiveCommit(log, paths.Top(), release.Commit(), os.WriteFile); err != nil {
-		errs = append(errs, fmt.Errorf("writing active commit: %w", err))
-	}
-
-	// 4. Mark the upgrade as failed so the coordinator reports it to Fleet.
-	if marker.Details == nil {
-		marker.Details = details.NewDetails(marker.Version, details.StateFailed, marker.GetActionID())
-	}
-	marker.Details.SetStateWithReason(details.StateFailed, "running agent does not match upgrade marker target")
-	if err := upgrade.SaveMarker(paths.Data(), marker, true); err != nil {
-		errs = append(errs, fmt.Errorf("saving failed-state marker: %w", err))
-	}
-
-	return goerrors.Join(errs...)
-}
-
 // discardStaleMarker handles a marker that references neither the running
 // version nor the previous one. Be conservative: don't touch versioned homes
 // we don't understand, just remove the misleading metadata so we don't keep
@@ -987,16 +927,6 @@ func discardStaleMarker(ctx context.Context, log *logger.Logger) error {
 		return fmt.Errorf("clearing stale marker: %w", err)
 	}
 	return nil
-}
-
-// restoreSymlink atomically points symlinkPath at target.
-func restoreSymlink(symlinkPath, target string) error {
-	tmp := symlinkPath + ".tmp"
-	_ = os.Remove(tmp)
-	if err := os.Symlink(target, tmp); err != nil {
-		return err
-	}
-	return os.Rename(tmp, symlinkPath)
 }
 
 func ensureInstallMarkerPresent() error {

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -869,7 +869,7 @@ func handleUpgrade(ctx context.Context, log *logger.Logger) (*upgrade.UpdateMark
 		log.Errorw("upgrade marker references neither the running agent nor a known previous version; discarding",
 			"marker.hash", upgradeMarker.Hash, "marker.prev_hash", upgradeMarker.PrevHash,
 			"running.hash", runningHash)
-		return nil, discardStaleMarker(ctx, log)
+		return nil, upgrade.DiscardStaleMarker(ctx, log, &upgrade.AgentWatcherHelper{}, paths.Top())
 	}
 }
 
@@ -907,25 +907,6 @@ func postUpgradeHousekeeping(log *logger.Logger, upgradeMarker *upgrade.UpdateMa
 		}
 	}
 
-	return nil
-}
-
-// discardStaleMarker handles a marker that references neither the running
-// version nor the previous one. Be conservative: don't touch versioned homes
-// we don't understand, just remove the misleading metadata so we don't keep
-// tripping over it on reboots.
-func discardStaleMarker(ctx context.Context, log *logger.Logger) error {
-	helper := upgrade.AgentWatcherHelper{}
-	if lock, err := helper.TakeOverWatcher(ctx, log, paths.Top()); err == nil {
-		defer func() { _ = lock.Unlock() }()
-	} else {
-		log.Warnw("could not take over watcher when discarding stale marker",
-			"error.message", err.Error())
-	}
-
-	if err := upgrade.CleanMarker(log, paths.Data()); err != nil {
-		return fmt.Errorf("clearing stale marker: %w", err)
-	}
 	return nil
 }
 


### PR DESCRIPTION
## What does this PR do?

Addresses the **P0 stale-marker hazard** from [#13505](https://github.com/elastic/elastic-agent/issues/13505) on two fronts (the issue's separate P1 retry-storm concern is out of scope and tracked separately):

- **Structural fix:** `upgrade.cleanup` resolves the live agent symlink and unconditionally adds its versioned home to the keep list. A stale keep list (e.g. a `marker.VersionedHome` referring to a directory that has already been removed) can no longer cause deletion of the live install.
- **Operational fix:** the agent reconciles its on-disk upgrade state on startup. When the running agent matches `marker.PrevHash`, it aligns the symlink and `active.commit`, removes the partial new home, and rewrites the marker as `state=Failed` so the failure is reported to Fleet through the existing upgrade-details path.

Implementation summary:

- `UpdateMarker.IsTarget` / `UpdateMarker.IsPrevious` predicates ([step_mark.go](internal/pkg/agent/application/upgrade/step_mark.go)).
- `AlignActiveInstall` and `liveVersionedHome` helpers ([step_relink.go](internal/pkg/agent/application/upgrade/step_relink.go)) — shared between rollback, reconcile, and the cleanup guard.
- Cleanup guard in `upgrade.cleanup` ([rollback.go](internal/pkg/agent/application/upgrade/rollback.go)).
- `ReconcileMismatchedUpgrade` ([reconcile.go](internal/pkg/agent/application/upgrade/reconcile.go)).
- `handleUpgrade` rewrite ([run.go](internal/pkg/agent/cmd/run.go)) — switches on the marker classification and delegates; takes the upstream context.
- Documentation: new "Marker reconciliation on startup" and "Cleanup safety guarantee" sections in [docs/upgrades.md](docs/upgrades.md).

## Why is it important?

The failure mode this prevents:

1. An upgrade reaches `markUpgrade`, writes the marker, then fails in a later step.
2. `rollbackInstall` flips the symlink back, removes the partial new home, but leaves the marker on disk pointing at the now-missing directory.
3. The agent keeps running as the previous version. The marker is stale.
4. An orphan watcher (or any code path that calls `cleanup` with the marker's keep list) treats the missing directory as the "keep" target and deletes everything else — including the live install.

The cleanup guard removes step 4 as a data-loss possibility regardless of how the keep list got stale. The reconcile path makes the agent self-heal the marker on next restart and surfaces the failure through the normal Fleet flow rather than leaving the agent perpetually "updating."

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

None for healthy upgrades. Agents previously stuck in a perpetual "updating" state from a stale marker will transition to `state=Failed` on the next restart and surface that to Fleet — intended.

## How to test this PR locally

Unit tests in [reconcile_test.go](internal/pkg/agent/application/upgrade/reconcile_test.go):

- `TestReconcileMismatchedUpgrade` — happy path: stale marker + wrongly-pointed symlink + partial home become a consistent `state=Failed` marker pointing at the running install.
- `TestReconcileMismatchedUpgrade_NoMarkerVersionedHome` — defensive: empty `marker.VersionedHome` doesn't trigger over-aggressive deletion.
- `TestReconcileMismatchedUpgrade_TakeoverFailureProceeds` — best-effort behavior when watcher takeover fails (now safe under the cleanup guard).
- `TestCleanup_PreservesLiveInstallEvenWithStaleKeep` — regression test for the cleanup guard: even with a stale caller-supplied keep list, the live install survives.

```bash
go test ./internal/pkg/agent/application/upgrade/ ./internal/pkg/agent/cmd/
```

## Related issues

- Relates [#13505](https://github.com/elastic/elastic-agent/issues/13505) — addresses the P0 stale-marker hazard; the P1 retry-storm concern from the same issue is not covered here.
