### PR TITLE
fix: prevent upgrade watcher panic when grace period expires

### DIFF
--- a/changelog/fragments/1778716751-prevent-upgrade-watcher-panic-when-grace-period-expires.yaml
+++ b/changelog/fragments/1778716751-prevent-upgrade-watcher-panic-when-grace-period-expires.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: prevent upgrade watcher panic when grace period expires
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/upgrade/watcher.go
+++ b/internal/pkg/agent/application/upgrade/watcher.go
@@ -202,6 +202,14 @@ LOOP:
 					ch.log.Debugf("received state: error: %s",
 						err)
 
+					// Context was canceled — the watcher is shutting down normally.
+					// Do not count this as a lost connection.
+					if ctx.Err() != nil {
+						stateCancel()
+						ch.agentClient.Disconnect()
+						return
+					}
+
 					// agent has crashed or exited
 					stateCancel()
 					ch.agentClient.Disconnect()

--- a/internal/pkg/agent/application/upgrade/watcher.go
+++ b/internal/pkg/agent/application/upgrade/watcher.go
@@ -131,7 +131,11 @@ func (ch *AgentWatcher) Run(ctx context.Context) {
 				if flipFlopCount > statusFailureFlipFlopsAllowed {
 					err := fmt.Errorf("%w '%d' times in a row", ErrAgentFlipFlopFailed, flipFlopCount)
 					ch.log.Error(err)
-					ch.notifyChan <- err
+					select {
+					case ch.notifyChan <- err:
+					case <-ctx.Done():
+						return
+					}
 				}
 			case <-failedTimer.C:
 				if failedErr == nil {
@@ -139,8 +143,12 @@ func (ch *AgentWatcher) Run(ctx context.Context) {
 					continue
 				}
 				// error lasted longer than the checkInterval, notify!
-				ch.notifyChan <- fmt.Errorf("last error was not cleared before checkInterval (%s) elapsed: %w",
-					ch.checkInterval, failedErr)
+				select {
+				case ch.notifyChan <- fmt.Errorf("last error was not cleared before checkInterval (%s) elapsed: %w",
+					ch.checkInterval, failedErr):
+				case <-ctx.Done():
+					return
+				}
 			}
 		}
 	}()
