### PR TITLE
Fix k8s_attributes component name in otel-kube-stack configs

### DIFF
--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
@@ -159,7 +159,7 @@ collectors:
               - debug
               - otlp_grpc/gateway
             processors:
-              - k8sattributes
+              - k8s_attributes
               - resourcedetection/env
               - resourcedetection/eks
               - resourcedetection/gcp
@@ -478,7 +478,7 @@ collectors:
               - file_log
             processors:
               - batch
-              - k8sattributes
+              - k8s_attributes
               - resourcedetection/env
               - resourcedetection/system
               - resourcedetection/eks
@@ -494,7 +494,7 @@ collectors:
               - hostmetrics
             processors:
               - batch/metrics
-              - k8sattributes
+              - k8s_attributes
               - resourcedetection/env
               - resourcedetection/system
               - resourcedetection/eks

--- a/deploy/helm/edot-collector/kube-stack/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/values.yaml
@@ -159,7 +159,7 @@ collectors:
               - debug
               - otlp_grpc/gateway
             processors:
-              - k8sattributes
+              - k8s_attributes
               - resourcedetection/env
               - resourcedetection/eks
               - resourcedetection/gcp
@@ -479,7 +479,7 @@ collectors:
               - file_log
             processors:
               - batch
-              - k8sattributes
+              - k8s_attributes
               - resourcedetection/env
               - resourcedetection/system
               - resourcedetection/eks
@@ -495,7 +495,7 @@ collectors:
               - hostmetrics
             processors:
               - batch/metrics
-              - k8sattributes
+              - k8s_attributes
               - resourcedetection/env
               - resourcedetection/system
               - resourcedetection/eks


### PR DESCRIPTION
https://github.com/elastic/elastic-agent/pull/14418 updated some deprecated component names, but missed a few. This is causing k8s test flakiness. Why just flakiness, and why the tests passed on that PR, remains to be figured out.

@osullivandonal could you cherry pick this change into the backport PRs?