### PR TITLE
Clamp non-positive agent.download.retry_sleep_init_duration to default 30s

### DIFF
--- a/changelog/fragments/1777882926-drosiek-validate-download-retrysleepinit-time.yaml
+++ b/changelog/fragments/1777882926-drosiek-validate-download-retrysleepinit-time.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Clamp non-positive agent.download.retry_sleep_init_duration to default 30s
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/upgrade/artifact/config.go
+++ b/internal/pkg/agent/application/upgrade/artifact/config.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	c "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 )
@@ -174,6 +175,17 @@ func (c *Config) Unpack(cfg *c.C) error {
 
 	if err := cfg.Unpack(&tmp); err != nil {
 		return err
+	}
+
+	// A non-positive RetrySleepInitDuration would be passed straight to
+	// cenkalti/backoff's InitialInterval, which then yields 0 from NextBackOff()
+	// and turns transient download failures into a tight retry loop. Clamp to
+	// the default so a misconfigured policy can't cause that.
+	if tmp.RetrySleepInitDuration <= 0 {
+		def := DefaultConfig().RetrySleepInitDuration
+		logp.L().Warnf("agent.download.retry_sleep_init_duration must be > 0, got %s; using default %s",
+			tmp.RetrySleepInitDuration, def)
+		tmp.RetrySleepInitDuration = def
 	}
 
 	transport := DefaultConfig().HTTPTransportSettings

--- a/internal/pkg/agent/application/upgrade/artifact/config_test.go
+++ b/internal/pkg/agent/application/upgrade/artifact/config_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,4 +74,60 @@ func TestConfig_Unpack(t *testing.T) {
 	err = defaultcfg.Unpack(emptycgf)
 	require.NoError(t, err, "UnpackTo failed")
 	assert.Equal(t, DefaultConfig(), defaultcfg)
+}
+
+// TestConfig_Unpack_RetrySleepInitDuration covers the validation of
+// retry_sleep_init_duration during YAML unpack. A non-positive value would feed
+// directly into cenkalti/backoff's InitialInterval and produce a 0-duration
+// retry loop on transient download failures (see #13505), so the unpack must
+// clamp it back to the default. Positive values must pass through unchanged.
+func TestConfig_Unpack_RetrySleepInitDuration(t *testing.T) {
+	defaultRetry := DefaultConfig().RetrySleepInitDuration
+
+	tcs := []struct {
+		name     string
+		yaml     string
+		expected time.Duration
+	}{
+		{
+			name:     "zero is clamped to default",
+			yaml:     "retry_sleep_init_duration: 0s",
+			expected: defaultRetry,
+		},
+		{
+			name:     "negative is clamped to default",
+			yaml:     "retry_sleep_init_duration: -5s",
+			expected: defaultRetry,
+		},
+		{
+			name:     "sub-nanosecond negative is clamped to default",
+			yaml:     "retry_sleep_init_duration: -1ns",
+			expected: defaultRetry,
+		},
+		{
+			name:     "positive value is preserved",
+			yaml:     "retry_sleep_init_duration: 5s",
+			expected: 5 * time.Second,
+		},
+		{
+			name:     "absent key keeps default",
+			yaml:     "",
+			expected: defaultRetry,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+
+			raw, err := agentlibsconfig.NewConfigFrom(tc.yaml)
+			require.NoError(t, err, "could not create config from yaml")
+
+			err = cfg.Unpack(raw)
+			require.NoError(t, err, "Unpack failed")
+
+			assert.Equal(t, tc.expected, cfg.RetrySleepInitDuration,
+				"RetrySleepInitDuration was not clamped/preserved as expected")
+		})
+	}
 }


### PR DESCRIPTION
## What does this PR do?

