### PR TITLE
Disable sparse checkout in pipeline.agentless-app-release.yaml

### DIFF
--- a/.buildkite/pipeline.agentless-app-release.yaml
+++ b/.buildkite/pipeline.agentless-app-release.yaml
@@ -89,11 +89,5 @@ steps:
                 SYNTHETICS_TAG: "agentless-ci"
       YAML
       fi
-    plugins:
-    - sparse-checkout#v1.6.0:
-        paths:
-        - .buildkite
-        - .go-version
-        - version/version.go
     agents:
       image: docker.elastic.co/ci-agent-images/serverless-helm-builder:0.0.2@sha256:d00e8a7a0ab3618cfaacb0a7b1e1b06ee29728eb2b44de602374bd8f6b9b92ac


### PR DESCRIPTION
Reverting this change from https://github.com/elastic/elastic-agent/pull/12082, as it causes issues and isn't really necessary. The agentless team can pick it up later if they want.
