### PR TITLE
Fix silent early-return when removing stale enrollment and upgrade artifacts

### DIFF
--- a/changelog/fragments/1778661566-drosiek-fix-is-not-exist.yaml
+++ b/changelog/fragments/1778661566-drosiek-fix-is-not-exist.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix silent early-return when removing stale enrollment and upgrade artifacts
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/enroll/enroll.go
+++ b/internal/pkg/agent/application/enroll/enroll.go
@@ -8,8 +8,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	goerrors "errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"math/rand/v2"
 	"os"
 	"strings"
@@ -260,17 +262,17 @@ func enroll(
 func clearAgentStores(actionStoreFile, stateStoreFile string) error {
 	// clear action store
 	// fail only if file exists and there was a failure.
-	// The leading err != nil guard is load-bearing — os.IsNotExist(nil)
+	// The leading err != nil guard is load-bearing — errors.Is(nil, fs.ErrNotExist)
 	// returns false, so dropping the guard would cause the success case
 	// (err == nil) to fall into the return branch and skip the state
 	// store removal below.
-	if err := os.Remove(actionStoreFile); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(actionStoreFile); err != nil && !goerrors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 
 	// clear state store
 	// fail only if file exists and there was a failure.
-	if err := os.Remove(stateStoreFile); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(stateStoreFile); err != nil && !goerrors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 
@@ -434,7 +436,7 @@ func SafelyStoreAgentInfo(s saver, reader io.Reader) error {
 func LoadPersistentConfig(pathConfigFile string) (map[string]interface{}, error) {
 	persistentMap := make(map[string]interface{})
 	rawConfig, err := config.LoadFile(pathConfigFile)
-	if os.IsNotExist(err) {
+	if goerrors.Is(err, fs.ErrNotExist) {
 		return persistentMap, nil
 	}
 	if err != nil {

--- a/internal/pkg/agent/application/enroll/enroll.go
+++ b/internal/pkg/agent/application/enroll/enroll.go
@@ -248,15 +248,29 @@ func enroll(
 		return fmt.Errorf("failed to store agent config: %w", err)
 	}
 
-	// clear action store
-	// fail only if file exists and there was a failure
-	if err := os.Remove(paths.AgentActionStoreFile()); !os.IsNotExist(err) {
+	if err := clearAgentStores(paths.AgentActionStoreFile(), paths.AgentStateStoreFile()); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+// clearAgentStores removes the action and state store files left over from
+// previous enrollments. A missing file is the happy case.
+func clearAgentStores(actionStoreFile, stateStoreFile string) error {
 	// clear action store
-	// fail only if file exists and there was a failure
-	if err := os.Remove(paths.AgentStateStoreFile()); !os.IsNotExist(err) {
+	// fail only if file exists and there was a failure.
+	// The leading err != nil guard is load-bearing — os.IsNotExist(nil)
+	// returns false, so dropping the guard would cause the success case
+	// (err == nil) to fall into the return branch and skip the state
+	// store removal below.
+	if err := os.Remove(actionStoreFile); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	// clear state store
+	// fail only if file exists and there was a failure.
+	if err := os.Remove(stateStoreFile); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 

--- a/internal/pkg/agent/application/enroll/enroll_test.go
+++ b/internal/pkg/agent/application/enroll/enroll_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -171,6 +172,37 @@ func TestRetryEnroll_InterruptsBackoffWaitOnCtxCancel(t *testing.T) {
 		err := <-errCh
 		require.ErrorIs(t, err, context.Canceled)
 	})
+}
+
+// TestClearAgentStores_RemovesBothFiles is a regression test for the
+// !os.IsNotExist(err) antipattern that previously lived inline in enroll().
+// When the action store file existed and was successfully removed, the
+// subsequent os.IsNotExist(nil) returned false and the function returned
+// early without ever attempting to remove the state store file — leaving
+// stale state-store data behind across enrollments.
+func TestClearAgentStores_RemovesBothFiles(t *testing.T) {
+	dir := t.TempDir()
+	actionStore := filepath.Join(dir, "action_store.yml")
+	stateStore := filepath.Join(dir, "state.enc")
+
+	require.NoError(t, os.WriteFile(actionStore, []byte("stale-action"), 0o600))
+	require.NoError(t, os.WriteFile(stateStore, []byte("stale-state"), 0o600))
+
+	require.NoError(t, clearAgentStores(actionStore, stateStore))
+
+	_, err := os.Stat(actionStore)
+	require.True(t, os.IsNotExist(err), "action store file must be removed, got err=%v", err)
+
+	_, err = os.Stat(stateStore)
+	require.True(t, os.IsNotExist(err), "state store file must be removed, got err=%v", err)
+}
+
+func TestClearAgentStores_MissingFilesAreOK(t *testing.T) {
+	dir := t.TempDir()
+	actionStore := filepath.Join(dir, "action_store.yml")
+	stateStore := filepath.Join(dir, "state.enc")
+
+	require.NoError(t, clearAgentStores(actionStore, stateStore))
 }
 
 func TestLoadPersistentConfig_FleetCheckin(t *testing.T) {

--- a/internal/pkg/agent/application/enroll/enroll_test.go
+++ b/internal/pkg/agent/application/enroll/enroll_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -191,10 +192,10 @@ func TestClearAgentStores_RemovesBothFiles(t *testing.T) {
 	require.NoError(t, clearAgentStores(actionStore, stateStore))
 
 	_, err := os.Stat(actionStore)
-	require.True(t, os.IsNotExist(err), "action store file must be removed, got err=%v", err)
+	require.True(t, errors.Is(err, fs.ErrNotExist), "action store file must be removed, got err=%v", err)
 
 	_, err = os.Stat(stateStore)
-	require.True(t, os.IsNotExist(err), "state store file must be removed, got err=%v", err)
+	require.True(t, errors.Is(err, fs.ErrNotExist), "state store file must be removed, got err=%v", err)
 }
 
 func TestClearAgentStores_MissingFilesAreOK(t *testing.T) {

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -188,7 +188,12 @@ func UpdateActiveCommit(log *logger.Logger, topDirPath, hash string, writeFile w
 func CleanMarker(log *logger.Logger, dataDirPath string) error {
 	markerFile := markerFilePath(dataDirPath)
 	log.Infow("Removing marker file", "file.path", markerFile)
-	if err := os.Remove(markerFile); !os.IsNotExist(err) {
+	// The leading err != nil guard is load-bearing — os.IsNotExist(nil)
+	// returns false, so dropping the guard would cause the success case
+	// (err == nil) to also enter the return branch. Currently harmless
+	// because there's no work after this block, but brittle to future
+	// additions; keep the guard.
+	if err := os.Remove(markerFile); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -6,6 +6,7 @@ package upgrade
 
 import (
 	goerrors "errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
@@ -188,12 +189,12 @@ func UpdateActiveCommit(log *logger.Logger, topDirPath, hash string, writeFile w
 func CleanMarker(log *logger.Logger, dataDirPath string) error {
 	markerFile := markerFilePath(dataDirPath)
 	log.Infow("Removing marker file", "file.path", markerFile)
-	// The leading err != nil guard is load-bearing — os.IsNotExist(nil)
+	// The leading err != nil guard is load-bearing — errors.Is(nil, fs.ErrNotExist)
 	// returns false, so dropping the guard would cause the success case
 	// (err == nil) to also enter the return branch. Currently harmless
 	// because there's no work after this block, but brittle to future
 	// additions; keep the guard.
-	if err := os.Remove(markerFile); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(markerFile); err != nil && !goerrors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 

--- a/internal/pkg/agent/application/upgrade/step_mark_test.go
+++ b/internal/pkg/agent/application/upgrade/step_mark_test.go
@@ -5,8 +5,6 @@
 package upgrade
 
 import (
-	"errors"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -23,24 +21,6 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
 	agtversion "github.com/elastic/elastic-agent/pkg/version"
 )
-
-// TestCleanMarker_RemovesExistingMarker is a regression test for the
-// !os.IsNotExist(err) antipattern previously present in CleanMarker.
-// When the marker existed and os.Remove succeeded, os.IsNotExist(nil)
-// returned false and the function returned the nil error — happening to
-// be correct only because there was no subsequent work. The guard is
-// still load-bearing for future additions; this test pins the behavior.
-func TestCleanMarker_RemovesExistingMarker(t *testing.T) {
-	dataDir := t.TempDir()
-	markerFile := markerFilePath(dataDir)
-	require.NoError(t, os.WriteFile(markerFile, []byte("placeholder"), 0o600))
-
-	log, _ := loggertest.New(t.Name())
-	require.NoError(t, CleanMarker(log, dataDir))
-
-	_, err := os.Stat(markerFile)
-	require.True(t, errors.Is(err, fs.ErrNotExist), "marker file must be removed, got err=%v", err)
-}
 
 func TestCleanMarker_MissingMarkerIsOK(t *testing.T) {
 	dataDir := t.TempDir()

--- a/internal/pkg/agent/application/upgrade/step_mark_test.go
+++ b/internal/pkg/agent/application/upgrade/step_mark_test.go
@@ -22,6 +22,31 @@ import (
 	agtversion "github.com/elastic/elastic-agent/pkg/version"
 )
 
+// TestCleanMarker_RemovesExistingMarker is a regression test for the
+// !os.IsNotExist(err) antipattern previously present in CleanMarker.
+// When the marker existed and os.Remove succeeded, os.IsNotExist(nil)
+// returned false and the function returned the nil error — happening to
+// be correct only because there was no subsequent work. The guard is
+// still load-bearing for future additions; this test pins the behavior.
+func TestCleanMarker_RemovesExistingMarker(t *testing.T) {
+	dataDir := t.TempDir()
+	markerFile := markerFilePath(dataDir)
+	require.NoError(t, os.WriteFile(markerFile, []byte("placeholder"), 0o600))
+
+	log, _ := loggertest.New(t.Name())
+	require.NoError(t, CleanMarker(log, dataDir))
+
+	_, err := os.Stat(markerFile)
+	require.True(t, os.IsNotExist(err), "marker file must be removed, got err=%v", err)
+}
+
+func TestCleanMarker_MissingMarkerIsOK(t *testing.T) {
+	dataDir := t.TempDir()
+
+	log, _ := loggertest.New(t.Name())
+	require.NoError(t, CleanMarker(log, dataDir))
+}
+
 func TestSaveAndLoadMarker_NoLoss(t *testing.T) {
 	// Create a temporary directory for the test
 	tempDir := t.TempDir()

--- a/internal/pkg/agent/application/upgrade/step_mark_test.go
+++ b/internal/pkg/agent/application/upgrade/step_mark_test.go
@@ -5,6 +5,8 @@
 package upgrade
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -37,7 +39,7 @@ func TestCleanMarker_RemovesExistingMarker(t *testing.T) {
 	require.NoError(t, CleanMarker(log, dataDir))
 
 	_, err := os.Stat(markerFile)
-	require.True(t, os.IsNotExist(err), "marker file must be removed, got err=%v", err)
+	require.True(t, errors.Is(err, fs.ErrNotExist), "marker file must be removed, got err=%v", err)
 }
 
 func TestCleanMarker_MissingMarkerIsOK(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Fixes three places where `os.Remove` (and similar) used the `!os.IsNotExist(err)` pattern without first checking `err != nil`. The correct guard is `err != nil && !errors.Is(err, fs.ErrNotExist)`.

[`errors.Is`](https://pkg.go.dev/errors#Is) with [`fs.ErrNotExist`](https://pkg.go.dev/io/fs#ErrNotExist) is the current recommended way to check for not-exist errors ([`os.IsNotExist`](https://pkg.go.dev/os#IsNotExist) is a legacy wrapper). Both return `false` for a `nil` error, which makes the bare negation misbehave on success:

| `err` | `errors.Is(err, fs.ErrNotExist)` | `!errors.Is(err, fs.ErrNotExist)` | Meaning |
|---|---|---|---|
| `nil` | `false` | `true` | File existed and was removed successfully |
| `*fs.PathError` (file not found) | `true` | `false` | File did not exist — nothing to remove |
| `*fs.PathError` (permission denied, etc.) | `false` | `true` | Removal failed for an unrelated reason |

Without `err != nil`, the success row and the real-error row are indistinguishable — both enter the `return err` branch. No linter in this repo catches this (checked [`errcheck`](https://github.com/kisielk/errcheck), [`nilerr`](https://github.com/gostaticanalysis/nilerr), [`staticcheck`](https://staticcheck.io)).

**Fixes:**

- **`enroll.go` — state store file was silently skipped on re-enrollment**
  When the action store file existed and `os.Remove` succeeded (`err == nil`), `errors.Is(nil, fs.ErrNotExist)` returned `false`, so the function returned `nil` early — never reaching the state store removal. Stale state-store data was left behind across re-enrollments. The fix also extracts both removals into a `clearAgentStores` helper so they can be unit-tested directly.

- **`step_mark.go` — `CleanMarker` returned early on success**
  Same pattern: successful removal returned `nil` early. Harmless today because there is no code after the block, but a latent trap for anyone adding work there.

- ~**`step_relink.go` — `changeSymlink` returned early on successful cleanup**
  When the staging symlink did not exist (the normal path), `os.Remove` returned a not-exists error and was correctly skipped. But when it *did* exist and was successfully removed, the function returned `nil` early and skipped the symlink creation and rotation that follow.~ Fixed in #14238

## Why is it important?

The `enroll.go` bug causes stale state to persist across re-enrollments. The `step_relink.go` bug aborts symlink rotation on the code path where a leftover staging symlink is actually cleaned up — potentially leaving the agent in a broken state after an interrupted upgrade.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added an integration test or an E2E test~~

## How to test this PR locally

Unit tests cover all three fixes:

```sh
go test ./internal/pkg/agent/application/enroll/... -run TestClearAgentStores -v
go test ./internal/pkg/agent/application/upgrade/... -run TestCleanMarker -v
go test ./internal/pkg/agent/application/upgrade/... -run TestChangeSymlink -v
```

## Related issues

- Closes #14230