### PR TITLE
Fix packaging install snippet to use local binary prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ To install the agent extract the package and run the install command:
 cd build/distributions
 tar xvfz elastic-agent-8.8.0-SNAPSHOT-darwin-aarch64.tar.gz
 cd elastic-agent-8.8.0-SNAPSHOT-darwin-aarch64
-sudo elastic-agent install
+sudo ./elastic-agent install
 ```
 
-For basic use the agent binary can be run directly, with the `sudo elastic-agent run` command.
+For basic use the agent binary can be run directly, with the `./elastic-agent run` command.
 
 #### Packaging for other architectures
 When packaging for an architecture different than the host machine,


### PR DESCRIPTION
## What does this PR do?

Replaces `sudo elastic-agent install` with `sudo ./elastic-agent install` and `elastic-agent run` with `./elastic-agent run` in the `README.md` packaging section.

## Why is it important?

After extracting a locally built package, `elastic-agent` is not on `PATH`, so the old command fails with `command not found` for new contributors. Using `./elastic-agent` explicitly invokes the local binary just extracted, consistent with the `--develop` example already on line 36.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the changelog tool~~
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None. Documentation-only change.

## How to test this PR locally

Read the updated `README.md` packaging section and verify the commands reference the local binary (`./elastic-agent`).

## Related issues

- Closes #14550