### PR TITLE
Disable async preemption in Windows 11 unit tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -220,6 +220,8 @@ steps:
             allowed: true
 
       - label: "Unit tests - Windows 11"
+        env:
+          GODEBUG: "asyncpreemptoff=1"  # see https://github.com/elastic/elastic-agent/issues/13796
         key: "unit-tests-win11"
         command: .buildkite/scripts/steps/unit-tests.ps1
         artifact_paths:
@@ -240,6 +242,8 @@ steps:
             allowed: true
 
       - label: "Unit tests - Windows 11 arm64"
+        env:
+          GODEBUG: "asyncpreemptoff=1"  # see https://github.com/elastic/elastic-agent/issues/13796
         key: "unit-tests-win11-arm64"
         command: .buildkite/scripts/steps/unit-tests.ps1
         artifact_paths:


### PR DESCRIPTION
## What does this PR do?

It disabled asynchronous preemption in Windows 11 unit tests. We've had some crashes involving memory corruption in these tests lately. [Experimentally](https://github.com/elastic/elastic-agent/pull/14246), this setting appears to fix them. Set it while we investigate, and to verify that it's effective.

There's a chance the root cause is the same as https://github.com/elastic/elastic-agent/issues/13796. It needs to be validated before we report back upstream.

## Why is it important?

Tests not crashing would be nice.

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/13796 https://github.com/elastic/elastic-agent/issues/14248

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
