### PR TITLE
Fix support for abreceiver, hbreceiver, osqreceiver, and pbreceiver

### DIFF
--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -396,9 +396,6 @@ func getReceiversConfigForComponent(
 	}
 
 	receiverId := GetReceiverID(receiverType, comp.ID)
-	// Beat config inside a beat receiver is nested under an additional key. Not sure if this simple translation is
-	// always safe. We should either ensure this is always the case, or have an explicit mapping.
-	beatName := strings.TrimSuffix(receiverType.String(), "receiver")
 	binaryName := comp.BeatName()
 	dataset := fmt.Sprintf("elastic_agent.%s", strings.ReplaceAll(strings.ReplaceAll(binaryName, "-", "_"), "/", "_"))
 
@@ -423,17 +420,33 @@ func getReceiversConfigForComponent(
 			},
 		},
 	}
-	switch beatName {
+	switch binaryName {
 	case "filebeat":
-		receiverConfig[beatName] = map[string]any{
+		receiverConfig[binaryName] = map[string]any{
 			"inputs": inputs,
 		}
 		if fbfeatures.IsElasticsearchStateStoreEnabled() {
 			receiverConfig["storage"] = elasticsearchStateStoreExtensionName
 		}
 	case "metricbeat":
-		receiverConfig[beatName] = map[string]any{
+		receiverConfig[binaryName] = map[string]any{
 			"modules": inputs,
+		}
+	case "auditbeat":
+		receiverConfig[binaryName] = map[string]any{
+			"modules": inputs,
+		}
+	case "heartbeat":
+		receiverConfig[binaryName] = map[string]any{
+			"monitors": inputs,
+		}
+	case "osquerybeat":
+		receiverConfig[binaryName] = map[string]any{
+			"inputs": inputs,
+		}
+	case "packetbeat":
+		receiverConfig[binaryName] = map[string]any{
+			"protocols": inputs,
 		}
 	}
 
@@ -500,7 +513,7 @@ func getExporterConfigForComponent(comp *component.Component, exporterType otelc
 func getSignalForComponent(comp *component.Component) (pipeline.Signal, error) {
 	beatName := comp.BeatName()
 	switch beatName {
-	case "filebeat", "metricbeat":
+	case "filebeat", "metricbeat", "auditbeat", "heartbeat", "osquerybeat", "packetbeat":
 		return pipeline.SignalLogs, nil
 	default:
 		return pipeline.Signal{}, fmt.Errorf("unknown otel signal for input type: %s", comp.InputType)
@@ -515,6 +528,14 @@ func getReceiverTypeForComponent(comp *component.Component) (otelcomponent.Type,
 		return otelcomponent.MustNewType("filebeatreceiver"), nil
 	case "metricbeat":
 		return otelcomponent.MustNewType("metricbeatreceiver"), nil
+	case "auditbeat":
+		return otelcomponent.MustNewType("abreceiver"), nil
+	case "heartbeat":
+		return otelcomponent.MustNewType("hbreceiver"), nil
+	case "osquerybeat":
+		return otelcomponent.MustNewType("osqreceiver"), nil
+	case "packetbeat":
+		return otelcomponent.MustNewType("pbreceiver"), nil
 	default:
 		return otelcomponent.Type{}, fmt.Errorf("unknown otel receiver type for input type: %s", comp.InputType)
 	}
@@ -720,7 +741,7 @@ func OutputConfigToExporterConfig(logger *logp.Logger,
 func getDefaultDatastreamTypeForComponent(comp *component.Component) (string, error) {
 	beatName := comp.BeatName()
 	switch beatName {
-	case "filebeat":
+	case "filebeat", "auditbeat", "heartbeat", "osquerybeat", "packetbeat":
 		return "logs", nil
 	case "metricbeat":
 		return "metrics", nil

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -613,66 +613,35 @@ func TestGetOtelConfig(t *testing.T) {
 	}
 
 	// expects input id
-	expectedFilestreamConfig := func(id string) (config map[string]any) {
-		config = map[string]any{
-			"filebeat": map[string]any{
-				"inputs": []map[string]any{
-					{
-						"id":   "test-1",
-						"type": "filestream",
-						"data_stream": map[string]any{
-							"dataset": "generic-1",
-						},
-						"paths": []any{
-							"/var/log/*.log",
-						},
-						"index":      "logs-generic-1-default",
-						"processors": defaultInputProcessors("test-1", "generic-1", "logs"),
+	expectedFilestreamConfig := func(id string) map[string]any {
+		config := beatReceiverBaseConfig(id, "filebeat", "filestream")
+		config["filebeat"] = map[string]any{
+			"inputs": []map[string]any{
+				{
+					"id":   "test-1",
+					"type": "filestream",
+					"data_stream": map[string]any{
+						"dataset": "generic-1",
 					},
-					{
-						"id":   "test-2",
-						"type": "filestream",
-						"data_stream": map[string]any{
-							"dataset": "generic-2",
-						},
-						"paths": []any{
-							"/var/log/*.log",
-						},
-						"index":      "logs-generic-2-default",
-						"processors": defaultInputProcessors("test-2", "generic-2", "logs"),
+					"paths": []any{
+						"/var/log/*.log",
 					},
+					"index":      "logs-generic-1-default",
+					"processors": defaultInputProcessors("test-1", "generic-1", "logs"),
+				},
+				{
+					"id":   "test-2",
+					"type": "filestream",
+					"data_stream": map[string]any{
+						"dataset": "generic-2",
+					},
+					"paths": []any{
+						"/var/log/*.log",
+					},
+					"index":      "logs-generic-2-default",
+					"processors": defaultInputProcessors("test-2", "generic-2", "logs"),
 				},
 			},
-			"path": map[string]any{
-				"home": paths.Components(),
-				"data": filepath.Join(paths.Run(), id),
-			},
-			"queue": map[string]any{
-				"mem": map[string]any{
-					"events": uint64(3200),
-					"flush": map[string]any{
-						"min_events": uint64(1600),
-						"timeout":    "10s",
-					},
-				},
-			},
-			"logging": map[string]any{
-				"with_fields": map[string]any{
-					"component": map[string]any{
-						"binary":  "filebeat",
-						"dataset": "elastic_agent.filebeat",
-						"type":    "filestream",
-						"id":      id,
-					},
-					"log": map[string]any{
-						"source": id,
-					},
-				},
-			},
-			"http": map[string]any{
-				"enabled": false,
-			},
-			"management.otel.enabled": true,
 		}
 		return config
 	}

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -50,6 +50,22 @@ func TestBeatNameToDefaultDatastreamType(t *testing.T) {
 			beatName:      "cloudbeat",
 			expectedError: fmt.Errorf("input type not supported by Otel: "),
 		},
+		{
+			beatName:     "auditbeat",
+			expectedType: "logs",
+		},
+		{
+			beatName:     "heartbeat",
+			expectedType: "logs",
+		},
+		{
+			beatName:     "osquerybeat",
+			expectedType: "logs",
+		},
+		{
+			beatName:     "packetbeat",
+			expectedType: "logs",
+		},
 	}
 
 	for _, tt := range tests {
@@ -129,6 +145,66 @@ func TestGetSignalForComponent(t *testing.T) {
 			},
 			expectedSignal: pipeline.SignalLogs,
 		},
+		{
+			name: "auditbeat",
+			component: component.Component{
+				InputType: "audit/auditd",
+				InputSpec: &component.InputRuntimeSpec{
+					BinaryName: "elastic-otel-collector",
+					Spec: component.InputSpec{
+						Command: &component.CommandSpec{
+							Args: []string{"auditbeat"},
+						},
+					},
+				},
+			},
+			expectedSignal: pipeline.SignalLogs,
+		},
+		{
+			name: "heartbeat",
+			component: component.Component{
+				InputType: "synthetics/http",
+				InputSpec: &component.InputRuntimeSpec{
+					BinaryName: "elastic-otel-collector",
+					Spec: component.InputSpec{
+						Command: &component.CommandSpec{
+							Args: []string{"heartbeat"},
+						},
+					},
+				},
+			},
+			expectedSignal: pipeline.SignalLogs,
+		},
+		{
+			name: "osquerybeat",
+			component: component.Component{
+				InputType: "osquery",
+				InputSpec: &component.InputRuntimeSpec{
+					BinaryName: "elastic-otel-collector",
+					Spec: component.InputSpec{
+						Command: &component.CommandSpec{
+							Args: []string{"osquerybeat"},
+						},
+					},
+				},
+			},
+			expectedSignal: pipeline.SignalLogs,
+		},
+		{
+			name: "packetbeat",
+			component: component.Component{
+				InputType: "packet",
+				InputSpec: &component.InputRuntimeSpec{
+					BinaryName: "elastic-otel-collector",
+					Spec: component.InputSpec{
+						Command: &component.CommandSpec{
+							Args: []string{"packetbeat"},
+						},
+					},
+				},
+			},
+			expectedSignal: pipeline.SignalLogs,
+		},
 	}
 
 	for _, tt := range tests {
@@ -148,6 +224,68 @@ func TestGetSignalForComponent(t *testing.T) {
 
 func TestGetOtelConfig(t *testing.T) {
 	agentInfo := &info.AgentInfo{}
+	auditbeatInputConfig := map[string]any{
+		"id":         "test",
+		"use_output": "default",
+		"type":       "audit/auditd",
+		"streams": []any{
+			map[string]any{
+				"id": "test-1",
+				"data_stream": map[string]any{
+					"dataset": "generic-1",
+				},
+				"audit_rules": "-a exit,always -F arch=b64 -S open",
+			},
+		},
+	}
+
+	heartbeatInputConfig := map[string]any{
+		"id":         "test",
+		"use_output": "default",
+		"type":       "synthetics/http",
+		"streams": []any{
+			map[string]any{
+				"id": "test-1",
+				"data_stream": map[string]any{
+					"dataset": "generic-1",
+				},
+				"urls":     []any{"https://example.com"},
+				"schedule": "@every 5s",
+			},
+		},
+	}
+
+	osquerybeatInputConfig := map[string]any{
+		"id":         "test",
+		"use_output": "default",
+		"type":       "osquery",
+		"streams": []any{
+			map[string]any{
+				"id": "test-1",
+				"data_stream": map[string]any{
+					"dataset": "generic-1",
+				},
+				"query":    "SELECT * FROM processes",
+				"interval": "3600",
+			},
+		},
+	}
+
+	packetbeatInputConfig := map[string]any{
+		"id":         "test",
+		"use_output": "default",
+		"type":       "packet",
+		"streams": []any{
+			map[string]any{
+				"id": "test-1",
+				"data_stream": map[string]any{
+					"dataset": "generic-1",
+				},
+				"ports": []any{443, 8443},
+			},
+		},
+	}
+
 	fileStreamConfig := map[string]any{
 		"id":         "test",
 		"use_output": "default",
@@ -352,6 +490,126 @@ func TestGetOtelConfig(t *testing.T) {
 		{"add_cloud_metadata": nil},
 		{"add_docker_metadata": nil},
 		{"add_kubernetes_metadata": nil},
+	}
+
+	// expected receiver config shared shape for ES-output beats with a single stream.
+	// queue uses uint64 because the "balanced" ES preset produces typed uint64 values.
+	beatReceiverBaseConfig := func(id, binaryName, inputType string) map[string]any {
+		dataset := fmt.Sprintf("elastic_agent.%s", binaryName)
+		return map[string]any{
+			"path": map[string]any{
+				"home": paths.Components(),
+				"data": filepath.Join(paths.Run(), id),
+			},
+			"queue": map[string]any{
+				"mem": map[string]any{
+					"events": uint64(3200),
+					"flush": map[string]any{
+						"min_events": uint64(1600),
+						"timeout":    "10s",
+					},
+				},
+			},
+			"logging": map[string]any{
+				"with_fields": map[string]any{
+					"component": map[string]any{
+						"binary":  binaryName,
+						"dataset": dataset,
+						"type":    inputType,
+						"id":      id,
+					},
+					"log": map[string]any{
+						"source": id,
+					},
+				},
+			},
+			"http": map[string]any{
+				"enabled": false,
+			},
+			"management.otel.enabled": true,
+		}
+	}
+
+	// expects component id
+	expectedAuditbeatReceiverConfig := func(id string) map[string]any {
+		cfg := beatReceiverBaseConfig(id, "auditbeat", "audit/auditd")
+		cfg["auditbeat"] = map[string]any{
+			"modules": []map[string]any{
+				{
+					"id": "test-1",
+					"data_stream": map[string]any{
+						"dataset": "generic-1",
+					},
+					"audit_rules": "-a exit,always -F arch=b64 -S open",
+					"index":       "logs-generic-1-default",
+					"processors":  defaultInputProcessors("test-1", "generic-1", "logs"),
+					"type":        "audit/auditd",
+				},
+			},
+		}
+		return cfg
+	}
+
+	// expects component id
+	expectedHeartbeatReceiverConfig := func(id string) map[string]any {
+		cfg := beatReceiverBaseConfig(id, "heartbeat", "synthetics/http")
+		cfg["heartbeat"] = map[string]any{
+			"monitors": []map[string]any{
+				{
+					"id": "test-1",
+					"data_stream": map[string]any{
+						"dataset": "generic-1",
+					},
+					"urls":       []any{"https://example.com"},
+					"schedule":   "@every 5s",
+					"index":      "logs-generic-1-default",
+					"processors": defaultInputProcessors("test-1", "generic-1", "logs"),
+					"type":       "synthetics/http",
+				},
+			},
+		}
+		return cfg
+	}
+
+	// expects component id
+	expectedOsquerybeatReceiverConfig := func(id string) map[string]any {
+		cfg := beatReceiverBaseConfig(id, "osquerybeat", "osquery")
+		cfg["osquerybeat"] = map[string]any{
+			"inputs": []map[string]any{
+				{
+					"id": "test-1",
+					"data_stream": map[string]any{
+						"dataset": "generic-1",
+					},
+					"query":      "SELECT * FROM processes",
+					"interval":   "3600",
+					"index":      "logs-generic-1-default",
+					"processors": defaultInputProcessors("test-1", "generic-1", "logs"),
+					"type":       "osquery",
+				},
+			},
+		}
+		return cfg
+	}
+
+	// expects component id
+	expectedPacketbeatReceiverConfig := func(id string) map[string]any {
+		cfg := beatReceiverBaseConfig(id, "packetbeat", "packet")
+		cfg["packetbeat"] = map[string]any{
+			"protocols": []map[string]any{
+				{
+					"id": "test-1",
+					"data_stream": map[string]any{
+						"dataset": "generic-1",
+					},
+					"ports":      []any{443, 8443},
+					"index":      "logs-generic-1-default",
+					"processors": defaultInputProcessors("test-1", "generic-1", "logs"),
+					"type":       "packet",
+				},
+			},
+		}
+		return cfg
 	}
 
 	// expects input id
@@ -1823,6 +2081,242 @@ func TestGetOtelConfig(t *testing.T) {
 				},
 			}),
 		},
+		{
+			name: "auditbeat",
+			model: &component.Model{
+				Components: []component.Component{
+					{
+						ID:         "auditbeat-default",
+						InputType:  "audit/auditd",
+						OutputType: "elasticsearch",
+						OutputName: "default",
+						InputSpec: &component.InputRuntimeSpec{
+							BinaryName: "elastic-otel-collector",
+							Spec: component.InputSpec{
+								Command: &component.CommandSpec{
+									Args: []string{"auditbeat"},
+								},
+							},
+						},
+						Units: []component.Unit{
+							{
+								ID:     "auditbeat-unit",
+								Type:   client.UnitTypeInput,
+								Config: component.MustExpectedConfig(auditbeatInputConfig),
+							},
+							{
+								ID:     "auditbeat-default",
+								Type:   client.UnitTypeOutput,
+								Config: component.MustExpectedConfig(esOutputConfig()),
+							},
+						},
+					},
+				},
+			},
+			expectedConfig: confmap.NewFromStringMap(map[string]any{
+				"exporters": map[string]any{
+					"elasticsearch/_agent-component/default": expectedESConfig("default"),
+				},
+				"extensions": map[string]any{
+					"beatsauth/_agent-component/default": expectedExtensionConfig(),
+				},
+				"processors": map[string]any{
+					"beat/_agent-component": map[string]any{
+						"processors": defaultGlobalProcessors,
+					},
+				},
+				"receivers": map[string]any{
+					"abreceiver/_agent-component/auditbeat-default": expectedAuditbeatReceiverConfig("auditbeat-default"),
+				},
+				"service": map[string]any{
+					"extensions": []any{"beatsauth/_agent-component/default"},
+					"pipelines": map[string]any{
+						"logs/_agent-component/auditbeat-default": map[string][]string{
+							"exporters":  {"elasticsearch/_agent-component/default"},
+							"processors": {"beat/_agent-component"},
+							"receivers":  {"abreceiver/_agent-component/auditbeat-default"},
+						},
+					},
+				},
+			}),
+		},
+		{
+			name: "heartbeat",
+			model: &component.Model{
+				Components: []component.Component{
+					{
+						ID:         "heartbeat-default",
+						InputType:  "synthetics/http",
+						OutputType: "elasticsearch",
+						OutputName: "default",
+						InputSpec: &component.InputRuntimeSpec{
+							BinaryName: "elastic-otel-collector",
+							Spec: component.InputSpec{
+								Command: &component.CommandSpec{
+									Args: []string{"heartbeat"},
+								},
+							},
+						},
+						Units: []component.Unit{
+							{
+								ID:     "heartbeat-unit",
+								Type:   client.UnitTypeInput,
+								Config: component.MustExpectedConfig(heartbeatInputConfig),
+							},
+							{
+								ID:     "heartbeat-default",
+								Type:   client.UnitTypeOutput,
+								Config: component.MustExpectedConfig(esOutputConfig()),
+							},
+						},
+					},
+				},
+			},
+			expectedConfig: confmap.NewFromStringMap(map[string]any{
+				"exporters": map[string]any{
+					"elasticsearch/_agent-component/default": expectedESConfig("default"),
+				},
+				"extensions": map[string]any{
+					"beatsauth/_agent-component/default": expectedExtensionConfig(),
+				},
+				"processors": map[string]any{
+					"beat/_agent-component": map[string]any{
+						"processors": defaultGlobalProcessors,
+					},
+				},
+				"receivers": map[string]any{
+					"hbreceiver/_agent-component/heartbeat-default": expectedHeartbeatReceiverConfig("heartbeat-default"),
+				},
+				"service": map[string]any{
+					"extensions": []any{"beatsauth/_agent-component/default"},
+					"pipelines": map[string]any{
+						"logs/_agent-component/heartbeat-default": map[string][]string{
+							"exporters":  {"elasticsearch/_agent-component/default"},
+							"processors": {"beat/_agent-component"},
+							"receivers":  {"hbreceiver/_agent-component/heartbeat-default"},
+						},
+					},
+				},
+			}),
+		},
+		{
+			name: "osquerybeat",
+			model: &component.Model{
+				Components: []component.Component{
+					{
+						ID:         "osquerybeat-default",
+						InputType:  "osquery",
+						OutputType: "elasticsearch",
+						OutputName: "default",
+						InputSpec: &component.InputRuntimeSpec{
+							BinaryName: "elastic-otel-collector",
+							Spec: component.InputSpec{
+								Command: &component.CommandSpec{
+									Args: []string{"osquerybeat"},
+								},
+							},
+						},
+						Units: []component.Unit{
+							{
+								ID:     "osquerybeat-unit",
+								Type:   client.UnitTypeInput,
+								Config: component.MustExpectedConfig(osquerybeatInputConfig),
+							},
+							{
+								ID:     "osquerybeat-default",
+								Type:   client.UnitTypeOutput,
+								Config: component.MustExpectedConfig(esOutputConfig()),
+							},
+						},
+					},
+				},
+			},
+			expectedConfig: confmap.NewFromStringMap(map[string]any{
+				"exporters": map[string]any{
+					"elasticsearch/_agent-component/default": expectedESConfig("default"),
+				},
+				"extensions": map[string]any{
+					"beatsauth/_agent-component/default": expectedExtensionConfig(),
+				},
+				"processors": map[string]any{
+					"beat/_agent-component": map[string]any{
+						"processors": defaultGlobalProcessors,
+					},
+				},
+				"receivers": map[string]any{
+					"osqreceiver/_agent-component/osquerybeat-default": expectedOsquerybeatReceiverConfig("osquerybeat-default"),
+				},
+				"service": map[string]any{
+					"extensions": []any{"beatsauth/_agent-component/default"},
+					"pipelines": map[string]any{
+						"logs/_agent-component/osquerybeat-default": map[string][]string{
+							"exporters":  {"elasticsearch/_agent-component/default"},
+							"processors": {"beat/_agent-component"},
+							"receivers":  {"osqreceiver/_agent-component/osquerybeat-default"},
+						},
+					},
+				},
+			}),
+		},
+		{
+			name: "packetbeat",
+			model: &component.Model{
+				Components: []component.Component{
+					{
+						ID:         "packetbeat-default",
+						InputType:  "packet",
+						OutputType: "elasticsearch",
+						OutputName: "default",
+						InputSpec: &component.InputRuntimeSpec{
+							BinaryName: "elastic-otel-collector",
+							Spec: component.InputSpec{
+								Command: &component.CommandSpec{
+									Args: []string{"packetbeat"},
+								},
+							},
+						},
+						Units: []component.Unit{
+							{
+								ID:     "packetbeat-unit",
+								Type:   client.UnitTypeInput,
+								Config: component.MustExpectedConfig(packetbeatInputConfig),
+							},
+							{
+								ID:     "packetbeat-default",
+								Type:   client.UnitTypeOutput,
+								Config: component.MustExpectedConfig(esOutputConfig()),
+							},
+						},
+					},
+				},
+			},
+			expectedConfig: confmap.NewFromStringMap(map[string]any{
+				"exporters": map[string]any{
+					"elasticsearch/_agent-component/default": expectedESConfig("default"),
+				},
+				"extensions": map[string]any{
+					"beatsauth/_agent-component/default": expectedExtensionConfig(),
+				},
+				"processors": map[string]any{
+					"beat/_agent-component": map[string]any{
+						"processors": defaultGlobalProcessors,
+					},
+				},
+				"receivers": map[string]any{
+					"pbreceiver/_agent-component/packetbeat-default": expectedPacketbeatReceiverConfig("packetbeat-default"),
+				},
+				"service": map[string]any{
+					"extensions": []any{"beatsauth/_agent-component/default"},
+					"pipelines": map[string]any{
+						"logs/_agent-component/packetbeat-default": map[string][]string{
+							"exporters":  {"elasticsearch/_agent-component/default"},
+							"processors": {"beat/_agent-component"},
+							"receivers":  {"pbreceiver/_agent-component/packetbeat-default"},
+						},
+					},
+				},
+			}),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1937,6 +2431,143 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 		},
 	}
 
+	auditbeatComponent := &component.Component{
+		ID:        "auditbeat-test-id",
+		InputType: "audit/auditd",
+		InputSpec: &component.InputRuntimeSpec{
+			BinaryName: "elastic-otel-collector",
+			Spec: component.InputSpec{
+				Name: "audit/auditd",
+				Command: &component.CommandSpec{
+					Args: []string{"auditbeat"},
+				},
+			},
+		},
+		Units: []component.Unit{
+			{
+				ID:   "auditbeat-test-id-unit",
+				Type: client.UnitTypeInput,
+				Config: component.MustExpectedConfig(map[string]any{
+					"id":         "test",
+					"use_output": "default",
+					"type":       "audit/auditd",
+					"streams": []any{
+						map[string]any{
+							"id": "test-1",
+							"data_stream": map[string]any{
+								"dataset": "generic-1",
+							},
+							"audit_rules": "-a exit,always -F arch=b64 -S open",
+						},
+					},
+				}),
+			},
+		},
+	}
+
+	heartbeatComponent := &component.Component{
+		ID:        "heartbeat-test-id",
+		InputType: "synthetics/http",
+		InputSpec: &component.InputRuntimeSpec{
+			BinaryName: "elastic-otel-collector",
+			Spec: component.InputSpec{
+				Name: "synthetics/http",
+				Command: &component.CommandSpec{
+					Args: []string{"heartbeat"},
+				},
+			},
+		},
+		Units: []component.Unit{
+			{
+				ID:   "heartbeat-test-id-unit",
+				Type: client.UnitTypeInput,
+				Config: component.MustExpectedConfig(map[string]any{
+					"id":         "test",
+					"use_output": "default",
+					"type":       "synthetics/http",
+					"streams": []any{
+						map[string]any{
+							"id": "test-1",
+							"data_stream": map[string]any{
+								"dataset": "generic-1",
+							},
+							"urls":     []any{"https://example.com"},
+							"schedule": "@every 5s",
+						},
+					},
+				}),
+			},
+		},
+	}
+
+	osquerybeatComponent := &component.Component{
+		ID:        "osquerybeat-test-id",
+		InputType: "osquery",
+		InputSpec: &component.InputRuntimeSpec{
+			BinaryName: "elastic-otel-collector",
+			Spec: component.InputSpec{
+				Name: "osquery",
+				Command: &component.CommandSpec{
+					Args: []string{"osquerybeat"},
+				},
+			},
+		},
+		Units: []component.Unit{
+			{
+				ID:   "osquerybeat-test-id-unit",
+				Type: client.UnitTypeInput,
+				Config: component.MustExpectedConfig(map[string]any{
+					"id":         "test",
+					"use_output": "default",
+					"type":       "osquery",
+					"streams": []any{
+						map[string]any{
+							"id": "test-1",
+							"data_stream": map[string]any{
+								"dataset": "generic-1",
+							},
+							"query": "SELECT * FROM processes",
+						},
+					},
+				}),
+			},
+		},
+	}
+
+	packetbeatComponent := &component.Component{
+		ID:        "packetbeat-test-id",
+		InputType: "packet",
+		InputSpec: &component.InputRuntimeSpec{
+			BinaryName: "elastic-otel-collector",
+			Spec: component.InputSpec{
+				Name: "packet",
+				Command: &component.CommandSpec{
+					Args: []string{"packetbeat"},
+				},
+			},
+		},
+		Units: []component.Unit{
+			{
+				ID:   "packetbeat-test-id-unit",
+				Type: client.UnitTypeInput,
+				Config: component.MustExpectedConfig(map[string]any{
+					"id":         "test",
+					"use_output": "default",
+					"type":       "packet",
+					"streams": []any{
+						map[string]any{
+							"id": "test-1",
+							"data_stream": map[string]any{
+								"dataset": "generic-1",
+							},
+							"ports": []any{443},
+						},
+					},
+				}),
+			},
+		},
+	}
+
 	tests := []struct {
 		name                 string
 		component            *component.Component
@@ -1961,6 +2592,34 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 			},
 			expectedReceiverType: "metricbeatreceiver",
 			expectedBeatName:     "metricbeat",
+		},
+		{
+			name:                 "auditbeat component",
+			component:            auditbeatComponent,
+			outputQueueConfig:    nil,
+			expectedReceiverType: "abreceiver",
+			expectedBeatName:     "auditbeat",
+		},
+		{
+			name:                 "heartbeat component",
+			component:            heartbeatComponent,
+			outputQueueConfig:    nil,
+			expectedReceiverType: "hbreceiver",
+			expectedBeatName:     "heartbeat",
+		},
+		{
+			name:                 "osquerybeat component",
+			component:            osquerybeatComponent,
+			outputQueueConfig:    nil,
+			expectedReceiverType: "osqreceiver",
+			expectedBeatName:     "osquerybeat",
+		},
+		{
+			name:                 "packetbeat component",
+			component:            packetbeatComponent,
+			outputQueueConfig:    nil,
+			expectedReceiverType: "pbreceiver",
+			expectedBeatName:     "packetbeat",
 		},
 		{
 			name: "component with no input units",

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -602,7 +602,7 @@ func TestGetOtelConfig(t *testing.T) {
 					"data_stream": map[string]any{
 						"dataset": "generic-1",
 					},
-					"ports":      []any{443, 8443},
+					"ports":      []any{float64(443), float64(8443)},
 					"index":      "logs-generic-1-default",
 					"processors": defaultInputProcessors("test-1", "generic-1", "logs"),
 					"type":       "packet",

--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -182,19 +183,24 @@ func (runner *AuditDRunner) TestBeatsMetrics() {
 		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
 			5*time.Minute, time.Second)
 
-		// Verify the component is running as a beats receiver
+		// Verify the user beat component (not monitoring components) is running as a beats receiver.
+		// Monitoring components are excluded because they may independently run as process-based
+		// beats regardless of the agent.internal.runtime.default override.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			status, statusErr := runner.agentFixture.ExecStatus(ctx)
 			require.NoError(collect, statusErr)
-			var hasReceiver bool
+			var hasUserReceiver bool
 			for _, comp := range status.Components {
+				if strings.HasSuffix(comp.ID, "-monitoring") {
+					continue
+				}
 				if comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
-					hasReceiver = true
+					hasUserReceiver = true
 					break
 				}
 			}
-			assert.True(collect, hasReceiver, "expected a component running as beats receiver")
-		}, 2*time.Minute, 5*time.Second, "component should be running as beats receiver")
+			assert.True(collect, hasUserReceiver, "expected the user beat component to be running as beats receiver")
+		}, 2*time.Minute, 5*time.Second, "user beat component should be running as beats receiver")
 
 		otelDoc = runner.validateAuditdEvents(ctx, agentStatus.Info.ID, otelSince)
 	})

--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -152,20 +152,6 @@ func (runner *AuditDRunner) TestBeatsMetrics() {
 	// Switch to OTel runtime and validate the same data
 	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
-		// Identify the auditd integration component (input type "audit/auditd") before
-		// switching runtime so we can verify that specific component transitions to the
-		// OTel receiver.
-		status, err := runner.agentFixture.ExecStatus(ctx)
-		require.NoError(t, err)
-		var integrationComponentID string
-		for _, comp := range status.Components {
-			if strings.HasPrefix(comp.ID, "audit/auditd") {
-				integrationComponentID = comp.ID
-				break
-			}
-		}
-		require.NotEmpty(t, integrationComponentID, "could not find auditd integration component before OTel switch")
-
 		otelSince := time.Now()
 		policyRevision := switchPolicyToOtelRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
 
@@ -173,19 +159,21 @@ func (runner *AuditDRunner) TestBeatsMetrics() {
 		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
 			5*time.Minute, time.Second)
 
-		// Verify the auditd integration component is now running as a beats receiver.
+		// Verify that an audit/auditd component is running as a beats receiver.
+		// The component may not appear immediately after the policy switch, so we
+		// look for it inside the loop rather than capturing its ID up front.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			status, statusErr := runner.agentFixture.ExecStatus(ctx)
 			require.NoError(collect, statusErr)
-			var isReceiver bool
+			var foundReceiver bool
 			for _, comp := range status.Components {
-				if comp.ID == integrationComponentID &&
+				if strings.HasPrefix(comp.ID, "audit/auditd") &&
 					comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
-					isReceiver = true
+					foundReceiver = true
 					break
 				}
 			}
-			assert.True(collect, isReceiver, "expected component %s to be running as beats receiver", integrationComponentID)
+			assert.True(collect, foundReceiver, "expected an audit/auditd component to be running as beats receiver")
 		}, 2*time.Minute, 5*time.Second, "beat component should be running as beats receiver")
 
 		t.Skip("abreceiver does not yet produce events, skipping OTel data validation")

--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -152,20 +152,19 @@ func (runner *AuditDRunner) TestBeatsMetrics() {
 	// Switch to OTel runtime and validate the same data
 	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
-		t.Skip("abreceiver does not yet produce events, skipping OTel validation")
-
-		// Identify the auditd integration component before switching runtime so we
-		// can verify that specific component transitions to the OTel receiver.
+		// Identify the auditd integration component (input type "audit/auditd") before
+		// switching runtime so we can verify that specific component transitions to the
+		// OTel receiver.
 		status, err := runner.agentFixture.ExecStatus(ctx)
 		require.NoError(t, err)
 		var integrationComponentID string
 		for _, comp := range status.Components {
-			if !strings.HasSuffix(comp.ID, "-monitoring") {
+			if strings.HasPrefix(comp.ID, "audit/auditd") {
 				integrationComponentID = comp.ID
 				break
 			}
 		}
-		require.NotEmpty(t, integrationComponentID, "could not find integration component ID before OTel switch")
+		require.NotEmpty(t, integrationComponentID, "could not find auditd integration component before OTel switch")
 
 		otelSince := time.Now()
 		policyRevision := switchPolicyToOtelRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
@@ -189,6 +188,7 @@ func (runner *AuditDRunner) TestBeatsMetrics() {
 			assert.True(collect, isReceiver, "expected component %s to be running as beats receiver", integrationComponentID)
 		}, 2*time.Minute, 5*time.Second, "beat component should be running as beats receiver")
 
+		t.Skip("abreceiver does not yet produce events, skipping OTel data validation")
 		otelDoc = runner.validateAuditdEvents(t, ctx, agentStatus.Info.ID, otelSince)
 	})
 

--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -173,6 +173,8 @@ func (runner *AuditDRunner) TestBeatsMetrics() {
 	// Switch to OTel runtime and validate the same data
 	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
+		t.Skip("abreceiver does not yet produce events, skipping OTel validation")
+
 		otelSince := time.Now()
 		policyRevision := runner.switchToOtelRuntime(ctx)
 

--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -134,7 +134,7 @@ func (runner *AuditDRunner) validateAuditdEvents(ctx context.Context, agentID st
 	}()
 
 	t.Logf("starting to query ES for auditd events at %s", now.Format(time.RFC3339Nano))
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		query = genESQuery(agentID,
 			[][]string{
 				{"exists", "field", "auditd.summary.actor.primary"},
@@ -148,12 +148,9 @@ func (runner *AuditDRunner) validateAuditdEvents(ctx context.Context, agentID st
 		}
 		now = time.Now()
 		res, err := estools.PerformQueryForRawQuery(ctx, query, "logs-auditd_manager.auditd*", runner.info.ESClient)
-		require.NoError(t, err)
-		if res.Hits.Total.Value < 1 {
-			return false
-		}
+		require.NoError(collect, err)
+		require.NotEmpty(collect, res.Hits.Hits)
 		doc = res.Hits.Hits[0].Source
-		return true
 	}, time.Minute*10, time.Second*10, "could not fetch events for auditd_manager")
 	return doc
 }

--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -7,23 +7,21 @@
 package ess
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
-	"net/http"
-	"net/http/httputil"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/elastic/elastic-agent-libs/kibana"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/testing/estools"
+	"github.com/elastic/elastic-agent/pkg/component"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
@@ -36,6 +34,7 @@ type AuditDRunner struct {
 	agentFixture *atesting.Fixture
 
 	ESHost     string
+	agentID    string
 	policyID   string
 	policyName string
 }
@@ -81,9 +80,10 @@ func (runner *AuditDRunner) SetupSuite() {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
-	policyResp, _, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
+	policyResp, agentID, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
 
+	runner.agentID = agentID
 	runner.policyID = policyResp.ID
 	runner.policyName = policyResp.Name
 
@@ -94,47 +94,26 @@ func (runner *AuditDRunner) SetupSuite() {
 
 }
 
-func (runner *AuditDRunner) switchToOtelRuntime() {
-	body := fmt.Sprintf(`
-{
-  "name": "%s",
-  "namespace": "%s",
-  "overrides": {
-    "agent": {
-      "internal": {
-        "runtime": {
-          "default": "otel"
-        }
-      }
-    }
-  }
-}
-`, runner.policyName, runner.info.Namespace)
-	resp, err := runner.info.KibanaClient.Send(
-		http.MethodPut,
-		fmt.Sprintf("/api/fleet/agent_policies/%s", runner.policyID),
-		nil,
-		nil,
-		bytes.NewBufferString(body),
-	)
-	if err != nil {
-		runner.T().Fatalf("could not execute request to Kibana/Fleet: %s", err)
+func (runner *AuditDRunner) switchToOtelRuntime(ctx context.Context) int {
+	updateReq := kibana.AgentPolicyUpdateRequest{
+		Name:      runner.policyName,
+		Namespace: runner.info.Namespace,
+		Overrides: map[string]interface{}{
+			"agent": map[string]interface{}{
+				"internal": map[string]interface{}{
+					"runtime": map[string]interface{}{
+						"default": "otel",
+					},
+				},
+			},
+		},
 	}
-	if resp.StatusCode != http.StatusOK {
-		runner.T().Errorf("received a non 200-OK when adding overwrite to policy. "+
-			"Status code: %d", resp.StatusCode)
-		respDump, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			runner.T().Fatalf("could not dump error response from Kibana: %s", err)
-		}
-		runner.T().Log("================================================================================")
-		runner.T().Log("Kibana error response:")
-		runner.T().Log(string(respDump))
-		runner.T().FailNow()
-	}
+	policyResp, err := runner.info.KibanaClient.UpdatePolicy(ctx, runner.policyID, updateReq)
+	require.NoError(runner.T(), err)
+	return policyResp.Revision
 }
 
-func (runner *AuditDRunner) validateAuditdEvents(ctx context.Context, agentID string) mapstr.M {
+func (runner *AuditDRunner) validateAuditdEvents(ctx context.Context, agentID string, since time.Time) mapstr.M {
 	t := runner.T()
 
 	now := time.Now()
@@ -159,6 +138,13 @@ func (runner *AuditDRunner) validateAuditdEvents(ctx context.Context, agentID st
 			[][]string{
 				{"exists", "field", "auditd.summary.actor.primary"},
 			})
+		if !since.IsZero() {
+			query["query"].(map[string]interface{})["bool"].(map[string]interface{})["filter"] = map[string]any{
+				"range": map[string]any{
+					"@timestamp": map[string]any{"gte": since.UTC().Format("2006-01-02T15:04:05.000Z")},
+				},
+			}
+		}
 		now = time.Now()
 		res, err := estools.PerformQueryForRawQuery(ctx, query, "logs-auditd_manager.auditd*", runner.info.ESClient)
 		require.NoError(t, err)
@@ -183,25 +169,34 @@ func (runner *AuditDRunner) TestBeatsMetrics() {
 	// Validate process mode
 	var processDoc mapstr.M
 	t.Run("process", func(t *testing.T) {
-		processDoc = runner.validateAuditdEvents(ctx, agentStatus.Info.ID)
+		processDoc = runner.validateAuditdEvents(ctx, agentStatus.Info.ID, time.Time{})
 	})
 
 	// Switch to OTel runtime and validate the same data
 	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
-		runner.switchToOtelRuntime()
+		otelSince := time.Now()
+		policyRevision := runner.switchToOtelRuntime(ctx)
 
-		// Wait for the agent to pick up the new policy and become healthy
-		require.Eventually(t, func() bool {
-			err := runner.agentFixture.IsHealthy(ctx)
-			if err != nil {
-				t.Logf("waiting for agent healthy after otel switch: %s", err.Error())
-				return false
+		// Wait for the agent to apply the new policy revision
+		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
+			5*time.Minute, time.Second)
+
+		// Verify the component is running as a beats receiver
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			status, statusErr := runner.agentFixture.ExecStatus(ctx)
+			require.NoError(collect, statusErr)
+			var hasReceiver bool
+			for _, comp := range status.Components {
+				if comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
+					hasReceiver = true
+					break
+				}
 			}
-			return true
-		}, 2*time.Minute, 5*time.Second)
+			assert.True(collect, hasReceiver, "expected a component running as beats receiver")
+		}, 2*time.Minute, 5*time.Second, "component should be running as beats receiver")
 
-		otelDoc = runner.validateAuditdEvents(ctx, agentStatus.Info.ID)
+		otelDoc = runner.validateAuditdEvents(ctx, agentStatus.Info.ID, otelSince)
 	})
 
 	// Compare documents from process and otel modes have the same keys

--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -95,25 +95,6 @@ func (runner *AuditDRunner) SetupSuite() {
 
 }
 
-func (runner *AuditDRunner) switchToOtelRuntime(ctx context.Context) int {
-	updateReq := kibana.AgentPolicyUpdateRequest{
-		Name:      runner.policyName,
-		Namespace: runner.info.Namespace,
-		Overrides: map[string]interface{}{
-			"agent": map[string]interface{}{
-				"internal": map[string]interface{}{
-					"runtime": map[string]interface{}{
-						"default": "otel",
-					},
-				},
-			},
-		},
-	}
-	policyResp, err := runner.info.KibanaClient.UpdatePolicy(ctx, runner.policyID, updateReq)
-	require.NoError(runner.T(), err)
-	return policyResp.Revision
-}
-
 func (runner *AuditDRunner) validateAuditdEvents(t *testing.T, ctx context.Context, agentID string, since time.Time) mapstr.M {
 	now := time.Now()
 	var query map[string]any
@@ -137,12 +118,10 @@ func (runner *AuditDRunner) validateAuditdEvents(t *testing.T, ctx context.Conte
 			[][]string{
 				{"exists", "field", "auditd.summary.actor.primary"},
 			})
-		if !since.IsZero() {
-			query["query"].(map[string]interface{})["bool"].(map[string]interface{})["filter"] = map[string]any{
-				"range": map[string]any{
-					"@timestamp": map[string]any{"gte": since.UTC().Format("2006-01-02T15:04:05.000Z")},
-				},
-			}
+		query["query"].(map[string]interface{})["bool"].(map[string]interface{})["filter"] = map[string]any{
+			"range": map[string]any{
+				"@timestamp": map[string]any{"gte": since.UTC().Format("2006-01-02T15:04:05.000Z")},
+			},
 		}
 		now = time.Now()
 		res, err := estools.PerformQueryForRawQuery(ctx, query, "logs-auditd_manager.auditd*", runner.info.ESClient)
@@ -162,10 +141,12 @@ func (runner *AuditDRunner) TestBeatsMetrics() {
 	agentStatus, err := runner.agentFixture.ExecStatus(ctx)
 	require.NoError(t, err, "could not get agent status")
 
+	testStart := time.Now()
+
 	// Validate process mode
 	var processDoc mapstr.M
 	t.Run("process", func(t *testing.T) {
-		processDoc = runner.validateAuditdEvents(t, ctx, agentStatus.Info.ID, time.Time{})
+		processDoc = runner.validateAuditdEvents(t, ctx, agentStatus.Info.ID, testStart)
 	})
 
 	// Switch to OTel runtime and validate the same data
@@ -173,31 +154,40 @@ func (runner *AuditDRunner) TestBeatsMetrics() {
 	t.Run("otel", func(t *testing.T) {
 		t.Skip("abreceiver does not yet produce events, skipping OTel validation")
 
+		// Identify the auditd integration component before switching runtime so we
+		// can verify that specific component transitions to the OTel receiver.
+		status, err := runner.agentFixture.ExecStatus(ctx)
+		require.NoError(t, err)
+		var integrationComponentID string
+		for _, comp := range status.Components {
+			if !strings.HasSuffix(comp.ID, "-monitoring") {
+				integrationComponentID = comp.ID
+				break
+			}
+		}
+		require.NotEmpty(t, integrationComponentID, "could not find integration component ID before OTel switch")
+
 		otelSince := time.Now()
-		policyRevision := runner.switchToOtelRuntime(ctx)
+		policyRevision := switchPolicyToOtelRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
 
 		// Wait for the agent to apply the new policy revision
 		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
 			5*time.Minute, time.Second)
 
-		// Verify the user beat component (not monitoring components) is running as a beats receiver.
-		// Monitoring components are excluded because they may independently run as process-based
-		// beats regardless of the agent.internal.runtime.default override.
+		// Verify the auditd integration component is now running as a beats receiver.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			status, statusErr := runner.agentFixture.ExecStatus(ctx)
 			require.NoError(collect, statusErr)
-			var hasUserReceiver bool
+			var isReceiver bool
 			for _, comp := range status.Components {
-				if strings.HasSuffix(comp.ID, "-monitoring") {
-					continue
-				}
-				if comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
-					hasUserReceiver = true
+				if comp.ID == integrationComponentID &&
+					comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
+					isReceiver = true
 					break
 				}
 			}
-			assert.True(collect, hasUserReceiver, "expected the user beat component to be running as beats receiver")
-		}, 2*time.Minute, 5*time.Second, "user beat component should be running as beats receiver")
+			assert.True(collect, isReceiver, "expected component %s to be running as beats receiver", integrationComponentID)
+		}, 2*time.Minute, 5*time.Second, "beat component should be running as beats receiver")
 
 		otelDoc = runner.validateAuditdEvents(t, ctx, agentStatus.Info.ID, otelSince)
 	})

--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -114,9 +114,7 @@ func (runner *AuditDRunner) switchToOtelRuntime(ctx context.Context) int {
 	return policyResp.Revision
 }
 
-func (runner *AuditDRunner) validateAuditdEvents(ctx context.Context, agentID string, since time.Time) mapstr.M {
-	t := runner.T()
-
+func (runner *AuditDRunner) validateAuditdEvents(t *testing.T, ctx context.Context, agentID string, since time.Time) mapstr.M {
 	now := time.Now()
 	var query map[string]any
 	var doc mapstr.M
@@ -167,7 +165,7 @@ func (runner *AuditDRunner) TestBeatsMetrics() {
 	// Validate process mode
 	var processDoc mapstr.M
 	t.Run("process", func(t *testing.T) {
-		processDoc = runner.validateAuditdEvents(ctx, agentStatus.Info.ID, time.Time{})
+		processDoc = runner.validateAuditdEvents(t, ctx, agentStatus.Info.ID, time.Time{})
 	})
 
 	// Switch to OTel runtime and validate the same data
@@ -201,7 +199,7 @@ func (runner *AuditDRunner) TestBeatsMetrics() {
 			assert.True(collect, hasUserReceiver, "expected the user beat component to be running as beats receiver")
 		}, 2*time.Minute, 5*time.Second, "user beat component should be running as beats receiver")
 
-		otelDoc = runner.validateAuditdEvents(ctx, agentStatus.Info.ID, otelSince)
+		otelDoc = runner.validateAuditdEvents(t, ctx, agentStatus.Info.ID, otelSince)
 	})
 
 	// Compare documents from process and otel modes have the same keys

--- a/testing/integration/ess/beat_monitoring_helpers_test.go
+++ b/testing/integration/ess/beat_monitoring_helpers_test.go
@@ -1,0 +1,38 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build integration
+
+package ess
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/kibana"
+)
+
+// switchPolicyToOtelRuntime updates the given policy to use the OTel runtime
+// and returns the new policy revision.
+func switchPolicyToOtelRuntime(ctx context.Context, t testing.TB, kibanaClient *kibana.Client, policyID, policyName, namespace string) int {
+	t.Helper()
+	updateReq := kibana.AgentPolicyUpdateRequest{
+		Name:      policyName,
+		Namespace: namespace,
+		Overrides: map[string]interface{}{
+			"agent": map[string]interface{}{
+				"internal": map[string]interface{}{
+					"runtime": map[string]interface{}{
+						"default": "otel",
+					},
+				},
+			},
+		},
+	}
+	policyResp, err := kibanaClient.UpdatePolicy(ctx, policyID, updateReq)
+	require.NoError(t, err)
+	return policyResp.Revision
+}

--- a/testing/integration/ess/checkin_compress_test.go
+++ b/testing/integration/ess/checkin_compress_test.go
@@ -79,13 +79,6 @@ func TestCheckinCompress(t *testing.T) {
 		},
 	}
 
