### PR TITLE
Fix independent agent release packaging

### DIFF
--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -897,7 +897,8 @@ func (s *Settings) WithManifestInfo(ctx context.Context) (*Settings, error) {
 	clone.Packaging.Manifest = &resp
 	clone.Build.Snapshot = parsedVersion.IsSnapshot()
 	clone.Build.AgentCoreVersion = parsedVersion.CoreVersion()
-	clone.Packaging.AgentPackageVersion = parsedVersion.CoreVersion()
+	// This has to be the full version to account for Independent Agent Releases
+	clone.Packaging.AgentPackageVersion = parsedVersion.String()
 	clone.Build.AgentCoreCommitHash = agentCoreProject.CommitHash
 	clone.Build.DependenciesVersion = parsedVersion.VersionWithPrerelease()
 	return clone, nil

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -897,8 +897,9 @@ func (s *Settings) WithManifestInfo(ctx context.Context) (*Settings, error) {
 	clone.Packaging.Manifest = &resp
 	clone.Build.Snapshot = parsedVersion.IsSnapshot()
 	clone.Build.AgentCoreVersion = parsedVersion.CoreVersion()
-	// This has to be the full version to account for Independent Agent Releases
-	clone.Packaging.AgentPackageVersion = parsedVersion.String()
+	// VersionWithBuildMetadata preserves the build ID for Independent Agent Releases while
+	// omitting the prerelease — snapshot state is captured in Build.Snapshot.
+	clone.Packaging.AgentPackageVersion = parsedVersion.VersionWithBuildMetadata()
 	clone.Build.AgentCoreCommitHash = agentCoreProject.CommitHash
 	clone.Build.DependenciesVersion = parsedVersion.VersionWithPrerelease()
 	return clone, nil

--- a/dev-tools/mage/settings_test.go
+++ b/dev-tools/mage/settings_test.go
@@ -6,12 +6,18 @@ package mage
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/dev-tools/mage/manifest"
 )
 
 func TestGetVersion(t *testing.T) {
@@ -454,7 +460,7 @@ func TestSettingsContext(t *testing.T) {
 		original := DefaultSettings()
 		original.Build.DevBuild = true
 
-		ctx := ContextWithSettings(context.Background(), original)
+		ctx := ContextWithSettings(t.Context(), original)
 		retrieved := SettingsFromContext(ctx)
 
 		assert.Same(t, original, retrieved)
@@ -462,7 +468,7 @@ func TestSettingsContext(t *testing.T) {
 	})
 
 	t.Run("SettingsFromContext returns fresh settings when not in context", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 
 		settings := SettingsFromContext(ctx)
 
@@ -470,7 +476,7 @@ func TestSettingsContext(t *testing.T) {
 	})
 
 	t.Run("SettingsFromContext returns fresh settings for nil value", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), settingsContextKey{}, (*Settings)(nil))
+		ctx := context.WithValue(t.Context(), settingsContextKey{}, (*Settings)(nil))
 
 		settings := SettingsFromContext(ctx)
 
@@ -951,5 +957,166 @@ func TestEnvMap(t *testing.T) {
 		})
 
 		assert.Equal(t, "CustomValue", envMap["CustomKey"])
