### PR TITLE
[main] Revert kube-stack chart to 0.14.11

### DIFF
--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/logs-values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/logs-values.yaml
@@ -66,8 +66,12 @@ collectors:
         # [Batch Processor](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor)
         batch: {}
         # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
+        resourcedetection/env:
+          detectors: [env] # Detects resources from environment variables.
+          timeout: 2s
+          override: false
         resourcedetection/eks:
-          detectors: [env, eks] # Detects resources from environment variables and EKS (Elastic Kubernetes Service).
+          detectors: [eks] # Detects resources from EKS (Elastic Kubernetes Service).
           timeout: 15s
           override: true
           eks:
@@ -75,11 +79,11 @@ collectors:
               k8s.cluster.name:
                 enabled: true
         resourcedetection/gcp:
-          detectors: [env, gcp] # Detects resources from environment variables and GCP (Google Cloud Platform).
+          detectors: [gcp] # Detects resources from GCP (Google Cloud Platform).
           timeout: 2s
           override: true
         resourcedetection/aks:
-          detectors: [env, aks] # Detects resources from environment variables and AKS (Azure Kubernetes Service).
+          detectors: [aks] # Detects resources from AKS (Azure Kubernetes Service).
           timeout: 2s
           override: true
           aks:
@@ -142,13 +146,18 @@ collectors:
             node_from_env_var: OTEL_K8S_NODE_NAME
           passthrough: false
           pod_association:
-            # Below association takes a look at the k8s.pod.ip and k8s.pod.uid resource attributes or connection's context, and tries to match it with the pod having the same attribute.
+            # Below association takes a look at the k8s.pod.ip, then k8s.pod.uid, then k8s.pod.name + k8s.namespace.name, and tries to match it with the pod having the same attribute. If all three fail, it will use the connection's context.
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.ip
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.uid
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.name
+                - from: resource_attribute
+                  name: k8s.namespace.name
             - sources:
                 - from: connection
           extract:
@@ -191,6 +200,7 @@ collectors:
             processors:
               - batch
               - k8sattributes
+              - resourcedetection/env
               - resourcedetection/system
               - resourcedetection/eks
               - resourcedetection/gcp

--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/logs-values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/logs-values.yaml
@@ -39,7 +39,7 @@ collectors:
     fullnameOverride: "opentelemetry-kube-stack-daemon"
     env:
       - name: ELASTIC_AGENT_OTEL
-        value: "true"
+        value: '"true"'
     presets:
       kubeletMetrics:
         enabled: false
@@ -66,12 +66,8 @@ collectors:
         # [Batch Processor](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor)
         batch: {}
         # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
-        resourcedetection/env:
-          detectors: [env] # Detects resources from environment variables.
-          timeout: 2s
-          override: false
         resourcedetection/eks:
-          detectors: [eks] # Detects resources from EKS (Elastic Kubernetes Service).
+          detectors: [env, eks] # Detects resources from environment variables and EKS (Elastic Kubernetes Service).
           timeout: 15s
           override: true
           eks:
@@ -79,11 +75,11 @@ collectors:
               k8s.cluster.name:
                 enabled: true
         resourcedetection/gcp:
-          detectors: [gcp] # Detects resources from GCP (Google Cloud Platform).
+          detectors: [env, gcp] # Detects resources from environment variables and GCP (Google Cloud Platform).
           timeout: 2s
           override: true
         resourcedetection/aks:
-          detectors: [aks] # Detects resources from AKS (Azure Kubernetes Service).
+          detectors: [env, aks] # Detects resources from environment variables and AKS (Azure Kubernetes Service).
           timeout: 2s
           override: true
           aks:
@@ -146,18 +142,13 @@ collectors:
             node_from_env_var: OTEL_K8S_NODE_NAME
           passthrough: false
           pod_association:
-            # Below association takes a look at the k8s.pod.ip, then k8s.pod.uid, then k8s.pod.name + k8s.namespace.name, and tries to match it with the pod having the same attribute. If all three fail, it will use the connection's context.
+            # Below association takes a look at the k8s.pod.ip and k8s.pod.uid resource attributes or connection's context, and tries to match it with the pod having the same attribute.
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.ip
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.uid
-            - sources:
-                - from: resource_attribute
-                  name: k8s.pod.name
-                - from: resource_attribute
-                  name: k8s.namespace.name
             - sources:
                 - from: connection
           extract:
@@ -200,7 +191,6 @@ collectors:
             processors:
               - batch
               - k8sattributes
-              - resourcedetection/env
               - resourcedetection/system
               - resourcedetection/eks
               - resourcedetection/gcp
@@ -230,7 +220,7 @@ collectors:
     enabled: true
     env:
       - name: ELASTIC_AGENT_OTEL
-        value: "true"
+        value: '"true"'
       - name: ELASTIC_OTLP_ENDPOINT
         valueFrom:
           secretKeyRef:

--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
@@ -54,9 +54,14 @@ collectors:
             insecure: true
       processors:
         # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
+        resourcedetection/env:
+          # Detects resources from environment variables.
+          detectors: [env]
+          timeout: 2s
+          override: false
         resourcedetection/eks:
-          # Detects resources from environment variables and EKS (Elastic Kubernetes Service).
-          detectors: [env, eks]
+          # Detects resources from EKS (Elastic Kubernetes Service).
+          detectors: [eks]
           timeout: 15s
           override: true
           eks:
@@ -64,13 +69,13 @@ collectors:
               k8s.cluster.name:
                 enabled: true
         resourcedetection/gcp:
-          # Detects resources from environment variables and GCP (Google Cloud Platform).
-          detectors: [env, gcp]
+          # Detects resources from GCP (Google Cloud Platform).
+          detectors: [gcp]
           timeout: 2s
           override: true
         resourcedetection/aks:
-          # Detects resources from environment variables and AKS (Azure Kubernetes Service).
-          detectors: [env, aks]
+          # Detects resources from AKS (Azure Kubernetes Service).
+          detectors: [aks]
           timeout: 2s
           override: true
           aks:
@@ -86,13 +91,18 @@ collectors:
         k8sattributes:
           passthrough: false # Annotates resources with the pod IP and does not try to extract any other metadata.
           pod_association:
-            # Below association takes a look at the k8s.pod.ip and k8s.pod.uid resource attributes or connection's context, and tries to match it with the pod having the same attribute.
+            # Below association takes a look at the k8s.pod.ip, then k8s.pod.uid, then k8s.pod.name + k8s.namespace.name, and tries to match it with the pod having the same attribute. If all three fail, it will use the connection's context.
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.ip
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.uid
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.name
+                - from: resource_attribute
+                  name: k8s.namespace.name
             - sources:
                 - from: connection
           extract:
@@ -150,6 +160,7 @@ collectors:
               - otlp/gateway
             processors:
               - k8sattributes
+              - resourcedetection/env
               - resourcedetection/eks
               - resourcedetection/gcp
               - resourcedetection/aks
@@ -160,6 +171,7 @@ collectors:
             receivers:
               - k8s_events
             processors:
+              - resourcedetection/env
               - resourcedetection/eks
               - resourcedetection/gcp
               - resourcedetection/aks
@@ -205,9 +217,14 @@ collectors:
           send_batch_max_size: 0
           timeout: 1s
         # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
+        resourcedetection/env:
+          # Detects resources from environment variables.
+          detectors: [env]
+          timeout: 2s
+          override: false
         resourcedetection/eks:
-          # Detects resources from environment variables and EKS (Elastic Kubernetes Service).
-          detectors: [env, eks]
+          # Detects resources from EKS (Elastic Kubernetes Service).
+          detectors: [eks]
           timeout: 15s
           override: true
           eks:
@@ -215,13 +232,13 @@ collectors:
               k8s.cluster.name:
                 enabled: true
         resourcedetection/gcp:
-          # Detects resources from environment variables and GCP (Google Cloud Platform).
-          detectors: [env, gcp]
+          # Detects resources from GCP (Google Cloud Platform).
+          detectors: [gcp]
           timeout: 2s
           override: true
         resourcedetection/aks:
-          # Detects resources from environment variables and AKS (Azure Kubernetes Service).
-          detectors: [env, aks]
+          # Detects resources from AKS (Azure Kubernetes Service).
+          detectors: [aks]
           timeout: 2s
           override: true
           aks:
