### PR TITLE
Use the latency preset in integration tests

### DIFF
--- a/pkg/testing/tools/fleettools/fleet.go
+++ b/pkg/testing/tools/fleettools/fleet.go
@@ -174,11 +174,17 @@ const (
 	OutputPresetLatency OutputPreset = "latency"
 )
 
-// UpdateESOutputPreset updates the performance preset for the Elasticsearch output in the given policy.
+// UpdateESOutputPreset updates the Fleet Elasticsearch output used by policy to
+// the given preset. Use OutputPresetLatency to lower the output flush interval
+// from 10s to 1s, which speeds up tests that poll Elasticsearch for ingested
+// data. When policy has no explicit data output ID set, DefaultFleetOutputID is
+// used.
 func UpdateESOutputPreset(ctx context.Context, client *kibana.Client, policy kibana.PolicyResponse, preset OutputPreset) error {
 	outputID := policy.DataOutputID
 	if outputID == "" {
-		return errors.New("policy has no data output ID")
+		// DefaultFleetOutputID is the well-known ID of the default Fleet Elasticsearch
+		// output, as defined in the Kibana Fleet plugin source code.
+		outputID = "fleet-default-output"
 	}
 
 	updateBytes, err := json.Marshal(map[string]any{"preset": preset})

--- a/pkg/testing/tools/fleettools/fleet.go
+++ b/pkg/testing/tools/fleettools/fleet.go
@@ -166,41 +166,43 @@ func NewEnrollParams(ctx context.Context, client *kibana.Client) (*EnrollParams,
 type OutputPreset string
 
 const (
+	// DefaultFleetOutputID is the well-known ID of the default Fleet Elasticsearch
+	// output, as defined in the Kibana Fleet plugin source:
+	// x-pack/platform/plugins/shared/fleet/common/constants/output.ts
+	DefaultFleetOutputID = "fleet-default-output"
+
+	// OutputPresetLatency lowers the output flush timeout from the default 10s to 1s. Prefer it in all tests.
+	OutputPresetLatency    OutputPreset = "latency"
 	OutputPresetBalanced   OutputPreset = "balanced"
 	OutputPresetCustom     OutputPreset = "custom"
 	OutputPresetThroughput OutputPreset = "throughput"
 	OutputPresetScale      OutputPreset = "scale"
-	// OutputPresetLatency lowers the output flush timeout from the default 10s to 1s. Prefer it in all tests.
-	OutputPresetLatency OutputPreset = "latency"
 )
 
-// UpdateESOutputPreset updates the Fleet Elasticsearch output used by policy to
-// the given preset. Use OutputPresetLatency to lower the output flush interval
-// from 10s to 1s, which speeds up tests that poll Elasticsearch for ingested
-// data. When policy has no explicit data output ID set, DefaultFleetOutputID is
-// used.
-func UpdateESOutputPreset(ctx context.Context, client *kibana.Client, policy kibana.PolicyResponse, preset OutputPreset) error {
-	outputID := policy.DataOutputID
-	if outputID == "" {
-		// DefaultFleetOutputID is the well-known ID of the default Fleet Elasticsearch
-		// output, as defined in the Kibana Fleet plugin source code.
-		outputID = "fleet-default-output"
-	}
-
+// UpdateESOutputPreset updates the Fleet Elasticsearch output with the given ID
+// to use the given preset. Use DefaultFleetOutputID to target the default output
+// and OutputPresetLatency to lower the flush interval from 10s to 1s, which
+// speeds up tests that poll Elasticsearch for ingested data.
+//
+// Call this before enrolling the agent so that the preset is in effect from the
+// agent's first check-in, avoiding an extra policy revision bump mid-test.
+func UpdateESOutputPreset(ctx context.Context, client *kibana.Client, outputID string, preset OutputPreset) error {
 	updateBytes, err := json.Marshal(map[string]any{"preset": preset})
 	if err != nil {
 		return fmt.Errorf("marshaling Fleet output update: %w", err)
 	}
 
-	apiURL := "/api/fleet/outputs/" + outputID
-	putResp, err := client.SendWithContext(ctx, http.MethodPut, apiURL, nil, nil, bytes.NewReader(updateBytes))
+	url := "/api/fleet/outputs/" + outputID
+	resp, err := client.SendWithContext(ctx, http.MethodPut, url, nil, nil, bytes.NewReader(updateBytes))
 	if err != nil {
 		return fmt.Errorf("updating Fleet output %s: %w", outputID, err)
 	}
-	defer putResp.Body.Close()
-	if putResp.StatusCode != http.StatusOK {
-		putBody, _ := io.ReadAll(putResp.Body)
-		return fmt.Errorf("updating Fleet output %s returned status %d: %s", outputID, putResp.StatusCode, putBody)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("updating Fleet output %s returned status %d: %s", outputID, resp.StatusCode, body)
 	}
+
 	return nil
 }

--- a/pkg/testing/tools/fleettools/fleet.go
+++ b/pkg/testing/tools/fleettools/fleet.go
@@ -5,7 +5,9 @@
 package fleettools
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -157,4 +159,86 @@ func NewEnrollParams(ctx context.Context, client *kibana.Client) (*EnrollParams,
 		FleetURL:        fleetServerURL,
 		PolicyID:        policyResp.ID,
 	}, nil
+}
+
+// OutputPreset is a Fleet Elasticsearch output prefermance preset value.
+type OutputPreset string
+
+const (
+	OutputPresetBalanced   OutputPreset = "balanced"
+	OutputPresetCustom     OutputPreset = "custom"
+	OutputPresetThroughput OutputPreset = "throughput"
+	OutputPresetScale      OutputPreset = "scale"
+	OutputPresetLatency    OutputPreset = "latency"
+)
+
+// SetDefaultESOutputPreset updates the default Fleet Elasticsearch output to use
+// the given preset. Use OutputPresetLatency to lower the output flush interval from
+// 10s to 1s, which speeds up tests that poll Elasticsearch for ingested data.
+func SetDefaultESOutputPreset(ctx context.Context, client *kibana.Client, preset OutputPreset) error {
+	type outputItem struct {
+		ID                  string   `json:"id"`
+		Name                string   `json:"name"`
+		Type                string   `json:"type"`
+		Hosts               []string `json:"hosts"`
+		IsDefault           bool     `json:"is_default"`
+		IsDefaultMonitoring bool     `json:"is_default_monitoring"`
+		Preset              string   `json:"preset"`
+	}
+
+	listResp, err := client.SendWithContext(ctx, http.MethodGet, "/api/fleet/outputs", nil, nil, nil)
+	if err != nil {
+		return fmt.Errorf("listing Fleet outputs: %w", err)
+	}
+	defer listResp.Body.Close()
+	listBody, err := io.ReadAll(listResp.Body)
+	if err != nil {
+		return fmt.Errorf("reading Fleet outputs response: %w", err)
+	}
+	if listResp.StatusCode != http.StatusOK {
+		return fmt.Errorf("listing Fleet outputs returned status %d: %s", listResp.StatusCode, listBody)
+	}
+
+	var outputs struct {
+		Items []outputItem `json:"items"`
+	}
+	if err := json.Unmarshal(listBody, &outputs); err != nil {
+		return fmt.Errorf("parsing Fleet outputs response: %w", err)
+	}
+
+	var defaultOutput *outputItem
+	for i := range outputs.Items {
+		if outputs.Items[i].IsDefault && outputs.Items[i].Type == "elasticsearch" {
+			defaultOutput = &outputs.Items[i]
+			break
+		}
+	}
+	if defaultOutput == nil {
+		return errors.New("no default Elasticsearch Fleet output found")
+	}
+
+	updateBody := map[string]any{
+		"name":                  defaultOutput.Name,
+		"type":                  defaultOutput.Type,
+		"hosts":                 defaultOutput.Hosts,
+		"is_default":            defaultOutput.IsDefault,
+		"is_default_monitoring": defaultOutput.IsDefaultMonitoring,
+		"preset":                preset,
+	}
+	updateBytes, err := json.Marshal(updateBody)
+	if err != nil {
+		return fmt.Errorf("marshaling Fleet output update: %w", err)
+	}
+
+	apiURL := "/api/fleet/outputs/" + defaultOutput.ID
+	putResp, err := client.SendWithContext(ctx, http.MethodPut, apiURL, nil, nil, bytes.NewReader(updateBytes))
+	if err != nil {
+		return fmt.Errorf("updating Fleet output %s: %w", defaultOutput.ID, err)
+	}
+	defer putResp.Body.Close()
+	if putResp.StatusCode != http.StatusOK {
+		putBody, _ := io.ReadAll(putResp.Body)
+		return fmt.Errorf("updating Fleet output %s returned status %d: %s", defaultOutput.ID, putResp.StatusCode, putBody)
+	}
+	return nil
 }

--- a/pkg/testing/tools/fleettools/fleet.go
+++ b/pkg/testing/tools/fleettools/fleet.go
@@ -162,6 +162,7 @@ func NewEnrollParams(ctx context.Context, client *kibana.Client) (*EnrollParams,
 }
 
 // OutputPreset is a Fleet Elasticsearch output prefermance preset value.
+// See https://www.elastic.co/docs/reference/fleet/es-output-settings#es-output-settings-performance-tuning-settings
 type OutputPreset string
 
 const (
@@ -169,76 +170,31 @@ const (
 	OutputPresetCustom     OutputPreset = "custom"
 	OutputPresetThroughput OutputPreset = "throughput"
 	OutputPresetScale      OutputPreset = "scale"
-	OutputPresetLatency    OutputPreset = "latency"
+	// OutputPresetLatency lowers the output flush timeout from the default 10s to 1s. Prefer it in all tests.
+	OutputPresetLatency OutputPreset = "latency"
 )
 
-// SetDefaultESOutputPreset updates the default Fleet Elasticsearch output to use
-// the given preset. Use OutputPresetLatency to lower the output flush interval from
-// 10s to 1s, which speeds up tests that poll Elasticsearch for ingested data.
-func SetDefaultESOutputPreset(ctx context.Context, client *kibana.Client, preset OutputPreset) error {
-	type outputItem struct {
-		ID                  string   `json:"id"`
-		Name                string   `json:"name"`
-		Type                string   `json:"type"`
-		Hosts               []string `json:"hosts"`
-		IsDefault           bool     `json:"is_default"`
-		IsDefaultMonitoring bool     `json:"is_default_monitoring"`
-		Preset              string   `json:"preset"`
+// UpdateESOutputPreset updates the performance preset for the Elasticsearch output in the given policy.
+func UpdateESOutputPreset(ctx context.Context, client *kibana.Client, policy kibana.PolicyResponse, preset OutputPreset) error {
+	outputID := policy.DataOutputID
+	if outputID == "" {
+		return errors.New("policy has no data output ID")
 	}
 
-	listResp, err := client.SendWithContext(ctx, http.MethodGet, "/api/fleet/outputs", nil, nil, nil)
-	if err != nil {
-		return fmt.Errorf("listing Fleet outputs: %w", err)
-	}
-	defer listResp.Body.Close()
-	listBody, err := io.ReadAll(listResp.Body)
-	if err != nil {
-		return fmt.Errorf("reading Fleet outputs response: %w", err)
-	}
-	if listResp.StatusCode != http.StatusOK {
-		return fmt.Errorf("listing Fleet outputs returned status %d: %s", listResp.StatusCode, listBody)
-	}
-
-	var outputs struct {
-		Items []outputItem `json:"items"`
-	}
-	if err := json.Unmarshal(listBody, &outputs); err != nil {
-		return fmt.Errorf("parsing Fleet outputs response: %w", err)
-	}
-
-	var defaultOutput *outputItem
-	for i := range outputs.Items {
-		if outputs.Items[i].IsDefault && outputs.Items[i].Type == "elasticsearch" {
-			defaultOutput = &outputs.Items[i]
-			break
-		}
-	}
-	if defaultOutput == nil {
-		return errors.New("no default Elasticsearch Fleet output found")
-	}
-
-	updateBody := map[string]any{
-		"name":                  defaultOutput.Name,
-		"type":                  defaultOutput.Type,
-		"hosts":                 defaultOutput.Hosts,
-		"is_default":            defaultOutput.IsDefault,
-		"is_default_monitoring": defaultOutput.IsDefaultMonitoring,
-		"preset":                preset,
-	}
-	updateBytes, err := json.Marshal(updateBody)
+	updateBytes, err := json.Marshal(map[string]any{"preset": preset})
 	if err != nil {
 		return fmt.Errorf("marshaling Fleet output update: %w", err)
 	}
 
-	apiURL := "/api/fleet/outputs/" + defaultOutput.ID
+	apiURL := "/api/fleet/outputs/" + outputID
 	putResp, err := client.SendWithContext(ctx, http.MethodPut, apiURL, nil, nil, bytes.NewReader(updateBytes))
 	if err != nil {
-		return fmt.Errorf("updating Fleet output %s: %w", defaultOutput.ID, err)
+		return fmt.Errorf("updating Fleet output %s: %w", outputID, err)
 	}
 	defer putResp.Body.Close()
 	if putResp.StatusCode != http.StatusOK {
 		putBody, _ := io.ReadAll(putResp.Body)
-		return fmt.Errorf("updating Fleet output %s returned status %d: %s", defaultOutput.ID, putResp.StatusCode, putBody)
+		return fmt.Errorf("updating Fleet output %s returned status %d: %s", outputID, putResp.StatusCode, putBody)
 	}
 	return nil
 }

--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -84,7 +84,7 @@ func (runner *AuditDRunner) SetupSuite() {
 
 	policyResp, agentID, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
-	require.NoError(runner.T(), fleettools.SetDefaultESOutputPreset(ctx, runner.info.KibanaClient, fleettools.OutputPresetLatency))
+	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, policyResp, fleettools.OutputPresetLatency))
 
 	runner.agentID = agentID
 	runner.policyID = policyResp.ID

--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -82,9 +82,9 @@ func (runner *AuditDRunner) SetupSuite() {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
+	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, fleettools.DefaultFleetOutputID, fleettools.OutputPresetLatency))
 	policyResp, agentID, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
-	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, policyResp, fleettools.OutputPresetLatency))
 
 	runner.agentID = agentID
 	runner.policyID = policyResp.ID

--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -26,6 +26,7 @@ import (
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/fleettools"
 	"github.com/elastic/elastic-agent/testing/integration"
 )
 
@@ -83,6 +84,7 @@ func (runner *AuditDRunner) SetupSuite() {
 
 	policyResp, agentID, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
+	require.NoError(runner.T(), fleettools.SetDefaultESOutputPreset(ctx, runner.info.KibanaClient, fleettools.OutputPresetLatency))
 
 	runner.agentID = agentID
 	runner.policyID = policyResp.ID

--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -531,7 +531,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
-	preset: latency
+    preset: latency
     hosts: [{{.ESEndpoint}}]
     api_key: {{.BeatsESApiKey}}
 `
@@ -775,7 +775,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
-	preset: latency
+    preset: latency
     hosts: [http://localhost:9200]
     api_key: placeholder
 agent.monitoring.enabled: false
@@ -915,13 +915,13 @@ inputs:
 outputs:
   default:
     type: elasticsearch
-	preset: latency
+    preset: latency
     hosts: [%s]
     api_key: placeholder
     indices: [] # not supported by the elasticsearch exporter
   supported:
     type: elasticsearch
-	preset: latency
+    preset: latency
     hosts: [%s]
     api_key: placeholder
 `, esURL.Host, esURL.Host)
@@ -1036,7 +1036,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
-	preset: latency
+    preset: latency
     hosts: [%s]
     api_key: placeholder
 providers:
@@ -1180,7 +1180,7 @@ outputs:
     hosts:
     - %s
     type: elasticsearch
-	preset: latency
+    preset: latency
 `, esURL.Host)
 
 	// this is the context for the whole test, with a global timeout defined
@@ -1283,7 +1283,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
-	preset: latency
+    preset: latency
     hosts: [http://localhost:9200]
     api_key: placeholder
 agent.monitoring.enabled: false
@@ -1371,7 +1371,7 @@ inputs: []
 outputs:
   default:
     type: elasticsearch
-	preset: latency
+    preset: latency
     hosts: [http://localhost:9200]
     api_key: placeholder
 agent.monitoring.enabled: false
@@ -1522,7 +1522,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
-	preset: latency
+    preset: latency
     hosts: [{{.ESEndpoint}}]
     api_key: "{{.ESApiKey}}"
     otel:
@@ -1703,7 +1703,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
-	preset: latency
+    preset: latency
     hosts: [{{.ESEndpoint}}]
     api_key: "{{.ESApiKey}}"
 agent:

--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -531,6 +531,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
+	preset: latency
     hosts: [{{.ESEndpoint}}]
     api_key: {{.BeatsESApiKey}}
 `
@@ -774,6 +775,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
+	preset: latency
     hosts: [http://localhost:9200]
     api_key: placeholder
 agent.monitoring.enabled: false
@@ -913,11 +915,13 @@ inputs:
 outputs:
   default:
     type: elasticsearch
+	preset: latency
     hosts: [%s]
     api_key: placeholder
     indices: [] # not supported by the elasticsearch exporter
   supported:
     type: elasticsearch
+	preset: latency
     hosts: [%s]
     api_key: placeholder
 `, esURL.Host, esURL.Host)
@@ -1032,6 +1036,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
+	preset: latency
     hosts: [%s]
     api_key: placeholder
 providers:
@@ -1175,6 +1180,7 @@ outputs:
     hosts:
     - %s
     type: elasticsearch
+	preset: latency
 `, esURL.Host)
 
 	// this is the context for the whole test, with a global timeout defined
@@ -1277,6 +1283,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
+	preset: latency
     hosts: [http://localhost:9200]
     api_key: placeholder
 agent.monitoring.enabled: false
@@ -1364,6 +1371,7 @@ inputs: []
 outputs:
   default:
     type: elasticsearch
+	preset: latency
     hosts: [http://localhost:9200]
     api_key: placeholder
 agent.monitoring.enabled: false
@@ -1514,6 +1522,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
+	preset: latency
     hosts: [{{.ESEndpoint}}]
     api_key: "{{.ESApiKey}}"
     otel:
@@ -1694,6 +1703,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
+	preset: latency
     hosts: [{{.ESEndpoint}}]
     api_key: "{{.ESApiKey}}"
 agent:

--- a/testing/integration/ess/container_cmd_test.go
+++ b/testing/integration/ess/container_cmd_test.go
@@ -778,6 +778,7 @@ func createSimpleAgentMonitoringConfig(t *testing.T, workDir string, esAddr stri
 outputs:
   default:
     type: elasticsearch
+	preset: latency
     hosts:
       - %s
 

--- a/testing/integration/ess/container_cmd_test.go
+++ b/testing/integration/ess/container_cmd_test.go
@@ -778,7 +778,7 @@ func createSimpleAgentMonitoringConfig(t *testing.T, workDir string, esAddr stri
 outputs:
   default:
     type: elasticsearch
-	preset: latency
+    preset: latency
     hosts:
       - %s
 

--- a/testing/integration/ess/diagnostics_test.go
+++ b/testing/integration/ess/diagnostics_test.go
@@ -383,6 +383,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
+	preset: latency
     hosts: [{{ .ESHost }}]
     api_key: placeholder
 agent.monitoring.enabled: {{ .MonitoringEnabled }}

--- a/testing/integration/ess/diagnostics_test.go
+++ b/testing/integration/ess/diagnostics_test.go
@@ -383,7 +383,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
-	preset: latency
+    preset: latency
     hosts: [{{ .ESHost }}]
     api_key: placeholder
 agent.monitoring.enabled: {{ .MonitoringEnabled }}

--- a/testing/integration/ess/fips_test.go
+++ b/testing/integration/ess/fips_test.go
@@ -182,7 +182,7 @@ func enrollLocalFIPSAgentInFleetServer(t *testing.T, info *define.Info) (*atesti
 
 	policyResp, _, err := tools.InstallAgentWithPolicy(ctx, t, installOpts, fixture, info.KibanaClient, basePolicy)
 	require.NoError(t, err)
-	require.NoError(t, fleettools.SetDefaultESOutputPreset(ctx, info.KibanaClient, fleettools.OutputPresetLatency))
+	require.NoError(t, fleettools.UpdateESOutputPreset(ctx, info.KibanaClient, policyResp, fleettools.OutputPresetLatency))
 
 	return fixture, policyResp.ID
 }

--- a/testing/integration/ess/fips_test.go
+++ b/testing/integration/ess/fips_test.go
@@ -182,6 +182,7 @@ func enrollLocalFIPSAgentInFleetServer(t *testing.T, info *define.Info) (*atesti
 
 	policyResp, _, err := tools.InstallAgentWithPolicy(ctx, t, installOpts, fixture, info.KibanaClient, basePolicy)
 	require.NoError(t, err)
+	require.NoError(t, fleettools.SetDefaultESOutputPreset(ctx, info.KibanaClient, fleettools.OutputPresetLatency))
 
 	return fixture, policyResp.ID
 }

--- a/testing/integration/ess/fips_test.go
+++ b/testing/integration/ess/fips_test.go
@@ -180,9 +180,9 @@ func enrollLocalFIPSAgentInFleetServer(t *testing.T, info *define.Info) (*atesti
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
+	require.NoError(t, fleettools.UpdateESOutputPreset(ctx, info.KibanaClient, fleettools.DefaultFleetOutputID, fleettools.OutputPresetLatency))
 	policyResp, _, err := tools.InstallAgentWithPolicy(ctx, t, installOpts, fixture, info.KibanaClient, basePolicy)
 	require.NoError(t, err)
-	require.NoError(t, fleettools.UpdateESOutputPreset(ctx, info.KibanaClient, policyResp, fleettools.OutputPresetLatency))
 
 	return fixture, policyResp.ID
 }

--- a/testing/integration/ess/fqdn_test.go
+++ b/testing/integration/ess/fqdn_test.go
@@ -91,7 +91,7 @@ func TestFQDN(t *testing.T) {
 	}
 	policy, agentID, err := tools.InstallAgentWithPolicy(ctx, t, installOpts, agentFixture, kibClient, createPolicyReq)
 	require.NoError(t, err)
-	require.NoError(t, fleettools.SetDefaultESOutputPreset(ctx, kibClient, fleettools.OutputPresetLatency))
+	require.NoError(t, fleettools.UpdateESOutputPreset(ctx, kibClient, policy, fleettools.OutputPresetLatency))
 
 	t.Cleanup(func() {
 		// Use a separate context as the one in the test body will have been cancelled at this point.

--- a/testing/integration/ess/fqdn_test.go
+++ b/testing/integration/ess/fqdn_test.go
@@ -89,9 +89,9 @@ func TestFQDN(t *testing.T) {
 		NonInteractive: true,
 		Force:          true,
 	}
+	require.NoError(t, fleettools.UpdateESOutputPreset(ctx, kibClient, fleettools.DefaultFleetOutputID, fleettools.OutputPresetLatency))
 	policy, agentID, err := tools.InstallAgentWithPolicy(ctx, t, installOpts, agentFixture, kibClient, createPolicyReq)
 	require.NoError(t, err)
-	require.NoError(t, fleettools.UpdateESOutputPreset(ctx, kibClient, policy, fleettools.OutputPresetLatency))
 
 	t.Cleanup(func() {
 		// Use a separate context as the one in the test body will have been cancelled at this point.

--- a/testing/integration/ess/fqdn_test.go
+++ b/testing/integration/ess/fqdn_test.go
@@ -91,6 +91,7 @@ func TestFQDN(t *testing.T) {
 	}
 	policy, agentID, err := tools.InstallAgentWithPolicy(ctx, t, installOpts, agentFixture, kibClient, createPolicyReq)
 	require.NoError(t, err)
+	require.NoError(t, fleettools.SetDefaultESOutputPreset(ctx, kibClient, fleettools.OutputPresetLatency))
 
 	t.Cleanup(func() {
 		// Use a separate context as the one in the test body will have been cancelled at this point.

--- a/testing/integration/ess/metrics_monitoring_test.go
+++ b/testing/integration/ess/metrics_monitoring_test.go
@@ -85,7 +85,7 @@ func (runner *MetricsRunner) SetupSuite() {
 
 	policyResp, _, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
-	require.NoError(runner.T(), fleettools.SetDefaultESOutputPreset(ctx, runner.info.KibanaClient, fleettools.OutputPresetLatency))
+	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, policyResp, fleettools.OutputPresetLatency))
 
 	runner.policyName = policyResp.Name
 	runner.policyID = policyResp.ID

--- a/testing/integration/ess/metrics_monitoring_test.go
+++ b/testing/integration/ess/metrics_monitoring_test.go
@@ -30,6 +30,7 @@ import (
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/fleettools"
 	"github.com/elastic/elastic-agent/testing/integration"
 )
 
@@ -84,6 +85,7 @@ func (runner *MetricsRunner) SetupSuite() {
 
 	policyResp, _, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
+	require.NoError(runner.T(), fleettools.SetDefaultESOutputPreset(ctx, runner.info.KibanaClient, fleettools.OutputPresetLatency))
 
 	runner.policyName = policyResp.Name
 	runner.policyID = policyResp.ID

--- a/testing/integration/ess/metrics_monitoring_test.go
+++ b/testing/integration/ess/metrics_monitoring_test.go
@@ -83,9 +83,9 @@ func (runner *MetricsRunner) SetupSuite() {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
+	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, fleettools.DefaultFleetOutputID, fleettools.OutputPresetLatency))
 	policyResp, _, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
-	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, policyResp, fleettools.OutputPresetLatency))
 
 	runner.policyName = policyResp.Name
 	runner.policyID = policyResp.ID

--- a/testing/integration/ess/monitoring_endpoint_test.go
+++ b/testing/integration/ess/monitoring_endpoint_test.go
@@ -82,10 +82,10 @@ func (runner *EndpointMetricsMonRunner) SetupSuite() {
 		Privileged:     true,
 	}
 
+	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, fleettools.DefaultFleetOutputID, fleettools.OutputPresetLatency))
 	policy, _, err := tools.InstallAgentWithPolicy(ctx, runner.T(),
 		installOpts, runner.fixture, runner.info.KibanaClient, createPolicyReq)
 	require.NoError(runner.T(), err, "failed to install agent with policy")
-	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, policy, fleettools.OutputPresetLatency))
 
 	runner.T().Log("Installing Elastic Defend")
 	pkgPolicyResp, err := installElasticDefendPackage(runner.T(), runner.info, policy.ID)

--- a/testing/integration/ess/monitoring_endpoint_test.go
+++ b/testing/integration/ess/monitoring_endpoint_test.go
@@ -22,6 +22,7 @@ import (
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/fleettools"
 	"github.com/elastic/elastic-agent/pkg/testing/tools/testcontext"
 	"github.com/elastic/elastic-agent/testing/integration"
 )
@@ -84,6 +85,7 @@ func (runner *EndpointMetricsMonRunner) SetupSuite() {
 	policy, _, err := tools.InstallAgentWithPolicy(ctx, runner.T(),
 		installOpts, runner.fixture, runner.info.KibanaClient, createPolicyReq)
 	require.NoError(runner.T(), err, "failed to install agent with policy")
+	require.NoError(runner.T(), fleettools.SetDefaultESOutputPreset(ctx, runner.info.KibanaClient, fleettools.OutputPresetLatency))
 
 	runner.T().Log("Installing Elastic Defend")
 	pkgPolicyResp, err := installElasticDefendPackage(runner.T(), runner.info, policy.ID)

--- a/testing/integration/ess/monitoring_endpoint_test.go
+++ b/testing/integration/ess/monitoring_endpoint_test.go
@@ -85,7 +85,7 @@ func (runner *EndpointMetricsMonRunner) SetupSuite() {
 	policy, _, err := tools.InstallAgentWithPolicy(ctx, runner.T(),
 		installOpts, runner.fixture, runner.info.KibanaClient, createPolicyReq)
 	require.NoError(runner.T(), err, "failed to install agent with policy")
-	require.NoError(runner.T(), fleettools.SetDefaultESOutputPreset(ctx, runner.info.KibanaClient, fleettools.OutputPresetLatency))
+	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, policy, fleettools.OutputPresetLatency))
 
 	runner.T().Log("Installing Elastic Defend")
 	pkgPolicyResp, err := installElasticDefendPackage(runner.T(), runner.info, policy.ID)

--- a/testing/integration/ess/monitoring_probe_preserve_text_cfg_test.go
+++ b/testing/integration/ess/monitoring_probe_preserve_text_cfg_test.go
@@ -32,7 +32,7 @@ outputs:
     type: elasticsearch
     hosts: [%s]
     api_key: "example-key"
-    preset: balanced
+    preset: latency
     allow_older_versions: true
 
 inputs:

--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -89,7 +89,7 @@ func (runner *NetworkTrafficRunner) SetupSuite() {
 
 	policyResp, agentID, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
-	require.NoError(runner.T(), fleettools.SetDefaultESOutputPreset(ctx, runner.info.KibanaClient, fleettools.OutputPresetLatency))
+	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, policyResp, fleettools.OutputPresetLatency))
 
 	runner.agentID = agentID
 	runner.policyID = policyResp.ID

--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -87,9 +87,9 @@ func (runner *NetworkTrafficRunner) SetupSuite() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
+	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, fleettools.DefaultFleetOutputID, fleettools.OutputPresetLatency))
 	policyResp, agentID, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
-	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, policyResp, fleettools.OutputPresetLatency))
 
 	runner.agentID = agentID
 	runner.policyID = policyResp.ID

