### PR TITLE
Explicitly disable TLS in TestSystemMetricsWithLogstashOutput

### DIFF
--- a/testing/integration/ess/testdata/pipelines.yml
+++ b/testing/integration/ess/testdata/pipelines.yml
@@ -8,6 +8,7 @@
       beats {
         port => "5044"
         enrich => "none"
+        ssl_enabled => false
       }
     }
     filter {
@@ -28,6 +29,7 @@
       beats {
         port => "5055"
         enrich => "none"
+        ssl_enabled => false
       }
     }
     filter {


### PR DESCRIPTION
I saw a weird failure in https://buildkite.com/elastic/elastic-agent/builds/39651/canvas?jid=019e3acb-d939-4c1a-a6e4-a4a081e21611&tab=output:

```
 [logstash.inputs.beats] Invalid setting for beats input plugin:
    input {
      beats {
        # This setting must be a ["TLSv1.1", "TLSv1.2", "TLSv1.3"]
        # ["TLSv1.2", "Expected one of [...], got []"]
        ssl_supported_protocols => ["TLSv1.2", nil]
```

This isn't something we set in our test config, which is quite vanilla for this test, so I'm not sure how this can be intermittent:

```yaml

services:
  init-logstash:
    image: busybox:latest
    user: "0:0"
    command: ["sh", "-c", "chown -R 1000:1000 /data && chmod 777 /data"]
    volumes:
      - %s:/data
    restart: "no"
  logstash:
    image: docker.elastic.co/logstash/logstash:9.2.2
    depends_on:
      init-logstash:
        condition: service_completed_successfully
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
      retries: 300
      interval: 1s
    volumes:
      - %s:/usr/share/logstash/config/pipelines.yml
      - %s:/usr/share/logstash/testdata
    ports:
      - 9600:9600
      - 5044:5044
      - 5055:5055
```

Either way, we're not using TLS in this test at all, so disabling it doesn't cost us anything.