### PR TITLE
Read TLS cert paths from env variables in container mode

### DIFF
--- a/changelog/fragments/1779995943-read-container-tls-from-env.yaml
+++ b/changelog/fragments/1779995943-read-container-tls-from-env.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Read TLS config from environment variables in container mode
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: TLS certificate paths will now always be read from ELASTIC_AGENT_CERT and ELASTIC_AGENT_CERT_KEY in container mode rather than reading from potentially stale fleet.enc values.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1779996772-fix-container-override-inconsistencies.yaml
+++ b/changelog/fragments/1779996772-fix-container-override-inconsistencies.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix container config override inconsistencies
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: Fixes a bug where container-mode overrides were correctly applied to the running agent but were overwritten by fleet.enc before being passed to the coordinator. This could result in incorrect config diagnostics and unnecessary restarts on policy updates.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -123,33 +123,28 @@ func (h *PolicyChangeHandler) Watch() <-chan coordinator.ConfigChange {
 	return h.ch
 }
 
-func (h *PolicyChangeHandler) validateFleetServerHosts(ctx context.Context, cfg *config.Config) (*remote.Config, error) {
+func (h *PolicyChangeHandler) validateFleetServerHosts(ctx context.Context, cfg *configuration.Configuration) (*remote.Config, error) {
 	// do not update fleet-server host from policy; no setters provided with local Fleet Server
 	if len(h.setters) == 0 {
 		return nil, nil
 	}
 
-	parsedConfig, err := configuration.NewPartialFromConfigNoDefaults(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("parsing fleet config: %w", err)
-	}
-
-	if parsedConfig.Fleet == nil {
+	if cfg.Fleet == nil {
 		// there is no client config (weird)
 		return nil, nil
 	}
 
-	if clientEqual(h.config.Fleet.Client, parsedConfig.Fleet.Client) {
+	if clientEqual(h.config.Fleet.Client, cfg.Fleet.Client) {
 		// already the same hosts
 		return nil, nil
 	}
 
 	// make a copy the current client config and apply the changes on this copy
 	newFleetClientConfig := h.config.Fleet.Client
-	updateFleetConfig(h.log, parsedConfig.Fleet.Client, &newFleetClientConfig)
+	updateFleetConfig(h.log, cfg.Fleet.Client, &newFleetClientConfig)
 
 	// Test new config
-	err = testFleetConfig(ctx, h.log, newFleetClientConfig, h.config.Fleet.AccessAPIKey)
+	err := testFleetConfig(ctx, h.log, newFleetClientConfig, h.config.Fleet.AccessAPIKey)
 	if err != nil {
 		return nil, fmt.Errorf("validating fleet client config: %w", err)
 	}
@@ -242,13 +237,18 @@ func emptyCertificateConfig() tlscommon.CertificateConfig {
 }
 
 func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.Config) error {
+	partialCfg, err := configuration.NewPartialFromConfigNoDefaults(c)
+	if err != nil {
+		return fmt.Errorf("parsing fleet config: %w", err)
+	}
+
 	// Step 1: Validate policy configuration.
 	var validationErr error
-	validatedFleetConfig, err := h.validateFleetServerHosts(ctx, c)
+	validatedFleetConfig, err := h.validateFleetServerHosts(ctx, partialCfg)
 	if err != nil {
 		validationErr = goerrors.Join(validationErr, fmt.Errorf("failed to validate Fleet client config: %w", err))
 	}
-	loggingConfig, err := validateLoggingConfig(c)
+	loggingConfig, err := validateLoggingConfig(partialCfg)
 	if err != nil {
 		validationErr = goerrors.Join(validationErr, fmt.Errorf("failed to validate logging config: %w", err))
 	}
@@ -267,14 +267,9 @@ func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.
 		policyLogLevel = loggingConfig.Level.String()
 	}
 
-	hasEventLoggingOutputChanged := h.hasEventLoggingOutputChanged(cfg)
-
 	// Step 3: Update in-memory caches.
 	if validatedFleetConfig != nil {
 		h.config.Fleet.Client = *validatedFleetConfig
-	}
-	if hasEventLoggingOutputChanged {
-		h.config.Settings.EventLoggingConfig = cfg.Settings.EventLoggingConfig
 	}
 	if loggingConfig != nil {
 		h.config.Settings.LoggingConfig.Level = loggingConfig.Level
@@ -307,7 +302,7 @@ func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.
 
 	// If the event logging output has changed, re-exec the agent so it picks up
 	// the newly-persisted logging config on startup.
-	if hasEventLoggingOutputChanged {
+	if h.applyEventLoggingOutputChange(partialCfg) {
 		h.runtimeLogLevelSetter.ReExec(nil)
 	}
 
@@ -318,38 +313,36 @@ func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.
 	return nil
 }
 
-// hasEventLoggingOutputChanged returns true if the output of the event logger has changed
-func (h *PolicyChangeHandler) hasEventLoggingOutputChanged(new *configuration.Configuration) bool {
-	switch {
-	case h.config.Settings.EventLoggingConfig.ToFiles != new.Settings.EventLoggingConfig.ToFiles:
-		return true
-	case h.config.Settings.EventLoggingConfig.ToStderr != new.Settings.EventLoggingConfig.ToStderr:
-		return true
-	default:
+func (h *PolicyChangeHandler) applyEventLoggingOutputChange(new *configuration.Configuration) bool {
+	if new == nil || new.Settings == nil || new.Settings.EventLoggingConfig == nil {
 		return false
 	}
-}
 
-func validateLoggingConfig(cfg *config.Config) (*logger.Config, error) {
+	current := h.config.Settings.EventLoggingConfig
+	incoming := new.Settings.EventLoggingConfig
 
-	parsedConfig, err := configuration.NewPartialFromConfigNoDefaults(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("parsing fleet config: %w", err)
+	if current.ToFiles == incoming.ToFiles && current.ToStderr == incoming.ToStderr {
+		return false
 	}
 
-	if parsedConfig == nil || parsedConfig.Settings == nil || parsedConfig.Settings.LoggingConfig == nil {
+	current.ToFiles = incoming.ToFiles
+	current.ToStderr = incoming.ToStderr
+	return true
+}
+
+func validateLoggingConfig(cfg *configuration.Configuration) (*logger.Config, error) {
+	if cfg == nil || cfg.Settings == nil || cfg.Settings.LoggingConfig == nil {
 		// no logging config, nothing to do
 		return nil, nil
 	}
 
-	loggingConfig := parsedConfig.Settings.LoggingConfig
+	loggingConfig := cfg.Settings.LoggingConfig
 	logLevel := loggingConfig.Level
 	if logLevel < logp.DebugLevel || logLevel > logp.CriticalLevel {
 		return nil, fmt.Errorf("unrecognized log level %d", logLevel)
 	}
 
 	return loggingConfig, nil
-
 }
 
 func (h *PolicyChangeHandler) applyFleetClientConfig(validatedConfig *remote.Config) error {

--- a/internal/pkg/agent/application/application.go
+++ b/internal/pkg/agent/application/application.go
@@ -49,9 +49,6 @@ import (
 	"github.com/elastic/elastic-agent/version"
 )
 
-// CfgOverrider allows for application driven overrides of configuration read from disk.
-type CfgOverrider func(cfg *configuration.Configuration)
-
 // New creates a new Agent and bootstrap the required subsystem.
 func New(
 	ctx context.Context,
@@ -64,7 +61,7 @@ func New(
 	testingMode bool,
 	fleetInitTimeout time.Duration,
 	disableMonitoring bool,
-	override CfgOverrider,
+	cfg *configuration.Configuration,
 	initialUpdateMarker *upgrade.UpdateMarker,
 	availableRollbacksSource ttl.Source,
 	modifiers ...component.PlatformModifier,
@@ -96,34 +93,11 @@ func New(
 
 	pathConfigFile := paths.ConfigFile()
 
-	var rawConfig *config.Config
 	if testingMode {
-		// testing mode doesn't read any configuration from the disk
-		rawConfig, err = config.NewConfigFrom("")
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to load configuration: %w", err)
-		}
-
+		cfg = configuration.DefaultConfiguration()
+		cfg.UCfg = config.MustNewConfigFrom(cfg)
 		// monitoring is always disabled in testing mode
 		disableMonitoring = true
-	} else {
-		log.Infof("Loading baseline config from %v", pathConfigFile)
-		rawConfig, err = config.LoadFile(pathConfigFile)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to load configuration: %w", err)
-		}
-	}
-	if err := info.InjectAgentConfig(rawConfig); err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to load configuration: %w", err)
-	}
-
-	cfg, err := configuration.NewFromConfig(rawConfig)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to load configuration: %w", err)
-	}
-
-	if override != nil {
-		override(cfg)
 	}
 
 	// monitoring is not supported in bootstrap mode https://github.com/elastic/elastic-agent/issues/1761
@@ -176,7 +150,7 @@ func New(
 		configMgr = newTestingModeConfigManager(log)
 	} else if configuration.IsStandalone(cfg.Fleet) {
 		log.Info("Parsed configuration and determined agent is managed locally")
-		flags, err := features.Parse(rawConfig)
+		flags, err := features.Parse(cfg.GetUCfg())
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("could not parse and apply feature flags config: %w", err)
 		}
@@ -192,7 +166,7 @@ func New(
 			configMgr = newEncryptedOnce(log, paths.AgentConfigFile())
 		} else {
 			loader := config.NewLoader(log, paths.ExternalInputs())
-			rawCfgMap, err := rawConfig.ToMapStr()
+			rawCfgMap, err := cfg.GetUCfg().ToMapStr()
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("failed to transform agent configuration into a map: %w", err)
 			}
@@ -208,16 +182,14 @@ func New(
 		}
 	} else {
 		isManaged = true
-		var store storage.Store
-		store, cfg, err = mergeFleetConfig(ctx, rawConfig)
-		if err != nil {
-			return nil, nil, nil, err
+		if err := cfg.Fleet.Valid(); err != nil {
+			return nil, nil, nil, fmt.Errorf("fleet configuration is invalid: %w", err)
 		}
 		if configuration.IsFleetServerBootstrap(cfg.Fleet) {
 			log.Info("Parsed configuration and determined agent is in Fleet Server bootstrap mode")
 
 			compModifiers = append(compModifiers, FleetServerComponentModifier(cfg.Fleet.Server))
-			configMgr = coordinator.NewConfigPatchManager(newFleetServerBootstrapManager(log), PatchAPMConfig(log, rawConfig))
+			configMgr = coordinator.NewConfigPatchManager(newFleetServerBootstrapManager(log), PatchAPMConfig(log, cfg.GetUCfg()))
 		} else {
 			log.Info("Parsed configuration and determined agent is managed by Fleet")
 
@@ -261,16 +233,20 @@ func New(
 				initialUpgradeDetails = dispatcher.GetScheduledUpgradeDetails(log, actionQueue.Actions(), time.Now())
 			}
 
+			store, err := storage.NewEncryptedDiskStore(ctx, paths.AgentConfigFile())
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("failed to create encrypted disk store: %w", err)
+			}
 			// TODO: stop using global state
 			managed, err = newManagedConfigManager(ctx, log, agentInfo, cfg, store, runtime, fleetInitTimeout, paths.Top(), client, fleetAcker, actionAcker, retrier, stateStorage, actionQueue, availableRollbacksSource, upgrader)
 			if err != nil {
 				return nil, nil, nil, err
 			}
-			configMgr = coordinator.NewConfigPatchManager(managed, injectOutputOverrides(log, rawConfig), PatchAPMConfig(log, rawConfig))
+			configMgr = coordinator.NewConfigPatchManager(managed, injectOutputOverrides(log, cfg.GetUCfg()), PatchAPMConfig(log, cfg.GetUCfg()))
 		}
 	}
 
-	varsManager, err := composable.New(log, rawConfig, composableManaged)
+	varsManager, err := composable.New(log, cfg.GetUCfg(), composableManaged)
 	if err != nil {
 		return nil, nil, nil, errors.New(err, "failed to initialize composable controller")
 	}
@@ -299,13 +275,13 @@ func New(
 		log.Debugf("agent limits have changed: %+v -> %+v", old, new)
 	}, "application.go")
 	// applying the initial limits for the agent process
-	if err := limits.Apply(rawConfig); err != nil {
+	if err := limits.Apply(cfg.GetUCfg()); err != nil {
 		return nil, nil, nil, fmt.Errorf("could not parse and apply limits config: %w", err)
 	}
 
 	// It is important that feature flags from configuration are applied as late as possible.  This will ensure that
 	// any feature flag change callbacks are registered before they get called by `features.Apply`.
-	if err := features.Apply(rawConfig); err != nil {
+	if err := features.Apply(cfg.GetUCfg()); err != nil {
 		return nil, nil, nil, fmt.Errorf("could not parse and apply feature flags config: %w", err)
 	}
 
@@ -348,59 +324,6 @@ func normalizeAgentInstalls(log *logger.Logger, topDir string, now time.Time, in
 	if err != nil {
 		log.Warnf("Error cleaning available rollbacks: %s", err)
 	}
-}
-
-func mergeFleetConfig(ctx context.Context, rawConfig *config.Config) (storage.Store, *configuration.Configuration, error) {
-	path := paths.AgentConfigFile()
-	store, err := storage.NewEncryptedDiskStore(ctx, path)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error instantiating encrypted disk store: %w", err)
-	}
-
-	reader, err := store.Load()
-	if err != nil {
-		return store, nil, errors.New(err, "could not initialize config store",
-			errors.TypeFilesystem,
-			errors.M(errors.MetaKeyPath, path))
-	}
-	config, err := config.NewConfigFrom(reader)
-	if err != nil {
-		return store, nil, errors.New(err,
-			fmt.Sprintf("fail to read configuration %s for the elastic-agent", path),
-			errors.TypeFilesystem,
-			errors.M(errors.MetaKeyPath, path))
-	}
-
-	// merge local configuration and configuration persisted from fleet.
-	err = rawConfig.Merge(config)
-	if err != nil {
-		return store, nil, errors.New(err,
-			fmt.Sprintf("fail to merge configuration with %s for the elastic-agent", path),
-			errors.TypeConfig,
-			errors.M(errors.MetaKeyPath, path))
-	}
-
-	cfg, err := configuration.NewFromConfig(rawConfig)
-	if err != nil {
-		return store, nil, errors.New(err,
-			fmt.Sprintf("fail to unpack configuration from %s", path),
-			errors.TypeFilesystem,
-			errors.M(errors.MetaKeyPath, path))
-	}
-
-	// Fix up fleet.agent.id otherwise the fleet.agent.id is empty string
-	if cfg.Settings != nil && cfg.Fleet != nil && cfg.Fleet.Info != nil && cfg.Fleet.Info.ID == "" {
-		cfg.Fleet.Info.ID = cfg.Settings.ID
-	}
-
-	if err := cfg.Fleet.Valid(); err != nil {
-		return store, nil, errors.New(err,
-			"fleet configuration is invalid",
-			errors.TypeFilesystem,
-			errors.M(errors.MetaKeyPath, path))
-	}
-
-	return store, cfg, nil
 }
 
 // injectOutputOverrides takes local configuration for specific outputs and applies them to the configuration.

--- a/internal/pkg/agent/application/application_test.go
+++ b/internal/pkg/agent/application/application_test.go
@@ -726,9 +726,7 @@ func TestApplicationStandaloneEncryptedWithFleetEnabled(t *testing.T) {
 	t.Cleanup(func() { paths.SetConfig(cfgPath) })
 	paths.SetConfig(t.TempDir())
 
-	p, err := os.ReadFile(filepath.Join("..", "..", "..", "..", "_meta", "elastic-agent.fleet.yml"))
-	require.NoError(t, err)
-	err = os.WriteFile(paths.ConfigFile(), p, 0640) //nolint:gosec // test fixture writing to controlled temp path
+	err := os.WriteFile(paths.ConfigFile(), DefaultAgentFleetConfig, 0640)
 	require.NoError(t, err)
 
 	isRoot, err := utils.HasRoot()
@@ -764,5 +762,5 @@ func TestApplicationStandaloneEncryptedWithFleetEnabled(t *testing.T) {
 
 	ymlBytes, err := os.ReadFile(paths.ConfigFile())
 	require.NoError(t, err)
-	require.EqualValues(t, p, ymlBytes, "unexpected contents in elastic-agent.yml")
+	require.EqualValues(t, DefaultAgentFleetConfig, ymlBytes, "unexpected contents in elastic-agent.yml")
 }

--- a/internal/pkg/agent/application/application_test.go
+++ b/internal/pkg/agent/application/application_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/details"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/ttl"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/storage"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/vault"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
@@ -33,30 +34,84 @@ import (
 	"github.com/elastic/elastic-agent/pkg/utils"
 )
 
-func TestMergeFleetConfig(t *testing.T) {
-	testutils.InitStorage(t)
+func TestLoadConfig(t *testing.T) {
+	validFleetEnc := `fleet:
+  enabled: true
+  kibana:
+    host: demo
+  access_api_key: "123"
+agent:
+  grpc:
+    port: 6790`
 
-	cfg := map[string]interface{}{
-		"fleet": map[string]interface{}{
-			"enabled":        true,
-			"kibana":         map[string]interface{}{"host": "demo"},
-			"access_api_key": "123",
+	cases := []struct {
+		name     string
+		baseCfg  string
+		fleetEnc string
+		assert   func(t *testing.T, cfg *configuration.Configuration)
+	}{
+		{
+			name:     "fleet enabled, fleet.enc merged",
+			baseCfg:  "fleet:\n  enabled: true\n",
+			fleetEnc: validFleetEnc,
+			assert: func(t *testing.T, cfg *configuration.Configuration) {
+				assert.True(t, cfg.Fleet.Enabled)
+				assert.Equal(t, "123", cfg.Fleet.AccessAPIKey)
+				assert.Equal(t, uint16(6790), cfg.Settings.GRPC.Port)
+			},
 		},
-		"agent": map[string]interface{}{
-			"grpc": map[string]interface{}{
-				"port": uint16(6790),
+		{
+			name:     "standalone ignores fleet.enc",
+			baseCfg:  "fleet:\n  enabled: false\n",
+			fleetEnc: validFleetEnc,
+			assert: func(t *testing.T, cfg *configuration.Configuration) {
+				assert.False(t, cfg.Fleet.Enabled)
+				assert.Empty(t, cfg.Fleet.AccessAPIKey)
+			},
+		},
+		{
+			name: "overlapping agent.logging.level",
+			baseCfg: `fleet:
+  enabled: true
+agent:
+  logging:
+    level: info
+`,
+			fleetEnc: `fleet:
+  enabled: true
+  kibana:
+    host: demo
+  access_api_key: "123"
+agent:
+  logging:
+    level: debug`,
+			assert: func(t *testing.T, cfg *configuration.Configuration) {
+				assert.True(t, cfg.Fleet.Enabled)
+				assert.Equal(t, logp.DebugLevel, cfg.Settings.LoggingConfig.Level)
 			},
 		},
 	}
 
-	rawConfig := config.MustNewConfigFrom(cfg)
-	storage, conf, err := mergeFleetConfig(context.Background(), rawConfig)
-	require.NoError(t, err)
-	assert.NotNil(t, storage)
-	assert.NotNil(t, conf)
-	assert.Equal(t, conf.Fleet.Enabled, cfg["fleet"].(map[string]interface{})["enabled"])
-	assert.Equal(t, conf.Fleet.AccessAPIKey, cfg["fleet"].(map[string]interface{})["access_api_key"])
-	assert.Equal(t, conf.Settings.GRPC.Port, cfg["agent"].(map[string]interface{})["grpc"].(map[string]interface{})["port"].(uint16))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			origCfg := paths.Config()
+			t.Cleanup(func() { paths.SetConfig(origCfg) })
+			paths.SetConfig(t.TempDir())
+			testutils.InitStorage(t)
+			require.NoError(t, os.WriteFile(paths.ConfigFile(), []byte(tc.baseCfg), 0o644))
+
+			if tc.fleetEnc != "" {
+				store, err := storage.NewEncryptedDiskStore(t.Context(), paths.AgentConfigFile())
+				require.NoError(t, err)
+				require.NoError(t, store.Save(strings.NewReader(tc.fleetEnc)))
+			}
+
+			cfg, err := configuration.LoadConfig(t.Context(), nil)
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+			tc.assert(t, cfg)
+		})
+	}
 }
 
 func TestLimitsLog(t *testing.T) {
@@ -77,7 +132,7 @@ func TestLimitsLog(t *testing.T) {
 		true,              // testingMode
 		time.Millisecond,  // fleetInitTimeout
 		true,              // disable monitoring
-		nil,               // no configuration overrides
+		configuration.DefaultConfiguration(),
 		nil,
 		rollbackSrc,
 	)
@@ -512,6 +567,8 @@ func TestApplicationStandaloneEncrypted(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Ensure New encrypts config")
+	cfg, err := configuration.LoadConfig(t.Context(), nil)
+	require.NoError(t, err)
 	_, _, _, err = New(
 		t.Context(),
 		log,
@@ -523,7 +580,7 @@ func TestApplicationStandaloneEncrypted(t *testing.T) {
 		false, // not in testing mode - we are testing fs interactions
 		time.Second,
 		true,
-		nil,
+		cfg,
 		nil,
 		nil,
 	)
@@ -537,6 +594,8 @@ func TestApplicationStandaloneEncrypted(t *testing.T) {
 	require.EqualValues(t, storage.DefaultAgentEncryptedStandaloneConfig, ymlBytes, "unexpected contents in elastic-agent.yml")
 
 	t.Log("Ensure New does not alter contents when no changes are made")
+	cfg, err = configuration.LoadConfig(t.Context(), nil)
+	require.NoError(t, err)
 	_, _, _, err = New(
 		t.Context(),
 		log,
@@ -548,7 +607,7 @@ func TestApplicationStandaloneEncrypted(t *testing.T) {
 		false, // not in testing mode - we are testing fs interactions
 		time.Second,
 		true,
-		nil,
+		cfg,
 		nil,
 		nil,
 	)
@@ -568,6 +627,8 @@ func TestApplicationStandaloneEncrypted(t *testing.T) {
       enabled: true`), 0640)
 	require.NoError(t, err)
 
+	cfg, err = configuration.LoadConfig(t.Context(), nil)
+	require.NoError(t, err)
 	_, _, _, err = New(
 		t.Context(),
 		log,
@@ -579,7 +640,7 @@ func TestApplicationStandaloneEncrypted(t *testing.T) {
 		false, // not in testing mode - we are testing fs interactions
 		time.Second,
 		true,
-		nil,
+		cfg,
 		nil,
 		nil,
 	)
@@ -601,6 +662,8 @@ func TestApplicationStandaloneEncrypted(t *testing.T) {
     level: debug`), 0640)
 	require.NoError(t, err)
 
+	cfg, err = configuration.LoadConfig(t.Context(), nil)
+	require.NoError(t, err)
 	_, _, _, err = New(
 		t.Context(),
 		log,
@@ -612,7 +675,7 @@ func TestApplicationStandaloneEncrypted(t *testing.T) {
 		false, // not in testing mode - we are testing fs interactions
 		time.Second,
 		true,
-		nil,
+		cfg,
 		nil,
 		nil,
 	)
@@ -680,6 +743,8 @@ func TestApplicationStandaloneEncryptedWithFleetEnabled(t *testing.T) {
   host: https://localhost:8220`))
 	require.NoError(t, err)
 
+	cfg, err := configuration.LoadConfig(t.Context(), nil)
+	require.NoError(t, err)
 	_, _, _, err = New(
 		t.Context(),
 		log,
@@ -691,7 +756,7 @@ func TestApplicationStandaloneEncryptedWithFleetEnabled(t *testing.T) {
 		false, // not in testing mode - we are testing fs interactions
 		time.Second,
 		true,
-		nil,
+		cfg,
 		nil,
 		nil,
 	)

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -875,38 +875,31 @@ func runLegacyAPMServer(streams *cli.IOStreams) (*process.Info, error) {
 	return process.Start(spec.BinaryPath, options...)
 }
 
-func containerCfgOverrides(cfg *configuration.Configuration) {
-	logsPath := envWithDefault("", "LOGS_PATH")
-	if logsPath == "" {
-		// when no LOGS_PATH defined the container should log to stderr
-		cfg.Settings.LoggingConfig.ToStderr = true
-		cfg.Settings.LoggingConfig.ToFiles = false
+func containerCfgOverrides(cfg *config.Config) error {
+	uCfg := map[string]any{}
+
+	if logsPath := envWithDefault("", "LOGS_PATH"); logsPath == "" {
+		uCfg["agent.logging.to_stderr"] = true
+		uCfg["agent.logging.to_files"] = false
 	}
 
 	if envBool("HTTPPROF") {
-		// sanity checks to ensure monitoring config is setup
-		if cfg.Settings.MonitoringConfig == nil {
-			cfg.Settings.MonitoringConfig = monitoringCfg.DefaultConfig()
-		}
-
-		if cfg.Settings.MonitoringConfig.Pprof == nil {
-			cfg.Settings.MonitoringConfig.Pprof = &monitoringCfg.PprofConfig{}
-		}
-
-		cfg.Settings.MonitoringConfig.Pprof.Enabled = true
+		uCfg["agent.monitoring.pprof.enabled"] = true
 	}
 
 	eventsToStderrEnv := envWithDefault("false", "EVENTS_TO_STDERR")
 	eventsToStderr, err := strconv.ParseBool(eventsToStderrEnv)
 	if err != nil {
-		logp.Warn("cannot parse EVENS_TO_STDERR='%s' as boolean, logging events to file'", eventsToStderrEnv)
+		logp.Warn("cannot parse EVENTS_TO_STDERR='%s' as boolean, logging events to file", eventsToStderrEnv)
 	}
 	if eventsToStderr {
-		cfg.Settings.EventLoggingConfig.ToFiles = false
-		cfg.Settings.EventLoggingConfig.ToStderr = true
+		uCfg["agent.logging.event_data.to_files"] = false
+		uCfg["agent.logging.event_data.to_stderr"] = true
 	}
 
-	configuration.OverrideDefaultContainerGRPCPort(cfg.Settings.GRPC)
+	uCfg["agent.grpc.port"] = configuration.GetContainerGRPCPort()
+
+	return cfg.Merge(uCfg)
 }
 
 func setPaths(statePath, configPath, logsPath, socketPath string, writePaths bool) error {

--- a/internal/pkg/agent/cmd/container.go
+++ b/internal/pkg/agent/cmd/container.go
@@ -53,6 +53,7 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/process"
 	"github.com/elastic/elastic-agent/pkg/utils"
 	"github.com/elastic/elastic-agent/version"
+	"github.com/elastic/go-ucfg"
 )
 
 const (
@@ -899,6 +900,10 @@ func containerCfgOverrides(cfg *config.Config) error {
 
 	uCfg["agent.grpc.port"] = configuration.GetContainerGRPCPort()
 
+	// Always read certs from env.
+	uCfg["fleet.ssl.certificate"] = envWithDefault("", "ELASTIC_AGENT_CERT")
+	uCfg["fleet.ssl.key"] = envWithDefault("", "ELASTIC_AGENT_CERT_KEY")
+
 	return cfg.Merge(uCfg)
 }
 
@@ -1169,6 +1174,15 @@ func shouldFleetEnroll(setupCfg setupConfig) (bool, error) {
 	cfg, err := config.NewConfigFrom(reader)
 	if err != nil {
 		return false, fmt.Errorf("failed to read from disk store: %w", err)
+	}
+
+	err = cfg.Agent.SetString("fleet.ssl.certificate", -1, envWithDefault("", "ELASTIC_AGENT_CERT"), ucfg.PathSep("."))
+	if err != nil {
+		return false, fmt.Errorf("failed to override cert: %w", err)
+	}
+	err = cfg.Agent.SetString("fleet.ssl.key", -1, envWithDefault("", "ELASTIC_AGENT_CERT_KEY"), ucfg.PathSep("."))
+	if err != nil {
+		return false, fmt.Errorf("failed to override cert key: %w", err)
 	}
 
 	storedConfig, err := configuration.NewFromConfig(cfg)

--- a/internal/pkg/agent/cmd/container_test.go
+++ b/internal/pkg/agent/cmd/container_test.go
@@ -9,9 +9,11 @@ import (
 	"encoding/base64"
 	"errors"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -22,8 +24,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/kibana"
+	"github.com/elastic/elastic-agent-libs/testing/certutil"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/secret"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/storage"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/vault"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/crypto"
@@ -1314,4 +1320,41 @@ func TestKibanaFetchToken(t *testing.T) {
 		require.Error(t, err)
 		require.Empty(t, token)
 	})
+}
+
+// Regression test for #13810: ensure env vars override fleet.enc for certs
+func TestContainerEnvOverridesFleetTLSPaths(t *testing.T) {
+	_, childPair, err := certutil.NewRSARootAndChildCerts()
+	require.NoError(t, err)
+	certDir := t.TempDir()
+	envCertPath := filepath.Join(certDir, "tls.crt")
+	envKeyPath := filepath.Join(certDir, "tls.key")
+	require.NoError(t, os.WriteFile(envCertPath, childPair.Cert, 0o644))
+	require.NoError(t, os.WriteFile(envKeyPath, childPair.Key, 0o600))
+
+	t.Setenv("ELASTIC_AGENT_CERT", envCertPath)
+	t.Setenv("ELASTIC_AGENT_CERT_KEY", envKeyPath)
+
+	origCfg := paths.Config()
+	t.Cleanup(func() { paths.SetConfig(origCfg) })
+	paths.SetConfig(t.TempDir())
+
+	ctx := t.Context()
+	require.NoError(t, secret.CreateAgentSecret(ctx, vault.WithUnprivileged(true)))
+	require.NoError(t, os.WriteFile(paths.ConfigFile(), []byte("fleet:\n  enabled: true\n"), 0o644))
+
+	store, err := storage.NewEncryptedDiskStore(ctx, paths.AgentConfigFile())
+	require.NoError(t, err)
+	require.NoError(t, store.Save(strings.NewReader(`fleet:
+  ssl:
+    certificate: "/nonexistent/tls.crt"
+    key: "/nonexistent/tls.key"`)))
+
+	_, err = shouldFleetEnroll(setupConfig{Fleet: fleetConfig{Enroll: true}})
+	require.NotErrorIs(t, err, fs.ErrNotExist, "unpack must not try to open stale stored TLS path")
+
+	loaded, err := configuration.LoadConfig(ctx, containerCfgOverrides)
+	require.NoError(t, err)
+	require.Equal(t, envCertPath, loaded.Fleet.Client.Transport.TLS.Certificate.Certificate)
+	require.Equal(t, envKeyPath, loaded.Fleet.Client.Transport.TLS.Certificate.Key)
 }

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -51,7 +51,6 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/migration"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/storage"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
-	"github.com/elastic/elastic-agent/internal/pkg/config"
 	monitoringCfg "github.com/elastic/elastic-agent/internal/pkg/core/monitoring/config"
 	"github.com/elastic/elastic-agent/internal/pkg/diagnostics"
 	"github.com/elastic/elastic-agent/internal/pkg/release"
@@ -123,7 +122,7 @@ func newRunCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
 	return cmd
 }
 
-func run(override application.CfgOverrider, testingMode bool, fleetInitTimeout time.Duration, modifiers ...component.PlatformModifier) error {
+func run(override configuration.CfgOverrider, testingMode bool, fleetInitTimeout time.Duration, modifiers ...component.PlatformModifier) error {
 	// Windows: Mark service as stopped.
 	// After this is run, the service is considered by the OS to be stopped.
 	// This must be the first deferred cleanup task (last to execute).
@@ -164,7 +163,7 @@ func logReturn(l *logger.Logger, err error) error {
 func runElasticAgentCritical(
 	ctx context.Context,
 	cancel context.CancelFunc,
-	override application.CfgOverrider,
+	override configuration.CfgOverrider,
 	stop chan bool,
 	testingMode bool,
 	fleetInitTimeout time.Duration,
@@ -195,7 +194,7 @@ func runElasticAgentCritical(
 	}
 
 	// try load config, but don't error yet
-	cfg, err := loadConfig(ctx, override)
+	cfg, err := configuration.LoadConfig(ctx, override)
 	if err != nil {
 		// failed to load configuration, just load the default to create the logger
 		errs = append(errs, fmt.Errorf("failed to load configuration: %w", err))
@@ -254,7 +253,7 @@ func runElasticAgent(
 	baseLogger *logger.Logger,
 	l *logger.Logger,
 	cfg *configuration.Configuration,
-	override application.CfgOverrider,
+	override configuration.CfgOverrider,
 	stop chan bool,
 	testingMode bool,
 	fleetInitTimeout time.Duration,
@@ -355,6 +354,12 @@ func runElasticAgent(
 		return errors.New(err, "error migrating agent state")
 	}
 
+	// Reload in case migration wrote fleet.enc.
+	cfg, err = configuration.LoadConfig(ctx, override)
+	if err != nil {
+		return errors.New(err, "failed to reload configuration")
+	}
+
 	agentInfo, err := info.NewAgentInfoWithLog(ctx, defaultLogLevel(cfg, logLvl.String()), createAgentID)
 	if err != nil {
 		return errors.New(err,
@@ -409,7 +414,7 @@ func runElasticAgent(
 	availableRollbacksSource := ttl.NewTTLMarkerRegistry(l, paths.Top())
 
 	coord, configMgr, _, err := application.New(ctx, l, baseLogger, logLvl, agentInfo, rex, tracer, testingMode,
-		fleetInitTimeout, isBootstrap, override, initialUpgradeMarker, availableRollbacksSource, modifiers...)
+		fleetInitTimeout, isBootstrap, cfg, initialUpgradeMarker, availableRollbacksSource, modifiers...)
 	if err != nil {
 		return err
 	}
@@ -547,35 +552,6 @@ LOOP:
 	return err
 }
 
-func loadConfig(ctx context.Context, override application.CfgOverrider) (*configuration.Configuration, error) {
-	pathConfigFile := paths.ConfigFile()
-	rawConfig, err := config.LoadFile(pathConfigFile)
-	if err != nil {
-		return nil, errors.New(err,
-			fmt.Sprintf("could not read configuration file %s", pathConfigFile),
-			errors.TypeFilesystem,
-			errors.M(errors.MetaKeyPath, pathConfigFile))
-	}
-
-	if err := getOverwrites(ctx, rawConfig); err != nil {
-		return nil, errors.New(err, "could not read overwrites")
-	}
-
-	cfg, err := configuration.NewFromConfig(rawConfig)
-	if err != nil {
-		return nil, errors.New(err,
-			fmt.Sprintf("could not parse configuration file %s", pathConfigFile),
-			errors.TypeFilesystem,
-			errors.M(errors.MetaKeyPath, pathConfigFile))
-	}
-
-	if override != nil {
-		override(cfg)
-	}
-
-	return cfg, nil
-}
-
 func reexecPath() (string, error) {
 	// set executable path to symlink instead of binary
 	// in case of updated symlinks we should spin up new agent
@@ -587,51 +563,6 @@ func reexecPath() (string, error) {
 	}
 
 	return potentialReexec, nil
-}
-
-func getOverwrites(ctx context.Context, rawConfig *config.Config) error {
-	cfg, err := configuration.NewFromConfig(rawConfig)
-	if err != nil {
-		return err
-	}
-
-	if !cfg.Fleet.Enabled {
-		// overrides should apply only for fleet mode
-		return nil
-	}
-	path := paths.AgentConfigFile()
-	store, err := storage.NewEncryptedDiskStore(ctx, path)
-	if err != nil {
-		return fmt.Errorf("error instantiating encrypted disk store: %w", err)
-	}
-
-	reader, err := store.Load()
-	if err != nil && errors.Is(err, os.ErrNotExist) {
-		// no fleet file ignore
-		return nil
-	} else if err != nil {
-		return errors.New(err, "could not initialize config store",
-			errors.TypeFilesystem,
-			errors.M(errors.MetaKeyPath, path))
-	}
-
-	config, err := config.NewConfigFrom(reader)
-	if err != nil {
-		return errors.New(err,
-			fmt.Sprintf("fail to read configuration %s for the elastic-agent", path),
-			errors.TypeFilesystem,
-			errors.M(errors.MetaKeyPath, path))
-	}
-
-	err = rawConfig.Merge(config)
-	if err != nil {
-		return errors.New(err,
-			fmt.Sprintf("fail to merge configuration with %s for the elastic-agent", path),
-			errors.TypeConfig,
-			errors.M(errors.MetaKeyPath, path))
-	}
-
-	return nil
 }
 
 // applyCustomLogsPath overrides the logging config to write to the user-specified
@@ -670,7 +601,7 @@ func defaultLogLevel(cfg *configuration.Configuration, currentLevel string) stri
 	return ""
 }
 
-func tryDelayEnroll(ctx context.Context, logger *logger.Logger, cfg *configuration.Configuration, override application.CfgOverrider) (*configuration.Configuration, error) {
+func tryDelayEnroll(ctx context.Context, logger *logger.Logger, cfg *configuration.Configuration, override configuration.CfgOverrider) (*configuration.Configuration, error) {
 	enrollPath := paths.AgentEnrollFile()
 	if _, err := os.Stat(enrollPath); err != nil {
 		//nolint:nilerr // ignore the error, this is expected
@@ -747,7 +678,7 @@ func tryDelayEnroll(ctx context.Context, logger *logger.Logger, cfg *configurati
 			errors.M("path", enrollPath)))
 	}
 	logger.Info("Successfully performed delayed enrollment of this Elastic Agent.")
-	return loadConfig(ctx, override)
+	return configuration.LoadConfig(ctx, override)
 }
 
 func initTracer(agentName, version string, mcfg *monitoringCfg.MonitoringConfig) (*apm.Tracer, error) {

--- a/internal/pkg/agent/cmd/run_test.go
+++ b/internal/pkg/agent/cmd/run_test.go
@@ -157,9 +157,10 @@ func TestRunLoadConfig(t *testing.T) {
 			err := os.WriteFile(filepath.Join(dir, paths.DefaultConfigName), tt.file, 0o644)
 			require.NoError(t, err)
 
-			cfg, err := loadConfig(t.Context(), nil)
+			cfg, err := configuration.LoadConfig(t.Context(), nil)
 			require.NoError(t, err)
-			require.Equal(t, tt.expect(), cfg)
+			require.Equal(t, tt.expect().Fleet, cfg.Fleet)
+			require.Equal(t, tt.expect().Settings, cfg.Settings)
 		})
 	}
 }
@@ -219,7 +220,7 @@ func TestApplyCustomLogsPath(t *testing.T) {
 			paths.SetConfig(dir)
 			require.NoError(t, os.WriteFile(filepath.Join(dir, paths.DefaultConfigName), toStderrYAML, 0o644))
 
-			cfg, err := loadConfig(t.Context(), nil)
+			cfg, err := configuration.LoadConfig(t.Context(), nil)
 			require.NoError(t, err)
 
 			applyCustomLogsPath(cfg)

--- a/internal/pkg/agent/configuration/configuration.go
+++ b/internal/pkg/agent/configuration/configuration.go
@@ -5,15 +5,26 @@
 package configuration
 
 import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/storage"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/go-ucfg"
 )
+
+// CfgOverrider allows for application-driven overrides of the raw config before it is parsed.
+type CfgOverrider func(cfg *config.Config) error
 
 // Configuration is a overall agent configuration
 type Configuration struct {
 	Fleet    *FleetAgentConfig `config:"fleet"  yaml:"fleet" json:"fleet"`
 	Settings *SettingsConfig   `config:"agent"  yaml:"agent" json:"agent"`
+	UCfg     *config.Config    `config:"-"      yaml:"-"     json:"-"`
 }
 
 // DefaultConfiguration creates a configuration prepopulated with default values.
@@ -24,13 +35,21 @@ func DefaultConfiguration() *Configuration {
 	}
 }
 
+// GetUCfg returns the raw config, initializing it from the structured fields if nil.
+func (c *Configuration) GetUCfg() *config.Config {
+	if c.UCfg == nil {
+		c.UCfg = config.MustNewConfigFrom(c)
+	}
+	return c.UCfg
+}
+
 // NewFromConfig creates a configuration based on common Config.
 func NewFromConfig(cfg *config.Config) (*Configuration, error) {
 	c := DefaultConfiguration()
 	if err := cfg.UnpackTo(c); err != nil {
 		return nil, errors.New(err, errors.TypeConfig)
 	}
-
+	c.UCfg = cfg
 	return c, nil
 }
 
@@ -48,4 +67,89 @@ func NewPartialFromConfigNoDefaults(cfg *config.Config) (*Configuration, error) 
 // AgentInfo is a set of agent information.
 type AgentInfo struct {
 	ID string `json:"id" yaml:"id" config:"id"`
+}
+
+func LoadConfig(ctx context.Context, override CfgOverrider) (*Configuration, error) {
+	uCfg, err := loadBaseFileConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	loadFleet, _ := uCfg.Agent.Bool("fleet.enabled", -1, ucfg.PathSep("."))
+	if loadFleet {
+		fleetCfg, err := loadFleetFileConfig(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if fleetCfg != nil {
+			if err := uCfg.Merge(fleetCfg); err != nil {
+				return nil, errors.New(err, "could not merge fleet configuration",
+					errors.TypeConfig,
+					errors.M(errors.MetaKeyPath, paths.AgentConfigFile()))
+			}
+		}
+	}
+
+	if err := info.InjectAgentConfig(uCfg); err != nil {
+		return nil, errors.New(err, "could not inject agent path/host/runtime config")
+	}
+
+	if override != nil {
+		if err := override(uCfg); err != nil {
+			return nil, errors.New(err, "could not apply config override")
+		}
+	}
+
+	cfg, err := NewFromConfig(uCfg)
+	if err != nil {
+		return nil, errors.New(err, "could not parse agent configuration")
+	}
+
+	return cfg, nil
+}
+
+func loadBaseFileConfig() (*config.Config, error) {
+	pathConfigFile := paths.ConfigFile()
+	uCfg, err := config.LoadFile(pathConfigFile)
+	if err != nil {
+		return nil, errors.New(err,
+			fmt.Sprintf("could not read configuration file %s", pathConfigFile),
+			errors.TypeFilesystem,
+			errors.M(errors.MetaKeyPath, pathConfigFile))
+	}
+	return uCfg, nil
+}
+
+func loadFleetFileConfig(ctx context.Context) (*config.Config, error) {
+	path := paths.AgentConfigFile()
+	store, err := storage.NewEncryptedDiskStore(ctx, path)
+	if err != nil {
+		return nil, errors.New(err, "could not create encrypted disk store")
+	}
+
+	reader, err := store.Load()
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	} else if err != nil {
+		return nil, errors.New(err, "could not initialize config store",
+			errors.TypeFilesystem,
+			errors.M(errors.MetaKeyPath, path))
+	}
+
+	fleetCfg, err := config.NewConfigFrom(reader)
+	if err != nil {
+		return nil, errors.New(err,
+			fmt.Sprintf("fail to read configuration %s for the elastic-agent", path),
+			errors.TypeFilesystem,
+			errors.M(errors.MetaKeyPath, path))
+	}
+
+	// Fix up fleet.agent.id otherwise the fleet.agent.id is empty string
+	if fleetAgentID, _ := fleetCfg.Agent.String("fleet.agent.id", -1, ucfg.PathSep(".")); fleetAgentID == "" {
+		if agentID, err := fleetCfg.Agent.String("agent.id", -1, ucfg.PathSep(".")); err == nil && agentID != "" {
+			_ = fleetCfg.Agent.SetString("fleet.agent.id", -1, agentID, ucfg.PathSep("."))
+		}
+	}
+
+	return fleetCfg, nil
 }

--- a/internal/pkg/agent/configuration/grpc.go
+++ b/internal/pkg/agent/configuration/grpc.go
@@ -55,18 +55,18 @@ func DefaultGRPCConfig() *GRPCConfig {
 
 // OverrideDefaultContainerGRPCPort is the configuration override used by the container command
 // to switch to a more convenient default port.
-func OverrideDefaultContainerGRPCPort(cfg *GRPCConfig) {
-	cfg.Port = DefaultGPRCPortInContainer
-
+func GetContainerGRPCPort() uint16 {
 	// Allow manually specifying the port via an undocumented environment variable in case
 	// the change from the original DefaultGRPCPort causes unexpected problems.
 	grpcPortEnv, ok := os.LookupEnv(grpcPortContainerEnvVar)
 	if ok {
 		port, err := strconv.Atoi(grpcPortEnv)
 		if err == nil {
-			cfg.Port = uint16(port) //nolint:gosec // integer size truncation is fine here.
+			return uint16(port) //nolint:gosec // integer size truncation is fine here.
 		}
 	}
+
+	return DefaultGPRCPortInContainer
 }
 
 // String returns the composed listen address for the GRPC.

--- a/internal/pkg/agent/configuration/grpc_test.go
+++ b/internal/pkg/agent/configuration/grpc_test.go
@@ -32,13 +32,11 @@ func TestOverrideDefaultGRPCPort(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := GRPCConfig{}
 			if tc.env != "" {
 				os.Setenv(grpcPortContainerEnvVar, tc.env)
 				defer os.Unsetenv(grpcPortContainerEnvVar)
 			}
-			OverrideDefaultContainerGRPCPort(&cfg)
-			assert.Equal(t, tc.expected, cfg.Port)
+			assert.Equal(t, tc.expected, GetContainerGRPCPort())
 		})
 	}
 }

--- a/testing/integration/ess/container_cmd_test.go
+++ b/testing/integration/ess/container_cmd_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/kibana"
+	"github.com/elastic/elastic-agent-libs/testing/certutil"
 	monitoringCfg "github.com/elastic/elastic-agent/internal/pkg/core/monitoring/config"
 	"github.com/elastic/elastic-agent/pkg/component"
 	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
@@ -983,6 +984,97 @@ func TestContainerCMDDiagnosticsSocket(t *testing.T) {
 	},
 		5*time.Minute, time.Second,
 		"Elastic-Agent did not report healthy. Agent status error: \"%v\", Agent logs\n%s",
+		err, agentOutput,
+	)
+}
+
+// Regression test for #13810: ensure env vars override fleet.enc for certs
+func TestContainerCMDTLSCertOverride(t *testing.T) {
+	info := define.Require(t, define.Requirements{
+		Stack: &define.Stack{},
+		Local: false,
+		Sudo:  true,
+		OS: []define.OS{
+			{Type: define.Linux},
+		},
+		Group: "container",
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
+	require.NoError(t, err)
+
+	require.NoError(t, agentFixture.Prepare(ctx))
+	require.NoError(t, err)
+
+	_, childPair, err := certutil.NewRSARootAndChildCerts()
+	require.NoError(t, err)
+
+	certDir := t.TempDir()
+	certPath := filepath.Join(certDir, "tls.crt")
+	keyPath := filepath.Join(certDir, "tls.key")
+	require.NoError(t, os.WriteFile(certPath, childPair.Cert, 0o644))
+	require.NoError(t, os.WriteFile(keyPath, childPair.Key, 0o600))
+
+	fleetURL, err := fleettools.DefaultURL(ctx, info.KibanaClient)
+	require.NoErrorf(t, err, "could not get Fleet URL")
+
+	_, enrollmentToken := createPolicy(
+		t, ctx, agentFixture, info,
+		fmt.Sprintf("%s-%s", t.Name(), uuid.Must(uuid.NewV4()).String()),
+		"")
+
+	statePath := agentFixture.WorkDir()
+	env := []string{
+		"FLEET_ENROLL=1",
+		"FLEET_URL=" + fleetURL,
+		"FLEET_ENROLLMENT_TOKEN=" + enrollmentToken,
+		"STATE_PATH=" + statePath,
+	}
+	envWithCerts := append([]string{
+		"ELASTIC_AGENT_CERT=" + certPath,
+		"ELASTIC_AGENT_CERT_KEY=" + keyPath,
+	}, env...)
+
+	cmd, agentOutput := prepareAgentCMD(t, ctx, agentFixture, []string{"container"}, envWithCerts)
+	t.Logf(">> running binary with: %v", cmd.Args)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("error running container cmd: %s", err)
+	}
+
+	require.Eventuallyf(t, func() bool {
+		err = agentFixture.IsHealthy(ctx, atesting.WithCmdOptions(withEnv(envWithCerts)))
+		return err == nil
+	},
+		2*time.Minute, time.Second,
+		"Elastic-Agent did not report healthy after first enrollment. Agent status error: \"%v\", Agent logs\n%s",
+		err, agentOutput,
+	)
+
+	require.FileExists(t, filepath.Join(statePath, "fleet.enc"),
+		"fleet.enc must exist for regression test")
+
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+	cmd.Process = nil
+
+	require.NoError(t, os.Remove(certPath))
+	require.NoError(t, os.Remove(keyPath))
+
+	cmd, agentOutput = prepareAgentCMD(t, ctx, agentFixture, []string{"container"}, env)
+	t.Logf(">> running binary with: %v", cmd.Args)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("error running container cmd: %s", err)
+	}
+
+	require.Eventuallyf(t, func() bool {
+		err = agentFixture.IsHealthy(ctx, atesting.WithCmdOptions(withEnv(env)))
+		return err == nil
+	},
+		2*time.Minute, time.Second,
+		"Elastic-Agent did not report healthy after restart without certs. Agent status error: \"%v\", Agent logs\n%s",
 		err, agentOutput,
 	)
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #13810 by always reading TLS cert paths from ELASTIC_AGENT_CERT and ELASTIC_AGENT_CERT_KEY instead of using potentially stale values from fleet.enc when running in container mode.

Modifying the certificate paths in the config at the ucfg layer is required because unpacking httpcommon.HTTPTransportSettings calls tlscommon.LoadTLSConfig, which validates the files and cannot be overridden. To do this cleanly, the existing container override code is refactored to modify a ucfg config.Config rather than an unpacked config so all overrides are applied before the struct is built.

Consolidates duplicate config loading code into configuration.LoadConfig, which as a result also fixes an ordering issue where existing container overrides were correctly applied during startup but passed a different config to the coordinator that could have values overwritten by fleet.enc. This could result in incorrect config diagnostics and unnecessary re-execs on policy updates.


## Why is it important?

When Fleet Server's mTLS is disabled in container deployments and the agent's certificate paths are unmounted, the agent restarts and crashloops as fleet.enc attempts to load the old files. The agent should be able to handle this configuration change smoothly.

## Checklist

- [X] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [X] I have added an integration test or an E2E test

## Disruptive User Impact

N/A

## How to test this PR locally

Unit test: TestContainerEnvOverridesFleetTLSPaths
Integration test: TestContainerCMDTLSCertOverride
Manually: Using kind, deploy ECK cluster. Enroll an agent with certificates mounted and with ELASTIC_AGENT_CERT and ELASTIC_AGENT_CERT_KEY set. Unmount the certificate volume and unset env vars and verify that agent restarts healthy.

## Related issues

- Closes #13810