### PR TITLE
Fix setup in TestRollbackWithOpts

### DIFF
--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -370,6 +370,9 @@ func TestRollbackWithOpts(t *testing.T) {
 						useVersionInPath: true,
 					},
 				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
 			},
 			setupMocks: func(mockClient *client.MockClient) {
 				mockClient.EXPECT().Connect(
@@ -409,6 +412,9 @@ func TestRollbackWithOpts(t *testing.T) {
 						useVersionInPath: true,
 					},
 				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
 			},
 			setupMocks: func(mockClient *client.MockClient) {
 				// nothing to do here, no restart will be issued
@@ -442,6 +448,9 @@ func TestRollbackWithOpts(t *testing.T) {
 						useVersionInPath: true,
 					},
 				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
 			},
 			setupMocks: func(mockClient *client.MockClient) {
 				mockClient.EXPECT().Connect(
@@ -489,6 +498,9 @@ func TestRollbackWithOpts(t *testing.T) {
 						useVersionInPath: true,
 					},
 				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
 			},
 			setupMocks: func(mockClient *client.MockClient) {
 				// no restart request should be made
@@ -526,6 +538,9 @@ func TestRollbackWithOpts(t *testing.T) {
 						useVersionInPath: true,
 					},
 				},
+				upgradeFrom:  version123Snapshot,
+				upgradeTo:    version456Snapshot,
+				currentAgent: version456Snapshot,
 			},
 			setupMocks: func(mockClient *client.MockClient) {
 				mockClient.EXPECT().Connect(


### PR DESCRIPTION
Ensure upgrade markers actually exist for this test. This has a chance of fixing some mysterious failures happening to this test on CI, and is generally more correct.

Example failure on Windows: https://buildkite.com/elastic/elastic-agent/builds/39034/table?jid=019e1765-d7f2-472a-a6ae-067143bb2184&tab=output