### PR TITLE
[mage] Fix docker service image for Independent Agent Releases

### DIFF
--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -125,7 +125,7 @@ components:
     # using the agent_package_version or similar
     # We don't support that yet, so we are defining a rootDir that will error out if rendered. This is not a problem since
     # we don't extract/manipulate the archive during packaging, it has its own special handling in the 'service' docker image
-    rootDir: connectors-{{agent_package_version}}
+    rootDir: connectors-{{ agent_package_version }}
     binaryName: connectors
     fips: false
     platforms:
@@ -299,44 +299,44 @@ shared:
       /lib/systemd/system/{{.BeatServiceName}}.service:
         template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/linux/elastic-agent.unit.tmpl'
         mode: 0644
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ core_commit_short }}/{{.BeatName}}{{.BinaryExt}}:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ agent_package_version }}{{snapshot_suffix}}-{{ core_commit_short }}/{{.BeatName}}{{.BinaryExt}}:
         source: '{{ repo.RootDir }}/build/core/extracted/{{.GOOS}}-{{.Platform.Arch}}/{{.BeatName}}{{.BinaryExt}}'
         mode: 0755
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ core_commit_short }}/package.version:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ agent_package_version }}{{snapshot_suffix}}-{{ core_commit_short }}/package.version:
         content: >
           {{ agent_package_version }}
         mode: 0644
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ core_commit_short }}/components:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ agent_package_version }}{{snapshot_suffix}}-{{ core_commit_short }}/components:
         source: '{{.AgentDropPath}}/{{.GOOS}}-{{.AgentArchName}}.tar.gz/'
         mode: 0755
         config_mode: 0644
         skip_on_missing: true
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ core_commit_short }}/components/elastic-otel-collector:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ agent_package_version }}{{snapshot_suffix}}-{{ core_commit_short }}/components/elastic-otel-collector:
         source: '{{ repo.RootDir }}/build/core/extracted/{{.GOOS}}-{{.Platform.Arch}}/components/elastic-otel-collector{{.BinaryExt}}'
         mode: 0755
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ core_commit_short }}/components/elastic-otel-collector.spec.yml:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ agent_package_version }}{{snapshot_suffix}}-{{ core_commit_short }}/components/elastic-otel-collector.spec.yml:
         source: '{{ repo.RootDir }}/build/core/extracted/{{.GOOS}}-{{.Platform.Arch}}/components/elastic-otel-collector.spec.yml'
         mode: 0644
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ core_commit_short }}/components/endpoint-security-resources.zip:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ agent_package_version }}{{snapshot_suffix}}-{{ core_commit_short }}/components/endpoint-security-resources.zip:
         source: '{{.AgentDropPath}}/{{.GOOS}}-{{.AgentArchName}}.tar.gz/endpoint-security-resources.zip'
         mode: 0644
         skip_on_missing: true
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ core_commit_short }}/components/module:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ agent_package_version }}{{snapshot_suffix}}-{{ core_commit_short }}/components/module:
         source: '{{ repo.RootDir }}/build/core/extracted/{{.GOOS}}-{{.Platform.Arch}}/components/module'
         preserve_mode: true
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ core_commit_short }}/components/certs/certs.pem:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ agent_package_version }}{{snapshot_suffix}}-{{ core_commit_short }}/components/certs/certs.pem:
         source: '{{ repo.RootDir }}/build/core/extracted/{{.GOOS}}-{{.Platform.Arch}}/components/certs/certs.pem'
         mode: 0640
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ core_commit_short }}/components/lenses:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ agent_package_version }}{{snapshot_suffix}}-{{ core_commit_short }}/components/lenses:
         source: '{{ repo.RootDir }}/build/core/extracted/{{.GOOS}}-{{.Platform.Arch}}/components/lenses'
         preserve_mode: true
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ core_commit_short }}/components/osqueryd:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ agent_package_version }}{{snapshot_suffix}}-{{ core_commit_short }}/components/osqueryd:
         source: '{{ repo.RootDir }}/build/core/extracted/{{.GOOS}}-{{.Platform.Arch}}/components/osqueryd'
         mode: 0755
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ core_commit_short }}/components/osquery-extension.ext:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ agent_package_version }}{{snapshot_suffix}}-{{ core_commit_short }}/components/osquery-extension.ext:
         source: '{{ repo.RootDir }}/build/core/extracted/{{.GOOS}}-{{.Platform.Arch}}/components/osquery-extension.ext'
         mode: 0755
-      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{agent_package_version}}{{snapshot_suffix}}-{{ core_commit_short }}/manifest.yaml:
+      /var/lib/{{.BeatName}}/data/{{.BeatName}}-{{ agent_package_version }}{{snapshot_suffix}}-{{ core_commit_short }}/manifest.yaml:
         mode: 0644
         content: >
           {{ manifest .fips }}
@@ -774,8 +774,11 @@ shared:
     extra_tags:
       - 'git-{{ substring core_commit 0 12 }}'
     files:
-      'data/service/connectors-{{ agent_package_version }}{{if .Snapshot}}-SNAPSHOT{{end}}.zip':
-        source: '{{.AgentDropPath}}/archives/{{.GOOS}}-{{.AgentArchName}}.tar.gz/connectors-{{ agent_package_version }}{{if .Snapshot}}-SNAPSHOT{{end}}.zip'
+      # Use the core version because the package version can contain build metadata for Independent Agent Releases
+      # IAR typically use non-IAR components, so we should use the version without build metadata here.
+      # TODO: Clarify what these versions should actually use and whether it matters at all.
+      'data/service/connectors-{{ agent_core_version }}{{if .Snapshot}}-SNAPSHOT{{end}}.zip':
+        source: '{{.AgentDropPath}}/archives/{{.GOOS}}-{{.AgentArchName}}.tar.gz/connectors-{{ agent_core_version }}{{if .Snapshot}}-SNAPSHOT{{end}}.zip'
         mode: 0755
       'data/{{.BeatName}}-{{ core_commit_short }}/components/connectors':
         source: '{{ elastic_beats_dir }}/dev-tools/packaging/files/linux/connectors.sh'


### PR DESCRIPTION
Fix a final bit of breakage from https://github.com/elastic/elastic-agent/pull/14247 and https://github.com/elastic/elastic-agent/pull/14626. Unfortunately, connectors in the service docker image are a special case, where the directory doesn't use the commit hash, and we need to resolve the version that's in the manifest. 

This fix is more like going back to the hacky workaround we had before, we should be either directly using the version from the manifest, or a path independent of that version, like we do for other components. I'd like to fix this properly in a follow-up, for now I'd just like to unbreak independent agent releases.

I also did a small `{{agent_package_version}}` -> `{{ agent_package_version }}` conversion in the packaging file to keep things consistent and make grepping easier.