### PR TITLE
otel: remove per-input default processors when global defaults exist

### DIFF
--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -662,9 +662,47 @@ func getInputsForUnit(unit component.Unit, info info.Agent, defaultDataStreamTyp
 		} else if _, ok := input["type"]; !ok {
 			input["type"] = inputType
 		}
+
+		// When the beatprocessor runs the default enrichment processors globally for every
+		// event in the pipeline, remove them from per-input processor lists to avoid running
+		// each processor twice per event.
+		if features.DefaultProcessors() {
+			input["processors"] = stripDefaultProcessors(input["processors"])
+		}
 	}
 
 	return inputs, nil
+}
+
+// stripDefaultProcessors removes processors from the per-input list that are already
+// applied globally by the beatprocessor in the OTel pipeline. Matching is by processor
+// key name — a processor entry is dropped when its only key matches a default processor name.
+func stripDefaultProcessors(raw any) []any {
+	list, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	defaultKeys := make(map[string]struct{})
+	for _, p := range GetDefaultProcessors() {
+		for k := range p {
+			defaultKeys[k] = struct{}{}
+		}
+	}
+	filtered := list[:0:0]
+	for _, item := range list {
+		p, ok := item.(map[string]any)
+		if ok && len(p) == 1 {
+			key := ""
+			for k := range p {
+				key = k
+			}
+			if _, isDefault := defaultKeys[key]; isDefault {
+				continue
+			}
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
 }
 
 // extractOtelProcessors extracts the processor IDs from the output configuration.

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -1822,6 +1822,168 @@ func TestGetOtelConfig(t *testing.T) {
 				},
 			}),
 		},
+		{
+			name:              "filestream per stream default processors are stripped when DefaultProcessors is enabled",
+			defaultProcessors: func() *bool { b := true; return &b }(),
+			model: &component.Model{
+				Components: []component.Component{
+					{
+						ID:         "filestream-default",
+						InputType:  "filestream",
+						OutputType: "elasticsearch",
+						OutputName: "default",
+						InputSpec: &component.InputRuntimeSpec{
+							BinaryName: "elastic-otel-collector",
+							Spec: component.InputSpec{
+								Command: &component.CommandSpec{
+									Args: []string{"filebeat"},
+								},
+							},
+						},
+						Units: []component.Unit{
+							{
+								ID:   "filestream-unit",
+								Type: client.UnitTypeInput,
+								Config: component.MustExpectedConfig(map[string]any{
+									"id":         "test",
+									"use_output": "default",
+									"streams": []any{
+										map[string]any{
+											"id": "test-1",
+											"data_stream": map[string]any{
+												"dataset": "generic-1",
+											},
+											"paths": []any{"/var/log/*.log"},
+											// Mix of default processors (should be stripped) and a
+											// custom one (must be preserved).
+											"processors": []any{
+												map[string]any{"add_cloud_metadata": nil},
+												map[string]any{"add_docker_metadata": nil},
+												map[string]any{"add_kubernetes_metadata": nil},
+												map[string]any{
+													"add_host_metadata": map[string]any{
+														"when.not.contains.tags": "forwarded",
+													},
+												},
+												map[string]any{
+													"timestamp": map[string]any{
+														"field":   "datetime",
+														"layouts": []any{"2006-01-02T15:04:05.999999999"},
+													},
+												},
+											},
+										},
+									},
+								}),
+							},
+							{
+								ID:     "filestream-default",
+								Type:   client.UnitTypeOutput,
+								Config: component.MustExpectedConfig(esOutputConfig()),
+							},
+						},
+					},
+				},
+			},
+			expectedConfig: confmap.NewFromStringMap(map[string]any{
+				"exporters": map[string]any{
+					"elasticsearch/_agent-component/default": expectedESConfig("default"),
+				},
+				"extensions": map[string]any{
+					"beatsauth/_agent-component/default": expectedExtensionConfig(),
+				},
+				"processors": map[string]any{
+					// Default processors must appear here — applied once globally per event.
+					"beat/_agent-component": map[string]any{
+						"processors": defaultGlobalProcessors,
+					},
+				},
+				"receivers": map[string]any{
+					"filebeatreceiver/_agent-component/filestream-default": map[string]any{
+						"filebeat": map[string]any{
+							"inputs": []map[string]any{
+								{
+									"id":   "test-1",
+									"type": "filestream",
+									"data_stream": map[string]any{
+										"dataset": "generic-1",
+									},
+									"paths": []any{"/var/log/*.log"},
+									"index": "logs-generic-1-default",
+									// Default processors must NOT appear here; only add_agent_metadata
+									// (injected by createStreamRulesForReceiver) and the custom timestamp
+									// processor must survive.
+									"processors": []any{
+										mapstr.M{
+											"add_agent_metadata": mapstr.M{
+												"data_stream": mapstr.M{
+													"dataset":   "generic-1",
+													"namespace": "default",
+													"type":      "logs",
+												},
+												"elastic_agent": mapstr.M{
+													"id":       agentInfo.AgentID(),
+													"snapshot": agentInfo.Snapshot(),
+													"version":  agentInfo.Version(),
+												},
+												"input_id":  "test",
+												"stream_id": "test-1",
+											},
+										},
+										map[string]any{
+											"timestamp": map[string]any{
+												"field":   "datetime",
+												"layouts": []any{"2006-01-02T15:04:05.999999999"},
+											},
+										},
+									},
+								},
+							},
+						},
+						"path": map[string]any{
+							"home": paths.Components(),
+							"data": filepath.Join(paths.Run(), "filestream-default"),
+						},
+						"queue": map[string]any{
+							"mem": map[string]any{
+								"events": uint64(3200),
+								"flush": map[string]any{
+									"min_events": uint64(1600),
+									"timeout":    "10s",
+								},
+							},
+						},
+						"logging": map[string]any{
+							"with_fields": map[string]any{
+								"component": map[string]any{
+									"binary":  "filebeat",
+									"dataset": "elastic_agent.filebeat",
+									"type":    "filestream",
+									"id":      "filestream-default",
+								},
+								"log": map[string]any{
+									"source": "filestream-default",
+								},
+							},
+						},
+						"http": map[string]any{
+							"enabled": false,
+						},
+						"management.otel.enabled": true,
+					},
+				},
+				"service": map[string]any{
+					"extensions": []any{"beatsauth/_agent-component/default"},
+					"pipelines": map[string]any{
+						"logs/_agent-component/filestream-default": map[string][]string{
+							"exporters":  {"elasticsearch/_agent-component/default"},
+							"processors": {"beat/_agent-component"},
+							"receivers":  {"filebeatreceiver/_agent-component/filestream-default"},
+						},
+					},
+				},
+			}),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

With filebeat inputs running as receivers and the beatprocessor applying global processors by default, there is an edge case where if the individual stream specifies processors that intersect with the ones enabled globally, we end up running the processors twice for each event. Once per receiver and a second time in the otel pipeline by beatprocessor.

Discovered this while investigating https://github.com/elastic/elastic-agent/issues/14281. Turns out the [benchbuilder filebeat benchmark](https://github.com/elastic/ingest-dev/blob/3dcda35e70eeacb509c4cd53addb674af0f528d0/performance/use_cases/bb/filebeat/single-input-filestream.yaml#L49) adds an additional `add_cloud_metadata`. This used to work without extra cost because we didn't had these processors enabled globally in elastic-agent with agentbeat runtime, but now it is via beatprocessor.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## Related issues

For https://github.com/elastic/elastic-agent/issues/14281