### PR TITLE
Extract CheckinCmd to pkg/fleetapi for cross-repo sharing

### DIFF
--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -6,6 +6,7 @@ package fleet
 
 import (
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"sync"
 	"time"
@@ -29,6 +30,7 @@ import (
 	"github.com/elastic/elastic-agent/pkg/backoff"
 	"github.com/elastic/elastic-agent/pkg/component/runtime"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
+	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/pkg/scheduler"
 )
 
@@ -189,8 +191,11 @@ func (f *FleetGateway) Run(ctx context.Context) error {
 				continue
 			}
 
-			actions := make([]fleetapi.Action, len(resp.Actions))
-			copy(actions, resp.Actions)
+			var actions fleetapi.Actions
+			if err := json.Unmarshal(resp.Actions, &actions); err != nil {
+				f.log.Errorf("failed to unmarshal checkin actions: %v", err)
+				continue
+			}
 			if len(actions) > 0 {
 				f.actionCh <- actions
 			}
@@ -203,7 +208,7 @@ func (f *FleetGateway) Errors() <-chan error {
 	return f.errCh
 }
 
-func (f *FleetGateway) doExecute(ctx context.Context, bo backoff.Backoff) (*fleetapi.CheckinResponse, error) {
+func (f *FleetGateway) doExecute(ctx context.Context, bo backoff.Backoff) (*pkgfleetapi.CheckinResponse, error) {
 	bo.Reset()
 
 	// Guard if the context is stopped by a out of bound call,
@@ -277,7 +282,7 @@ func (f *FleetGateway) doExecute(ctx context.Context, bo backoff.Backoff) (*flee
 	return nil, ctx.Err()
 }
 
-func convertToCheckinComponents(logger *logp.Logger, components []runtime.ComponentComponentState, collector *status.AggregateStatus) []fleetapi.CheckinComponent {
+func convertToCheckinComponents(logger *logp.Logger, components []runtime.ComponentComponentState, collector *status.AggregateStatus) []pkgfleetapi.CheckinComponent {
 	if components == nil && (collector == nil || len(collector.ComponentStatusMap) == 0) {
 		return nil
 	}
@@ -314,13 +319,13 @@ func convertToCheckinComponents(logger *logp.Logger, components []runtime.Compon
 	if collector != nil {
 		size += len(collector.ComponentStatusMap)
 	}
-	checkinComponents := make([]fleetapi.CheckinComponent, 0, size)
+	checkinComponents := make([]pkgfleetapi.CheckinComponent, 0, size)
 
 	for _, item := range components {
 		component := item.Component
 		state := item.State
 
-		checkinComponent := fleetapi.CheckinComponent{
+		checkinComponent := pkgfleetapi.CheckinComponent{
 			ID:      component.ID,
 			Type:    component.Type(),
 			Status:  stateString(state.State),
@@ -328,10 +333,10 @@ func convertToCheckinComponents(logger *logp.Logger, components []runtime.Compon
 		}
 
 		if state.Units != nil {
-			units := make([]fleetapi.CheckinUnit, 0, len(state.Units))
+			units := make([]pkgfleetapi.CheckinUnit, 0, len(state.Units))
 
 			for unitKey, unitState := range state.Units {
-				units = append(units, fleetapi.CheckinUnit{
+				units = append(units, pkgfleetapi.CheckinUnit{
 					ID:      unitKey.UnitID,
 					Type:    unitTypeString(unitKey.UnitType),
 					Status:  stateString(unitState.State),
@@ -350,7 +355,7 @@ func convertToCheckinComponents(logger *logp.Logger, components []runtime.Compon
 		for id, item := range collector.ComponentStatusMap {
 			state, msg := translate.StateWithMessage(item)
 
-			checkinComponent := fleetapi.CheckinComponent{
+			checkinComponent := pkgfleetapi.CheckinComponent{
 				ID:      id,
 				Type:    "otel",
 				Status:  stateString(state),
@@ -358,10 +363,10 @@ func convertToCheckinComponents(logger *logp.Logger, components []runtime.Compon
 			}
 
 			if len(item.ComponentStatusMap) > 0 {
-				units := make([]fleetapi.CheckinUnit, 0, len(item.ComponentStatusMap))
+				units := make([]pkgfleetapi.CheckinUnit, 0, len(item.ComponentStatusMap))
 				for unitId, unitItem := range item.ComponentStatusMap {
 					unitState, unitMsg := translate.StateWithMessage(unitItem)
-					units = append(units, fleetapi.CheckinUnit{
+					units = append(units, pkgfleetapi.CheckinUnit{
 						ID:      unitId,
 						Status:  stateString(unitState),
 						Message: unitMsg,
@@ -378,7 +383,7 @@ func convertToCheckinComponents(logger *logp.Logger, components []runtime.Compon
 	return checkinComponents
 }
 
-func (f *FleetGateway) execute(ctx context.Context) (*fleetapi.CheckinResponse, time.Duration, error) {
+func (f *FleetGateway) execute(ctx context.Context) (*pkgfleetapi.CheckinResponse, time.Duration, error) {
 	ecsMeta, err := info.Metadata(ctx, f.log)
 	if err != nil {
 		f.log.Error(errors.New("failed to load metadata", err))
@@ -417,14 +422,14 @@ func (f *FleetGateway) execute(ctx context.Context) (*fleetapi.CheckinResponse, 
 		rollbacks = nil
 	}
 
-	var validRollbacks []fleetapi.CheckinRollback
+	var validRollbacks []pkgfleetapi.CheckinRollback
 	if len(rollbacks) > 0 {
 		now := time.Now()
-		validRollbacks = make([]fleetapi.CheckinRollback, 0, len(rollbacks))
+		validRollbacks = make([]pkgfleetapi.CheckinRollback, 0, len(rollbacks))
 		for _, rollback := range rollbacks {
 			if rollback.ValidUntil.After(now) {
-				// map the `ttl.Marker` to the `fleetapi.CheckinRollback`
-				validRollbacks = append(validRollbacks, fleetapi.CheckinRollback{
+				// map the `ttl.Marker` to the `pkgfleetapi.CheckinRollback`
+				validRollbacks = append(validRollbacks, pkgfleetapi.CheckinRollback{
 					Version:    rollback.Version,
 					ValidUntil: rollback.ValidUntil,
 				})
@@ -433,8 +438,8 @@ func (f *FleetGateway) execute(ctx context.Context) (*fleetapi.CheckinResponse, 
 	}
 
 	// checkin
-	cmd := fleetapi.NewCheckinCmd(f.agentInfo, f.client, f.compression)
-	req := &fleetapi.CheckinRequest{
+	cmd := pkgfleetapi.NewCheckinCmd(f.agentInfo, f.client, f.compression)
+	req := &pkgfleetapi.CheckinRequest{
 		AckToken:          ackToken,
 		Metadata:          ecsMeta,
 		Status:            agentStateToString(state.State),
@@ -455,7 +460,7 @@ func (f *FleetGateway) execute(ctx context.Context) (*fleetapi.CheckinResponse, 
 		if f.shouldUseLongSched() {
 			f.log.Warnf("retrieved an invalid api key error '%d' times. will use long scheduler", f.unauthCounter)
 			f.scheduler.SetDuration(defaultGatewaySettings.ErrConsecutiveUnauthDuration)
-			return &fleetapi.CheckinResponse{}, took, nil
+			return &pkgfleetapi.CheckinResponse{}, took, nil
 		}
 
 		return nil, took, err
@@ -489,7 +494,7 @@ func (f *FleetGateway) shouldUseLongSched() bool {
 }
 
 func isUnauth(err error) bool {
-	return errors.Is(err, client.ErrInvalidAPIKey)
+	return errors.Is(err, pkgfleetapi.ErrInvalidAPIKey)
 }
 
 func (f *FleetGateway) SetClient(c client.Sender) {

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -855,7 +855,7 @@ func TestConvertToCheckingComponents(t *testing.T) {
 		name       string
 		components []runtime.ComponentComponentState
 		collector  *status.AggregateStatus
-		expected   []fleetapi.CheckinComponent
+		expected   []pkgfleetapi.CheckinComponent
 	}{
 		{
 			name:       "Nil inputs",
@@ -867,7 +867,7 @@ func TestConvertToCheckingComponents(t *testing.T) {
 			name:       "Empty inputs",
 			components: []runtime.ComponentComponentState{},
 			collector:  &status.AggregateStatus{},
-			expected:   []fleetapi.CheckinComponent{},
+			expected:   []pkgfleetapi.CheckinComponent{},
 		},
 		{
 			name: "Only agent components",
@@ -895,7 +895,7 @@ func TestConvertToCheckingComponents(t *testing.T) {
 				},
 			},
 			collector: nil,
-			expected: []fleetapi.CheckinComponent{
+			expected: []pkgfleetapi.CheckinComponent{
 				{
 					ID:      "comp-1",
 					Type:    "log",
@@ -907,7 +907,7 @@ func TestConvertToCheckingComponents(t *testing.T) {
 					Type:    "log",
 					Status:  "DEGRADED",
 					Message: "Component is degraded",
-					Units: []fleetapi.CheckinUnit{
+					Units: []pkgfleetapi.CheckinUnit{
 						{
 							ID:      "unit-1",
 							Type:    "input",
@@ -948,13 +948,13 @@ func TestConvertToCheckingComponents(t *testing.T) {
 					},
 				},
 			},
-			expected: []fleetapi.CheckinComponent{
+			expected: []pkgfleetapi.CheckinComponent{
 				{
 					ID:      "extensions",
 					Type:    "otel",
 					Status:  "HEALTHY",
 					Message: "Healthy",
-					Units: []fleetapi.CheckinUnit{
+					Units: []pkgfleetapi.CheckinUnit{
 						{
 							ID:      "extensions:healthcheck",
 							Type:    "",
@@ -968,7 +968,7 @@ func TestConvertToCheckingComponents(t *testing.T) {
 					Type:    "otel",
 					Status:  "DEGRADED",
 					Message: "Recoverable: pipeline error",
-					Units: []fleetapi.CheckinUnit{
+					Units: []pkgfleetapi.CheckinUnit{
 						{
 							ID:      "exporter:elasticsearch",
 							Type:    "output",
@@ -1009,7 +1009,7 @@ func TestConvertToCheckingComponents(t *testing.T) {
 					},
 				},
 			},
-			expected: []fleetapi.CheckinComponent{
+			expected: []pkgfleetapi.CheckinComponent{
 				{
 					ID:      "comp-1",
 					Type:    "log",
@@ -1042,13 +1042,13 @@ func TestConvertToCheckingComponents(t *testing.T) {
 				},
 			},
 			collector: nil,
-			expected: []fleetapi.CheckinComponent{
+			expected: []pkgfleetapi.CheckinComponent{
 				{
 					ID:      "comp-1",
 					Type:    "log",
 					Status:  "",
 					Message: "Unknown state",
-					Units: []fleetapi.CheckinUnit{
+					Units: []pkgfleetapi.CheckinUnit{
 						{
 							ID:      "unit-1",
 							Type:    "",
@@ -1074,13 +1074,13 @@ func TestConvertToCheckingComponents(t *testing.T) {
 					},
 				},
 			},
-			expected: []fleetapi.CheckinComponent{
+			expected: []pkgfleetapi.CheckinComponent{
 				{
 					ID:      "invalid-id",
 					Type:    "otel",
 					Status:  "HEALTHY",
 					Message: "Healthy",
-					Units: []fleetapi.CheckinUnit{
+					Units: []pkgfleetapi.CheckinUnit{
 						{
 							ID:      "invalid-unit-id",
 							Type:    "",
@@ -1097,11 +1097,11 @@ func TestConvertToCheckingComponents(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := convertToCheckinComponents(logp.NewNopLogger(), tt.components, tt.collector)
 			// Testify diffs are nicer if we sort and compare directly vs using ElementsMathc
-			slices.SortFunc(result, func(a, b fleetapi.CheckinComponent) int {
+			slices.SortFunc(result, func(a, b pkgfleetapi.CheckinComponent) int {
 				return strings.Compare(a.ID, b.ID)
 			})
 			for _, c := range result {
-				slices.SortFunc(c.Units, func(a, b fleetapi.CheckinUnit) int {
+				slices.SortFunc(c.Units, func(a, b pkgfleetapi.CheckinUnit) int {
 					return strings.Compare(a.ID, b.ID)
 				})
 			}

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -35,12 +35,12 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/storage/store"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/acker/noop"
-	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
 	"github.com/elastic/elastic-agent/pkg/component"
 	"github.com/elastic/elastic-agent/pkg/component/runtime"
 	agentclient "github.com/elastic/elastic-agent/pkg/control/v2/client"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
+	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/pkg/scheduler"
 	"github.com/elastic/elastic-agent/pkg/upgrade/details"
 )
@@ -337,7 +337,7 @@ func TestFleetGateway(t *testing.T) {
 				data, err := io.ReadAll(body)
 				require.NoError(t, err)
 
-				var checkinRequest fleetapi.CheckinRequest
+				var checkinRequest pkgfleetapi.CheckinRequest
 				err = json.Unmarshal(data, &checkinRequest)
 				require.NoError(t, err)
 
@@ -399,7 +399,7 @@ func TestFleetGateway(t *testing.T) {
 				data, err := io.ReadAll(body)
 				require.NoError(t, err)
 
-				var checkinRequest fleetapi.CheckinRequest
+				var checkinRequest pkgfleetapi.CheckinRequest
 				err = json.Unmarshal(data, &checkinRequest)
 				require.NoError(t, err)
 
@@ -725,7 +725,7 @@ func TestFleetGatewaySchedulerSwitch(t *testing.T) {
 		defer cancel()
 
 		unauth := func(_ context.Context, _ http.Header, _ io.Reader) (*http.Response, error) {
-			return nil, client.ErrInvalidAPIKey
+			return nil, pkgfleetapi.ErrInvalidAPIKey
 		}
 
 		clientWaitFn := c.Answer(unauth)
@@ -1115,7 +1115,7 @@ func TestAvailableRollbacks(t *testing.T) {
 		name                  string
 		setup                 func(t *testing.T, rbSource *ttl.MockReadOnlySource, client *testingClient)
 		wantErr               assert.ErrorAssertionFunc
-		assertCheckinResponse func(t *testing.T, resp *fleetapi.CheckinResponse)
+		assertCheckinResponse func(t *testing.T, resp *pkgfleetapi.CheckinResponse)
 	}{
 		{
 			name: "no available rollbacks - normal checkin",
@@ -1157,11 +1157,11 @@ func TestAvailableRollbacks(t *testing.T) {
 					assert.NoError(t, err, "error decoding checkin body")
 					if assert.Contains(t, unmarshaled, "upgrade") {
 						// verify that we got the correct data
-						var actualUpgrade fleetapi.CheckinUpgrade
+						var actualUpgrade pkgfleetapi.CheckinUpgrade
 						err = json.Unmarshal(unmarshaled["upgrade"], &actualUpgrade)
 						require.NoError(t, err, "error decoding upgrade info from checkin body")
 
-						expected := []fleetapi.CheckinRollback{{
+						expected := []pkgfleetapi.CheckinRollback{{
 							Version:    "1.2.3",
 							ValidUntil: validUntil,
 						}}

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -36,6 +36,7 @@ import (
 	comprt "github.com/elastic/elastic-agent/pkg/component/runtime"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 	"github.com/elastic/elastic-agent/pkg/features"
+	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/pkg/utils"
 )
 
@@ -188,12 +189,12 @@ func notifyFleetIfNeeded(ctx context.Context, log *logp.Logger, pt ProgressDescr
 	}
 }
 
-type NotifyFleetAuditUninstall func(ctx context.Context, log *logp.Logger, pt ProgressDescriber, cfg *configuration.Configuration, ai fleetapi.AgentInfo) error
+type NotifyFleetAuditUninstall func(ctx context.Context, log *logp.Logger, pt ProgressDescriber, cfg *configuration.Configuration, ai pkgfleetapi.AgentInfo) error
 
 // notifyFleetAuditUninstall will attempt to notify fleet-server of the agent's uninstall.
 //
 // There are retries for the attempt after a 10s wait, but it is a best-effort approach.
-func notifyFleetAuditUninstall(ctx context.Context, log *logp.Logger, pt ProgressDescriber, cfg *configuration.Configuration, ai fleetapi.AgentInfo) error {
+func notifyFleetAuditUninstall(ctx context.Context, log *logp.Logger, pt ProgressDescriber, cfg *configuration.Configuration, ai pkgfleetapi.AgentInfo) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	pt.Describe("Attempting to notify Fleet of uninstall")

--- a/internal/pkg/agent/install/uninstall_test.go
+++ b/internal/pkg/agent/install/uninstall_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/secret"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/vault"
-	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/internal/pkg/remote"
+	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 )
 
 func Test_checkForUnprivilegedVault(t *testing.T) {
@@ -231,7 +231,7 @@ type MockNotifyFleetAuditUninstall struct {
 	Called bool
 }
 
-func (m *MockNotifyFleetAuditUninstall) Call(ctx context.Context, log *logp.Logger, pt *progressbar.ProgressBar, cfg *configuration.Configuration, ai fleetapi.AgentInfo) {
+func (m *MockNotifyFleetAuditUninstall) Call(ctx context.Context, log *logp.Logger, pt *progressbar.ProgressBar, cfg *configuration.Configuration, ai pkgfleetapi.AgentInfo) {
 	m.Called = true
 }
 

--- a/internal/pkg/fleetapi/ack_cmd.go
+++ b/internal/pkg/fleetapi/ack_cmd.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
+	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 )
 
 const ackPath = "/api/fleet/agents/%s/acks"
@@ -84,11 +85,11 @@ func (e *AckResponse) Validate() error {
 // AckCmd is a fleet API command.
 type AckCmd struct {
 	client client.Sender
-	info   AgentInfo
+	info   pkgfleetapi.AgentInfo
 }
 
 // NewAckCmd creates a new api command.
-func NewAckCmd(info AgentInfo, client client.Sender) *AckCmd {
+func NewAckCmd(info pkgfleetapi.AgentInfo, client client.Sender) *AckCmd {
 	return &AckCmd{
 		client: client,
 		info:   info,

--- a/internal/pkg/fleetapi/audit_unenroll_cmd.go
+++ b/internal/pkg/fleetapi/audit_unenroll_cmd.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
+	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 )
 
 // ReqError is an error wrapper to wrap errors with a request.
@@ -60,10 +61,10 @@ func (e *AuditUnenrollRequest) Validate() error {
 
 type AuditUnenrollCmd struct {
 	client client.Sender
-	info   AgentInfo
+	info   pkgfleetapi.AgentInfo
 }
 
-func NewAuditUnenrollCmd(info AgentInfo, client client.Sender) *AuditUnenrollCmd {
+func NewAuditUnenrollCmd(info pkgfleetapi.AgentInfo, client client.Sender) *AuditUnenrollCmd {
 	return &AuditUnenrollCmd{
 		client: client,
 		info:   info,

--- a/internal/pkg/fleetapi/checkin_cmd_test.go
+++ b/internal/pkg/fleetapi/checkin_cmd_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
 	"github.com/elastic/elastic-agent/internal/pkg/remote"
 	"github.com/elastic/elastic-agent/pkg/ecsmeta"
+	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 )
 
 type agentinfo struct{}
@@ -51,9 +52,9 @@ func TestCheckin(t *testing.T) {
 			return mux
 		}, withAPIKey,
 		func(t *testing.T, client client.Sender) {
-			cmd := NewCheckinCmd(agentInfo, client, defaultCompression)
+			cmd := pkgfleetapi.NewCheckinCmd(agentInfo, client, defaultCompression)
 
-			request := CheckinRequest{}
+			request := pkgfleetapi.CheckinRequest{}
 
 			_, took, err := cmd.Execute(ctx, &request)
 			require.Error(t, err)
@@ -102,18 +103,20 @@ func TestCheckin(t *testing.T) {
 			return mux
 		}, withAPIKey,
 		func(t *testing.T, client client.Sender) {
-			cmd := NewCheckinCmd(agentInfo, client, defaultCompression)
+			cmd := pkgfleetapi.NewCheckinCmd(agentInfo, client, defaultCompression)
 
-			request := CheckinRequest{}
+			request := pkgfleetapi.CheckinRequest{}
 
 			r, _, err := cmd.Execute(ctx, &request)
 			require.NoError(t, err)
 
-			require.Equal(t, 1, len(r.Actions))
+			var actions Actions
+			require.NoError(t, json.Unmarshal(r.Actions, &actions))
+			require.Equal(t, 1, len(actions))
 
 			// ActionPolicyChange
-			require.Equal(t, "id1", r.Actions[0].ID())
-			require.Equal(t, "POLICY_CHANGE", r.Actions[0].Type())
+			require.Equal(t, "id1", actions[0].ID())
+			require.Equal(t, "POLICY_CHANGE", actions[0].Type())
 		},
 	))
 
@@ -163,23 +166,25 @@ func TestCheckin(t *testing.T) {
 			return mux
 		}, withAPIKey,
 		func(t *testing.T, client client.Sender) {
-			cmd := NewCheckinCmd(agentInfo, client, defaultCompression)
+			cmd := pkgfleetapi.NewCheckinCmd(agentInfo, client, defaultCompression)
 
-			request := CheckinRequest{}
+			request := pkgfleetapi.CheckinRequest{}
 
 			r, _, err := cmd.Execute(ctx, &request)
 			require.NoError(t, err)
 
-			require.Equal(t, 2, len(r.Actions))
+			var actions Actions
+			require.NoError(t, json.Unmarshal(r.Actions, &actions))
+			require.Equal(t, 2, len(actions))
 
 			// ActionPolicyChange
-			require.Equal(t, "id1", r.Actions[0].ID())
-			require.Equal(t, "POLICY_CHANGE", r.Actions[0].Type())
+			require.Equal(t, "id1", actions[0].ID())
+			require.Equal(t, "POLICY_CHANGE", actions[0].Type())
 
 			// UnknownAction
-			require.Equal(t, "id2", r.Actions[1].ID())
-			require.Equal(t, "UNKNOWN", r.Actions[1].Type())
-			require.Equal(t, "WHAT_TO_DO_WITH_IT", r.Actions[1].(*ActionUnknown).OriginalType)
+			require.Equal(t, "id2", actions[1].ID())
+			require.Equal(t, "UNKNOWN", actions[1].Type())
+			require.Equal(t, "WHAT_TO_DO_WITH_IT", actions[1].(*ActionUnknown).OriginalType)
 		},
 	))
 
@@ -195,14 +200,16 @@ func TestCheckin(t *testing.T) {
 			return mux
 		}, withAPIKey,
 		func(t *testing.T, client client.Sender) {
-			cmd := NewCheckinCmd(agentInfo, client, defaultCompression)
+			cmd := pkgfleetapi.NewCheckinCmd(agentInfo, client, defaultCompression)
 
-			request := CheckinRequest{}
+			request := pkgfleetapi.CheckinRequest{}
 
 			r, _, err := cmd.Execute(ctx, &request)
 			require.NoError(t, err)
 
-			require.Equal(t, 0, len(r.Actions))
+			var actions Actions
+			require.NoError(t, json.Unmarshal(r.Actions, &actions))
+			require.Equal(t, 0, len(actions))
 		},
 	))
 
@@ -229,14 +236,16 @@ func TestCheckin(t *testing.T) {
 			return mux
 		}, withAPIKey,
 		func(t *testing.T, client client.Sender) {
-			cmd := NewCheckinCmd(agentInfo, client, defaultCompression)
+			cmd := pkgfleetapi.NewCheckinCmd(agentInfo, client, defaultCompression)
 
-			request := CheckinRequest{Metadata: testMetadata()}
+			request := pkgfleetapi.CheckinRequest{Metadata: testMetadata()}
 
 			r, _, err := cmd.Execute(ctx, &request)
 			require.NoError(t, err)
 
-			require.Equal(t, 0, len(r.Actions))
+			var actions Actions
+			require.NoError(t, json.Unmarshal(r.Actions, &actions))
+			require.Equal(t, 0, len(actions))
 		},
 	))
 
@@ -263,14 +272,16 @@ func TestCheckin(t *testing.T) {
 			return mux
 		}, withAPIKey,
 		func(t *testing.T, client client.Sender) {
-			cmd := NewCheckinCmd(agentInfo, client, defaultCompression)
+			cmd := pkgfleetapi.NewCheckinCmd(agentInfo, client, defaultCompression)
 
-			request := CheckinRequest{}
+			request := pkgfleetapi.CheckinRequest{}
 
 			r, _, err := cmd.Execute(ctx, &request)
 			require.NoError(t, err)
 
-			require.Equal(t, 0, len(r.Actions))
+			var actions Actions
+			require.NoError(t, json.Unmarshal(r.Actions, &actions))
+			require.Equal(t, 0, len(actions))
 		},
 	))
 
@@ -302,14 +313,16 @@ func TestCheckin(t *testing.T) {
 			return mux
 		}, withAPIKey,
 		func(t *testing.T, client client.Sender) {
-			cmd := NewCheckinCmd(agentInfo, client, defaultCompression)
+			cmd := pkgfleetapi.NewCheckinCmd(agentInfo, client, defaultCompression)
 
-			request := CheckinRequest{}
+			request := pkgfleetapi.CheckinRequest{}
 
 			r, _, err := cmd.Execute(ctx, &request)
 			require.NoError(t, err)
 
-			require.Equal(t, 0, len(r.Actions))
+			var actions Actions
+			require.NoError(t, json.Unmarshal(r.Actions, &actions))
+			require.Equal(t, 0, len(actions))
 		},
 		func(config *remote.Config) {
 			config.Headers = map[string]string{
@@ -355,7 +368,7 @@ func TestCheckinCompression(t *testing.T) {
 						assert.Empty(t, r.Header.Get("Content-Encoding"))
 					}
 
-					var checkinRequest CheckinRequest
+					var checkinRequest pkgfleetapi.CheckinRequest
 					require.NoError(t, json.Unmarshal(checkinPayload, &checkinRequest))
 
 					w.WriteHeader(http.StatusOK)
@@ -365,8 +378,8 @@ func TestCheckinCompression(t *testing.T) {
 			},
 			withAPIKey,
 			func(t *testing.T, client client.Sender) {
-				cmd := NewCheckinCmd(agentInfo, client, tc.compression)
-				_, _, err := cmd.Execute(t.Context(), &CheckinRequest{})
+				cmd := pkgfleetapi.NewCheckinCmd(agentInfo, client, tc.compression)
+				_, _, err := cmd.Execute(t.Context(), &pkgfleetapi.CheckinRequest{})
 				require.NoError(t, err)
 			},
 		))

--- a/internal/pkg/fleetapi/client/round_trippers.go
+++ b/internal/pkg/fleetapi/client/round_trippers.go
@@ -9,10 +9,11 @@ import (
 	"net/http"
 
 	"github.com/elastic/elastic-agent/internal/pkg/remote"
+	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 )
 
-// ErrInvalidAPIKey is returned when authentication fail to fleet.
-var ErrInvalidAPIKey = errors.New("invalid api key to authenticate with fleet")
+// ErrInvalidAPIKey is re-exported from pkg/fleetapi for backwards compatibility.
+var ErrInvalidAPIKey = pkgfleetapi.ErrInvalidAPIKey
 
 // FleetUserAgentRoundTripper adds the Fleet user agent.
 type FleetUserAgentRoundTripper struct {
@@ -53,7 +54,7 @@ func (r *FleetAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		defer resp.Body.Close()
-		return nil, ErrInvalidAPIKey
+		return nil, pkgfleetapi.ErrInvalidAPIKey
 	}
 
 	return resp, err

--- a/pkg/fleetapi/checkin_cmd.go
+++ b/pkg/fleetapi/checkin_cmd.go
@@ -9,20 +9,55 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
-	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
-	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
 	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	"github.com/elastic/elastic-agent/pkg/upgrade/details"
 )
 
+// ErrInvalidAPIKey is returned when Fleet Server responds with 401 Unauthorized.
+var ErrInvalidAPIKey = errors.New("invalid API key")
+
 const checkingPath = "/api/fleet/agents/%s/checkin"
 const checkinContentEncodingHeader = "Content-Encoding"
 const checkinContentEncodingGzip = "gzip"
+
+// Sender is the interface for sending HTTP requests to Fleet Server.
+type Sender interface {
+	Send(
+		ctx context.Context,
+		method string,
+		path string,
+		params url.Values,
+		headers http.Header,
+		body io.Reader,
+	) (*http.Response, error)
+}
+
+// AgentInfo provides the agent's identity.
+type AgentInfo interface {
+	AgentID() string
+}
+
+// SerializableEvent is a representation of the event to be sent to the Fleet Server API via the checkin
+// endpoint, we are liberal into what we accept to be sent you only need a type and be able to be
+// serialized into JSON.
+type SerializableEvent interface {
+	// Type return the type of the event, this must be included in the serialized document.
+	Type() string
+
+	// Timestamp is used to keep track when the event was created in the system.
+	Timestamp() time.Time
+
+	// Message is a human readable string to explain what the event does, this would be displayed in
+	// the UI as a string of text.
+	Message() string
+}
 
 // CheckinUnit provides information about a unit during checkin.
 type CheckinUnit struct {
@@ -42,11 +77,13 @@ type CheckinComponent struct {
 	Units   []CheckinUnit `json:"units,omitempty"`
 }
 
+// CheckinRollback provides rollback information during checkin.
 type CheckinRollback struct {
 	Version    string    `json:"version"`
 	ValidUntil time.Time `json:"valid_until"`
 }
 
+// CheckinUpgrade provides upgrade information during checkin.
 type CheckinUpgrade struct {
 	Rollbacks []CheckinRollback `json:"rollbacks,omitempty"`
 }
@@ -64,53 +101,35 @@ type CheckinRequest struct {
 	Upgrade           CheckinUpgrade     `json:"upgrade,omitempty"`
 }
 
-// SerializableEvent is a representation of the event to be send to the Fleet Server API via the checkin
-// endpoint, we are liberal into what we accept to be send you only need a type and be able to be
-// serialized into JSON.
-type SerializableEvent interface {
-	// Type return the type of the event, this must be included in the serialized document.
-	Type() string
-
-	// Timestamp is used to keep track when the event was created in the system.
-	Timestamp() time.Time
-
-	// Message is a human readable string to explain what the event does, this would be displayed in
-	// the UI as a string of text.
-	Message() string
-}
-
 // Validate validates the enrollment request before sending it to the API.
 func (e *CheckinRequest) Validate() error {
 	return nil
 }
 
-// CheckinResponse is the response send back from the server which contains all the action that
-// need to be executed or proxy to running processes.
+// CheckinResponse is the response sent back from the server which contains all the actions that
+// need to be executed or proxied to running processes.
+// Actions is json.RawMessage so consumers can unmarshal into their own action types.
 type CheckinResponse struct {
-	AckToken     string  `json:"ack_token"`
-	Actions      Actions `json:"actions"`
-	FleetWarning string  `json:"-"`
+	AckToken     string          `json:"ack_token"`
+	Actions      json.RawMessage `json:"actions"`
+	FleetWarning string          `json:"-"`
 }
 
-// Validate validates the response send from the server.
+// Validate validates the response sent from the server.
 func (e *CheckinResponse) Validate() error {
 	return nil
 }
 
 // CheckinCmd is a fleet API command.
 type CheckinCmd struct {
-	client      client.Sender
+	client      Sender
 	info        AgentInfo
 	compression string // "gzip" or "none"
 }
 
-type AgentInfo interface {
-	AgentID() string
-}
-
 // NewCheckinCmd creates a new api command.
 // compression must be either "gzip" (compress request bodies) or "none" (no compression).
-func NewCheckinCmd(info AgentInfo, client client.Sender, compression string) *CheckinCmd {
+func NewCheckinCmd(info AgentInfo, client Sender, compression string) *CheckinCmd {
 	return &CheckinCmd{
 		client:      client,
 		info:        info,
@@ -118,7 +137,7 @@ func NewCheckinCmd(info AgentInfo, client client.Sender, compression string) *Ch
 	}
 }
 
-// Execute enroll the Agent in the Fleet Server. Returns the decoded check in response, a duration indicating
+// Execute checks in the Agent to the Fleet Server. Returns the decoded check in response, a duration indicating
 // how long the request took, and an error.
 func (e *CheckinCmd) Execute(ctx context.Context, r *CheckinRequest) (*CheckinResponse, time.Duration, error) {
 	if err := r.Validate(); err != nil {
@@ -127,9 +146,7 @@ func (e *CheckinCmd) Execute(ctx context.Context, r *CheckinRequest) (*CheckinRe
 
 	b, err := json.Marshal(r)
 	if err != nil {
-		return nil, 0, errors.New(err,
-			"fail to encode the checkin request",
-			errors.TypeUnexpected)
+		return nil, 0, fmt.Errorf("fail to encode the checkin request: %w", err)
 	}
 
 	requestHeaders := http.Header{}
@@ -137,9 +154,7 @@ func (e *CheckinCmd) Execute(ctx context.Context, r *CheckinRequest) (*CheckinRe
 	if e.compression == "gzip" {
 		requestBody, err = gzipEncodeCheckinRequestBody(b)
 		if err != nil {
-			return nil, 0, errors.New(err,
-				"fail to gzip encode checkin request",
-				errors.TypeUnexpected)
+			return nil, 0, fmt.Errorf("fail to gzip encode checkin request: %w", err)
 		}
 		requestHeaders.Set(checkinContentEncodingHeader, checkinContentEncodingGzip)
 	}
@@ -149,30 +164,24 @@ func (e *CheckinCmd) Execute(ctx context.Context, r *CheckinRequest) (*CheckinRe
 	resp, err := e.client.Send(ctx, http.MethodPost, cp, nil, requestHeaders, requestBody)
 	sendDuration := time.Since(sendStart)
 	if err != nil {
-		return nil, sendDuration, errors.New(err,
-			"fail to checkin to fleet-server",
-			errors.TypeNetwork,
-			errors.M(errors.MetaKeyURI, cp))
+		return nil, sendDuration, fmt.Errorf("fail to checkin to fleet-server (uri: %s): %w", cp, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, sendDuration, client.ExtractError(resp.Body)
+		return nil, sendDuration, extractError(resp.Body)
 	}
 
 	rs, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, sendDuration, errors.New(err, "failed to read checkin response")
+		return nil, sendDuration, fmt.Errorf("failed to read checkin response: %w", err)
 	}
 
 	checkinResponse := &CheckinResponse{}
 	checkinResponse.FleetWarning = resp.Header.Get("Warning")
 	decoder := json.NewDecoder(bytes.NewReader(rs))
 	if err := decoder.Decode(checkinResponse); err != nil {
-		return nil, sendDuration, errors.New(err,
-			"fail to decode checkin response",
-			errors.TypeNetwork,
-			errors.M(errors.MetaKeyURI, cp))
+		return nil, sendDuration, fmt.Errorf("fail to decode checkin response (uri: %s): %w", cp, err)
 	}
 
 	if err := checkinResponse.Validate(); err != nil {
@@ -180,6 +189,35 @@ func (e *CheckinCmd) Execute(ctx context.Context, r *CheckinRequest) (*CheckinRe
 	}
 
 	return checkinResponse, sendDuration, nil
+}
+
+// extractError extracts an error from a fleet-server response body.
+func extractError(resp io.Reader) error {
+	e := &struct {
+		StatusCode int    `json:"statusCode"`
+		Error      string `json:"error"`
+		Message    string `json:"message"`
+	}{}
+
+	data, err := io.ReadAll(resp)
+	if err != nil {
+		return fmt.Errorf("fail to read original error: %w", err)
+	}
+
+	err = json.Unmarshal(data, e)
+	if err == nil {
+		if len(e.Message) == 0 {
+			return fmt.Errorf("status code: %d, fleet-server returned an error: %s", e.StatusCode, e.Error)
+		}
+		return fmt.Errorf(
+			"status code: %d, fleet-server returned an error: %s, message: %s",
+			e.StatusCode,
+			e.Error,
+			e.Message,
+		)
+	}
+
+	return fmt.Errorf("could not decode the response, raw response: %s", string(data))
 }
 
 func gzipEncodeCheckinRequestBody(body []byte) (*bytes.Buffer, error) {

--- a/testing/fleetservertest/fleetserver_test.go
+++ b/testing/fleetservertest/fleetserver_test.go
@@ -826,7 +826,11 @@ func (a agentInfo) AgentID() string {
 }
 
 // mustUnmarshalActions unmarshals raw JSON into fleetapi.Actions, panicking on error.
+// Returns an empty slice when raw is nil or empty (no actions in response).
 func mustUnmarshalActions(raw json.RawMessage) fleetapi.Actions {
+	if len(raw) == 0 {
+		return fleetapi.Actions{}
+	}
 	var actions fleetapi.Actions
 	if err := json.Unmarshal(raw, &actions); err != nil {
 		panic(fmt.Sprintf("failed to unmarshal actions: %v", err))

--- a/testing/fleetservertest/fleetserver_test.go
+++ b/testing/fleetservertest/fleetserver_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/pkg/ecsmeta"
+	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 )
 
 // TestRunFleetServer shows how to configure and run a fleet-server capable of
@@ -163,15 +164,15 @@ func ExampleNewServer_checkin() {
 		WithAgentID(agentID))
 
 	defaultCheckinConfig := configuration.DefaultFleetCheckin()
-	cmd := fleetapi.NewCheckinCmd(
+	cmd := pkgfleetapi.NewCheckinCmd(
 		agentInfo(agentID), sender{url: ts.URL, path: NewPathCheckin(agentID)}, defaultCheckinConfig.GetCompression())
 
-	got, _, err := cmd.Execute(context.Background(), &fleetapi.CheckinRequest{})
+	got, _, err := cmd.Execute(context.Background(), &pkgfleetapi.CheckinRequest{})
 	if err != nil {
 		panic(fmt.Sprintf("ExampleNewServer_checkin failed executing checkin: %v", err))
 	}
 
-	fmt.Println(got.Actions)
+	fmt.Println(mustUnmarshalActions(got.Actions))
 	// Output:
 	// [id: anActionID, type: POLICY_CHANGE]
 }
@@ -192,15 +193,15 @@ func ExampleNewServer_checkin_compress() {
 		})},
 		WithAgentID(agentID))
 
-	cmd := fleetapi.NewCheckinCmd(
+	cmd := pkgfleetapi.NewCheckinCmd(
 		agentInfo(agentID), sender{url: ts.URL, path: NewPathCheckin(agentID)}, "gzip")
 
-	got, _, err := cmd.Execute(context.Background(), &fleetapi.CheckinRequest{})
+	got, _, err := cmd.Execute(context.Background(), &pkgfleetapi.CheckinRequest{})
 	if err != nil {
 		panic(fmt.Sprintf("ExampleNewServer_checkin failed executing checkin: %v", err))
 	}
 
-	fmt.Println(got.Actions)
+	fmt.Println(mustUnmarshalActions(got.Actions))
 	// Output:
 	// [id: anActionID, type: POLICY_CHANGE]
 }
@@ -231,17 +232,18 @@ func ExampleNewServer_checkin_fleetConnectionParams() {
 		WithAgentID(agentID))
 
 	defaultCheckinConfig := configuration.DefaultFleetCheckin()
-	cmd := fleetapi.NewCheckinCmd(
+	cmd := pkgfleetapi.NewCheckinCmd(
 		agentInfo(agentID), sender{url: ts.URL, path: NewPathCheckin(agentID)}, defaultCheckinConfig.GetCompression())
 
-	got, _, err := cmd.Execute(context.Background(), &fleetapi.CheckinRequest{})
+	got, _, err := cmd.Execute(context.Background(), &pkgfleetapi.CheckinRequest{})
 	if err != nil {
 		panic(fmt.Sprintf("ExampleNewServer_checkin_fleetConnectionParams failed executing checkin: %v", err))
 	}
 
-	fmt.Println(got.Actions)
-	if len(got.Actions) > 0 {
-		policy := got.Actions[0].(*fleetapi.ActionPolicyChange).Data.Policy
+	checkinActions := mustUnmarshalActions(got.Actions)
+	fmt.Println(checkinActions)
+	if len(checkinActions) > 0 {
+		policy := checkinActions[0].(*fleetapi.ActionPolicyChange).Data.Policy
 		b := new(strings.Builder)
 		encoder := json.NewEncoder(b)
 		encoder.SetIndent("", "  ")
@@ -492,27 +494,27 @@ func ExampleNewServer_checkin_fakeComponent() {
 
 	// 1st call, nextAction() will return a POLICY_CHANGE.
 	defaultCheckinConfig := configuration.DefaultFleetCheckin()
-	cmd := fleetapi.NewCheckinCmd(
+	cmd := pkgfleetapi.NewCheckinCmd(
 		agentInfo(agentID), sender{url: ts.URL, path: NewPathCheckin(agentID)}, defaultCheckinConfig.GetCompression())
-	resp, _, err := cmd.Execute(context.Background(), &fleetapi.CheckinRequest{})
+	resp, _, err := cmd.Execute(context.Background(), &pkgfleetapi.CheckinRequest{})
 	if err != nil {
 		panic(fmt.Sprintf("failed executing 3rd checkin: %v", err))
 	}
-	fmt.Println(resp.Actions)
+	fmt.Println(mustUnmarshalActions(resp.Actions))
 
 	// 2nd subsequent call to nextAction() will return an error.
-	_, _, err = cmd.Execute(context.Background(), &fleetapi.CheckinRequest{})
+	_, _, err = cmd.Execute(context.Background(), &pkgfleetapi.CheckinRequest{})
 	if err == nil {
 		panic("expected an error, got none")
 	}
 	fmt.Println("Error:", err)
 
 	// any subsequent call to nextAction() will return no action.
-	resp, _, err = cmd.Execute(context.Background(), &fleetapi.CheckinRequest{})
+	resp, _, err = cmd.Execute(context.Background(), &pkgfleetapi.CheckinRequest{})
 	if err != nil {
 		panic(fmt.Sprintf("failed executing 3rd checkin: %v", err))
 	}
-	fmt.Println(resp.Actions)
+	fmt.Println(mustUnmarshalActions(resp.Actions))
 
 	// Output:
 	// [id: anActionID, type: POLICY_CHANGE]
@@ -559,11 +561,11 @@ func ExampleNewServer_checkin_withDelay() {
 
 	// 1st - call actions have a delay.
 	defaultCheckinConfig := configuration.DefaultFleetCheckin()
-	cmd := fleetapi.NewCheckinCmd(
+	cmd := pkgfleetapi.NewCheckinCmd(
 		agentInfo(agentID), sender{url: ts.URL, path: NewPathCheckin(agentID)}, defaultCheckinConfig.GetCompression())
 
 	start := time.Now()
-	resp, _, err := cmd.Execute(context.Background(), &fleetapi.CheckinRequest{})
+	resp, _, err := cmd.Execute(context.Background(), &pkgfleetapi.CheckinRequest{})
 	if err != nil {
 		panic(fmt.Sprintf("failed executing 3rd checkin: %v", err))
 	}
@@ -571,11 +573,11 @@ func ExampleNewServer_checkin_withDelay() {
 	fmt.Printf("took more than %s: %t. response: %s\n",
 		delay,
 		elapsed > delay,
-		resp.Actions)
+		mustUnmarshalActions(resp.Actions))
 
 	// 2nd - subsequent call to nextAction() will return immediately.
 	start = time.Now()
-	resp, _, err = cmd.Execute(context.Background(), &fleetapi.CheckinRequest{})
+	resp, _, err = cmd.Execute(context.Background(), &pkgfleetapi.CheckinRequest{})
 	if err != nil {
 		panic(fmt.Sprintf("failed executing 3rd checkin: %v", err))
 	}
@@ -583,7 +585,7 @@ func ExampleNewServer_checkin_withDelay() {
 	fmt.Printf("took more than %s: %t. response: %s\n",
 		delay,
 		elapsed > time.Second,
-		resp.Actions)
+		mustUnmarshalActions(resp.Actions))
 
 	// Output:
 	// took more than 250ms: true. response: [id: anActionID, type: POLICY_CHANGE]
@@ -742,7 +744,7 @@ func ExampleNewServer_checkin_and_ackWithAcker() {
 	// =========================================================================
 	// 4th - instantiate the fleetapi commands
 	defaultCheckinConfig := configuration.DefaultFleetCheckin()
-	cmdCheckin := fleetapi.NewCheckinCmd(
+	cmdCheckin := pkgfleetapi.NewCheckinCmd(
 		agentInfo(agentID), sender{url: ts.URL, path: NewPathCheckin(agentID)}, defaultCheckinConfig.GetCompression())
 	cmdAck := fleetapi.NewAckCmd(
 		agentInfo(agentID), sender{url: ts.URL, path: NewPathAgentAcks(agentID)})
@@ -771,11 +773,11 @@ func ExampleNewServer_checkin_and_ackWithAcker() {
 
 	// 1st checkin: it will return a POLICY_CHANGE.
 	// TODO: make the acker only ack if the checkin was called
-	respCheckin, _, err := cmdCheckin.Execute(context.Background(), &fleetapi.CheckinRequest{})
+	respCheckin, _, err := cmdCheckin.Execute(context.Background(), &pkgfleetapi.CheckinRequest{})
 	if err != nil {
 		panic(fmt.Sprintf("failed executing 3rd checkin: %v", err))
 	}
-	fmt.Println("[1st checkin]", respCheckin.Actions)
+	fmt.Println("[1st checkin]", mustUnmarshalActions(respCheckin.Actions))
 
 	// 2dn ack: acking the POLICY_CHANGE
 	respAck, err = cmdAck.Execute(context.Background(),
@@ -786,7 +788,7 @@ func ExampleNewServer_checkin_and_ackWithAcker() {
 	fmt.Printf("[2nd ack] %#v\n", respAck)
 
 	// 2nd checkin: it will fail.
-	_, _, err = cmdCheckin.Execute(context.Background(), &fleetapi.CheckinRequest{})
+	_, _, err = cmdCheckin.Execute(context.Background(), &pkgfleetapi.CheckinRequest{})
 	if err == nil {
 		panic("expected an error, got none")
 	}
@@ -821,6 +823,15 @@ type agentInfo string
 
 func (a agentInfo) AgentID() string {
 	return string(a)
+}
+
+// mustUnmarshalActions unmarshals raw JSON into fleetapi.Actions, panicking on error.
+func mustUnmarshalActions(raw json.RawMessage) fleetapi.Actions {
+	var actions fleetapi.Actions
+	if err := json.Unmarshal(raw, &actions); err != nil {
+		panic(fmt.Sprintf("failed to unmarshal actions: %v", err))
+	}
+	return actions
 }
 
 type sender struct {


### PR DESCRIPTION
## What does this PR do?

Moves `CheckinCmd`, `CheckinRequest`, `CheckinResponse`, and related types (`CheckinComponent`, `CheckinUnit`, `CheckinRollback`, `CheckinUpgrade`, `AgentInfo`, `SerializableEvent`) from `internal/pkg/fleetapi` to a new `pkg/fleetapi` package with zero `internal/` imports.

Also moves `ErrInvalidAPIKey` to `pkg/fleetapi` so both Agent and Horde can share the same 401 sentinel. `client.ErrInvalidAPIKey` is kept as a re-export alias for backwards compatibility.

`CheckinResponse.Actions` is `json.RawMessage` so consumers can unmarshal into their own action types. The Agent unmarshals into `fleetapi.Actions` in `fleet_gateway.go`.

## Why is it important?

This is a prerequisite for cross-repo sharing of Fleet API client code (e.g. with Horde), which requires types to live in a non-internal package. Types in `internal/` cannot be imported by external modules.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

No user-facing impact. This is a pure internal refactoring — no behaviour changes.

## How to test this PR locally

```
go vet ./pkg/fleetapi/... ./internal/pkg/fleetapi/... ./internal/pkg/agent/application/gateway/fleet/... ./internal/pkg/agent/install/...
go test ./internal/pkg/fleetapi/... ./internal/pkg/agent/application/gateway/fleet/... ./internal/pkg/agent/install/... ./testing/fleetservertest/...
```

## Related issues

- Relates elastic/ingest-dev#7601 (item 10)