### PR TITLE
Add health_check extension to kube-stack otel collector configs

### DIFF
--- a/changelog/fragments/1779881482-otel-kube-stack-healthcheck.yaml
+++ b/changelog/fragments/1779881482-otel-kube-stack-healthcheck.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add health checks to EDOT collectors used in K8s Onboarding flow
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: edot-collector
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/logs-values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/logs-values.yaml
@@ -192,9 +192,10 @@ collectors:
             - /var/log/pods/*opentelemetry-kube-stack*/*/*.log
       extensions:
         cgroup_runtime: {}
+        health_check: {}
       # [Service Section](https://opentelemetry.io/docs/collector/configuration/#service)
       service:
-        extensions: [cgroup_runtime]
+        extensions: [cgroup_runtime, health_check]
         pipelines:
           logs: null
           metrics: null
@@ -274,8 +275,9 @@ collectors:
           timeout: 15s
       extensions:
         cgroup_runtime: {}
+        health_check: {}
       service:
-        extensions: [cgroup_runtime]
+        extensions: [cgroup_runtime, health_check]
         pipelines:
           logs:
             receivers: [otlp]

--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/logs-values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/logs-values.yaml
@@ -192,7 +192,8 @@ collectors:
             - /var/log/pods/*opentelemetry-kube-stack*/*/*.log
       extensions:
         cgroup_runtime: {}
-        health_check: {}
+        health_check:
+          endpoint: "0.0.0.0:13133"
       # [Service Section](https://opentelemetry.io/docs/collector/configuration/#service)
       service:
         extensions: [cgroup_runtime, health_check]
@@ -275,7 +276,8 @@ collectors:
           timeout: 15s
       extensions:
         cgroup_runtime: {}
-        health_check: {}
+        health_check:
+          endpoint: "0.0.0.0:13133"
       service:
         extensions: [cgroup_runtime, health_check]
         pipelines:

--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
@@ -150,7 +150,8 @@ collectors:
               enabled: true
       extensions:
         cgroup_runtime: {}
-        health_check: {}
+        health_check:
+          endpoint: "0.0.0.0:13133"
       # [Service Section](https://opentelemetry.io/docs/collector/configuration/#service)
       service:
         extensions: [cgroup_runtime, health_check]
@@ -466,7 +467,8 @@ collectors:
             - container.id
       extensions:
         cgroup_runtime: {}
-        health_check: {}
+        health_check:
+          endpoint: "0.0.0.0:13133"
       # [Service Section](https://opentelemetry.io/docs/collector/configuration/#service)
       service:
         extensions: [cgroup_runtime, health_check]
@@ -608,7 +610,8 @@ collectors:
           timeout: 15s
       extensions:
         cgroup_runtime: {}
-        health_check: {}
+        health_check:
+          endpoint: "0.0.0.0:13133"
       service:
         extensions: [cgroup_runtime, health_check]
         pipelines:

--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml
@@ -150,9 +150,10 @@ collectors:
               enabled: true
       extensions:
         cgroup_runtime: {}
+        health_check: {}
       # [Service Section](https://opentelemetry.io/docs/collector/configuration/#service)
       service:
-        extensions: [cgroup_runtime]
+        extensions: [cgroup_runtime, health_check]
         pipelines:
           metrics:
             exporters:
@@ -465,9 +466,10 @@ collectors:
             - container.id
       extensions:
         cgroup_runtime: {}
+        health_check: {}
       # [Service Section](https://opentelemetry.io/docs/collector/configuration/#service)
       service:
-        extensions: [cgroup_runtime]
+        extensions: [cgroup_runtime, health_check]
         pipelines:
           # Disable default non used kube-stack Helm Chart pipelines
           logs: null
@@ -606,8 +608,9 @@ collectors:
           timeout: 15s
       extensions:
         cgroup_runtime: {}
+        health_check: {}
       service:
-        extensions: [cgroup_runtime]
+        extensions: [cgroup_runtime, health_check]
         pipelines:
           metrics:
             receivers: [otlp]

--- a/deploy/helm/edot-collector/kube-stack/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/values.yaml
@@ -54,6 +54,7 @@ collectors:
             insecure: true
       extensions:
         cgroup_runtime: {}
+        health_check: {}
       processors:
         # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
         resourcedetection/env:
@@ -152,7 +153,7 @@ collectors:
               enabled: true
       # [Service Section](https://opentelemetry.io/docs/collector/configuration/#service)
       service:
-        extensions: [cgroup_runtime]
+        extensions: [cgroup_runtime, health_check]
         pipelines:
           metrics:
             exporters:
@@ -466,9 +467,10 @@ collectors:
             - container.id
       extensions:
         cgroup_runtime: {}
+        health_check: {}
       # [Service Section](https://opentelemetry.io/docs/collector/configuration/#service)
       service:
-        extensions: [cgroup_runtime]
+        extensions: [cgroup_runtime, health_check]
         pipelines:
           # Disable default non used kube-stack Helm Chart pipelines
           logs: null
@@ -603,8 +605,9 @@ collectors:
             mode: otel
       extensions:
         cgroup_runtime: {}
+        health_check: {}
       service:
-        extensions: [cgroup_runtime]
+        extensions: [cgroup_runtime, health_check]
         pipelines:
           metrics:
             receivers: [otlp]

--- a/deploy/helm/edot-collector/kube-stack/values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/values.yaml
@@ -54,7 +54,8 @@ collectors:
             insecure: true
       extensions:
         cgroup_runtime: {}
-        health_check: {}
+        health_check:
+          endpoint: "0.0.0.0:13133"
       processors:
         # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
         resourcedetection/env:
@@ -467,7 +468,8 @@ collectors:
             - container.id
       extensions:
         cgroup_runtime: {}
-        health_check: {}
+        health_check:
+          endpoint: "0.0.0.0:13133"
       # [Service Section](https://opentelemetry.io/docs/collector/configuration/#service)
       service:
         extensions: [cgroup_runtime, health_check]
@@ -605,7 +607,8 @@ collectors:
             mode: otel
       extensions:
         cgroup_runtime: {}
-        health_check: {}
+        health_check:
+          endpoint: "0.0.0.0:13133"
       service:
         extensions: [cgroup_runtime, health_check]
         pipelines:

--- a/testing/integration/k8s/otel_helm_test.go
+++ b/testing/integration/k8s/otel_helm_test.go
@@ -248,7 +248,7 @@ func k8sStepCheckRunningPods(podLabelSelector string, expectedPodNumber int, con
 						continue
 					}
 
-					if container.RestartCount == 0 && container.State.Running != nil {
+					if container.Ready {
 						checkedAgentContainers++
 					}
 				}


### PR DESCRIPTION
## What does this PR do?

The healthcheck extension is now included in all OTelCol collector configs (cluster, daemon, gateway) across values.yaml, managed_otlp/values.yaml, and managed_otlp/logs-values.yaml.

## Why is it important?

The OpenTelemetry Operator automatically creates a readiness probe for any collector that exposes the health_check extension. Without it, Kubernetes marks the container as Ready the moment the process starts, which can mask problems. 

In particular, the lack of health check can make crashing collectors pass integration tests if they win the data race. This is how tests passed for https://github.com/elastic/elastic-agent/pull/14418, in spite of that PR breaking the configuration.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
