### PR TITLE
Add background RPM lock diagnostics to CI on RHEL

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -42,7 +42,8 @@ disable_background_package_managers() {
     return 0
   fi
   echo "Disabling background package managers to prevent RPM lock contention"
-  for unit in dnf-automatic.timer dnf-makecache.timer dnf-makecache.service packagekit.service; do
+  # google-osconfig-agent performs GCP patch management and is a known RPM lock holder
+  for unit in dnf-automatic.timer dnf-makecache.timer dnf-makecache.service packagekit.service google-osconfig-agent.service; do
     sudo systemctl disable --now "$unit" 2>/dev/null || true
   done
 }
@@ -59,8 +60,8 @@ start_rpm_lock_diagnostics() {
   (
     while true; do
       echo "--- RPM lock diagnostics: $(date -u +%Y-%m-%dT%H:%M:%SZ) ---"
-      echo "lsof /var/lib/rpm/.rpm.lock:"
-      sudo lsof /var/lib/rpm/.rpm.lock 2>&1 || echo "(lock not held)"
+      echo "fuser /var/lib/rpm/.rpm.lock:"
+      sudo fuser -v /var/lib/rpm/.rpm.lock 2>&1 || echo "(lock not held)"
       echo "Running systemd services:"
       systemctl list-units --state=running --type=service --no-pager 2>&1 || true
       sleep 30

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -61,7 +61,14 @@ start_rpm_lock_diagnostics() {
     while true; do
       echo "--- RPM lock diagnostics: $(date -u +%Y-%m-%dT%H:%M:%SZ) ---"
       echo "fuser /var/lib/rpm/.rpm.lock:"
-      sudo fuser -v /var/lib/rpm/.rpm.lock 2>&1 || echo "(lock not held)"
+      lock_pids=$(sudo fuser /var/lib/rpm/.rpm.lock 2>/dev/null) || true
+      if [[ -n "${lock_pids}" ]]; then
+        sudo fuser -v /var/lib/rpm/.rpm.lock 2>&1
+        echo "process tree for lock holders:"
+        ps -p "${lock_pids// /,}" -o pid,ppid,cmd 2>&1 || true
+      else
+        echo "(lock not held)"
+      fi
       echo "Running systemd services:"
       systemctl list-units --state=running --type=service --no-pager 2>&1 || true
       sleep 30

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -65,7 +65,7 @@ start_rpm_lock_diagnostics() {
       if [[ -n "${lock_pids}" ]]; then
         sudo fuser -v /var/lib/rpm/.rpm.lock 2>&1
         echo "process tree for lock holders:"
-        ps -p "${lock_pids// /,}" -o pid,ppid,cmd 2>&1 || true
+        ps -p "$(echo "${lock_pids}" | tr -s ' ' ',' | sed 's/^,//;s/,$//')" -o pid,ppid,cmd 2>&1 || true
       else
         echo "(lock not held)"
       fi

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -49,6 +49,27 @@ disable_background_package_managers() {
 
 disable_background_package_managers
 
+# On RPM-based systems, log the RPM lock state every 30 seconds in the background.
+# This captures which process holds /var/lib/rpm/.rpm.lock so that intermittent
+# lock contention failures have context in CI logs even when the failure is flaky.
+start_rpm_lock_diagnostics() {
+  if ! command -v dnf >/dev/null 2>&1; then
+    return 0
+  fi
+  (
+    while true; do
+      echo "--- RPM lock diagnostics: $(date -u +%Y-%m-%dT%H:%M:%SZ) ---"
+      echo "lsof /var/lib/rpm/.rpm.lock:"
+      sudo lsof /var/lib/rpm/.rpm.lock 2>&1 || echo "(lock not held)"
+      echo "Running systemd services:"
+      systemctl list-units --state=running --type=service --no-pager 2>&1 || true
+      sleep 30
+    done
+  ) &
+}
+
+start_rpm_lock_diagnostics
+
 getOSOptions() {
   case $(uname | tr '[:upper:]' '[:lower:]') in
     linux*)


### PR DESCRIPTION
Start a background loop in common.sh that logs lsof output for /var/lib/rpm/.rpm.lock and running systemd services every 30 seconds. This captures which process holds the lock so that intermittent "Resource temporarily unavailable" failures have context in CI logs even when the failure is flaky.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
