### PR TITLE
kb(k8s): bk pipeline for running k8s

### DIFF
--- a/.buildkite/k8s-testing-pipeline.yml
+++ b/.buildkite/k8s-testing-pipeline.yml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+#
+# Kubernetes Integration Tests - Dynamic Pipeline
+# This pipeline is uploaded dynamically based on the test tier needed
+#
+# Expected environment variables:
+#   K8S_TEST_TIER: "tier1", "tier2", or "tier3"
+#   K8S_TEST_VERSIONS: JSON array of k8s versions to test
+#   K8S_TEST_VARIANTS: JSON array of container variants to test
+
+env:
+  ASDF_MAGE_VERSION: 1.14.0
+  ASDF_KIND_VERSION: "0.27.0"
+  TARGET_ARCH: "amd64"
+
+  # The following images are defined here and their values will be updated by updatecli
+  # Please do not change them manually.
+  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-elastic-agent-ubuntu-2404-1777597312"
+
+common:
+  - google_oidc_observability_plugin: &google_oidc_observability_plugin
+      elastic/oblt-google-auth#v1.3.0:
+        lifetime: 10800
+  - oblt_cli_plugin: &oblt_cli_plugin
+      elastic/oblt-cli#v0.4.1:
+        version-file: .oblt-cli-version
+  - vault_github_token: &vault_github_token
+      elastic/vault-github-token#v0.1.0:
+
+steps:
+  - label: ":kubernetes: {{matrix.version}}:amd64:{{matrix.variant}}"
+    env:
+      K8S_VERSION: "{{matrix.version}}"
+      DOCKER_VARIANTS: "{{matrix.variant}}"
+      TARGET_ARCH: "amd64"
+    command: |
+      buildkite-agent artifact download build/distributions/*-linux-amd64.docker.tar.gz . --step 'packaging-containers-amd64'
+      .buildkite/scripts/steps/integration_tests_oblt-cli.sh kubernetes false
+    artifact_paths:
+      - build/*
+      - build/diagnostics/**
+      - build/*.pod_logs_dump/*
+    retry:
+      automatic:
+        limit: 1
+    agents:
+      provider: "gcp"
+      machineType: "n2-standard-8"
+      image: "${IMAGE_UBUNTU_2404_X86_64}"
+      diskSizeGb: 80
+    plugins:
+      - *google_oidc_observability_plugin
+      - *oblt_cli_plugin
+      - *vault_github_token
+    matrix: $K8S_TEST_MATRIX

--- a/.buildkite/k8s-testing-pipeline.yml
+++ b/.buildkite/k8s-testing-pipeline.yml
@@ -1,55 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 #
-# Kubernetes Integration Tests - Dynamic Pipeline
-# This pipeline is uploaded dynamically based on the test tier needed
-#
-# Expected environment variables:
-#   K8S_TEST_TIER: "tier1", "tier2", or "tier3"
-#   K8S_TEST_VERSIONS: JSON array of k8s versions to test
-#   K8S_TEST_VARIANTS: JSON array of container variants to test
-
-env:
-  ASDF_MAGE_VERSION: 1.14.0
-  ASDF_KIND_VERSION: "0.27.0"
-  TARGET_ARCH: "amd64"
-
-  # The following images are defined here and their values will be updated by updatecli
-  # Please do not change them manually.
-  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-elastic-agent-ubuntu-2404-1777597312"
-
-common:
-  - google_oidc_observability_plugin: &google_oidc_observability_plugin
-      elastic/oblt-google-auth#v1.3.0:
-        lifetime: 10800
-  - oblt_cli_plugin: &oblt_cli_plugin
-      elastic/oblt-cli#v0.4.1:
-        version-file: .oblt-cli-version
-  - vault_github_token: &vault_github_token
-      elastic/vault-github-token#v0.1.0:
 
 steps:
-  - label: ":kubernetes: {{matrix.version}}:amd64:{{matrix.variant}}"
-    env:
-      K8S_VERSION: "{{matrix.version}}"
-      DOCKER_VARIANTS: "{{matrix.variant}}"
-      TARGET_ARCH: "amd64"
-    command: |
-      buildkite-agent artifact download build/distributions/*-linux-amd64.docker.tar.gz . --step 'packaging-containers-amd64'
-      .buildkite/scripts/steps/integration_tests_oblt-cli.sh kubernetes false
-    artifact_paths:
-      - build/*
-      - build/diagnostics/**
-      - build/*.pod_logs_dump/*
-    retry:
-      automatic:
-        limit: 1
-    agents:
-      provider: "gcp"
-      machineType: "n2-standard-8"
-      image: "${IMAGE_UBUNTU_2404_X86_64}"
-      diskSizeGb: 80
-    plugins:
-      - *google_oidc_observability_plugin
-      - *oblt_cli_plugin
-      - *vault_github_token
-    matrix: $K8S_TEST_MATRIX
+  - label: ":kubernetes:"
+    command: true

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -575,7 +575,7 @@ spec:
           message: Daily trigger of Extended pipeline for all the active branches
           env:
             PIPELINES_TO_TRIGGER: 'elastic-agent-extended-testing'
-            skip_intermediate_builds: true
+      skip_intermediate_builds: true
       provider_settings:
         trigger_mode: none
       teams:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -575,6 +575,7 @@ spec:
           message: Daily trigger of Extended pipeline for all the active branches
           env:
             PIPELINES_TO_TRIGGER: 'elastic-agent-extended-testing'
+            skip_intermediate_builds: true
       provider_settings:
         trigger_mode: none
       teams:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -496,6 +496,49 @@ spec:
         everyone:
           access_level: READ_ONLY
 
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elastic-agent-k8s-testing
+  description: Buildkite pipeline for the Elastic Agent k8s testing
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elastic-agent-k8s-testing
+
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: platform-ingest
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: elastic-agent-k8s-testing
+      description: Buildkite pipeline for the Elastic Agent k8s testing
+    spec:
+      repository: elastic/elastic-agent
+      pipeline_file: ".buildkite/k8s-testing-pipeline.yml"
+      provider_settings:
+        trigger_mode: none # don't trigger jobs from github activity
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: "!main !8.19 !9.*"
+      skip_intermediate_builds: true
+      skip_intermediate_builds_branch_filter: "!main !8.19 !9.*"
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: "true"
+        SLACK_NOTIFICATIONS_CHANNEL: "#ingest-notifications"
+        SLACK_NOTIFICATIONS_ALL_BRANCHES: "false"
+        SLACK_NOTIFICATIONS_ON_SUCCESS: "false"
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        observablt-robots:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: BUILD_AND_READ
+
 # **************************************************************
 # SECTION START: Scheduler pipeline
 # (Definitions for scheduled runs of various Elastic Agent pipelines)
@@ -532,6 +575,13 @@ spec:
           message: Daily trigger of Extended pipeline for all the active branches
           env:
             PIPELINES_TO_TRIGGER: 'elastic-agent-extended-testing'
+        K8s Tests:
+          branch: main
+          cronline: "@daily"
+          message: Daily trigger of K8s pipeline for all the active branches
+          env:
+            PIPELINES_TO_TRIGGER: 'elastic-agent-k8s-testing'
+            K8S_SCHEDULED_TIER3: 'true'
       skip_intermediate_builds: true
       provider_settings:
         trigger_mode: none

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -575,14 +575,6 @@ spec:
           message: Daily trigger of Extended pipeline for all the active branches
           env:
             PIPELINES_TO_TRIGGER: 'elastic-agent-extended-testing'
-        K8s Tests:
-          branch: main
-          cronline: "@daily"
-          message: Daily trigger of K8s pipeline for all the active branches
-          env:
-            PIPELINES_TO_TRIGGER: 'elastic-agent-k8s-testing'
-            K8S_SCHEDULED_TIER3: 'true'
-      skip_intermediate_builds: true
       provider_settings:
         trigger_mode: none
       teams:


### PR DESCRIPTION
## What does this PR do?

Create a k8s tests pipeline skeleton

This diagram shows when and how K8s testing pipelines are triggered.

```mermaid
flowchart TD
    subgraph GitHub["GitHub Events"]
        PR[Pull Request<br/>to main/8.*]
        Push[Push to<br/>main/8.*]
        Schedule[Schedule<br/>Daily 2:00 AM UTC]
        Manual[Manual Trigger<br/>workflow_dispatch]
    end
    
    subgraph GitHubActions["GitHub Actions"]
        GHA_K8s[kubernetes-integration-tests.yml<br/>Self-contained K8s tests]
        GHA_Scheduled[k8s-tier3-scheduled.yml<br/>Triggers Buildkite]
    end
    
    subgraph Buildkite["Buildkite Pipeline"]
        BK_Main[bk.integration.pipeline.yml<br/>Main integration pipeline]
        BK_Upload[upload-k8s-tests.sh<br/>Determines tier & uploads]
        BK_K8s[k8s-testing-pipeline.yml<br/>Dynamic K8s tests]
    end
    
    PR --> GHA_K8s
    Push --> GHA_K8s
    PR -.-> BK_Main
    Push -.-> BK_Main
    
    Schedule --> GHA_Scheduled
    Manual --> GHA_Scheduled
    
    GHA_Scheduled -->|Sets K8S_SCHEDULED_TIER3=true| BK_Main
    
    BK_Main -->|Kubernetes group step| BK_Upload
    BK_Upload -->|buildkite-agent pipeline upload| BK_K8s
    
    BK_Upload -.->|Tier 1/2/3 decision| Decision{Tier Selection}
    
    Decision -->|Tier 1<br/>PR + no packaging| Config1[2 versions × 1 variant]
    Decision -->|Tier 2<br/>PR + packaging<br/>or branch build| Config2[2 versions × 9 variants]
    Decision -->|Tier 3<br/>Scheduled| Config3[8 versions × 9 variants]
    
    Config1 -.-> BK_K8s
    Config2 -.-> BK_K8s
    Config3 -.-> BK_K8s
    
    style GHA_K8s fill:#1a4d6d,stroke:#29b6f6,color:#fff
    style GHA_Scheduled fill:#6d4d1a,stroke:#ff9800,color:#fff
    style BK_Main fill:#4d1a6d,stroke:#ab47bc,color:#fff
    style BK_Upload fill:#1a6d3a,stroke:#66bb6a,color:#fff
    style BK_K8s fill:#6d5d1a,stroke:#ffca28,color:#fff
    style Decision fill:#6d1a1a,stroke:#ef5350,color:#fff
```


## Why is it important?

Help with running k8s smarter based on tiers, but for this, we need the k8s pipeline in place using the `catalogue-info.yaml` file.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Notifies https://github.com/elastic/elastic-agent/pull/14164

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