+	})
+}
+
+// newTestManifestServer starts a TLS httptest server serving b as JSON, adds the server host to
+// manifest.AllowedManifestHosts, and replaces http.DefaultClient with one that trusts the test
+// certificate. All mutations are reverted via t.Cleanup. Returns a manifest URL ready for use in
+// Settings.Packaging.ManifestURL.
+//
+// DownloadManifest rewrites every URL to https://<host><path>, so a TLS server is required.
+// Tests using this helper must not run in parallel since http.DefaultClient is global.
+func newTestManifestServer(t *testing.T, b manifest.Build) string {
+	t.Helper()
+
+	data, err := json.Marshal(b)
+	require.NoError(t, err)
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	}))
+	t.Cleanup(server.Close)
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	origHosts := manifest.AllowedManifestHosts
+	manifest.AllowedManifestHosts = append(append([]string{}, origHosts...), parsedURL.Host)
+	t.Cleanup(func() { manifest.AllowedManifestHosts = origHosts })
+
+	origClient := http.DefaultClient
+	http.DefaultClient = server.Client()
+	t.Cleanup(func() { http.DefaultClient = origClient })
+
+	return server.URL + "/manifest.json"
+}
+
+func TestWithManifestInfo(t *testing.T) {
+	t.Run("no-op when ManifestURL is empty", func(t *testing.T) {
+		s := DefaultSettings()
+
+		result, err := s.WithManifestInfo(t.Context())
+
+		require.NoError(t, err)
+		assert.Same(t, s, result)
+	})
+
+	t.Run("standard release version", func(t *testing.T) {
+		const commitHash = "abc123def456789abc123def456789abc12345"
+		manifestURL := newTestManifestServer(t, manifest.Build{
+			Version: "9.3.5",
+			Projects: map[string]manifest.Project{
+				AgentCoreProjectName: {CommitHash: commitHash},
+			},
+		})
+
+		s := DefaultSettings()
+		s.Packaging.ManifestURL = manifestURL
+
+		result, err := s.WithManifestInfo(t.Context())
+
+		require.NoError(t, err)
+		assert.False(t, result.Build.Snapshot)
+		assert.Equal(t, "9.3.5", result.Build.AgentCoreVersion)
+		assert.Equal(t, "9.3.5", result.Packaging.AgentPackageVersion)
+		assert.Equal(t, "9.3.5", result.Build.DependenciesVersion)
+		assert.Equal(t, commitHash, result.Build.AgentCoreCommitHash)
+		assert.NotNil(t, result.Packaging.Manifest)
+	})
+
+	t.Run("snapshot version", func(t *testing.T) {
+		const commitHash = "def456abc123def456abc123def456abc12345"
+		manifestURL := newTestManifestServer(t, manifest.Build{
+			Version: "9.3.5-SNAPSHOT",
+			Projects: map[string]manifest.Project{
+				AgentCoreProjectName: {CommitHash: commitHash},
+			},
+		})
+
+		s := DefaultSettings()
+		s.Packaging.ManifestURL = manifestURL
+
+		result, err := s.WithManifestInfo(t.Context())
+
+		require.NoError(t, err)
+		assert.True(t, result.Build.Snapshot)
+		assert.Equal(t, "9.3.5", result.Build.AgentCoreVersion)
+		assert.Equal(t, "9.3.5-SNAPSHOT", result.Packaging.AgentPackageVersion)
+		assert.Equal(t, "9.3.5-SNAPSHOT", result.Build.DependenciesVersion)
+		assert.Equal(t, commitHash, result.Build.AgentCoreCommitHash)
+	})
+
+	// Independent Agent Releases use a version like "9.3.5+build202605290902".
+	// WithManifestInfo must set AgentPackageVersion to the full string (including build metadata)
+	// so package layout matches the wrapped core, while AgentCoreVersion and DependenciesVersion
+	// receive only major.minor.patch so they can be used for package filename resolution.
+	t.Run("version with build ID (Independent Agent Release)", func(t *testing.T) {
+		const (
+			commitHash = "abc123def456789abc123def456789abc12345"
+			buildID    = "build202605290902"
+		)
+		manifestURL := newTestManifestServer(t, manifest.Build{
+			Version: "9.3.5+" + buildID,
+			Projects: map[string]manifest.Project{
+				AgentCoreProjectName: {CommitHash: commitHash},
+			},
+		})
+
+		s := DefaultSettings()
+		s.Packaging.ManifestURL = manifestURL
+
+		result, err := s.WithManifestInfo(t.Context())
+
+		require.NoError(t, err)
+		assert.False(t, result.Build.Snapshot)
+		// AgentCoreVersion is major.minor.patch only.
+		assert.Equal(t, "9.3.5", result.Build.AgentCoreVersion)
+		// AgentPackageVersion keeps the full version including build metadata.
+		assert.Equal(t, "9.3.5+"+buildID, result.Packaging.AgentPackageVersion)
+		// DependenciesVersion strips build metadata; used for resolving package filenames.
+		assert.Equal(t, "9.3.5", result.Build.DependenciesVersion)
+		assert.Equal(t, commitHash, result.Build.AgentCoreCommitHash)
+	})
+
+	t.Run("missing agent-core project returns error", func(t *testing.T) {
+		manifestURL := newTestManifestServer(t, manifest.Build{
+			Version:  "9.3.5",
+			Projects: map[string]manifest.Project{},
+		})
+
+		s := DefaultSettings()
+		s.Packaging.ManifestURL = manifestURL
+
+		_, err := s.WithManifestInfo(t.Context())
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), AgentCoreProjectName)
+	})
+
+	t.Run("original settings are not mutated", func(t *testing.T) {
+		const commitHash = "abc123def456789abc123def456789abc12345"
+		manifestURL := newTestManifestServer(t, manifest.Build{
+			Version: "9.3.5",
+			Projects: map[string]manifest.Project{
+				AgentCoreProjectName: {CommitHash: commitHash},
+			},
+		})
+
+		s := DefaultSettings()
+		s.Packaging.ManifestURL = manifestURL
+		origSnapshot := s.Build.Snapshot
+		origCoreVersion := s.Build.AgentCoreVersion
+		origPackageVersion := s.Packaging.AgentPackageVersion
+		origManifest := s.Packaging.Manifest
+
+		_, err := s.WithManifestInfo(t.Context())
+		require.NoError(t, err)
+
+		assert.Equal(t, origSnapshot, s.Build.Snapshot)
+		assert.Equal(t, origCoreVersion, s.Build.AgentCoreVersion)
+		assert.Equal(t, origPackageVersion, s.Packaging.AgentPackageVersion)
+		assert.Equal(t, origManifest, s.Packaging.Manifest)
 	})
 }

