### PR TITLE
Extract ECSMeta types to pkg/ecsmeta for cross-repo sharing

### DIFF
--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/enroll"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/reexec"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade"
@@ -1261,7 +1262,7 @@ func (c *Coordinator) DiagnosticHooks() diagnostics.Hooks {
 					LogLevelRuntime  string            `yaml:"log_level"`
 					LogLevelPolicy   string            `yaml:"log_level_policy"`
 					LogLevelOverride string            `yaml:"log_level_override"`
-					Metadata         *info.ECSMeta     `yaml:"metadata"`
+					Metadata         *ecsmeta.ECSMeta  `yaml:"metadata"`
 				}{
 					Headers:          c.agentInfo.Headers(),
 					LogLevelRuntime:  c.agentInfo.GetLogLevelRuntime(),

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/enroll"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
-	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/reexec"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade"
@@ -56,6 +55,7 @@ import (
 	agentclient "github.com/elastic/elastic-agent/pkg/control/v2/client"
 	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/pkg/features"
 	"github.com/elastic/elastic-agent/pkg/limits"
 	"github.com/elastic/elastic-agent/pkg/utils/broadcaster"

--- a/internal/pkg/agent/application/coordinator/diagnostics_test.go
+++ b/internal/pkg/agent/application/coordinator/diagnostics_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/details"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/transpiler"
@@ -155,9 +155,9 @@ func TestDiagnosticAgentInfo(t *testing.T) {
 		},
 		LogLevelPolicy:   "info",
 		LogLevelOverride: "trace",
-		meta: &info.ECSMeta{
-			Elastic: &info.ElasticECSMeta{
-				Agent: &info.AgentECSMeta{
+		meta: &ecsmeta.ECSMeta{
+			Elastic: &ecsmeta.ElasticECSMeta{
+				Agent: &ecsmeta.AgentECSMeta{
 					BuildOriginal: "8.14.0-SNAPSHOT",
 					ID:            "agent-id",
 					LogLevel:      "trace",
@@ -167,11 +167,11 @@ func TestDiagnosticAgentInfo(t *testing.T) {
 					Upgradeable:   true,
 				},
 			},
-			Host: &info.HostECSMeta{
+			Host: &ecsmeta.HostECSMeta{
 				Arch:     "arm64",
 				Hostname: "Test-Macbook-Pro.local",
 			},
-			OS: &info.SystemECSMeta{
+			OS: &ecsmeta.SystemECSMeta{
 				Name:     "macos",
 				Platform: "darwin",
 			},
@@ -754,7 +754,7 @@ type fakeAgentInfo struct {
 	version          string
 	unprivileged     bool
 	isStandalone     bool
-	meta             *info.ECSMeta
+	meta             *ecsmeta.ECSMeta
 }
 
 func (a fakeAgentInfo) AgentID() string {
@@ -796,7 +796,7 @@ func (a fakeAgentInfo) IsStandalone() bool {
 	return a.isStandalone
 }
 
-func (a fakeAgentInfo) ECSMetadata(l *logger.Logger) (*info.ECSMeta, error) {
+func (a fakeAgentInfo) ECSMetadata(l *logger.Logger) (*ecsmeta.ECSMeta, error) {
 	return a.meta, nil
 }
 

--- a/internal/pkg/agent/application/coordinator/diagnostics_test.go
+++ b/internal/pkg/agent/application/coordinator/diagnostics_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 
-	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/details"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/transpiler"
@@ -31,6 +30,7 @@ import (
 	agentclient "github.com/elastic/elastic-agent/pkg/control/v2/client"
 	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/pkg/utils/broadcaster"
 )
 

--- a/internal/pkg/agent/application/info/agent_info.go
+++ b/internal/pkg/agent/application/info/agent_info.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/elastic/elastic-agent/internal/pkg/release"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/pkg/utils"
 )
 
@@ -52,7 +53,7 @@ type Agent interface {
 	IsStandalone() bool
 
 	// ECSMetadata returns the ECS metadata that is attached as part of every Fleet checkin.
-	ECSMetadata(*logger.Logger) (*ECSMeta, error)
+	ECSMetadata(*logger.Logger) (*ecsmeta.ECSMeta, error)
 }
 
 // AgentInfo is a collection of information about agent.

--- a/internal/pkg/agent/application/info/agent_metadata.go
+++ b/internal/pkg/agent/application/info/agent_metadata.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/pkg/features"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
@@ -22,76 +23,14 @@ import (
 	"github.com/elastic/go-sysinfo/types"
 )
 
-// ECSMeta is a collection of agent related metadata in ECS compliant object form.
-type ECSMeta struct {
-	Elastic *ElasticECSMeta `json:"elastic"`
-	Host    *HostECSMeta    `json:"host"`
-	OS      *SystemECSMeta  `json:"os"`
-}
-
-// ElasticECSMeta is a collection of elastic vendor metadata in ECS compliant object form.
-type ElasticECSMeta struct {
-	Agent *AgentECSMeta `json:"agent"`
-}
-
-// AgentECSMeta is a collection of agent metadata in ECS compliant object form.
-type AgentECSMeta struct {
-	// ID is a generated (in standalone) or assigned (in fleet) agent identifier.
-	ID string `json:"id"`
-	// Version specifies current version of an agent.
-	Version string `json:"version"`
-	// Snapshot is a flag specifying that the agent used is a snapshot build.
-	Snapshot bool `json:"snapshot"`
-	// BuildOriginal is an extended build information for the agent.
-	BuildOriginal string `json:"build.original"`
-	// Upgradeable is a flag specifying if it is possible for agent to be upgraded.
-	Upgradeable bool `json:"upgradeable"`
-	// LogLevel describes currently set log level.
-	// Possible values: "debug"|"info"|"warning"|"error"
-	LogLevel string `json:"log_level"`
-	// Complete is a flag specifying that the agent used is a complete image.
-	Complete bool `json:"complete"`
-	// Unprivileged is a flag specifying that the agent is running in unprivileged mode.
-	Unprivileged bool `json:"unprivileged"`
-	// FIPS is a flag specifying if the agent is a FIPS distribution
-	FIPS bool `json:"fips"`
-}
-
-// SystemECSMeta is a collection of operating system metadata in ECS compliant object form.
-type SystemECSMeta struct {
-	// Family defines a family of underlying operating system (e.g. redhat, debian, freebsd, windows).
-	Family string `json:"family"`
-	// Kernel specifies current version of a kernel in a semver format.
-	Kernel string `json:"kernel"`
-	// Platform specifies platform agent is running on (e.g. centos, ubuntu, windows).
-	Platform string `json:"platform"`
-	// Version specifies version of underlying operating system (e.g. 10.12.6).
-	Version string `json:"version"`
-	// Name is a operating system name.
-	// Currently we just normalize the name (i.e. macOS, Windows, Linux). See https://www.elastic.co/guide/en/ecs/current/ecs-html
-	Name string `json:"name"`
-	// Full is an operating system name, including the version or code name.
-	FullName string `json:"full"`
-}
-
-// HostECSMeta is a collection of host metadata in ECS compliant object form.
-type HostECSMeta struct {
-	// Arch defines architecture of a host (e.g. x86_64, arm, ppc, mips).
-	Arch string `json:"architecture"`
-	// Hostname specifies hostname of the host.
-	Hostname string `json:"hostname"`
-	// Name specifies hostname of the host.
-	Name string `json:"name"`
-	// ID is a Unique host id.
-	// As hostname is not always unique, use values that are meaningful in your environment.
-	ID string `json:"id"`
-	// IP is Host ip addresses.
-	// Note: this field should contain an array of values.
-	IP []string `json:"ip"`
-	// Mac is Host mac addresses.
-	// Note: this field should contain an array of values.
-	MAC []string `json:"mac"`
-}
+// Type aliases so existing callers within this package continue to compile.
+type (
+	ECSMeta        = ecsmeta.ECSMeta
+	ElasticECSMeta = ecsmeta.ElasticECSMeta
+	AgentECSMeta   = ecsmeta.AgentECSMeta
+	SystemECSMeta  = ecsmeta.SystemECSMeta
+	HostECSMeta    = ecsmeta.HostECSMeta
+)
 
 // List of variables available to be used in constraint definitions.
 const (

--- a/internal/pkg/agent/application/info/agent_metadata.go
+++ b/internal/pkg/agent/application/info/agent_metadata.go
@@ -23,15 +23,6 @@ import (
 	"github.com/elastic/go-sysinfo/types"
 )
 
-// Type aliases so existing callers within this package continue to compile.
-type (
-	ECSMeta        = ecsmeta.ECSMeta
-	ElasticECSMeta = ecsmeta.ElasticECSMeta
-	AgentECSMeta   = ecsmeta.AgentECSMeta
-	SystemECSMeta  = ecsmeta.SystemECSMeta
-	HostECSMeta    = ecsmeta.HostECSMeta
-)
-
 // List of variables available to be used in constraint definitions.
 const (
 	// `agent.id` is a generated (in standalone) or assigned (in fleet) agent identifier.
@@ -71,7 +62,7 @@ const (
 )
 
 // Metadata loads metadata from disk.
-func Metadata(ctx context.Context, l *logger.Logger) (*ECSMeta, error) {
+func Metadata(ctx context.Context, l *logger.Logger) (*ecsmeta.ECSMeta, error) {
 	agentInfo, err := NewAgentInfo(ctx, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new agent info: %w", err)
@@ -86,7 +77,7 @@ func Metadata(ctx context.Context, l *logger.Logger) (*ECSMeta, error) {
 }
 
 // ECSMetadata returns an agent ECS compliant metadata.
-func (i *AgentInfo) ECSMetadata(l *logger.Logger) (*ECSMeta, error) {
+func (i *AgentInfo) ECSMetadata(l *logger.Logger) (*ecsmeta.ECSMeta, error) {
 	sysInfo, err := sysinfo.Host()
 	if err != nil {
 		return nil, err
@@ -95,9 +86,9 @@ func (i *AgentInfo) ECSMetadata(l *logger.Logger) (*ECSMeta, error) {
 	info := sysInfo.Info()
 	hostname := util.GetHostName(features.FQDN(), info, sysInfo, l)
 
-	return &ECSMeta{
-		Elastic: &ElasticECSMeta{
-			Agent: &AgentECSMeta{
+	return &ecsmeta.ECSMeta{
+		Elastic: &ecsmeta.ElasticECSMeta{
+			Agent: &ecsmeta.AgentECSMeta{
 				ID:            i.agentID,
 				Version:       release.Version(),
 				Snapshot:      release.Snapshot(),
@@ -111,7 +102,7 @@ func (i *AgentInfo) ECSMetadata(l *logger.Logger) (*ECSMeta, error) {
 				FIPS:         release.FIPSDistribution(),
 			},
 		},
-		Host: &HostECSMeta{
+		Host: &ecsmeta.HostECSMeta{
 			Arch:     info.Architecture,
 			Hostname: hostname,
 			Name:     strings.ToLower(hostname),
@@ -121,7 +112,7 @@ func (i *AgentInfo) ECSMetadata(l *logger.Logger) (*ECSMeta, error) {
 		},
 
 		// Operating system
-		OS: &SystemECSMeta{
+		OS: &ecsmeta.SystemECSMeta{
 			Family:   info.OS.Family,
 			Kernel:   info.KernelVersion,
 			Platform: info.OS.Platform,

--- a/internal/pkg/agent/application/info/mocks.go
+++ b/internal/pkg/agent/application/info/mocks.go
@@ -14,6 +14,7 @@ import (
 	mock "github.com/stretchr/testify/mock"
 
 	"github.com/elastic/elastic-agent/pkg/core/logger"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 )
 
 // NewMockAgent creates a new instance of MockAgent. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -88,23 +89,23 @@ func (_c *MockAgent_AgentID_Call) RunAndReturn(run func() string) *MockAgent_Age
 }
 
 // ECSMetadata provides a mock function for the type MockAgent
-func (_mock *MockAgent) ECSMetadata(v *logger.Logger) (*ECSMeta, error) {
+func (_mock *MockAgent) ECSMetadata(v *logger.Logger) (*ecsmeta.ECSMeta, error) {
 	ret := _mock.Called(v)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ECSMetadata")
 	}
 
-	var r0 *ECSMeta
+	var r0 *ecsmeta.ECSMeta
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*logger.Logger) (*ECSMeta, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(*logger.Logger) (*ecsmeta.ECSMeta, error)); ok {
 		return returnFunc(v)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*logger.Logger) *ECSMeta); ok {
+	if returnFunc, ok := ret.Get(0).(func(*logger.Logger) *ecsmeta.ECSMeta); ok {
 		r0 = returnFunc(v)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*ECSMeta)
+			r0 = ret.Get(0).(*ecsmeta.ECSMeta)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(*logger.Logger) error); ok {
@@ -139,12 +140,12 @@ func (_c *MockAgent_ECSMetadata_Call) Run(run func(v *logger.Logger)) *MockAgent
 	return _c
 }
 
-func (_c *MockAgent_ECSMetadata_Call) Return(eCSMeta *ECSMeta, err error) *MockAgent_ECSMetadata_Call {
+func (_c *MockAgent_ECSMetadata_Call) Return(eCSMeta *ecsmeta.ECSMeta, err error) *MockAgent_ECSMetadata_Call {
 	_c.Call.Return(eCSMeta, err)
 	return _c
 }
 
-func (_c *MockAgent_ECSMetadata_Call) RunAndReturn(run func(v *logger.Logger) (*ECSMeta, error)) *MockAgent_ECSMetadata_Call {
+func (_c *MockAgent_ECSMetadata_Call) RunAndReturn(run func(v *logger.Logger) (*ecsmeta.ECSMeta, error)) *MockAgent_ECSMetadata_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/pkg/fleetapi/checkin_cmd.go
+++ b/internal/pkg/fleetapi/checkin_cmd.go
@@ -14,10 +14,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/details"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 )
 
 const checkingPath = "/api/fleet/agents/%s/checkin"
@@ -55,7 +55,7 @@ type CheckinUpgrade struct {
 type CheckinRequest struct {
 	Status            string             `json:"status"`
 	AckToken          string             `json:"ack_token,omitempty"`
-	Metadata          *info.ECSMeta      `json:"local_metadata,omitempty"`
+	Metadata          *ecsmeta.ECSMeta   `json:"local_metadata,omitempty"`
 	Message           string             `json:"message"`    // V2 Agent message
 	Components        []CheckinComponent `json:"components"` // V2 Agent components
 	UpgradeDetails    *details.Details   `json:"upgrade_details,omitempty"`

--- a/internal/pkg/fleetapi/checkin_cmd_test.go
+++ b/internal/pkg/fleetapi/checkin_cmd_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
 	"github.com/elastic/elastic-agent/internal/pkg/remote"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 )
 
 type agentinfo struct{}

--- a/internal/pkg/fleetapi/checkin_cmd_test.go
+++ b/internal/pkg/fleetapi/checkin_cmd_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
 	"github.com/elastic/elastic-agent/internal/pkg/remote"
@@ -213,7 +213,7 @@ func TestCheckin(t *testing.T) {
 			path := fmt.Sprintf("/api/fleet/agents/%s/checkin", agentInfo.AgentID())
 			mux.HandleFunc(path, authHandler(func(w http.ResponseWriter, r *http.Request) {
 				type Request struct {
-					Metadata *info.ECSMeta `json:"local_metadata"`
+					Metadata *ecsmeta.ECSMeta `json:"local_metadata"`
 				}
 
 				var req *Request
@@ -247,7 +247,7 @@ func TestCheckin(t *testing.T) {
 			path := fmt.Sprintf("/api/fleet/agents/%s/checkin", agentInfo.AgentID())
 			mux.HandleFunc(path, authHandler(func(w http.ResponseWriter, r *http.Request) {
 				type Request struct {
-					Metadata *info.ECSMeta `json:"local_metadata"`
+					Metadata *ecsmeta.ECSMeta `json:"local_metadata"`
 				}
 
 				var req *Request
@@ -281,7 +281,7 @@ func TestCheckin(t *testing.T) {
 			path := fmt.Sprintf("/api/fleet/agents/%s/checkin", agentInfo.AgentID())
 			mux.HandleFunc(path, authHandler(func(w http.ResponseWriter, r *http.Request) {
 				type Request struct {
-					Metadata *info.ECSMeta `json:"local_metadata"`
+					Metadata *ecsmeta.ECSMeta `json:"local_metadata"`
 				}
 
 				var req *Request

--- a/internal/pkg/fleetapi/enroll_cmd.go
+++ b/internal/pkg/fleetapi/enroll_cmd.go
@@ -17,8 +17,8 @@ import (
 	"time"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
-	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 )
 
 // EnrollType is the type of enrollment to do with the elastic-agent.

--- a/internal/pkg/fleetapi/enroll_cmd.go
+++ b/internal/pkg/fleetapi/enroll_cmd.go
@@ -16,8 +16,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
 )
 
@@ -111,7 +111,7 @@ type EnrollRequest struct {
 
 // Metadata is a all the metadata send or received from the elastic-agent.
 type Metadata struct {
-	Local        *info.ECSMeta          `json:"local"`
+	Local        *ecsmeta.ECSMeta       `json:"local"`
 	UserProvided map[string]interface{} `json:"user_provided"`
 	Tags         []string               `json:"tags"`
 }

--- a/internal/pkg/fleetapi/enroll_cmd_test.go
+++ b/internal/pkg/fleetapi/enroll_cmd_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/remote"
 )
@@ -161,9 +161,9 @@ func TestEnroll(t *testing.T) {
 	))
 }
 
-func testMetadata() *info.ECSMeta {
-	return &info.ECSMeta{
-		OS: &info.SystemECSMeta{
+func testMetadata() *ecsmeta.ECSMeta {
+	return &ecsmeta.ECSMeta{
+		OS: &ecsmeta.SystemECSMeta{
 			Name: "linux",
 		},
 	}

--- a/internal/pkg/fleetapi/enroll_cmd_test.go
+++ b/internal/pkg/fleetapi/enroll_cmd_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/remote"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 )
 
 func TestEnroll(t *testing.T) {

--- a/pkg/component/runtime/runtime_comm_test.go
+++ b/pkg/component/runtime/runtime_comm_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/internal/pkg/core/authority"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
@@ -61,7 +61,9 @@ func (a agentInfoMock) SetLogLevelPolicy(level string)     { panic("implement me
 func (a agentInfoMock) SetLogLevelOverride(_ context.Context, _ string) error {
 	panic("implement me")
 }
-func (a agentInfoMock) ECSMetadata(l *logger.Logger) (*info.ECSMeta, error) { panic("implement me") }
+func (a agentInfoMock) ECSMetadata(l *logger.Logger) (*ecsmeta.ECSMeta, error) {
+	panic("implement me")
+}
 
 func TestCheckinExpected(t *testing.T) {
 	ca, err := authority.NewCA()

--- a/pkg/component/runtime/runtime_comm_test.go
+++ b/pkg/component/runtime/runtime_comm_test.go
@@ -19,10 +19,10 @@ import (
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
-	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/internal/pkg/core/authority"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 )
 
 type agentInfoMock struct {

--- a/pkg/ecsmeta/ecsmeta.go
+++ b/pkg/ecsmeta/ecsmeta.go
@@ -1,0 +1,50 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package ecsmeta
+
+// ECSMeta is a collection of agent related metadata in ECS compliant object form.
+type ECSMeta struct {
+	Elastic *ElasticECSMeta `json:"elastic"`
+	Host    *HostECSMeta    `json:"host"`
+	OS      *SystemECSMeta  `json:"os"`
+}
+
+// ElasticECSMeta is a collection of elastic vendor metadata in ECS compliant object form.
+type ElasticECSMeta struct {
+	Agent *AgentECSMeta `json:"agent"`
+}
+
+// AgentECSMeta is a collection of agent metadata in ECS compliant object form.
+type AgentECSMeta struct {
+	ID            string `json:"id"`
+	Version       string `json:"version"`
+	Snapshot      bool   `json:"snapshot"`
+	BuildOriginal string `json:"build.original"`
+	Upgradeable   bool   `json:"upgradeable"`
+	LogLevel      string `json:"log_level"`
+	Complete      bool   `json:"complete"`
+	Unprivileged  bool   `json:"unprivileged"`
+	FIPS          bool   `json:"fips"`
+}
+
+// SystemECSMeta is a collection of operating system metadata in ECS compliant object form.
+type SystemECSMeta struct {
+	Family   string `json:"family"`
+	Kernel   string `json:"kernel"`
+	Platform string `json:"platform"`
+	Version  string `json:"version"`
+	Name     string `json:"name"`
+	FullName string `json:"full"`
+}
+
+// HostECSMeta is a collection of host metadata in ECS compliant object form.
+type HostECSMeta struct {
+	Arch     string   `json:"architecture"`
+	Hostname string   `json:"hostname"`
+	Name     string   `json:"name"`
+	ID       string   `json:"id"`
+	IP       []string `json:"ip"`
+	MAC      []string `json:"mac"`
+}

--- a/testing/fleetservertest/fleetserver_test.go
+++ b/testing/fleetservertest/fleetserver_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
 )
@@ -398,8 +398,8 @@ func ExampleNewServer_enroll() {
 		EnrollAPIKey: enrollAPIKey,
 		Type:         "PERMANENT",
 		Metadata: fleetapi.Metadata{
-			Local: &info.ECSMeta{
-				Elastic: &info.ElasticECSMeta{Agent: &info.AgentECSMeta{
+			Local: &ecsmeta.ECSMeta{
+				Elastic: &ecsmeta.ElasticECSMeta{Agent: &ecsmeta.AgentECSMeta{
 					ID: "wrongAgentID",
 				}},
 			},

--- a/testing/fleetservertest/fleetserver_test.go
+++ b/testing/fleetservertest/fleetserver_test.go
@@ -16,9 +16,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
+	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 )
 
 // TestRunFleetServer shows how to configure and run a fleet-server capable of


### PR DESCRIPTION
## What does this PR do?

Moves `ECSMeta` and its sub-types (`ElasticECSMeta`, `AgentECSMeta`, `SystemECSMeta`, `HostECSMeta`) from `internal/pkg/agent/application/info/` to a new `pkg/ecsmeta/` package. The new package has zero dependencies — pure stdlib data structs with JSON tags.

Constructor functions (`Metadata`, `ECSMetadata`) remain in `internal/` since they depend on Agent-internal packages (`go-sysinfo`, `paths`, `release`, etc.). All callers — including the `Agent` interface, its mock, and test files — now import `pkg/ecsmeta` directly.

## Why is it important?

Part of [ingest-dev#7601](https://github.com/elastic/ingest-dev/issues/7601), which tracks sharing Fleet Server client behavior between Elastic Agent and Horde. `CheckinRequest.Metadata` was previously typed as `*info.ECSMeta`, gating behind 13+ internal transitive dependencies. Exposing the type in `pkg/` enables Horde to use the same typed `CheckinRequest` without importing Agent internals, preserving compile-time type safety across repos.

This is item 8 in the issue and a prerequisite for item 9 (extract `CheckinCmd.Execute` to `pkg/`).

## Checklist

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~ (no doc impact)
- [x] ~~I have made corresponding change to the default configuration files~~ (no config impact)
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~ (pure refactor, existing tests updated)
- [x] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~ (internal refactor, no user-facing change)
- [x] ~~I have added an integration test or an E2E test~~ (no behavioral change)

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/7601