### PR TITLE
Re-enable Windows 11 unit tests without the race detector

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -271,9 +271,13 @@ steps:
           - *google_oidc_plugin
 
       - label: "Unit tests - Windows 11"
-        skip: "See https://github.com/elastic/elastic-agent/issues/14248"
         key: "unit-tests-win11"
         command: .buildkite/scripts/steps/unit-tests.ps1
+        # The race detector is disabled here because it triggers a Go runtime
+        # GC-metadata corruption crash specific to Windows 11 amd64.
+        # See https://github.com/elastic/elastic-agent/issues/14248
+        env:
+          DISABLE_RACE_DETECTOR: "true"
         artifact_paths:
           - "build/TEST-*.html"
           - "build/TEST-*.xml"

--- a/.buildkite/scripts/steps/unit-tests.ps1
+++ b/.buildkite/scripts/steps/unit-tests.ps1
@@ -9,7 +9,14 @@ $env:GOTMPDIR = "$env:BUILDKITE_BUILD_CHECKOUT_PATH"
 
 Write-Host "--- Unit tests"
 $env:TEST_COVERAGE = $true
-if ($env:PROCESSOR_ARCHITECTURE -ne "ARM64") {
+# The race detector is disabled on:
+#   - ARM64: the Go race detector is not supported on windows/arm64.
+#   - Windows 11 amd64 (DISABLE_RACE_DETECTOR set by the pipeline step): running
+#     the unit tests under -race reliably triggers a Go runtime GC-metadata
+#     corruption crash that is specific to this platform. The tests are otherwise
+#     healthy, so we keep them running without -race rather than skipping them.
+#     See https://github.com/elastic/elastic-agent/issues/14248
+if ($env:PROCESSOR_ARCHITECTURE -ne "ARM64" -and $env:DISABLE_RACE_DETECTOR -ne "true") {
   $env:RACE_DETECTOR = $true
 }
 mage unitTest


### PR DESCRIPTION
The Windows 11 amd64 unit tests were skipped (issue #14248) because they reliably crash with a Go runtime GC-metadata corruption that only manifests under the race detector on that platform. The tests themselves are healthy, so rather than leaving the platform uncovered, re-enable the step and disable only the race detector for Windows 11 amd64.

The pipeline step sets DISABLE_RACE_DETECTOR=true; unit-tests.ps1 honors it (alongside the existing ARM64 carve-out) and skips setting RACE_DETECTOR.

See https://github.com/elastic/elastic-agent/issues/14248