-	// NOTE: Privileged is intentionally unset (defaults to false = unprivileged install).
-	// If this test starts failing with "dial unix /opt/Elastic/Agent/elastic-agent.sock:
-	// connect: no such file or directory" during enrollment, the root cause is that the
-	// elastic-agent-user service account does not have write access to the install
-	// directory and therefore cannot create the control socket. Fix by ensuring the
-	// agent writes its socket to a path writable by elastic-agent-user in unprivileged
-	// mode (see internal/pkg/agent/cmd/enroll_cmd.go daemonReloadWithBackoff).
 	installOpts := atesting.InstallOpts{
 		NonInteractive: true,
 		Force:          true,

--- a/testing/integration/ess/checkin_compress_test.go
+++ b/testing/integration/ess/checkin_compress_test.go
@@ -79,6 +79,13 @@ func TestCheckinCompress(t *testing.T) {
 		},
 	}
 
+	// NOTE: Privileged is intentionally unset (defaults to false = unprivileged install).
+	// If this test starts failing with "dial unix /opt/Elastic/Agent/elastic-agent.sock:
+	// connect: no such file or directory" during enrollment, the root cause is that the
+	// elastic-agent-user service account does not have write access to the install
+	// directory and therefore cannot create the control socket. Fix by ensuring the
+	// agent writes its socket to a path writable by elastic-agent-user in unprivileged
+	// mode (see internal/pkg/agent/cmd/enroll_cmd.go daemonReloadWithBackoff).
 	installOpts := atesting.InstallOpts{
 		NonInteractive: true,
 		Force:          true,

--- a/testing/integration/ess/fips_test.go
+++ b/testing/integration/ess/fips_test.go
@@ -205,9 +205,6 @@ func addIntegrationAndCheckData(t *testing.T, info *define.Info, fixture *atesti
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		docs, err := estools.GetResultsForAgentAndDatastream(ctx, info.ESClient, "system.cpu", status.Info.ID)
 		require.NoError(collect, err, "error fetching system metrics")
-		if err != nil {
-			return
-		}
 		t.Logf("Generated %d system events", docs.Hits.Total.Value)
 		assert.True(collect, docs.Hits.Total.Value > 0)
 	}, 2*time.Minute, 5*time.Second, "no system.cpu data received in Elasticsearch")

