### PR TITLE
Temporarily skip serverless tests in CI

### DIFF
--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -614,6 +614,7 @@ steps:
               - *k8s_max_test_version
 
   - group: "Serverless integration test"
+    skip: "See https://github.com/elastic/elastic-agent/issues/13927"
     key: integration-tests-serverless
     notify:
       - github_commit_status:


### PR DESCRIPTION
See https://github.com/elastic/elastic-agent/issues/13927.