@@ -292,6 +309,11 @@ collectors:
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.uid
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.name
+                - from: resource_attribute
+                  name: k8s.namespace.name
             - sources:
                 - from: connection
           extract:
@@ -457,6 +479,7 @@ collectors:
             processors:
               - batch
               - k8sattributes
+              - resourcedetection/env
               - resourcedetection/system
               - resourcedetection/eks
               - resourcedetection/gcp
@@ -472,6 +495,7 @@ collectors:
             processors:
               - batch/metrics
               - k8sattributes
+              - resourcedetection/env
               - resourcedetection/system
               - resourcedetection/eks
               - resourcedetection/gcp

--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
@@ -41,7 +41,7 @@ collectors:
     fullnameOverride: "opentelemetry-kube-stack-cluster-stats"
     env:
       - name: ELASTIC_AGENT_OTEL
-        value: "true"
+        value: '"true"'
     config:
       exporters:
         # [Debug exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/debugexporter/README.md)
@@ -54,14 +54,9 @@ collectors:
             insecure: true
       processors:
         # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
-        resourcedetection/env:
-          # Detects resources from environment variables.
-          detectors: [env]
-          timeout: 2s
-          override: false
         resourcedetection/eks:
-          # Detects resources from EKS (Elastic Kubernetes Service).
-          detectors: [eks]
+          # Detects resources from environment variables and EKS (Elastic Kubernetes Service).
+          detectors: [env, eks]
           timeout: 15s
           override: true
           eks:
@@ -69,13 +64,13 @@ collectors:
               k8s.cluster.name:
                 enabled: true
         resourcedetection/gcp:
-          # Detects resources from GCP (Google Cloud Platform).
-          detectors: [gcp]
+          # Detects resources from environment variables and GCP (Google Cloud Platform).
+          detectors: [env, gcp]
           timeout: 2s
           override: true
         resourcedetection/aks:
-          # Detects resources from AKS (Azure Kubernetes Service).
-          detectors: [aks]
+          # Detects resources from environment variables and AKS (Azure Kubernetes Service).
+          detectors: [env, aks]
           timeout: 2s
           override: true
           aks:
@@ -91,18 +86,13 @@ collectors:
         k8sattributes:
           passthrough: false # Annotates resources with the pod IP and does not try to extract any other metadata.
           pod_association:
-            # Below association takes a look at the k8s.pod.ip, then k8s.pod.uid, then k8s.pod.name + k8s.namespace.name, and tries to match it with the pod having the same attribute. If all three fail, it will use the connection's context.
+            # Below association takes a look at the k8s.pod.ip and k8s.pod.uid resource attributes or connection's context, and tries to match it with the pod having the same attribute.
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.ip
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.uid
-            - sources:
-                - from: resource_attribute
-                  name: k8s.pod.name
-                - from: resource_attribute
-                  name: k8s.namespace.name
             - sources:
                 - from: connection
           extract:
@@ -160,7 +150,6 @@ collectors:
               - otlp/gateway
             processors:
               - k8sattributes
-              - resourcedetection/env
               - resourcedetection/eks
               - resourcedetection/gcp
               - resourcedetection/aks
@@ -171,7 +160,6 @@ collectors:
             receivers:
               - k8s_events
             processors:
-              - resourcedetection/env
               - resourcedetection/eks
               - resourcedetection/gcp
               - resourcedetection/aks
@@ -186,7 +174,7 @@ collectors:
     fullnameOverride: "opentelemetry-kube-stack-daemon"
     env:
       - name: ELASTIC_AGENT_OTEL
-        value: "true"
+        value: '"true"'
     presets:
       logsCollection:
         enabled: true # Enable/disable the collection of node's logs.
@@ -217,14 +205,9 @@ collectors:
           send_batch_max_size: 0
           timeout: 1s
         # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
-        resourcedetection/env:
-          # Detects resources from environment variables.
-          detectors: [env]
-          timeout: 2s
-          override: false
         resourcedetection/eks:
-          # Detects resources from EKS (Elastic Kubernetes Service).
-          detectors: [eks]
+          # Detects resources from environment variables and EKS (Elastic Kubernetes Service).
+          detectors: [env, eks]
           timeout: 15s
           override: true
           eks:
@@ -232,13 +215,13 @@ collectors:
               k8s.cluster.name:
                 enabled: true
         resourcedetection/gcp:
-          # Detects resources from GCP (Google Cloud Platform).
-          detectors: [gcp]
+          # Detects resources from environment variables and GCP (Google Cloud Platform).
+          detectors: [env, gcp]
           timeout: 2s
           override: true
         resourcedetection/aks:
-          # Detects resources from AKS (Azure Kubernetes Service).
-          detectors: [aks]
+          # Detects resources from environment variables and AKS (Azure Kubernetes Service).
+          detectors: [env, aks]
           timeout: 2s
           override: true
           aks:
@@ -309,11 +292,6 @@ collectors:
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.uid
-            - sources:
-                - from: resource_attribute
-                  name: k8s.pod.name
-                - from: resource_attribute
-                  name: k8s.namespace.name
             - sources:
                 - from: connection
           extract:
@@ -479,7 +457,6 @@ collectors:
             processors:
               - batch
               - k8sattributes
-              - resourcedetection/env
               - resourcedetection/system
               - resourcedetection/eks
               - resourcedetection/gcp
@@ -495,7 +472,6 @@ collectors:
             processors:
               - batch/metrics
               - k8sattributes
-              - resourcedetection/env
               - resourcedetection/system
               - resourcedetection/eks
               - resourcedetection/gcp
@@ -553,7 +529,7 @@ collectors:
     enabled: true
     env:
       - name: ELASTIC_AGENT_OTEL
-        value: "true"
+        value: '"true"'
       - name: ELASTIC_OTLP_ENDPOINT
         valueFrom:
           secretKeyRef:

--- a/deploy/helm/edot-collector/kube-stack/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/values.yaml
@@ -56,6 +56,11 @@ collectors:
         cgroupruntime: {}
       processors:
         # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
+        resourcedetection/env:
+          # Detects resources from environment variables.
+          detectors: [env]
+          timeout: 2s
+          override: false
         resourcedetection/eks:
           # Detects resources from environment variables and EKS (Elastic Kubernetes Service).
           detectors: [env, eks]
@@ -66,13 +71,13 @@ collectors:
               k8s.cluster.name:
                 enabled: true
         resourcedetection/gcp:
-          # Detects resources from environment variables and GCP (Google Cloud Platform).
-          detectors: [env, gcp]
+          # Detects resources from GCP (Google Cloud Platform).
+          detectors: [gcp]
           timeout: 2s
           override: true
         resourcedetection/aks:
-          # Detects resources from environment variables and AKS (Azure Kubernetes Service).
-          detectors: [env, aks]
+          # Detects resources from AKS (Azure Kubernetes Service).
+          detectors: [aks]
           timeout: 2s
           override: true
           aks:
@@ -88,13 +93,18 @@ collectors:
         k8sattributes:
           passthrough: false # Annotates resources with the pod IP and does not try to extract any other metadata.
           pod_association:
-            # Below association takes a look at the k8s.pod.ip and k8s.pod.uid resource attributes or connection's context, and tries to match it with the pod having the same attribute.
+            # Below association takes a look at the k8s.pod.ip, then k8s.pod.uid, then k8s.pod.name + k8s.namespace.name, and tries to match it with the pod having the same attribute. If all three fail, it will use the connection's context.
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.ip
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.uid
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.name
+                - from: resource_attribute
+                  name: k8s.namespace.name
             - sources:
                 - from: connection
           extract:
@@ -150,6 +160,7 @@ collectors:
               - otlp/gateway
             processors:
               - k8sattributes
+              - resourcedetection/env
               - resourcedetection/eks
               - resourcedetection/gcp
               - resourcedetection/aks
@@ -160,6 +171,7 @@ collectors:
             receivers:
               - k8s_events
             processors:
+              - resourcedetection/env
               - resourcedetection/eks
               - resourcedetection/gcp
               - resourcedetection/aks
@@ -206,9 +218,14 @@ collectors:
           send_batch_max_size: 0
           timeout: 1s
         # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
