### PR TITLE
[8.19] nit: rename disabled to enabled for clarity in TLS cert reload guards

### DIFF
--- a/internal/pkg/agent/configuration/fleet_server.go
+++ b/internal/pkg/agent/configuration/fleet_server.go
@@ -28,8 +28,8 @@ func (c *FleetServerConfig) Validate() error {
 	// by default so it does not land silently in a patch release. Operators who
 	// want it can set ssl.certificate_reload.enabled: true in their config.
 	if c.TLS != nil && c.TLS.CertificateReload.Enabled == nil {
-		disabled := false
-		c.TLS.CertificateReload.Enabled = &disabled
+		enabled := false
+		c.TLS.CertificateReload.Enabled = &enabled
 	}
 	return nil
 }
@@ -71,8 +71,8 @@ func (c *Elasticsearch) Validate() error {
 	// by default so it does not land silently in a patch release. Operators who
 	// want it can set ssl.certificate_reload.enabled: true in their config.
 	if c.TLS != nil && c.TLS.CertificateReload.Enabled == nil {
-		disabled := false
-		c.TLS.CertificateReload.Enabled = &disabled
+		enabled := false
+		c.TLS.CertificateReload.Enabled = &enabled
 	}
 	return nil
 }

--- a/internal/pkg/remote/config.go
+++ b/internal/pkg/remote/config.go
@@ -75,8 +75,8 @@ func (c *Config) Validate() error {
 		// by default so it does not land silently in a patch release. Operators who
 		// want it can set ssl.certificate_reload.enabled: true in their config.
 		if c.Transport.TLS.CertificateReload.Enabled == nil {
-			disabled := false
-			c.Transport.TLS.CertificateReload.Enabled = &disabled
+			enabled := false
+			c.Transport.TLS.CertificateReload.Enabled = &enabled
 		}
 		return c.Transport.TLS.Validate()
 	}


### PR DESCRIPTION
## What does this PR do?

Follow-up to #14599 to address review feedback: renames the local variable `disabled` to `enabled` in the three `Validate()` functions that guard TLS certificate hot-reload. The variable is assigned `false` and then used to set `CertificateReload.Enabled`, so naming it `enabled` is clearer and less confusing to read.

This is a pure rename — no behavioral change.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added an entry in `changelog/fragments` for user-facing changes