--- a/testing/integration/ess/fips_test.go
+++ b/testing/integration/ess/fips_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/kibana"
@@ -79,12 +80,17 @@ func ensureFleetServerInDeploymentIsHealthyAndFIPSCapable(t *testing.T, info *de
 	t.Logf("statusUrl = %s", statusUrl)
 	require.NoError(t, err)
 
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		resp, err := http.Get(statusUrl)
-		require.NoError(t, err)
+		require.NoError(collect, err)
+		if err != nil {
+			return
+		}
 		defer resp.Body.Close()
 
-		require.Equal(t, http.StatusOK, resp.StatusCode)
+		if !assert.Equal(collect, http.StatusOK, resp.StatusCode) {
+			return
+		}
 
 		var body struct {
 			Name   string `json:"name"`
@@ -92,13 +98,16 @@ func ensureFleetServerInDeploymentIsHealthyAndFIPSCapable(t *testing.T, info *de
 		}
 		decoder := json.NewDecoder(resp.Body)
 		err = decoder.Decode(&body)
-		require.NoError(t, err)
+		require.NoError(collect, err)
+		if err != nil {
+			return
+		}
 
 		t.Logf("body.Status = %s", body.Status)
-		return body.Status == "HEALTHY"
+		assert.Equal(collect, "HEALTHY", body.Status)
 	}, 5*time.Minute, 10*time.Second, "Fleet Server in ECH deployment is not healthy")
 
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
@@ -115,9 +124,14 @@ func ensureFleetServerInDeploymentIsHealthyAndFIPSCapable(t *testing.T, info *de
 				}
 			}`,
 			)))
-		require.NoError(t, err)
+		require.NoError(collect, err)
+		if err != nil {
+			return
+		}
 		defer searchResp.Body.Close()
-		require.Equal(t, http.StatusOK, searchResp.StatusCode)
+		if !assert.Equal(collect, http.StatusOK, searchResp.StatusCode) {
+			return
+		}
 
 		respObj := struct {
 			Hits struct {
@@ -140,14 +154,20 @@ func ensureFleetServerInDeploymentIsHealthyAndFIPSCapable(t *testing.T, info *de
 		}{}
 
 		err = json.NewDecoder(searchResp.Body).Decode(&respObj)
-		require.NoError(t, err)
-		require.Equal(t, 1, respObj.Hits.Total.Value, "expected only one hit from the ES query")
+		require.NoError(collect, err)
+		if err != nil {
+			return
+		}
+		if !assert.Equal(collect, 1, respObj.Hits.Total.Value, "expected only one hit from the ES query") || len(respObj.Hits.Hits) == 0 {
+			return
+		}
 
 		// Check that this Agent is online (i.e. healthy) and is FIPS-capable. This
 		// will prove that a FIPS-capable Agent is able to connect to a FIPS-capable
 		// Fleet Server, with both running in ECH.
 		t.Logf("FIPS: %v, Status: %s", respObj.Hits.Hits[0].Source.LocalMetadata.Elastic.Agent.FIPS, respObj.Hits.Hits[0].Source.LastCheckinStatus)
-		return respObj.Hits.Hits[0].Source.LocalMetadata.Elastic.Agent.FIPS && respObj.Hits.Hits[0].Source.LastCheckinStatus == "online"
+		assert.True(collect, respObj.Hits.Hits[0].Source.LocalMetadata.Elastic.Agent.FIPS, "expected Fleet Server's Agent to be FIPS-capable")
+		assert.Equal(collect, "online", respObj.Hits.Hits[0].Source.LastCheckinStatus, "expected Fleet Server's Agent to be online")
 	}, 10*time.Second, 200*time.Millisecond, "Fleet Server's Elastic Agent should be healthy and FIPS-capable")
 }
 
@@ -200,12 +220,14 @@ func addIntegrationAndCheckData(t *testing.T, info *define.Info, fixture *atesti
 	t.Logf("status: %v", status)
 
 	// Check that system metrics show up in Elasticsearch
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		docs, err := estools.GetResultsForAgentAndDatastream(ctx, info.ESClient, "system.cpu", status.Info.ID)
-		require.NoError(t, err, "error fetching system metrics")
+		require.NoError(collect, err, "error fetching system metrics")
+		if err != nil {
+			return
+		}
 		t.Logf("Generated %d system events", docs.Hits.Total.Value)
-
-		return docs.Hits.Total.Value > 0
+		assert.True(collect, docs.Hits.Total.Value > 0)
 	}, 2*time.Minute, 5*time.Second, "no system.cpu data received in Elasticsearch")
 
 	// Check that system logs show up in Elasticsearch
@@ -215,12 +237,14 @@ func addIntegrationAndCheckData(t *testing.T, info *define.Info, fixture *atesti
 	} else {
 		dataStreamName = "system.syslog"
 	}
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		docs, err := estools.GetResultsForAgentAndDatastream(ctx, info.ESClient, dataStreamName, status.Info.ID)
-		require.NoError(t, err, "error fetching system logs")
+		require.NoError(collect, err, "error fetching system logs")
+		if err != nil {
+			return
+		}
 		t.Logf("Generated %d system events", docs.Hits.Total.Value)
-
-		return docs.Hits.Total.Value > 0
+		assert.True(collect, docs.Hits.Total.Value > 0)
 	}, 2*time.Minute, 5*time.Second, "no system.syslog data received in Elasticsearch")
 }
 

--- a/testing/integration/ess/fips_test.go
+++ b/testing/integration/ess/fips_test.go
@@ -83,14 +83,9 @@ func ensureFleetServerInDeploymentIsHealthyAndFIPSCapable(t *testing.T, info *de
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		resp, err := http.Get(statusUrl)
 		require.NoError(collect, err)
-		if err != nil {
-			return
-		}
 		defer resp.Body.Close()
 
-		if !assert.Equal(collect, http.StatusOK, resp.StatusCode) {
-			return
-		}
+		require.Equal(collect, http.StatusOK, resp.StatusCode)
 
 		var body struct {
 			Name   string `json:"name"`
@@ -99,9 +94,6 @@ func ensureFleetServerInDeploymentIsHealthyAndFIPSCapable(t *testing.T, info *de
 		decoder := json.NewDecoder(resp.Body)
 		err = decoder.Decode(&body)
 		require.NoError(collect, err)
-		if err != nil {
-			return
-		}
 
 		t.Logf("body.Status = %s", body.Status)
 		assert.Equal(collect, "HEALTHY", body.Status)
@@ -125,13 +117,8 @@ func ensureFleetServerInDeploymentIsHealthyAndFIPSCapable(t *testing.T, info *de
 			}`,
 			)))
 		require.NoError(collect, err)