--- a/dev-tools/mage/settings_test.go
+++ b/dev-tools/mage/settings_test.go
@@ -1043,7 +1043,7 @@ func TestWithManifestInfo(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, result.Build.Snapshot)
 		assert.Equal(t, "9.3.5", result.Build.AgentCoreVersion)
-		assert.Equal(t, "9.3.5-SNAPSHOT", result.Packaging.AgentPackageVersion)
+		assert.Equal(t, "9.3.5", result.Packaging.AgentPackageVersion) // prerelease stripped; snapshot state is in Build.Snapshot
 		assert.Equal(t, "9.3.5-SNAPSHOT", result.Build.DependenciesVersion)
 		assert.Equal(t, commitHash, result.Build.AgentCoreCommitHash)
 	})

--- a/pkg/version/version_parser.go
+++ b/pkg/version/version_parser.go
@@ -96,6 +96,19 @@ func (psv ParsedSemVer) VersionWithPrerelease() string {
 	return b.String()
 }
 
+// VersionWithBuildMetadata returns major.minor.patch with build metadata appended when present,
+// omitting the prerelease string. Use this when the build ID must be preserved (e.g. Independent
+// Agent Releases) but prerelease state is tracked separately.
+func (psv ParsedSemVer) VersionWithBuildMetadata() string {
+	b := new(strings.Builder)
+	b.WriteString(psv.CoreVersion())
+	if psv.buildMetadata != "" {
+		b.WriteString(metadataSeparator)
+		b.WriteString(psv.buildMetadata)
+	}
+	return b.String()
+}
+
 func (psv ParsedSemVer) ExtractSnapshotFromVersionString() (string, bool) {
 
 	b := new(strings.Builder)

--- a/pkg/version/version_parser_test.go
+++ b/pkg/version/version_parser_test.go
@@ -435,6 +435,26 @@ func TestExtractSnapshotFromVersionString(t *testing.T) {
 	}
 }
 
+func TestVersionWithBuildMetadata(t *testing.T) {
+	testcases := []struct {
+		input    string
+		expected string
+	}{
+		{input: "9.3.5", expected: "9.3.5"},
+		{input: "9.3.5-SNAPSHOT", expected: "9.3.5"},
+		{input: "9.3.5+build202605290902", expected: "9.3.5+build202605290902"},
+		{input: "9.3.5-SNAPSHOT+build202605290902", expected: "9.3.5+build202605290902"},
+		{input: "9.3.5-rc1+build202605290902", expected: "9.3.5+build202605290902"},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.input, func(t *testing.T) {
+			psv, err := ParseVersion(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, psv.VersionWithBuildMetadata())
+		})
+	}
+}
+
 func TestComparisons(t *testing.T) {
 	testcases := []struct {
 		name         string


### PR DESCRIPTION
## What does this PR do?

Fixes independent agent release after https://github.com/elastic/elastic-agent/pull/14247 subtly broke the version resolution.

It also adds missing tests for this functionality.

## Why is it important?

In an independent agent release, the agent package version needs to be the full version string rather than just the core. An IAR version has the form `9.3.5+build202605290902` and the package must reflect this.

See failed build here: https://buildkite.com/elastic/elastic-agent-package/builds/12617.

