### PR TITLE
Make otel runtime the default for filebeat inputs

### DIFF
--- a/changelog/fragments/1777903110-make-otel-runtime-the-default-for-filebeat-inputs..yaml
+++ b/changelog/fragments/1777903110-make-otel-runtime-the-default-for-filebeat-inputs..yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Make otel runtime the default for filebeat inputs.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/13991
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/elastic/ingest-dev/issues/7319

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -60,6 +60,7 @@ func DefaultRuntimeConfig() *RuntimeConfig {
 			InputType: map[string]string{},
 		},
 		Filebeat: BeatRuntimeConfig{
+			Default: string(OtelRuntimeManager),
 			// go-ucfg sets this while unpacking, having it in the default makes testing easier
 			InputType: make(map[string]string),
 		},
@@ -68,7 +69,6 @@ func DefaultRuntimeConfig() *RuntimeConfig {
 }
 
 func (r *RuntimeConfig) Validate() error {
-
 	validateRuntime := func(val string, allowEmpty bool) error {
 		if allowEmpty && val == "" {
 			return nil

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -704,7 +704,7 @@ func TestToComponents(t *testing.T) {
 							Err:      fmt.Errorf("decoding error: %w", makeMapStructureErr(t)),
 						},
 					},
-					RuntimeManager: DefaultRuntimeManager,
+					RuntimeManager: OtelRuntimeManager,
 				},
 			},
 		},
@@ -930,7 +930,7 @@ func TestToComponents(t *testing.T) {
 							}),
 						},
 					},
-					RuntimeManager: DefaultRuntimeManager,
+					RuntimeManager: OtelRuntimeManager,
 				},
 			},
 		},
@@ -980,6 +980,15 @@ func TestToComponents(t *testing.T) {
 							}),
 						},
 						{
+							ID:       "filestream-default-filestream-0",
+							Type:     client.UnitTypeInput,
+							LogLevel: defaultUnitLogLevel,
+							Config: MustExpectedConfig(map[string]interface{}{
+								"type": "filestream",
+								"id":   "filestream-0",
+							}),
+						},
+						{
 							ID:       "filestream-default-filestream-2",
 							Type:     client.UnitTypeInput,
 							LogLevel: defaultUnitLogLevel,
@@ -1006,15 +1015,6 @@ func TestToComponents(t *testing.T) {
 							LogLevel: defaultUnitLogLevel,
 							Config: MustExpectedConfig(map[string]interface{}{
 								"type": "elasticsearch",
-							}),
-						},
-						{
-							ID:       "filestream-default-filestream-0",
-							Type:     client.UnitTypeInput,
-							LogLevel: defaultUnitLogLevel,
-							Config: MustExpectedConfig(map[string]interface{}{
-								"type": "filestream",
-								"id":   "filestream-0",
 							}),
 						},
 						{
@@ -1552,7 +1552,7 @@ func TestToComponents(t *testing.T) {
 							}),
 						},
 					},
-					RuntimeManager: DefaultRuntimeManager,
+					RuntimeManager: OtelRuntimeManager,
 				},
 			},
 		},
@@ -1665,7 +1665,7 @@ func TestToComponents(t *testing.T) {
 							}),
 						},
 					},
-					RuntimeManager: DefaultRuntimeManager,
+					RuntimeManager: OtelRuntimeManager,
 				},
 			},
 		},
@@ -1836,7 +1836,7 @@ func TestToComponents(t *testing.T) {
 							}),
 						},
 					},
-					RuntimeManager: DefaultRuntimeManager,
+					RuntimeManager: OtelRuntimeManager,
 				},
 				{
 					InputType:  "filestream",
@@ -1874,7 +1874,7 @@ func TestToComponents(t *testing.T) {
 							}),
 						},
 					},
-					RuntimeManager: DefaultRuntimeManager,
+					RuntimeManager: OtelRuntimeManager,
 				},
 				{
 					InputType:  "log",
@@ -1911,7 +1911,7 @@ func TestToComponents(t *testing.T) {
 							}),
 						},
 					},