-		if err != nil {
-			return
-		}
 		defer searchResp.Body.Close()
-		if !assert.Equal(collect, http.StatusOK, searchResp.StatusCode) {
-			return
-		}
+		require.Equal(collect, http.StatusOK, searchResp.StatusCode)
 
 		respObj := struct {
 			Hits struct {
@@ -155,12 +142,7 @@ func ensureFleetServerInDeploymentIsHealthyAndFIPSCapable(t *testing.T, info *de
 
 		err = json.NewDecoder(searchResp.Body).Decode(&respObj)
 		require.NoError(collect, err)
-		if err != nil {
-			return
-		}
-		if !assert.Equal(collect, 1, respObj.Hits.Total.Value, "expected only one hit from the ES query") || len(respObj.Hits.Hits) == 0 {
-			return
-		}
+		require.Equal(collect, 1, respObj.Hits.Total.Value, "expected only one hit from the ES query")
 
 		// Check that this Agent is online (i.e. healthy) and is FIPS-capable. This
 		// will prove that a FIPS-capable Agent is able to connect to a FIPS-capable

--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -100,25 +100,6 @@ func (runner *NetworkTrafficRunner) SetupSuite() {
 
 }
 
-func (runner *NetworkTrafficRunner) switchToOtelRuntime(ctx context.Context) int {
-	updateReq := kibana.AgentPolicyUpdateRequest{
-		Name:      runner.policyName,
-		Namespace: runner.info.Namespace,
-		Overrides: map[string]interface{}{
-			"agent": map[string]interface{}{
-				"internal": map[string]interface{}{
-					"runtime": map[string]interface{}{
-						"default": "otel",
-					},
-				},
-			},
-		},
-	}
-	policyResp, err := runner.info.KibanaClient.UpdatePolicy(ctx, runner.policyID, updateReq)
-	require.NoError(runner.T(), err)
-	return policyResp.Revision
-}
-
 func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(t *testing.T, ctx context.Context, agentID string, since time.Time) mapstr.M {
 	now := time.Now()
 	var query map[string]any
@@ -142,12 +123,10 @@ func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(t *testing.T, c
 			[][]string{
 				{"exists", "field", "tls.client.server_name"},
 			})
-		if !since.IsZero() {
-			query["query"].(map[string]interface{})["bool"].(map[string]interface{})["filter"] = map[string]any{
-				"range": map[string]any{
-					"@timestamp": map[string]any{"gte": since.UTC().Format("2006-01-02T15:04:05.000Z")},
-				},
-			}
+		query["query"].(map[string]interface{})["bool"].(map[string]interface{})["filter"] = map[string]any{
+			"range": map[string]any{
+				"@timestamp": map[string]any{"gte": since.UTC().Format("2006-01-02T15:04:05.000Z")},
+			},
 		}
 		now = time.Now()
 		res, err := estools.PerformQueryForRawQuery(ctx, query, "logs-network_traffic.tls*", runner.info.ESClient)
@@ -167,10 +146,12 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 	agentStatus, err := runner.agentFixture.ExecStatus(ctx)
 	require.NoError(t, err, "could not get agent status")
 
+	testStart := time.Now()
+
 	// Validate process mode
 	var processDoc mapstr.M
 	t.Run("process", func(t *testing.T) {
-		processDoc = runner.validateNetworkTrafficEvents(t, ctx, agentStatus.Info.ID, time.Time{})
+		processDoc = runner.validateNetworkTrafficEvents(t, ctx, agentStatus.Info.ID, testStart)
 	})
 
 	// Switch to OTel runtime and validate the same data
@@ -178,31 +159,40 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 	t.Run("otel", func(t *testing.T) {
 		t.Skip("pbreceiver does not yet produce events, skipping OTel validation")
 
+		// Identify the network_traffic integration component before switching runtime so
+		// we can verify that specific component transitions to the OTel receiver.
+		status, err := runner.agentFixture.ExecStatus(ctx)
+		require.NoError(t, err)
+		var integrationComponentID string
+		for _, comp := range status.Components {
+			if !strings.HasSuffix(comp.ID, "-monitoring") {
+				integrationComponentID = comp.ID
+				break
+			}
+		}
+		require.NotEmpty(t, integrationComponentID, "could not find integration component ID before OTel switch")
+
 		otelSince := time.Now()
-		policyRevision := runner.switchToOtelRuntime(ctx)
+		policyRevision := switchPolicyToOtelRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
 
 		// Wait for the agent to apply the new policy revision
 		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
 			5*time.Minute, time.Second)
 
-		// Verify the user beat component (not monitoring components) is running as a beats receiver.
-		// Monitoring components are excluded because they may independently run as process-based
-		// beats regardless of the agent.internal.runtime.default override.
+		// Verify the network_traffic integration component is now running as a beats receiver.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			status, statusErr := runner.agentFixture.ExecStatus(ctx)
 			require.NoError(collect, statusErr)
-			var hasUserReceiver bool
+			var isReceiver bool
 			for _, comp := range status.Components {
-				if strings.HasSuffix(comp.ID, "-monitoring") {
-					continue
-				}
-				if comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
-					hasUserReceiver = true
+				if comp.ID == integrationComponentID &&
+					comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
+					isReceiver = true
 					break
 				}
 			}
-			assert.True(collect, hasUserReceiver, "expected the user beat component to be running as beats receiver")
-		}, 2*time.Minute, 5*time.Second, "user beat component should be running as beats receiver")
+			assert.True(collect, isReceiver, "expected component %s to be running as beats receiver", integrationComponentID)
+		}, 2*time.Minute, 5*time.Second, "beat component should be running as beats receiver")
 
 		otelDoc = runner.validateNetworkTrafficEvents(t, ctx, agentStatus.Info.ID, otelSince)
 	})

