### PR TITLE
Fix running integration tests without .git

### DIFF
--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -561,14 +561,34 @@ func listSrcGOPATHs() ([]string, error) {
 // settingsContextKey is the key used to store Settings in context.
 type settingsContextKey struct{}
 
+// LoadOptions configures optional behavior during settings loading.
+type LoadOptions struct {
+	// SkipVCS disables git-based initialization (commit hash lookup).
+	// Use this when running mage targets in a directory that is not a git
+	// repository and the commit hash is not needed.
+	SkipVCS bool
+}
+
 // SettingsFromContext returns the Settings from the context if present,
 // otherwise loads fresh settings from environment variables. This is the preferred
 // way to get settings in mage targets that receive a context.
 func SettingsFromContext(ctx context.Context) *Settings {
+	return SettingsFromContextWithOptions(ctx, LoadOptions{})
+}
+
+// SettingsFromContextWithOptions returns the Settings from the context if present,
+// otherwise loads fresh settings using the provided LoadOptions. Use this in mage
+// targets that need non-default load behaviour (e.g. LoadOptions{SkipVCS: true})
+// but still want to reuse already-loaded settings stored in the context.
+func SettingsFromContextWithOptions(ctx context.Context, opts LoadOptions) *Settings {
 	if s, ok := ctx.Value(settingsContextKey{}).(*Settings); ok && s != nil {
 		return s
 	}
-	return MustLoadSettings()
+	s, err := LoadSettingsWithOptions(opts)
+	if err != nil {
+		panic(fmt.Errorf("failed to load settings: %w", err))
+	}
+	return s
 }
 
 // ContextWithSettings returns a new context with the given Settings stored in it.
@@ -1277,6 +1297,13 @@ func MustLoadSettings() *Settings {
 // LoadSettings reads all settings from environment variables and returns a new Settings.
 // Each call returns a fresh settings with defaults, then overridden by environment variables.
 func LoadSettings() (*Settings, error) {
+	return LoadSettingsWithOptions(LoadOptions{})
+}
+
+// LoadSettingsWithOptions reads all settings from environment variables and returns a new Settings,
+// respecting the provided LoadOptions. Use LoadOptions.SkipVCS to skip git-based initialization
+// when running in a directory that is not a git repository.
+func LoadSettingsWithOptions(opts LoadOptions) (*Settings, error) {
 	s := DefaultSettings()
 
 	if err := s.loadBuildSettingsFromEnv(); err != nil {
@@ -1314,8 +1341,10 @@ func LoadSettings() (*Settings, error) {
 	if err := s.initBuildVariables(); err != nil {
 		return nil, fmt.Errorf("initializing build variables: %w", err)
 	}
-	if err := s.initCommitHash(); err != nil {
-		return nil, fmt.Errorf("initializing commit hash: %w", err)
+	if !opts.SkipVCS {
+		if err := s.initCommitHash(); err != nil {
+			return nil, fmt.Errorf("initializing commit hash: %w", err)
+		}
 	}
 
 	return s, nil

--- a/dev-tools/mage/settings_test.go
+++ b/dev-tools/mage/settings_test.go
@@ -6,6 +6,7 @@ package mage
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -911,7 +912,8 @@ func TestLoadSettingsWithOptionsSkipVCS(t *testing.T) {
 	t.Run("initCommitHash fails outside a git repository", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		// Prevent git from walking up past tmpDir and finding the checkout's .git.
-		t.Setenv("GIT_CEILING_DIRECTORIES", tmpDir)
+		// The ceiling must be a strict ancestor of cwd; listing tmpDir itself is ignored.
+		t.Setenv("GIT_CEILING_DIRECTORIES", filepath.Dir(tmpDir))
 		t.Chdir(tmpDir)
 
 		s := &Settings{}

--- a/dev-tools/mage/settings_test.go
+++ b/dev-tools/mage/settings_test.go
@@ -909,7 +909,10 @@ func TestMustLoadSettings(t *testing.T) {
 
 func TestLoadSettingsWithOptionsSkipVCS(t *testing.T) {
 	t.Run("initCommitHash fails outside a git repository", func(t *testing.T) {
-		t.Chdir(t.TempDir())
+		tmpDir := t.TempDir()
+		// Prevent git from walking up past tmpDir and finding the checkout's .git.
+		t.Setenv("GIT_CEILING_DIRECTORIES", tmpDir)
+		t.Chdir(tmpDir)
 
 		s := &Settings{}
 		err := s.initCommitHash()

--- a/dev-tools/mage/settings_test.go
+++ b/dev-tools/mage/settings_test.go
@@ -907,6 +907,22 @@ func TestMustLoadSettings(t *testing.T) {
 	})
 }
 
+func TestLoadSettingsWithOptionsSkipVCS(t *testing.T) {
+	t.Run("initCommitHash fails outside a git repository", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+
+		s := &Settings{}
+		err := s.initCommitHash()
+		require.Error(t, err)
+	})
+
+	t.Run("SkipVCS=true succeeds and leaves commit hash empty", func(t *testing.T) {
+		cfg, err := LoadSettingsWithOptions(LoadOptions{SkipVCS: true})
+		require.NoError(t, err)
+		assert.Empty(t, cfg.Build.CommitHash())
+	})
+}
+
 func TestEnvMap(t *testing.T) {
 	t.Run("includes settings values", func(t *testing.T) {
 		cfg, err := LoadSettings()

--- a/magefile.go
+++ b/magefile.go
@@ -2830,7 +2830,7 @@ func (i Integration) testForResourceLeaks(ctx context.Context, matrix bool, test
 
 // TestOnRemote shouldn't be called locally (called on remote host to perform testing)
 func (Integration) TestOnRemote(ctx context.Context) error {
-	cfg := devtools.SettingsFromContext(ctx)
+	cfg := devtools.SettingsFromContextWithOptions(ctx, devtools.LoadOptions{SkipVCS: true})
 	mg.Deps(Build.TestFakeComponent)
 	version := cfg.IntegrationTest.AgentVersion
 	if version == "" {


### PR DESCRIPTION
## What does this PR do?

Allows `mage integration:testOnRemote` to run outside of a git repository. This is a fix for a regression introduced by https://github.com/elastic/elastic-agent/pull/13823, which moved git commit hash determination to the settings load step. As a side effect, some targets which we used to run without `.git` present started failing. This PR introduces the ability to skip loading settings from the git repo.

Ideally, the integration target should be able to load only the settings it actually needs, but that's more involved. This is the simplest change that fixes the problem.

## Why is it important?

Serverless beats tests are currently failing in CI, and the same would be true of integration tests run via `mage integration:*`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

Any use of `mage integration:single XXX` will do.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
