### PR TITLE
fix: guard os.Remove error check in symlink, marker, and enrollment cleanup

### DIFF
--- a/internal/pkg/agent/application/enroll/enroll.go
+++ b/internal/pkg/agent/application/enroll/enroll.go
@@ -250,13 +250,13 @@ func enroll(
 
 	// clear action store
 	// fail only if file exists and there was a failure
-	if err := os.Remove(paths.AgentActionStoreFile()); !os.IsNotExist(err) {
+	if err := os.Remove(paths.AgentActionStoreFile()); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
 	// clear action store
 	// fail only if file exists and there was a failure
-	if err := os.Remove(paths.AgentStateStoreFile()); !os.IsNotExist(err) {
+	if err := os.Remove(paths.AgentStateStoreFile()); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -188,7 +188,7 @@ func UpdateActiveCommit(log *logger.Logger, topDirPath, hash string, writeFile w
 func CleanMarker(log *logger.Logger, dataDirPath string) error {
 	markerFile := markerFilePath(dataDirPath)
 	log.Infow("Removing marker file", "file.path", markerFile)
-	if err := os.Remove(markerFile); !os.IsNotExist(err) {
+	if err := os.Remove(markerFile); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 

--- a/internal/pkg/agent/application/upgrade/step_relink.go
+++ b/internal/pkg/agent/application/upgrade/step_relink.go
@@ -31,7 +31,7 @@ func changeSymlink(log *logger.Logger, topDirPath, symlinkPath, newTarget string
 	log.Infow("Changing symlink", "symlink_path", symlinkPath, "new_path", newTarget, "prev_path", prevNewPath)
 
 	// remove symlink to avoid upgrade failures
-	if err := os.Remove(prevNewPath); !os.IsNotExist(err) {
+	if err := os.Remove(prevNewPath); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

When `os.Remove` succeeds (`err == nil`), the expression `!os.IsNotExist(err)` evaluates to `true` because `nil` is not `os.ErrNotExist`, causing a spurious early return with a nil error being returned as an actual error.

This bug affects three locations:
- `changeSymlink` in `internal/pkg/agent/application/upgrade/step_relink.go`
- `CleanMarker` in `internal/pkg/agent/application/upgrade/step_mark.go`
- Enrollment store cleanup in `internal/pkg/agent/application/enroll/enroll.go`

## Fix

Add `err != nil &&` guard before the `!os.IsNotExist` check in all three locations so that successful removals do not return an error.

## Testing

All affected package tests pass:
- `internal/pkg/agent/application/upgrade` ✅
- `internal/pkg/agent/application/enroll` ✅