### PR TITLE
ci: run go mod tidy after beats submodule bump

### DIFF
--- a/.github/workflows/bump-beats-version.yml
+++ b/.github/workflows/bump-beats-version.yml
@@ -62,6 +62,9 @@ jobs:
       env:
         BRANCH_NAME: ${{ matrix.branch }}
 
+    - name: Tidy all Go modules
+      run: mage tidy
+
     - name: Export beats versions to environment variables
       run: |
         echo BEATS_PREVIOUS_VERSION=$(cat /tmp/.beats-previous-version) >> "$GITHUB_ENV"


### PR DESCRIPTION
## What does this PR do?

The `update-beats` automation workflow now runs `make tidy` after updating the beats submodule, so that any transitive dependency changes introduced by the new beats version are reflected in `go.mod` and `go.sum` in the same PR commit.

## Why is it important?

When beats is bumped (e.g. https://github.com/elastic/elastic-agent/pull/14220), its updated dependencies are not automatically reflected in the root `go.mod`. The drift only shows up later when someone runs `go mod tidy` locally.

For example, https://github.com/elastic/elastic-agent/pull/14231 PR was failing with:

```
go: updates to go.mod needed; to update it:
	go mod tidy
Error: error compiling magefiles
Beat version:
go: updates to go.mod needed; to update it:
	go mod tidy
Error: error compiling magefiles
make: *** [Makefile:42: check-ci] Error 1
```

Manual `go mod tidy` was needed to fix it: https://github.com/elastic/elastic-agent/pull/14231/commits/da8678f18800d6c2a1a7c3b142f9daf8aa4d6b47