### PR TITLE
[ci] Increase cpu and memory limits for DRA version bump pipeline

### DIFF
--- a/.buildkite/pipeline.version-bump.yml
+++ b/.buildkite/pipeline.version-bump.yml
@@ -34,8 +34,8 @@ steps:
     depends_on: block-get-dra-artifacts
     agents:
       image: docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest
-      cpu: 250m
-      memory: 512Mi
+      cpu: 500m
+      memory: 1Gi
       ephemeralStorage: 1Gi
     command:
       - echo "Placeholder"


### PR DESCRIPTION
Recommended increases by Release Eng team to address the current pipeline failures: https://buildkite.com/elastic/elastic-agent-version-bump/builds/1#019e02f3-4697-4d60-a417-c3401d98eb15.