### PR TITLE
Fix assertions in TestCISKeepsRunningOnNonFatalExitCodeFromStart

### DIFF
--- a/pkg/component/runtime/service_test.go
+++ b/pkg/component/runtime/service_test.go
@@ -359,8 +359,8 @@ func TestCISKeepsRunningOnNonFatalExitCodeFromStart(t *testing.T) {
 		var conn net.Conn
 		if runtime.GOOS != "windows" {
 			dialCtx, cancelDial := context.WithTimeout(ctx, time.Second)
-			defer cancelDial()
 			conn, err = (&net.Dialer{}).DialContext(dialCtx, "unix", parsedCISAddr.Host+parsedCISAddr.Path)
+			cancelDial()
 		} else {
 			if strings.HasPrefix(cisAddr, "npipe:///") {
 				path := strings.TrimPrefix(cisAddr, "npipe:///")

--- a/pkg/component/runtime/service_test.go
+++ b/pkg/component/runtime/service_test.go
@@ -358,7 +358,9 @@ func TestCISKeepsRunningOnNonFatalExitCodeFromStart(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		var conn net.Conn
 		if runtime.GOOS != "windows" {
-			conn, err = net.Dial("unix", parsedCISAddr.Host+parsedCISAddr.Path)
+			dialCtx, cancelDial := context.WithTimeout(ctx, time.Second)
+			defer cancelDial()
+			conn, err = (&net.Dialer{}).DialContext(dialCtx, "unix", parsedCISAddr.Host+parsedCISAddr.Path)
 		} else {
 			if strings.HasPrefix(cisAddr, "npipe:///") {
 				path := strings.TrimPrefix(cisAddr, "npipe:///")

--- a/pkg/component/runtime/service_test.go
+++ b/pkg/component/runtime/service_test.go
@@ -152,9 +152,9 @@ func TestResolveUninstallTokenArg(t *testing.T) {
 			uninstallSpec: &component.ServiceOperationsCommandSpec{
 				Args: []string{"uninstall", "--log", "stderr", "--uninstall-token"},
 			},
-			uninstallToken: "EQo1ML2T95pdcH",
+			uninstallToken: "placeholder",
 			wantUninstallSpec: &component.ServiceOperationsCommandSpec{
-				Args: []string{"uninstall", "--log", "stderr", "--uninstall-token", "EQo1ML2T95pdcH"},
+				Args: []string{"uninstall", "--log", "stderr", "--uninstall-token", "placeholder"},
 			},
 		},
 		{
@@ -166,9 +166,9 @@ func TestResolveUninstallTokenArg(t *testing.T) {
 					return args
 				}(),
 			},
-			uninstallToken: "EQo1ML2T95pdcH",
+			uninstallToken: "placeholder",
 			wantUninstallSpec: &component.ServiceOperationsCommandSpec{
-				Args: []string{"uninstall", "--log", "stderr", "--uninstall-token", "EQo1ML2T95pdcH"},
+				Args: []string{"uninstall", "--log", "stderr", "--uninstall-token", "placeholder"},
 			},
 		},
 	}
@@ -459,7 +459,8 @@ func mockEndpointBinary(t *testing.T, exitCode int) string {
 		outPath += ".exe"
 	}
 
-	cmd := exec.Command(
+	cmd := exec.CommandContext(
+		t.Context(),
 		"go", "build",
 		"-o", outPath,
 		"-ldflags", "-X 'main.ExitCode="+strconv.Itoa(exitCode)+"'",

--- a/pkg/component/runtime/service_test.go
+++ b/pkg/component/runtime/service_test.go
@@ -342,33 +342,38 @@ func TestCISKeepsRunningOnNonFatalExitCodeFromStart(t *testing.T) {
 	parsedCISAddr, err := url.Parse(cisAddr)
 	require.NoError(t, err)
 
+	// First, wait for the warning log message indicating the runtime continued
+	// past the non-fatal install failure. Filtering the observer (rather than
+	// draining it with TakeAll) means the assertion does not race with the
+	// connection-server dial below.
 	expectedWarnLogMsg := fmt.Sprintf("exit code %d is non-fatal, continuing to run...", nonFatalExitCode)
-	require.Eventually(t, func() bool {
+	require.Eventuallyf(t, func() bool {
+		return logObs.FilterLevelExact(zapcore.WarnLevel).FilterMessage(expectedWarnLogMsg).Len() > 0
+	}, 30*time.Second, 100*time.Millisecond, "did not observe expected non-fatal warn log %q", expectedWarnLogMsg)
+
+	// Then verify the connection-info server is still accepting connections.
+	// The dial is retried because on Windows winio's DialPipe can intermittently
+	// return ERROR_PIPE_BUSY between Accept calls; the conn is closed each
+	// attempt to avoid leaking client-side pipe handles.
+	require.Eventuallyf(t, func() bool {
+		var conn net.Conn
 		if runtime.GOOS != "windows" {
-			_, err = net.Dial("unix", parsedCISAddr.Host+parsedCISAddr.Path)
+			conn, err = net.Dial("unix", parsedCISAddr.Host+parsedCISAddr.Path)
 		} else {
 			if strings.HasPrefix(cisAddr, "npipe:///") {
 				path := strings.TrimPrefix(cisAddr, "npipe:///")
 				cisAddr = `\\.\pipe\` + path
 			}
-			_, err = npipe.Dial(cisAddr)("", "")
+			conn, err = npipe.Dial(cisAddr)("", "")
 		}
 
 		if err != nil {
 			t.Logf("Connection info server is not running: %v", err)
 			return false
 		}
-
-		logs := logObs.TakeAll()
-		for _, l := range logs {
-			t.Logf("[%s] %s", l.Level, l.Message)
-			if l.Level == zapcore.WarnLevel && l.Message == expectedWarnLogMsg {
-				return true
-			}
-		}
-
-		return false
-	}, 30*time.Second, 1*time.Second)
+		_ = conn.Close()
+		return true
+	}, 30*time.Second, 1*time.Second, "connection info server did not accept a connection")
 }
 
 // TestServiceStartRetry tests that the service runtime will


### PR DESCRIPTION
Fix some test flakiness, where it was possible to fail on Windows due to the dial returning a busy pipe error on subsequent checks, despite the test conditions being successfully met.

The fix consists of splitting a single Eventually assertion into two: first we wait for the warning log line we expect, then we check whether the connection info server is up. This also makes the test faster, down to around 200ms from 1s.

Relates https://github.com/elastic/elastic-agent/issues/11590.