### PR TITLE
Fix race condition in TestAgentStartShutdown

### DIFF
--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -495,6 +495,7 @@ func runElasticAgent(
 	// listen for signals
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
+	l.Debug("Registered signal handlers")
 	isRex := false
 	logShutdown := true
 LOOP:

--- a/testing/integration/ess/agent_start_shutdown_test.go
+++ b/testing/integration/ess/agent_start_shutdown_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/elastic-agent/pkg/control/v2/client"
 	aTesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools/testcontext"
@@ -40,20 +39,27 @@ func TestAgentStartShutdown(t *testing.T) {
 	err = fixture.Prepare(ctx, fakeComponent)
 	require.NoError(t, err)
 
+	// set logging level to debug so we see the log message we want
+	var config = `
+agent:
+  logging:
+    level: debug
+outputs:
+  default:
+    type: fake-output
+inputs:
+  - id: fake
+    type: fake
+    state: 2
+    message: Healthy
+`
+
+	require.NoError(t, fixture.Configure(ctx, []byte(config)))
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		// simpleConfig2 wires up the fake input/output component so the
-		// agent has something to run; Reached returning false keeps the
-		// fixture's state machine from advancing, which means the agent
-		// keeps running until we explicitly stop it.
-		assert.NoError(t, fixture.Run(ctx, aTesting.State{
-			Configure: simpleConfig2,
-			Reached: func(*client.AgentState) bool {
-				return false
-			},
-		}))
+		assert.NoError(t, fixture.Run(ctx))
 	}()
 
 	t.Cleanup(func() {
@@ -64,7 +70,7 @@ func TestAgentStartShutdown(t *testing.T) {
 	})
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.Contains(collect, output.String(), "Elastic Agent started")
+		assert.Contains(collect, output.String(), "Registered signal handlers")
 	}, 30*time.Second, time.Second)
 
 	fixture.Stop()


### PR DESCRIPTION
The test looked for the `Elastic Agent started` log line, but signal handlers aren't installed yet at that point. As a result, the process would be killed without emitting anything else.

As a quick fix, add a Debug log line after the handlers are registered. In the long term, we should install the handlers as soon as possible.