### PR TITLE
Document TEST_INTEG_CLEAN_ON_EXIT and BUILD_AGENT

### DIFF
--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -144,6 +144,8 @@ share similar leavers as the packaging process.
        in Docker. This needs to be set if running Kubernetes integration
        tests.
 
+When running local mode integration tests, `BUILD_AGENT=true` will build the agent for the current platform before running.
+
 An example for running a single test, including packaging the artifacts for it is:
 ```
 EXTERNAL=true DEV=true PACKAGES="tar.gz,rpm,deb" PLATFORMS="linux/amd64" SNAPSHOT=true mage package # create elastic-agent SNAPSHOT package using external sources for components
@@ -298,6 +300,8 @@ Tests with external dependencies might need more environment variables to be set
 when running them manually, such as `ELASTICSEARCH_HOST`, `ELASTICSEARCH_USERNAME`,
 `ELASTICSEARCH_PASSWORD`, `KIBANA_HOST`, `KIBANA_USERNAME`, `KIBANA_PASSWORD`, and
 `ELASTIC_APM_SERVER_URL`.
+
+`TEST_INTEG_CLEAN_ON_EXIT=true|false` will determine whether mage artifacts and .integration-cache are cleaned on exit automatically.
 
 ### Debugging tests
 


### PR DESCRIPTION
## What does this PR do?

Adds TEST_INTEG_CLEAN_ON_EXIT and BUILD_AGENT to the test framework developer guide.

## Checklist

- [X] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [X] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~