+        resourcedetection/env:
+          # Detects resources from environment variables.
+          detectors: [env]
+          timeout: 2s
+          override: false
         resourcedetection/eks:
-          # Detects resources from environment variables and EKS (Elastic Kubernetes Service).
-          detectors: [env, eks]
+          # Detects resources from EKS (Elastic Kubernetes Service).
+          detectors: [eks]
           timeout: 15s
           override: true
           eks:
@@ -216,13 +233,13 @@ collectors:
               k8s.cluster.name:
                 enabled: true
         resourcedetection/gcp:
-          # Detects resources from environment variables and GCP (Google Cloud Platform).
-          detectors: [env, gcp]
+          # Detects resources from GCP (Google Cloud Platform).
+          detectors: [gcp]
           timeout: 2s
           override: true
         resourcedetection/aks:
-          # Detects resources from environment variables and AKS (Azure Kubernetes Service).
-          detectors: [env, aks]
+          # Detects resources from AKS (Azure Kubernetes Service).
+          detectors: [aks]
           timeout: 2s
           override: true
           aks:
@@ -286,13 +303,18 @@ collectors:
             node_from_env_var: OTEL_K8S_NODE_NAME
           passthrough: false
           pod_association:
-            # Below association takes a look at the k8s.pod.ip and k8s.pod.uid resource attributes or connection's context, and tries to match it with the pod having the same attribute.
+            # Below association takes a look at the k8s.pod.ip, then k8s.pod.uid, then k8s.pod.name + k8s.namespace.name, and tries to match it with the pod having the same attribute. If all three fail, it will use the connection's context.
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.ip
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.uid
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.name
+                - from: resource_attribute
+                  name: k8s.namespace.name
             - sources:
                 - from: connection
           extract:
@@ -458,6 +480,7 @@ collectors:
             processors:
               - batch
               - k8sattributes
+              - resourcedetection/env
               - resourcedetection/system
               - resourcedetection/eks
               - resourcedetection/gcp
@@ -473,6 +496,7 @@ collectors:
             processors:
               - batch/metrics
               - k8sattributes
+              - resourcedetection/env
               - resourcedetection/system
               - resourcedetection/eks
               - resourcedetection/gcp

--- a/deploy/helm/edot-collector/kube-stack/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/values.yaml
@@ -309,6 +309,7 @@ collectors:
               - "k8s.pod.ip"
               - "k8s.pod.uid"
               - "k8s.pod.start_time"
+              - "container.id"
               # Service attributes added based on https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/#service-attributes
               - "service.name"
               - "service.version"
@@ -486,6 +487,7 @@ collectors:
               - otlp
             processors:
               - batch/metrics
+              - k8sattributes
               - resource/hostname
             exporters:
               - otlp/gateway
@@ -494,6 +496,7 @@ collectors:
               - otlp
             processors:
               - batch
+              - k8sattributes
               - resource/hostname
             exporters:
               - otlp/gateway
@@ -502,6 +505,7 @@ collectors:
               - otlp
             processors:
               - batch
+              - k8sattributes
               - resource/hostname
             exporters:
               - otlp/gateway

--- a/deploy/helm/edot-collector/kube-stack/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/values.yaml
@@ -41,7 +41,7 @@ collectors:
     fullnameOverride: "opentelemetry-kube-stack-cluster-stats"
     env:
       - name: ELASTIC_AGENT_OTEL
-        value: "true"
+        value: '"true"'
     config:
       exporters:
         # [Debug exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/debugexporter/README.md)
@@ -56,11 +56,6 @@ collectors:
         cgroupruntime: {}
       processors:
         # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
-        resourcedetection/env:
-          # Detects resources from environment variables.
-          detectors: [env]
-          timeout: 2s
-          override: false
         resourcedetection/eks:
           # Detects resources from environment variables and EKS (Elastic Kubernetes Service).
           detectors: [env, eks]
@@ -71,13 +66,13 @@ collectors:
               k8s.cluster.name:
                 enabled: true
         resourcedetection/gcp:
-          # Detects resources from GCP (Google Cloud Platform).
-          detectors: [gcp]
+          # Detects resources from environment variables and GCP (Google Cloud Platform).
+          detectors: [env, gcp]
           timeout: 2s
           override: true
         resourcedetection/aks:
-          # Detects resources from AKS (Azure Kubernetes Service).
-          detectors: [aks]
+          # Detects resources from environment variables and AKS (Azure Kubernetes Service).
+          detectors: [env, aks]
           timeout: 2s
           override: true
           aks:
@@ -93,18 +88,13 @@ collectors:
         k8sattributes:
           passthrough: false # Annotates resources with the pod IP and does not try to extract any other metadata.
           pod_association:
-            # Below association takes a look at the k8s.pod.ip, then k8s.pod.uid, then k8s.pod.name + k8s.namespace.name, and tries to match it with the pod having the same attribute. If all three fail, it will use the connection's context.
+            # Below association takes a look at the k8s.pod.ip and k8s.pod.uid resource attributes or connection's context, and tries to match it with the pod having the same attribute.
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.ip
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.uid
-            - sources:
-                - from: resource_attribute
-                  name: k8s.pod.name
-                - from: resource_attribute
-                  name: k8s.namespace.name
             - sources:
                 - from: connection
           extract:
@@ -160,7 +150,6 @@ collectors:
               - otlp/gateway
             processors:
               - k8sattributes
-              - resourcedetection/env
               - resourcedetection/eks
               - resourcedetection/gcp
               - resourcedetection/aks
@@ -171,7 +160,6 @@ collectors:
             receivers:
               - k8s_events
             processors:
-              - resourcedetection/env
               - resourcedetection/eks
               - resourcedetection/gcp
               - resourcedetection/aks
@@ -186,7 +174,7 @@ collectors:
     fullnameOverride: "opentelemetry-kube-stack-daemon"
     env:
       - name: ELASTIC_AGENT_OTEL
-        value: "true"
+        value: '"true"'
     presets:
       logsCollection:
         enabled: true # Enable/disable the collection of node's logs.
@@ -218,14 +206,9 @@ collectors:
           send_batch_max_size: 0
           timeout: 1s
         # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
-        resourcedetection/env:
-          # Detects resources from environment variables.
-          detectors: [env]
-          timeout: 2s
-          override: false
         resourcedetection/eks:
-          # Detects resources from EKS (Elastic Kubernetes Service).
-          detectors: [eks]
+          # Detects resources from environment variables and EKS (Elastic Kubernetes Service).
+          detectors: [env, eks]
           timeout: 15s
           override: true
           eks:
@@ -233,13 +216,13 @@ collectors:
               k8s.cluster.name:
                 enabled: true
         resourcedetection/gcp:
-          # Detects resources from GCP (Google Cloud Platform).
-          detectors: [gcp]
+          # Detects resources from environment variables and GCP (Google Cloud Platform).
+          detectors: [env, gcp]
           timeout: 2s
           override: true
         resourcedetection/aks:
-          # Detects resources from AKS (Azure Kubernetes Service).
-          detectors: [aks]
+          # Detects resources from environment variables and AKS (Azure Kubernetes Service).
+          detectors: [env, aks]
           timeout: 2s
           override: true
           aks:
@@ -303,18 +286,13 @@ collectors:
             node_from_env_var: OTEL_K8S_NODE_NAME
           passthrough: false
           pod_association:
-            # Below association takes a look at the k8s.pod.ip, then k8s.pod.uid, then k8s.pod.name + k8s.namespace.name, and tries to match it with the pod having the same attribute. If all three fail, it will use the connection's context.
+            # Below association takes a look at the k8s.pod.ip and k8s.pod.uid resource attributes or connection's context, and tries to match it with the pod having the same attribute.
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.ip
             - sources:
                 - from: resource_attribute
                   name: k8s.pod.uid
-            - sources:
-                - from: resource_attribute
-                  name: k8s.pod.name
-                - from: resource_attribute
-                  name: k8s.namespace.name
             - sources:
                 - from: connection
           extract:
@@ -331,7 +309,6 @@ collectors:
               - "k8s.pod.ip"
               - "k8s.pod.uid"
               - "k8s.pod.start_time"
-              - "container.id"
               # Service attributes added based on https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/#service-attributes
               - "service.name"
               - "service.version"
