### PR TITLE
ci: declare workflow-level `contents: read` on 2 workflows

### DIFF
--- a/.github/workflows/fragment-in-pr.yml
+++ b/.github/workflows/fragment-in-pr.yml
@@ -3,6 +3,10 @@ name: fragment-in-pr
 on:
   pull_request:
     types: [ labeled, unlabeled, opened, reopened, synchronize ]
+
+permissions:
+  contents: read
+
 jobs:
   fragments:
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-changelog') && !contains(github.event.pull_request.labels.*.name, 'backport')"

--- a/.github/workflows/validate-docs-structure.yml
+++ b/.github/workflows/validate-docs-structure.yml
@@ -7,6 +7,9 @@ on:
       - 'docs/scripts/update-docs/**'
       - '.github/workflows/validate-docs-structure.yml'
 
+permissions:
+  contents: read
+
 jobs:
   validate-structure:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 2 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.