### PR TITLE
Drop unnecessary mage build from Windows unit-tests.ps1

### DIFF
--- a/.buildkite/scripts/steps/unit-tests.ps1
+++ b/.buildkite/scripts/steps/unit-tests.ps1
@@ -7,13 +7,6 @@ git reset --quiet --hard
 
 $env:GOTMPDIR = "$env:BUILDKITE_BUILD_CHECKOUT_PATH"
 
-Write-Host "--- Build"
-mage build
-
-if ($LASTEXITCODE -ne 0) {
-  exit 1
-}
-
 Write-Host "--- Unit tests"
 $env:TEST_COVERAGE = $true
 if ($env:PROCESSOR_ARCHITECTURE -ne "ARM64") {


### PR DESCRIPTION
There's no apparent reason for building the agent binary in Windows unit tests. We don't do it on Linux or MacOS. It was added in [this PR](https://github.com/elastic/elastic-agent/pull/3573) without any justification.