### PR TITLE
Fix cleanup in TestContextProvider

### DIFF
--- a/internal/pkg/composable/providers/filesource/filesource_test.go
+++ b/internal/pkg/composable/providers/filesource/filesource_test.go
@@ -123,7 +123,6 @@ func TestContextProvider(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	comm := ctesting.NewContextComm(ctx)
 	setChan := make(chan map[string]interface{})
 	comm.CallOnSet(func(value map[string]interface{}) {
@@ -131,9 +130,19 @@ func TestContextProvider(t *testing.T) {
 		setChan <- value
 	})
 
+	// Ensure the provider goroutine exits and closes its fsnotify watcher
+	// before t.TempDir's cleanup runs RemoveAll; on Windows the watcher
+	// holds an open directory handle that blocks deletion.
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		_ = provider.Run(ctx, comm)
 	}()
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
 
 	// wait for it to be called once
 	var current map[string]interface{}

--- a/internal/pkg/composable/providers/filesource/filesource_test.go
+++ b/internal/pkg/composable/providers/filesource/filesource_test.go
@@ -5,7 +5,6 @@
 package filesource
 
 import (
-	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -122,7 +121,7 @@ func TestContextProvider(t *testing.T) {
 	provider, err := builder(log, c, true)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := t.Context()
 	comm := ctesting.NewContextComm(ctx)
 	setChan := make(chan map[string]interface{})
 	comm.CallOnSet(func(value map[string]interface{}) {
@@ -139,10 +138,7 @@ func TestContextProvider(t *testing.T) {
 		defer wg.Done()
 		_ = provider.Run(ctx, comm)
 	}()
-	t.Cleanup(func() {
-		cancel()
-		wg.Wait()
-	})
+	t.Cleanup(func() { wg.Wait() })
 
 	// wait for it to be called once
 	var current map[string]interface{}


### PR DESCRIPTION
Ensure the provider exits before the testing framework's cleanup runs. The filesource provider puts a watch on a file in the test's temp directory, and if this watch is still active when the test is cleaned up, we get an error on Windows. See https://buildkite.com/elastic/elastic-agent/builds/39022/table?jid=019e16ef-a10f-4523-bbaf-d23e0f0fc95a&tab=output for example.