--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -157,20 +157,19 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 	// Switch to OTel runtime and validate the same data
 	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
-		t.Skip("pbreceiver does not yet produce events, skipping OTel validation")
-
-		// Identify the network_traffic integration component before switching runtime so
-		// we can verify that specific component transitions to the OTel receiver.
+		// Identify the network_traffic integration component (input type "packet") before
+		// switching runtime so we can verify that specific component transitions to the
+		// OTel receiver.
 		status, err := runner.agentFixture.ExecStatus(ctx)
 		require.NoError(t, err)
 		var integrationComponentID string
 		for _, comp := range status.Components {
-			if !strings.HasSuffix(comp.ID, "-monitoring") {
+			if strings.HasPrefix(comp.ID, "packet") {
 				integrationComponentID = comp.ID
 				break
 			}
 		}
-		require.NotEmpty(t, integrationComponentID, "could not find integration component ID before OTel switch")
+		require.NotEmpty(t, integrationComponentID, "could not find packet (network_traffic) integration component before OTel switch")
 
 		otelSince := time.Now()
 		policyRevision := switchPolicyToOtelRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
@@ -194,6 +193,7 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 			assert.True(collect, isReceiver, "expected component %s to be running as beats receiver", integrationComponentID)
 		}, 2*time.Minute, 5*time.Second, "beat component should be running as beats receiver")
 
