### PR TITLE
Make the GHA lint workflow more performant and reliable

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,10 +1,18 @@
 name: golangci-lint
 on:
-  #push:
-  #  branches:
-  #    - main
-  #    - 8.*
-  #    - 7.17
+  push:
+    # This is only here to establish a base cache and make the PR executions faster
+    branches:
+      - 'main'
+      - '8.19'
+      - '9.*'
+    paths:
+      - '**/*.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - '.golangci.yml'
+      - '.golangci-lint-version'
+      - '.github/workflows/golangci-lint.yml'
   pull_request:
     paths:
       - '**/*.go'
@@ -48,7 +56,7 @@ jobs:
           # which can lead to some frustration from developers who would like to
           # fix a single line in an existing codebase and the linter would force them
           # into fixing all linting issues in the whole file instead.
-          args: --timeout=30m --whole-files
+          args: --timeout=60m --whole-files
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,6 +106,7 @@ linters:
       - third_party$
       - builtin$
       - examples$
+      - ^beats
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Makes the GHA lint workflow faster and more reliable. It does so through the following changes:

- Increase timeout to 60m. A run on macos with a cold cache can take longer and we have regular failures.
- Run on pushes to release branches. The point is to warm up a baseline cache for PRs.
- Don't lint the `beats` directory.

## Why is it important?

This workflow should be reliable and as fast as possible.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
