### PR TITLE
Update license override and include license check in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ notice:
 check-ci:
 	@mage -v check
 	@$(MAKE) notice
+	@dev-tools/dependencies-report
 	@GENERATEKUSTOMIZE=true $(MAKE) -C deploy/kubernetes generate-k8s
 	@$(MAKE) -C deploy/kubernetes generate-k8s
 	@mage -v helm:lint

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ notice:
 check-ci:
 	@mage -v check
 	@$(MAKE) notice
-	@dev-tools/dependencies-report
+	@dev-tools/dependencies-report && rm dependencies.csv
 	@GENERATEKUSTOMIZE=true $(MAKE) -C deploy/kubernetes generate-k8s
 	@$(MAKE) -C deploy/kubernetes generate-k8s
 	@mage -v helm:lint

--- a/dev-tools/notice/overrides.json
+++ b/dev-tools/notice/overrides.json
@@ -19,7 +19,7 @@
 {"name": "github.com/dnaeon/go-vcr", "licenceFile": "LICENSE", "licenceType": "BSD-2-Clause"}
 {"name": "github.com/grpc-ecosystem/go-grpc-middleware/v2", "licenceFile": "LICENSE", "licenceType": "Apache-2.0"}
 {"name": "github.com/JohnCGriffin/overflow", "licenceFile": "README.md", "licenceType": "MIT"}
-{"name": "github.com/elastic/cloud-on-k8s/v2", "licenceType": "Elastic"}
+{"name": "github.com/elastic/cloud-on-k8s/v3", "licenceType": "Elastic"}
 {"name": "github.com/elastic/elastic-agent/internal/edot", "licenceType": "Elastic"}
 {"name": "github.com/elastic/ebpfevents", "licenceType": "Apache-2.0"}
 {"name": "github.com/spdx/tools-golang", "licenceFile": "LICENSE.code", "licenceType": "Apache-2.0"}


### PR DESCRIPTION
https://github.com/elastic/elastic-agent/pull/14115 upgraded the `elastic/cloud-on-k8s` dependency to v3, but didn't update the license rule override for it. This is currently blocking DRA builds. CI didn't catch it because this check only happens in those builds, and we only run them for PRs if the packaging code changes.

This fixes the issue and also adds the check to `make check-ci`. I'll manually port this change to https://github.com/elastic/elastic-agent/pull/14115 backports.