+		t.Skip("pbreceiver does not yet produce events, skipping OTel data validation")
 		otelDoc = runner.validateNetworkTrafficEvents(t, ctx, agentStatus.Info.ID, otelSince)
 	})
 

--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -7,23 +7,21 @@
 package ess
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
-	"net/http"
-	"net/http/httputil"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/elastic/elastic-agent-libs/kibana"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/testing/estools"
+	"github.com/elastic/elastic-agent/pkg/component"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
@@ -36,6 +34,7 @@ type NetworkTrafficRunner struct {
 	agentFixture *atesting.Fixture
 
 	ESHost     string
+	agentID    string
 	policyID   string
 	policyName string
 }
@@ -84,9 +83,10 @@ func (runner *NetworkTrafficRunner) SetupSuite() {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
-	policyResp, _, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
+	policyResp, agentID, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
 
+	runner.agentID = agentID
 	runner.policyID = policyResp.ID
 	runner.policyName = policyResp.Name
 
@@ -97,47 +97,26 @@ func (runner *NetworkTrafficRunner) SetupSuite() {
 
 }
 
-func (runner *NetworkTrafficRunner) switchToOtelRuntime() {
-	body := fmt.Sprintf(`
-{
-  "name": "%s",
-  "namespace": "%s",
-  "overrides": {
-    "agent": {
-      "internal": {
-        "runtime": {
-          "default": "otel"
-        }
-      }
-    }
-  }
-}
-`, runner.policyName, runner.info.Namespace)
-	resp, err := runner.info.KibanaClient.Send(
-		http.MethodPut,
-		fmt.Sprintf("/api/fleet/agent_policies/%s", runner.policyID),
-		nil,
-		nil,
-		bytes.NewBufferString(body),
-	)
-	if err != nil {
-		runner.T().Fatalf("could not execute request to Kibana/Fleet: %s", err)
+func (runner *NetworkTrafficRunner) switchToOtelRuntime(ctx context.Context) int {
+	updateReq := kibana.AgentPolicyUpdateRequest{
+		Name:      runner.policyName,
+		Namespace: runner.info.Namespace,
+		Overrides: map[string]interface{}{
+			"agent": map[string]interface{}{
+				"internal": map[string]interface{}{
+					"runtime": map[string]interface{}{
+						"default": "otel",
+					},
+				},
+			},
+		},
 	}
-	if resp.StatusCode != http.StatusOK {
-		runner.T().Errorf("received a non 200-OK when adding overwrite to policy. "+
-			"Status code: %d", resp.StatusCode)
-		respDump, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			runner.T().Fatalf("could not dump error response from Kibana: %s", err)
-		}
-		runner.T().Log("================================================================================")
-		runner.T().Log("Kibana error response:")
-		runner.T().Log(string(respDump))
-		runner.T().FailNow()
-	}
+	policyResp, err := runner.info.KibanaClient.UpdatePolicy(ctx, runner.policyID, updateReq)
+	require.NoError(runner.T(), err)
+	return policyResp.Revision
 }
 
-func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(ctx context.Context, agentID string) mapstr.M {
+func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(ctx context.Context, agentID string, since time.Time) mapstr.M {
 	t := runner.T()
 
 	now := time.Now()
@@ -162,6 +141,13 @@ func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(ctx context.Con
 			[][]string{
 				{"exists", "field", "tls.client.server_name"},
 			})
+		if !since.IsZero() {
+			query["query"].(map[string]interface{})["bool"].(map[string]interface{})["filter"] = map[string]any{
+				"range": map[string]any{
+					"@timestamp": map[string]any{"gte": since.UTC().Format("2006-01-02T15:04:05.000Z")},
+				},
+			}
+		}
 		now = time.Now()
 		res, err := estools.PerformQueryForRawQuery(ctx, query, "logs-network_traffic.tls*", runner.info.ESClient)
 		require.NoError(t, err)
@@ -186,25 +172,34 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 	// Validate process mode
 	var processDoc mapstr.M
 	t.Run("process", func(t *testing.T) {
-		processDoc = runner.validateNetworkTrafficEvents(ctx, agentStatus.Info.ID)
+		processDoc = runner.validateNetworkTrafficEvents(ctx, agentStatus.Info.ID, time.Time{})
 	})
 
 	// Switch to OTel runtime and validate the same data
 	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
-		runner.switchToOtelRuntime()
+		otelSince := time.Now()
+		policyRevision := runner.switchToOtelRuntime(ctx)
 
-		// Wait for the agent to pick up the new policy and become healthy
-		require.Eventually(t, func() bool {
-			err := runner.agentFixture.IsHealthy(ctx)
-			if err != nil {
-				t.Logf("waiting for agent healthy after otel switch: %s", err.Error())
-				return false
+		// Wait for the agent to apply the new policy revision
+		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
+			5*time.Minute, time.Second)
+
+		// Verify the component is running as a beats receiver
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			status, statusErr := runner.agentFixture.ExecStatus(ctx)
+			require.NoError(collect, statusErr)
+			var hasReceiver bool
+			for _, comp := range status.Components {
+				if comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
+					hasReceiver = true
+					break
+				}
 			}
-			return true
-		}, 2*time.Minute, 5*time.Second)
+			assert.True(collect, hasReceiver, "expected a component running as beats receiver")
+		}, 2*time.Minute, 5*time.Second, "component should be running as beats receiver")
 
-		otelDoc = runner.validateNetworkTrafficEvents(ctx, agentStatus.Info.ID)
+		otelDoc = runner.validateNetworkTrafficEvents(ctx, agentStatus.Info.ID, otelSince)
 	})
 
 	// Compare documents from process and otel modes have the same keys

--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -157,20 +157,6 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 	// Switch to OTel runtime and validate the same data
 	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
-		// Identify the network_traffic integration component (input type "packet") before
-		// switching runtime so we can verify that specific component transitions to the
-		// OTel receiver.
-		status, err := runner.agentFixture.ExecStatus(ctx)
-		require.NoError(t, err)
-		var integrationComponentID string
-		for _, comp := range status.Components {
-			if strings.HasPrefix(comp.ID, "packet") {
-				integrationComponentID = comp.ID
-				break
-			}
-		}
-		require.NotEmpty(t, integrationComponentID, "could not find packet (network_traffic) integration component before OTel switch")
-
 		otelSince := time.Now()
 		policyRevision := switchPolicyToOtelRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
 
