### PR TITLE
Use redact.REDACTED constant in integration tests

### DIFF
--- a/testing/integration/ess/endpoint_security_test.go
+++ b/testing/integration/ess/endpoint_security_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/kibana"
+	"github.com/elastic/elastic-agent-libs/redact"
 	"github.com/elastic/elastic-agent-libs/testing/certutil"
 	"github.com/elastic/elastic-agent-libs/testing/proxytest"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
@@ -1429,8 +1430,8 @@ func TestInstallDefendWithMTLSandEncCertKey(t *testing.T) {
 				require.NoErrorf(t, err, "error running inspect cmd")
 
 				assert.Equal(t, proxyCLI.URL, got.Fleet.ProxyURL)
-				assert.Equal(t, "REDACTED", got.Fleet.Ssl.Certificate)
-				assert.Equal(t, "REDACTED", got.Fleet.Ssl.Key)
+				assert.Equal(t, redact.REDACTED, got.Fleet.Ssl.Certificate)
+				assert.Equal(t, redact.REDACTED, got.Fleet.Ssl.Key)
 				assert.Empty(t, got.Fleet.Ssl.KeyPassphrasePath, "policy should have removed key_passphrase_path as key isn't passphrase protected anymore")
 			},
 		},
@@ -1449,9 +1450,9 @@ func TestInstallDefendWithMTLSandEncCertKey(t *testing.T) {
 				require.NoErrorf(t, err, "error running inspect cmd")
 
 				assert.Equal(t, proxyCLI.URL, got.Fleet.ProxyURL)
-				assert.Equal(t, "REDACTED", got.Fleet.Ssl.Certificate)
-				assert.Equal(t, "REDACTED", got.Fleet.Ssl.Key)
-				assert.Equal(t, "REDACTED", got.Fleet.Ssl.KeyPassphrasePath)
+				assert.Equal(t, redact.REDACTED, got.Fleet.Ssl.Certificate)
+				assert.Equal(t, redact.REDACTED, got.Fleet.Ssl.Key)
+				assert.Equal(t, redact.REDACTED, got.Fleet.Ssl.KeyPassphrasePath)
 			},
 		},
 		{
@@ -1521,8 +1522,8 @@ func TestInstallDefendWithMTLSandEncCertKey(t *testing.T) {
 					return
 				}
 				assert.Equal(t, proxyPolicymTLS.URL, got.Fleet.ProxyURL)
-				assert.Equal(t, "REDACTED", got.Fleet.Ssl.Certificate)
-				assert.Equal(t, "REDACTED", got.Fleet.Ssl.Key)
+				assert.Equal(t, redact.REDACTED, got.Fleet.Ssl.Certificate)
+				assert.Equal(t, redact.REDACTED, got.Fleet.Ssl.Key)
 				assert.Empty(t, got.Fleet.Ssl.KeyPassphrasePath, "policy should have removed key_passphrase_path as key isn't passphrase protected anymore")
 			},
 		},
@@ -1559,8 +1560,8 @@ func TestInstallDefendWithMTLSandEncCertKey(t *testing.T) {
 				}
 
 				assert.Equal(t, proxyPolicymTLS.URL, got.Fleet.ProxyURL)
-				assert.Equal(t, "REDACTED", got.Fleet.Ssl.Certificate)
-				assert.Equal(t, "REDACTED", got.Fleet.Ssl.Key)
+				assert.Equal(t, redact.REDACTED, got.Fleet.Ssl.Certificate)
+				assert.Equal(t, redact.REDACTED, got.Fleet.Ssl.Key)
 				assert.Empty(t, got.Fleet.Ssl.KeyPassphrasePath, "policy should have removed key_passphrase_path as key isn't passphrase protected anymore")
 			},
 		},
@@ -1591,8 +1592,8 @@ func TestInstallDefendWithMTLSandEncCertKey(t *testing.T) {
 				}
 
 				assert.Equal(t, proxyPolicymTLS.URL, got.Fleet.ProxyURL)
-				assert.Equal(t, "REDACTED", got.Fleet.Ssl.Certificate)
-				assert.Equal(t, "REDACTED", got.Fleet.Ssl.Key)
+				assert.Equal(t, redact.REDACTED, got.Fleet.Ssl.Certificate)
+				assert.Equal(t, redact.REDACTED, got.Fleet.Ssl.Key)
 				assert.Empty(t, got.Fleet.Ssl.KeyPassphrasePath, "key_passphrase_path was never set")
 			},
 		},

--- a/testing/integration/ess/inspect_test.go
+++ b/testing/integration/ess/inspect_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
+	"github.com/elastic/elastic-agent-libs/redact"
+
 	integrationtest "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools/check"
@@ -97,9 +99,9 @@ func TestInspect(t *testing.T) {
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"inputs.0.custom_attr"}, yObj.SecretPaths)
 	require.Len(t, yObj.Inputs, 1)
-	assert.Equalf(t, "REDACTED", yObj.Inputs[0].CustomAttr, "inspect output: %s", p)
-	assert.Equalf(t, "REDACTED", yObj.Agent.Protection.SigningKey, "`signing_key` is not redacted but it should be, because it contains `key`. inspect output: %s", p)
-	assert.Equalf(t, "REDACTED", yObj.Agent.Protection.UninstallTokenHash, "`uninstall_token_hash` is not redacted but it should be, because it contains `token`. inspect output: %s", p)
+	assert.Equalf(t, redact.REDACTED, yObj.Inputs[0].CustomAttr, "inspect output: %s", p)
+	assert.Equalf(t, redact.REDACTED, yObj.Agent.Protection.SigningKey, "`signing_key` is not redacted but it should be, because it contains `key`. inspect output: %s", p)
+	assert.Equalf(t, redact.REDACTED, yObj.Agent.Protection.UninstallTokenHash, "`uninstall_token_hash` is not redacted but it should be, because it contains `token`. inspect output: %s", p)
 
 	p, err = fixture.Exec(ctx, []string{"inspect", "components", "beat/metrics-monitoring"})
 	require.NoErrorf(t, err, "Error when running inspect components, output: %s", p)


### PR DESCRIPTION
## What does this PR do?

Follow-up to #14007: replace hardcoded `"REDACTED"` strings in integration tests with the `redact.REDACTED` constant imported from `elastic-agent-libs/redact`.

## Why is it important?

Using the constant instead of a hardcoded string means the tests will automatically stay in sync if the redaction marker value ever changes in the library.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~I have added an integration test or an E2E test~~

## Related issues

- Follow-up to #14007