### PR TITLE
Use t.Fatal instead of t.Error to stop test execution on error

### DIFF
--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -602,17 +602,17 @@ func (f *Fixture) RunOtelWithClient(ctx context.Context, states ...State) error 
 // by [RunOtelWithCliet] or [Run].
 // If the Elastic Agent has been installed, or the process
 // has not been started by [RunOtelWithClient] or [Run],
-// Stop fails the test by calling t.Error
+// Stop fails the test by calling t.Fatal
 func (f *Fixture) Stop() {
 	f.procMutex.Lock()
 	defer f.procMutex.Unlock()
 
 	if f.installed {
-		f.t.Error("an installed Elastic Agent cannot be stopped")
+		f.t.Fatal("an installed Elastic Agent cannot be stopped")
 	}
 
 	if f.proc == nil {
-		f.t.Error("Elastic Agent has not been started")
+		f.t.Fatal("Elastic Agent has not been started")
 	}
 
 	f.stopping = true


### PR DESCRIPTION
## What does this PR do?

See title

## Why is it important?

It prevents a panic in the testing

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~

~~## Disruptive User Impact~~
~~## How to test this PR locally~~

## Related issues

- Relates #11155 

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