@@ -480,7 +457,6 @@ collectors:
             processors:
               - batch
               - k8sattributes
-              - resourcedetection/env
               - resourcedetection/system
               - resourcedetection/eks
               - resourcedetection/gcp
@@ -496,7 +472,6 @@ collectors:
             processors:
               - batch/metrics
               - k8sattributes
-              - resourcedetection/env
               - resourcedetection/system
               - resourcedetection/eks
               - resourcedetection/gcp
@@ -511,7 +486,6 @@ collectors:
               - otlp
             processors:
               - batch/metrics
-              - k8sattributes
               - resource/hostname
             exporters:
               - otlp/gateway
@@ -520,7 +494,6 @@ collectors:
               - otlp
             processors:
               - batch
-              - k8sattributes
               - resource/hostname
             exporters:
               - otlp/gateway
@@ -529,7 +502,6 @@ collectors:
               - otlp
             processors:
               - batch
-              - k8sattributes
               - resource/hostname
             exporters:
               - otlp/gateway
@@ -549,7 +521,7 @@ collectors:
     enabled: true
     env:
       - name: ELASTIC_AGENT_OTEL
-        value: "true"
+        value: '"true"'
       - name: ELASTIC_ENDPOINT
         valueFrom:
           secretKeyRef:

--- a/testing/integration/k8s/k8s.go
+++ b/testing/integration/k8s/k8s.go
@@ -7,7 +7,7 @@ package k8s
 import "path/filepath"
 
 const (
-	KubeStackChartVersion         = "0.15.0"
+	KubeStackChartVersion         = "0.14.11"
 	KubeStackChartName            = "opentelemetry-kube-stack"
 	KubeStackChartNameWithVersion = KubeStackChartName + "-" + KubeStackChartVersion
 	KubeStackChartArchiveName     = KubeStackChartNameWithVersion + ".tgz"

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/Chart.lock
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.0.0
 - name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.113.1
+  version: 0.105.1
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 6.3.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.48.0
-digest: sha256:0bc649ea2dff6ba5885f295a74847cb477ed71374f15daa40f68d87b01ec82b6
-generated: "2026-05-18T12:13:31.924545+02:00"
+digest: sha256:2ec77416b3a4f1ed3c0cd19512e929b8911fc64e31f5fb909fc50ac61e9c8256
+generated: "2026-02-12T15:44:34.531542519+11:00"

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/Chart.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.151.0
+appVersion: 0.144.0
 dependencies:
 - condition: crds.install,crds.installOtel
   name: otel-crds
@@ -12,7 +12,7 @@ dependencies:
 - condition: opentelemetry-operator.enabled
   name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.113.1
+  version: 0.105.1
 - condition: kubeStateMetrics.enabled
   name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
@@ -34,4 +34,4 @@ name: opentelemetry-kube-stack
 sources:
 - https://github.com/open-telemetry/opentelemetry-operator
 type: application
-version: 0.15.0
+version: 0.14.11

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/Chart.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.151.0
+appVersion: 0.144.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 home: https://opentelemetry.io/
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
@@ -12,4 +12,4 @@ name: opentelemetry-operator
 sources:
 - https://github.com/open-telemetry/opentelemetry-operator
 type: application
-version: 0.113.1
+version: 0.105.1

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/UPGRADING.md
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/UPGRADING.md
@@ -1,53 +1,5 @@
 # Upgrade guidelines
 
-## 0.109.x to 0.110.0
-
-### Migration from kube-rbac-proxy to controller-runtime metrics
-
-The OpenTelemetry Operator (v0.142.0+) has removed its dependency on kube-rbac-proxy. Metrics authentication is now handled by controller-runtime's built-in implementation.
-
-**Breaking Change:** The `kubeRBACProxy` configuration section has been removed. Metrics configuration is now under `manager.metrics` and `manager.ports.metricsPort`.
-
-**Migration Guide:**
-
-If you were using the default configuration (`kubeRBACProxy.enabled: true`), no action is required. The new default (`manager.metrics.secure: true`) provides authenticated metrics on port 8443.
-
-If you need unauthenticated metrics access, update your values.yaml:
-
-```yaml
-# OLD (no longer supported)
-kubeRBACProxy:
-  enabled: true
-  ports:
-    proxyPort: 8443
-
-# NEW
-manager:
-  ports:
-    metricsPort: 8080
-  metrics:
-    secure: false
-```
-
-If you also have the ServiceMonitor enabled, you will need to override the default `metricsEndpoints` to use plain HTTP:
-
-```yaml
-manager:
-  serviceMonitor:
-    enabled: true
-    metricsEndpoints:
-      - port: metrics
-```
-
-**Key Changes:**
-- Deployment now has 1 container (manager only) instead of 2
-- Metrics port configured via `manager.ports.metricsPort` (default: 8443)
-- RBAC: ClusterRole for `/metrics` access only created when `manager.metrics.secure: true`
-- TLS certificates: Auto-generated if not provided when secure mode is enabled
-- ServiceMonitor defaults to HTTPS scraping with bearer token auth to match the secure default
-
-For more details, see [upstream PR #4576](https://github.com/open-telemetry/opentelemetry-operator/pull/4576).
-
 ## 0.86.4 to 0.87.0
 
 In the v0.123.1 Collector release we stopped pushing images to Dockerhub due to how their new rate limit changes affected our CI. If you're using the dockerhub repository (`otel/`) for the image you should switch to `ghcr.io/open-telemetry/opentelemetry-collector-releases/` instead. See https://github.com/open-telemetry/community/issues/2641 for more details.

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_opampbridges.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_opampbridges.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.21.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
@@ -1597,10 +1597,6 @@ spec:
                                     type: integer
                                   signerName:
                                     type: string
-                                  userAnnotations:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
                                 required:
                                 - keyType
                                 - signerName

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_targetallocators.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_targetallocators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.21.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
@@ -1334,26 +1334,9 @@ spec:
                 type: string
               global:
                 type: object
-              hostAliases:
-                items:
-                  properties:
-                    hostnames:
-                      items:
-                        type: string
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    ip:
-                      type: string
-                  required:
-                  - ip
-                  type: object
-                type: array
-                x-kubernetes-list-type: atomic
               hostNetwork:
                 type: boolean
               hostPID:
-                type: boolean
-              hostUsers:
                 type: boolean
               image:
                 type: string
@@ -2213,87 +2196,6 @@ spec:
                   stopSignal:
                     type: string
                 type: object
-              livenessProbe:
-                properties:
-                  exec:
-                    properties:
-                      command:
-                        items:
-                          type: string
-                        type: array
-                        x-kubernetes-list-type: atomic
-                    type: object
-                  failureThreshold:
-                    format: int32
-                    type: integer
-                  grpc:
-                    properties:
-                      port:
-                        format: int32
-                        type: integer
-                      service:
-                        default: ""
-                        type: string
-                    required:
-                    - port
-                    type: object
-                  httpGet:
-                    properties:
-                      host:
-                        type: string
-                      httpHeaders:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      path:
-                        type: string
-                      port:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        x-kubernetes-int-or-string: true
-                      scheme:
-                        type: string
-                    required:
-                    - port
-                    type: object
-                  initialDelaySeconds:
-                    format: int32
-                    type: integer
-                  periodSeconds:
-                    format: int32
-                    type: integer
-                  successThreshold:
-                    format: int32
-                    type: integer
-                  tcpSocket:
-                    properties:
-                      host:
-                        type: string
-                      port:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        x-kubernetes-int-or-string: true
-                    required:
-                    - port
-                    type: object
-                  terminationGracePeriodSeconds:
-                    format: int64
-                    type: integer
-                  timeoutSeconds:
-                    format: int32
-                    type: integer
-                type: object
               managementState:
                 default: managed
                 enum:
@@ -2487,65 +2389,7 @@ spec:
                     type: array
                   enabled:
                     type: boolean
-                  evaluationInterval:
-                    default: 30s
-                    format: duration
-                    type: string
-                  podMonitorNamespaceSelector:
-                    default: {}
-                    properties:
-                      matchExpressions:
-                        items:
-                          properties:
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            values:
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        type: object
-                    type: object
-                    x-kubernetes-map-type: atomic
                   podMonitorSelector:
-                    properties:
-                      matchExpressions:
-                        items:
-                          properties:
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            values:
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        type: object
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  probeNamespaceSelector:
-                    default: {}
                     properties:
                       matchExpressions:
                         items:
@@ -2603,33 +2447,6 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                     x-kubernetes-preserve-unknown-fields: true
-                  scrapeConfigNamespaceSelector:
-                    default: {}
-                    properties:
-                      matchExpressions:
-                        items:
-                          properties:
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            values:
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        type: object
-                    type: object
-                    x-kubernetes-map-type: atomic
                   scrapeConfigSelector:
                     properties:
                       matchExpressions:
@@ -2660,41 +2477,6 @@ spec:
                     default: 30s
                     format: duration
                     type: string
-                  scrapeProtocols:
-                    items:
-                      type: string
-                    type: array
-                  secretNamespaces:
-                    items:
-                      type: string
-                    type: array
-                  serviceMonitorNamespaceSelector:
-                    default: {}
-                    properties:
-                      matchExpressions:
-                        items:
-                          properties:
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            values:
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        type: object
-                    type: object
-                    x-kubernetes-map-type: atomic
                   serviceMonitorSelector:
                     properties:
                       matchExpressions:
@@ -2721,87 +2503,6 @@ spec:
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
-                type: object
-              readinessProbe:
-                properties:
-                  exec:
-                    properties:
-                      command:
-                        items:
-                          type: string
-                        type: array
-                        x-kubernetes-list-type: atomic
-                    type: object
-                  failureThreshold:
-                    format: int32
-                    type: integer
-                  grpc:
-                    properties:
-                      port:
-                        format: int32
-                        type: integer
-                      service:
-                        default: ""
-                        type: string
-                    required:
-                    - port
-                    type: object
-                  httpGet:
-                    properties:
-                      host:
-                        type: string
-                      httpHeaders:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      path:
-                        type: string
-                      port:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        x-kubernetes-int-or-string: true
-                      scheme:
-                        type: string
-                    required:
-                    - port
-                    type: object
-                  initialDelaySeconds:
-                    format: int32
-                    type: integer
-                  periodSeconds:
-                    format: int32
-                    type: integer
-                  successThreshold:
-                    format: int32
-                    type: integer
-                  tcpSocket:
-                    properties:
-                      host:
-                        type: string
-                      port:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        x-kubernetes-int-or-string: true
-                    required:
-                    - port
-                    type: object
-                  terminationGracePeriodSeconds:
-                    format: int64
-                    type: integer
-                  timeoutSeconds:
-                    format: int32
-                    type: integer
                 type: object
               replicas:
                 default: 1
@@ -3646,10 +3347,6 @@ spec:
                                     type: integer
                                   signerName:
                                     type: string
-                                  userAnnotations:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
                                 required:
                                 - keyType
                                 - signerName

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/conf/crds/crd-opentelemetrycollector.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/conf/crds/crd-opentelemetrycollector.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ include "opentelemetry-operator.webhookCertAnnotation" . }}
-    controller-gen.kubebuilder.io/version: v0.21.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
@@ -4501,10 +4501,6 @@ spec:
                                     type: integer
                                   signerName:
                                     type: string
