### PR TITLE
Run FIPS unit tests on Windows

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -79,10 +79,7 @@ steps:
 
       - label: "Unit tests - fips140=only Ubuntu 22.04"
         key: "unit-tests-2204-fips140-only"
-        # Note: The GODEBUG=fips140=only environment variable must be set in the command itself (as opposed to
-        # in the env block) so that it is applied *only* to the 'go' command invoked by the script, and
-        # not to any other Go code executed as part of the Buildkite agent itself.
-        command: 'GODEBUG="fips140=only,tlsmlkem=0" .buildkite/scripts/steps/unit-tests.sh'
+        command: ".buildkite/scripts/steps/unit-tests.sh"
         env:
           FIPS: "true"
         artifact_paths:
@@ -150,6 +147,28 @@ steps:
         agents:
           provider: "gcp"
           image: "${IMAGE_WIN_2016}"
+          machineType: "n2-standard-8"
+          disk_size: 200
+          disk_type: "pd-ssd"
+        retry:
+          automatic:
+            limit: 1
+          manual:
+            allowed: true
+
+      - label: "Unit tests - fips140=only Windows 2022"
+        key: "unit-tests-win2022-fips140-only"
+        command: .buildkite/scripts/steps/unit-tests.ps1
+        env:
+          FIPS: "true"
+        artifact_paths:
+          - "build/TEST-*.html"
+          - "build/TEST-*.xml"
+          - "build/diagnostics/*"
+          - "coverage-*.out"
+        agents:
+          provider: "gcp"
+          image: "${IMAGE_WIN_2022}"
           machineType: "n2-standard-8"
           disk_size: 200
           disk_type: "pd-ssd"
@@ -264,6 +283,28 @@ steps:
           manual:
             allowed: true
 
+      - label: "Unit tests - fips140=only Windows 11 arm64"
+        key: "unit-tests-win11-arm64-fips140-only"
+        command: .buildkite/scripts/steps/unit-tests.ps1
+        env:
+          FIPS: "true"
+        artifact_paths:
+          - "build/TEST-*.html"
+          - "build/TEST-*.xml"
+          - "build/diagnostics/*"
+          - "coverage-*.out"
+        agents:
+          provider: "azure"
+          image: "${IMAGE_WIN_11_ARM64}"
+          imageVersion: "${IMAGE_WIN_11_ARM64_VERSION}"
+          vmSize: "Standard_D8ps_v6"
+          diskSizeGb: "256"
+        retry:
+          automatic:
+            limit: 1
+          manual:
+            allowed: true
+
   - label: ":junit: Junit annotate"
     agents:
       # requires at least "bash", "curl" and "git"
@@ -293,6 +334,10 @@ steps:
       - step: "unit-tests-win11"
         allow_failure: true
       - step: "unit-tests-win11-arm64"
+        allow_failure: true
+      - step: "unit-tests-win2022-fips140-only"
+        allow_failure: true
+      - step: "unit-tests-win11-arm64-fips140-only"
         allow_failure: true
 
   - group: "K8s tests"

--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -51,6 +51,13 @@ func makeGoTestArgs(cfg *Settings, name string) GoTestArgs {
 	if cfg.Test.Coverage {
 		params.CoverageProfileFile = fileName + ".cov"
 	}
+	if cfg.Build.FIPSBuild {
+		// fips140=only causes the Go runtime to reject non-FIPS algorithms.
+		// tlsmlkem=0 disables X25519MLKEM768 (uses X25519, which is not FIPS-compliant).
+		// Both are set here rather than in the shell environment so that they apply
+		// only to the 'go test' subprocess and not to mage itself.
+		params.Env["GODEBUG"] = "fips140=only,tlsmlkem=0"
+	}
 	return params
 }
 

--- a/magefile.go
+++ b/magefile.go
@@ -586,7 +586,6 @@ func (Test) FIPSOnlyUnit(ctx context.Context) error {
 	cfg := devtools.SettingsFromContext(ctx)
 	params := devtools.DefaultGoTestUnitArgs(cfg)
 	params.Env["FIPS"] = "true"
-	params.Env["GODEBUG"] = "fips140=only"
 	params.Tags = append(params.Tags, "requirefips")
 	return devtools.GoTest(ctx, params)
 }

--- a/magefile.go
+++ b/magefile.go
@@ -583,7 +583,7 @@ func (Test) Unit(ctx context.Context) error {
 func (Test) FIPSOnlyUnit(ctx context.Context) error {
 	mg.Deps(Prepare.Env, Build.UnitTestBinaries)
 
-	cfg := devtools.SettingsFromContext(ctx)
+	cfg := devtools.SettingsFromContext(ctx).WithFIPSBuild(true)
 	params := devtools.DefaultGoTestUnitArgs(cfg)
 	params.Env["FIPS"] = "true"
 	params.Tags = append(params.Tags, "requirefips")


### PR DESCRIPTION
## What does this PR do?

Runs unit tests in `fips140=only` mode on Windows the same way we do on Linux. We run on Windows Server 2022 amd64 and Windows 11 arm for some additional arch coverage.

I've refactored the fips test orchestration slightly. The way it worked on Linux was invalid, and only succeeded because mage is pinned to 1.14 there, which was built with an old enough version of Go that it doesn't understand the flags. Mage understandably fails in `fips140=only` mode because it uses SHA-1 for file hashing. My change only sets `FIPS=true` for the mage target, which then sets `GODEBUG=fips140=only,tlsmlkem=0` for the actual go test invocation.

## Why is it important?

To verify that our codebase behaves reasonably in fips mode on Windows.

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/7431

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
