### PR TITLE
Upgrade npm to v11 in non-wolfi elastic-agent-complete Docker images

### DIFF
--- a/changelog/fragments/1778526445-upgrade-npm-elastic-agent-docker.yaml
+++ b/changelog/fragments/1778526445-upgrade-npm-elastic-agent-docker.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: security
+
+# Change summary; a 80ish characters long description of the change.
+summary: Upgrade npm to v11 in non-wolfi elastic-agent-complete Docker images
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -244,6 +244,8 @@ RUN cd {{$beatHome}}/.node \
 # Install synthetics as a regular user, installing npm deps as root odesn't work
    # fix .node .npm and .synthetics
    && chown -R {{ .user }}:{{ .user }} $NODE_PATH
+# TODO: Remove this step when Node.js is bumped to a version that bundles npm >= 11.14.0
+RUN npm install -g npm@11.14.1
 USER {{ .user }}
 # If this fails dump the NPM logs
 RUN (npm i -g --loglevel verbose --production --engine-strict @elastic/synthetics@stack_release || sh -c 'tail -n +1 /root/.npm/_logs/* && exit 1') && \

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -248,7 +248,8 @@ RUN cd {{$beatHome}}/.node \
 # Bootstrap npm 11.14.1 from a downloaded copy to avoid npm 10.x self-replacement failures
 RUN curl -fsSL https://registry.npmjs.org/npm/-/npm-11.14.1.tgz | tar xz -C /tmp \
     && node /tmp/package/bin/npm-cli.js install -g npm@11.14.1 \
-    && rm -rf /tmp/package
+    && rm -rf /tmp/package \
+    && chown -R {{ .user }}:{{ .user }} $NODE_PATH
 USER {{ .user }}
 # If this fails dump the NPM logs
 RUN (npm i -g --loglevel verbose --production --engine-strict @elastic/synthetics@stack_release || sh -c 'tail -n +1 /root/.npm/_logs/* && exit 1') && \

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -245,7 +245,10 @@ RUN cd {{$beatHome}}/.node \
    # fix .node .npm and .synthetics
    && chown -R {{ .user }}:{{ .user }} $NODE_PATH
 # TODO: Remove this step when Node.js is bumped to a version that bundles npm >= 11.14.0
-RUN npm install -g npm@11.14.1
+# Bootstrap npm 11.14.1 from a downloaded copy to avoid npm 10.x self-replacement failures
+RUN curl -fsSL https://registry.npmjs.org/npm/-/npm-11.14.1.tgz | tar xz -C /tmp \
+    && node /tmp/package/bin/npm-cli.js install -g npm@11.14.1 \
+    && rm -rf /tmp/package
 USER {{ .user }}
 # If this fails dump the NPM logs
 RUN (npm i -g --loglevel verbose --production --engine-strict @elastic/synthetics@stack_release || sh -c 'tail -n +1 /root/.npm/_logs/* && exit 1') && \


### PR DESCRIPTION
## What does this PR do?

Adds a step to upgrade npm to 11.14.1 after Node.js installation in the
non-wolfi elastic-agent-complete Docker image template. Node.js 22.22.2
bundles npm 10.9.7, while the wolfi variant already uses npm 11.12.0 via a
separate apk package. This aligns both variants on npm 11 and picks up the
latest transitive dependency versions.

Because the bundled npm 10.x cannot reliably self-upgrade to npm 11.x (it
fails with `MODULE_NOT_FOUND: Cannot find module 'promise-retry'` due to
overwriting its own dependencies mid-operation), the upgrade is performed by
downloading the npm 11.14.1 tarball and running its CLI via `node` directly.

This step can be removed once Node.js is bumped to a version that bundles
npm >= 11.14.0.

## Why is it important?

The wolfi and non-wolfi image variants currently ship different npm major versions
(11 vs 10), which means they have different transitive dependency trees. This
upgrade brings them into alignment on npm 11.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None expected. The wolfi variant already runs npm 11.

## How to test this PR locally

Build the non-wolfi elastic-agent-complete Docker image:
```
DEV=true EXTERNAL=true SNAPSHOT=true PLATFORMS=linux/amd64 PACKAGES=docker DOCKER_VARIANTS=complete mage -v package
```

Then verify npm version:
```
docker run --rm <image> npm --version
# Should output: 11.14.1
```

## Related issues

-