Addresses the **P1** finding in [#13505](https://github.com/elastic/elastic-agent/issues/13505) — _non-positive download retry backoff allows immediate/negative retry intervals (retry storm)_ — by validating `agent.download.retry_sleep_init_duration` at config-unpack time.

- **Clamp non-positive values in [`Config.Unpack`](internal/pkg/agent/application/upgrade/artifact/config.go).** When the unpacked YAML value for `retry_sleep_init_duration` is `<= 0`, the value is overridden with the default (`30s`) and a `Warn` log is emitted naming the offending value. The clamp lives at the unpack boundary so every callsite that constructs an `artifact.Config` from operator-provided YAML or Fleet-pushed policy is protected uniformly — the runtime path in [`downloadWithRetries`](internal/pkg/agent/application/upgrade/step_download.go) was left untouched, which keeps validation in one place and avoids duplicate clamping at two layers.

The original issue lists three suggested fix directions: validate at unpack/reload, clamp invalid values, or add a runtime safety net inside `downloadWithRetries`. This PR implements the first two together (validation + clamp + warning) and intentionally drops the runtime safety net — once `Unpack` is the only path through which a `Config` gets populated from external input, a defensive `<= 0` check inside `downloadWithRetries` would be testing a state that the type system already prevents.

### Tests

- `TestConfig_Unpack_RetrySleepInitDuration` — table-driven, five subtests:
  - `zero is clamped to default` — YAML `retry_sleep_init_duration: 0s` → `30s`.
  - `negative is clamped to default` — YAML `retry_sleep_init_duration: -5s` → `30s`.
  - `sub-nanosecond negative is clamped to default` — YAML `retry_sleep_init_duration: -1ns` → `30s` (covers values below the time package's printable resolution).
  - `positive value is preserved` — YAML `retry_sleep_init_duration: 5s` → `5s` (regression guard).
  - `absent key keeps default` — empty YAML → `30s` from `DefaultConfig()` survives unchanged.

The three invalid-input subtests fail on `main` (they observe `0s`, `-5s`, `-1ns` respectively) and pass after the clamp; the two valid-input subtests pass on both `main` and the fix.

## Why is it important?

`agent.download.retry_sleep_init_duration` is exposed in [elastic-agent.yml](elastic-agent.yml) and [elastic-agent.reference.yml](elastic-agent.reference.yml) under `agent.download`, so an operator (standalone) or Fleet-pushed policy can set it. Until now there was no lower-bound check: a value of `0s` (or any negative duration) flowed through [`config.go:Unpack`](internal/pkg/agent/application/upgrade/artifact/config.go) into the `artifact.Config` and from there into [`step_download.go`](internal/pkg/agent/application/upgrade/step_download.go) where it became `cenkalti/backoff/v4`'s `ExponentialBackOff.InitialInterval`. With `InitialInterval <= 0`, `NextBackOff()` returns `0` indefinitely (the multiplier and randomization factor multiply against zero), so transient download failures turn into a tight retry loop bounded only by the operation's CPU cost — hammering artifact endpoints during exactly the network/outage scenarios the backoff was supposed to soften.

Clamping at unpack time fails closed: a misconfigured policy can no longer produce the retry storm, and the `Warn` log gives operators an actionable signal pointing at the offending value.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~ (no behavior change for valid config values; the existing reference docs already document `retry_sleep_init_duration: 30s` as the default)
- [ ] ~~I have made corresponding change to the default configuration files~~ (the default is unchanged)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] ~~I have added an integration test or an E2E test~~ (validation lives entirely at the config-unpack boundary; an integration test would only re-prove what the unit test already covers, with added flakiness from real download timing)

## Disruptive User Impact

Minimal. The only behavior change is for configurations that explicitly set `agent.download.retry_sleep_init_duration` to a non-positive value (`0s`, negative durations). Such configurations were already broken in practice — they produced a retry storm rather than the intended exponential backoff — and are now silently overridden to the documented default of `30s`, with a `Warn` log:

```
agent.download.retry_sleep_init_duration must be > 0, got <value>; using default 30s
```

Operators who deliberately wanted a sub-second initial backoff (which has never been a supported configuration) will need to set a positive value such as `1ms`. No change for any policy that omits the key or sets a positive duration.

## How to test this PR locally

```bash
go test ./internal/pkg/agent/application/upgrade/artifact/ \
  -run TestConfig_Unpack \
  -count=1 -v
```

Manual smoke check: launch a standalone agent with `agent.download.retry_sleep_init_duration: 0s` in `elastic-agent.yml` and confirm the `Warn` line above appears at startup and the in-memory config carries `30s`.

## Related issues

- Relates [#13505](https://github.com/elastic/elastic-agent/issues/13505) (P1 finding only; the P0 stale-marker fix shipped in [#13935](https://github.com/elastic/elastic-agent/pull/13935))

## Questions to ask yourself

- **How are we going to support this in production?** The new `Warn` log line `agent.download.retry_sleep_init_duration must be > 0, got %s; using default %s` fires once per config load when an invalid value is supplied. It names both the offending value and the substituted default, so triage can confirm whether a misconfigured policy was responsible without correlating against multiple log streams.
- **How are we going to measure its adoption?** Aggregate counts of the new `Warn` log across the fleet indicate how many agents had a misconfigured policy in flight. Zero occurrences after the fix rolls out means no operator has the bad value set; a non-zero count is itself the signal that the validation gap was being hit in the wild.
- **How are we going to debug this?** The clamped value is what reaches `downloadWithRetries`, so any subsequent download-retry timing analysis can trust the `RetrySleepInitDuration` field on `artifact.Config` as authoritative. The `Warn` log is the breadcrumb back to the operator-supplied value if a discrepancy is investigated.
