### PR TITLE
Add windows/amd64 and windows/arm64 to FIPS elastic-agent packages

### DIFF
--- a/.buildkite/pipeline.elastic-agent-package.yml
+++ b/.buildkite/pipeline.elastic-agent-package.yml
@@ -102,7 +102,7 @@ steps:
           diskSizeGb: 400
           image: "${IMAGE_UBUNTU_2404_X86_64}"
         env:
-          PLATFORMS: "linux/amd64"
+          PLATFORMS: "linux/amd64 windows/amd64"
           PACKAGES: "all"
           FIPS: "true"
         command: |
@@ -156,8 +156,8 @@ steps:
           image: "${IMAGE_UBUNTU_2404_ARM_64}"
           diskSizeGb: 400
         env:
-          PLATFORMS: "linux/arm64"
-          PACKAGES: "docker,tar.gz,deb,rpm"
+          PLATFORMS: "linux/arm64 windows/arm64"
+          PACKAGES: "docker,tar.gz,deb,rpm,zip"
           FIPS: "true"
         command: |
           echo "Add support for multiarch"


### PR DESCRIPTION
## What does this PR do?

Extend the FIPS packaging steps in the elastic-agent-package DRA pipeline to include windows builds alongside their Linux counterparts:

- x86 FIPS step (GCP): linux/amd64 windows/amd64
- arm FIPS step (AWS arm): linux/arm64 windows/arm64, add zip to PACKAGES

The binary DRA is already present from https://github.com/elastic/elastic-agent/pull/14419, but it needs to be published in a DRA manifest before this PR can be merged.

## Why is it important?

We'd like to publish FIPS-compatible Windows builds in one of the upcoming major releases.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/7432

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->