### PR TITLE
fix: notify endpoint-security just before symlink swap, not before upgrade attempt

### DIFF
--- a/changelog/fragments/1779219800-fix-notify-endpoint-security-just-before-symlink-swap,-not-before-upgrade-attempt.yaml
+++ b/changelog/fragments/1779219800-fix-notify-endpoint-security-just-before-symlink-swap,-not-before-upgrade-attempt.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Notify endpoint-security just before symlink swap, not before upgrade attempt
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/actions/handlers/handler_action_upgrade_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_upgrade_test.go
@@ -43,7 +43,7 @@ type mockUpgradeManager struct {
 		details *details.Details,
 		skipVerifyOverride bool,
 		skipDefaultPgp bool,
-		pgpBytes ...string) (reexec.ShutdownCallbackFn, error)
+		pgpBytes []string) (reexec.ShutdownCallbackFn, error)
 }
 
 func (u *mockUpgradeManager) Upgradeable() bool {
@@ -54,7 +54,7 @@ func (u *mockUpgradeManager) Reload(rawConfig *config.Config) error {
 	return nil
 }
 
-func (u *mockUpgradeManager) Upgrade(ctx context.Context, version string, rollback bool, sourceURI string, action *fleetapi.ActionUpgrade, details *details.Details, skipVerifyOverride bool, skipDefaultPgp bool, pgpBytes ...string) (reexec.ShutdownCallbackFn, error) {
+func (u *mockUpgradeManager) Upgrade(ctx context.Context, version string, rollback bool, sourceURI string, action *fleetapi.ActionUpgrade, details *details.Details, skipVerifyOverride bool, skipDefaultPgp bool, pgpBytes []string, opts ...upgrade.Option) (reexec.ShutdownCallbackFn, error) {
 
 	return u.UpgradeFn(
 		ctx,
@@ -64,7 +64,7 @@ func (u *mockUpgradeManager) Upgrade(ctx context.Context, version string, rollba
 		details,
 		skipVerifyOverride,
 		skipDefaultPgp,
-		pgpBytes...)
+		pgpBytes)
 }
 
 func (u *mockUpgradeManager) Ack(_ context.Context, _ acker.Acker) error {
@@ -107,7 +107,7 @@ func TestUpgradeHandler(t *testing.T) {
 				details *details.Details,
 				skipVerifyOverride bool,
 				skipDefaultPgp bool,
-				pgpBytes ...string) (reexec.ShutdownCallbackFn, error) {
+				pgpBytes []string) (reexec.ShutdownCallbackFn, error) {
 
 				upgradeCalledChan <- struct{}{}
 				return nil, nil
@@ -161,7 +161,7 @@ func TestUpgradeHandlerSameVersion(t *testing.T) {
 				details *details.Details,
 				skipVerifyOverride bool,
 				skipDefaultPgp bool,
-				pgpBytes ...string) (reexec.ShutdownCallbackFn, error) {
+				pgpBytes []string) (reexec.ShutdownCallbackFn, error) {
 
 				if upgradeCalled.CompareAndSwap(false, true) {
 					upgradeCalledChan <- struct{}{}
@@ -222,7 +222,7 @@ func TestDuplicateActionsHandled(t *testing.T) {
 				details *details.Details,
 				skipVerifyOverride bool,
 				skipDefaultPgp bool,
-				pgpBytes ...string) (reexec.ShutdownCallbackFn, error) {
+				pgpBytes []string) (reexec.ShutdownCallbackFn, error) {
 
 				defer func() {
 					upgradeCalledChan <- action.ActionID
@@ -313,7 +313,7 @@ func TestUpgradeHandlerNewVersion(t *testing.T) {
 				details *details.Details,
 				skipVerifyOverride bool,
 				skipDefaultPgp bool,
-				pgpBytes ...string) (reexec.ShutdownCallbackFn, error) {
+				pgpBytes []string) (reexec.ShutdownCallbackFn, error) {
 
 				defer func() {
 					upgradeCalledChan <- version

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -95,7 +95,7 @@ type UpgradeManager interface {
 	Reload(rawConfig *config.Config) error
 
 	// Upgrade upgrades running agent.
-	Upgrade(ctx context.Context, version string, rollback bool, sourceURI string, action *fleetapi.ActionUpgrade, details *details.Details, skipVerifyOverride bool, skipDefaultPgp bool, pgpBytes ...string) (_ reexec.ShutdownCallbackFn, err error)
+	Upgrade(ctx context.Context, version string, rollback bool, sourceURI string, action *fleetapi.ActionUpgrade, details *details.Details, skipVerifyOverride bool, skipDefaultPgp bool, pgpBytes []string, opts ...upgrade.Option) (_ reexec.ShutdownCallbackFn, err error)
 
 	// Ack is used on startup to check if the agent has upgraded and needs to send an ack for the action
 	Ack(ctx context.Context, acker acker.Acker) error
@@ -945,16 +945,12 @@ func (c *Coordinator) Upgrade(ctx context.Context, version string, sourceURI str
 		}
 	}
 
-	// run any pre upgrade callback
+	var upgradeOpts []upgrade.Option
 	if uOpts.preUpgradeCallback != nil {
-		if err := uOpts.preUpgradeCallback(ctx, c.logger, action); err != nil {
-			c.ClearOverrideState()
-			det.Fail(err)
-			return err
-		}
+		upgradeOpts = append(upgradeOpts, upgrade.WithPreSymlinkCallback(uOpts.preUpgradeCallback))
 	}
 
-	cb, err := c.upgradeMgr.Upgrade(ctx, version, uOpts.rollback, sourceURI, action, det, uOpts.skipVerifyOverride, uOpts.skipDefaultPgp, uOpts.pgpBytes...)
+	cb, err := c.upgradeMgr.Upgrade(ctx, version, uOpts.rollback, sourceURI, action, det, uOpts.skipVerifyOverride, uOpts.skipDefaultPgp, uOpts.pgpBytes, upgradeOpts...)
 	if err != nil {
 		c.ClearOverrideState()
 		if errors.Is(err, upgrade.ErrUpgradeSameVersion) {

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -835,7 +835,7 @@ type upgradeOpts struct {
 	skipVerifyOverride bool
 	skipDefaultPgp     bool
 	pgpBytes           []string
-	preUpgradeCallback func(ctx context.Context, log *logger.Logger, action *fleetapi.ActionUpgrade) error
+	upgradeOpts        []upgrade.Option
 	rollback           bool
 }
 
@@ -861,7 +861,7 @@ func WithPgpBytes(pgpBytes []string) UpgradeOpt {
 
 func WithPreUpgradeCallback(preUpgradeCallback func(ctx context.Context, log *logger.Logger, action *fleetapi.ActionUpgrade) error) UpgradeOpt {
 	return func(opts *upgradeOpts) {
-		opts.preUpgradeCallback = preUpgradeCallback
+		opts.upgradeOpts = append(opts.upgradeOpts, upgrade.WithPreSymlinkCallback(preUpgradeCallback))
 	}
 }
 
@@ -945,12 +945,7 @@ func (c *Coordinator) Upgrade(ctx context.Context, version string, sourceURI str
 		}
 	}
 
-	var upgradeOpts []upgrade.Option
-	if uOpts.preUpgradeCallback != nil {
-		upgradeOpts = append(upgradeOpts, upgrade.WithPreSymlinkCallback(uOpts.preUpgradeCallback))
-	}
-
-	cb, err := c.upgradeMgr.Upgrade(ctx, version, uOpts.rollback, sourceURI, action, det, uOpts.skipVerifyOverride, uOpts.skipDefaultPgp, uOpts.pgpBytes, upgradeOpts...)
+	cb, err := c.upgradeMgr.Upgrade(ctx, version, uOpts.rollback, sourceURI, action, det, uOpts.skipVerifyOverride, uOpts.skipDefaultPgp, uOpts.pgpBytes, uOpts.upgradeOpts...)
 	if err != nil {
 		c.ClearOverrideState()
 		if errors.Is(err, upgrade.ErrUpgradeSameVersion) {

--- a/internal/pkg/agent/application/coordinator/coordinator_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_test.go
@@ -639,13 +639,17 @@ func TestReplayedRollbackActionAcked(t *testing.T) {
 }
 
 func TestPreUpgradeCallback(t *testing.T) {
+	// Verify that WithPreUpgradeCallback is forwarded to upgradeMgr.Upgrade as an
+	// upgrade.WithPreSymlinkCallback option. The callback is invoked by the
+	// upgrader (not by the coordinator directly); if it returns an error the
+	// whole upgrade fails and the error is propagated back to the caller.
 	coordCh := make(chan error)
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	upgradeManager := &fakeUpgradeManager{
 		upgradeable: true,
-		upgradeErr:  upgrade.ErrUpgradeSameVersion,
+		// No upgradeErr — the error comes from the pre-symlink callback itself.
 	}
 
 	acker := acker.NewMockAcker(t)
@@ -675,9 +679,8 @@ func TestPreUpgradeCallback(t *testing.T) {
 			return preUpgradeCallbackErr
 		}))
 
-	assert.ErrorIs(t, preUpgradeCallbackErr, upgradeErr)
+	assert.ErrorIs(t, upgradeErr, preUpgradeCallbackErr)
 	assert.Nil(t, coord.overrideState)
-	assert.Equal(t, preUpgradeCallbackErr, upgradeErr, "expected pre upgrade callback error")
 	assert.Eventually(t, func() bool {
 		ud := coord.State().UpgradeDetails
 		return ud != nil && ud.State == details.StateFailed
@@ -1603,8 +1606,11 @@ func (f *fakeUpgradeManager) Reload(cfg *config.Config) error {
 	return nil
 }
 
-func (f *fakeUpgradeManager) Upgrade(ctx context.Context, version string, rollback bool, sourceURI string, action *fleetapi.ActionUpgrade, details *details.Details, skipVerifyOverride bool, skipDefaultPgp bool, pgpBytes ...string) (_ reexec.ShutdownCallbackFn, err error) {
+func (f *fakeUpgradeManager) Upgrade(ctx context.Context, version string, rollback bool, sourceURI string, action *fleetapi.ActionUpgrade, details *details.Details, skipVerifyOverride bool, skipDefaultPgp bool, pgpBytes []string, opts ...upgrade.Option) (_ reexec.ShutdownCallbackFn, err error) {
 	f.upgradeCalled = true
+	if cbErr := upgrade.InvokePreSymlinkCallback(opts, ctx, nil, action); cbErr != nil {
+		return nil, cbErr
+	}
 	if f.upgradeErr != nil {
 		return nil, f.upgradeErr
 	}

--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -2586,7 +2586,7 @@ func (m *mockUpgradeManager) Reload(cfg *config.Config) error {
 	return nil
 }
 
-func (m *mockUpgradeManager) Upgrade(ctx context.Context, version string, rollback bool, sourceURI string, action *fleetapi.ActionUpgrade, details *details.Details, skipVerifyOverride bool, skipDefaultPgp bool, pgpBytes ...string) (_ reexec.ShutdownCallbackFn, err error) {
+func (m *mockUpgradeManager) Upgrade(ctx context.Context, version string, rollback bool, sourceURI string, action *fleetapi.ActionUpgrade, details *details.Details, skipVerifyOverride bool, skipDefaultPgp bool, pgpBytes []string, opts ...upgrade.Option) (_ reexec.ShutdownCallbackFn, err error) {
 	return nil, m.upgradeErr
 }
 

--- a/internal/pkg/agent/application/upgrade/options.go
+++ b/internal/pkg/agent/application/upgrade/options.go
@@ -1,0 +1,49 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package upgrade
+
+import (
+	"context"
+
+	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+)
+
+// Option is a functional option for Upgrader.Upgrade.
+type Option func(*upgradeOptions)
+
+type upgradeOptions struct {
+	// preSymlinkCallback is invoked just before changeSymlink, after all go/no-go
+	// checks have passed. This is where components like endpoint-security should be
+	// notified to drop tamper protection, since at this point the upgrade is
+	// committed to completing.
+	preSymlinkCallback func(ctx context.Context, log *logger.Logger, action *fleetapi.ActionUpgrade) error
+}
+
+// WithPreSymlinkCallback registers a callback to be called just before the
+// symlink is switched to the new agent binary, after all upgrade viability
+// checks (same-version guard, artifact download, signature verification, and
+// package validation) have passed.
+func WithPreSymlinkCallback(fn func(ctx context.Context, log *logger.Logger, action *fleetapi.ActionUpgrade) error) Option {
+	return func(o *upgradeOptions) {
+		o.preSymlinkCallback = fn
+	}
+}
+
+// InvokePreSymlinkCallback resolves opts and calls the preSymlinkCallback if one
+// is registered. Returns nil when no callback is set or when the callback
+// succeeds. Implementations of UpgradeManager (typically test fakes) can use
+// this to honor the pre-symlink callback contract without knowing about the
+// internal upgradeOptions type.
+func InvokePreSymlinkCallback(opts []Option, ctx context.Context, log *logger.Logger, action *fleetapi.ActionUpgrade) error {
+	var uOpts upgradeOptions
+	for _, opt := range opts {
+		opt(&uOpts)
+	}
+	if uOpts.preSymlinkCallback != nil {
+		return uOpts.preSymlinkCallback(ctx, log, action)
+	}
+	return nil
+}

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -283,7 +283,12 @@ func checkUpgrade(log *logger.Logger, currentVersion, newVersion agentVersion, m
 }
 
 // Upgrade upgrades running agent, function returns shutdown callback that must be called by reexec.
-func (u *Upgrader) Upgrade(ctx context.Context, version string, rollback bool, sourceURI string, action *fleetapi.ActionUpgrade, det *details.Details, skipVerifyOverride bool, skipDefaultPgp bool, pgpBytes ...string) (_ reexec.ShutdownCallbackFn, err error) {
+func (u *Upgrader) Upgrade(ctx context.Context, version string, rollback bool, sourceURI string, action *fleetapi.ActionUpgrade, det *details.Details, skipVerifyOverride bool, skipDefaultPgp bool, pgpBytes []string, opts ...Option) (_ reexec.ShutdownCallbackFn, err error) {
+
+	var uOpts upgradeOptions
+	for _, opt := range opts {
+		opt(&uOpts)
+	}
 
 	if rollback {
 		return u.rollbackToPreviousVersion(ctx, paths.Top(), time.Now(), version, action)
@@ -448,6 +453,16 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, rollback bool, s
 
 	// paths.BinaryPath properly derives the binary directory depending on the platform. The path to the binary for macOS is inside of the app bundle.
 	newPath := paths.BinaryPath(filepath.Join(paths.Top(), hashedDir), AgentName)
+
+	// All go/no-go checks have passed; the upgrade is committed to completing.
+	// Notify components (e.g. endpoint-security) that need to act before the
+	// symlink changes. Invoking this here — not earlier — prevents spurious
+	// unprotect signals when the upgrade is later aborted.
+	if uOpts.preSymlinkCallback != nil {
+		if err := uOpts.preSymlinkCallback(ctx, u.log, action); err != nil {
+			return nil, fmt.Errorf("pre-symlink callback failed: %w", err)
+		}
+	}
 
 	if err := u.changeSymlink(u.log, paths.Top(), symlinkPath, newPath); err != nil {
 		u.log.Errorw("Rolling back: changing symlink failed", "error.message", err)

--- a/internal/pkg/agent/application/upgrade/upgrade_test.go
+++ b/internal/pkg/agent/application/upgrade/upgrade_test.go
@@ -465,7 +465,7 @@ Moylz3f/lBMBLKFUD19ZzS4Z8c31iZPFXkN+KCjW8B7hNv6qKDSvQo74yvA0NYkv
 ncHUVm1hDPg8p7GUVgwd2m6M7uidGjTtSH1wjZ4=
 -----END CERTIFICATE-----
 `},
-				Certificate: tlscommon.CertificateConfig{
+				Certificate: tlscommon.CertificateConfig{ //nolint:gosec // test-only fake credentials
 					Certificate: `-----BEGIN CERTIFICATE-----
 MIIDQzCCAiugAwIBAgIVAJtAaYlLhZ/4qmigwOyX79az1ZZ3MA0GCSqGSIb3DQEB
 CwUAMDQxMjAwBgNVBAMTKUVsYXN0aWMgQ2VydGlmaWNhdGUgVG9vbCBBdXRvZ2Vu

--- a/internal/pkg/agent/application/upgrade/upgrade_test.go
+++ b/internal/pkg/agent/application/upgrade/upgrade_test.go
@@ -1079,6 +1079,7 @@ func TestUpgradeErrorHandling(t *testing.T) {
 		isDiskSpaceErrorResult    bool
 		expectedError             error
 		upgraderMocker            upgraderMocker
+		upgradeOpts               []Option
 		checkArchiveCleanup       bool
 		checkVersionedHomeCleanup bool
 		setupMocks                func(t *testing.T, mockAgentInfo *info.MockAgent, mockRollbackSrc *mockAvailableRollbacksSource, mockWatcherHelper *MockWatcherHelper)
@@ -1357,6 +1358,89 @@ func TestUpgradeErrorHandling(t *testing.T) {
 				mockRollbackSrc.EXPECT().Get().Return(nil, nil)
 			},
 		},
+		// Regression tests for https://github.com/elastic/elastic-agent/issues/14118:
+		// pre-symlink callback must not fire when the upgrade is aborted before reaching the symlink step.
+		"pre-symlink callback must not be called if download fails": {
+			expectedError: testError,
+			upgradeOpts: []Option{
+				WithPreSymlinkCallback(func(_ context.Context, _ *logger.Logger, _ *fleetapi.ActionUpgrade) error {
+					// This must never be called when the upgrade is aborted early.
+					require.Fail(t, "pre-symlink callback must not be called when download fails")
+					return nil
+				}),
+			},
+			upgraderMocker: func(upgrader *Upgrader, archivePath string, versionedHome string) {
+				upgrader.artifactDownloader = &mockArtifactDownloader{
+					returnError:       testError,
+					returnArchivePath: archivePath,
+				}
+			},
+			checkArchiveCleanup: true,
+			setupMocks: func(t *testing.T, mockAgentInfo *info.MockAgent, mockRollbackSrc *mockAvailableRollbacksSource, mockWatcherHelper *MockWatcherHelper) {
+				mockAgentInfo.EXPECT().Version().Return("9.0.0")
+				mockRollbackSrc.EXPECT().Get().Return(nil, nil)
+			},
+		},
+		"pre-symlink callback must not be called if unpack fails": {
+			expectedError: testError,
+			upgradeOpts: []Option{
+				WithPreSymlinkCallback(func(_ context.Context, _ *logger.Logger, _ *fleetapi.ActionUpgrade) error {
+					require.Fail(t, "pre-symlink callback must not be called when unpack fails")
+					return nil
+				}),
+			},
+			upgraderMocker: func(upgrader *Upgrader, archivePath string, versionedHome string) {
+				upgrader.artifactDownloader = &mockArtifactDownloader{
+					returnArchivePath: archivePath,
+				}
+				upgrader.extractAgentVersion = func(metadata packageMetadata, upgradeVersion string) agentVersion {
+					return agentVersion{version: upgradeVersion, hash: metadata.hash}
+				}
+				upgrader.unpacker = &mockUnpacker{
+					returnPackageMetadata: packageMetadata{manifest: &v1.PackageManifest{}, hash: "hash"},
+					returnUnpackError:     testError,
+					returnUnpackResult:    UnpackResult{Hash: "hash", VersionedHome: versionedHome},
+				}
+			},
+			checkArchiveCleanup:       true,
+			checkVersionedHomeCleanup: true,
+			setupMocks: func(t *testing.T, mockAgentInfo *info.MockAgent, mockRollbackSrc *mockAvailableRollbacksSource, mockWatcherHelper *MockWatcherHelper) {
+				mockAgentInfo.EXPECT().Version().Return("9.0.0")
+				mockRollbackSrc.EXPECT().Get().Return(nil, nil)
+			},
+		},
+		"pre-symlink callback error aborts upgrade before changeSymlink and triggers cleanup": {
+			expectedError: testError,
+			upgradeOpts: []Option{
+				WithPreSymlinkCallback(func(_ context.Context, _ *logger.Logger, _ *fleetapi.ActionUpgrade) error {
+					return testError
+				}),
+			},
+			upgraderMocker: func(upgrader *Upgrader, archivePath string, versionedHome string) {
+				upgrader.artifactDownloader = &mockArtifactDownloader{
+					returnArchivePath: archivePath,
+				}
+				upgrader.extractAgentVersion = func(metadata packageMetadata, upgradeVersion string) agentVersion {
+					return agentVersion{version: upgradeVersion, hash: metadata.hash}
+				}
+				upgrader.unpacker = &mockUnpacker{
+					returnPackageMetadata: packageMetadata{manifest: &v1.PackageManifest{}, hash: "hash"},
+					returnUnpackResult:    UnpackResult{Hash: "hash", VersionedHome: versionedHome},
+				}
+				upgrader.copyActionStore = func(_ *logger.Logger, _ string) error { return nil }
+				upgrader.copyRunDirectory = func(_ *logger.Logger, _, _ string) error { return nil }
+				upgrader.changeSymlink = func(_ *logger.Logger, _, _, _ string) error {
+					require.Fail(t, "changeSymlink must not be called when pre-symlink callback fails")
+					return nil
+				}
+			},
+			checkArchiveCleanup:       true,
+			checkVersionedHomeCleanup: true,
+			setupMocks: func(t *testing.T, mockAgentInfo *info.MockAgent, mockRollbackSrc *mockAvailableRollbacksSource, mockWatcherHelper *MockWatcherHelper) {
+				mockAgentInfo.EXPECT().Version().Return("9.0.0")
+				mockRollbackSrc.EXPECT().Get().Return(nil, nil)
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -1391,7 +1475,7 @@ func TestUpgradeErrorHandling(t *testing.T) {
 				return tc.isDiskSpaceErrorResult
 			}
 
-			_, err = upgrader.Upgrade(context.Background(), "9.0.0", false, "", nil, details.NewDetails("9.0.0", details.StateRequested, "test"), true, true)
+			_, err = upgrader.Upgrade(context.Background(), "9.0.0", false, "", nil, details.NewDetails("9.0.0", details.StateRequested, "test"), true, true, nil, tc.upgradeOpts...)
 			require.ErrorIs(t, err, tc.expectedError)
 
 			// If the downloaded archive needs to be cleaned up assert that it is indeed cleaned up, if not assert that it still exists. The downloaded archive is a mock file that is created for all tests cases.


### PR DESCRIPTION
## What does this PR do?

Fixes #14118.

Elastic Defend (`endpoint-security`) was being told to unprotect itself via a
`preUpgradeCallback` that fired before `upgradeMgr.Upgrade()` was called in
the coordinator. This meant Defend could receive a spurious unprotect signal
even when the upgrade was subsequently aborted:

- **Same-version skip** — `upgrade.go` returns `ErrUpgradeSameVersion` without
  ever replacing the binary, but the notification had already fired.
- **Download failure** — network errors, disk-space errors, or signature
  verification failures all occur inside `upgradeMgr.Upgrade()`, after the
  notification.
- **Canceled/replaced action** — a superseded in-flight upgrade cancels the
  first one, causing two notifications for different action IDs.

### Fix

The callback is now invoked just before `changeSymlink` in `upgrade.go`, after
all go/no-go checks have passed (same-version guard, artifact download,
signature verification, package unpacking). At that point the upgrade is
committed to completing, so the notification is never wasted.

### Implementation notes

- New `upgrade.Option` / `upgrade.WithPreSymlinkCallback` functional option
  threads the callback from handler → coordinator → upgrader cleanly.
- `UpgradeManager.Upgrade()` interface changes: `pgpBytes ...string` →
  `pgpBytes []string, opts ...upgrade.Option`. All implementations (real +
  three test fakes) updated.
- `upgrade.InvokePreSymlinkCallback` helper lets test fakes honor the
  pre-symlink callback contract without access to the unexported
  `upgradeOptions` struct.
- `WithPreUpgradeCallback` in the coordinator is preserved (no handler change
  needed); its effect changes from "fire before the upgrade attempt" to "wrap
  and forward as a pre-symlink option to the upgrader".

### Testing

- All existing tests pass.
- Three new regression tests in `TestUpgradeErrorHandling`:
  1. **Callback not called on download failure** — verifies the callback never
     fires when `downloadArtifact` returns an error.
  2. **Callback not called on unpack failure** — same guard for the unpack step.
  3. **Callback error aborts upgrade before `changeSymlink`** — verifies that
     if the callback returns an error the symlink is never touched and both the
     downloaded archive and extracted versioned-home directory are cleaned up.

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the tests
- [ ] I have made corresponding change to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.