### PR TITLE
Fix documentation drift in readme, integration test guide, and hybrid agent guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ To build a local version of the agent for development, run the command below. Th
 * linux/amd64
 * linux/arm64
 * windows/amd64
+* windows/arm64
 
 ```sh
 # EXTERNAL=true downloads the matching version of the binaries that are packaged with agent, not necessary if only using Beats.

--- a/docs/hybrid-agent-beats-receivers.md
+++ b/docs/hybrid-agent-beats-receivers.md
@@ -4,8 +4,7 @@ This page provides a brief overview of the Beat receivers and Hybrid Agent proje
 These are part of Elastic's larger effort to base data collection on OpenTelemetry technologies. For more context, see
 https://www.elastic.co/observability-labs/blog/elastic-agent-pivot-opentelemetry. This document does not aim to be a
 comprehensive explanation of beat receivers or hybrid agent as concepts, it is only a brief overview along with
-testing instructions. Beat receivers and hybrid agent capabilities are available starting with the 9.1.0 and 8.19.0
-releases at a technical preview level and are not enabled or used by default.
+testing instructions.
 
 ## Beat Receivers
 
@@ -19,9 +18,12 @@ is currently gated by a feature flag.
 
 ### Beat Receivers for Agent Monitoring
 
-The first part of the Elastic Agent configuration that will run as Beat receivers
-by default will be the self-monitoring functionality. To use Beat receivers for self-monitoring set the
-`_runtime_experimental: "otel"` feature flag in the `agent.monitoring` section of the configuration:
+The first part of the Elastic Agent configuration that was converted to run as Beat receivers
+by default was  the self-monitoring functionality. To use Beat receivers for self-monitoring set the
+`_runtime_experimental: "otel"` feature flag in the `agent.monitoring` section of the configuration as shown below.
+This setting is available as a toggle in the Fleet UI as part of the agent policy advanced settings and via the
+`AGENT_MONITORING_RUNTIME_EXPERIMENTAL` environment variable in the Elastic Agent container images.
+The "otel" runtime is the default for self-monitoring as of 9.2.1.
 
 ```yaml
 agent.monitoring:
@@ -31,21 +33,10 @@ agent.monitoring:
   _runtime_experimental: otel
 ```
 
-This setting will be available as a toggle in the Fleet UI as part of the agent policy advanced settings once
-https://github.com/elastic/kibana/issues/233186 is implemented. Before that change is implemented, the agent policy
-overrides API can be used to add `_runtime_experimental: "otel"` to the `agent.monitoring` section of the policy.
-See https://support.elastic.dev/knowledge/view/06b69893 for details on the policy overrides API.
-
-For the Elastic Agent container images, the `AGENT_MONITORING_RUNTIME_EXPERIMENTAL` environment variable can be set to either `process` or `otel` to override the default runtime used for agent monitoring.
-
-Executing the `elastic-agent diagnostics` command in this mode will now produce an `otel-final.yml` file showing the generated
-collector configuration used to run the Beat receivers.
-
 ### Beat Receivers for Data Collection
 
-The capability to use Beat receivers is being enabled on per Beat and per input type basis. At the time of writing (August 2025),
-Filebeat and Metricbeat can run as receivers and both the `filestream` and `system/metrics` inputs work outside of
-monitoring use cases.
+The capability to use Beat receivers is being enabled on per Beat and per input type basis. As of 9.4.0 all Metricbeat inputs run as
+beats receivers by default, and all other beat inputs are capable of being run as beats receivers.
 
 With the changes in https://github.com/elastic/elastic-agent/pull/11186 a new `agent.internal.runtime` section allows controlling
 the default runtime where `otel` indicates the input should run as a receiver. The default can be controlled on a per Beat and per
@@ -100,7 +91,7 @@ agent:
       metricbeat:
         system/metrics: otel
       output: # Override the runtime used based on the output type.
-        elasticsearch: otel # Force all inputs using the Elasticearch output to use the otel runtime 
+        elasticsearch: otel # Force all inputs using the Elasticearch output to use the otel runtime
         logstash: process # Force all inputs using the Logstash output to use the process runtime
         kafka: process # Force all inputs using the kafka output to use the process runtime
 ```
