### PR TITLE
testing: inject logger at provisioner construction

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -170,6 +170,14 @@ type Otel mg.Namespace
 // Devmachine namespace contains tasks related to remote development machines.
 type Devmachine mg.Namespace
 
+// magefileLogger satisfies common.Logger for test-framework helpers (like
+// ess.NewClient) that magefile targets construct directly outside the runner.
+type magefileLogger struct{}
+
+func (magefileLogger) Logf(format string, args ...any) {
+	fmt.Fprintf(os.Stdout, ">>> "+format+"\n", args...)
+}
+
 func CheckNoChanges() error {
 	fmt.Println(">> fmt - go run")
 	err := sh.RunV("go", "mod", "tidy", "-v")
@@ -3045,6 +3053,9 @@ func getTestRunnerVersions(cfg *devtools.Settings) (string, string, error) {
 func createTestRunner(cfg *devtools.Settings, matrix bool, singleTest string, goTestFlags string, batches ...define.Batch) (*runner.Runner, error) {
 	goVersion := cfg.GoVersion()
 
+	timestamp := cfg.IntegrationTest.TimestampEnabled
+	logger := runner.NewLogger(timestamp)
+
 	agentVersion, agentStackVersion, err := getTestRunnerVersions(cfg)
 	if err != nil {
 		return nil, err
@@ -3093,11 +3104,11 @@ func createTestRunner(cfg *devtools.Settings, matrix bool, singleTest string, go
 	switch instanceProvisionerMode {
 	case "", gcloud.Name:
 		instanceProvisionerMode = gcloud.Name
-		instanceProvisioner, err = gcloud.NewProvisioner(gcloudCfg)
+		instanceProvisioner, err = gcloud.NewProvisioner(logger, gcloudCfg)
 	case multipass.Name:
-		instanceProvisioner = multipass.NewProvisioner()
+		instanceProvisioner = multipass.NewProvisioner(logger)
 	case kind.Name:
-		instanceProvisioner = kind.NewProvisioner()
+		instanceProvisioner = kind.NewProvisioner(logger)
 	default:
 		return nil, fmt.Errorf("INSTANCE_PROVISIONER environment variable must be one of 'gcloud' or 'multipass', not %s", instanceProvisionerMode)
 	}
@@ -3118,14 +3129,14 @@ func createTestRunner(cfg *devtools.Settings, matrix bool, singleTest string, go
 	switch stackProvisionerMode {
 	case "", ess.ProvisionerStateful:
 		stackProvisionerMode = ess.ProvisionerStateful
-		stackProvisioner, err = ess.NewProvisioner(provisionCfg)
+		stackProvisioner, err = ess.NewProvisioner(logger, provisionCfg)
 		if err != nil {
 			return nil, err
 		}
 	case ess.ProvisionerServerless:
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
-		stackProvisioner, err = ess.NewServerlessProvisioner(ctx, provisionCfg)
+		stackProvisioner, err = ess.NewServerlessProvisioner(ctx, logger, provisionCfg)
 		if err != nil {
 			return nil, err
 		}
@@ -3135,8 +3146,6 @@ func createTestRunner(cfg *devtools.Settings, matrix bool, singleTest string, go
 			ess.ProvisionerServerless,
 			stackProvisionerMode)
 	}
-
-	timestamp := cfg.IntegrationTest.TimestampEnabled
 
 	extraEnv := map[string]string{}
 	if cfg.IntegrationTest.CollectDiag != "" {
@@ -3185,7 +3194,7 @@ func createTestRunner(cfg *devtools.Settings, matrix bool, singleTest string, go
 		BinaryName:     binaryName,
 	}
 
-	r, err := runner.NewRunner(runnerCfg, instanceProvisioner, stackProvisioner, batches...)
+	r, err := runner.NewRunner(runnerCfg, logger, instanceProvisioner, stackProvisioner, batches...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create runner: %w", err)
 	}
@@ -3450,7 +3459,7 @@ func authESS(ctx context.Context) error {
 
 	// Attempt to use API key to check if it's valid
 	for authSuccess := false; !authSuccess; {
-		client := ess.NewClient(ess.Config{ApiKey: essAPIKey})
+		client := ess.NewClient(magefileLogger{}, ess.Config{ApiKey: essAPIKey})
 		u, err := client.GetAccount(ctx, ess.GetAccountRequest{})
 		if err != nil {
 			return fmt.Errorf("unable to successfully connect to ESS API: %w", err)

--- a/pkg/testing/common/instance.go
+++ b/pkg/testing/common/instance.go
@@ -51,9 +51,6 @@ type InstanceProvisioner interface {
 	// Type returns the type of the provisioner.
 	Type() ProvisionerType
 
-	// SetLogger sets the logger for it to use.
-	SetLogger(l Logger)
-
 	// Supported returns true of false if the provisioner supports the given batch.
 	Supported(batch define.OS) bool
 

--- a/pkg/testing/common/stack.go
+++ b/pkg/testing/common/stack.go
@@ -68,9 +68,6 @@ type StackProvisioner interface {
 	// Name returns the name of the stack provisioner.
 	Name() string
 
-	// SetLogger sets the logger for it to use.
-	SetLogger(l Logger)
-
 	// Create creates a stack.
 	Create(ctx context.Context, request StackRequest) (Stack, error)
 

--- a/pkg/testing/ess/client.go
+++ b/pkg/testing/ess/client.go
@@ -20,19 +20,16 @@ type Client struct {
 	logger common.Logger
 }
 
-func NewClient(config Config) *Client {
+func NewClient(logger common.Logger, config Config) *Client {
 	cfg := defaultConfig()
 	cfg.Merge(config)
 
 	c := new(Client)
 	c.client = http.DefaultClient
 	c.config = cfg
+	c.logger = logger
 
 	return c
-}
-
-func (c *Client) SetLogger(logger common.Logger) {
-	c.logger = logger
 }
 
 func (c *Client) doGet(ctx context.Context, relativeUrl string) (*http.Response, error) {

--- a/pkg/testing/ess/client_test.go
+++ b/pkg/testing/ess/client_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func TestClient_CreateAndShutdownDeployment(t *testing.T) {
@@ -20,8 +22,11 @@ func TestClient_CreateAndShutdownDeployment(t *testing.T) {
 		t.Skip("ESS_API_KEY (for QA) environment variable not set")
 	}
 
+	logger, err := logp.NewDevelopmentLogger("ess-test")
+	require.NoError(t, err)
+
 	cfg := Config{ApiKey: essApiKey}
-	client := NewClient(cfg)
+	client := NewClient(&defaultLogger{wrapped: logger}, cfg)
 
 	// Create deployment
 	resp, err := client.CreateDeployment(context.Background(), CreateDeploymentRequest{

--- a/pkg/testing/ess/serverless_provisioner.go
+++ b/pkg/testing/ess/serverless_provisioner.go
@@ -48,10 +48,10 @@ type ServerlessRegions struct {
 }
 
 // NewServerlessProvisioner creates a new StackProvisioner instance for serverless
-func NewServerlessProvisioner(ctx context.Context, cfg ProvisionerConfig) (common.StackProvisioner, error) {
+func NewServerlessProvisioner(ctx context.Context, log common.Logger, cfg ProvisionerConfig) (common.StackProvisioner, error) {
 	prov := &ServerlessProvisioner{
 		cfg: cfg,
-		log: &defaultLogger{wrapped: logp.L()},
+		log: log,
 	}
 	err := prov.CheckCloudRegion(ctx)
 	if err != nil {
@@ -62,11 +62,6 @@ func NewServerlessProvisioner(ctx context.Context, cfg ProvisionerConfig) (commo
 
 func (prov *ServerlessProvisioner) Name() string {
 	return ProvisionerServerless
-}
-
-// SetLogger sets the logger for the
-func (prov *ServerlessProvisioner) SetLogger(l common.Logger) {
-	prov.log = l
 }
 
 // Create creates a stack.

--- a/pkg/testing/ess/serverless_test.go
+++ b/pkg/testing/ess/serverless_test.go
@@ -20,7 +20,9 @@ func TestProvisionGetRegions(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	defer cancel()
 
-	_ = logp.DevelopmentSetup()
+	logger, err := logp.NewDevelopmentLogger("ess-test")
+	require.NoError(t, err)
+
 	key, found, err := GetESSAPIKey()
 	if !found {
 		t.Skip("No credentials found for ESS")
@@ -31,7 +33,7 @@ func TestProvisionGetRegions(t *testing.T) {
 	cfg := ProvisionerConfig{Region: "bad-region-ID", APIKey: key}
 	prov := &ServerlessProvisioner{
 		cfg: cfg,
-		log: &defaultLogger{wrapped: logp.L()},
+		log: &defaultLogger{wrapped: logger},
 	}
 	err = prov.CheckCloudRegion(ctx)
 	require.NoError(t, err)
@@ -43,7 +45,9 @@ func TestStackProvisioner(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	_ = logp.DevelopmentSetup()
+	logger, err := logp.NewDevelopmentLogger("ess-test")
+	require.NoError(t, err)
+
 	key, found, err := GetESSAPIKey()
 	if !found {
 		t.Skip("No credentials found for ESS")
@@ -52,8 +56,9 @@ func TestStackProvisioner(t *testing.T) {
 	require.True(t, found)
 
 	cfg := ProvisionerConfig{Region: "aws-eu-west-1", APIKey: key}
-	provClient, err := NewServerlessProvisioner(ctx, cfg)
+	provClient, err := NewServerlessProvisioner(ctx, &defaultLogger{wrapped: logger}, cfg)
 	require.NoError(t, err)
+
 	request := common.StackRequest{ID: "stack-test-one", Version: "8.9.0"}
 
 	stack, err := provClient.Create(ctx, request)
@@ -72,7 +77,9 @@ func TestStackProvisioner(t *testing.T) {
 }
 
 func TestStartServerless(t *testing.T) {
-	_ = logp.DevelopmentSetup()
+	logger, err := logp.NewDevelopmentLogger("ess-test")
+	require.NoError(t, err)
+
 	key, found, err := GetESSAPIKey()
 	if !found {
 		t.Skip("No credentials found for ESS")
@@ -81,7 +88,7 @@ func TestStartServerless(t *testing.T) {
 	clientHandle := NewServerlessClient("aws-eu-west-1",
 		"observability",
 		key,
-		&defaultLogger{wrapped: logp.L()})
+		&defaultLogger{wrapped: logger})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	defer cancel()

--- a/pkg/testing/ess/statful_provisioner.go
+++ b/pkg/testing/ess/statful_provisioner.go
@@ -48,15 +48,16 @@ type StatefulProvisioner struct {
 }
 
 // NewProvisioner creates the ESS stateful Provisioner
-func NewProvisioner(cfg ProvisionerConfig) (common.StackProvisioner, error) {
+func NewProvisioner(log common.Logger, cfg ProvisionerConfig) (common.StackProvisioner, error) {
 	err := cfg.Validate()
 	if err != nil {
 		return nil, err
 	}
-	essClient := NewClient(Config{
+	essClient := NewClient(log, Config{
 		ApiKey: cfg.APIKey,
 	})
 	return &StatefulProvisioner{
+		logger: log,
 		cfg:    cfg,
 		client: essClient,
 	}, nil
@@ -64,11 +65,6 @@ func NewProvisioner(cfg ProvisionerConfig) (common.StackProvisioner, error) {
 
 func (p *StatefulProvisioner) Name() string {
 	return ProvisionerStateful
-}
-
-func (p *StatefulProvisioner) SetLogger(l common.Logger) {
-	p.logger = l
-	p.client.SetLogger(l)
 }
 
 // Create creates a stack.

--- a/pkg/testing/gcloud/provisioner.go
+++ b/pkg/testing/gcloud/provisioner.go
@@ -46,20 +46,16 @@ type provisioner struct {
 }
 
 // NewProvisioner creates the gcloud provisioner.
-func NewProvisioner(cfg Config) (common.InstanceProvisioner, error) {
+func NewProvisioner(log common.Logger, cfg Config) (common.InstanceProvisioner, error) {
 	err := cfg.Validate()
 	if err != nil {
 		return nil, err
 	}
-	return &provisioner{cfg: cfg}, nil
+	return &provisioner{logger: log, cfg: cfg}, nil
 }
 
 func (p *provisioner) Name() string {
 	return Name
-}
-
-func (p *provisioner) SetLogger(l common.Logger) {
-	p.logger = l
 }
 
 func (p *provisioner) Type() common.ProvisionerType {

--- a/pkg/testing/kubernetes/kind/provisioner.go
+++ b/pkg/testing/kubernetes/kind/provisioner.go
@@ -49,8 +49,8 @@ nodes:
         secure-port: "10257"
 `
 
-func NewProvisioner() common.InstanceProvisioner {
-	return &provisioner{}
+func NewProvisioner(log common.Logger) common.InstanceProvisioner {
+	return &provisioner{logger: log}
 }
 
 type provisioner struct {
@@ -63,10 +63,6 @@ func (p *provisioner) Name() string {
 
 func (p *provisioner) Type() common.ProvisionerType {
 	return common.ProvisionerTypeK8SCluster
-}
-
-func (p *provisioner) SetLogger(l common.Logger) {
-	p.logger = l
 }
 
 func (p *provisioner) Supported(batch define.OS) bool {

--- a/pkg/testing/kubernetes/kind/provisioner.go
+++ b/pkg/testing/kubernetes/kind/provisioner.go
@@ -92,7 +92,7 @@ func (p *provisioner) Provision(ctx context.Context, cfg common.Config, batches 
 			return nil, fmt.Errorf("failed to add k8s tests to image %s: %w", agentImageName, err)
 		}
 
-		exists, err := p.clusterExists(instanceName)
+		exists, err := p.clusterExists(ctx, instanceName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check if cluster exists: %w", err)
 		}
@@ -101,12 +101,12 @@ func (p *provisioner) Provision(ctx context.Context, cfg common.Config, batches 
 			nodeImage := fmt.Sprintf("kindest/node:%s", k8sVersion)
 			clusterConfig := strings.NewReader(clusterCfg)
 
-			ret, err := p.kindCmd(clusterConfig, "create", "cluster", "--name", instanceName, "--image", nodeImage, "--config", "-")
+			ret, err := p.kindCmd(ctx, clusterConfig, "create", "cluster", "--name", instanceName, "--image", nodeImage, "--config", "-")
 			if err != nil {
 				return nil, fmt.Errorf("kind: failed to create cluster %s: %s", instanceName, ret.stderr)
 			}
 
-			exists, err = p.clusterExists(instanceName)
+			exists, err = p.clusterExists(ctx, instanceName)
 			if err != nil {
 				return nil, err
 			}
@@ -118,7 +118,7 @@ func (p *provisioner) Provision(ctx context.Context, cfg common.Config, batches 
 			p.logger.Logf("Kind cluster %s already exists", instanceName)
 		}
 
-		kConfigPath, err := p.writeKubeconfig(instanceName)
+		kConfigPath, err := p.writeKubeconfig(ctx, instanceName)
 		if err != nil {
 			return nil, err
 		}
@@ -155,7 +155,7 @@ func (p *provisioner) Provision(ctx context.Context, cfg common.Config, batches 
 }
 
 func (p *provisioner) LoadImage(ctx context.Context, clusterName string, image string) error {
-	ret, err := p.kindCmd(nil, "load", "docker-image", "--name", clusterName, image)
+	ret, err := p.kindCmd(ctx, nil, "load", "docker-image", "--name", clusterName, image)
 	if err != nil {
 		return fmt.Errorf("kind: load docker-image %s failed: %w: %s", image, err, ret.stderr)
 	}
@@ -210,7 +210,7 @@ func (p *provisioner) Clean(ctx context.Context, cfg common.Config, instances []
 	for _, instance := range instances {
 		// manually check if the cluster exists
 		// kind will not return an error if we try to delete a nonexistent cluster
-		exists, err := p.clusterExists(instance.Name)
+		exists, err := p.clusterExists(ctx, instance.Name)
 		if err != nil {
 			p.logger.Logf("Failed to check if cluster exists: %s", err)
 			continue
@@ -219,7 +219,7 @@ func (p *provisioner) Clean(ctx context.Context, cfg common.Config, instances []
 			p.logger.Logf("Tried to delete instance, but it was not found: %s", instance.Name)
 			continue
 		}
-		err = p.deleteCluster(instance.Name)
+		err = p.deleteCluster(ctx, instance.Name)
 		if err != nil {
 			// prevent a failure from stopping the other instances and clean
 			p.logger.Logf("Delete instance %s failed: %s", instance.Name, err)
@@ -229,8 +229,8 @@ func (p *provisioner) Clean(ctx context.Context, cfg common.Config, instances []
 	return nil
 }
 
-func (p *provisioner) clusterExists(name string) (bool, error) {
-	ret, err := p.kindCmd(nil, "get", "clusters")
+func (p *provisioner) clusterExists(ctx context.Context, name string) (bool, error) {
+	ret, err := p.kindCmd(ctx, nil, "get", "clusters")
 	if err != nil {
 		return false, err
 	}
@@ -243,10 +243,10 @@ func (p *provisioner) clusterExists(name string) (bool, error) {
 	return false, nil
 }
 
-func (p *provisioner) writeKubeconfig(name string) (string, error) {
+func (p *provisioner) writeKubeconfig(ctx context.Context, name string) (string, error) {
 	kubecfg := fmt.Sprintf("%s-kubecfg", name)
 
-	ret, err := p.kindCmd(nil, "get", "kubeconfig", "--name", name)
+	ret, err := p.kindCmd(ctx, nil, "get", "kubeconfig", "--name", name)
 	if err != nil {
 		return "", fmt.Errorf("kind get kubeconfig: stderr: %s: %w", ret.stderr, err)
 	}
@@ -269,10 +269,9 @@ type cmdResult struct {
 	stderr string
 }
 
-func (p *provisioner) kindCmd(stdIn io.Reader, args ...string) (cmdResult, error) {
-
+func (p *provisioner) kindCmd(ctx context.Context, stdIn io.Reader, args ...string) (cmdResult, error) {
 	var stdout, stderr bytes.Buffer
-	cmd := exec.Command("kind", args...)
+	cmd := exec.CommandContext(ctx, "kind", args...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if stdIn != nil {
@@ -285,7 +284,7 @@ func (p *provisioner) kindCmd(stdIn io.Reader, args ...string) (cmdResult, error
 	}, err
 }
 
-func (p *provisioner) deleteCluster(name string) error {
-	_, err := p.kindCmd(nil, "delete", "cluster", "--name", name)
+func (p *provisioner) deleteCluster(ctx context.Context, name string) error {
+	_, err := p.kindCmd(ctx, nil, "delete", "cluster", "--name", name)
 	return err
 }

--- a/pkg/testing/multipass/provisioner.go
+++ b/pkg/testing/multipass/provisioner.go
@@ -34,16 +34,12 @@ type provisioner struct {
 }
 
 // NewProvisioner creates the multipass provisioner
-func NewProvisioner() common.InstanceProvisioner {
-	return &provisioner{}
+func NewProvisioner(log common.Logger) common.InstanceProvisioner {
+	return &provisioner{logger: log}
 }
 
 func (p *provisioner) Name() string {
 	return Name
-}
-
-func (p *provisioner) SetLogger(l common.Logger) {
-	p.logger = l
 }
 
 func (p *provisioner) Type() common.ProvisionerType {

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -76,8 +76,17 @@ type Runner struct {
 	state   State
 }
 
+// NewLogger returns a logger suitable for the runner and provisioners. The
+// timestamp argument controls whether each line is prefixed with a timestamp.
+func NewLogger(timestamp bool) common.Logger {
+	return &runnerLogger{
+		writer:    os.Stdout,
+		timestamp: timestamp,
+	}
+}
+
 // NewRunner creates a new runner based on the provided batches.
-func NewRunner(cfg common.Config, ip common.InstanceProvisioner, sp common.StackProvisioner, batches ...define.Batch) (*Runner, error) {
+func NewRunner(cfg common.Config, log common.Logger, ip common.InstanceProvisioner, sp common.StackProvisioner, batches ...define.Batch) (*Runner, error) {
 	err := cfg.Validate()
 	if err != nil {
 		return nil, err
@@ -93,16 +102,9 @@ func NewRunner(cfg common.Config, ip common.InstanceProvisioner, sp common.Stack
 	}
 	osBatches = filterSupportedOS(osBatches, ip)
 
-	logger := &runnerLogger{
-		writer:    os.Stdout,
-		timestamp: cfg.Timestamp,
-	}
-	ip.SetLogger(logger)
-	sp.SetLogger(logger)
-
 	r := &Runner{
 		cfg:            cfg,
-		logger:         logger,
+		logger:         log,
 		ip:             ip,
 		sp:             sp,
 		batches:        osBatches,

--- a/pkg/testing/runner/runner_test.go
+++ b/pkg/testing/runner/runner_test.go
@@ -40,7 +40,7 @@ func TestNewRunner_Clean(t *testing.T) {
 	}
 	ip := &fakeInstanceProvisioner{}
 	sp := &fakeStackProvisioner{}
-	r, err := NewRunner(cfg, ip, sp)
+	r, err := NewRunner(cfg, NewLogger(false), ip, sp)
 	require.NoError(t, err)
 
 	i1 := common.Instance{
@@ -89,7 +89,7 @@ func TestNewRunner_Clean(t *testing.T) {
 	require.NoError(t, err)
 
 	// create the runner again ensuring that it loads the saved state
-	r, err = NewRunner(cfg, ip, sp)
+	r, err = NewRunner(cfg, NewLogger(false), ip, sp)
 	require.NoError(t, err)
 
 	// clean should use the stored state
@@ -111,9 +111,6 @@ func (p *fakeInstanceProvisioner) Name() string {
 
 func (p *fakeInstanceProvisioner) Type() common.ProvisionerType {
 	return common.ProvisionerTypeVM
-}
-
-func (p *fakeInstanceProvisioner) SetLogger(_ common.Logger) {
 }
 
 func (p *fakeInstanceProvisioner) Supported(_ define.OS) bool {
@@ -149,9 +146,6 @@ type fakeStackProvisioner struct {
 
 func (p *fakeStackProvisioner) Name() string {
 	return "fake"
-}
-
-func (p *fakeStackProvisioner) SetLogger(_ common.Logger) {
 }
 
 func (p *fakeStackProvisioner) Create(_ context.Context, request common.StackRequest) (common.Stack, error) {

--- a/testing/integration/ess/upgrade_integrations_server_test.go
+++ b/testing/integration/ess/upgrade_integrations_server_test.go
@@ -48,13 +48,12 @@ func TestUpgradeIntegrationsServer(t *testing.T) {
 	startVersions := getUpgradeableFIPSVersions(t)
 	endVersion := define.Version()
 
-	prov, err := ess.NewProvisioner(ess.ProvisionerConfig{
+	prov, err := ess.NewProvisioner(t, ess.ProvisionerConfig{
 		Identifier: "it-upgrade-integrations-server",
 		APIKey:     echApiKey,
 		Region:     echRegion,
 	})
 	require.NoError(t, err)
-	prov.SetLogger(t)
 	statefulProv, ok := prov.(*ess.StatefulProvisioner)
 	require.True(t, ok)
 


### PR DESCRIPTION
<!-- Type of change: Cleanup -->

## What does this PR do?

Make `common.Logger` a required constructor argument for every test-framework provisioner (and the inner `ess.Client`). Removes `SetLogger` from the `StackProvisioner` / `InstanceProvisioner` interfaces. Replaces the deprecated `logp.DevelopmentSetup()` calls in `serverless_test.go` with per-test `logp.NewDevelopmentLogger` instances passed at construction.

Surface area:

- **Interfaces** — drop `SetLogger` from [`common.StackProvisioner`](pkg/testing/common/stack.go) and [`common.InstanceProvisioner`](pkg/testing/common/instance.go).
- **New constructor signatures** — `ess.NewProvisioner(log, cfg)`, `ess.NewServerlessProvisioner(ctx, log, cfg)`, `gcloud.NewProvisioner(log, cfg)`, `kind.NewProvisioner(log)`, `multipass.NewProvisioner(log)`, `ess.NewClient(log, cfg)`. Convention: `ctx → log → cfg`.
- **Runner** — new public [`runner.NewLogger(timestamp bool) common.Logger`](pkg/testing/runner/runner.go); [`runner.NewRunner`](pkg/testing/runner/runner.go) takes `log` as second arg; internal `SetLogger` calls removed.
- **Callers** — `magefile.go` (constructs the logger once and threads it everywhere; tiny `magefileLogger` for the `authESS` `ess.NewClient` call), `runner_test.go` (fakes drop `SetLogger`), `serverless_test.go`, `client_test.go`, `upgrade_integrations_server_test.go` (passes `t` — `*testing.T` already implements `common.Logger`).
- **Piggyback unblocker** — [`pkg/testing/kubernetes/kind/provisioner.go`](pkg/testing/kubernetes/kind/provisioner.go): `exec.Command` → `exec.CommandContext`, ctx plumbed through `kindCmd` / `clusterExists` / `writeKubeconfig` / `deleteCluster`. This file's pre-existing `noctx` finding would otherwise fail CI's changed-files lint scope. Maps to a PR-C6 item in [#13976](https://github.com/elastic/elastic-agent/issues/13976).

## Why is it important?

`logp.DevelopmentSetup` is deprecated in `elastic-agent-libs v0.41.1` (`SA1019`). The naive `DevelopmentSetup` → `NewDevelopmentLogger` swap doesn't work because `DevelopmentSetup` mutates the global `logp.L()` while `NewDevelopmentLogger` returns an independent `*Logger`; `ess.NewServerlessProvisioner` silently defaults its logger to `logp.L()`, so the old test relied on the global being configured. Fixing SA1019 cleanly requires injecting the logger explicitly. While doing it, the interface-level `SetLogger` and the unwritten "caller must call SetLogger before use" contract come out too — a logger is now a compile-time requirement.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~ — internal test-framework refactor.
- [ ] ~~I have made corresponding change to the default configuration files~~ — no configuration surface affected.
- [x] I have added tests that prove my fix is effective or that my feature works — existing `pkg/testing/runner` and `pkg/testing/gcloud` unit tests cover the changed call paths and pass; `pkg/testing/ess/...` tests compile against the new signatures (gated on `ESS_API_KEY` for execution).
- [ ] ~~I have added an entry in `./changelog/fragments`~~ — no user-visible behaviour change. Use `skip-changelog`.
- [ ] ~~I have added an integration test or an E2E test~~ — covered by existing integration suites via `magefile.go`.

## Disruptive User Impact

None for end users. Out-of-tree consumers of `pkg/testing/...` need a one-line update per provisioner-construction call site; custom `StackProvisioner` / `InstanceProvisioner` implementations must drop their `SetLogger` method. The compiler points at every site that needs an update.

## How to test this PR locally

```bash
go build ./...
go test ./pkg/testing/runner/... ./pkg/testing/gcloud/... ./pkg/testing/ess/...
go vet -tags=integration ./testing/...
GOTOOLCHAIN=go1.25.9 ./bin/golangci-lint run ./pkg/testing/kubernetes/kind/...   # confirms noctx fix
grep -rn "SetLogger" --include="*.go" --exclude-dir=beats .                      # expect: no matches
```

## Related issues

- Relates [#13976](https://github.com/elastic/elastic-agent/issues/13976) — closes PR-B1 (`logp.DevelopmentSetup` SA1019) and one item from PR-C6 (`kind` provisioner `noctx`).

## Questions to ask yourself

- **How are we going to support this in production?** Test-framework-only; production runtime unaffected.
- **How are we going to measure its adoption?** Compile-time enforcement.
- **How are we going to debug this?** Logger constructed in one place (`createTestRunner`) and threaded explicitly.
- **What are the metrics I should take care of?** None.