-					RuntimeManager: DefaultRuntimeManager,
+					RuntimeManager: OtelRuntimeManager,
 				},
 				{
 					InputType:  "log",
@@ -1940,7 +1940,7 @@ func TestToComponents(t *testing.T) {
 							}, "log"),
 						},
 					},
-					RuntimeManager: DefaultRuntimeManager,
+					RuntimeManager: OtelRuntimeManager,
 				},
 				{
 					InputType:  "log",
@@ -1969,7 +1969,7 @@ func TestToComponents(t *testing.T) {
 							}, "log"),
 						},
 					},
-					RuntimeManager: DefaultRuntimeManager,
+					RuntimeManager: OtelRuntimeManager,
 				},
 				{
 					InputType:  "log",
@@ -1998,7 +1998,7 @@ func TestToComponents(t *testing.T) {
 							}, "log"),
 						},
 					},
-					RuntimeManager: DefaultRuntimeManager,
+					RuntimeManager: OtelRuntimeManager,
 				},
 				{
 					InputType:  "apm",
@@ -2457,7 +2457,7 @@ func TestToComponents(t *testing.T) {
 							}),
 						},
 					},
-					RuntimeManager: DefaultRuntimeManager,
+					RuntimeManager: OtelRuntimeManager,
 				},
 			},
 		},
@@ -2510,7 +2510,7 @@ func TestToComponents(t *testing.T) {
 							}),
 						},
 					},
-					RuntimeManager: DefaultRuntimeManager,
+					RuntimeManager: OtelRuntimeManager,
 				},
 			},
 			headers: &testHeadersProvider{headers: map[string]string{
@@ -2628,7 +2628,7 @@ func TestToComponents(t *testing.T) {
 							}),
 						},
 					},
-					RuntimeManager: DefaultRuntimeManager,
+					RuntimeManager: OtelRuntimeManager,
 				},
 			},
 			headers: &testHeadersProvider{headers: map[string]string{
@@ -2745,7 +2745,7 @@ func TestToComponents(t *testing.T) {
 							}),
 						},
 					},
-					RuntimeManager: DefaultRuntimeManager,
+					RuntimeManager: OtelRuntimeManager,
 				},
 			},
 			headers: &testHeadersProvider{headers: map[string]string{
@@ -2851,7 +2851,7 @@ func TestToComponents(t *testing.T) {
 							}),
 						},
 					},