@@ -287,21 +278,21 @@ service:
 
 ### Beats receivers delivery guarantees in OTel mode
 
-When Beat receivers are used in OTel mode, event delivery guarantees depend on the configuration of the OpenTelemetry Collector `sending_queue` and retry settings.  
-Unlike standalone Beats, the EDOT pipeline allows users to customize queue behavior through the Collector configuration.  
+When Beat receivers are used in OTel mode, event delivery guarantees depend on the configuration of the OpenTelemetry Collector `sending_queue` and retry settings.
+Unlike standalone Beats, the EDOT pipeline allows users to customize queue behavior through the Collector configuration.
 This flexibility is useful, but it also means that not every option combination is compatible with reliable delivery.
 
-Elastic Agent in OTel mode provides an **at least once** delivery guarantee for Beat receivers **only when using the supported `sending_queue` settings described below**.  
+Elastic Agent in OTel mode provides an **at least once** delivery guarantee for Beat receivers **only when using the supported `sending_queue` settings described below**.
 These settings mirror Beats pipeline behavior closely enough to preserve durability expectations.
 
-If users provide arbitrary `sending_queue` or Beat queue overrides, delivery semantics become **undefined** and **at least once delivery cannot be guaranteed**.  
+If users provide arbitrary `sending_queue` or Beat queue overrides, delivery semantics become **undefined** and **at least once delivery cannot be guaranteed**.
 These combinations are not tested and may result in event loss during backpressure or shutdown.
 
 To achieve the intended delivery guarantee, the exporter that receives events from Beat receivers must define a `sending_queue` with the following characteristics:
 
-- `enabled: true`: The queue must be active.  
-- `wait_for_result: true`: The pipeline must wait for the exporter response before removing events.  
-- `block_on_overflow: true`: Prevents event drops when the queue is full.  
+- `enabled: true`: The queue must be active.
+- `wait_for_result: true`: The pipeline must wait for the exporter response before removing events.
+- `block_on_overflow: true`: Prevents event drops when the queue is full.
 - The `batch` configuration must include explicit `max_size`, `min_size`, and `flush_timeout` values to ensure events are grouped and flushed in predictable, controlled batches.
 
 Additionally, the retry settings must be enabled on the exporter, using a backoff policy that retries until the operation succeeds. By default, `max_retries` is set to 3, which is how most Beats behave. Standalone Filebeat, however, retries indefinitely. Beats receivers don't support unlimited retries yet, and this is being tracked at https://github.com/elastic/beats/issues/47892.

--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -20,7 +20,8 @@ The integration testing framework spins up resources in GCP.  To achieve this, i
 [GCloud CLI](https://cloud.google.com/sdk/gcloud) to be installed on the system where the tests are initiated from.
 
 #### Beats
-The Elastic Agent package that is used for integration tests packages Beats built from the Unified Release (as opposed to DRA).  There is no explicit action needed for this prerequisite but just keep in mind that if any Agent integration tests rely on certain Beats features or bugfixes, they may not be available in the integration tests yet because a unified release containing those features or bugfixes may not have happened yet.
+The Elastic Agent package that is used for integration tests packages Beats from the beats submodule in this repository. The submodule must be explicitly intialized with `git submodule update --init` on first checkout. The commit of beats packaged and tested in this repository is the commit of
+beats pinned in the submodule.
 
 #### Helm & Helm charts
 To run the Kubernetes integration tests you need to install


### PR DESCRIPTION
- Closes https://github.com/elastic/elastic-agent/issues/14113
- Closes https://github.com/elastic/elastic-agent/issues/14421
- Closes https://github.com/elastic/elastic-agent/issues/14195

Fix a few instances of documentation drift by updating the readme to reference windows/arm, the test guide to reference the beat submodule, and the hybrid agent guide to reference which beats run as receivers and where.