### PR TITLE
oblt-cli: wait might be flaky if github is flaky

### DIFF
--- a/.buildkite/scripts/steps/ess.ps1
+++ b/.buildkite/scripts/steps/ess.ps1
@@ -43,7 +43,7 @@ function ess_up {
       if (Test-Path $clusterInfoPath) {
           $ClusterName = (Get-Content -Path $clusterInfoPath | ConvertFrom-Json).ClusterName
           if ($ClusterName) {
-              & oblt-cli cluster secrets env --cluster-name $ClusterName --output-file nul | Out-Null
+              & oblt-cli cluster secrets env --cluster-name $ClusterName --output-file nul
               if ($LASTEXITCODE -eq 0) {
                   Write-Output "Cluster creation wait timed out, but secrets are available - continuing"
               } else {

--- a/.buildkite/scripts/steps/ess.ps1
+++ b/.buildkite/scripts/steps/ess.ps1
@@ -34,30 +34,33 @@ function ess_up {
         --parameters-file $paramsPath `
         --output-file $clusterInfoPath `
         --wait 20
+
+    if ($LASTEXITCODE -ne 0) {
+      throw "oblt-cli cluster create failed with exit code $LASTEXITCODE"
+    }
+  } catch {
+    # fallback to check if secrets are available in case the cluster was created
+    # but wait timed out (e.g. due to slow cluster creation or transient oblt-cli issues)
+    if (Test-Path $clusterInfoPath) {
+      $ClusterName = (Get-Content -Path $clusterInfoPath | ConvertFrom-Json).ClusterName
+      if ($ClusterName) {
+        & oblt-cli cluster secrets env --cluster-name $ClusterName --output-file nul
+        if ($LASTEXITCODE -eq 0) {
+          Write-Output "Cluster creation wait timed out, but secrets are available - continuing"
+        } else {
+          Write-Error "Error: oblt-cli cluster create custom failed and secrets check failed"
+          return 1
+        }
+      } else {
+        Write-Error "Error: oblt-cli cluster create custom failed and no cluster name found"
+        return 1
+      }
+    } else {
+      Write-Error "Error: oblt-cli cluster create custom failed"
+      return 1
+    }
   } finally {
     Remove-Item -Path $paramsPath -Force -ErrorAction SilentlyContinue
-  }
-  # fallback to check if secrets are available in case the cluster was created
-  # but wait timed out (e.g. due to slow cluster creation or transient oblt-cli issues)
-  if ($LASTEXITCODE -ne 0) {
-      if (Test-Path $clusterInfoPath) {
-          $ClusterName = (Get-Content -Path $clusterInfoPath | ConvertFrom-Json).ClusterName
-          if ($ClusterName) {
-              & oblt-cli cluster secrets env --cluster-name $ClusterName --output-file nul
-              if ($LASTEXITCODE -eq 0) {
-                  Write-Output "Cluster creation wait timed out, but secrets are available - continuing"
-              } else {
-                  Write-Error "Error: oblt-cli cluster create custom failed (exit=$LASTEXITCODE) and secrets check failed"
-                  return 1
-              }
-          } else {
-              Write-Error "Error: oblt-cli cluster create custom failed (exit=$LASTEXITCODE) and no cluster name found"
-              return 1
-          }
-      } else {
-          Write-Error "Error: oblt-cli cluster create custom failed (exit=$LASTEXITCODE)"
-          return 1
-      }
   }
 
   if (-not (Test-Path $clusterInfoPath)) {

--- a/.buildkite/scripts/steps/ess.ps1
+++ b/.buildkite/scripts/steps/ess.ps1
@@ -33,13 +33,31 @@ function ess_up {
         --cluster-name-prefix ea-hosted-it `
         --parameters-file $paramsPath `
         --output-file $clusterInfoPath `
-        --wait 30
+        --wait 20
   } finally {
     Remove-Item -Path $paramsPath -Force -ErrorAction SilentlyContinue
   }
+  # fallback to check if secrets are available in case the cluster was created
+  # but wait timed out (e.g. due to slow cluster creation or transient oblt-cli issues)
   if ($LASTEXITCODE -ne 0) {
-      Write-Error "Error: oblt-cli cluster create custom failed (exit=$LASTEXITCODE)"
-      return 1
+      if (Test-Path $clusterInfoPath) {
+          $ClusterName = (Get-Content -Path $clusterInfoPath | ConvertFrom-Json).ClusterName
+          if ($ClusterName) {
+              & oblt-cli cluster secrets env --cluster-name $ClusterName --output-file "nul"
+              if ($LASTEXITCODE -eq 0) {
+                  Write-Output "Cluster creation wait timed out, but secrets are available - continuing"
+              } else {
+                  Write-Error "Error: oblt-cli cluster create custom failed (exit=$LASTEXITCODE) and secrets check failed"
+                  return 1
+              }
+          } else {
+              Write-Error "Error: oblt-cli cluster create custom failed (exit=$LASTEXITCODE) and no cluster name found"
+              return 1
+          }
+      } else {
+          Write-Error "Error: oblt-cli cluster create custom failed (exit=$LASTEXITCODE)"
+          return 1
+      }
   }
 
   if (-not (Test-Path $clusterInfoPath)) {

--- a/.buildkite/scripts/steps/ess.ps1
+++ b/.buildkite/scripts/steps/ess.ps1
@@ -43,7 +43,7 @@ function ess_up {
       if (Test-Path $clusterInfoPath) {
           $ClusterName = (Get-Content -Path $clusterInfoPath | ConvertFrom-Json).ClusterName
           if ($ClusterName) {
-              & oblt-cli cluster secrets env --cluster-name $ClusterName --output-file "nul"
+              & oblt-cli cluster secrets env --cluster-name $ClusterName --output-file nul | Out-Null
               if ($LASTEXITCODE -eq 0) {
                   Write-Output "Cluster creation wait timed out, but secrets are available - continuing"
               } else {

--- a/.buildkite/scripts/steps/ess_oblt-cli.sh
+++ b/.buildkite/scripts/steps/ess_oblt-cli.sh
@@ -11,12 +11,18 @@ function ess_up() {
   fi
 
   # Create a cluster with the specified stack version and store the cluster information in a file
-  oblt-cli cluster create custom \
+  if ! oblt-cli cluster create custom \
       --template ess-ea-it \
       --cluster-name-prefix ea-hosted-it \
       --parameters="{\"GitOps\":\"true\",\"GitHubRepository\":\"${BUILDKITE_REPO}\",\"GitHubCommit\":\"${BUILDKITE_COMMIT}\",\"EphemeralCluster\":\"true\",\"StackVersion\":\"$STACK_VERSION\"}" \
       --output-file="${PWD}/cluster-info.json" \
-      --wait 30
+      --wait 20 ; then
+
+    # fallback to check if secrets are available in case the cluster was created
+    # but wait timed out (e.g. due to slow cluster creation or transient oblt-cli issues)
+    CLUSTER_NAME=$(jq -r '.ClusterName' cluster-info.json)
+    oblt-cli cluster secrets env --cluster-name "$CLUSTER_NAME" --output-file="/dev/null"
+  fi
 
   # Extract the cluster name from the cluster information file
   CLUSTER_NAME=$(jq -r '.ClusterName' cluster-info.json)


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Add more reliability by using the secrets to know if the deployment is available.
Timeout earlier 20 minutes - deployments normally take about 5 / 7 minutes average

## Why is it important?

GitHub sometimes is not 100% available and we use gitops, the deployment ran successfully but the git status cannot be retrieved, so, we need to fallback to a known oblt-cli command that confirms the deployment is available

Eventually, this will move to the `--wait` flag when running `oblt-cli cluster create` command

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
