### PR TITLE
Refactor edot commands to allow component factory injection

### DIFF
--- a/internal/edot/cmd/command_components.go
+++ b/internal/edot/cmd/command_components.go
@@ -6,12 +6,13 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/collector/otelcol"
 
-	"github.com/elastic/elastic-agent/internal/edot/otelcol"
+	edotOtelCol "github.com/elastic/elastic-agent/internal/edot/otelcol"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
 )
 
-func newComponentsCommandWithArgs(_ []string, _ *cli.IOStreams) *cobra.Command {
+func newComponentsCommandWithArgs(_ []string, _ *cli.IOStreams, componentsFn func() (otelcol.Factories, error)) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "components",
 		Short:         "Outputs available components in this collector distribution",
@@ -19,7 +20,7 @@ func newComponentsCommandWithArgs(_ []string, _ *cli.IOStreams) *cobra.Command {
 		SilenceUsage:  true, // do not display usage on error
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return otelcol.Components(cmd)
+			return edotOtelCol.Components(cmd, componentsFn)
 		},
 	}
 

--- a/internal/edot/cmd/command_components_fips_test.go
+++ b/internal/edot/cmd/command_components_fips_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent/internal/edot/otelcol"
+	"github.com/elastic/elastic-agent/internal/edot/otelcol/components"
 )
 
 type componentsOutput struct {
@@ -50,7 +51,7 @@ func TestComponentsCommand(t *testing.T) {
 
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
-	err = otelcol.Components(cmd)
+	err = otelcol.Components(cmd, components.Default())
 	require.NoError(t, err)
 	outputComponents := &componentsOutput{}
 	err = yaml.Unmarshal(b.Bytes(), outputComponents)

--- a/internal/edot/cmd/command_components_nofips_test.go
+++ b/internal/edot/cmd/command_components_nofips_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent/internal/edot/otelcol"
+	"github.com/elastic/elastic-agent/internal/edot/otelcol/components"
 )
 
 type componentsOutput struct {
@@ -50,7 +51,7 @@ func TestComponentsCommand(t *testing.T) {
 
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
-	err = otelcol.Components(cmd)
+	err = otelcol.Components(cmd, components.Default())
 	require.NoError(t, err)
 	outputComponents := &componentsOutput{}
 	err = yaml.Unmarshal(b.Bytes(), outputComponents)

--- a/internal/edot/cmd/otel.go
+++ b/internal/edot/cmd/otel.go
@@ -34,7 +34,7 @@ const (
 	defaultStateDirectory = agentBaseDirectory + "/state" // directory that will hold the state data
 )
 
-func NewOtelCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Command {
+func NewOtelCommandWithArgs(args []string, streams *cli.IOStreams, componentsFn func() (otelcol.Factories, error)) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "otel",
 		Short: "Start the Elastic Agent in otel mode",
@@ -59,7 +59,7 @@ func NewOtelCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Comman
 			if err := prepareEnv(); err != nil {
 				return err
 			}
-			return RunCollector(cmd.Context(), cfgFiles, supervised, supervisedLoggingLevel, supervisedMonitoringURL)
+			return RunCollector(cmd.Context(), cfgFiles, supervised, supervisedLoggingLevel, supervisedMonitoringURL, componentsFn)
 		},
 		PreRun: func(c *cobra.Command, args []string) {
 			// hide inherited flags not to bloat help with flags not related to otel
@@ -76,8 +76,8 @@ func NewOtelCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Comman
 	})
 
 	SetupOtelFlags(cmd.Flags())
-	cmd.AddCommand(newValidateCommandWithArgs(args, streams))
-	cmd.AddCommand(newComponentsCommandWithArgs(args, streams))
+	cmd.AddCommand(newValidateCommandWithArgs(args, streams, componentsFn))
+	cmd.AddCommand(newComponentsCommandWithArgs(args, streams, componentsFn))
 	cmd.AddCommand(newOtelDiagnosticsCommand(streams))
 
 	return cmd
@@ -89,8 +89,8 @@ func hideInheritedFlags(c *cobra.Command) {
 	})
 }
 