@@ -178,19 +164,21 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
 			5*time.Minute, time.Second)
 
-		// Verify the network_traffic integration component is now running as a beats receiver.
+		// Verify that a packet (network_traffic) component is running as a beats receiver.
+		// The component may not appear immediately after the policy switch, so we
+		// look for it inside the loop rather than capturing its ID up front.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			status, statusErr := runner.agentFixture.ExecStatus(ctx)
 			require.NoError(collect, statusErr)
-			var isReceiver bool
+			var foundReceiver bool
 			for _, comp := range status.Components {
-				if comp.ID == integrationComponentID &&
+				if strings.HasPrefix(comp.ID, "packet") &&
 					comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
-					isReceiver = true
+					foundReceiver = true
 					break
 				}
 			}
-			assert.True(collect, isReceiver, "expected component %s to be running as beats receiver", integrationComponentID)
+			assert.True(collect, foundReceiver, "expected a packet (network_traffic) component to be running as beats receiver")
 		}, 2*time.Minute, 5*time.Second, "beat component should be running as beats receiver")
 
 		t.Skip("pbreceiver does not yet produce events, skipping OTel data validation")

--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -119,9 +119,7 @@ func (runner *NetworkTrafficRunner) switchToOtelRuntime(ctx context.Context) int
 	return policyResp.Revision
 }
 
-func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(ctx context.Context, agentID string, since time.Time) mapstr.M {
-	t := runner.T()
-
+func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(t *testing.T, ctx context.Context, agentID string, since time.Time) mapstr.M {
 	now := time.Now()
 	var query map[string]any
 	var doc mapstr.M
@@ -172,12 +170,14 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 	// Validate process mode
 	var processDoc mapstr.M
 	t.Run("process", func(t *testing.T) {
-		processDoc = runner.validateNetworkTrafficEvents(ctx, agentStatus.Info.ID, time.Time{})
+		processDoc = runner.validateNetworkTrafficEvents(t, ctx, agentStatus.Info.ID, time.Time{})
 	})
 
 	// Switch to OTel runtime and validate the same data
 	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
+		t.Skip("pbreceiver does not yet produce events, skipping OTel validation")
+
 		otelSince := time.Now()
 		policyRevision := runner.switchToOtelRuntime(ctx)
 
@@ -204,7 +204,7 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 			assert.True(collect, hasUserReceiver, "expected the user beat component to be running as beats receiver")
 		}, 2*time.Minute, 5*time.Second, "user beat component should be running as beats receiver")
 
-		otelDoc = runner.validateNetworkTrafficEvents(ctx, agentStatus.Info.ID, otelSince)
+		otelDoc = runner.validateNetworkTrafficEvents(t, ctx, agentStatus.Info.ID, otelSince)
 	})
 
 	// Compare documents from process and otel modes have the same keys

--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -81,7 +81,9 @@ func (runner *NetworkTrafficRunner) SetupSuite() {
 		Privileged:     true,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	// 5 minutes: agent install can take 2+ minutes on slow machines, leaving
+	// insufficient time for the subsequent package install with a 3-minute budget.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	policyResp, agentID, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)

--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -185,19 +186,24 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
 			5*time.Minute, time.Second)
 
-		// Verify the component is running as a beats receiver
+		// Verify the user beat component (not monitoring components) is running as a beats receiver.
+		// Monitoring components are excluded because they may independently run as process-based
+		// beats regardless of the agent.internal.runtime.default override.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			status, statusErr := runner.agentFixture.ExecStatus(ctx)
 			require.NoError(collect, statusErr)
-			var hasReceiver bool
+			var hasUserReceiver bool
 			for _, comp := range status.Components {
+				if strings.HasSuffix(comp.ID, "-monitoring") {
+					continue
+				}
 				if comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
-					hasReceiver = true
+					hasUserReceiver = true
 					break
 				}
 			}
-			assert.True(collect, hasReceiver, "expected a component running as beats receiver")
-		}, 2*time.Minute, 5*time.Second, "component should be running as beats receiver")
+			assert.True(collect, hasUserReceiver, "expected the user beat component to be running as beats receiver")
+		}, 2*time.Minute, 5*time.Second, "user beat component should be running as beats receiver")
 
 		otelDoc = runner.validateNetworkTrafficEvents(ctx, agentStatus.Info.ID, otelSince)
 	})

--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -137,7 +137,7 @@ func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(ctx context.Con
 	}()
 
 	t.Logf("starting to query ES for network traffic events at %s", now.Format(time.RFC3339Nano))
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		query = genESQuery(agentID,
 			[][]string{
 				{"exists", "field", "tls.client.server_name"},
@@ -151,12 +151,9 @@ func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(ctx context.Con
 		}
 		now = time.Now()
 		res, err := estools.PerformQueryForRawQuery(ctx, query, "logs-network_traffic.tls*", runner.info.ESClient)
-		require.NoError(t, err)
-		if res.Hits.Total.Value < 1 {
-			return false
-		}
+		require.NoError(collect, err)
+		require.NotEmpty(collect, res.Hits.Hits)
 		doc = res.Hits.Hits[0].Source
-		return true
 	}, time.Minute*10, time.Second*10, "could not fetch events for network_traffic")
 	return doc
 }

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -150,20 +150,6 @@ func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 	// Switch to OTel runtime and validate the same data
 	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
-		// Identify the osquery integration component (input type "osquery") before
-		// switching runtime so we can verify that specific component transitions to the
-		// OTel receiver.
-		status, err := runner.agentFixture.ExecStatus(ctx)
-		require.NoError(t, err)
-		var integrationComponentID string
-		for _, comp := range status.Components {
-			if strings.HasPrefix(comp.ID, "osquery") {
-				integrationComponentID = comp.ID
-				break
-			}
-		}
-		require.NotEmpty(t, integrationComponentID, "could not find osquery integration component before OTel switch")
-
 		otelSince := time.Now()
 		policyRevision := switchPolicyToOtelRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
 
@@ -171,19 +157,21 @@ func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
 			5*time.Minute, time.Second)
 
-		// Verify the osquery integration component is now running as a beats receiver.
+		// Verify that an osquery component is running as a beats receiver.
+		// The component may not appear immediately after the policy switch, so we
+		// look for it inside the loop rather than capturing its ID up front.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			status, statusErr := runner.agentFixture.ExecStatus(ctx)
 			require.NoError(collect, statusErr)
-			var isReceiver bool
+			var foundReceiver bool
 			for _, comp := range status.Components {
-				if comp.ID == integrationComponentID &&
+				if strings.HasPrefix(comp.ID, "osquery") &&
 					comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
-					isReceiver = true
+					foundReceiver = true
 					break
 				}
 			}
-			assert.True(collect, isReceiver, "expected component %s to be running as beats receiver", integrationComponentID)
+			assert.True(collect, foundReceiver, "expected an osquery component to be running as beats receiver")
 		}, 2*time.Minute, 5*time.Second, "beat component should be running as beats receiver")
 
 		t.Skip("osqreceiver does not yet produce events, skipping OTel data validation")

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -150,20 +150,19 @@ func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 	// Switch to OTel runtime and validate the same data
 	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
-		t.Skip("osqreceiver does not yet produce events, skipping OTel validation")
-
-		// Identify the osquery integration component before switching runtime so we
-		// can verify that specific component transitions to the OTel receiver.
+		// Identify the osquery integration component (input type "osquery") before
+		// switching runtime so we can verify that specific component transitions to the
+		// OTel receiver.
 		status, err := runner.agentFixture.ExecStatus(ctx)
 		require.NoError(t, err)
 		var integrationComponentID string
 		for _, comp := range status.Components {
-			if !strings.HasSuffix(comp.ID, "-monitoring") {
+			if strings.HasPrefix(comp.ID, "osquery") {
 				integrationComponentID = comp.ID
 				break
 			}
 		}
-		require.NotEmpty(t, integrationComponentID, "could not find integration component ID before OTel switch")
+		require.NotEmpty(t, integrationComponentID, "could not find osquery integration component before OTel switch")
 
 		otelSince := time.Now()
 		policyRevision := switchPolicyToOtelRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
@@ -187,6 +186,7 @@ func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 			assert.True(collect, isReceiver, "expected component %s to be running as beats receiver", integrationComponentID)
 		}, 2*time.Minute, 5*time.Second, "beat component should be running as beats receiver")
 
+		t.Skip("osqreceiver does not yet produce events, skipping OTel data validation")
 		otelDoc = runner.validateOsqueryEvents(t, ctx, agentStatus.Info.ID, otelSince)
 	})
 

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -7,23 +7,21 @@
 package ess
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
-	"net/http"
-	"net/http/httputil"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/elastic/elastic-agent-libs/kibana"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/testing/estools"
+	"github.com/elastic/elastic-agent/pkg/component"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
@@ -36,6 +34,7 @@ type OsqueryManagerRunner struct {
 	agentFixture *atesting.Fixture
 
 	ESHost     string
+	agentID    string
 	policyID   string
 	policyName string
 }
@@ -79,9 +78,10 @@ func (runner *OsqueryManagerRunner) SetupSuite() {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
-	policyResp, _, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
+	policyResp, agentID, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
 
+	runner.agentID = agentID
 	runner.policyID = policyResp.ID
 	runner.policyName = policyResp.Name
 
@@ -92,47 +92,26 @@ func (runner *OsqueryManagerRunner) SetupSuite() {
 
 }
 
-func (runner *OsqueryManagerRunner) switchToOtelRuntime() {
-	body := fmt.Sprintf(`
-{
-  "name": "%s",
-  "namespace": "%s",
-  "overrides": {
-    "agent": {
-      "internal": {
-        "runtime": {
-          "default": "otel"
-        }
-      }
-    }
-  }
-}
-`, runner.policyName, runner.info.Namespace)
-	resp, err := runner.info.KibanaClient.Send(
-		http.MethodPut,
-		fmt.Sprintf("/api/fleet/agent_policies/%s", runner.policyID),
-		nil,
-		nil,
-		bytes.NewBufferString(body),
-	)
-	if err != nil {
-		runner.T().Fatalf("could not execute request to Kibana/Fleet: %s", err)
+func (runner *OsqueryManagerRunner) switchToOtelRuntime(ctx context.Context) int {
+	updateReq := kibana.AgentPolicyUpdateRequest{
+		Name:      runner.policyName,
+		Namespace: runner.info.Namespace,
+		Overrides: map[string]interface{}{
+			"agent": map[string]interface{}{
+				"internal": map[string]interface{}{
+					"runtime": map[string]interface{}{
+						"default": "otel",
+					},
+				},
+			},
+		},
 	}
-	if resp.StatusCode != http.StatusOK {
-		runner.T().Errorf("received a non 200-OK when adding overwrite to policy. "+
-			"Status code: %d", resp.StatusCode)
-		respDump, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			runner.T().Fatalf("could not dump error response from Kibana: %s", err)
-		}
-		runner.T().Log("================================================================================")
-		runner.T().Log("Kibana error response:")
-		runner.T().Log(string(respDump))
-		runner.T().FailNow()
-	}
+	policyResp, err := runner.info.KibanaClient.UpdatePolicy(ctx, runner.policyID, updateReq)
+	require.NoError(runner.T(), err)
+	return policyResp.Revision
 }
 
-func (runner *OsqueryManagerRunner) validateOsqueryEvents(ctx context.Context, agentID string) mapstr.M {
+func (runner *OsqueryManagerRunner) validateOsqueryEvents(ctx context.Context, agentID string, since time.Time) mapstr.M {
 	t := runner.T()
 
 	now := time.Now()
@@ -157,6 +136,13 @@ func (runner *OsqueryManagerRunner) validateOsqueryEvents(ctx context.Context, a
 			[][]string{
 				{"exists", "field", "osquery.physical_memory"},
 			})
+		if !since.IsZero() {
+			query["query"].(map[string]interface{})["bool"].(map[string]interface{})["filter"] = map[string]any{
+				"range": map[string]any{
+					"@timestamp": map[string]any{"gte": since.UTC().Format("2006-01-02T15:04:05.000Z")},
+				},
+			}
+		}
 		now = time.Now()
 		res, err := estools.PerformQueryForRawQuery(ctx, query, "logs-osquery_manager.result*", runner.info.ESClient)
 		require.NoError(t, err)
@@ -181,25 +167,34 @@ func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 	// Validate process mode
 	var processDoc mapstr.M
 	t.Run("process", func(t *testing.T) {
-		processDoc = runner.validateOsqueryEvents(ctx, agentStatus.Info.ID)
+		processDoc = runner.validateOsqueryEvents(ctx, agentStatus.Info.ID, time.Time{})
 	})
 
 	// Switch to OTel runtime and validate the same data
 	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
-		runner.switchToOtelRuntime()
+		otelSince := time.Now()
+		policyRevision := runner.switchToOtelRuntime(ctx)
 
-		// Wait for the agent to pick up the new policy and become healthy
-		require.Eventually(t, func() bool {
-			err := runner.agentFixture.IsHealthy(ctx)
-			if err != nil {
-				t.Logf("waiting for agent healthy after otel switch: %s", err.Error())
-				return false
+		// Wait for the agent to apply the new policy revision
+		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
+			5*time.Minute, time.Second)
+
+		// Verify the component is running as a beats receiver
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			status, statusErr := runner.agentFixture.ExecStatus(ctx)
+			require.NoError(collect, statusErr)
+			var hasReceiver bool
+			for _, comp := range status.Components {
+				if comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
+					hasReceiver = true
+					break
+				}
 			}
-			return true
-		}, 2*time.Minute, 5*time.Second)
+			assert.True(collect, hasReceiver, "expected a component running as beats receiver")
+		}, 2*time.Minute, 5*time.Second, "component should be running as beats receiver")
 
-		otelDoc = runner.validateOsqueryEvents(ctx, agentStatus.Info.ID)
+		otelDoc = runner.validateOsqueryEvents(ctx, agentStatus.Info.ID, otelSince)
 	})
 
 	// Compare documents from process and otel modes have the same keys

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -112,9 +112,7 @@ func (runner *OsqueryManagerRunner) switchToOtelRuntime(ctx context.Context) int
 	return policyResp.Revision
 }
 
