### PR TITLE
fix: prevent agent startup failure when upgrade marker file is corrupt

### DIFF
--- a/changelog/fragments/1778590690-upgrade-marker-startup-resilience.yaml
+++ b/changelog/fragments/1778590690-upgrade-marker-startup-resilience.yaml
@@ -1,0 +1,51 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user's deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Agent no longer fails to start when the upgrade marker file is corrupt
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  If the machine lost power while the agent was in the middle of an upgrade,
+  the upgrade marker file could be left in a broken state. This caused the
+  agent to refuse to start on the next boot. The agent now moves the broken
+  file out of the way (keeping it for support diagnostics) and starts up
+  normally as if no upgrade was in progress. The upgrade marker file is also
+  now written more safely, making this situation less likely to occur.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/upgrade/marker_access_common.go
+++ b/internal/pkg/agent/application/upgrade/marker_access_common.go
@@ -31,14 +31,13 @@ func writeMarkerFileCommon(markerFile string, markerBytes []byte, shouldFsync bo
 		return fmt.Errorf("failed to write upgrade marker file: %w", err)
 	}
 
-	if !shouldFsync {
-		return nil
+	if shouldFsync {
+		if err := f.Sync(); err != nil {
+			return fmt.Errorf("failed to sync upgrade marker file to disk: %w", err)
+		}
 	}
 
-	if err := f.Sync(); err != nil {
-		return fmt.Errorf("failed to sync upgrade marker file to disk: %w", err)
-	}
-	// I think we need to close before trying to swap the files on Windows
+	// Close before rotating on Windows to avoid sharing violations.
 	closeFile()
 
 	if err := file.SafeFileRotate(markerFile, f.Name()); err != nil {

--- a/internal/pkg/agent/application/upgrade/marker_access_test.go
+++ b/internal/pkg/agent/application/upgrade/marker_access_test.go
@@ -19,16 +19,26 @@ import (
 )
 
 func TestWriteMarkerFile(t *testing.T) {
-	tmpDir := t.TempDir()
-	markerFile := filepath.Join(tmpDir, markerFilename)
+	tests := []struct {
+		name        string
+		shouldFsync bool
+	}{
+		{name: "with fsync", shouldFsync: true},
+		{name: "without fsync", shouldFsync: false},
+	}
 
-	markerBytes := []byte("foo bar")
-	err := writeMarkerFile(markerFile, markerBytes, true)
-	require.NoError(t, err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			markerFile := filepath.Join(t.TempDir(), markerFilename)
+			markerBytes := []byte("foo bar")
 
-	data, err := os.ReadFile(markerFile)
-	require.NoError(t, err)
-	require.Equal(t, markerBytes, data)
+			require.NoError(t, writeMarkerFile(markerFile, markerBytes, tc.shouldFsync))
+
+			data, err := os.ReadFile(markerFile)
+			require.NoError(t, err)
+			require.Equal(t, markerBytes, data, "writeMarkerFile must persist data to the final file path")
+		})
+	}
 }
 
 func TestWriteMarkerFileWithTruncation(t *testing.T) {

--- a/internal/pkg/agent/application/upgrade/marker_access_test.go
+++ b/internal/pkg/agent/application/upgrade/marker_access_test.go
@@ -162,15 +162,11 @@ func watchFileNotEmpty(t *testing.T, ctx context.Context, filePath string, errCh
 }
 
 func randomBytes(length int) []byte {
-	chars := []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZÅÄÖ" +
-		"abcdefghijklmnopqrstuvwxyzåäö" +
-		"0123456789" +
-		"~=+%^*/()[]{}/!@#$?|")
+	chars := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789~=+%^*/()[]{}/!@#$?|")
 
-	var b []byte
-	for i := 0; i < length; i++ {
-		rune := chars[rand.IntN(len(chars))]
-		b = append(b, byte(rune))
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = chars[rand.IntN(len(chars))]
 	}
 
 	return b

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -161,7 +161,7 @@ func markUpgradeProvider(updateActiveCommit updateActiveCommitFunc, writeFile wr
 
 		markerPath := markerFilePath(dataDirPath)
 		log.Infow("Writing upgrade marker file", "file.path", markerPath, "hash", marker.Hash, "prev_hash", marker.PrevHash)
-		if err := writeFile(markerPath, markerBytes, 0600); err != nil {
+		if err := writeMarkerFile(markerPath, markerBytes, true); err != nil {
 			return goerrors.Join(err, errors.New(errors.TypeFilesystem, "failed to create update marker file", errors.M(errors.MetaKeyPath, markerPath)))
 		}
 
@@ -199,6 +199,30 @@ func CleanMarker(log *logger.Logger, dataDirPath string) error {
 // and no error.
 func LoadMarker(dataDirPath string) (*UpdateMarker, error) {
 	return loadMarker(markerFilePath(dataDirPath))
+}
+
+// TryLoadMarker loads the upgrade marker. If the file does not exist it
+// returns nil and no error. Unlike LoadMarker, if the file exists but cannot be
+// parsed (e.g. corrupted by a crash during an upgrade write), it renames the
+// corrupt file and returns nil so startup can proceed without upgrade state.
+func TryLoadMarker(log *logger.Logger, dataDirPath string) (*UpdateMarker, error) {
+	markerFile := markerFilePath(dataDirPath)
+	marker, err := loadMarker(markerFile)
+	if err == nil {
+		return marker, nil
+	}
+
+	// The file exists but could not be parsed. Move it aside so the agent can
+	// start without upgrade state rather than aborting startup entirely.
+	corruptPath := markerFile + ".corrupt"
+	if renameErr := os.Rename(markerFile, corruptPath); renameErr != nil {
+		log.Warnf("corrupt upgrade marker at %s could not be moved to %s (parse error: %v, rename error: %v); starting without upgrade state",
+			markerFile, corruptPath, err, renameErr)
+	} else {
+		log.Warnf("corrupt upgrade marker moved to %s (parse error: %v); starting without upgrade state",
+			corruptPath, err)
+	}
+	return nil, nil
 }
 
 func loadMarker(markerFile string) (*UpdateMarker, error) {

--- a/internal/pkg/agent/application/upgrade/step_mark_test.go
+++ b/internal/pkg/agent/application/upgrade/step_mark_test.go
@@ -81,6 +81,35 @@ func TestSaveAndLoadMarker_NoLoss(t *testing.T) {
 	require.NoError(t, err, "Failed to clean up marker file")
 }
 
+func TestTryLoadMarker_CorruptMarker(t *testing.T) {
+	// Simulate a power loss mid-write: the action line is cut off inside a
+	// flow mapping, leaving an unclosed string that yaml.Unmarshal rejects.
+	const truncatedMarkerYAML = `version: 9.0.0
+hash: a1b2c3
+versioned_home: data/elastic-agent-9.0.0-a1b2c3
+updated_on: 2026-04-20T10:00:00Z
+prev_version: 8.17.6
+action: {id: "fleet-action-abc1`
+
+	log, _ := loggertest.New(t.Name())
+	dataDir := t.TempDir()
+	markerFile := markerFilePath(dataDir)
+	require.NoError(t, os.WriteFile(markerFile, []byte(truncatedMarkerYAML), 0600))
+
+	marker, err := TryLoadMarker(log, dataDir)
+	require.NoError(t, err, "truncated marker must not cause a startup error")
+	require.Nil(t, marker, "truncated marker must return nil so startup can continue")
+	require.NoFileExists(t, markerFile, "corrupt marker file must have been moved aside")
+	require.FileExists(t, markerFile+".corrupt", "corrupt marker must be preserved for diagnostics")
+}
+
+func TestTryLoadMarker_MissingFile(t *testing.T) {
+	log, _ := loggertest.New(t.Name())
+	marker, err := TryLoadMarker(log, t.TempDir())
+	require.NoError(t, err)
+	require.Nil(t, marker)
+}
+
 func TestMarkUpgrade(t *testing.T) {
 	var parsed123SNAPSHOT = agtversion.NewParsedSemVer(1, 2, 3, "SNAPSHOT", "")
 	var parsed456SNAPSHOT = agtversion.NewParsedSemVer(4, 5, 6, "SNAPSHOT", "")

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -817,7 +817,7 @@ func setupMetrics(
 // ongoing upgrade operation, i.e. being re-exec'd and performs
 // any upgrade-specific work, if needed.
 func handleUpgrade(log *logger.Logger) (*upgrade.UpdateMarker, error) {
-	upgradeMarker, err := upgrade.LoadMarker(paths.Data())
+	upgradeMarker, err := upgrade.TryLoadMarker(log, paths.Data())
 	if err != nil {
 		return nil, fmt.Errorf("unable to load upgrade marker to check if Agent is being upgraded: %w", err)
 	}


### PR DESCRIPTION
## What does this PR do?

When elastic-agent starts, it reads an upgrade marker file to determine whether a previous upgrade was in progress. If that file was corrupt (for example because power was lost while it was being written) the agent would fail to start entirely, requiring manual intervention to remove the file.

This PR introduces `TryLoadMarker`, which is used at startup instead of `LoadMarker`. If the marker file exists but cannot be parsed, the bad file is moved aside (renamed to `<marker>.corrupt`) and startup continues without upgrade state.

  ## Why is it important?

If a machine loses power during an upgrade, the partially-written upgrade marker causes the agent to refuse to start on every subsequent boot. This is a silent failure with no easy recovery path for operators who aren't aware of the marker file. The fix makes the agent self-healing in this scenario while preserving the bad file for diagnostics.

  ## Checklist

  - [x] I have read and understood the [pull request
  guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
  - [x] My code follows the style guidelines of this project
  - ~~I have commented my code, particularly in hard-to-understand areas~~
  - ~~I have made corresponding changes to the documentation~~
  - ~~I have made corresponding change to the default configuration files~~
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
  - ~~I have added an integration test or an E2E test~~

  ## Disruptive User Impact

  None

  ## How to test this PR locally

  ```
  go test -run TestTryLoadMarker ./internal/pkg/agent/application/upgrade/... -v
  go test -run TestWriteMarkerFile ./internal/pkg/agent/application/upgrade/... -v
  ```

  ## Related issues
  - Closes https://github.com/elastic/elastic-agent/issues/13306