-                                  userAnnotations:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
                                 required:
                                 - keyType
                                 - signerName
@@ -6308,43 +6304,10 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
-              hostAliases:
-                items:
-                  properties:
-                    hostnames:
-                      items:
-                        type: string
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    ip:
-                      type: string
-                  required:
-                  - ip
-                  type: object
-                type: array
-                x-kubernetes-list-type: atomic
               hostNetwork:
                 type: boolean
               hostPID:
                 type: boolean
-              hostUsers:
-                type: boolean
-              httpRoute:
-                properties:
-                  enabled:
-                    type: boolean
-                  gateway:
-                    type: string
-                  gatewayNamespace:
-                    type: string
-                  hostnames:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - enabled
-                - gateway
-                type: object
               image:
                 type: string
               imagePullPolicy:
@@ -7356,11 +7319,6 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
-              podManagementPolicy:
-                enum:
-                - OrderedReady
-                - Parallel
-                type: string
               podSecurityContext:
                 properties:
                   appArmorProfile:
@@ -8313,65 +8271,7 @@ spec:
                         type: array
                       enabled:
                         type: boolean
-                      evaluationInterval:
-                        default: 30s
-                        format: duration
-                        type: string
-                      podMonitorNamespaceSelector:
-                        default: {}
-                        properties:
-                          matchExpressions:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                operator:
-                                  type: string
-                                values:
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                        x-kubernetes-map-type: atomic
                       podMonitorSelector:
-                        properties:
-                          matchExpressions:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                operator:
-                                  type: string
-                                values:
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      probeNamespaceSelector:
-                        default: {}
                         properties:
                           matchExpressions:
                             items:
@@ -8429,33 +8329,6 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                         x-kubernetes-preserve-unknown-fields: true
-                      scrapeConfigNamespaceSelector:
-                        default: {}
-                        properties:
-                          matchExpressions:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                operator:
-                                  type: string
-                                values:
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                        x-kubernetes-map-type: atomic
                       scrapeConfigSelector:
                         properties:
                           matchExpressions:
@@ -8486,41 +8359,6 @@ spec:
                         default: 30s
                         format: duration
                         type: string
-                      scrapeProtocols:
-                        items:
-                          type: string
-                        type: array
-                      secretNamespaces:
-                        items:
-                          type: string
-                        type: array
-                      serviceMonitorNamespaceSelector:
-                        default: {}
-                        properties:
-                          matchExpressions:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                operator:
-                                  type: string
-                                values:
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                        x-kubernetes-map-type: atomic
                       serviceMonitorSelector:
                         properties:
                           matchExpressions:
@@ -9642,10 +9480,6 @@ spec:
                                     type: integer
                                   signerName:
                                     type: string
-                                  userAnnotations:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
                                 required:
                                 - keyType
                                 - signerName

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/conf/crds/crd-opentelemetryinstrumentation.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/conf/crds/crd-opentelemetryinstrumentation.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.21.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
@@ -131,8 +131,6 @@ spec:
                       type: object
                     type: array
                   configPath:
-                    maxLength: 256
-                    pattern: ^[A-Za-z0-9._/-]*$
                     type: string
                   env:
                     items:
@@ -838,78 +836,6 @@ spec:
                           x-kubernetes-int-or-string: true
                         type: object
                     type: object
-                  securityContext:
-                    properties:
-                      allowPrivilegeEscalation:
-                        type: boolean
-                      appArmorProfile:
-                        properties:
-                          localhostProfile:
-                            type: string
-                          type:
-                            type: string
-                        required:
-                        - type
-                        type: object
-                      capabilities:
-                        properties:
-                          add:
-                            items:
-                              type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          drop:
-                            items:
-                              type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
-                        type: object
-                      privileged:
-                        type: boolean
-                      procMount:
-                        type: string
-                      readOnlyRootFilesystem:
-                        type: boolean
-                      runAsGroup:
-                        format: int64
-                        type: integer
-                      runAsNonRoot:
-                        type: boolean
-                      runAsUser:
-                        format: int64
-                        type: integer
-                      seLinuxOptions:
-                        properties:
-                          level:
-                            type: string
-                          role:
-                            type: string
-                          type:
-                            type: string
-                          user:
-                            type: string
-                        type: object
-                      seccompProfile:
-                        properties:
-                          localhostProfile:
-                            type: string
-                          type:
-                            type: string
-                        required:
-                        - type
-                        type: object
-                      windowsOptions:
-                        properties:
-                          gmsaCredentialSpec:
-                            type: string
-                          gmsaCredentialSpecName:
-                            type: string
-                          hostProcess:
-                            type: boolean
-                          runAsUserName:
-                            type: string
-                        type: object
-                    type: object
                   volumeClaimTemplate:
                     properties:
                       metadata:
@@ -1031,78 +957,6 @@ spec:
                 type: object
               imagePullPolicy:
                 type: string
