### PR TITLE
Add windows builds to FIPS binary DRA packages

### DIFF
--- a/.buildkite/pipeline.elastic-agent-binary-dra.yml
+++ b/.buildkite/pipeline.elastic-agent-binary-dra.yml
@@ -48,7 +48,7 @@ steps:
       plugins:
         - *google_oidc_plugin
 
-    - label: ":package: linux/amd64 FIPS Elastic-Agent Core Snapshot"
+    - label: ":package: linux/amd64 windows/amd64 FIPS Elastic-Agent Core Snapshot"
       commands:
         - .buildkite/scripts/steps/build-agent-core.sh
       key: "build-dra-snapshot-x86-fips"
@@ -60,7 +60,7 @@ steps:
         image: "${IMAGE_UBUNTU_2404_X86_64}"
       env:
         DRA_WORKFLOW: "snapshot"
-        PLATFORMS: "linux/amd64"
+        PLATFORMS: "linux/amd64 windows/amd64"
         FIPS: "true"
       plugins:
         - *google_oidc_plugin
@@ -81,7 +81,7 @@ steps:
       plugins:
         - *google_oidc_plugin
 
-    - label: ":package: linux/arm64 FIPS Elastic-Agent Core Snapshot"
+    - label: ":package: linux/arm64 windows/arm64 FIPS Elastic-Agent Core Snapshot"
       commands:
         - .buildkite/scripts/steps/build-agent-core.sh
       key: "build-dra-snapshot-arm-fips"
@@ -93,7 +93,7 @@ steps:
         image: "${IMAGE_UBUNTU_2404_ARM_64}"
       env:
         DRA_WORKFLOW: "snapshot"
-        PLATFORMS: "linux/arm64"
+        PLATFORMS: "linux/arm64 windows/arm64"
         FIPS: "true"
       plugins:
         - *google_oidc_plugin
@@ -153,7 +153,7 @@ steps:
       plugins:
         - *google_oidc_plugin
 
-    - label: ":package: linux/amd64 FIPS Elastic-Agent Core staging"
+    - label: ":package: linux/amd64 windows/amd64 FIPS Elastic-Agent Core staging"
       commands: |
         source .buildkite/scripts/version_qualifier.sh
         .buildkite/scripts/steps/build-agent-core.sh
@@ -166,7 +166,7 @@ steps:
         image: "${IMAGE_UBUNTU_2404_X86_64}"
       env:
         DRA_WORKFLOW: "staging"
-        PLATFORMS: "linux/amd64"
+        PLATFORMS: "linux/amd64 windows/amd64"
         FIPS: "true"
       plugins:
         - *google_oidc_plugin
@@ -188,7 +188,7 @@ steps:
       plugins:
         - *google_oidc_plugin
 
-    - label: ":package: linux/arm64 FIPS Elastic-Agent Core staging"
+    - label: ":package: linux/arm64 windows/arm64 FIPS Elastic-Agent Core staging"
       commands: |
         source .buildkite/scripts/version_qualifier.sh
         .buildkite/scripts/steps/build-agent-core.sh
@@ -201,7 +201,7 @@ steps:
         image: "${IMAGE_UBUNTU_2404_ARM_64}"
       env:
         DRA_WORKFLOW: "dra-core-staging"
-        PLATFORMS: "linux/arm64"
+        PLATFORMS: "linux/arm64 windows/arm64"
         FIPS: "true"
       plugins:
         - *google_oidc_plugin


### PR DESCRIPTION
## What does this PR do?

Extend the FIPS snapshot and staging DRA binary build steps to include windows builds alongside their Linux counterparts:

- x86 FIPS step (GCP): linux/amd64 windows/amd64
- arm FIPS step (AWS arm): linux/arm64 windows/arm64

The binary DRA needs to go first, because it needs to be published before we can build the full package. Ran a build manually here: https://buildkite.com/elastic/elastic-agent-binary-dra/builds/8676.

## Why is it important?

We'd like to publish FIPS-compatible Windows builds in one of the upcoming major releases.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Related https://github.com/elastic/ingest-dev/issues/7432

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
