### PR TITLE
[ci] Use ci-agent-image over GCP standard

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -372,6 +372,8 @@ steps:
     build:
       commit: "${BUILDKITE_COMMIT}"
       branch: "${BUILDKITE_BRANCH}"
+      env:
+        IMAGE_UBUNTU_2204_X86_64: "${IMAGE_UBUNTU_2204_X86_64}"
     if_changed:
       include:
         - .buildkite/serverless.beats.tests.yml

--- a/.buildkite/serverless.beats.tests.yml
+++ b/.buildkite/serverless.beats.tests.yml
@@ -10,4 +10,4 @@ steps:
       .buildkite/scripts/steps/beats_tests.sh
     agents:
       provider: "gcp"
-      machineType: "n2-standard-8"
+      image: "${IMAGE_UBUNTU_2204_X86_64}"


### PR DESCRIPTION
After changed merged in https://github.com/elastic/elastic-agent/pull/13823, the `beats-agent-serverless-tests` consistently fail on `main`: https://buildkite.com/elastic/beats-agent-serverless-tests/builds?branch=main

Suspect the default tooling install on our curated CI runner image will resolve the missing `git` config.

### Background (Claude analysis)

 PR #13823 moved git commit-hash reading from a lazy, packaging-only path into an **eager, unconditional** step inside `LoadSettings()` (`dev-tools/mage/settings.go:1317-1319`). It also removed the `AGENT_COMMIT_HASH_OVERRIDE` env-var escape hatch.

  As a result, the Buildkite test in `.buildkite/scripts/steps/beats_tests.sh` now fails consistently with:

  `Test output (sudo) (stderr): Error: failed to load settings: initializing commit hash: failed to get commit hash: running "git rev-parse HEAD" failed with exit code 128`

  The failure occurs on the **remote integration VM** (not the Buildkite host) when the sudo'd mage invocation runs against the SCP'd `agent/` directory. Two combinable causes both produce git's exit 128:

  1. **Dubious ownership under sudo.** `agent/` is owned by the SSH user (e.g. `ubuntu`); mage runs as effective uid root via `sudo`. Git refuses without `safe.directory`. The new `initCommitHash` has a `safe.directory` workaround but it is gated on `s.Build.GolangCrossBuild`, which the remote runner does not set.
  2. **Possibly no `.git`** on the VM depending on how the integration runner ships sources.

  Before PR #13823 the lazy `CommitHash()` was never invoked on the remote VM (the `integration:testOnRemote` target does not package), so the failure could not surface. Now every `LoadSettings()` requires `git rev-parse HEAD` to succeed.