--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -26,6 +26,7 @@ import (
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/fleettools"
 	"github.com/elastic/elastic-agent/testing/integration"
 )
 
@@ -88,6 +89,7 @@ func (runner *NetworkTrafficRunner) SetupSuite() {
 
 	policyResp, agentID, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
+	require.NoError(runner.T(), fleettools.SetDefaultESOutputPreset(ctx, runner.info.KibanaClient, fleettools.OutputPresetLatency))
 
 	runner.agentID = agentID
 	runner.policyID = policyResp.ID

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -80,9 +80,9 @@ func (runner *OsqueryManagerRunner) SetupSuite() {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
+	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, fleettools.DefaultFleetOutputID, fleettools.OutputPresetLatency))
 	policyResp, agentID, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
-	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, policyResp, fleettools.OutputPresetLatency))
 
 	runner.agentID = agentID
 	runner.policyID = policyResp.ID

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -82,7 +82,7 @@ func (runner *OsqueryManagerRunner) SetupSuite() {
 
 	policyResp, agentID, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
-	require.NoError(runner.T(), fleettools.SetDefaultESOutputPreset(ctx, runner.info.KibanaClient, fleettools.OutputPresetLatency))
+	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, policyResp, fleettools.OutputPresetLatency))
 
 	runner.agentID = agentID
 	runner.policyID = policyResp.ID

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -26,6 +26,7 @@ import (
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/fleettools"
 	"github.com/elastic/elastic-agent/testing/integration"
 )
 
