### PR TITLE
bk: enable scheduler condition if using the scheduler BK pipeline

### DIFF
--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -420,7 +420,9 @@ steps:
 
   - group: "Stateful: Windows (tier 3)"
     key: integration-tests-win-tier-3
-    if: build.source == "schedule"
+    # NOTE: as long as we use the scheduler pipeline we need to use BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG.
+    #       We use that pipeline to run the tier 3 tests on a schedule for the active branches.
+    if: build.source == "schedule" || build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "elastic-agent-pipeline-scheduler"
     notify:
       - github_commit_status:
           context: "buildkite/elastic-agent-extended-testing - Windows - tier 3"
@@ -749,7 +751,9 @@ steps:
 
   - group: "Stateful: Linux (tier 3)"
     key: integration-tests-linux-tier-3
-    if: build.source == "schedule"
+    # NOTE: as long as we use the scheduler pipeline we need to use BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG.
+    #       We use that pipeline to run the tier 3 tests on a schedule for the active branches.
+    if: build.source == "schedule" || build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "elastic-agent-pipeline-scheduler"
     notify:
       - github_commit_status:
           context: "buildkite/elastic-agent-extended-testing - Linux - tier 3"
@@ -982,7 +986,9 @@ steps:
 
   - group: ":kubernetes: Kubernetes (tier 3)"
     key: integration-tests-kubernetes-tier-3
-    if: build.source == "schedule"
+    # NOTE: as long as we use the scheduler pipeline we need to use BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG.
+    #       We use that pipeline to run the tier 3 tests on a schedule for the active branches.
+    if: build.source == "schedule" || build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "elastic-agent-pipeline-scheduler"
     notify:
       - github_commit_status:
           context: "buildkite/elastic-agent-extended-testing - Kubernetes - tier 3"


### PR DESCRIPTION
## What does this PR do?

BK scheduler pipeline does not populate `build.source == "schedule"`, so we need to use the usptream env variable.

## Why is it important?

Otherwise tier 3 won't be executed when using the BK scheduler pipeline

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
