### PR TITLE
fix: skip EXEC_UID/EXEC_GID env vars when using rootless Docker

### DIFF
--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -961,7 +961,7 @@ func addFileToZip(ar *zip.Writer, baseDir string, pkgFile PackageFile) error {
 			return nil
 		}
 
-		file, err := os.Open(path)
+		file, err := os.Open(path) //nolint:gosec // G122: path comes from filepath.Walk on trusted build inputs, no user-controlled symlink attack surface
 		if err != nil {
 			return err
 		}
@@ -1044,7 +1044,7 @@ func addFileToTar(ar *tar.Writer, baseDir string, pkgFile PackageFile) error {
 			return nil
 		}
 
-		file, err := os.Open(path)
+		file, err := os.Open(path) //nolint:gosec // G122: path comes from filepath.WalkDir on trusted build inputs, no user-controlled symlink attack surface
 		if err != nil {
 			return err
 		}

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -889,10 +889,17 @@ func addUIDGidEnvArgs(args []string) ([]string, error) {
 			"Using UID=%d GID=%d", uid, gid)
 	}
 
-	return append(args,
-		"-e", "EXEC_UID="+strconv.Itoa(uid),
-		"-e", "EXEC_GID="+strconv.Itoa(gid),
-	), nil
+	// In rootless Docker, container UID 0 maps to the host user's UID, so files
+	// created as root inside the container are already owned by the correct user
+	// on the host.
+	if !isRootlessDocker() {
+		args = append(args,
+			"-e", "EXEC_UID="+strconv.Itoa(uid),
+			"-e", "EXEC_GID="+strconv.Itoa(gid),
+		)
+	}
+
+	return args, nil
 }
 
 // addFileToZip adds a file (or directory) to a zip archive.


### PR DESCRIPTION
## What does this PR do?

When building Linux rpm or deb packages using **rootless** Docker, the `mage package` command would fail with a `Permission denied` error:

```
$ DEV=true EXTERNAL=true SNAPSHOT=true PLATFORMS="linux/amd64" PACKAGES="tar.gz,rpm,deb" mage -v package
...
/var/lib/gems/2.7.0/gems/fpm-1.13.1/lib/fpm/package.rb:537:in `delete': Permission denied @ apply2files - build/distributions/elastic-agent-9.5.0-SNAPSHOT-x86_64.rpm (Errno::EACCES)
	from /var/lib/gems/2.7.0/gems/fpm-1.13.1/lib/fpm/package.rb:537:in `output_check'
	from /var/lib/gems/2.7.0/gems/fpm-1.13.1/lib/fpm/package/rpm.rb:436:in `output'
	from /var/lib/gems/2.7.0/gems/fpm-1.13.1/lib/fpm/command.rb:487:in `execute'
	from /var/lib/gems/2.7.0/gems/clamp-1.0.1/lib/clamp/command.rb:68:in `run'
	from /var/lib/gems/2.7.0/gems/fpm-1.13.1/lib/fpm/command.rb:574:in `run'
	from /var/lib/gems/2.7.0/gems/clamp-1.0.1/lib/clamp/command.rb:133:in `run'
	from /var/lib/gems/2.7.0/gems/fpm-1.13.1/bin/fpm:7:in `<top (required)>'
	from /usr/local/bin/fpm:23:in `load'
	from /usr/local/bin/fpm:23:in `<main>'
```

The FPM Docker image supports `EXEC_UID` and `EXEC_GID` environment variables to run as a specific user inside the container. In a regular Docker setup this is necessary so that the output files end up owned by the host user rather than root. However, in rootless Docker, container UID 0 already maps to the host user's UID so no ownership adjustment is needed.

## Why is it important?

Developers using **rootless** Docker could not build Linux packages at all. This makes `mage package` work correctly out of the box on rootless Docker setups.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None

## How to test this PR locally

On a system with [rootless Docker](https://docs.docker.com/engine/security/rootless/), run:

```
DEV=true EXTERNAL=true SNAPSHOT=true PLATFORMS="linux/amd64" PACKAGES="tar.gz,rpm" mage -v package
```

This should succeed on the first run (fresh build) and on subsequent runs (repeat build).

## Related issues

- Relates to https://github.com/elastic/elastic-agent/pull/13202