@@ -163,7 +171,7 @@ LOOP:
 			if err != nil {
 				ch.connectCounter.Add(1)
 				ch.log.Errorf("Failed connecting to running daemon: %s", err)
-				if ch.checkFailures() {
+				if ch.checkFailures(ctx) {
 					return
 				}
 				// agent is probably not running
@@ -178,7 +186,7 @@ LOOP:
 				ch.agentClient.Disconnect()
 				ch.log.Errorf("Failed to start state watch: %s", err)
 				ch.connectCounter.Add(1)
-				if ch.checkFailures() {
+				if ch.checkFailures(ctx) {
 					return
 				}
 				// agent is probably not running
@@ -218,7 +226,7 @@ LOOP:
 					ch.agentClient.Disconnect()
 					ch.log.Errorf("Lost connection: failed reading next state: %s", err)
 					ch.lostCounter.Add(1)
-					if ch.checkFailures() {
+					if ch.checkFailures(ctx) {
 						return
 					}
 					continue LOOP
@@ -238,7 +246,7 @@ LOOP:
 					// count the PID change as a lost connection, but allow
 					// the communication to continue unless has become a failure
 					ch.lostCounter.Add(1)
-					if ch.checkFailures() {
+					if ch.checkFailures(ctx) {
 						stateCancel()
 						ch.agentClient.Disconnect()
 						return
@@ -271,13 +279,19 @@ LOOP:
 	}
 }
 
-func (ch *AgentWatcher) checkFailures() bool {
+func (ch *AgentWatcher) checkFailures(ctx context.Context) bool {
 	if failures := ch.connectCounter.Load(); failures > statusCheckMissesAllowed {
-		ch.notifyChan <- fmt.Errorf("%w '%d' times in a row", ErrCannotConnect, failures)
+		select {
+		case ch.notifyChan <- fmt.Errorf("%w '%d' times in a row", ErrCannotConnect, failures):
+		case <-ctx.Done():
+		}
 		return true
 	}
 	if failures := ch.lostCounter.Load(); failures > statusLossesAllowed {
-		ch.notifyChan <- fmt.Errorf("%w '%d' times in a row", ErrLostConnection, failures)
+		select {
+		case ch.notifyChan <- fmt.Errorf("%w '%d' times in a row", ErrLostConnection, failures):
+		case <-ctx.Done():
+		}
 		return true
 	}
 	return false

--- a/internal/pkg/agent/application/upgrade/watcher.go
+++ b/internal/pkg/agent/application/upgrade/watcher.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"google.golang.org/grpc"
@@ -53,8 +54,10 @@ var (
 // AgentWatcher watches for the ability to connect to the running Elastic Agent, if it reports any errors
 // and how many times it disconnects from the Elastic Agent while running.
 type AgentWatcher struct {
-	connectCounter int
-	lostCounter    int
+	// connectCounter and lostCounter are written only by Run() but may be read
+	// concurrently by tests, so they use atomic types to avoid a data race.
+	connectCounter atomic.Int32
+	lostCounter    atomic.Int32
 	lastPid        int32
 
 	notifyChan    chan error
@@ -84,8 +87,8 @@ func NewAgentWatcher(ch chan error, log *logger.Logger, checkInterval time.Durat
 func (ch *AgentWatcher) Run(ctx context.Context) {
 	ch.log.Info("Agent watcher started")
 
-	ch.connectCounter = 0
-	ch.lostCounter = 0
+	ch.connectCounter.Store(0)
+	ch.lostCounter.Store(0)
 	ch.lastPid = -1
 
 	// tracking of an error runs in a separate goroutine, because
@@ -158,7 +161,7 @@ LOOP:
 			err := ch.agentClient.Connect(connectCtx, grpc.WithBlock(), grpc.WithDisableRetry(), grpc.FailOnNonTempDialError(true))
 			connectCancel()
 			if err != nil {
-				ch.connectCounter++
+				ch.connectCounter.Add(1)
 				ch.log.Errorf("Failed connecting to running daemon: %s", err)
 				if ch.checkFailures() {
 					return
@@ -174,7 +177,7 @@ LOOP:
 				stateCancel()
 				ch.agentClient.Disconnect()
 				ch.log.Errorf("Failed to start state watch: %s", err)
-				ch.connectCounter++
+				ch.connectCounter.Add(1)
 				if ch.checkFailures() {
 					return
 				}
@@ -187,7 +190,7 @@ LOOP:
 			// clear the connectCounter as connection was successfully made
 			// we don't want a disconnect and a reconnect to be counted with
 			// the connectCounter that is tracked with the lostCounter
-			ch.connectCounter = 0
+			ch.connectCounter.Store(0)
 
 			// failure is tracked only for the life of the connection to
 			// the watch streaming protocol. either an error that last longer
@@ -214,7 +217,7 @@ LOOP:
 					stateCancel()
 					ch.agentClient.Disconnect()
 					ch.log.Errorf("Lost connection: failed reading next state: %s", err)
-					ch.lostCounter++
+					ch.lostCounter.Add(1)
 					if ch.checkFailures() {
 						return
 					}
@@ -234,7 +237,7 @@ LOOP:
 					ch.lastPid = state.Info.PID
 					// count the PID change as a lost connection, but allow
 					// the communication to continue unless has become a failure
-					ch.lostCounter++
+					ch.lostCounter.Add(1)
 					if ch.checkFailures() {
 						stateCancel()
 						ch.agentClient.Disconnect()
@@ -269,11 +272,11 @@ LOOP:
 }
 
 func (ch *AgentWatcher) checkFailures() bool {
-	if failures := ch.connectCounter; failures > statusCheckMissesAllowed {
+	if failures := ch.connectCounter.Load(); failures > statusCheckMissesAllowed {
 		ch.notifyChan <- fmt.Errorf("%w '%d' times in a row", ErrCannotConnect, failures)
 		return true
 	}
-	if failures := ch.lostCounter; failures > statusLossesAllowed {
+	if failures := ch.lostCounter.Load(); failures > statusLossesAllowed {
 		ch.notifyChan <- fmt.Errorf("%w '%d' times in a row", ErrLostConnection, failures)
 		return true
 	}

--- a/internal/pkg/agent/application/upgrade/watcher_test.go
+++ b/internal/pkg/agent/application/upgrade/watcher_test.go
@@ -252,6 +252,69 @@ func TestWatcher_PIDChangeSuccess(t *testing.T) {
 	}
 }
 
+// TestWatcher_GracefulShutdownWithPreloadedLostCounter is a regression test
+// for the race where watch()'s deferred close(errChan) fires before
+// AgentWatcher.Run() exits, causing a panic (send on closed channel) when the
+// context.Canceled error from gRPC pushes lostCounter past statusLossesAllowed.
+//
+// The test preloads lostCounter to statusLossesAllowed via PID changes, then
+// cancels the context (simulating grace-period expiry) and asserts that no
+// error is written to errChan — i.e. the watcher exits cleanly rather than
+// treating the expected shutdown as a connection failure.
+func TestWatcher_GracefulShutdownWithPreloadedLostCounter(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Buffered so that a bug (send of ErrLostConnection) lands here instead of
+	// panicking, allowing the test to fail with a descriptive assertion.
+	errCh := make(chan error, 10)
+	logger, _ := loggertest.New("watcher")
+	// Long checkInterval to prevent reconnect races during the test.
+	w := NewAgentWatcher(errCh, logger, 500*time.Millisecond)
+
+	mockHandler := func(srv cproto.ElasticAgentControl_StateWatchServer) error {
+		// Three PIDs: first sets lastPid, next two each increment lostCounter.
+		for _, pid := range []int32{1, 2, 3} {
+			if err := srv.Send(&cproto.StateResponse{
+				Info:    &cproto.StateAgentInfo{Pid: pid},
+				State:   cproto.State_HEALTHY,
+				Message: "healthy",
+			}); err != nil {
+				return err
+			}
+		}
+		<-ctx.Done()
+		return nil
+	}
+	md := &mockDaemon{watch: mockHandler}
+	require.NoError(t, md.Start())
+	defer md.Stop()
+
+	w.agentClient = md.Client()
+	go w.Run(ctx)
+
+	// Wait until the watcher has processed both PID changes and lostCounter
+	// reaches the threshold. The test file is in the same package so it can
+	// read the private field directly.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, statusLossesAllowed, w.lostCounter)
+	}, 3*time.Second, 5*time.Millisecond)
+
+	// Cancel the context, simulating grace-period expiry triggering watch()'s
+	// deferred cleanup. Before the fix, Run() would increment lostCounter to 3
+	// (> statusLossesAllowed=2) and send ErrLostConnection on errCh (and panic
+	// if errCh had been closed). After the fix, Run() detects ctx.Err() != nil
+	// and returns cleanly.
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err, "watcher must not report an error when context is canceled")
+	case <-time.After(500 * time.Millisecond):
+		// clean exit — expected
+	}
+}
+
 func TestWatcher_AgentError(t *testing.T) {
 	// timeout ensures that if it doesn't work; it doesn't block forever
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/internal/pkg/agent/application/upgrade/watcher_test.go
+++ b/internal/pkg/agent/application/upgrade/watcher_test.go
@@ -297,7 +297,7 @@ func TestWatcher_GracefulShutdownWithPreloadedLostCounter(t *testing.T) {
 	// reaches the threshold. The test file is in the same package so it can
 	// read the private field directly.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, statusLossesAllowed, w.lostCounter)
+		assert.Equal(c, int32(statusLossesAllowed), w.lostCounter.Load())
 	}, 3*time.Second, 5*time.Millisecond)
 
 	// Cancel the context, simulating grace-period expiry triggering watch()'s

--- a/internal/pkg/agent/cmd/watch_impl.go
+++ b/internal/pkg/agent/cmd/watch_impl.go
@@ -44,11 +44,11 @@ func watch(ctx context.Context, tilGrace time.Duration, errorCheckInterval time.
 
 	ctx, cancel := context.WithCancel(ctx)
 
-	//cleanup
-	defer func() {
-		cancel()
-		close(errChan)
-	}()
+	// Cancel the context to signal Run() to stop. errChan is intentionally not
+	// closed here: per the channel-closing principle, only the sender should
+	// close a channel. Run() uses ctx.Done() on every send to avoid blocking
+	// after this cancel fires, so no close is needed.
+	defer cancel()
 
 	agtWatcher := upgrade.NewAgentWatcher(errChan, log, errorCheckInterval)
 	go agtWatcher.Run(ctx)


### PR DESCRIPTION
<!-- Type of change: Bug -->

## What does this PR do?

Fixes a panic in the upgrade watcher process that leaves the agent stuck reporting `UPG_WATCHING` to Fleet indefinitely.

### Root cause

`watch()` in `watch_impl.go` registered a deferred cleanup that called `cancel()` then `close(errChan)`:

```
defer func() {
    cancel()
    close(errChan)
}()
```

`cancel()` causes any in-flight `watch.Recv()` in `AgentWatcher.Run()` to return `context.Canceled`. The goroutine treated this as a lost connection and incremented `lostCounter`. If `lostCounter` had already reached `statusLossesAllowed` (2) from prior PID changes during a turbulent agent startup, this final increment crossed the threshold and `checkFailures()` attempted to send on `notifyChan` — the same channel that was just closed by the deferred cleanup. Sending on a closed channel panics in Go, crashing the watcher before `SetState(StateCompleted)` is reached.

### Fix (three commits)

**1. Channel-closing principle** (`ae70a3c623`) — the primary fix.

Per the [channel-closing principle](https://go101.org/article/channel-closing.html), the receiver must not close a data channel; only the sender should. `watch()` is the receiver of `errChan` — it must not close it. The fix removes `close(errChan)` from the deferred cleanup:

https://github.com/elastic/elastic-agent/blob/ae70a3c6236de57ef18e6434473c87e72f9b97e0/internal/pkg/agent/cmd/watch_impl.go#L47-L51

All sends from `AgentWatcher.Run()` onto `notifyChan` are now wrapped in `select { case …: case <-ctx.Done(): }` so senders drop notifications cleanly when the context is cancelled, with no blocking and no need for a channel buffer:

https://github.com/elastic/elastic-agent/blob/ae70a3c6236de57ef18e6434473c87e72f9b97e0/internal/pkg/agent/application/upgrade/watcher.go#L134-L137

https://github.com/elastic/elastic-agent/blob/ae70a3c6236de57ef18e6434473c87e72f9b97e0/internal/pkg/agent/application/upgrade/watcher.go#L284-L294

**2. `atomic.Int32` for watcher counters** (`e52826658d`) — data race fix.

`connectCounter` and `lostCounter` are written by `Run()` but read by the test goroutine. Plain `int` fields cause a detectable data race. Changed to `atomic.Int32` with an explanatory comment:

https://github.com/elastic/elastic-agent/blob/ae70a3c6236de57ef18e6434473c87e72f9b97e0/internal/pkg/agent/application/upgrade/watcher.go#L57-L60

**3. `ctx.Err()` check in `Recv()` error path** (`d6b4e6d1fa`) — belt-and-suspenders.

Even with the channel-closing fix in place, the `Recv()` error path now checks `ctx.Err() != nil` to distinguish a context-cancellation shutdown from a genuine lost connection, and returns cleanly without incrementing `lostCounter`:

https://github.com/elastic/elastic-agent/blob/ae70a3c6236de57ef18e6434473c87e72f9b97e0/internal/pkg/agent/application/upgrade/watcher.go#L216-L222

## Why is it important?

Without this fix, a turbulent upgraded-agent startup (two PID changes during the grace period) puts `lostCounter` right at the threshold. The normal grace-period teardown then tips it over, panics the watcher, and leaves the agent reporting `UPG_WATCHING` to Fleet indefinitely. A manual service restart is required to clear the state.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None. All changes are in the watcher shutdown path, exercised only when the context is cancelled (normal grace-period teardown). Genuine connection failures (where `ctx.Err()` is nil) are unaffected.

## How to test this PR locally

Run the regression test:

```
go test ./internal/pkg/agent/application/upgrade/ -run TestWatcher_GracefulShutdownWithPreloadedLostCounter -v
```

The test pre-loads `lostCounter` to `statusLossesAllowed` via PID changes (matching the turbulent-startup precondition), cancels the context, and asserts no error is sent on `notifyChan`. It fails against the pre-fix code with `lost connection to agent daemon '3' times in a row`.

https://github.com/elastic/elastic-agent/blob/ae70a3c6236de57ef18e6434473c87e72f9b97e0/internal/pkg/agent/application/upgrade/watcher_test.go#L255-L315

## Related issues

- Closes #14252