-func RunCollector(cmdCtx context.Context, configFiles []string, supervised bool, supervisedLoggingLevel string, supervisedMonitoringURL string) error {
-	settings, err := prepareCollectorSettings(configFiles, supervised, supervisedLoggingLevel)
+func RunCollector(cmdCtx context.Context, configFiles []string, supervised bool, supervisedLoggingLevel string, supervisedMonitoringURL string, componentsFn func() (otelcol.Factories, error)) error {
+	settings, err := prepareCollectorSettings(configFiles, supervised, supervisedLoggingLevel, componentsFn)
 	if err != nil {
 		return fmt.Errorf("failed to prepare collector settings: %w", err)
 	}
@@ -136,15 +136,17 @@ type edotSettings struct {
 	otelSettings *otelcol.CollectorSettings
 }
 
-func prepareCollectorSettings(configFiles []string, supervised bool, supervisedLoggingLevel string) (edotSettings, error) {
+func prepareCollectorSettings(configFiles []string, supervised bool, supervisedLoggingLevel string, componentsFn func() (otelcol.Factories, error)) (edotSettings, error) {
 	var settings edotSettings
 	conf := map[string]any{
 		"endpoint": paths.DiagnosticsExtensionSocket(),
 	}
+	baseOpts := []edotOtelCol.SettingOpt{
+		edotOtelCol.WithConfigConvertorFactory(manager.NewForceExtensionConverterFactory(elasticdiagnostics.DiagnosticsExtensionID.String(), conf)),
+		edotOtelCol.WithComponents(componentsFn),
+	}
 	if supervised {
-		settings.otelSettings = edotOtelCol.NewSettings(release.Version(), configFiles,
-			edotOtelCol.WithConfigConvertorFactory(manager.NewForceExtensionConverterFactory(elasticdiagnostics.DiagnosticsExtensionID.String(), conf)),
-		)
+		settings.otelSettings = edotOtelCol.NewSettings(release.Version(), configFiles, baseOpts...)
 
 		// setup logger
 		defaultCfg := logger.DefaultLoggingConfig()
@@ -181,7 +183,7 @@ func prepareCollectorSettings(configFiles []string, supervised bool, supervisedL
 
 		settings.otelSettings.DisableGracefulShutdown = false
 	} else {
-		settings.otelSettings = edotOtelCol.NewSettings(release.Version(), configFiles, edotOtelCol.WithConfigConvertorFactory(manager.NewForceExtensionConverterFactory(elasticdiagnostics.DiagnosticsExtensionID.String(), conf)))
+		settings.otelSettings = edotOtelCol.NewSettings(release.Version(), configFiles, baseOpts...)
 	}
 	return settings, nil
 }

--- a/internal/edot/cmd/otel_flags_test.go
+++ b/internal/edot/cmd/otel_flags_test.go
@@ -30,7 +30,7 @@ func TestOtelFlagsSetup(t *testing.T) {
 }
 
 func TestGetConfigFiles(t *testing.T) {
-	cmd := NewOtelCommandWithArgs(nil, nil)
+	cmd := NewOtelCommandWithArgs(nil, nil, nil)
 	configFile := "sample.yaml"
 	require.NoError(t, cmd.Flag(otelConfigFlagName).Value.Set(configFile))
 
@@ -46,7 +46,7 @@ func TestGetConfigFiles(t *testing.T) {
 }
 
 func TestGetConfigFilesWithDefault(t *testing.T) {
-	cmd := NewOtelCommandWithArgs(nil, nil)
+	cmd := NewOtelCommandWithArgs(nil, nil, nil)
 
 	setVal := "set=val"
 	sets, err := getSets([]string{setVal})
@@ -60,7 +60,7 @@ func TestGetConfigFilesWithDefault(t *testing.T) {
 }
 
 func TestGetConfigErrorWhenNoConfig(t *testing.T) {
-	cmd := NewOtelCommandWithArgs(nil, nil)
+	cmd := NewOtelCommandWithArgs(nil, nil, nil)
 
 	_, err := GetConfigFiles(cmd.Flags(), false)
 	require.Error(t, err)

--- a/internal/edot/cmd/validate.go
+++ b/internal/edot/cmd/validate.go
@@ -8,12 +8,13 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/collector/otelcol"
 
-	"github.com/elastic/elastic-agent/internal/edot/otelcol"
+	edotOtelCol "github.com/elastic/elastic-agent/internal/edot/otelcol"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
 )
 
-func newValidateCommandWithArgs(_ []string, _ *cli.IOStreams) *cobra.Command {
+func newValidateCommandWithArgs(_ []string, _ *cli.IOStreams, componentsFn func() (otelcol.Factories, error)) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "validate",
 		Short:         "Validates the OpenTelemetry collector configuration without running the collector",
@@ -25,7 +26,7 @@ func newValidateCommandWithArgs(_ []string, _ *cli.IOStreams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return validateOtelConfig(cmd.Context(), cfgFiles)
+			return validateOtelConfig(cmd.Context(), cfgFiles, componentsFn)
 		},
 	}
 
@@ -39,6 +40,6 @@ func newValidateCommandWithArgs(_ []string, _ *cli.IOStreams) *cobra.Command {
 	return cmd
 }
 
-func validateOtelConfig(ctx context.Context, cfgFiles []string) error {
-	return otelcol.Validate(ctx, cfgFiles)
+func validateOtelConfig(ctx context.Context, cfgFiles []string, componentsFn func() (otelcol.Factories, error)) error {
+	return edotOtelCol.Validate(ctx, cfgFiles, componentsFn)
 }

--- a/internal/edot/main.go
+++ b/internal/edot/main.go
@@ -10,11 +10,12 @@ import (
 
 	"github.com/elastic/elastic-agent/internal/edot/beats"
 	edotCmd "github.com/elastic/elastic-agent/internal/edot/cmd"
+	"github.com/elastic/elastic-agent/internal/edot/otelcol/components"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
 )
 
 func main() {
-	cmd := edotCmd.NewOtelCommandWithArgs(os.Args, cli.NewIOStreams())
+	cmd := edotCmd.NewOtelCommandWithArgs(os.Args, cli.NewIOStreams(), components.Default())
 	beats.AddCommands(cmd)
 	err := cmd.Execute()
 	if err != nil {

--- a/internal/edot/otelcol/command_components.go
+++ b/internal/edot/otelcol/command_components.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/otelcol"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/receiver"
 
@@ -35,8 +36,8 @@ type componentsOutput struct {
 	Extensions []componentWithStability
 }
 
-func Components(cmd *cobra.Command) error {
-	set := NewSettings(release.Version(), []string{})
+func Components(cmd *cobra.Command, componentsFn func() (otelcol.Factories, error)) error {
+	set := NewSettings(release.Version(), []string{}, WithComponents(componentsFn))
 	factories, err := set.Factories()
 	if err != nil {
 		return fmt.Errorf("failed to initialize factories: %w", err)

--- a/internal/edot/otelcol/components/components_fips.go
+++ b/internal/edot/otelcol/components/components_fips.go
@@ -4,7 +4,7 @@
 
 //go:build requirefips
 
-package otelcol
+package components
 
 import (
 	"go.opentelemetry.io/collector/exporter"

--- a/internal/edot/otelcol/components/components_linux.go
+++ b/internal/edot/otelcol/components/components_linux.go
@@ -5,7 +5,7 @@
 //go:build linux
 // +build linux
 
-package otelcol
+package components
 
 import (
 	"go.opentelemetry.io/collector/receiver"

--- a/internal/edot/otelcol/components/components_nofips.go
+++ b/internal/edot/otelcol/components/components_nofips.go
@@ -4,7 +4,7 @@
 
 //go:build !requirefips
 
-package otelcol
+package components
 
 import (
 	kafkaexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"

--- a/internal/edot/otelcol/components/components_others.go
+++ b/internal/edot/otelcol/components/components_others.go
@@ -5,7 +5,7 @@
 //go:build !linux
 // +build !linux
 
-package otelcol
+package components
 
 import "go.opentelemetry.io/collector/receiver"
 

--- a/internal/edot/otelcol/components/default.go
+++ b/internal/edot/otelcol/components/default.go
@@ -2,7 +2,12 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-package otelcol
+// Package components hosts the default EDOT collector component registry. It
+// is intentionally split out of the otelcol package so that callers (such as
+// the manager unit-test binary) can wire up a smaller component set without
+// dragging the full set of receivers, processors, exporters, and extensions
+// into their build.
+package components
 
 import (
 	"go.opentelemetry.io/collector/connector"
@@ -127,7 +132,9 @@ import (
 	elasticmonitoringreceiver "github.com/elastic/elastic-agent/internal/edot/receivers/elasticmonitoring"
 )
 
-func components(extensionFactories ...extension.Factory) func() (otelcol.Factories, error) {
+// Default returns the factory function for the full EDOT collector component
+// set. Pass extra extension factories to register them alongside the defaults.
+func Default(extensionFactories ...extension.Factory) func() (otelcol.Factories, error) {
 	return func() (otelcol.Factories, error) {
 		var err error
 		factories := otelcol.Factories{

--- a/internal/edot/otelcol/monitoring_test.go
+++ b/internal/edot/otelcol/monitoring_test.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 
 	"github.com/elastic/elastic-agent-libs/mapstr"
+	"github.com/elastic/elastic-agent/internal/edot/otelcol/components"
 	"github.com/elastic/elastic-agent/testing/integration"
 	"github.com/elastic/mock-es/pkg/api"
 )
@@ -99,7 +100,7 @@ service:
 		template.Must(template.New("config").Parse(cfg)).Execute(&configBuffer, configParams),
 	)
 
-	settings := NewSettings("test", []string{"yaml:" + configBuffer.String()})
+	settings := NewSettings("test", []string{"yaml:" + configBuffer.String()}, WithComponents(components.Default()))
 
 	featuregate.GlobalRegistry().Set("telemetry.newPipelineTelemetry", true)
 	collector, err := otelcol.NewCollector(*settings)
@@ -248,7 +249,7 @@ service:
 		template.Must(template.New("config").Parse(cfg)).Execute(&configBuffer, configParams),
 	)
 
-	settings := NewSettings("test", []string{"yaml:" + configBuffer.String()})
+	settings := NewSettings("test", []string{"yaml:" + configBuffer.String()}, WithComponents(components.Default()))
 
 	featuregate.GlobalRegistry().Set("telemetry.newPipelineTelemetry", true)
 	collector, err := otelcol.NewCollector(*settings)

--- a/internal/edot/otelcol/ratelimit_test.go
+++ b/internal/edot/otelcol/ratelimit_test.go
@@ -32,6 +32,7 @@ import (
 
 	mockes "github.com/elastic/mock-es/pkg/api"
 
+	"github.com/elastic/elastic-agent/internal/edot/otelcol/components"
 	"github.com/elastic/elastic-agent/testing/integration"
 )
 
@@ -86,7 +87,7 @@ service:
       exporters: [elasticsearch]
 `, port, processorsBlock, esURL)
 
-	settings := NewSettings("test", []string{"yaml:" + cfg})
+	settings := NewSettings("test", []string{"yaml:" + cfg}, WithComponents(components.Default()))
 	collector, err := otelcol.NewCollector(*settings)
 	require.NoError(t, err)
 

--- a/internal/edot/otelcol/run.go
+++ b/internal/edot/otelcol/run.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/collector/confmap/provider/httpprovider"
 	"go.opentelemetry.io/collector/confmap/provider/httpsprovider"
 	"go.opentelemetry.io/collector/confmap/provider/yamlprovider"
-	"go.opentelemetry.io/collector/extension"
 
 	"go.opentelemetry.io/collector/otelcol"
 
@@ -44,7 +43,7 @@ func Run(ctx context.Context, stop chan bool, settings *otelcol.CollectorSetting
 type options struct {
 	resolverConfigProviders    []confmap.ProviderFactory
 	resolverConverterFactories []confmap.ConverterFactory
-	extensionFactories         []extension.Factory
+	componentsFn               func() (otelcol.Factories, error)
 }
 
 type SettingOpt func(o *options)
@@ -61,9 +60,13 @@ func WithConfigConvertorFactory(converter confmap.ConverterFactory) SettingOpt {
 	}
 }
 
-func WithExtensionFactory(factory extension.Factory) SettingOpt {
+// WithComponents sets the OTel component factory function. Callers must
+// provide one — the otelcol package no longer ships a built-in default so
+// that consumers (e.g. the manager unit-test binary) can avoid pulling in
+// the full set of EDOT receivers, processors, exporters, and extensions.
+func WithComponents(fn func() (otelcol.Factories, error)) SettingOpt {
 	return func(o *options) {
-		o.extensionFactories = append(o.extensionFactories, factory)
+		o.componentsFn = fn
 	}
 }
 
@@ -100,7 +103,7 @@ func NewSettings(version string, configPaths []string, opts ...SettingOpt) *otel
 	}
 
 	return &otelcol.CollectorSettings{
-		Factories:              components(o.extensionFactories...),
+		Factories:              o.componentsFn,
 		BuildInfo:              buildInfo,
 		ConfigProviderSettings: configProviderSettings,
 		// we're handling DisableGracefulShutdown via the cancelCtx being passed

--- a/internal/edot/otelcol/run_fips_test.go
+++ b/internal/edot/otelcol/run_fips_test.go
@@ -13,11 +13,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/otelcol"
+
+	"github.com/elastic/elastic-agent/internal/edot/otelcol/components"
 )
 
 func TestStartCollectorFIPS(t *testing.T) {
 	configFiles := getConfigFiles("all-components-fips.yml")
-	settings := NewSettings("test", configFiles)
+	settings := NewSettings("test", configFiles, WithComponents(components.Default()))
 
 	collector, err := otelcol.NewCollector(*settings)
 	require.NoError(t, err)

--- a/internal/edot/otelcol/run_nofips_test.go
+++ b/internal/edot/otelcol/run_nofips_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/otelcol"
+
+	"github.com/elastic/elastic-agent/internal/edot/otelcol/components"
 )
 
 func TestStartCollector(t *testing.T) {
@@ -34,7 +36,7 @@ func TestStartCollector(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.configFile, func(t *testing.T) {
 			configFiles := getConfigFiles(tc.configFile)
-			settings := NewSettings("test", configFiles)
+			settings := NewSettings("test", configFiles, WithComponents(components.Default()))
 
 			collector, err := otelcol.NewCollector(*settings)
 			require.NoError(t, err)

--- a/internal/edot/otelcol/validate.go
+++ b/internal/edot/otelcol/validate.go
@@ -12,8 +12,8 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/release"
 )
 
-func Validate(ctx context.Context, configPaths []string) error {
-	settings := NewSettings(release.Version(), configPaths)
+func Validate(ctx context.Context, configPaths []string, componentsFn func() (otelcol.Factories, error)) error {
+	settings := NewSettings(release.Version(), configPaths, WithComponents(componentsFn))
 	col, err := otelcol.NewCollector(*settings)
 	if err != nil {
 		return err

--- a/internal/edot/testing/components.go
+++ b/internal/edot/testing/components.go
@@ -1,0 +1,62 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package main
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/nopexporter"
+	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/otelcol"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/processor/batchprocessor"
+	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/nopreceiver"
+
+	"github.com/elastic/elastic-agent/internal/edot/internaltelemetry"
+	"github.com/elastic/elastic-agent/internal/pkg/otel/extension/elasticdiagnostics"
+)
+
+// testComponents returns the minimal set of OTel factories needed by the
+// manager unit tests. Tests only use nop receivers/exporters, batch processor,
+// healthcheckv2 extension (injected by the manager), and elasticdiagnostics
+// extension (force-injected on every startup).
+func testComponents() (otelcol.Factories, error) {
+	var err error
+	factories := otelcol.Factories{
+		Telemetry: internaltelemetry.NewFactory(),
+	}
+
+	factories.Receivers, err = otelcol.MakeFactoryMap[receiver.Factory](
+		nopreceiver.NewFactory(),
+	)
+	if err != nil {
+		return otelcol.Factories{}, err
+	}
+
+	factories.Processors, err = otelcol.MakeFactoryMap[processor.Factory](
+		batchprocessor.NewFactory(),
+	)
+	if err != nil {
+		return otelcol.Factories{}, err
+	}
+
+	factories.Exporters, err = otelcol.MakeFactoryMap[exporter.Factory](
+		nopexporter.NewFactory(),
+	)
+	if err != nil {
+		return otelcol.Factories{}, err
+	}
+
+	factories.Extensions, err = otelcol.MakeFactoryMap[extension.Factory](
+		healthcheckv2extension.NewFactory(),
+		elasticdiagnostics.NewFactory(),
+	)
+	if err != nil {
+		return otelcol.Factories{}, err
+	}
+
+	return factories, nil
+}

--- a/internal/edot/testing/testing.go
+++ b/internal/edot/testing/testing.go
@@ -15,9 +15,11 @@ import (
 
 // This is a test binary used by the OTEL manager unit tests.
 // It mirrors the behavior of the real EDOT binary (internal/edot/main.go)
-// but can be configured via env vars to simulate different scenarios:
+// but registers only the minimal OTel components required by the tests
+// (see components.go) instead of the full EDOT component set.
+// It can be configured via env vars to simulate different scenarios:
 //   - TEST_SUPERVISED_COLLECTOR_PANIC: triggers a panic after the given delay,
-//     allowing tests to verify the manager’s panic/restart behavior.
+//     allowing tests to verify the manager's panic/restart behavior.
 //   - TEST_SUPERVISED_COLLECTOR_DELAY: delays process shutdown by the given
 //     duration, letting tests observe graceful termination handling.
 //
@@ -42,7 +44,7 @@ func main() {
 		})
 	}
 
-	collectorCmd := cmd.NewOtelCommandWithArgs(os.Args, cli.NewIOStreams())
+	collectorCmd := cmd.NewOtelCommandWithArgs(os.Args, cli.NewIOStreams(), testComponents)
 	err = collectorCmd.Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Refactors the EDOT entrypoint to take the component factories as an argument. This allows us to easily build alternative EDOT collectors with different component lists. This PR uses it to aggressively scope the binary we use for otel manager tests to only the necessary components.

The default components for EDOT are moved to a separate package, so we don't unconditionally import all the dependencies.

## Why is it important?

Until now, our otel manager unit tests used the full EDOT collector binary. This meant we had to build it first, which can take a fair amount of time and requires the right toolchain. The fact that it works at all on our buildkite hosts is a happy accident. We recently tried to enable unit tests on ARM windows, and failed to build EDOT without the full toolchain, for example.

This changes makes the unit tests faster and easier to run with just the default Go toolchain.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

Run `mage build:testbinaries` and look at the size of `internal/edot/testing/testing`. This PR reduces it by 90%, `800Mi` -> `80Mi`.

## Related issues

- Relates https://github.com/elastic/elastic-agent/pull/13699

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