-					RuntimeManager: DefaultRuntimeManager,
+					RuntimeManager: OtelRuntimeManager,
 				},
 			},
 			headers: &testHeadersProvider{headers: map[string]string{
@@ -2930,7 +2930,7 @@ func TestToComponents(t *testing.T) {
 				assert.Equal(t, scenario.Err, err.Error())
 			} else {
 				require.NoError(t, err)
-				require.Len(t, result, len(scenario.Result))
+				require.Lenf(t, result, len(scenario.Result), "actual: %v\nexpected %v\n", result, scenario.Result)
 				sortComponents(scenario.Result)
 				sortComponents(result)
 				for i, expected := range scenario.Result {
@@ -3962,7 +3962,7 @@ func TestDefaultRuntimeConfig(t *testing.T) {
 	require.NotNil(t, config)
 	assert.Equal(t, string(DefaultRuntimeManager), config.Default)
 	assert.Equal(t, string(ProcessRuntimeManager), config.DynamicInputs)
-	assert.Equal(t, "", config.Filebeat.Default)
+	assert.Equal(t, "otel", config.Filebeat.Default)
 	assert.Empty(t, config.Filebeat.InputType)
 	assert.Equal(t, string(OtelRuntimeManager), config.Metricbeat.Default)
 	assert.Equal(t, map[string]string{}, config.Metricbeat.InputType)

--- a/testing/integration/ess/container_cmd_test.go
+++ b/testing/integration/ess/container_cmd_test.go
@@ -335,13 +335,45 @@ func TestContainerCMDEventToStderr(t *testing.T) {
 	require.NoError(t, agentFixture.Prepare(ctx), "failed preparing agent fixture")
 
 	_, outputID := createMockESOutput(t, info, 0, 0, 100, 0)
+	policyName := fmt.Sprintf("%s-%s", t.Name(), uuid.Must(uuid.NewV4()).String())
 	policyID, enrollmentAPIKey := createPolicy(
 		t,
 		ctx,
 		agentFixture,
 		info,
-		fmt.Sprintf("%s-%s", t.Name(), uuid.Must(uuid.NewV4()).String()),
+		policyName,
 		outputID)
+
+	reqBody := fmt.Sprintf(`
+{
+  "name": "%s",
+  "namespace": "default",
+  "overrides": {
+    "agent": {
+      "internal": {
+        "runtime": {
+          "filebeat": {
+            "default": "process"
+          }
+        }
+      }
+    }
+  }
+}
+`, policyName)
+
+	status, result, err := info.KibanaClient.Request(
+		http.MethodPut,
+		fmt.Sprintf("/api/fleet/agent_policies/%s", policyID),
+		nil,
+		nil,
+		bytes.NewBufferString(reqBody))
+	if err != nil {
+		t.Fatalf("could not execute request to update policy: %s", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("updating policy failed. Status code %d, response:\n%s", status, string(result))
+	}
 
 	fleetURL, err := fleettools.DefaultURL(ctx, info.KibanaClient)
 	if err != nil {
@@ -677,7 +709,7 @@ func TestContainerCMDAgentMonitoringRuntimeExperimentalPolicy(t *testing.T) {
 						// See https://github.com/elastic/elastic-agent/issues/11162.
 					default:
 						// Non-monitoring components should use the default runtime
-						assert.Equalf(ct, string(component.DefaultRuntimeManager), compRuntime, "expected default runtime for non-monitoring component %s with id %s", comp.Name, comp.ID)
+						assert.Equalf(ct, string(component.OtelRuntimeManager), compRuntime, "expected default runtime for non-monitoring component %s with id %s", comp.Name, comp.ID)
 					}
 				}
 			}, 1*time.Minute, 1*time.Second,

--- a/testing/integration/ess/event_logging_test.go
+++ b/testing/integration/ess/event_logging_test.go
@@ -68,6 +68,7 @@ agent.monitoring:
 agent.grpc:
   address: localhost
   port: 7001
+agent.internal.runtime.filebeat.default: process
 `
 
 func TestEventLogFile(t *testing.T) {
@@ -263,7 +264,6 @@ func TestEventLogOutputConfiguredViaFleet(t *testing.T) {
 
 		return false
 	}, 3*time.Minute, 10*time.Second, "cannot find events on stderr")
-
 }
 
 func addOverwriteToPolicy(t *testing.T, info *define.Info, policyName, policyID string) {
@@ -333,7 +333,6 @@ func readEventLogFile(t *testing.T, agentFixture *atesting.Fixture) string {
 		}
 
 		return false
-
 	}, time.Minute, time.Second, "could not find event log file")
 
 	logEntryBytes, err := os.ReadFile(logFileName)
@@ -388,8 +387,8 @@ func collectDiagnosticsAndVeriflyLogs(
 	ctx context.Context,
 	agentFixture *atesting.Fixture,
 	cmd,
-	expectedFiles []string) {
-
+	expectedFiles []string,
+) {
 	diagPath, err := agentFixture.ExecDiagnostics(ctx, cmd...)
 	if err != nil {
 		t.Fatalf("could not execute diagnostics excluding events log: %s", err)
@@ -413,7 +412,6 @@ func getLogFilenames(
 	t *testing.T,
 	basepath string,
 ) (logFiles, eventLogFiles []string) {
-
 	logFilesGlob := filepath.Join(basepath, "*.ndjson")
 	logFilesPath, err := filepath.Glob(logFilesGlob)
 	if err != nil {


### PR DESCRIPTION
## What does this PR do?

Changes the default for filebeat inputs from process runtime to otel runtime.

## Why is it important?

Continue moving to beat receivers for inputs.

## Checklist

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

Should not have a disruptive impact.  Can be reverted by setting
`agent.internal.runtime.filebeat.default` to `process` in the policy.


## How to test this PR locally

1. Run a policy with filebeat inputs
2. Verify that data is ingested correctly
3. Verify that `agentbeat filebeat` is not running

## Related issues

- Closes elastic/ingest-dev#7319

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
