### PR TITLE
Preserve unexpired available rollback agent versions during rollback

### DIFF
--- a/changelog/fragments/1777976666-drosiek-rollback-prune-issue.yaml
+++ b/changelog/fragments/1777976666-drosiek-rollback-prune-issue.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Preserve unexpired available rollback agent versions during rollback
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/ttl"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
 	"github.com/elastic/elastic-agent/pkg/backoff"
@@ -128,18 +129,16 @@ func RollbackWithOpts(ctx context.Context, log *logger.Logger, c client.Client, 
 	}
 
 	// cleanup everything except the version we're rolling back into and any
-	// in-TTL rollback targets recorded in the marker. The marker load is
-	// best-effort: if it fails or the marker is absent we fall back to
-	// preserving only prevVersionedHome rather than aborting the rollback.
+	// in-TTL rollback targets recorded in the live TTL registry. The registry
+	// read is best-effort: if it fails we fall back to preserving only
+	// prevVersionedHome rather than aborting the rollback.
 	versionedHomesToKeep := []string{prevVersionedHome}
-	marker, markerErr := LoadMarker(paths.DataFrom(topDirPath))
-	if markerErr != nil {
-		log.Warnw("could not load update marker; cleanup will only preserve the rollback target",
-			"error.message", markerErr.Error())
-	}
-
-	if marker != nil {
-		versionedHomesToKeep = AppendAvailableRollbacks(log, marker, versionedHomesToKeep)
+	inTTL, err := InTTLRollbacks(log, topDirPath, time.Now())
+	if err != nil {
+		log.Infow("could not read TTL registry; cleanup will only preserve the rollback target",
+			"error.message", err.Error())
+	} else {
+		versionedHomesToKeep = append(versionedHomesToKeep, inTTL...)
 	}
 	return Cleanup(log, topDirPath, settings.RemoveMarker, true, versionedHomesToKeep...)
 }
@@ -226,16 +225,38 @@ func cleanup(log *logger.Logger, topDirPath string, removeMarker, keepLogs bool,
 	return cumulativeError
 }
 
