### PR TITLE
Avoid Windows TempDir cleanup failure in beat-diagnostics tests

### DIFF
--- a/testing/integration/ess/diagnostics_test.go
+++ b/testing/integration/ess/diagnostics_test.go
@@ -451,21 +451,16 @@ agent.internal.runtime.filebeat.filestream: {{ .Runtime }}
 			err = f.Prepare(ctx)
 			require.NoError(t, err)
 
-			// Create the data file to ingest
-			inputFile, err := os.CreateTemp(t.TempDir(), "input.txt")
-			require.NoError(t, err, "failed to create temp file to hold data to ingest")
-			t.Cleanup(func() {
-				cErr := inputFile.Close()
-				assert.NoError(t, cErr)
-			})
-			_, err = inputFile.WriteString("hello world\n")
-			require.NoError(t, err, "failed to write data to temp file")
+			// Create the data file to ingest.
+			inputFilePath := filepath.Join(t.TempDir(), "input.txt")
+			err = os.WriteFile(inputFilePath, []byte("hello world\n"), 0o600)
+			require.NoError(t, err, "failed to create input file for ingestion")
 
 			var configBuffer bytes.Buffer
 			require.NoError(t,
 				template.Must(template.New("config").Parse(configTemplate)).Execute(&configBuffer, map[string]any{
 					"Runtime":           tc.runtime,
-					"InputFile":         inputFile.Name(),
+					"InputFile":         inputFilePath,
 					"ESHost":            esURL.Host,
 					"MonitoringEnabled": tc.monitoringEnabled,
 				}))
@@ -536,20 +531,15 @@ agent.internal.runtime.filebeat.filestream: otel
 	f, err := define.NewFixtureFromLocalBuild(t, define.Version(), integrationtest.WithAllowErrors())
 	require.NoError(t, err)
 
-	// Create the data file to ingest
-	inputFile, err := os.CreateTemp(t.TempDir(), "input.txt")
-	require.NoError(t, err, "failed to create temp file to hold data to ingest")
-	t.Cleanup(func() {
-		cErr := inputFile.Close()
-		assert.NoError(t, cErr)
-	})
-	_, err = inputFile.WriteString("hello world\n")
-	require.NoError(t, err, "failed to write data to temp file")
+	// Create the data file to ingest.
+	inputFilePath := filepath.Join(t.TempDir(), "input.txt")
+	err = os.WriteFile(inputFilePath, []byte("hello world\n"), 0o600)
+	require.NoError(t, err, "failed to create input file for ingestion")
 
 	var configBuffer bytes.Buffer
 	require.NoError(t,
 		template.Must(template.New("config").Parse(configTemplate)).Execute(&configBuffer, map[string]any{
-			"InputFile": inputFile.Name(),
+			"InputFile": inputFilePath,
 		}))
 	err = f.Prepare(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
## What does this PR do?

Makes diagnostics tests avoid holding open handles to files.

## Why is it important?

On Windows, os.CreateTemp opens the file without FILE_SHARE_DELETE, so while the handle remains open no other caller can open it with DELETE access.  Go 1.25+ os.RemoveAll uses NtOpenFile(DELETE) which fails in that window, leaving the directory non-empty and marking the test failed via t.TempDir()'s t.Errorf cleanup — even though the test logic itself succeeded.

The input file only needs to exist with content; it does not need to be held open.  Replace os.CreateTemp + t.Cleanup(Close) with os.WriteFile (open-write-close atomically) so no long-lived handle is ever held by the test process.

Fixes the flaky TestBeatDiagnostics/filebeat_receiver and TestEDOTDiagnostics on Windows.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/14624

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
