### PR TITLE
Supply explicit ID in TestFleetDownloadProxyURL

### DIFF
--- a/testing/integration/ess/proxy_url_test.go
+++ b/testing/integration/ess/proxy_url_test.go
@@ -962,6 +962,7 @@ func TestFleetDownloadProxyURL(t *testing.T) {
 	t.Cleanup(proxy.Close)
 
 	fleetProxyResp, err := kibClient.CreateFleetProxy(ctx, kibana.ProxiesRequest{
+		ID:   "fleet-upgrade-test-proxy-" + testUUID.String(),
 		Name: "fleet-upgrade-test-proxy-" + testUUID.String(),
 		URL:  proxy.LocalhostURL,
 	})


### PR DESCRIPTION
## What does this PR do?

Supplies a value for `ProxiesRequest.ID` rather than leaving it empty.

## Why is it important?

Integration tests on main are currently failing. See https://buildkite.com/elastic/elastic-agent/builds/40132 for example. 

This is caused by https://github.com/elastic/kibana/pull/270050, which actually causes Kibana to reject empty IDs. `kibana.ProxiesRequest.ID` lacks an `omitempty` JSON tag, so omitting it marshals to `"id": ""` which the upgraded API now rejects with:

```
  id is not valid: must be 1–255 characters and must not contain path separators, traversal sequences, or reserved keys.
```

Fix by supplying an explicit ID (same value as Name, consistent with how endpoint_security_test.go already calls CreateFleetProxy). The longer-term fix is to add `omitempty` to `ProxiesRequest.ID` in elastic-agent-libs.


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