-// AppendAvailableRollbacks appends every versioned home listed in
-// marker.RollbacksAvailable to versionedHomesToKeep and returns the result.
-// It is the canonical way to fold TTL-tracked rollback targets into a Cleanup
-// keep list so callers stay consistent.
-func AppendAvailableRollbacks(log *logger.Logger, marker *UpdateMarker, versionedHomesToKeep []string) []string {
-	for versionedHome, ra := range marker.RollbacksAvailable {
-		log.Debugf("Adding available rollback %s:%+v to the directories to keep during cleanup", versionedHome, ra)
-		versionedHomesToKeep = append(versionedHomesToKeep, versionedHome)
+// InTTLRollbacks reads the live TTL registry under topDir and returns the
+// versioned homes whose .ttl is parseable AND not expired (i.e. that
+// CleanupExpiredRollbacks would NOT remove). Reusing the cleanup predicate
+// keeps the keep-list and the periodic cleanup in lock-step.
+//
+// Directories whose .ttl is unparseable are deliberately NOT included: under
+// the current registry contract a parseable TTL is the only proof an install
+// is a valid rollback target, so a malformed entry is treated like a missing
+// one — the directory is unprotected and will be swept by Cleanup. This
+// preserves the self-healing property that a corrupt .ttl outside the active
+// install gets reaped at the next rollback.
+//
+// GetAll (vs. Get) is used so that one corrupt .ttl file does not prevent the
+// other in-TTL entries from being preserved.
+func InTTLRollbacks(log *logger.Logger, topDir string, now time.Time) ([]string, error) {
+	markers, malformed, err := ttl.NewTTLMarkerRegistry(log, topDir).GetAll()
+	if err != nil {
+		return nil, fmt.Errorf("getting available rollbacks: %w", err)
 	}
-	return versionedHomesToKeep
+	var inTTL []string
+	for versionedHome, ttlMarker := range markers {
+		if CleanupExpiredRollbacks(log, now, versionedHome, ttlMarker) {
+			continue
+		}
+		log.Debugf("Adding rollback %s:%+v to the directories to keep during cleanup", versionedHome, ttlMarker)
+		inTTL = append(inTTL, versionedHome)
+	}
+	for versionedHome, parseErr := range malformed {
+		log.Infow("rollback directory has unparseable TTL marker; not protecting it from cleanup",
+			"versionedHome", versionedHome, "error.message", parseErr.Error())
+	}
+	return inTTL, nil
 }
 
 // InvokeWatcher invokes an agent instance using watcher argument for watching behavior of

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -213,6 +213,18 @@ func cleanup(log *logger.Logger, topDirPath string, removeMarker, keepLogs bool,
 	return cumulativeError
 }
 
+// AppendAvailableRollbacks appends every versioned home listed in
+// marker.RollbacksAvailable to versionedHomesToKeep and returns the result.
+// It is the canonical way to fold TTL-tracked rollback targets into a Cleanup
+// keep list so callers stay consistent.
+func AppendAvailableRollbacks(log *logger.Logger, marker *UpdateMarker, versionedHomesToKeep []string) []string {
+	for versionedHome, ra := range marker.RollbacksAvailable {
+		log.Debugf("Adding available rollback %s:%+v to the directories to keep during cleanup", versionedHome, ra)
+		versionedHomesToKeep = append(versionedHomesToKeep, versionedHome)
+	}
+	return versionedHomesToKeep
+}
+
 // InvokeWatcher invokes an agent instance using watcher argument for watching behavior of
 // agent during upgrade period.
 func InvokeWatcher(log *logger.Logger, agentExecutable string, additionalWatchArgs ...string) (*exec.Cmd, error) {

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -127,8 +127,21 @@ func RollbackWithOpts(ctx context.Context, log *logger.Logger, c client.Client, 
 		return nil
 	}
 
-	// cleanup everything except version we're rolling back into
-	return Cleanup(log, topDirPath, settings.RemoveMarker, true, prevVersionedHome)
+	// cleanup everything except the version we're rolling back into and any
+	// in-TTL rollback targets recorded in the marker. The marker load is
+	// best-effort: if it fails or the marker is absent we fall back to
+	// preserving only prevVersionedHome rather than aborting the rollback.
+	versionedHomesToKeep := []string{prevVersionedHome}
+	marker, markerErr := LoadMarker(paths.DataFrom(topDirPath))
+	if markerErr != nil {
+		log.Warnw("could not load update marker; cleanup will only preserve the rollback target",
+			"error.message", markerErr.Error())
+	}
+
+	if marker != nil {
+		versionedHomesToKeep = AppendAvailableRollbacks(log, marker, versionedHomesToKeep)
+	}
+	return Cleanup(log, topDirPath, settings.RemoveMarker, true, versionedHomesToKeep...)
 }
 
 // Cleanup removes all artifacts and files related to a specified version.

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -21,6 +21,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/ttl"
 	"github.com/elastic/elastic-agent/pkg/control/v2/client"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
@@ -775,4 +776,87 @@ func createUpdateMarker(t *testing.T, log *logger.Logger, topDir, newAgentVersio
 		oldAgentInstall,
 		nil, nil, nil)
 	require.NoError(t, err, "error writing fake update marker")
+}
+
+// TestRollbackWithOpts_PreservesInTTLRollbacksAvailable encodes the
+// multi-rollback retention contract for RollbackWithOpts: in-TTL entries in
+// marker.RollbacksAvailable must survive a rollback regardless of which one is
+// chosen as the rollback target.
+//
+// Setup:
+//   - Three on-disk installs A, B, C.
+//   - Symlink points at C (the failing upgrade).
+//   - Update marker records C as new, A as previous, with both A and B listed
+//     in RollbacksAvailable with future TTLs.
+//
+// We roll back to A. B (also unexpired) must survive. On `main` it does not,
+// because RollbackWithOpts hard-codes the cleanup keep list to
+// [prevVersionedHome] — see
+// build/rollback-cleanup-deletes-other-rollback-targets.md. The
+// "other in-TTL rollback target B is preserved" subtest is the failing
+// demonstrator and will pass once the keep list is widened to union
+// marker.RollbacksAvailable.
+func TestRollbackWithOpts_PreservesInTTLRollbacksAvailable(t *testing.T) {
+	agentExecutableName := AgentName
+	if runtime.GOOS == "windows" {
+		agentExecutableName += ".exe"
+	}
+
+	versionA := testAgentVersion{version: "1.0.0", hash: "aaaaaa"}
+	versionB := testAgentVersion{version: "2.0.0", hash: "bbbbbb"}
+	versionC := testAgentVersion{version: "3.0.0", hash: "cccccc"}
+
+	testLogger, _ := loggertest.New(t.Name())
+	testTop := t.TempDir()
+
+	relA := createFakeAgentInstall(t, testTop, versionA.version, versionA.hash, true)
+	relB := createFakeAgentInstall(t, testTop, versionB.version, versionB.hash, true)
+	relC := createFakeAgentInstall(t, testTop, versionC.version, versionC.hash, true)
+
+	createLink(t, testTop, relC)
+
+	validUntil := time.Now().Add(24 * time.Hour)
+	availableRollbacks := map[string]ttl.TTLMarker{
+		relA: {Version: versionA.version, Hash: versionA.hash, ValidUntil: validUntil},
+		relB: {Version: versionB.version, Hash: versionB.hash, ValidUntil: validUntil},
+	}
+
+	markUpgrade := markUpgradeProvider(UpdateActiveCommit, os.WriteFile)
+	err := markUpgrade(
+		testLogger,
+		paths.DataFrom(testTop),
+		time.Now(),
+		agentInstall{version: versionC.version, hash: versionC.hash, versionedHome: relC},
+		agentInstall{version: versionA.version, hash: versionA.hash, versionedHome: relA},
+		nil, nil, availableRollbacks,
+	)
+	require.NoError(t, err, "writing update marker with two RollbacksAvailable entries")
+
+	mockClient := client.NewMockClient(t)
+	mockClient.EXPECT().Connect(
+		mock.AnythingOfType("*context.timerCtx"),
+		mock.AnythingOfType("*grpc.funcDialOption"),
+		mock.AnythingOfType("*grpc.funcDialOption"),
+	).Return(nil)
+	mockClient.EXPECT().Disconnect().Return()
+	mockClient.EXPECT().Restart(mock.Anything).Return(nil).Once()
+
+	err = RollbackWithOpts(t.Context(), testLogger, mockClient, testTop, relA, versionA.hash)
+	require.NoError(t, err, "RollbackWithOpts to A")
+
+	t.Run("rollback target A is preserved", func(t *testing.T) {
+		assertAgentInstallExists(t, filepath.Join(testTop, relA), agentExecutableName)
+	})
+
+	t.Run("failing upgrade C is cleaned up", func(t *testing.T) {
+		assertAgentInstallCleaned(t, filepath.Join(testTop, relC), agentExecutableName)
+	})
+
+	t.Run("other in-TTL rollback target B is preserved", func(t *testing.T) {
+		// EXPECTED: B's directory should survive — its TTL has not expired and
+		// it is listed in marker.RollbacksAvailable. Currently FAILS on main:
+		// RollbackWithOpts -> Cleanup is invoked with keep list [A], so B is
+		// removed despite its retention contract.
+		assertAgentInstallExists(t, filepath.Join(testTop, relB), agentExecutableName)
+	})
 }

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -789,13 +789,7 @@ func createUpdateMarker(t *testing.T, log *logger.Logger, topDir, newAgentVersio
 //   - Update marker records C as new, A as previous, with both A and B listed
 //     in RollbacksAvailable with future TTLs.
 //
-// We roll back to A. B (also unexpired) must survive. On `main` it does not,
-// because RollbackWithOpts hard-codes the cleanup keep list to
-// [prevVersionedHome] — see
-// build/rollback-cleanup-deletes-other-rollback-targets.md. The
-// "other in-TTL rollback target B is preserved" subtest is the failing
-// demonstrator and will pass once the keep list is widened to union
-// marker.RollbacksAvailable.
+// We roll back to A. B (also unexpired) must survive
 func TestRollbackWithOpts_PreservesInTTLRollbacksAvailable(t *testing.T) {
 	agentExecutableName := AgentName
 	if runtime.GOOS == "windows" {

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -815,6 +815,10 @@ func TestRollbackWithOpts_PreservesInTTLRollbacksAvailable(t *testing.T) {
 		relB: {Version: versionB.version, Hash: versionB.hash, ValidUntil: validUntil},
 	}
 
+	require.NoError(t,
+		ttl.NewTTLMarkerRegistry(testLogger, testTop).Set(availableRollbacks),
+		"writing TTL registry with two valid entries")
+
 	markUpgrade := markUpgradeProvider(UpdateActiveCommit, os.WriteFile)
 	err := markUpgrade(
 		testLogger,
@@ -847,10 +851,156 @@ func TestRollbackWithOpts_PreservesInTTLRollbacksAvailable(t *testing.T) {
 	})
 
 	t.Run("other in-TTL rollback target B is preserved", func(t *testing.T) {
-		// EXPECTED: B's directory should survive — its TTL has not expired and
-		// it is listed in marker.RollbacksAvailable. Currently FAILS on main:
-		// RollbackWithOpts -> Cleanup is invoked with keep list [A], so B is
-		// removed despite its retention contract.
+		// B's directory must survive — its TTL has not expired and the live
+		// TTL registry still lists it as a valid rollback target.
 		assertAgentInstallExists(t, filepath.Join(testTop, relB), agentExecutableName)
+	})
+}
+
+// TestRollbackWithOpts_RemovesMalformedTTLRollbacksAvailable verifies that a
+// directory whose .ttl marker is corrupt is NOT preserved by post-rollback
+// cleanup. Under the registry contract a parseable TTL is the only proof an
+// install is a valid rollback target, so a malformed entry is treated like a
+// missing one. This preserves the self-healing property that a corrupt .ttl
+// outside the active install gets reaped at the next rollback, allowing
+// future upgrades to proceed against a clean registry.
+func TestRollbackWithOpts_RemovesMalformedTTLRollbacksAvailable(t *testing.T) {
+	agentExecutableName := AgentName
+	if runtime.GOOS == "windows" {
+		agentExecutableName += ".exe"
+	}
+
+	versionA := testAgentVersion{version: "1.0.0", hash: "aaaaaa"}
+	versionB := testAgentVersion{version: "2.0.0", hash: "bbbbbb"}
+	versionC := testAgentVersion{version: "3.0.0", hash: "cccccc"}
+
+	testLogger, _ := loggertest.New(t.Name())
+	testTop := t.TempDir()
+
+	relA := createFakeAgentInstall(t, testTop, versionA.version, versionA.hash, true)
+	relB := createFakeAgentInstall(t, testTop, versionB.version, versionB.hash, true)
+	relC := createFakeAgentInstall(t, testTop, versionC.version, versionC.hash, true)
+
+	createLink(t, testTop, relC)
+
+	// A has a valid in-TTL marker; B has a corrupt one (unparseable YAML).
+	// Both directories must survive the rollback to A.
+	now := time.Now()
+	availableRollbacks := map[string]ttl.TTLMarker{
+		relA: {Version: versionA.version, Hash: versionA.hash, ValidUntil: now.Add(24 * time.Hour)},
+	}
+	require.NoError(t,
+		ttl.NewTTLMarkerRegistry(testLogger, testTop).Set(availableRollbacks),
+		"writing TTL registry with single valid entry")
+	require.NoError(t,
+		os.WriteFile(filepath.Join(testTop, relB, ".ttl"), []byte("this is not yaml"), 0644),
+		"writing corrupt .ttl for B")
+
+	markUpgrade := markUpgradeProvider(UpdateActiveCommit, os.WriteFile)
+	err := markUpgrade(
+		testLogger,
+		paths.DataFrom(testTop),
+		now,
+		agentInstall{version: versionC.version, hash: versionC.hash, versionedHome: relC},
+		agentInstall{version: versionA.version, hash: versionA.hash, versionedHome: relA},
+		nil, nil, availableRollbacks,
+	)
+	require.NoError(t, err, "writing update marker")
+
+	mockClient := client.NewMockClient(t)
+	mockClient.EXPECT().Connect(
+		mock.AnythingOfType("*context.timerCtx"),
+		mock.AnythingOfType("*grpc.funcDialOption"),
+		mock.AnythingOfType("*grpc.funcDialOption"),
+	).Return(nil)
+	mockClient.EXPECT().Disconnect().Return()
+	mockClient.EXPECT().Restart(mock.Anything).Return(nil).Once()
+
+	err = RollbackWithOpts(t.Context(), testLogger, mockClient, testTop, relA, versionA.hash)
+	require.NoError(t, err, "RollbackWithOpts to A")
+
+	t.Run("rollback target A is preserved", func(t *testing.T) {
+		assertAgentInstallExists(t, filepath.Join(testTop, relA), agentExecutableName)
+	})
+
+	t.Run("failing upgrade C is cleaned up", func(t *testing.T) {
+		assertAgentInstallCleaned(t, filepath.Join(testTop, relC), agentExecutableName)
+	})
+
+	t.Run("install B with corrupt .ttl is cleaned up", func(t *testing.T) {
+		// B's .ttl is unparseable, so we cannot prove B is a valid rollback
+		// target. Treat it like a directory with no .ttl and let cleanup
+		// reap it — that's the self-healing path that lets the next upgrade
+		// proceed against a clean registry.
+		assertAgentInstallCleaned(t, filepath.Join(testTop, relB), agentExecutableName)
+	})
+}
+
+// TestRollbackWithOpts_RemovesExpiredRollbacksAvailable verifies that expired
+// entries in marker.RollbacksAvailable are not preserved by the rollback
+// cleanup: the keep list is filtered by ValidUntil so expired directories get
+// swept alongside the failing upgrade target.
+func TestRollbackWithOpts_RemovesExpiredRollbacksAvailable(t *testing.T) {
+	agentExecutableName := AgentName
+	if runtime.GOOS == "windows" {
+		agentExecutableName += ".exe"
+	}
+
+	versionA := testAgentVersion{version: "1.0.0", hash: "aaaaaa"}
+	versionB := testAgentVersion{version: "2.0.0", hash: "bbbbbb"}
+	versionC := testAgentVersion{version: "3.0.0", hash: "cccccc"}
+
+	testLogger, _ := loggertest.New(t.Name())
+	testTop := t.TempDir()
+
+	relA := createFakeAgentInstall(t, testTop, versionA.version, versionA.hash, true)
+	relB := createFakeAgentInstall(t, testTop, versionB.version, versionB.hash, true)
+	relC := createFakeAgentInstall(t, testTop, versionC.version, versionC.hash, true)
+
+	createLink(t, testTop, relC)
+
+	now := time.Now()
+	availableRollbacks := map[string]ttl.TTLMarker{
+		relA: {Version: versionA.version, Hash: versionA.hash, ValidUntil: now.Add(24 * time.Hour)},
+		relB: {Version: versionB.version, Hash: versionB.hash, ValidUntil: now.Add(-1 * time.Hour)},
+	}
+
+	require.NoError(t,
+		ttl.NewTTLMarkerRegistry(testLogger, testTop).Set(availableRollbacks),
+		"writing TTL registry with mixed-TTL entries")
+
+	markUpgrade := markUpgradeProvider(UpdateActiveCommit, os.WriteFile)
+	err := markUpgrade(
+		testLogger,
+		paths.DataFrom(testTop),
+		now,
+		agentInstall{version: versionC.version, hash: versionC.hash, versionedHome: relC},
+		agentInstall{version: versionA.version, hash: versionA.hash, versionedHome: relA},
+		nil, nil, availableRollbacks,
+	)
+	require.NoError(t, err, "writing update marker with mixed TTL RollbacksAvailable entries")
+
+	mockClient := client.NewMockClient(t)
+	mockClient.EXPECT().Connect(
+		mock.AnythingOfType("*context.timerCtx"),
+		mock.AnythingOfType("*grpc.funcDialOption"),
+		mock.AnythingOfType("*grpc.funcDialOption"),
+	).Return(nil)
+	mockClient.EXPECT().Disconnect().Return()
+	mockClient.EXPECT().Restart(mock.Anything).Return(nil).Once()
+
+	err = RollbackWithOpts(t.Context(), testLogger, mockClient, testTop, relA, versionA.hash)
+	require.NoError(t, err, "RollbackWithOpts to A")
+
+	t.Run("rollback target A is preserved", func(t *testing.T) {
+		assertAgentInstallExists(t, filepath.Join(testTop, relA), agentExecutableName)
+	})
+
+	t.Run("failing upgrade C is cleaned up", func(t *testing.T) {
+		assertAgentInstallCleaned(t, filepath.Join(testTop, relC), agentExecutableName)
+	})
+
+	t.Run("expired rollback target B is cleaned up", func(t *testing.T) {
+		assertAgentInstallCleaned(t, filepath.Join(testTop, relB), agentExecutableName)
 	})
 }

--- a/internal/pkg/agent/application/upgrade/ttl/ttl_marker_source.go
+++ b/internal/pkg/agent/application/upgrade/ttl/ttl_marker_source.go
@@ -71,27 +71,66 @@ func (T TTLMarkerRegistry) Remove(versionedHome string) error {
 	return nil
 }
 
-func (T TTLMarkerRegistry) Get() (map[string]TTLMarker, error) {
+// GetAll reads all .ttl markers under the registry's base directory and
+// returns two maps:
+//   - markers: successfully parsed entries keyed by versioned home (relative
+//     to baseDir).
+//   - malformed: per-entry errors keyed by versioned home for entries whose
+//     .ttl file could not be read or parsed (e.g. corrupt YAML, permissions,
+//     ENOENT during read). Entries whose path cannot be made relative to
+//     baseDir are keyed by the original glob match instead.
+//
+// The returned error is non-nil only on structural failures (e.g. a glob
+// failure) where no scan could be performed. Callers that need to be
+// conservative about disk-state decisions (e.g. cleanup keep lists) should
+// inspect malformed and decide whether to preserve those directories rather
+// than discarding them as untracked.
+func (T TTLMarkerRegistry) GetAll() (map[string]TTLMarker, map[string]error, error) {
 	matches, err := filepath.Glob(filepath.Join(T.baseDir, T.markerFileGlobPattern))
 	if err != nil {
-		return nil, fmt.Errorf("failed to glob files using %q: %w", T.markerFileGlobPattern, err)
+		return nil, nil, fmt.Errorf("failed to glob files using %q: %w", T.markerFileGlobPattern, err)
 	}
 	T.log.Debugf("Found matching versionedHomes: %v", matches)
 	ttlMarkers := make(map[string]TTLMarker, len(matches))
+	malformed := map[string]error{}
 	for _, match := range matches {
 		T.log.Debugf("Reading marker from versionedHome: %s", match)
-		relPath, err := filepath.Rel(T.baseDir, filepath.Dir(match))
-		if err != nil {
-			return nil, fmt.Errorf("failed to determine path for %q relative to %q : %w", match, T.baseDir, err)
+		relPath, relErr := filepath.Rel(T.baseDir, filepath.Dir(match))
+		if relErr != nil {
+			T.log.Infof("skipping marker %q: failed to compute path relative to %q: %s", match, T.baseDir, relErr)
+			malformed[match] = fmt.Errorf("computing path relative to %q: %w", T.baseDir, relErr)
+			continue
 		}
-		marker, err := readTTLMarker(match)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read marker from file %q: %w", match, err)
+		marker, readErr := readTTLMarker(match)
+		if readErr != nil {
+			T.log.Infof("skipping malformed marker %q: %s", match, readErr)
+			malformed[relPath] = fmt.Errorf("reading marker file %q: %w", match, readErr)
+			continue
 		}
 		ttlMarkers[relPath] = marker
 	}
 
-	return ttlMarkers, nil
+	return ttlMarkers, malformed, nil
+}
+
+// Get reads all .ttl markers and returns only successfully parsed entries.
+// It preserves the all-or-nothing contract: if any per-entry parse fails,
+// Get returns (nil, joined error) so existing callers continue to see the
+// same behavior. Callers that want partial results plus a list of malformed
+// entries should use GetAll directly.
+func (T TTLMarkerRegistry) Get() (map[string]TTLMarker, error) {
+	markers, malformed, err := T.GetAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(malformed) > 0 {
+		errs := make([]error, 0, len(malformed))
+		for _, e := range malformed {
+			errs = append(errs, e)
+		}
+		return nil, errors.Join(errs...)
+	}
+	return markers, nil
 }
 
 func (T TTLMarkerRegistry) addOrReplace(m map[string]TTLMarker) error {

--- a/internal/pkg/agent/application/upgrade/ttl/ttl_marker_source_test.go
+++ b/internal/pkg/agent/application/upgrade/ttl/ttl_marker_source_test.go
@@ -281,4 +281,3 @@ func TestTTLMarkerRegistry_Set(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/pkg/agent/application/upgrade/ttl/ttl_marker_source_test.go
+++ b/internal/pkg/agent/application/upgrade/ttl/ttl_marker_source_test.go
@@ -137,6 +137,45 @@ func TestTTLMarkerRegistry_Get(t *testing.T) {
 	}
 }
 
+// TestTTLMarkerRegistry_GetAll_PartialReturnsMalformedAlongsideParsed proves
+// that GetAll keeps returning successfully parsed entries even when a sibling
+// .ttl file is unparseable, and surfaces the broken entry via the malformed
+// map instead of discarding the whole read. This is the contract InTTLRollbacks
+// relies on to preserve recoverable installs whose metadata got corrupted.
+func TestTTLMarkerRegistry_GetAll_PartialReturnsMalformedAlongsideParsed(t *testing.T) {
+	tmpDir := t.TempDir()
+	goodHome := filepath.Join("data", "elastic-agent-1.2.3-good")
+	badHome := filepath.Join("data", "elastic-agent-9.9.9-corrupt")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, goodHome), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, badHome), 0755))
+
+	validUntil := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+	goodMarker := strings.TrimSpace(fmt.Sprintf(
+		"version: 1.2.3\nvalid_until: %s",
+		validUntil.Format(time.RFC3339),
+	))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, goodHome, ttlMarkerName), []byte(goodMarker), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, badHome, ttlMarkerName), []byte("this is not yaml"), 0644))
+
+	testLogger, _ := loggertest.New(t.Name())
+	T := NewTTLMarkerRegistry(testLogger, tmpDir)
+
+	markers, malformed, err := T.GetAll()
+	require.NoError(t, err, "GetAll should not return a structural error here")
+
+	assert.Len(t, markers, 1, "expected exactly one parsed marker")
+	if assert.Contains(t, markers, goodHome) {
+		assert.Equal(t, "1.2.3", markers[goodHome].Version)
+		assert.True(t, markers[goodHome].ValidUntil.Equal(validUntil), "ValidUntil mismatch")
+	}
+
+	assert.Len(t, malformed, 1, "expected exactly one malformed entry")
+	if assert.Contains(t, malformed, badHome) {
+		assert.Error(t, malformed[badHome])
+	}
+}
+
 func TestTTLMarkerRegistry_Set(t *testing.T) {
 	const TTLMarkerYAMLTemplate = `
         version: {{ .Version }}
@@ -242,3 +281,4 @@ func TestTTLMarkerRegistry_Set(t *testing.T) {
 		})
 	}
 }
+

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -215,7 +215,11 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 			versionedHomesToKeep = append(versionedHomesToKeep, currentVersionedHome)
 		}
 
-		versionedHomesToKeep = upgrade.AppendAvailableRollbacks(log, marker, versionedHomesToKeep)
+		if inTTL, err := upgrade.InTTLRollbacks(log, topDir, time.Now()); err != nil {
+			log.Infow("could not read TTL registry; cleanup will only preserve the current versioned home", "error.message", err.Error())
+		} else {
+			versionedHomesToKeep = append(versionedHomesToKeep, inTTL...)
+		}
 		log.Infof("About to clean up upgrade. Keeping versioned homes: %v", versionedHomesToKeep)
 		if err := installModifier.Cleanup(log, paths.Top(), true, false, versionedHomesToKeep...); err != nil {
 			log.Error("clean up of prior watcher run failed", err)
@@ -291,7 +295,11 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 	}
 	versionedHomesToKeep := make([]string, 0, len(marker.RollbacksAvailable)+1)
 	versionedHomesToKeep = append(versionedHomesToKeep, newVersionedHome)
-	versionedHomesToKeep = upgrade.AppendAvailableRollbacks(log, marker, versionedHomesToKeep)
+	if inTTL, keepErr := upgrade.InTTLRollbacks(log, topDir, time.Now()); keepErr != nil {
+		log.Infow("could not read TTL registry; cleanup will only preserve the new versioned home", "error.message", keepErr.Error())
+	} else {
+		versionedHomesToKeep = append(versionedHomesToKeep, inTTL...)
+	}
 
 	err = installModifier.Cleanup(log, topDir, removeMarker, false, versionedHomesToKeep...)
 	if err != nil {

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -215,7 +215,7 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 			versionedHomesToKeep = append(versionedHomesToKeep, currentVersionedHome)
 		}
 
-		versionedHomesToKeep = appendAvailableRollbacks(log, marker, versionedHomesToKeep)
+		versionedHomesToKeep = upgrade.AppendAvailableRollbacks(log, marker, versionedHomesToKeep)
 		log.Infof("About to clean up upgrade. Keeping versioned homes: %v", versionedHomesToKeep)
 		if err := installModifier.Cleanup(log, paths.Top(), true, false, versionedHomesToKeep...); err != nil {
 			log.Error("clean up of prior watcher run failed", err)
@@ -291,22 +291,13 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 	}
 	versionedHomesToKeep := make([]string, 0, len(marker.RollbacksAvailable)+1)
 	versionedHomesToKeep = append(versionedHomesToKeep, newVersionedHome)
-	versionedHomesToKeep = appendAvailableRollbacks(log, marker, versionedHomesToKeep)
+	versionedHomesToKeep = upgrade.AppendAvailableRollbacks(log, marker, versionedHomesToKeep)
 
 	err = installModifier.Cleanup(log, topDir, removeMarker, false, versionedHomesToKeep...)
 	if err != nil {
 		log.Error("cleanup after successful watch failed", err)
 	}
 	return err
-}
-
-func appendAvailableRollbacks(log *logp.Logger, marker *upgrade.UpdateMarker, versionedHomesToKeep []string) []string {
-	// add any available rollbacks
-	for versionedHome, ra := range marker.RollbacksAvailable {
-		log.Debugf("Adding available rollback %s:%+v to the directories to keep during cleanup", versionedHome, ra)
-		versionedHomesToKeep = append(versionedHomesToKeep, versionedHome)
-	}
-	return versionedHomesToKeep
 }
 
 func rollback(log *logp.Logger, topDir string, client client.Client, installModifier installationModifier, versionedHome string) error {


### PR DESCRIPTION
## What does this PR do?

Fixes a data-loss bug in the post-rollback cleanup: when the upgrade watcher auto-rolls back a failed upgrade, or an operator triggers a manual rollback, every TTL-tracked entry in `marker.RollbacksAvailable` other than the rollback target was being deleted from `data/`, regardless of whether the entry's TTL had expired.

Concretely, this PR:

1. **Extracts** the existing `appendAvailableRollbacks` helper from `internal/pkg/agent/cmd/watch.go` into the `upgrade` package as `upgrade.AppendAvailableRollbacks`. The two existing watcher cleanup sites (`watchCmd` stale-marker recovery and successful-watch cleanup) are updated to call the shared helper. Behavior at those sites is unchanged.
2. **Wires `RollbackWithOpts` to use it.** Before invoking `Cleanup`, `RollbackWithOpts` now loads the upgrade marker (best-effort) and folds `marker.RollbacksAvailable` into the keep list alongside `prevVersionedHome`. If the marker cannot be loaded, the keep list falls back to the previous single-element `[prevVersionedHome]` and the rollback proceeds — preserving today's invariant that rollback always restarts the agent regardless of marker state.
3. **Adds a regression test.** `TestRollbackWithOpts_PreservesInTTLRollbacksAvailable` constructs three on-disk installs (A, B, C), seeds the marker with both A and B in `RollbacksAvailable` with future TTLs, rolls back to A, and asserts that B's directory survives. The test fails on `main` and passes after the fix.

All three `Cleanup` call sites — stale-marker recovery, successful-watch cleanup, and post-rollback cleanup — now derive their keep list through the same helper, so future callers can't accidentally drop in-TTL rollback targets again.

## Why is it important?

The multi-rollback retention feature depends on `marker.RollbacksAvailable` actually being honored on disk for the duration of each entry's TTL. Before this PR:

- Auto-rollback after a failed upgrade silently discarded other in-TTL rollback options.
- Manual rollback (`elastic-agent watch --rollback`) had the same effect — an operator stepping back one version unintentionally lost two-versions-back.
- When the marker was preserved post-rollback (the `>= 9.2.0-SNAPSHOT` path that sets `removeMarker = false`), `RollbacksAvailable` ended up referencing directories that had just been deleted, leaving the marker in a stale, internally inconsistent state.

The structural inconsistency was confined to the rollback path: the two `watch.go` cleanup sites already folded `RollbacksAvailable` into the keep list via `appendAvailableRollbacks`. The rollback path simply didn't, because `RollbackWithOpts` constructed its keep list as a hard-coded one-element slice. Centralizing the helper makes the rule explicit and uniform across all three cleanup scenarios.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~ — covered by unit tests in [`rollback_test.go`](../internal/pkg/agent/application/upgrade/rollback_test.go); a chained-upgrade + rollback integration test would cost time per run for a fix already pinned by deterministic unit tests, so the cost/value didn't justify it.

## Disruptive User Impact

None expected. This PR strictly closes a data-loss path; no API, configuration, or operator-facing workflow changes. After the fix, in-TTL rollback options that were already being created and tracked by the agent are simply preserved on disk, as the multi-rollback feature originally intended. Users do not need to take any action.

## How to test this PR locally

Unit tests:

```bash
go test -count=1 -v -run TestRollbackWithOpts_PreservesInTTLRollbacksAvailable \
  ./internal/pkg/agent/application/upgrade/
```

Expected output: all three subtests pass:
- `rollback_target_A_is_preserved`
- `failing_upgrade_C_is_cleaned_up`
- `other_in-TTL_rollback_target_B_is_preserved`

Full upgrade-package suite (no regressions):

```bash
go test -count=1 ./internal/pkg/agent/application/upgrade/
```

Manual reproduction (optional, illustrates the user-visible difference):

1. Install the agent on a host with multi-rollback enabled, and accumulate at least two valid TTL-tracked rollback targets (versions A and B) under `data/elastic-agent-*`. They should both appear under `marker.RollbacksAvailable` in the upgrade marker.
2. Trigger a rollback to A — either by failing an upgrade so the watcher auto-rolls back, or by invoking the manual rollback command.
3. Inspect `data/`:
   - **Before this PR:** only `data/elastic-agent-<A>` survives; `data/elastic-agent-<B>` is gone despite an unexpired TTL.
   - **After this PR:** both `data/elastic-agent-<A>` and `data/elastic-agent-<B>` survive.

## Related issues

- Closes #14021

## Questions to ask yourself

- **How are we going to support this in production?** No new operator surface. The fix is observable as the absence of a data-loss event; logs at `INFO` level continue to report the keep list passed to `Cleanup`, and the additional `Adding available rollback ... to the directories to keep during cleanup` debug lines (now emitted via the shared helper) make the keep list construction discoverable on the rollback path too.
- **How are we going to measure its adoption?** Not applicable — this is a correctness fix, not a new feature.
- **How are we going to debug this?** The shared helper logs each preserved rollback at debug level. The cleanup function logs the final keep list at info level. Together they make it possible to confirm — from a single watcher log — that `marker.RollbacksAvailable` entries are being preserved across both upgrade-success and rollback paths.
- **What are the metrics I should take care of?** None new. The pre-existing upgrade-state telemetry (`details.State`) is untouched.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