-              initContainerSecurityContext:
-                properties:
-                  allowPrivilegeEscalation:
-                    type: boolean
-                  appArmorProfile:
-                    properties:
-                      localhostProfile:
-                        type: string
-                      type:
-                        type: string
-                    required:
-                    - type
-                    type: object
-                  capabilities:
-                    properties:
-                      add:
-                        items:
-                          type: string
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      drop:
-                        items:
-                          type: string
-                        type: array
-                        x-kubernetes-list-type: atomic
-                    type: object
-                  privileged:
-                    type: boolean
-                  procMount:
-                    type: string
-                  readOnlyRootFilesystem:
-                    type: boolean
-                  runAsGroup:
-                    format: int64
-                    type: integer
-                  runAsNonRoot:
-                    type: boolean
-                  runAsUser:
-                    format: int64
-                    type: integer
-                  seLinuxOptions:
-                    properties:
-                      level:
-                        type: string
-                      role:
-                        type: string
-                      type:
-                        type: string
-                      user:
-                        type: string
-                    type: object
-                  seccompProfile:
-                    properties:
-                      localhostProfile:
-                        type: string
-                      type:
-                        type: string
-                    required:
-                    - type
-                    type: object
-                  windowsOptions:
-                    properties:
-                      gmsaCredentialSpec:
-                        type: string
-                      gmsaCredentialSpecName:
-                        type: string
-                      hostProcess:
-                        type: boolean
-                      runAsUserName:
-                        type: string
-                    type: object
-                type: object
               java:
                 properties:
                   env:
@@ -1440,8 +1294,6 @@ spec:
                       type: object
                     type: array
                   configFile:
-                    maxLength: 256
-                    pattern: ^[A-Za-z0-9._/-]*$
                     type: string
                   env:
                     items:
@@ -2198,11 +2050,6 @@ spec:
                 type: object
             type: object
           status:
-            properties:
-              upgradeBlockedVersions:
-                additionalProperties:
-                  type: string
-                type: object
             type: object
         type: object
     served: true

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
@@ -184,11 +184,7 @@ rules:
   - apiGroups:
       - ""
     resources:
-{{- if semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version }}
-      - nodes/pods
-{{- else }}
       - nodes/proxy
-{{- end }}
     verbs:
       - get
   - apiGroups:
@@ -216,32 +212,11 @@ rules:
       - list
       - update
   - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - events.k8s.io
     resources:
       - events
     verbs:
-      - create
       - list
-      - patch
-      - watch
-  - apiGroups:
-      - gateway.networking.k8s.io
-    resources:
-      - httproutes
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - monitoring.coreos.com
@@ -399,19 +374,13 @@ rules:
       - patch
       - delete
   - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
       - authorization.k8s.io
     resources:
       - subjectaccessreviews
     verbs:
       - create
 
-{{ if .Values.manager.metrics.secure }}
+{{ if .Values.kubeRBACProxy.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -425,5 +394,20 @@ rules:
       - /metrics
     verbs:
       - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "opentelemetry-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller-manager
+  name: {{ template "opentelemetry-operator.fullname" . }}-proxy
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
 {{- end }}
 {{ end }}

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
@@ -14,4 +14,23 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "opentelemetry-operator.serviceAccountName" . }}
     namespace: {{ template "opentelemetry-operator.namespace" . }}
+
+{{ if .Values.kubeRBACProxy.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "opentelemetry-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller-manager
+  name: {{ template "opentelemetry-operator.fullname" . }}-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "opentelemetry-operator.fullname" . }}-proxy
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "opentelemetry-operator.serviceAccountName" . }}
+    namespace: {{ template "opentelemetry-operator.namespace" . }}
+{{- end }}
 {{ end }}

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/deployment.yaml
@@ -14,9 +14,6 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  {{- if .Values.minReadySeconds }}
-  minReadySeconds: {{ .Values.minReadySeconds }}
-  {{- end }}
   selector:
     matchLabels:
       {{- include "opentelemetry-operator.selectorLabels" . | nindent 6 }}
@@ -49,7 +46,6 @@ spec:
       containers:
         - args:
             - --metrics-addr=0.0.0.0:{{ .Values.manager.ports.metricsPort }}
-            - --metrics-secure={{ .Values.manager.metrics.secure }}
             {{- if .Values.manager.leaderElection.enabled }}
             - --enable-leader-election
             {{- end }}
@@ -158,6 +154,33 @@ spec:
           {{- with .Values.manager.securityContext }}
           securityContext: {{ toYaml . | nindent 12 }}
           {{- end }}
+        {{ if .Values.kubeRBACProxy.enabled }}
+        - args:
+            - --secure-listen-address=0.0.0.0:{{ .Values.kubeRBACProxy.ports.proxyPort }}
+            - --upstream=http://127.0.0.1:{{ .Values.manager.ports.metricsPort }}/
+            - --v=0
+            {{-  if .Values.kubeRBACProxy.extraArgs  }}
+            {{- .Values.kubeRBACProxy.extraArgs | toYaml | nindent 12 }}
+            {{-  end  }}
+          image: "{{ .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}"
+          name: kube-rbac-proxy
+          ports:
+            - containerPort: {{ .Values.kubeRBACProxy.ports.proxyPort }}
+              name: https
+              protocol: TCP
+          {{- with .Values.kubeRBACProxy.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.kubeRBACProxy.securityContext }}
+          securityContext: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if $explicitMount }}
+          volumeMounts:
+            - name: access-token
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
+          {{- end }}
+        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/extramanifests.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/extramanifests.yaml
@@ -1,4 +1,0 @@
-{{ range .Values.extraObjects }}
----
-{{ tpl (toYaml .) $ }}
-{{ end }}

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/service.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/service.yaml
@@ -12,6 +12,12 @@ metadata:
   namespace: {{ template "opentelemetry-operator.namespace" . }}
 spec:
   ports:
+    {{- if .Values.kubeRBACProxy.enabled }}
+    - name: https
+      port: {{ .Values.kubeRBACProxy.ports.proxyPort }}
+      protocol: TCP
+      targetPort: https
+    {{- end }}
     - name: metrics
       port: {{ .Values.manager.ports.metricsPort }}
       protocol: TCP

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/tests/test-service-connection.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/tests/test-service-connection.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.kubeRBACProxy.enabled }}
 ---
 apiVersion: v1
 kind: Pod
@@ -17,7 +18,7 @@ spec:
         - name: MANAGER_METRICS_SERVICE_CLUSTERIP
           value: "{{ include "opentelemetry-operator.fullname" . }}"
         - name: MANAGER_METRICS_SERVICE_PORT
-          value: "{{ .Values.manager.ports.metricsPort }}"
+          value: "{{ .Values.kubeRBACProxy.ports.proxyPort }}"
       command:
         - sh
         - -c
@@ -51,6 +52,7 @@ spec:
   {{- end }}
   securityContext:
 {{ toYaml .Values.securityContext | indent 4 }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Pod

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/verticalpodautoscaler.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/verticalpodautoscaler.yaml
@@ -16,8 +16,7 @@ spec:
     containerPolicies:
     - containerName: manager
       {{- if .Values.manager.verticalPodAutoscaler.controlledResources }}
-      controlledResources:
-        {{- toYaml .Values.manager.verticalPodAutoscaler.controlledResources | nindent 8 }}
+      controlledResources: {{ .Values.manager.verticalPodAutoscaler.controlledResources }}
       {{- end }}
       {{- if .Values.manager.verticalPodAutoscaler.maxAllowed }}
       maxAllowed:
@@ -34,7 +33,7 @@ spec:
   {{- if .Values.manager.verticalPodAutoscaler.updatePolicy }}
   updatePolicy:
     {{- if .Values.manager.verticalPodAutoscaler.updatePolicy.updateMode }}
-    updateMode: {{ .Values.manager.verticalPodAutoscaler.updatePolicy.updateMode | quote }}
+    updateMode: {{ .Values.manager.verticalPodAutoscaler.updatePolicy.updateMode }}
     {{- end }}
     {{- if .Values.manager.verticalPodAutoscaler.updatePolicy.minReplicas }}
     minReplicas: {{ .Values.manager.verticalPodAutoscaler.updatePolicy.minReplicas }}

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/values.schema.json
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/values.schema.json
@@ -12,6 +12,7 @@
     "clusterDomain",
     "pdb",
     "manager",
+    "kubeRBACProxy",
     "admissionWebhooks",
     "crds",
     "role",
@@ -46,16 +47,6 @@
       "title": "The revisionHistoryLimit Schema",
       "examples": [
         1
-      ]
-    },
-    "minReadySeconds": {
-      "type": "integer",
-      "default": 0,
-      "minimum": 0,
-      "title": "The minReadySeconds Schema",
-      "examples": [
-        0,
-        30
       ]
     },
     "nameOverride": {
@@ -183,8 +174,7 @@
         "rolling",
         "securityContext",
         "ignoreMissingCollectorCRDs",
-        "autoInstrumentation",
-        "metrics"
+        "autoInstrumentation"
       ],
       "additionalProperties": false,
       "properties": {
@@ -713,7 +703,7 @@
           },
           "examples": [
             {
-              "metricsPort": 8443,
+              "metricsPort": 8080,
               "webhookPort": 9443,
               "healthzPort": 8081
             }
@@ -1276,72 +1266,6 @@
               "additionalProperties": false
             }
           }
