### PR TITLE
Build only the necessary binaries for integration tests

### DIFF
--- a/.buildkite/scripts/steps/integration_tests_oblt-cli.sh
+++ b/.buildkite/scripts/steps/integration_tests_oblt-cli.sh
@@ -52,7 +52,7 @@ if [[ "${GROUP_NAME}" == "kubernetes" ]]; then
 else
   # test binaries are needed only when running integration tests outside of k8s
   echo "~~~ Building test binaries"
-  mage build:testBinaries
+  mage build:integrationTestBinaries
 
   if [ "$TEST_SUDO" == "true" ]; then
     sudo -E .buildkite/scripts/buildkite-integration-tests.sh "$@"


### PR DESCRIPTION
https://github.com/elastic/elastic-agent/pull/12987 made integration tests only build the binaries they need. Then https://github.com/elastic/elastic-agent/pull/13642 added a new script for running integration tests which used the old target. Fix this to restore the intended logic.