### PR TITLE
Fix sparse checkout for package job trigger

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -398,7 +398,14 @@ steps:
       - .buildkite/scripts/steps/trigger-elastic-agent-package.sh
       - .buildkite/scripts/steps/trigger-elastic-agent-package.sh | buildkite-agent pipeline upload
     plugins:
-    - *sparse_checkout_plugin
+    - sparse-checkout#v1.6.0:
+        paths:
+        - .buildkite
+        - .go-version
+        - version/version.go
+        - .package-version
+        - magefile.go
+        - dev-tools
     if_changed:
       include:
         - .buildkite/pipeline.elastic-agent-package.yml


### PR DESCRIPTION
https://github.com/elastic/elastic-agent/pull/12082 introduced sparse checkouts for jobs which only upload pipelines, and was too aggressive about it.

The elastic-agent-package-trigger job needs to check out all the paths it uses to determine whether it should run.