-        },
-        "metrics": {
-          "type": "object",
-          "default": {},
-          "title": "Metrics server configuration",
-          "required": [
-            "secure",
-            "tls"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "secure": {
-              "type": "boolean",
-              "default": true,
-              "title": "Enable authentication and authorization for metrics",
-              "description": "Corresponds to --metrics-secure flag in the operator",
-              "examples": [
-                true
-              ]
-            },
-            "tls": {
-              "type": "object",
-              "default": {},
-              "title": "TLS configuration for metrics server",
-              "required": [
-                "certFile",
-                "keyFile"
-              ],
-              "additionalProperties": false,
-              "properties": {
-                "certFile": {
-                  "type": "string",
-                  "default": "",
-                  "title": "Path to TLS certificate file",
-                  "description": "Corresponds to --metrics-tls-cert-file flag",
-                  "examples": [
-                    ""
-                  ]
-                },
-                "keyFile": {
-                  "type": "string",
-                  "default": "",
-                  "title": "Path to TLS private key file",
-                  "description": "Corresponds to --metrics-tls-key-file flag",
-                  "examples": [
-                    ""
-                  ]
-                }
-              },
-              "examples": [
-                {
-                  "certFile": "",
-                  "keyFile": ""
-                }
-              ]
-            }
-          },
-          "examples": [
-            {
-              "secure": true,
-              "tls": {
-                "certFile": "",
-                "keyFile": ""
-              }
-            }
-          ]
         }
       },
       "examples": [
@@ -1390,7 +1314,7 @@
           },
           "featureGates": "",
           "ports": {
-            "metricsPort": 8443,
+            "metricsPort": 8080,
             "webhookPort": 9443,
             "healthzPort": 8081
           },
@@ -1449,14 +1373,214 @@
             }
           },
           "rolling": false,
-          "securityContext": {},
-          "metrics": {
-            "secure": true,
-            "tls": {
-              "certFile": "",
-              "keyFile": ""
+          "securityContext": {}
+        }
+      ]
+    },
+    "kubeRBACProxy": {
+      "type": "object",
+      "default": {},
+      "title": "The kubeRBACProxy Schema",
+      "required": [
+        "enabled",
+        "image",
+        "ports",
+        "extraArgs",
+        "securityContext"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "title": "The enabled Schema",
+          "examples": [
+            true
+          ]
+        },
+        "image": {
+          "type": "object",
+          "default": {},
+          "title": "The image Schema",
+          "required": [
+            "repository",
+            "tag"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "repository": {
+              "type": "string",
+              "default": "",
+              "title": "The repository Schema",
+              "examples": [
+                "quay.io/brancz/kube-rbac-proxy"
+              ]
+            },
+            "tag": {
+              "type": "string",
+              "default": "",
+              "title": "The tag Schema",
+              "examples": [
+                "v0.15.0"
+              ]
             }
-          }
+          },
+          "examples": [
+            {
+              "repository": "quay.io/brancz/kube-rbac-proxy",
+              "tag": "v0.15.0"
+            }
+          ]
+        },
+        "ports": {
+          "type": "object",
+          "default": {},
+          "title": "The ports Schema",
+          "required": [
+            "proxyPort"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "proxyPort": {
+              "type": "integer",
+              "default": 0,
+              "title": "The proxyPort Schema",
+              "examples": [
+                8443
+              ]
+            }
+          },
+          "examples": [
+            {
+              "proxyPort": 8443
+            }
+          ]
+        },
+        "resources": {
+          "type": "object",
+          "default": {},
+          "title": "The resources Schema",
+          "required": [],
+          "additionalProperties": false,
+          "properties": {
+            "limits": {
+              "type": "object",
+              "default": {},
+              "title": "The limits Schema",
+              "required": [],
+              "additionalProperties": true,
+              "properties": {
+                "cpu": {
+                  "type": "string",
+                  "default": "",
+                  "title": "The cpu Schema",
+                  "examples": [
+                    "500m"
+                  ]
+                },
+                "memory": {
+                  "type": "string",
+                  "default": "",
+                  "title": "The memory Schema",
+                  "examples": [
+                    "128Mi"
+                  ]
+                }
+              },
+              "examples": [
+                {
+                  "cpu": "500m",
+                  "memory": "128Mi"
+                }
+              ]
+            },
+            "requests": {
+              "type": "object",
+              "default": {},
+              "title": "The requests Schema",
+              "required": [],
+              "additionalProperties": true,
+              "properties": {
+                "cpu": {
+                  "type": "string",
+                  "default": "",
+                  "title": "The cpu Schema",
+                  "examples": [
+                    "5m"
+                  ]
+                },
+                "memory": {
+                  "type": "string",
+                  "default": "",
+                  "title": "The memory Schema",
+                  "examples": [
+                    "64Mi"
+                  ]
+                }
+              },
+              "examples": [
+                {
+                  "cpu": "5m",
+                  "memory": "64Mi"
+                }
+              ]
+            }
+          },
+          "examples": [
+            {
+              "limits": {
+                "cpu": "500m",
+                "memory": "128Mi"
+              },
+              "requests": {
+                "cpu": "5m",
+                "memory": "64Mi"
+              }
+            }
+          ]
+        },
+        "extraArgs": {
+          "type": "array",
+          "default": [],
+          "title": "The extraArgs Schema",
+          "items": {},
+          "examples": [
+            []
+          ]
+        },
+        "securityContext": {
+          "type": "object",
+          "default": {},
+          "title": "The securityContext Schema",
+          "required": [],
+          "properties": {},
+          "examples": [
+            {}
+          ]
+        }
+      },
+      "examples": [
+        {
+          "enabled": true,
+          "image": {
+            "repository": "quay.io/brancz/kube-rbac-proxy",
+            "tag": "v0.15.0"
+          },
+          "ports": {
+            "proxyPort": 8443
+          },
+          "resources": {
+            "limits": {
+              "cpu": "500m",
+              "memory": "128Mi"
+            },
+            "requests": {
+              "cpu": "5m",
+              "memory": "64Mi"
+            }
+          },
+          "extraArgs": [],
+          "securityContext": {}
         }
       ]
     },
@@ -2013,14 +2137,6 @@
       "examples": [
         false
       ]
-    },
-    "extraObjects": {
-      "type": "array",
-      "default": [],
-      "title": "Extra manifests to deploy as an array",
-      "items": {
-        "type": "object"
-      }
     }
   },
   "examples": [
@@ -2082,7 +2198,7 @@
         },
         "featureGates": "",
         "ports": {
-          "metricsPort": 8443,
+          "metricsPort": 8080,
           "webhookPort": 9443,
           "healthzPort": 8081
         },
@@ -2141,6 +2257,28 @@
           }
         },
         "rolling": false,
