### PR TITLE
Revert filelog receiver rename in managed_otlp/logs-values.yaml

### DIFF
--- a/deploy/helm/edot-collector/kube-stack/managed_otlp/logs-values.yaml
+++ b/deploy/helm/edot-collector/kube-stack/managed_otlp/logs-values.yaml
@@ -181,7 +181,12 @@ collectors:
       receivers:
         otlp: null
         # [File Log Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver)
-        file_log:
+        # Note: using the deprecated name "filelog" intentionally. The logsCollection preset
+        # in the kube-stack chart injects a base filelog: config (include paths, operators,
+        # etc.) that this block merges into via mustMergeOverwrite. If the canonical name
+        # "file_log" is used instead, the preset config lands under a different map key and
+        # the merge doesn't happen, leaving the receiver with no include: paths configured.
+        filelog:
           exclude:
             # exlude opentelemetry-kube-stack pod logs
             - /var/log/pods/*opentelemetry-kube-stack*/*/*.log
@@ -196,7 +201,7 @@ collectors:
           traces: null
           logs/node:
             receivers:
-              - file_log
+              - filelog
             processors:
               - batch
               - k8s_attributes


### PR DESCRIPTION
## What does this PR do?

Reverts a part of https://github.com/elastic/elastic-agent/pull/14418, using the deprecated `filelog` name again.

CC @osullivandonal 

## Why is it important?

This is an overlay above kube-stack chart's logsCollection preset, which  injects a base receiver config block under the key 'filelog:' (deprecated name) via mustMergeOverwrite. If we want to use it, we have to use the same name.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