-func (runner *OsqueryManagerRunner) validateOsqueryEvents(ctx context.Context, agentID string, since time.Time) mapstr.M {
-	t := runner.T()
-
+func (runner *OsqueryManagerRunner) validateOsqueryEvents(t *testing.T, ctx context.Context, agentID string, since time.Time) mapstr.M {
 	now := time.Now()
 	var query map[string]any
 	var doc mapstr.M
@@ -165,7 +163,7 @@ func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 	// Validate process mode
 	var processDoc mapstr.M
 	t.Run("process", func(t *testing.T) {
-		processDoc = runner.validateOsqueryEvents(ctx, agentStatus.Info.ID, time.Time{})
+		processDoc = runner.validateOsqueryEvents(t, ctx, agentStatus.Info.ID, time.Time{})
 	})
 
 	// Switch to OTel runtime and validate the same data
@@ -199,7 +197,7 @@ func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 			assert.True(collect, hasUserReceiver, "expected the user beat component to be running as beats receiver")
 		}, 2*time.Minute, 5*time.Second, "user beat component should be running as beats receiver")
 
-		otelDoc = runner.validateOsqueryEvents(ctx, agentStatus.Info.ID, otelSince)
+		otelDoc = runner.validateOsqueryEvents(t, ctx, agentStatus.Info.ID, otelSince)
 	})
 
 	// Compare documents from process and otel modes have the same keys

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -93,25 +93,6 @@ func (runner *OsqueryManagerRunner) SetupSuite() {
 
 }
 
-func (runner *OsqueryManagerRunner) switchToOtelRuntime(ctx context.Context) int {
-	updateReq := kibana.AgentPolicyUpdateRequest{
-		Name:      runner.policyName,
-		Namespace: runner.info.Namespace,
-		Overrides: map[string]interface{}{
-			"agent": map[string]interface{}{
-				"internal": map[string]interface{}{
-					"runtime": map[string]interface{}{
-						"default": "otel",
-					},
-				},
-			},
-		},
-	}
-	policyResp, err := runner.info.KibanaClient.UpdatePolicy(ctx, runner.policyID, updateReq)
-	require.NoError(runner.T(), err)
-	return policyResp.Revision
-}
-
 func (runner *OsqueryManagerRunner) validateOsqueryEvents(t *testing.T, ctx context.Context, agentID string, since time.Time) mapstr.M {
 	now := time.Now()
 	var query map[string]any
@@ -135,12 +116,10 @@ func (runner *OsqueryManagerRunner) validateOsqueryEvents(t *testing.T, ctx cont
 			[][]string{
 				{"exists", "field", "osquery.physical_memory"},
 			})
-		if !since.IsZero() {
-			query["query"].(map[string]interface{})["bool"].(map[string]interface{})["filter"] = map[string]any{
-				"range": map[string]any{
-					"@timestamp": map[string]any{"gte": since.UTC().Format("2006-01-02T15:04:05.000Z")},
-				},
-			}
+		query["query"].(map[string]interface{})["bool"].(map[string]interface{})["filter"] = map[string]any{
+			"range": map[string]any{
+				"@timestamp": map[string]any{"gte": since.UTC().Format("2006-01-02T15:04:05.000Z")},
+			},
 		}
 		now = time.Now()
 		res, err := estools.PerformQueryForRawQuery(ctx, query, "logs-osquery_manager.result*", runner.info.ESClient)
@@ -160,10 +139,12 @@ func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 	agentStatus, err := runner.agentFixture.ExecStatus(ctx)
 	require.NoError(t, err, "could not get agent status")
 
+	testStart := time.Now()
+
 	// Validate process mode
 	var processDoc mapstr.M
 	t.Run("process", func(t *testing.T) {
-		processDoc = runner.validateOsqueryEvents(t, ctx, agentStatus.Info.ID, time.Time{})
+		processDoc = runner.validateOsqueryEvents(t, ctx, agentStatus.Info.ID, testStart)
 	})
 
 	// Switch to OTel runtime and validate the same data
@@ -171,31 +152,40 @@ func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 	t.Run("otel", func(t *testing.T) {
 		t.Skip("osqreceiver does not yet produce events, skipping OTel validation")
 
+		// Identify the osquery integration component before switching runtime so we
+		// can verify that specific component transitions to the OTel receiver.
+		status, err := runner.agentFixture.ExecStatus(ctx)
+		require.NoError(t, err)
+		var integrationComponentID string
+		for _, comp := range status.Components {
+			if !strings.HasSuffix(comp.ID, "-monitoring") {
+				integrationComponentID = comp.ID
+				break
+			}
+		}
+		require.NotEmpty(t, integrationComponentID, "could not find integration component ID before OTel switch")
+
 		otelSince := time.Now()
-		policyRevision := runner.switchToOtelRuntime(ctx)
+		policyRevision := switchPolicyToOtelRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
 
 		// Wait for the agent to apply the new policy revision
 		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
 			5*time.Minute, time.Second)
 
-		// Verify the user beat component (not monitoring components) is running as a beats receiver.
-		// Monitoring components are excluded because they may independently run as process-based
-		// beats regardless of the agent.internal.runtime.default override.
+		// Verify the osquery integration component is now running as a beats receiver.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			status, statusErr := runner.agentFixture.ExecStatus(ctx)
 			require.NoError(collect, statusErr)
-			var hasUserReceiver bool
+			var isReceiver bool
 			for _, comp := range status.Components {
-				if strings.HasSuffix(comp.ID, "-monitoring") {
-					continue
-				}
-				if comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
-					hasUserReceiver = true
+				if comp.ID == integrationComponentID &&
+					comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
+					isReceiver = true
 					break
 				}
 			}
-			assert.True(collect, hasUserReceiver, "expected the user beat component to be running as beats receiver")
-		}, 2*time.Minute, 5*time.Second, "user beat component should be running as beats receiver")
+			assert.True(collect, isReceiver, "expected component %s to be running as beats receiver", integrationComponentID)
+		}, 2*time.Minute, 5*time.Second, "beat component should be running as beats receiver")
 
 		otelDoc = runner.validateOsqueryEvents(t, ctx, agentStatus.Info.ID, otelSince)
 	})

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -180,19 +181,24 @@ func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
 			5*time.Minute, time.Second)
 
-		// Verify the component is running as a beats receiver
+		// Verify the user beat component (not monitoring components) is running as a beats receiver.
+		// Monitoring components are excluded because they may independently run as process-based
+		// beats regardless of the agent.internal.runtime.default override.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			status, statusErr := runner.agentFixture.ExecStatus(ctx)
 			require.NoError(collect, statusErr)
-			var hasReceiver bool
+			var hasUserReceiver bool
 			for _, comp := range status.Components {
+				if strings.HasSuffix(comp.ID, "-monitoring") {
+					continue
+				}
 				if comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
-					hasReceiver = true
+					hasUserReceiver = true
 					break
 				}
 			}
-			assert.True(collect, hasReceiver, "expected a component running as beats receiver")
-		}, 2*time.Minute, 5*time.Second, "component should be running as beats receiver")
+			assert.True(collect, hasUserReceiver, "expected the user beat component to be running as beats receiver")
+		}, 2*time.Minute, 5*time.Second, "user beat component should be running as beats receiver")
 
 		otelDoc = runner.validateOsqueryEvents(ctx, agentStatus.Info.ID, otelSince)
 	})

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -132,7 +132,7 @@ func (runner *OsqueryManagerRunner) validateOsqueryEvents(ctx context.Context, a
 	}()
 
 	t.Logf("starting to query ES for osquery events at %s", now.Format(time.RFC3339Nano))
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		query = genESQuery(agentID,
 			[][]string{
 				{"exists", "field", "osquery.physical_memory"},
@@ -146,12 +146,9 @@ func (runner *OsqueryManagerRunner) validateOsqueryEvents(ctx context.Context, a
 		}
 		now = time.Now()
 		res, err := estools.PerformQueryForRawQuery(ctx, query, "logs-osquery_manager.result*", runner.info.ESClient)
-		require.NoError(t, err)
-		if res.Hits.Total.Value < 1 {
-			return false
-		}
+		require.NoError(collect, err)
+		require.NotEmpty(collect, res.Hits.Hits)
 		doc = res.Hits.Hits[0].Source
-		return true
 	}, time.Minute*15, time.Second*10, "could not fetch events for osquery_manager")
 	return doc
 }

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -171,6 +171,8 @@ func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 	// Switch to OTel runtime and validate the same data
 	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
+		t.Skip("osqreceiver does not yet produce events, skipping OTel validation")
+
 		otelSince := time.Now()
 		policyRevision := runner.switchToOtelRuntime(ctx)
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fixes support added in https://github.com/elastic/elastic-agent/pull/14029.

This includes:

- Handling the new receivers correctly in otel config generation and adding tests.
- Checking that the components run as otel receivers in integration tests
- Mostly skipping checking data parity - it can be done in a follow-up
- Some general integration test refactor around the area

## Why is it important?

The new receivers should actually be runnable, if not fully feature-complete.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [x] I have added an integration test or an E2E test

## How to test this PR locally

Build agent locally and run any input.

## Related issues

- Relates https://github.com/elastic/elastic-agent/pull/14029
- Closes https://github.com/elastic/elastic-agent/issues/14355


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
