### PR TITLE
Fix uncleared config manager errors permanently failing aggregate state

### DIFF
--- a/changelog/fragments/1778016504-fix-config-manager-errors-poisoning-aggregate-state.yaml
+++ b/changelog/fragments/1778016504-fix-config-manager-errors-poisoning-aggregate-state.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix uncleared config manager errors permanently failing aggregate state
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -408,10 +408,10 @@ type Coordinator struct {
 	// failures immediately https://github.com/elastic/elastic-agent/issues/2887.
 	// For now, we track three distinct errors for those three failure types,
 	// and merge them into a readable error in generateReportableState.
-	configErr        error
-	componentGenErr  error
-	runtimeUpdateErr error
-	otelErr          error
+	configErr         error
+	componentModelErr error
+	runtimeUpdateErr  error
+	otelErr           error
 
 	// The raw policy before spec lookup or variable substitution
 	ast *transpiler.AST
@@ -1656,7 +1656,6 @@ func (c *Coordinator) runLoopIteration(ctx context.Context) {
 			err := c.refreshComponentModel(ctx)
 			if err != nil {
 				err = fmt.Errorf("error refreshing component model for PID update: %w", err)
-				c.setConfigManagerError(err)
 				c.logger.Errorf("%s", err)
 			}
 		}
@@ -1968,6 +1967,11 @@ func (c *Coordinator) refreshComponentModel(ctx context.Context) (err error) {
 		// Nothing to process yet
 		return nil
 	}
+
+	defer func() {
+		// Update componentModelErr with the results.
+		c.setComponentModelError(err)
+	}()
 
 	span, ctx := apm.StartSpan(ctx, "refreshComponentModel", "app.internal")
 	defer func() {
@@ -2285,11 +2289,6 @@ func (c *Coordinator) ackMigration(ctx context.Context, action *fleetapi.ActionM
 // Called from both the main Coordinator goroutine and from external
 // goroutines via diagnostics hooks.
 func (c *Coordinator) generateComponentModel() (err error) {
-	defer func() {
-		// Update componentGenErr with the results.
-		c.setComponentGenError(err)
-	}()
-
 	ast := c.ast.ShallowClone()
 
 	// perform variable substitution for inputs

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -1667,27 +1667,12 @@ func (c *Coordinator) runLoopIteration(ctx context.Context) {
 		c.applyComponentState(componentState)
 
 	case change := <-c.managerChans.configManagerUpdate:
-		if err := c.processConfig(ctx, change.Config()); err != nil {
-			c.logger.Errorf("applying new policy: %s", err.Error())
-			change.Fail(err)
-		} else {
-			if err := change.Ack(); err != nil {
-				err = fmt.Errorf("failed to ack configuration change: %w", err)
-				// Workaround: setConfigManagerError is usually used by the config
-				// manager to report failed ACKs / etc when communicating with Fleet.
-				// We need to report a failed ACK here, but the policy change has
-				// already been successfully applied so we don't want to report it as
-				// a general Coordinator or policy failure.
-				// This arises uniquely here because this is the only case where an
-				// action is responsible for reporting the failure of its own ACK
-				// call. The "correct" fix is to make this Ack() call unfailable
-				// and handle ACK retries and reporting in the config manager like
-				// with other action types -- this error would then end up invoking
-				// setConfigManagerError "organically" via the config manager's
-				// reporting channel. In the meantime, we do it manually.
-				c.setConfigManagerError(err)
-				c.logger.Errorf("%s", err.Error())
-			}
+		err := c.processConfigChange(ctx, change)
+		if err != nil {
+			c.logger.Errorf("%s", err)
+		}
+		if c.isManaged {
+			c.setConfigManagerActionsError(err)
 		}
 
 	case vars := <-c.managerChans.varsManagerUpdate:
@@ -1725,20 +1710,27 @@ func (c *Coordinator) runLoopIteration(ctx context.Context) {
 }
 
 // Always called on the main Coordinator goroutine.
-func (c *Coordinator) processConfig(ctx context.Context, cfg *config.Config) (err error) {
+func (c *Coordinator) processConfigChange(ctx context.Context, change ConfigChange) (err error) {
 	c.migrationProgressWg.Wait()
 
-	// processConfigAgent will apply persisted config and set c.otelCfg before calling refreshComponentModel
-	err = c.processConfigAgent(ctx, cfg)
+	// processConfig will apply persisted config and set c.otelCfg before calling refreshComponentModel
+	err = c.processConfig(ctx, change.Config())
 	if err != nil {
-		return err
+		change.Fail(err)
+		return fmt.Errorf("failed to apply new policy change: %w", err)
+	}
+
+	if err := change.Ack(); err != nil {
+		// This currently only happens if we fail to save the action to the state store.
+		// Not a transient failure, so return error instead of just logging.
+		return fmt.Errorf("failed to ack new policy change: %w", err)
 	}
 
 	return nil
 }
 
 // Always called on the main Coordinator goroutine.
-func (c *Coordinator) processConfigAgent(ctx context.Context, cfg *config.Config) (err error) {
+func (c *Coordinator) processConfig(ctx context.Context, cfg *config.Config) (err error) {
 	span, ctx := apm.StartSpan(ctx, "config", "app.internal")
 	defer func() {
 		apm.CaptureError(ctx, err).Send()

--- a/internal/pkg/agent/application/coordinator/coordinator_state.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_state.go
@@ -115,11 +115,11 @@ func (c *Coordinator) setConfigError(err error) {
 	c.stateNeedsRefresh = true
 }
 
-// setComponentGenError updates the error state for generating a component
+// setComponentModelError updates the error state for generating a component
 // model from an AST and variables.
 // Called on the main Coordinator goroutine.
-func (c *Coordinator) setComponentGenError(err error) {
-	c.componentGenErr = err
+func (c *Coordinator) setComponentModelError(err error) {
+	c.componentModelErr = err
 	c.stateNeedsRefresh = true
 }
 
@@ -236,9 +236,9 @@ func (c *Coordinator) generateReportableState() (s State) {
 	} else if c.configErr != nil {
 		s.State = agentclient.Failed
 		s.Message = fmt.Sprintf("Invalid policy: %s", c.configErr.Error())
-	} else if c.componentGenErr != nil {
+	} else if c.componentModelErr != nil {
 		s.State = agentclient.Failed
-		s.Message = fmt.Sprintf("Invalid component model: %s", c.componentGenErr.Error())
+		s.Message = fmt.Sprintf("Invalid component model: %s", c.componentModelErr.Error())
 	} else if c.runtimeUpdateErr != nil {
 		s.State = agentclient.Failed
 		s.Message = fmt.Sprintf("Runtime update failed: %s", c.runtimeUpdateErr.Error())

--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -590,7 +590,7 @@ func TestCoordinatorReportsComponentModelError(t *testing.T) {
 	// and produces a valid AST, but can't be converted into a valid
 	// component model (which we trigger with invalid conditional
 	// expressions). In this case the resulting error should be stored
-	// in Coordinator.componentGenErr, and reported by Coordinator.State.
+	// in Coordinator.componentModelErr, and reported by Coordinator.State.
 
 	// Set a one-second timeout -- nothing here should block, but if it
 	// does let's report a failure instead of timing out the test runner.
@@ -630,7 +630,7 @@ func TestCoordinatorReportsComponentModelError(t *testing.T) {
 	}
 
 	// This configuration produces a valid AST but its EQL condition is
-	// invalid, so its failure should be reported in componentGenErr.
+	// invalid, so its failure should be reported in componentModelErr.
 	cfg := config.MustNewConfigFrom(`
 inputs:
   - type: filestream
@@ -640,8 +640,8 @@ inputs:
 	configChan <- cfgChange
 	coord.runLoopIteration(ctx)
 
-	require.Error(t, coord.componentGenErr)
-	require.Contains(t, coord.componentGenErr.Error(), "rendering inputs failed:")
+	require.Error(t, coord.componentModelErr)
+	require.Contains(t, coord.componentModelErr.Error(), "rendering inputs failed:")
 	select {
 	case state := <-stateChan:
 		assert.Equal(t, agentclient.Failed, state.State, "Failed component generation should cause failed state")
@@ -659,7 +659,7 @@ inputs:
 	varsChan <- emptyVars(t)
 	coord.runLoopIteration(ctx)
 
-	assert.Error(t, coord.componentGenErr, "Vars update shouldn't affect componentGenErr")
+	assert.Error(t, coord.componentModelErr, "Vars update shouldn't affect componentModelErr")
 	select {
 	case state := <-stateChan:
 		assert.Equal(t, agentclient.Failed, state.State, "Variable update should not overwrite component generation error")
@@ -676,6 +676,7 @@ inputs:
 	coord.runLoopIteration(ctx)
 
 	assert.NoError(t, coord.configErr, "Valid policy change should clear configErr")
+	assert.NoError(t, coord.componentModelErr, "Valid component model rebuild should clear componentModelErr")
 	select {
 	case state := <-stateChan:
 		assert.Equal(t, agentclient.Healthy, state.State, "Valid policy change should produce healthy state")

--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -1536,6 +1536,72 @@ func TestCoordinatorReportsOTelManagerUpdateFailure(t *testing.T) {
 	assert.Contains(t, state.Message, errorStr, "Failed policy update should be reported in Coordinator state message")
 }
 
+type ackErrConfigChange struct {
+	cfg *config.Config
+	err error
+}
+
+func (l *ackErrConfigChange) Config() *config.Config { return l.cfg }
+func (l *ackErrConfigChange) Ack() error             { return l.err }
+func (l *ackErrConfigChange) Fail(err error)         {}
+
+func TestCoordinatorReportsConfigChangeAckFailure(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	logger := logp.NewLogger("testing")
+
+	stateChan := make(chan State, 1)
+	configChan := make(chan ConfigChange, 1)
+
+	coord := &Coordinator{
+		logger:    logger,
+		agentInfo: &info.AgentInfo{},
+		state: State{
+			CoordinatorState:   agentclient.Healthy,
+			CoordinatorMessage: "Running",
+		},
+
+		stateBroadcaster: &broadcaster.Broadcaster[State]{InputChan: stateChan},
+		managerChans: managerChans{
+			configManagerUpdate: configChan,
+		},
+		runtimeMgr:         &fakeRuntimeManager{},
+		otelMgr:            &fakeOTelManager{},
+		vars:               emptyVars(t),
+		componentPIDTicker: time.NewTicker(time.Second * 30),
+		secretMarkerFunc:   testSecretMarkerFunc,
+		isManaged:          true,
+	}
+
+	const errorStr = "ack failed for testing reasons"
+	configChan <- &ackErrConfigChange{
+		cfg: config.MustNewConfigFrom(nil),
+		err: errors.New(errorStr),
+	}
+	coord.runLoopIteration(ctx)
+	require.Error(t, coord.actionsErr, "Ack failure should be saved in actionsErr")
+	select {
+	case state := <-stateChan:
+		assert.Equal(t, agentclient.Failed, state.State, "Ack failure should cause failed Coordinator")
+		assert.Contains(t, state.Message, errorStr, "Ack failure should be reported in Coordinator state message")
+	default:
+		assert.Fail(t, "Policy change should cause state update")
+	}
+
+	// A subsequent successful policy change ack should clear actionsErr.
+	configChan <- &configChange{cfg: config.MustNewConfigFrom(nil)}
+	coord.runLoopIteration(ctx)
+
+	assert.NoError(t, coord.actionsErr, "Successful Ack should clear actionsErr")
+	select {
+	case state := <-stateChan:
+		assert.Equal(t, agentclient.Healthy, state.State, "Successful Ack should restore healthy state")
+		assert.Equal(t, state.Message, "Running", "Successful Ack should restore previous state message")
+	default:
+		assert.Fail(t, "Policy change should cause state update")
+	}
+}
+
 func TestCoordinatorAppliesVarsToPolicy(t *testing.T) {
 	// Make sure:
 	// - An input unit that depends on an undefined variable is not created


### PR DESCRIPTION
## What does this PR do?

Fixes #13677, where the aggregate Agent state could be permanently left in a failed state due to configMgrErr never being cleared even upon recovery.

1. Moves component model building errors out of configMgrErr and into one field for all errors related to component model rebuilding, keeping responsibility for setting and clearing component model errors in one place. Renames componentGenErr to componentModelErr to reflect the broadening of its scope.

2. Consolidates config processing and ack handling together into processConfigChange and unconditionally sets actionErr to its result. In managed mode, configManagerUpdate is only ever triggered by a policy change action and is conceptually an extension of the policy change handler, so using actionsErr here keeps all policy change action errors together. This change also catches a few failures that were previously only being logged.

## Why is it important?

Both cases where configMgrErr was being set are potentially recoverable and shouldn't require a restart for Agent to show as healthy again. However, configMgrErr was serving as a shared error field from different sources and thus the error paths that set it are unrelated, which means that clearing it upon the success branch of either path would potentially overwrite an error set by the other. Handling the different errors independently in error fields specific to their paths avoids this problem.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

N/A.

## Related issues
- Closes #13677.