### PR TITLE
Fix dangling symlink when changeSymlink rotates to a non-existent target

### DIFF
--- a/changelog/fragments/1778666423-fix-dangling-symlink-when-rotating-to-a-non-existent-target.yaml
+++ b/changelog/fragments/1778666423-fix-dangling-symlink-when-rotating-to-a-non-existent-target.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: fix dangling symlink when rotating to a non-existent target
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -5,7 +5,9 @@
 package upgrade
 
 import (
+	goerrors "errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -41,9 +43,10 @@ func changeSymlink(log *logger.Logger, topDirPath, symlinkPath, newTarget string
 	// Remove any leftover staging symlink from a prior interrupted rotation.
 	// "Does not exist" is the happy case (nothing to clean up); any other
 	// error is fatal. The leading err != nil guard is load-bearing —
-	// os.IsNotExist(nil) returns false, so dropping the guard would cause
-	// the success case (err == nil) to fall into the return branch.
-	if err := os.Remove(prevNewPath); err != nil && !os.IsNotExist(err) {
+	// errors.Is(nil, fs.ErrNotExist) returns false, so dropping the guard would cause
+	// the success case (err == nil) to fall into the return branch and
+	// skip the symlink creation and rotation below.
+	if err := os.Remove(prevNewPath); err != nil && !goerrors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -5,6 +5,7 @@
 package upgrade
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -27,11 +28,22 @@ func changeSymlink(log *logger.Logger, topDirPath, symlinkPath, newTarget string
 		newTarget += exe
 	}
 
+	// refuse to rotate to a target that does not exist on disk: callers like the
+	// rollback path can pass a stale versioned-home path, which would otherwise
+	// leave a dangling live symlink that breaks the next agent restart.
+	if _, err := os.Stat(newTarget); err != nil {
+		return fmt.Errorf("refusing to rotate agent symlink to non-existent target %q: %w", newTarget, err)
+	}
+
 	prevNewPath := prevSymlinkPath(topDirPath)
 	log.Infow("Changing symlink", "symlink_path", symlinkPath, "new_path", newTarget, "prev_path", prevNewPath)
 
-	// remove symlink to avoid upgrade failures
-	if err := os.Remove(prevNewPath); !os.IsNotExist(err) {
+	// Remove any leftover staging symlink from a prior interrupted rotation.
+	// "Does not exist" is the happy case (nothing to clean up); any other
+	// error is fatal. The leading err != nil guard is load-bearing —
+	// os.IsNotExist(nil) returns false, so dropping the guard would cause
+	// the success case (err == nil) to fall into the return branch.
+	if err := os.Remove(prevNewPath); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 

--- a/internal/pkg/agent/application/upgrade/step_relink_test.go
+++ b/internal/pkg/agent/application/upgrade/step_relink_test.go
@@ -1,0 +1,120 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+)
+
+func agentExecutableForTest() string {
+	name := AgentName
+	if runtime.GOOS == windowsOSName {
+		name += exe
+	}
+	return name
+}
+
+// writeFakeAgentBinary creates a directory tree mirroring a real install and
+// writes a placeholder binary at the BinaryPath, returning the bare (no .exe)
+// path the caller should pass to changeSymlink.
+func writeFakeAgentBinary(t *testing.T, topDir, versionedHomeRel string) string {
+	t.Helper()
+
+	absVersionedHome := filepath.Join(topDir, versionedHomeRel)
+	require.NoError(t, os.MkdirAll(paths.BinaryPath(absVersionedHome, ""), 0o750))
+
+	binPath := paths.BinaryPath(absVersionedHome, agentExecutableForTest())
+	require.NoError(t, os.WriteFile(binPath, []byte("fake agent binary"), 0o750))
+
+	return paths.BinaryPath(absVersionedHome, AgentName)
+}
+
+func TestChangeSymlinkHappyPath(t *testing.T) {
+	topDir := t.TempDir()
+	log := newErrorLogger(t)
+
+	newTarget := writeFakeAgentBinary(t, topDir, filepath.Join("data", "elastic-agent-1.2.3-abcdef"))
+	symlinkPath := filepath.Join(topDir, AgentName)
+
+	require.NoError(t, changeSymlink(log, topDir, symlinkPath, newTarget))
+
+	livePath := filepath.Join(topDir, agentExecutableForTest())
+	linkTarget, err := os.Readlink(livePath)
+	require.NoError(t, err, "live symlink must exist after rotation")
+
+	expected := newTarget
+	if runtime.GOOS == windowsOSName {
+		expected += exe
+	}
+	assert.Equal(t, expected, linkTarget)
+
+	// staging symlink should not linger after a successful rotation
+	assert.NoFileExists(t, prevSymlinkPath(topDir))
+}
+
+func TestChangeSymlinkRefusesNonExistentTarget(t *testing.T) {
+	topDir := t.TempDir()
+	log := newErrorLogger(t)
+
+	newTarget := paths.BinaryPath(filepath.Join(topDir, "data", "elastic-agent-deleted"), AgentName)
+	symlinkPath := filepath.Join(topDir, AgentName)
+
+	err := changeSymlink(log, topDir, symlinkPath, newTarget)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to rotate")
+	assert.Contains(t, err.Error(), "non-existent target")
+
+	// no symlink should have been created at the live path
+	livePath := filepath.Join(topDir, agentExecutableForTest())
+	_, statErr := os.Lstat(livePath)
+	assert.True(t, os.IsNotExist(statErr), "live symlink must not be created when target is missing, got err=%v", statErr)
+
+	// nor should a staging symlink have been left behind
+	_, statErr = os.Lstat(prevSymlinkPath(topDir))
+	assert.True(t, os.IsNotExist(statErr), "staging symlink must not be created when target is missing, got err=%v", statErr)
+}
+
+// TestChangeSymlinkRotatesOverStalePrev ensures that a leftover staging
+// symlink from a prior interrupted rotation does not cause changeSymlink to
+// silently no-op. The pre-fix code did `if !os.IsNotExist(err) { return err }`
+// on the os.Remove of the staging path: when the Remove succeeded (err == nil),
+// !os.IsNotExist(nil) was true and the function returned nil without rotating.
+func TestChangeSymlinkRotatesOverStalePrev(t *testing.T) {
+	topDir := t.TempDir()
+	log := newErrorLogger(t)
+
+	newTarget := writeFakeAgentBinary(t, topDir, filepath.Join("data", "elastic-agent-1.2.3-abcdef"))
+	symlinkPath := filepath.Join(topDir, AgentName)
+
+	// pre-create a leftover .prev staging symlink pointing nowhere meaningful
+	stalePrev := prevSymlinkPath(topDir)
+	require.NoError(t, os.Symlink(filepath.Join(topDir, "nonexistent-stale-target"), stalePrev))
+	_, err := os.Lstat(stalePrev)
+	require.NoError(t, err, "stale staging symlink must exist before the call")
+
+	require.NoError(t, changeSymlink(log, topDir, symlinkPath, newTarget))
+
+	livePath := filepath.Join(topDir, agentExecutableForTest())
+	linkTarget, err := os.Readlink(livePath)
+	require.NoError(t, err, "live symlink must exist after rotation")
+
+	expected := newTarget
+	if runtime.GOOS == windowsOSName {
+		expected += exe
+	}
+	assert.Equal(t, expected, linkTarget, "live symlink must point at the new target, not the stale staging path")
+
+	// staging symlink should not linger after a successful rotation
+	_, statErr := os.Lstat(stalePrev)
+	assert.True(t, os.IsNotExist(statErr), "staging symlink must not linger after rotation, got err=%v", statErr)
+}

--- a/internal/pkg/agent/application/upgrade/step_relink_test.go
+++ b/internal/pkg/agent/application/upgrade/step_relink_test.go
@@ -5,6 +5,8 @@
 package upgrade
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -77,11 +79,11 @@ func TestChangeSymlinkRefusesNonExistentTarget(t *testing.T) {
 	// no symlink should have been created at the live path
 	livePath := filepath.Join(topDir, agentExecutableForTest())
 	_, statErr := os.Lstat(livePath)
-	assert.True(t, os.IsNotExist(statErr), "live symlink must not be created when target is missing, got err=%v", statErr)
+	assert.True(t, errors.Is(statErr, fs.ErrNotExist), "live symlink must not be created when target is missing, got err=%v", statErr)
 
 	// nor should a staging symlink have been left behind
 	_, statErr = os.Lstat(prevSymlinkPath(topDir))
-	assert.True(t, os.IsNotExist(statErr), "staging symlink must not be created when target is missing, got err=%v", statErr)
+	assert.True(t, errors.Is(statErr, fs.ErrNotExist), "staging symlink must not be created when target is missing, got err=%v", statErr)
 }
 
 // TestChangeSymlinkRotatesOverStalePrev ensures that a leftover staging
@@ -116,5 +118,5 @@ func TestChangeSymlinkRotatesOverStalePrev(t *testing.T) {
 
 	// staging symlink should not linger after a successful rotation
 	_, statErr := os.Lstat(stalePrev)
-	assert.True(t, os.IsNotExist(statErr), "staging symlink must not linger after rotation, got err=%v", statErr)
+	assert.True(t, errors.Is(statErr, fs.ErrNotExist), "staging symlink must not linger after rotation, got err=%v", statErr)
 }


### PR DESCRIPTION
## What does this PR do?

Adds an upfront existence check in `changeSymlink` that refuses to rotate the live `elastic-agent` symlink to a target that does not exist on disk.

```go
if _, err := os.Stat(newTarget); err != nil {
    return fmt.Errorf("refusing to rotate agent symlink to non-existent target %q: %w", newTarget, err)
}
```

Also fixes the `!os.IsNotExist(err)` antipattern on the staging-symlink cleanup (see #14234 for the full write-up of that pattern).

## Why is it important?

`changeSymlink` is called during both upgrade and rollback. On the rollback path a caller can pass a `versionedHome` that was already deleted (e.g. by a failed upgrade that cleaned up after itself). Without this guard the function would:

1. Successfully create a staging symlink pointing at the deleted path
2. Rotate it into the live position via `file.SafeFileRotate`

The live `elastic-agent` symlink then dangled, causing every subsequent agent restart to fail with a "no such file or directory" error.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added an integration test or an E2E test~~

## How to test this PR locally

```sh
go test ./internal/pkg/agent/application/upgrade/... -run TestChangeSymlink -v
```

## Related issues

-