@@ -81,6 +82,7 @@ func (runner *OsqueryManagerRunner) SetupSuite() {
 
 	policyResp, agentID, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
+	require.NoError(runner.T(), fleettools.SetDefaultESOutputPreset(ctx, runner.info.KibanaClient, fleettools.OutputPresetLatency))
 
 	runner.agentID = agentID
 	runner.policyID = policyResp.ID

--- a/testing/integration/ess/otel_test.go
+++ b/testing/integration/ess/otel_test.go
@@ -1223,7 +1223,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
-	preset: latency
+    preset: latency
     hosts: [{{.ESEndpoint}}]
     api_key: {{.BeatsESApiKey}}
     compression_level: 0
@@ -1449,7 +1449,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
-	preset: latency
+    preset: latency
     hosts: [{{.ESEndpoint}}]
     api_key: {{.BeatsESApiKey}}
     compression_level: 0
@@ -2217,7 +2217,7 @@ func TestLogReloading(t *testing.T) {
 outputs:
   default:
     type: elasticsearch
-	preset: latency
+    preset: latency
     hosts:
       - %s
     preset: balanced

--- a/testing/integration/ess/otel_test.go
+++ b/testing/integration/ess/otel_test.go
@@ -929,14 +929,14 @@ outputs:
     type: elasticsearch
     hosts: [{{.ESEndpoint}}]
     api_key: "{{.ESApiKey}}"
-    preset: "balanced"
+    preset: latency
     ssl.enabled: true
     ssl.verification_mode: full
   monitoring:
     type: elasticsearch
     hosts: [{{.ESEndpoint}}]
     api_key: "{{.ESApiKey}}"
-    preset: "balanced"
+    preset: latency
 agent:
   monitoring:
     metrics: true
@@ -1074,7 +1074,7 @@ outputs:
     type: elasticsearch
     hosts: [{{.ESEndpoint}}]
     api_key: "{{.ESApiKey}}"
-    preset: "balanced"
+    preset: latency
 agent.monitoring:
   metrics: false
   logs: false
@@ -1223,6 +1223,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
+	preset: latency
     hosts: [{{.ESEndpoint}}]
     api_key: {{.BeatsESApiKey}}
     compression_level: 0
@@ -1448,6 +1449,7 @@ inputs:
 outputs:
   default:
     type: elasticsearch
+	preset: latency
     hosts: [{{.ESEndpoint}}]
     api_key: {{.BeatsESApiKey}}
     compression_level: 0
@@ -2103,7 +2105,7 @@ outputs:
     type: elasticsearch
     hosts: [http://localhost:9200]
     api_key: placeholder
-    preset: "balanced"
+    preset: latency
     status_reporting:
       enabled: {{.StatusReportingEnabled}}
 `
@@ -2215,6 +2217,7 @@ func TestLogReloading(t *testing.T) {
 outputs:
   default:
     type: elasticsearch
+	preset: latency
     hosts:
       - %s
     preset: balanced
@@ -2558,7 +2561,7 @@ outputs:
     type: elasticsearch
     hosts: [{{.ESEndpoint}}]
     api_key: "{{.ESApiKey}}"
-    preset: balanced
+    preset: latency
 agent.grpc:
   # listen address for the GRPC server that spawned processes connect back to.
    address: localhost
@@ -2887,7 +2890,7 @@ outputs:
     sasl.mechanism: SCRAM-SHA-256
     headers:
     - some-key: some-value
-    - some-key: another-value 
+    - some-key: another-value
 agent.monitoring:
   metrics: false
   logs: false

--- a/testing/integration/ess/run_path_logs_test.go
+++ b/testing/integration/ess/run_path_logs_test.go
@@ -28,6 +28,7 @@ outputs:
   default:
     type: elasticsearch
     hosts: ["%s"]
+	preset: latency
     api_key: "fake-key"
 
 agent.monitoring:

--- a/testing/integration/ess/run_path_logs_test.go
+++ b/testing/integration/ess/run_path_logs_test.go
@@ -28,7 +28,7 @@ outputs:
   default:
     type: elasticsearch
     hosts: ["%s"]
-	preset: latency
+    preset: latency
     api_key: "fake-key"
 
 agent.monitoring:

--- a/testing/integration/ess/upgrade_rollback_test.go
+++ b/testing/integration/ess/upgrade_rollback_test.go
@@ -112,6 +112,7 @@ func TestStandaloneUpgradeRollback(t *testing.T) {
 outputs:
   default:
     type: elasticsearch
+	preset: latency
     hosts: [%s]
 
 inputs:

--- a/testing/integration/ess/upgrade_rollback_test.go
+++ b/testing/integration/ess/upgrade_rollback_test.go
@@ -112,7 +112,7 @@ func TestStandaloneUpgradeRollback(t *testing.T) {
 outputs:
   default:
     type: elasticsearch
-	preset: latency
+    preset: latency
     hosts: [%s]
 
 inputs:

--- a/testing/integration/k8s/testdata/elastic-agent-kustomize.yaml
+++ b/testing/integration/k8s/testdata/elastic-agent-kustomize.yaml
@@ -4,7 +4,6 @@ data:
     outputs:
       default:
         type: elasticsearch
-        preset: latency
         hosts:
           - >-
             ${ES_HOST}

--- a/testing/integration/k8s/testdata/elastic-agent-kustomize.yaml
+++ b/testing/integration/k8s/testdata/elastic-agent-kustomize.yaml
@@ -4,6 +4,7 @@ data:
     outputs:
       default:
         type: elasticsearch
+        preset: latency
         hosts:
           - >-
             ${ES_HOST}

--- a/testing/integration/k8s/testdata/journald-input.yml
+++ b/testing/integration/k8s/testdata/journald-input.yml
@@ -1,6 +1,7 @@
 outputs:
   default:
     type: elasticsearch
+    preset: latency
     hosts:
       - ${ES_HOST}
     username: ${ELASTICSEARCH_USERNAME}

--- a/testing/integration/leak/long_running_test.go
+++ b/testing/integration/leak/long_running_test.go
@@ -35,6 +35,7 @@ import (
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/fleettools"
 	"github.com/elastic/elastic-agent/pkg/utils"
 	"github.com/elastic/elastic-agent/testing/integration"
 	"github.com/elastic/go-sysinfo"
@@ -117,6 +118,7 @@ func (runner *ExtendedRunner) SetupSuite() {
 
 	policyResp, _, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
+	require.NoError(runner.T(), fleettools.SetDefaultESOutputPreset(ctx, runner.info.KibanaClient, fleettools.OutputPresetLatency))
 
 	_, err = tools.InstallPackageFromDefaultFile(
 		ctx,

--- a/testing/integration/leak/long_running_test.go
+++ b/testing/integration/leak/long_running_test.go
@@ -118,7 +118,7 @@ func (runner *ExtendedRunner) SetupSuite() {
 
 	policyResp, _, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
-	require.NoError(runner.T(), fleettools.SetDefaultESOutputPreset(ctx, runner.info.KibanaClient, fleettools.OutputPresetLatency))
+	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, policyResp, fleettools.OutputPresetLatency))
 
 	_, err = tools.InstallPackageFromDefaultFile(
 		ctx,

--- a/testing/integration/leak/long_running_test.go
+++ b/testing/integration/leak/long_running_test.go
@@ -116,9 +116,9 @@ func (runner *ExtendedRunner) SetupSuite() {
 		},
 	}
 
+	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, fleettools.DefaultFleetOutputID, fleettools.OutputPresetLatency))
 	policyResp, _, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
 	require.NoError(runner.T(), err)
-	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, policyResp, fleettools.OutputPresetLatency))
 
 	_, err = tools.InstallPackageFromDefaultFile(
 		ctx,


### PR DESCRIPTION
Convert the Elasticsearch configurations in integration tests to use the latency preset by default, which sends data after 1s instead of 10s. We might want a testing preset that sets it to 0s eventually but this was much faster to implement.

Looking at a couple of other arbitrary builds, this saves 2-5 minutes:

- https://buildkite.com/elastic/elastic-agent/builds/40922
- https://buildkite.com/elastic/elastic-agent/builds/40451

We should be able to get an even larger speed up by speeding up the agent checkin in integration tests, that one is a bit more work but also worth doing.

https://www.elastic.co/docs/reference/fleet/es-output-settings#es-output-settings-performance-tuning-settings

<img width="762" height="519" alt="Screenshot 2026-06-03 at 9 54 12 AM" src="https://github.com/user-attachments/assets/0325a81c-d82f-4f0d-992b-d2b939399738" />

