### PR TITLE
Explicitly disable scope info for the Prometheus exporter in otel collector telemetry

### DIFF
--- a/internal/pkg/otel/manager/execution_subprocess.go
+++ b/internal/pkg/otel/manager/execution_subprocess.go
@@ -194,10 +194,12 @@ func addCollectorMetricsReader(conf *confmap.Conf, port int) error {
 		"pull": map[string]any{
 			"exporter": map[string]any{
 				"prometheus": map[string]any{
-					"host":                "localhost",
-					"port":                port,
-					"without_units":       true,
-					"without_type_suffix": true,
+					"host": "localhost",
+					"port": port,
+					// without_scope_info=false keeps pipeline-identifying scope attributes (injected by
+					// telemetry.newPipelineTelemetry) as Prometheus labels, preventing label collisions
+					// when the same component type appears in multiple pipelines.
+					"without_scope_info": false,
 				},
 			},
 		},

--- a/internal/pkg/otel/manager/manager_test.go
+++ b/internal/pkg/otel/manager/manager_test.go
@@ -2436,10 +2436,9 @@ func TestAddCollectorMetricsPort(t *testing.T) {
 		"pull": map[string]any{
 			"exporter": map[string]any{
 				"prometheus": map[string]any{
-					"host":                "localhost",
-					"port":                0,
-					"without_units":       true,
-					"without_type_suffix": true,
+					"host":               "localhost",
+					"port":               0,
+					"without_scope_info": false,
 				},
 			},
 		},


### PR DESCRIPTION
## What does this PR do?

Explicitly sets `"without_scope_info":  false`. This erroneously used to be the default in otel collector core, but was fixed in https://github.com/open-telemetry/opentelemetry-collector/pull/15027 and released in v0.152.0.

For the current state of the repo, this is a no-op.

## Why is it important?

Fixes the test failure in https://github.com/elastic/elastic-agent/pull/14340 and unblocks the upgrade.

We enable the `telemetry.newPipelineTelemetry` feature gate, which injects pipeline-identifying attributes (pipeline_id, signal, component.kind) into each component's instrumentation scope. The Prometheus exporter exposes those scope attributes as metric labels only when without_scope_info=false; they are what differentiates per-pipeline instances of the same component (e.g. a batch processor shared across traces/metrics/logs pipelines).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Relates https://github.com/elastic/elastic-agent/pull/14340 

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