+        "securityContext": {}
+      },
+      "kubeRBACProxy": {
+        "enabled": true,
+        "image": {
+          "repository": "quay.io/brancz/kube-rbac-proxy",
+          "tag": "v0.15.0"
+        },
+        "ports": {
+          "proxyPort": 8443
+        },
+        "resources": {
+          "limits": {
+            "cpu": "500m",
+            "memory": "128Mi"
+          },
+          "requests": {
+            "cpu": "5m",
+            "memory": "64Mi"
+          }
+        },
+        "extraArgs": [],
         "securityContext": {}
       },
       "admissionWebhooks": {

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/values.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/values.yaml
@@ -11,11 +11,6 @@ replicaCount: 1
 ##
 revisionHistoryLimit: 10
 
-## Minimum number of seconds for which a newly created pod should be ready
-## without any of its container crashing, for it to be considered available.
-##
-minReadySeconds: 0
-
 ## Provide a name in place of opentelemetry-operator (includes the chart's release name).
 ##
 nameOverride: ""
@@ -55,7 +50,7 @@ manager:
     imagePullPolicy: IfNotPresent
   collectorImage:
     repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s
-    tag: 0.151.0
+    tag: 0.144.0
   opampBridgeImage:
     repository: ""
     tag: ""
@@ -109,23 +104,9 @@ manager:
   # operator.golang.flags: false
   # operator.collector.default.config: false
   ports:
-    metricsPort: 8443
+    metricsPort: 8080
     webhookPort: 9443
     healthzPort: 8081
-  ## Metrics server configuration
-  ## The operator uses controller-runtime built-in auth for the metrics server
-  metrics:
-    # Enable authentication and authorization for the metrics server
-    # Corresponds to --metrics-secure flag in the operator
-    secure: true
-
-    # TLS configuration (optional, self-signed certs generated if not provided)
-    # Corresponds to --metrics-tls-cert-file and --metrics-tls-key-file flags
-    tls:
-      # Path to TLS certificate file (optional)
-      certFile: ""
-      # Path to TLS private key file (optional)
-      keyFile: ""
   resources: {}
   # resources:
   #   limits:
@@ -166,10 +147,6 @@ manager:
     annotations: {}
     metricsEndpoints:
       - port: metrics
-        scheme: https
-        bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-        tlsConfig:
-          insecureSkipVerify: true
     # Used to set relabeling and metricRelabeling configs on the ServiceMonitor
     # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
     relabelings: []
@@ -247,6 +224,39 @@ manager:
       minReplicas: 2
   # Enable manager pod automatically rolling
   rolling: false
+
+  ## Container specific securityContext
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+
+## Provide OpenTelemetry Operator kube-rbac-proxy container image.
+##
+kubeRBACProxy:
+  enabled: true
+  image:
+    repository: quay.io/brancz/kube-rbac-proxy
+    tag: v0.20.0
+  ports:
+    proxyPort: 8443
+  resources: {}
+  # resources:
+  #   limits:
+  #     cpu: 500m
+  #     memory: 128Mi
+  #   requests:
+  #     cpu: 5m
+  #     memory: 64Mi
+
+  ## List of additional cli arguments to configure the kube-rbac-proxy
+  ## for example: --tls-cipher-suites, --tls-min-version, etc.
+  extraArgs: []
 
   ## Container specific securityContext
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
@@ -406,13 +416,3 @@ testFramework:
   #   requests:
   #     cpu: 10m
   #     memory: 64Mi
-
-## Extra manifests to deploy as an array
-## Supports tpl syntax for templating
-extraObjects: []
-  # - apiVersion: v1
-  #   kind: ConfigMap
-  #   metadata:
-  #     name: '{{ include "opentelemetry-operator.fullname" . }}-extra'
-  #   data:
-  #     key: value

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/templates/_helpers.tpl
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/templates/_helpers.tpl
@@ -75,7 +75,7 @@ Render a deduped list of environment variables and 'extraEnvs'
 {{- end }}
 {{- range $key, $value := $envMap }}
 - name: {{ $key }}
-  value: {{ $value | quote }}
+  value: {{ $value }}
 {{- end }}
 {{- range $key, $value := $valueFromMap }}
 - name: {{ $key }}

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/templates/hooks.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/templates/hooks.yaml
@@ -62,20 +62,12 @@ spec:
       {{- else}}
       serviceAccountName: {{ .Values.cleanupJob.existingServiceAccount }}
       {{- end}}
-      {{- with .Values.cleanupJob.podSecurityContext }}
-      securityContext:
-{{- toYaml . | nindent 8 }}
-      {{- end }}
       containers:
       - name: delete-resources
         {{- if $.Values.cleanupJob.image.digest }}
         image: "{{ $.Values.cleanupJob.image.repository }}@{{ $.Values.cleanupJob.image.digest }}"
         {{- else }}
         image: "{{ $.Values.cleanupJob.image.repository }}:{{ $.Values.cleanupJob.image.tag }}"
-        {{- end }}
-        {{- with $.Values.cleanupJob.securityContext }}
-        securityContext:
-{{- toYaml . | nindent 10 }}
         {{- end }}
         args:
           - "delete"

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/values.schema.json
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/values.schema.json
@@ -566,10 +566,7 @@
           "type": "string"
         },
         "value": {
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": "string"
         },
         "valueFrom": {
           "$ref": "#/$defs/EnvVarSource"
@@ -4224,29 +4221,6 @@
       "properties": {
         "enabled": {
           "type": "boolean"
-        },
-        "image": {
-          "type": "object",
-          "properties": {
-            "repository": {
-              "type": "string"
-            },
-            "tag": {
-              "type": "string"
-            },
-            "digest": {
-              "type": "string"
-            }
-          }
-        },
-        "existingServiceAccount": {
-          "type": "string"
-        },
-        "podSecurityContext": {
-          "$ref": "#/$defs/PodSecurityContext"
-        },
-        "securityContext": {
-          "$ref": "#/$defs/SecurityContext"
         }
       }
     },

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/values.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/values.yaml
@@ -26,22 +26,6 @@ cleanupJob:
   # To use the existingServiceAccount
   existingServiceAccount: ""
 
-  # Pod-level securityContext for the cleanup Job (Pod spec field name; PSA restricted needs seccomp).
-  podSecurityContext: {}
-  #   runAsNonRoot: true
-  #   seccompProfile:
-  #     type: RuntimeDefault
-
-  # Container security context for the cleanup Job.
-  securityContext: {}
-  #   allowPrivilegeEscalation: false
-  #   capabilities:
-  #     drop:
-  #       - ALL
-  #   readOnlyRootFilesystem: true
-  #   runAsNonRoot: true
-  #   runAsUser: 65534
-
 # Should the CRDs be installed by this chart.
 crds:
   # Control whether the opentelemetry.io CRDS should be installed.


### PR DESCRIPTION
## What does this PR do?

Restores the bundled opentelemetry-kube-stack chart used for tests, and the deploy/helm/edot-collector/kube-stack/ values files to the state immediately before https://github.com/elastic/elastic-agent/pull/13757 landed on main - undoing the chained chart
bumps (https://github.com/elastic/elastic-agent/pull/13757 0.14.11->0.14.12, https://github.com/elastic/elastic-agent/pull/14095 ->0.14.13, https://github.com/elastic/elastic-agent/pull/14377 ->0.15.0).

## Why is it important?

Kibana's observability onboarding flow [pins](https://github.com/elastic/kibana/blob/9429056dd34cd63eef08d523f4b78bfa9a8684aa/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/constants.ts#L9) the upstream opentelemetry-kube-stack chart to 0.12.4 while fetching the values file live from this repo at `v<agentVersion>`. After https://github.com/elastic/elastic-agent/pull/13757 the values file encodes ELASTIC_AGENT_OTEL as value: "true", which chart 0.12.4's pre-| quote env helper renders as the unquoted YAML token true. Kubernetes rejects that because corev1.EnvVar.value must be a string, breaking helm install for the 9.3 onboarding path.

## How to test this PR locally

Run

```
helm upgrade --install opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack \
  --namespace opentelemetry-operator-system \
  --values 'deploy/helm/edot-collector/kube-stack/managed_otlp/logs-values.yaml' \
  --version '0.12.4' \
  --set 'collectors.daemon.config.processors.resource\/onboarding_id.attributes[0].action=upsert' \
  --set 'collectors.daemon.config.processors.resource\/onboarding_id.attributes[0].key=onboarding.id' \
  --set 'collectors.daemon.config.processors.resource\/onboarding_id.attributes[0].value=placeholder' \
  --set 'collectors.daemon.config.service.pipelines.logs\/node.processors[8]=resource/onboarding_id' \
  --set 'defaultCRConfig.image.tag=9.3.4'
```

It will fail before this change and succeed afterwards.

## Related issues

- Relates https://github.com/elastic/elastic-agent/pull/14464 https://github.com/elastic/elastic-agent/pull/14466


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
