### PR TITLE
[8.19] Disable TLS certificate hot-reload by default

### DIFF
--- a/changelog/fragments/1779933797-disable-tls-certificate-hot-reload-by-default.yaml
+++ b/changelog/fragments/1779933797-disable-tls-certificate-hot-reload-by-default.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Disable TLS certificate hot-reload by default
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/elastic-agent.reference.yml
+++ b/elastic-agent.reference.yml
@@ -104,6 +104,11 @@ inputs:
 #     #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 #     #ssl.cipher_suites: []
 #     #ssl.curve_types: []
+#     #ssl.certificate_reload:
+#     #  enabled: false    # Disabled by default; set to true to enable periodic reload
+#     #  reload_interval: 5s  # How often to re-read cert/key files from disk.
+#     #                       # After rotation, new certs are picked up within
+#     #                       # this interval on the next TLS handshake.
 #   reporting:
 #     # Reporting threshold indicates how many events should be kept in-memory before reporting them to fleet.
 #     #reporting_threshold: 10000

--- a/elastic-agent.reference.yml
+++ b/elastic-agent.reference.yml
@@ -104,11 +104,6 @@ inputs:
 #     #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 #     #ssl.cipher_suites: []
 #     #ssl.curve_types: []
-#     #ssl.certificate_reload:
-#     #  enabled: false    # Disabled by default; set to true to enable periodic reload
-#     #  reload_interval: 5s  # How often to re-read cert/key files from disk.
-#     #                       # After rotation, new certs are picked up within
-#     #                       # this interval on the next TLS handshake.
 #   reporting:
 #     # Reporting threshold indicates how many events should be kept in-memory before reporting them to fleet.
 #     #reporting_threshold: 10000

--- a/internal/pkg/agent/configuration/fleet_server.go
+++ b/internal/pkg/agent/configuration/fleet_server.go
@@ -22,6 +22,18 @@ type FleetServerConfig struct {
 	TLS          *tlscommon.ServerConfig  `config:"ssl" yaml:"ssl,omitempty"`
 }
 
+// Validate applies backport-branch defaults and validates the fleet server configuration.
+func (c *FleetServerConfig) Validate() error {
+	// Certificate hot-reload was introduced after this branch was cut. Disable it
+	// by default so it does not land silently in a patch release. Operators who
+	// want it can set ssl.certificate_reload.enabled: true in their config.
+	if c.TLS != nil && c.TLS.CertificateReload.Enabled == nil {
+		disabled := false
+		c.TLS.CertificateReload.Enabled = &disabled
+	}
+	return nil
+}
+
 // FleetServerPolicyConfig is the configuration for the policy Fleet Server should run on.
 type FleetServerPolicyConfig struct {
 	ID string `config:"id"`
@@ -51,6 +63,18 @@ type Elasticsearch struct {
 	ProxyURL         string            `config:"proxy_url" yaml:"proxy_url,omitempty"`
 	ProxyDisable     bool              `config:"proxy_disable" yaml:"proxy_disable"`
 	ProxyHeaders     map[string]string `config:"proxy_headers" yaml:"proxy_headers"`
+}
+
+// Validate applies backport-branch defaults and validates the Elasticsearch configuration.
+func (c *Elasticsearch) Validate() error {
+	// Certificate hot-reload was introduced after this branch was cut. Disable it
+	// by default so it does not land silently in a patch release. Operators who
+	// want it can set ssl.certificate_reload.enabled: true in their config.
+	if c.TLS != nil && c.TLS.CertificateReload.Enabled == nil {
+		disabled := false
+		c.TLS.CertificateReload.Enabled = &disabled
+	}
+	return nil
 }
 
 // ElasticsearchFromConnStr returns an Elasticsearch configuration from the connection string.

--- a/internal/pkg/remote/config.go
+++ b/internal/pkg/remote/config.go
@@ -71,6 +71,13 @@ func (c *Config) GetHosts() []string {
 // Validate returns an error if the configuration is invalid; nil, otherwise.
 func (c *Config) Validate() error {
 	if c.Transport.TLS != nil {
+		// Certificate hot-reload was introduced after this branch was cut. Disable it
+		// by default so it does not land silently in a patch release. Operators who
+		// want it can set ssl.certificate_reload.enabled: true in their config.
+		if c.Transport.TLS.CertificateReload.Enabled == nil {
+			disabled := false
+			c.Transport.TLS.CertificateReload.Enabled = &disabled
+		}
 		return c.Transport.TLS.Validate()
 	}
 


### PR DESCRIPTION
## What does this PR do?

Certificate hot-reload was added in `elastic-agent-libs` v0.43.0, which is already the version on this branch. Its `IsEnabled()` method returns **`true` when the config field is absent** (`nil` pointer), meaning the feature silently activates for any TLS connection that has CAs or a certificate path configured. That is new behaviour for a patch release.

This PR adds explicit `Validate()` guards that set `CertificateReload.Enabled = false` when the operator has not opted in, mirroring what fleet-server did in elastic/fleet-server#7066, and documents the new setting, mirroring elastic/fleet-server#7095.

### Guards added

| File | Why |
|---|---|
| `internal/pkg/remote/config.go` | Elastic Agent's own outbound HTTP connections to Fleet Server / Kibana call `httpcommon.RoundTripper()` → `LoadTLSConfig()` — would silently start reloading certs |
| `internal/pkg/agent/configuration/fleet_server.go` | `FleetServerConfig.TLS` and `Elasticsearch.TLS` are passed to fleet-server's bootstrap config |

Operators who want certificate hot-reload can set `ssl.certificate_reload.enabled: true` in their config.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added an entry in `changelog/fragments` for user-facing changes