### PR TITLE
Add missing host.hostname to monitoring metrics for OTel outputs

### DIFF
--- a/changelog/fragments/1779390024-add-hostname-monitoring-metrics.yaml
+++ b/changelog/fragments/1779390024-add-hostname-monitoring-metrics.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Add missing host.hostname to monitoring-metrics
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/otel/manager/manager.go
+++ b/internal/pkg/otel/manager/manager.go
@@ -470,7 +470,7 @@ func (m *OTelManager) buildMergedConfig(
 				if mCfg.Enabled && mCfg.MonitorMetrics {
 					// Metrics monitoring is enabled, inject a receiver for the
 					// collector's internal telemetry.
-					if err := injectMonitoringReceiver(mergedOtelCfg, mCfg, agentInfo, cfgUpdate.components); err != nil {
+					if err := injectMonitoringReceiver(mergedOtelCfg, mCfg, agentInfo, cfgUpdate.components, logger); err != nil {
 						return nil, fmt.Errorf("merging internal telemetry config: %w", err)
 					}
 				}
@@ -538,7 +538,7 @@ func injectDiagnosticsExtension(config *confmap.Conf) error {
 	}))
 }
 
-func monitoringEventTemplate(monitoring *monitoringCfg.MonitoringConfig, agentInfo info.Agent) map[string]any {
+func monitoringEventTemplate(monitoring *monitoringCfg.MonitoringConfig, agentInfo info.Agent, logger *logp.Logger) map[string]any {
 	namespace := "default"
 	if monitoring.Namespace != "" {
 		namespace = monitoring.Namespace
@@ -572,8 +572,15 @@ func monitoringEventTemplate(monitoring *monitoringCfg.MonitoringConfig, agentIn
 		},
 	}
 
-	hostname, err := os.Hostname()
+	var hostname string
+	ecsMetadata, err := agentInfo.ECSMetadata(logger)
 	if err == nil {
+		hostname = ecsMetadata.Host.Hostname
+	} else if name, err := os.Hostname(); err == nil {
+		hostname = name
+	}
+
+	if hostname != "" {
 		result["agent"].(map[string]any)["name"] = hostname
 		result["host"] = map[string]any{
 			"hostname": hostname,
@@ -583,8 +590,8 @@ func monitoringEventTemplate(monitoring *monitoringCfg.MonitoringConfig, agentIn
 	return result
 }
 
-func monitoringInputEventTemplate(monitoring *monitoringCfg.MonitoringConfig, agentInfo info.Agent) map[string]any {
-	tmpl := monitoringEventTemplate(monitoring, agentInfo)
+func monitoringInputEventTemplate(monitoring *monitoringCfg.MonitoringConfig, agentInfo info.Agent, logger *logp.Logger) map[string]any {
+	tmpl := monitoringEventTemplate(monitoring, agentInfo, logger)
 	tmpl["data_stream"] = map[string]any{
 		"dataset":   "elastic_agent.filebeat_input",
 		"namespace": tmpl["data_stream"].(map[string]any)["namespace"],
@@ -634,6 +641,7 @@ func injectMonitoringReceiver(
 	monitoring *monitoringCfg.MonitoringConfig,
 	agentInfo info.Agent,
 	components []component.Component,
+	logger *logp.Logger,
 ) error {
 	// Check whether OTel-based monitoring is configured — it produces an ES exporter
 	// named "monitoring" that the internal telemetry pipeline can share.
@@ -681,8 +689,8 @@ func injectMonitoringReceiver(
 	collectorCfg := map[string]any{
 		"receivers": map[string]any{
 			receiverID: map[string]any{
-				"event_template":       monitoringEventTemplate(monitoring, agentInfo),
-				"input_event_template": monitoringInputEventTemplate(monitoring, agentInfo),
+				"event_template":       monitoringEventTemplate(monitoring, agentInfo, logger),
+				"input_event_template": monitoringInputEventTemplate(monitoring, agentInfo, logger),
 				"interval":             monitoring.MetricsPeriod,
 				"exporter_names":       outputNameLookup,
 			},

--- a/internal/pkg/otel/manager/manager.go
+++ b/internal/pkg/otel/manager/manager.go
@@ -543,15 +543,6 @@ func monitoringEventTemplate(monitoring *monitoringCfg.MonitoringConfig, agentIn
 	if monitoring.Namespace != "" {
 		namespace = monitoring.Namespace
 	}
-	agentFields := map[string]any{
-		"id":      agentInfo.AgentID(),
-		"version": agentInfo.Version(),
-	}
-	// Add hostname as agent.name if available
-	agentName, err := os.Hostname()
-	if err == nil {
-		agentFields["name"] = agentName
-	}
 
 	result := map[string]any{
 		"data_stream": map[string]any{
@@ -568,7 +559,10 @@ func monitoringEventTemplate(monitoring *monitoringCfg.MonitoringConfig, agentIn
 			"snapshot": agentInfo.Snapshot(),
 			"version":  agentInfo.Version(),
 		},
-		"agent": agentFields,
+		"agent": map[string]any{
+			"id":      agentInfo.AgentID(),
+			"version": agentInfo.Version(),
+		},
 		"component": map[string]any{
 			"binary": "elastic-otel-collector",
 			"id":     "elastic-otel-collector",
@@ -576,6 +570,14 @@ func monitoringEventTemplate(monitoring *monitoringCfg.MonitoringConfig, agentIn
 		"metricset": map[string]any{
 			"name": "stats",
 		},
+	}
+
+	hostname, err := os.Hostname()
+	if err == nil {
+		result["agent"].(map[string]any)["name"] = hostname
+		result["host"] = map[string]any{
+			"hostname": hostname,
+		}
 	}
 
 	return result

--- a/internal/pkg/otel/manager/manager_test.go
+++ b/internal/pkg/otel/manager/manager_test.go
@@ -2523,7 +2523,7 @@ func TestMonitoringReceiverProcessors(t *testing.T) {
 	monitoringConfig := &config.MonitoringConfig{}
 	agentInfo := &info.AgentInfo{}
 	components := []component.Component{}
-	err := injectMonitoringReceiver(cfg, monitoringConfig, agentInfo, components)
+	err := injectMonitoringReceiver(cfg, monitoringConfig, agentInfo, components, logp.NewNopLogger())
 	require.NoError(t, err, "injectMonitoringReceiver should succeed")
 	result := mapstr.M(cfg.ToStringMap()).Flatten()
 
@@ -2555,7 +2555,7 @@ func TestMonitoringReceiverFileExporter(t *testing.T) {
 			},
 		}
 		cfg := confmap.NewFromStringMap(baseConfig)
-		err := injectMonitoringReceiver(cfg, &config.MonitoringConfig{}, &info.AgentInfo{}, []component.Component{})
+		err := injectMonitoringReceiver(cfg, &config.MonitoringConfig{}, &info.AgentInfo{}, []component.Component{}, logp.NewNopLogger())
 		require.NoError(t, err, "injectMonitoringReceiver should succeed")
 		result := mapstr.M(cfg.ToStringMap()).Flatten()
 
@@ -2573,7 +2573,7 @@ func TestMonitoringReceiverFileExporter(t *testing.T) {
 		// monitoring is in use), the pipeline should still be injected so that
 		// internal telemetry is captured in the diagnostics file.
 		cfg := confmap.NewFromStringMap(map[string]any{})
-		err := injectMonitoringReceiver(cfg, &config.MonitoringConfig{}, &info.AgentInfo{}, []component.Component{})
+		err := injectMonitoringReceiver(cfg, &config.MonitoringConfig{}, &info.AgentInfo{}, []component.Component{}, logp.NewNopLogger())
 		require.NoError(t, err, "injectMonitoringReceiver should succeed without monitoring exporter")
 		result := mapstr.M(cfg.ToStringMap()).Flatten()
 
@@ -2588,7 +2588,7 @@ func TestMonitoringReceiverFileExporter(t *testing.T) {
 
 	t.Run("file exporter config", func(t *testing.T) {
 		cfg := confmap.NewFromStringMap(map[string]any{})
-		err := injectMonitoringReceiver(cfg, &config.MonitoringConfig{}, &info.AgentInfo{}, []component.Component{})
+		err := injectMonitoringReceiver(cfg, &config.MonitoringConfig{}, &info.AgentInfo{}, []component.Component{}, logp.NewNopLogger())
 		require.NoError(t, err, "injectMonitoringReceiver should succeed")
 		result := mapstr.M(cfg.ToStringMap()).Flatten()
 

--- a/testing/integration/ess/metrics_monitoring_test.go
+++ b/testing/integration/ess/metrics_monitoring_test.go
@@ -72,6 +72,12 @@ func (runner *MetricsRunner) SetupSuite() {
 			kibana.MonitoringEnabledLogs,
 			kibana.MonitoringEnabledMetrics,
 		},
+		AgentFeatures: []map[string]interface{}{
+			{
+				"name":    "default_processors",
+				"enabled": false,
+			},
+		},
 	}
 
 	installOpts := atesting.InstallOpts{
@@ -211,6 +217,32 @@ func (runner *MetricsRunner) TestBeatsMetrics() {
 		}
 		return true
 	}, time.Minute*10, time.Second*10, "could not fetch metrics for all known components in default install")
+
+	query = genESQuery(agentStatus.Info.ID,
+		[][]string{
+			{"match", "component.binary", "elastic-otel-collector"},
+			{"exists", "field", "data_stream.dataset"},
+			{"exists", "field", "data_stream.namespace"},
+			{"exists", "field", "data_stream.type"},
+			{"exists", "field", "event.dataset"},
+			{"exists", "field", "elastic_agent.id"},
+			{"exists", "field", "elastic_agent.process"},
+			{"exists", "field", "elastic_agent.snapshot"},
+			{"exists", "field", "elastic_agent.version"},
+			{"exists", "field", "agent.id"},
+			{"exists", "field", "agent.version"},
+			{"exists", "field", "agent.name"},
+			{"exists", "field", "component.id"},
+			{"exists", "field", "metricset.name"},
+			{"exists", "field", "host.hostname"},
+		})
+	require.Eventually(t, func() bool {
+		now = time.Now()
+		res, err := estools.PerformQueryForRawQuery(ctx, query, "metrics-elastic_agent*", runner.info.ESClient)
+		require.NoError(t, err)
+		t.Logf("Fetched monitoring metrics with event template fields, got %d hits", res.Hits.Total.Value)
+		return res.Hits.Total.Value >= 1
+	}, time.Minute*10, time.Second*10, "monitoring metrics missing expected event template fields")
 
 	// Add a policy overwrite to change the agent monitoring to use Otel runtime
 	runner.addMonitoringToOtelRuntimeOverwrite()


### PR DESCRIPTION
## What does this PR do?

Adds host.hostname to monitoring metrics for OTel outputs for #12577 in the base monitoring event template. Previously, host.hostname was only populated with default processors enabled.

## Why is it important?

host.hostname is needed for dashboard filtering.

## Checklist

- [X] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [X] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Closes #12577