### PR TITLE
Fix missing components logs from diagnostic bundle

### DIFF
--- a/changelog/fragments/1780322182-fix-missing-beat-receiver-trace-logs-from-diagnostic-bundle.yaml
+++ b/changelog/fragments/1780322182-fix-missing-beat-receiver-trace-logs-from-diagnostic-bundle.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: fix missing beat receiver trace logs from diagnostic bundle
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -319,7 +319,7 @@ func ZipArchive(
 	}
 
 	// Gather Logs:
-	return zipLogs(zw, ts, topPath, excludeEvents)
+	return zipLogs(zw, ts, topPath, excludeEvents, errOut)
 }
 
 func writeErrorResult(zw *zip.Writer, path string, errBody string) error {
@@ -379,7 +379,7 @@ func writeRedacted(errOut, resultWriter io.Writer, fullFilePath string, fileResu
 	return err
 }
 
-func zipLogs(zw *zip.Writer, ts time.Time, topPath string, excludeEvents bool) error {
+func zipLogs(zw *zip.Writer, ts time.Time, topPath string, excludeEvents bool, errOut io.Writer) error {
 	homePath := paths.HomeFrom(topPath)
 	dataPath := paths.DataFrom(topPath)
 	currentDir := filepath.Base(homePath)
@@ -394,13 +394,14 @@ func zipLogs(zw *zip.Writer, ts time.Time, topPath string, excludeEvents bool) e
 	}
 
 	if err := collectServiceComponentsLogs(zw); err != nil {
-		return fmt.Errorf("failed to collect endpoint-security logs: %w", err)
+		fmt.Fprintf(errOut, "[WARNING] failed to collect endpoint-security logs: %s\n", err)
 	}
 
 	if !paths.IsVersionHome() {
 		// running in a container with custom top path set
 		// logs are directly under top path
-		return zipLogsWithPath(homePath, currentDir, excludeEvents, zw, ts)
+		zipLogsWithPath(homePath, currentDir, excludeEvents, zw, ts, errOut)
+		return nil
 	}
 
 	dataDir, err := os.Open(dataPath)
@@ -420,9 +421,7 @@ func zipLogs(zw *zip.Writer, ts time.Time, topPath string, excludeEvents bool) e
 			continue
 		}
 		path := filepath.Join(dataPath, dir)
-		if err := zipLogsWithPath(path, dir, excludeEvents, zw, ts); err != nil {
-			return err
-		}
+		zipLogsWithPath(path, dir, excludeEvents, zw, ts, errOut)
 	}
 
 	return nil
@@ -430,38 +429,47 @@ func zipLogs(zw *zip.Writer, ts time.Time, topPath string, excludeEvents bool) e
 
 // zipLogsWithPath walks {pathsHome}/logs and {pathsHome}/components/logs and copies them into zw
 // under "logs/<commitName>/" and "logs/<commitName>/components/" respectively.
-func zipLogsWithPath(pathsHome, commitName string, excludeEvents bool, zw *zip.Writer, ts time.Time) error {
-	_, err := zw.CreateHeader(&zip.FileHeader{
+func zipLogsWithPath(pathsHome, commitName string, excludeEvents bool, zw *zip.Writer, ts time.Time, errOut io.Writer) {
+	if _, err := zw.CreateHeader(&zip.FileHeader{
 		Name:     "logs/" + commitName + "/",
 		Method:   zip.Deflate,
 		Modified: ts,
-	})
-	if err != nil {
-		return err
+	}); err != nil {
+		fmt.Fprintf(errOut, "[WARNING] failed to create logs dir entry for %s: %s\n", commitName, err)
 	}
 
-	if err := walkLogPath(filepath.Join(pathsHome, "logs"), commitName, excludeEvents, zw, ts); err != nil {
-		return err
+	if err := walkLogPath(filepath.Join(pathsHome, "logs"), commitName, excludeEvents, zw, ts, errOut); err != nil {
+		fmt.Fprintf(errOut, "[WARNING] failed to collect logs from %s: %s\n", pathsHome, err)
+	}
+
+	if _, err := zw.CreateHeader(&zip.FileHeader{
+		Name:     "logs/" + commitName + "/components/",
+		Method:   zip.Deflate,
+		Modified: ts,
+	}); err != nil {
+		fmt.Fprintf(errOut, "[WARNING] failed to create components logs dir entry for %s: %s\n", commitName, err)
 	}
 
 	// Beat receivers write trace logs under {pathsHome}/components/logs.
-	// Collect them under logs/<commitName>/ (same as agent logs) so the zip layout matches
-	// 8.19.x where trace files lived under {pathsHome}/logs directly.
-	return walkLogPath(filepath.Join(pathsHome, "components", "logs"), commitName, excludeEvents, zw, ts)
+	// Mirror that structure under logs/<commitName>/components/ to reflect the source layout.
+	if err := walkLogPath(filepath.Join(pathsHome, "components", "logs"), filepath.Join(commitName, "components"), excludeEvents, zw, ts, errOut); err != nil {
+		fmt.Fprintf(errOut, "[WARNING] failed to collect component logs from %s: %s\n", pathsHome, err)
+	}
 }
 
-func walkLogPath(logRoot, commitName string, excludeEvents bool, zw *zip.Writer, ts time.Time) error {
+func walkLogPath(logRoot, commitName string, excludeEvents bool, zw *zip.Writer, ts time.Time, errOut io.Writer) error {
 	logPath := logRoot + string(filepath.Separator)
-	return filepath.WalkDir(logPath, zipLogWalkFunc(logPath, commitName, excludeEvents, zw, ts))
+	return filepath.WalkDir(logPath, zipLogWalkFunc(logPath, commitName, excludeEvents, zw, ts, errOut))
 }
 
-func zipLogWalkFunc(logPath, commitName string, excludeEvents bool, zw *zip.Writer, ts time.Time) func(path string, d fs.DirEntry, fErr error) error {
+func zipLogWalkFunc(logPath, commitName string, excludeEvents bool, zw *zip.Writer, ts time.Time, errOut io.Writer) func(path string, d fs.DirEntry, fErr error) error {
 	return func(path string, d fs.DirEntry, fErr error) error {
 		if errors.Is(fErr, fs.ErrNotExist) {
 			return nil
 		}
 		if fErr != nil {
-			return fmt.Errorf("unable to walk log dir: %w", fErr)
+			fmt.Fprintf(errOut, "[WARNING] unable to walk log dir %s: %s\n", path, fErr)
+			return nil
 		}
 
 		// name is the relative dir/file name replacing any filepath seperators with /
@@ -482,13 +490,12 @@ func zipLogWalkFunc(logPath, commitName string, excludeEvents bool, zw *zip.Writ
 		name = filepath.Join(commitName, name)
 
 		if d.IsDir() {
-			_, err := zw.CreateHeader(&zip.FileHeader{
+			if _, err := zw.CreateHeader(&zip.FileHeader{
 				Name:     "logs/" + filepath.ToSlash(name) + "/",
 				Method:   zip.Deflate,
 				Modified: ts,
-			})
-			if err != nil {
-				return fmt.Errorf("unable to create log directory in archive: %w", err)
+			}); err != nil {
+				fmt.Fprintf(errOut, "[WARNING] unable to create log directory in archive %s: %s\n", name, err)
 			}
 			return nil
 		}
@@ -496,7 +503,7 @@ func zipLogWalkFunc(logPath, commitName string, excludeEvents bool, zw *zip.Writ
 		// Add the file to the zip.
 		// Ignore files that don't exist to account for races with log rotation.
 		if err := saveLogs(name, path, zw); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return err
+			fmt.Fprintf(errOut, "[WARNING] unable to save log file %s: %s\n", path, err)
 		}
 		return nil
 	}

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -393,15 +393,14 @@ func zipLogs(zw *zip.Writer, ts time.Time, topPath string, excludeEvents bool, e
 		return err
 	}
 
-	if err := collectServiceComponentsLogs(zw); err != nil {
+	if err := collectServiceComponentsLogs(zw, errOut); err != nil {
 		fmt.Fprintf(errOut, "[WARNING] failed to collect endpoint-security logs: %s\n", err)
 	}
 
 	if !paths.IsVersionHome() {
 		// running in a container with custom top path set
 		// logs are directly under top path
-		zipLogsWithPath(homePath, currentDir, excludeEvents, zw, ts, errOut)
-		return nil
+		return zipLogsWithPath(homePath, currentDir, excludeEvents, zw, ts, errOut)
 	}
 
 	dataDir, err := os.Open(dataPath)
@@ -421,7 +420,9 @@ func zipLogs(zw *zip.Writer, ts time.Time, topPath string, excludeEvents bool, e
 			continue
 		}
 		path := filepath.Join(dataPath, dir)
-		zipLogsWithPath(path, dir, excludeEvents, zw, ts, errOut)
+		if err := zipLogsWithPath(path, dir, excludeEvents, zw, ts, errOut); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -429,17 +430,17 @@ func zipLogs(zw *zip.Writer, ts time.Time, topPath string, excludeEvents bool, e
 
 // zipLogsWithPath walks {pathsHome}/logs and {pathsHome}/components/logs and copies them into zw
 // under "logs/<commitName>/" and "logs/<commitName>/components/" respectively.
-func zipLogsWithPath(pathsHome, commitName string, excludeEvents bool, zw *zip.Writer, ts time.Time, errOut io.Writer) {
+func zipLogsWithPath(pathsHome, commitName string, excludeEvents bool, zw *zip.Writer, ts time.Time, errOut io.Writer) error {
 	if _, err := zw.CreateHeader(&zip.FileHeader{
 		Name:     "logs/" + commitName + "/",
 		Method:   zip.Deflate,
 		Modified: ts,
 	}); err != nil {
-		fmt.Fprintf(errOut, "[WARNING] failed to create logs dir entry for %s: %s\n", commitName, err)
+		return fmt.Errorf("failed to create logs dir entry for %s: %w", commitName, err)
 	}
 
 	if err := walkLogPath(filepath.Join(pathsHome, "logs"), commitName, excludeEvents, zw, ts, errOut); err != nil {
-		fmt.Fprintf(errOut, "[WARNING] failed to collect logs from %s: %s\n", pathsHome, err)
+		return fmt.Errorf("failed to collect logs from %s: %w", pathsHome, err)
 	}
 
 	if _, err := zw.CreateHeader(&zip.FileHeader{
@@ -447,14 +448,16 @@ func zipLogsWithPath(pathsHome, commitName string, excludeEvents bool, zw *zip.W
 		Method:   zip.Deflate,
 		Modified: ts,
 	}); err != nil {
-		fmt.Fprintf(errOut, "[WARNING] failed to create components logs dir entry for %s: %s\n", commitName, err)
+		return fmt.Errorf("failed to create components logs dir entry for %s: %w", commitName, err)
 	}
 
-	// Beat receivers write trace logs under {pathsHome}/components/logs.
+	// Components may write logs under {pathsHome}/components/logs.
 	// Mirror that structure under logs/<commitName>/components/ to reflect the source layout.
 	if err := walkLogPath(filepath.Join(pathsHome, "components", "logs"), filepath.Join(commitName, "components"), excludeEvents, zw, ts, errOut); err != nil {
-		fmt.Fprintf(errOut, "[WARNING] failed to collect component logs from %s: %s\n", pathsHome, err)
+		return fmt.Errorf("failed to collect component logs from %s: %w", pathsHome, err)
 	}
+
+	return nil
 }
 
 func walkLogPath(logRoot, commitName string, excludeEvents bool, zw *zip.Writer, ts time.Time, errOut io.Writer) error {
@@ -495,21 +498,18 @@ func zipLogWalkFunc(logPath, commitName string, excludeEvents bool, zw *zip.Writ
 				Method:   zip.Deflate,
 				Modified: ts,
 			}); err != nil {
-				fmt.Fprintf(errOut, "[WARNING] unable to create log directory in archive %s: %s\n", name, err)
+				return fmt.Errorf("unable to create log directory in archive %s: %w", name, err)
 			}
 			return nil
 		}
 
-		// Add the file to the zip.
-		// Ignore files that don't exist to account for races with log rotation.
-		if err := saveLogs(name, path, zw); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			fmt.Fprintf(errOut, "[WARNING] unable to save log file %s: %s\n", path, err)
-		}
-		return nil
+		// saveLogs handles source-file errors (missing, permission denied) internally as
+		// warnings; it only returns zip-writer errors, which terminate the walk.
+		return saveLogs(name, path, zw, errOut)
 	}
 }
 
-func collectServiceComponentsLogs(zw *zip.Writer) error {
+func collectServiceComponentsLogs(zw *zip.Writer, errOut io.Writer) error {
 	platform, err := component.LoadPlatformDetail()
 	if err != nil {
 		return fmt.Errorf("failed to gather system information: %w", err)
@@ -543,7 +543,7 @@ func collectServiceComponentsLogs(zw *zip.Writer) error {
 				return nil
 			}
 
-			return saveLogs("services/"+name, path, zw)
+			return saveLogs("services/"+name, path, zw, errOut)
 		})
 		if err != nil {
 			return err
@@ -552,11 +552,19 @@ func collectServiceComponentsLogs(zw *zip.Writer) error {
 	return nil
 }
 
-func saveLogs(name string, logPath string, zw *zip.Writer) error {
+// saveLogs copies the log file at logPath into the zip under "logs/<name>".
+// Source-file errors (file not found, permission denied) are logged as warnings and the
+// function returns nil so the caller can continue collecting other logs.
+// Only zip-writer errors (CreateHeader, io.Copy to the zip) are returned so the caller
+// knows to stop writing to the archive.
+func saveLogs(name string, logPath string, zw *zip.Writer, errOut io.Writer) error {
 	ts := time.Now().UTC()
 	lf, err := os.Open(logPath)
 	if err != nil {
-		return fmt.Errorf("unable to open log file: %w", err)
+		if !errors.Is(err, fs.ErrNotExist) {
+			fmt.Fprintf(errOut, "[WARNING] unable to open log file %s: %s\n", logPath, err)
+		}
+		return nil
 	}
 	defer lf.Close()
 	if li, err := lf.Stat(); err == nil {
@@ -571,11 +579,7 @@ func saveLogs(name string, logPath string, zw *zip.Writer) error {
 		return err
 	}
 	_, err = io.Copy(zf, lf)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // AddSecretMarkers adds secret redaction markers to the config by looking at the secret_paths field.

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -383,10 +383,24 @@ func zipLogs(zw *zip.Writer, ts time.Time, topPath string, excludeEvents bool) e
 	homePath := paths.HomeFrom(topPath)
 	dataPath := paths.DataFrom(topPath)
 	currentDir := filepath.Base(homePath)
+
+	_, err := zw.CreateHeader(&zip.FileHeader{
+		Name:     "logs/",
+		Method:   zip.Deflate,
+		Modified: ts,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := collectServiceComponentsLogs(zw); err != nil {
+		return fmt.Errorf("failed to collect endpoint-security logs: %w", err)
+	}
+
 	if !paths.IsVersionHome() {
 		// running in a container with custom top path set
 		// logs are directly under top path
-		return zipLogsWithPath(homePath, currentDir, true, excludeEvents, zw, ts)
+		return zipLogsWithPath(homePath, currentDir, excludeEvents, zw, ts)
 	}
 
 	dataDir, err := os.Open(dataPath)
@@ -405,9 +419,8 @@ func zipLogs(zw *zip.Writer, ts time.Time, topPath string, excludeEvents bool) e
 		if !strings.HasPrefix(dir, dirPrefix) {
 			continue
 		}
-		collectServices := dir == currentDir
 		path := filepath.Join(dataPath, dir)
-		if err := zipLogsWithPath(path, dir, collectServices, excludeEvents, zw, ts); err != nil {
+		if err := zipLogsWithPath(path, dir, excludeEvents, zw, ts); err != nil {
 			return err
 		}
 	}
@@ -415,24 +428,10 @@ func zipLogs(zw *zip.Writer, ts time.Time, topPath string, excludeEvents bool) e
 	return nil
 }
 
-// zipLogs walks paths.Logs() and copies the file structure into zw in "logs/"
-func zipLogsWithPath(pathsHome, commitName string, collectServices, excludeEvents bool, zw *zip.Writer, ts time.Time) error {
+// zipLogsWithPath walks {pathsHome}/logs and {pathsHome}/components/logs and copies them into zw
+// under "logs/<commitName>/" and "logs/<commitName>/components/" respectively.
+func zipLogsWithPath(pathsHome, commitName string, excludeEvents bool, zw *zip.Writer, ts time.Time) error {
 	_, err := zw.CreateHeader(&zip.FileHeader{
-		Name:     "logs/",
-		Method:   zip.Deflate,
-		Modified: ts,
-	})
-	if err != nil {
-		return err
-	}
-
-	if collectServices {
-		if err := collectServiceComponentsLogs(zw); err != nil {
-			return fmt.Errorf("failed to collect endpoint-security logs: %w", err)
-		}
-	}
-
-	_, err = zw.CreateHeader(&zip.FileHeader{
 		Name:     "logs/" + commitName + "/",
 		Method:   zip.Deflate,
 		Modified: ts,
@@ -441,9 +440,23 @@ func zipLogsWithPath(pathsHome, commitName string, collectServices, excludeEvent
 		return err
 	}
 
-	// using Data() + "/logs", for some reason default paths/Logs() is the home dir...
-	logPath := filepath.Join(pathsHome, "logs") + string(filepath.Separator)
-	return filepath.WalkDir(logPath, func(path string, d fs.DirEntry, fErr error) error {
+	if err := walkLogPath(filepath.Join(pathsHome, "logs"), commitName, excludeEvents, zw, ts); err != nil {
+		return err
+	}
+
+	// Beat receivers write trace logs under {pathsHome}/components/logs.
+	// Collect them under logs/<commitName>/ (same as agent logs) so the zip layout matches
+	// 8.19.x where trace files lived under {pathsHome}/logs directly.
+	return walkLogPath(filepath.Join(pathsHome, "components", "logs"), commitName, excludeEvents, zw, ts)
+}
+
+func walkLogPath(logRoot, commitName string, excludeEvents bool, zw *zip.Writer, ts time.Time) error {
+	logPath := logRoot + string(filepath.Separator)
+	return filepath.WalkDir(logPath, zipLogWalkFunc(logPath, commitName, excludeEvents, zw, ts))
+}
+
+func zipLogWalkFunc(logPath, commitName string, excludeEvents bool, zw *zip.Writer, ts time.Time) func(path string, d fs.DirEntry, fErr error) error {
+	return func(path string, d fs.DirEntry, fErr error) error {
 		if errors.Is(fErr, fs.ErrNotExist) {
 			return nil
 		}
@@ -486,7 +499,7 @@ func zipLogsWithPath(pathsHome, commitName string, collectServices, excludeEvent
 			return err
 		}
 		return nil
-	})
+	}
 }
 
 func collectServiceComponentsLogs(zw *zip.Writer) error {

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -461,6 +461,8 @@ func zipLogsWithPath(pathsHome, commitName string, excludeEvents bool, zw *zip.W
 }
 
 func walkLogPath(logRoot, commitName string, excludeEvents bool, zw *zip.Writer, ts time.Time, errOut io.Writer) error {
+	// Trailing separator is required: zipLogWalkFunc uses logPath as a TrimPrefix argument,
+	// so it must end with a separator to avoid a leading slash on relative names.
 	logPath := logRoot + string(filepath.Separator)
 	return filepath.WalkDir(logPath, zipLogWalkFunc(logPath, commitName, excludeEvents, zw, ts, errOut))
 }

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -505,8 +505,6 @@ func zipLogWalkFunc(logPath, commitName string, excludeEvents bool, zw *zip.Writ
 			return nil
 		}
 
-		// saveLogs handles source-file errors (missing, permission denied) internally as
-		// warnings; it only returns zip-writer errors, which terminate the walk.
 		return saveLogs(name, path, zw, errOut)
 	}
 }

--- a/internal/pkg/diagnostics/diagnostics_test.go
+++ b/internal/pkg/diagnostics/diagnostics_test.go
@@ -541,6 +541,67 @@ func TestZipLogsComponentsLogsMultiVersionedHome(t *testing.T) {
 	assert.Equal(t, 1, count, "trace file should appear exactly once, attributed to the current version")
 }
 
+// TestZipLogsConflictingNames checks that every log file gets a unique zip entry and
+// its content is preserved, across all sources that could produce the same filename:
+// agent logs vs component logs, multiple components sharing the same filename, and
+// multiple versioned homes.
+func TestZipLogsConflictingNames(t *testing.T) {
+	topPath := t.TempDir()
+	dataPath := paths.DataFrom(topPath)
+	currentDir := filepath.Base(paths.HomeFrom(topPath))
+	oldDir := "elastic-agent-oldversion"
+
+	mkfile := func(path, content string) {
+		t.Helper()
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	}
+
+	// Current versioned home: agent log and two components all share the same filename.
+	mkfile(filepath.Join(dataPath, currentDir, "logs", "httpjson", "trace.ndjson"), "current-agent\n")
+	mkfile(filepath.Join(dataPath, currentDir, "components", "logs", "httpjson", "trace.ndjson"), "current-httpjson\n")
+	mkfile(filepath.Join(dataPath, currentDir, "components", "logs", "filestream", "trace.ndjson"), "current-filestream\n")
+
+	// Old versioned home: same filenames repeated.
+	mkfile(filepath.Join(dataPath, oldDir, "logs", "httpjson", "trace.ndjson"), "old-agent\n")
+	mkfile(filepath.Join(dataPath, oldDir, "components", "logs", "httpjson", "trace.ndjson"), "old-httpjson\n")
+
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+	require.NoError(t, zipLogs(w, time.Now(), topPath, true, io.Discard))
+	require.NoError(t, w.Close())
+
+	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+
+	want := map[string]string{
+		"logs/" + currentDir + "/httpjson/trace.ndjson":              "current-agent\n",
+		"logs/" + currentDir + "/components/httpjson/trace.ndjson":   "current-httpjson\n",
+		"logs/" + currentDir + "/components/filestream/trace.ndjson": "current-filestream\n",
+		"logs/" + oldDir + "/httpjson/trace.ndjson":                  "old-agent\n",
+		"logs/" + oldDir + "/components/httpjson/trace.ndjson":       "old-httpjson\n",
+	}
+
+	counts := make(map[string]int)
+	contents := make(map[string]string)
+	for _, f := range r.File {
+		counts[f.Name]++
+		if _, ok := want[f.Name]; ok {
+			rc, err := f.Open()
+			require.NoError(t, err)
+			data, err := io.ReadAll(rc)
+			rc.Close()
+			require.NoError(t, err)
+			contents[f.Name] = string(data)
+		}
+	}
+
+	for name, wantContent := range want {
+		assert.Equal(t, 1, counts[name], "entry %q should appear exactly once", name)
+		assert.Equal(t, wantContent, contents[name], "entry %q has wrong content", name)
+	}
+}
+
 func TestZipLogsUnversionedHome(t *testing.T) {
 	originalVersionHome := paths.IsVersionHome()
 	t.Cleanup(func() { paths.SetVersionHome(originalVersionHome) })

--- a/internal/pkg/diagnostics/diagnostics_test.go
+++ b/internal/pkg/diagnostics/diagnostics_test.go
@@ -469,6 +469,104 @@ func TestZipLogs(t *testing.T) {
 	}
 }
 
+func TestZipLogsComponentsLogs(t *testing.T) {
+	topPath := t.TempDir()
+	homePath := paths.HomeFrom(topPath)
+	// Create the versioned home so zipLogs iterates the current version.
+	require.NoError(t, os.MkdirAll(filepath.Join(homePath, "logs"), 0o700))
+
+	// Beat receivers write their trace logs under {pathsHome}/components/logs.
+	traceDir := filepath.Join(homePath, "components", "logs", "httpjson")
+	require.NoError(t, os.MkdirAll(traceDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(traceDir, "http-request-trace-test.ndjson"), []byte(".\n"), 0o600))
+
+	expected := []zippedItem{
+		{"logs/", true},
+		{"logs/elastic-agent-unknow/", true},
+		{"logs/elastic-agent-unknow/httpjson/", true},
+		{"logs/elastic-agent-unknow/httpjson/http-request-trace-test.ndjson", false},
+	}
+
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+	require.NoError(t, zipLogs(w, time.Now(), topPath, true))
+	require.NoError(t, w.Close())
+
+	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+	var observed []zippedItem
+	for _, f := range r.File {
+		observed = append(observed, zippedItem{Name: f.Name, IsDir: f.FileInfo().IsDir()})
+	}
+
+	// The components walk and the versioned-home walk emit entries in a different order than a strict
+	// depth-first walk would, so compare without ordering.
+	assert.ElementsMatch(t, expected, observed)
+}
+
+func TestZipLogsComponentsLogsMultiVersionedHome(t *testing.T) {
+	topPath := t.TempDir()
+	dataPath := paths.DataFrom(topPath)
+
+	// Two versioned homes under data: currentDir matches paths.HomeFrom, oldDir is a stale version.
+	currentDir := filepath.Base(paths.HomeFrom(topPath))
+	oldDir := "elastic-agent-oldversion"
+	require.NoError(t, os.MkdirAll(filepath.Join(dataPath, currentDir, "logs"), 0o700))
+	require.NoError(t, os.MkdirAll(filepath.Join(dataPath, oldDir, "logs"), 0o700))
+
+	// Beat receivers write their trace logs under each version's own components/logs.
+	traceDir := filepath.Join(dataPath, currentDir, "components", "logs", "httpjson")
+	require.NoError(t, os.MkdirAll(traceDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(traceDir, "http-request-trace-test.ndjson"), []byte(".\n"), 0o600))
+
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+	require.NoError(t, zipLogs(w, time.Now(), topPath, true))
+	require.NoError(t, w.Close())
+
+	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+
+	// Component trace logs land under logs/<version>/httpjson/ matching the 8.19 zip layout.
+	traceName := "logs/" + currentDir + "/httpjson/http-request-trace-test.ndjson"
+	var count int
+	for _, f := range r.File {
+		if f.Name == traceName {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "trace file should appear exactly once, attributed to the current version")
+}
+
+func TestZipLogsUnversionedHome(t *testing.T) {
+	originalVersionHome := paths.IsVersionHome()
+	t.Cleanup(func() { paths.SetVersionHome(originalVersionHome) })
+	// Container layout: the home path is unversioned and logs live directly under the top path.
+	paths.SetVersionHome(false)
+
+	topPath := t.TempDir()
+	logsDir := filepath.Join(topPath, "logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "log.ndjson"), []byte(".\n"), 0o600))
+
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+	require.NoError(t, zipLogs(w, time.Now(), topPath, true))
+	require.NoError(t, w.Close())
+
+	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+
+	wantName := "logs/" + filepath.Base(topPath) + "/log.ndjson"
+	var found bool
+	for _, f := range r.File {
+		if f.Name == wantName {
+			found = true
+		}
+	}
+	assert.Truef(t, found, "expected %q in zip", wantName)
+}
+
 func zipLogsAndAssertFiles(t *testing.T, topPath string, excludeEvents bool, expected []zippedItem) {
 	t.Helper()
 

--- a/internal/pkg/diagnostics/diagnostics_test.go
+++ b/internal/pkg/diagnostics/diagnostics_test.go
@@ -447,6 +447,7 @@ func TestZipLogs(t *testing.T) {
 				{"logs/elastic-agent-unknow/events/elastic-agent-events-log.ndjson", false},
 				{"logs/elastic-agent-unknow/sub-dir/", true},
 				{"logs/elastic-agent-unknow/sub-dir/log.ndjson", false},
+				{"logs/elastic-agent-unknow/components/", true},
 			},
 		},
 
@@ -458,6 +459,7 @@ func TestZipLogs(t *testing.T) {
 				{"logs/elastic-agent-unknow/", true},
 				{"logs/elastic-agent-unknow/sub-dir/", true},
 				{"logs/elastic-agent-unknow/sub-dir/log.ndjson", false},
+				{"logs/elastic-agent-unknow/components/", true},
 			},
 		},
 	}
@@ -483,13 +485,14 @@ func TestZipLogsComponentsLogs(t *testing.T) {
 	expected := []zippedItem{
 		{"logs/", true},
 		{"logs/elastic-agent-unknow/", true},
-		{"logs/elastic-agent-unknow/httpjson/", true},
-		{"logs/elastic-agent-unknow/httpjson/http-request-trace-test.ndjson", false},
+		{"logs/elastic-agent-unknow/components/", true},
+		{"logs/elastic-agent-unknow/components/httpjson/", true},
+		{"logs/elastic-agent-unknow/components/httpjson/http-request-trace-test.ndjson", false},
 	}
 
 	buf := new(bytes.Buffer)
 	w := zip.NewWriter(buf)
-	require.NoError(t, zipLogs(w, time.Now(), topPath, true))
+	require.NoError(t, zipLogs(w, time.Now(), topPath, true, io.Discard))
 	require.NoError(t, w.Close())
 
 	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
@@ -521,14 +524,14 @@ func TestZipLogsComponentsLogsMultiVersionedHome(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	w := zip.NewWriter(buf)
-	require.NoError(t, zipLogs(w, time.Now(), topPath, true))
+	require.NoError(t, zipLogs(w, time.Now(), topPath, true, io.Discard))
 	require.NoError(t, w.Close())
 
 	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
 	require.NoError(t, err)
 
-	// Component trace logs land under logs/<version>/httpjson/ matching the 8.19 zip layout.
-	traceName := "logs/" + currentDir + "/httpjson/http-request-trace-test.ndjson"
+	// Component trace logs land under logs/<version>/components/httpjson/ mirroring the source layout.
+	traceName := "logs/" + currentDir + "/components/httpjson/http-request-trace-test.ndjson"
 	var count int
 	for _, f := range r.File {
 		if f.Name == traceName {
@@ -551,7 +554,7 @@ func TestZipLogsUnversionedHome(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	w := zip.NewWriter(buf)
-	require.NoError(t, zipLogs(w, time.Now(), topPath, true))
+	require.NoError(t, zipLogs(w, time.Now(), topPath, true, io.Discard))
 	require.NoError(t, w.Close())
 
 	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
@@ -573,7 +576,7 @@ func zipLogsAndAssertFiles(t *testing.T, topPath string, excludeEvents bool, exp
 	// Zip the logs directory.
 	buf := new(bytes.Buffer)
 	w := zip.NewWriter(buf)
-	require.NoError(t, zipLogs(w, time.Now(), topPath, excludeEvents))
+	require.NoError(t, zipLogs(w, time.Now(), topPath, excludeEvents, io.Discard))
 	require.NoError(t, w.Close())
 
 	// Read back the contents.

--- a/internal/pkg/diagnostics/diagnostics_test.go
+++ b/internal/pkg/diagnostics/diagnostics_test.go
@@ -10,6 +10,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/hex"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -477,7 +478,7 @@ func TestZipLogsComponentsLogs(t *testing.T) {
 	// Create the versioned home so zipLogs iterates the current version.
 	require.NoError(t, os.MkdirAll(filepath.Join(homePath, "logs"), 0o700))
 
-	// Beat receivers write their trace logs under {pathsHome}/components/logs.
+	// Components may write logs under {pathsHome}/components/logs.
 	traceDir := filepath.Join(homePath, "components", "logs", "httpjson")
 	require.NoError(t, os.MkdirAll(traceDir, 0o700))
 	require.NoError(t, os.WriteFile(filepath.Join(traceDir, "http-request-trace-test.ndjson"), []byte(".\n"), 0o600))
@@ -517,7 +518,7 @@ func TestZipLogsComponentsLogsMultiVersionedHome(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(dataPath, currentDir, "logs"), 0o700))
 	require.NoError(t, os.MkdirAll(filepath.Join(dataPath, oldDir, "logs"), 0o700))
 
-	// Beat receivers write their trace logs under each version's own components/logs.
+	// Components may write logs under each version's own components/logs.
 	traceDir := filepath.Join(dataPath, currentDir, "components", "logs", "httpjson")
 	require.NoError(t, os.MkdirAll(traceDir, 0o700))
 	require.NoError(t, os.WriteFile(filepath.Join(traceDir, "http-request-trace-test.ndjson"), []byte(".\n"), 0o600))
@@ -609,9 +610,12 @@ func TestZipLogsUnversionedHome(t *testing.T) {
 	paths.SetVersionHome(false)
 
 	topPath := t.TempDir()
-	logsDir := filepath.Join(topPath, "logs")
-	require.NoError(t, os.MkdirAll(logsDir, 0o700))
-	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "log.ndjson"), []byte(".\n"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(topPath, "logs"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(topPath, "logs", "log.ndjson"), []byte(".\n"), 0o600))
+
+	// Component logs (e.g. beat receiver trace logs) live under components/logs.
+	require.NoError(t, os.MkdirAll(filepath.Join(topPath, "components", "logs", "httpjson"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(topPath, "components", "logs", "httpjson", "trace.ndjson"), []byte(".\n"), 0o600))
 
 	buf := new(bytes.Buffer)
 	w := zip.NewWriter(buf)
@@ -621,15 +625,63 @@ func TestZipLogsUnversionedHome(t *testing.T) {
 	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
 	require.NoError(t, err)
 
-	wantName := "logs/" + filepath.Base(topPath) + "/log.ndjson"
-	var found bool
+	names := make(map[string]struct{}, len(r.File))
 	for _, f := range r.File {
-		if f.Name == wantName {
-			found = true
-		}
+		names[f.Name] = struct{}{}
 	}
-	assert.Truef(t, found, "expected %q in zip", wantName)
+
+	base := filepath.Base(topPath)
+	assert.Contains(t, names, "logs/"+base+"/log.ndjson", "agent log should be in zip")
+	assert.Contains(t, names, "logs/"+base+"/components/httpjson/trace.ndjson", "component log should be in zip")
 }
+
+// TestSaveLogs verifies the error-handling contract of saveLogs:
+// source-file errors are non-fatal (warning logged, nil returned) and
+// zip-writer errors are fatal (error returned, no warning logged).
+func TestSaveLogs(t *testing.T) {
+	t.Run("missing source file is non-fatal", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		w := zip.NewWriter(buf)
+		errOut := new(bytes.Buffer)
+
+		err := saveLogs("test.ndjson", filepath.Join(t.TempDir(), "nonexistent.ndjson"), w, errOut)
+
+		assert.NoError(t, err)
+		assert.Empty(t, errOut.String())
+	})
+
+	t.Run("broken zip writer is fatal", func(t *testing.T) {
+		// zip.NewWriter wraps the underlying writer in a bufio.Writer (4 KB buffer),
+		// so small writes never reach the broken writer — they sit in the bufio.
+		// The deflate compressor emits a compressed block every ~32 768 tokens; for
+		// truly incompressible data (LCG bytes, no back-references) each token is one
+		// literal byte, so a 40 KB incompressible file forces the compressor to emit a
+		// ~32 KB block during io.Copy, overflowing the bufio and surfacing the error
+		// inside saveLogs before it returns.
+		const dataSize = 40 * 1024
+		data := make([]byte, dataSize)
+		v := uint32(0xdeadbeef)
+		for i := range data {
+			v = v*1664525 + 1013904223 // Knuth LCG — uniform, no short repetitions
+			data[i] = byte(v >> 24)
+		}
+		logFile := filepath.Join(t.TempDir(), "agent.ndjson")
+		require.NoError(t, os.WriteFile(logFile, data, 0o600))
+
+		w := zip.NewWriter(alwaysErrWriter{})
+		errOut := new(bytes.Buffer)
+
+		err := saveLogs("test.ndjson", logFile, w, errOut)
+
+		assert.Error(t, err)
+		assert.Empty(t, errOut.String()) // returned as error, not logged as warning
+	})
+}
+
+// alwaysErrWriter is an io.Writer that always returns an error, used to simulate a broken zip writer.
+type alwaysErrWriter struct{}
+
+func (alwaysErrWriter) Write([]byte) (int, error) { return 0, errors.New("write error") }
 
 func zipLogsAndAssertFiles(t *testing.T, topPath string, excludeEvents bool, expected []zippedItem) {
 	t.Helper()

--- a/testing/integration/ess/diagnostics_test.go
+++ b/testing/integration/ess/diagnostics_test.go
@@ -423,6 +423,11 @@ outputs:
     hosts: [{{ .ESHost }}]
     api_key: placeholder
 agent.monitoring.enabled: false
+# Force process (subprocess) mode for httpjson. The default runtime for all filebeat inputs
+# is otel (see DefaultRuntimeConfig), but in otel mode the fbreceiver stores paths in
+# b.Info.Paths rather than the global paths.Paths, so the httpjson tracer path validation
+# reads an uninitialised paths.Paths.Logs and rejects the tracer filename. In process mode
+# filebeat runs as a subprocess and initialises the global paths normally.
 agent.internal.runtime.filebeat.httpjson: process
 `
 

--- a/testing/integration/ess/diagnostics_test.go
+++ b/testing/integration/ess/diagnostics_test.go
@@ -713,10 +713,10 @@ func testDiagnosticsFactory(t *testing.T, compSetup map[string]integrationtest.C
 		require.NoError(t, err)
 
 		if checkBeatReceiverTraceLogs {
-			// The diagnostic bundle places logs under logs/<commit>/. Use the real
+			// The diagnostic bundle places logs under logs/<commit>/components. Use the real
 			// commit hash so the pattern matches the exact path in the bundle.
 			extraPatterns = append(extraPatterns, filePattern{
-				pattern:  path.Join("logs", "elastic-agent-"+avi.Commit[:6], "httpjson", "http-request-trace-*.ndjson"),
+				pattern:  path.Join("logs", "elastic-agent-"+avi.Commit[:6], "components", "httpjson", "http-request-trace-*.ndjson"),
 				optional: false,
 			})
 		}

--- a/testing/integration/ess/diagnostics_test.go
+++ b/testing/integration/ess/diagnostics_test.go
@@ -138,7 +138,7 @@ func TestDiagnosticsOptionalValues(t *testing.T) {
 		Configure:  simpleConfig2,
 		AgentState: integrationtest.NewClientState(client.Healthy),
 		Components: componentSetup,
-		After:      testDiagnosticsFactory(t, componentSetup, diagpprof, diagCompPprof, fixture, []string{"diagnostics", "-p"}),
+		After:      testDiagnosticsFactory(t, componentSetup, diagpprof, diagCompPprof, fixture, []string{"diagnostics", "-p"}, false),
 	})
 	require.NoError(t, err)
 }
@@ -164,7 +164,7 @@ func TestIsolatedUnitsDiagnosticsOptionalValues(t *testing.T) {
 		Configure:  complexIsolatedUnitsConfig,
 		AgentState: integrationtest.NewClientState(client.Healthy),
 		Components: isolatedUnitsComponentSetup,
-		After:      testDiagnosticsFactory(t, isolatedUnitsComponentSetup, diagpprof, diagCompPprof, fixture, []string{"diagnostics", "-p"}),
+		After:      testDiagnosticsFactory(t, isolatedUnitsComponentSetup, diagpprof, diagCompPprof, fixture, []string{"diagnostics", "-p"}, false),
 	})
 	require.NoError(t, err)
 }
@@ -187,7 +187,7 @@ func TestDiagnosticsCommand(t *testing.T) {
 		Configure:  simpleConfig2,
 		AgentState: integrationtest.NewClientState(client.Healthy),
 		Components: componentSetup,
-		After:      testDiagnosticsFactory(t, componentSetup, diagnosticsFiles, compDiagnosticsFiles, f, []string{"diagnostics", "collect"}),
+		After:      testDiagnosticsFactory(t, componentSetup, diagnosticsFiles, compDiagnosticsFiles, f, []string{"diagnostics", "collect"}, false),
 	})
 	assert.NoError(t, err)
 }
@@ -210,7 +210,7 @@ func TestIsolatedUnitsDiagnosticsCommand(t *testing.T) {
 		Configure:  complexIsolatedUnitsConfig,
 		AgentState: integrationtest.NewClientState(client.Healthy),
 		Components: isolatedUnitsComponentSetup,
-		After:      testDiagnosticsFactory(t, isolatedUnitsComponentSetup, diagnosticsFiles, compDiagnosticsFiles, f, []string{"diagnostics", "collect"}),
+		After:      testDiagnosticsFactory(t, isolatedUnitsComponentSetup, diagnosticsFiles, compDiagnosticsFiles, f, []string{"diagnostics", "collect"}, false),
 	})
 	assert.NoError(t, err)
 }
@@ -472,6 +472,9 @@ agent.internal.runtime.filebeat.httpjson: process
 		diagCompSetup                map[string]integrationtest.ComponentState
 		configTemplate               string
 		extraPatterns                []filePattern
+		// checkBeatReceiverTraceLogs tells testDiagnosticsFactory to assert that an
+		// httpjson trace log file is present in the bundle under logs/<commit>/.
+		checkBeatReceiverTraceLogs bool
 	}{
 		{
 			name:              "filebeat process",
@@ -524,13 +527,8 @@ agent.internal.runtime.filebeat.httpjson: process
 			diagCompSetup: map[string]integrationtest.ComponentState{
 				"httpjson-default": {State: integrationtest.NewClientState(client.Healthy)},
 			},
-			configTemplate: httpjsonTracerConfigTemplate,
-			extraPatterns: []filePattern{
-				{
-					pattern:  path.Join("logs", "*", "httpjson", "http-request-trace-*.ndjson"),
-					optional: false,
-				},
-			},
+			configTemplate:             httpjsonTracerConfigTemplate,
+			checkBeatReceiverTraceLogs: true,
 		},
 	}
 
@@ -583,7 +581,7 @@ agent.internal.runtime.filebeat.httpjson: process
 				Configure:  configBuffer.String(),
 				AgentState: expectedAgentState,
 				Components: tc.agentCompState,
-				After:      testDiagnosticsFactory(t, tc.diagCompSetup, expDiagFiles, tc.expectedCompDiagnosticsFiles, f, []string{"diagnostics", "collect"}, extraPatterns...),
+				After:      testDiagnosticsFactory(t, tc.diagCompSetup, expDiagFiles, tc.expectedCompDiagnosticsFiles, f, []string{"diagnostics", "collect"}, tc.checkBeatReceiverTraceLogs, extraPatterns...),
 			})
 			assert.NoError(t, err)
 		})
@@ -685,7 +683,7 @@ agent.internal.runtime.filebeat.filestream: otel
 	verifyFilebeatRegistry(t, filepath.Join(extractionDir, "components/filestream-default/registry.tar.gz"))
 }
 
-func testDiagnosticsFactory(t *testing.T, compSetup map[string]integrationtest.ComponentState, diagFiles []string, diagCompFiles []string, fix *integrationtest.Fixture, cmd []string, extraPatterns ...filePattern) func(ctx context.Context) error {
+func testDiagnosticsFactory(t *testing.T, compSetup map[string]integrationtest.ComponentState, diagFiles []string, diagCompFiles []string, fix *integrationtest.Fixture, cmd []string, checkBeatReceiverTraceLogs bool, extraPatterns ...filePattern) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		// If any required extra patterns are present (e.g. the metrics file
 		// written by the OTel file exporter after the first collection cycle),
@@ -693,14 +691,18 @@ func testDiagnosticsFactory(t *testing.T, compSetup map[string]integrationtest.C
 		// diagnostics. The metrics period configured in the test is 2 s, so
 		// 10 s gives a comfortable margin even if the OTel monitoring collector
 		// takes a few seconds to start after the agent reports HEALTHY.
+		needsWait := checkBeatReceiverTraceLogs
 		for _, p := range extraPatterns {
 			if !p.optional {
-				select {
-				case <-time.After(10 * time.Second):
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+				needsWait = true
 				break
+			}
+		}
+		if needsWait {
+			select {
+			case <-time.After(10 * time.Second):
+			case <-ctx.Done():
+				return ctx.Err()
 			}
 		}
 
@@ -709,6 +711,15 @@ func testDiagnosticsFactory(t *testing.T, compSetup map[string]integrationtest.C
 		// get the version of the running agent
 		avi, err := getRunningAgentVersion(ctx, fix)
 		require.NoError(t, err)
+
+		if checkBeatReceiverTraceLogs {
+			// The diagnostic bundle places logs under logs/<commit>/. Use the real
+			// commit hash so the pattern matches the exact path in the bundle.
+			extraPatterns = append(extraPatterns, filePattern{
+				pattern:  path.Join("logs", "elastic-agent-"+avi.Commit[:6], "httpjson", "http-request-trace-*.ndjson"),
+				optional: false,
+			})
+		}
 
 		verifyDiagnosticArchive(t, compSetup, diagZip, diagFiles, diagCompFiles, avi, extraPatterns...)
 

--- a/testing/integration/ess/diagnostics_test.go
+++ b/testing/integration/ess/diagnostics_test.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path"
 	"path/filepath"
@@ -371,7 +373,14 @@ func TestBeatDiagnostics(t *testing.T) {
 
 	esURL := integration.StartMockES(t, 0, 0, 0, 0)
 
-	configTemplate := `
+	// Mock HTTP server polled by the httpjson trace logs test case.
+	httpjsonServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"message":"hello"}`)
+	}))
+	t.Cleanup(httpjsonServer.Close)
+
+	fileStreamConfigTemplate := `
 inputs:
   - id: filestream-filebeat
     type: filestream
@@ -391,15 +400,33 @@ agent.monitoring.enabled: {{ .MonitoringEnabled }}
 agent.internal.runtime.filebeat.filestream: {{ .Runtime }}
 `
 
-	var filebeatSetup = map[string]integrationtest.ComponentState{
-		"filestream-default": {
-			State: integrationtest.NewClientState(client.Healthy),
-		},
-	}
+	// httpjsonTracerConfigTemplate runs httpjson as a normal filebeat subprocess (process
+	// mode). In that mode filebeat sets the global paths.Paths.Logs, so the httpjson tracer
+	// path validation works and writes trace files to {versionedHome}/components/logs/httpjson/
+	// — the directory the diagnostic bundle fix now collects.
+	httpjsonTracerConfigTemplate := `
+inputs:
+  - type: httpjson
+    id: httpjson-trace-test
+    use_output: default
+    streams:
+      - id: httpjson-trace-stream
+        data_stream:
+          dataset: httpjson.generic
+          type: logs
+        request.url: {{ .MockServerURL }}
+        request.tracer.filename: http-request-trace-*.ndjson
+        interval: 1s
+outputs:
+  default:
+    type: elasticsearch
+    hosts: [{{ .ESHost }}]
+    api_key: placeholder
+agent.monitoring.enabled: false
+agent.internal.runtime.filebeat.httpjson: process
+`
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
-	defer cancel()
-	expectedComponentState := map[string]integrationtest.ComponentState{
+	fileStreamAgentCompState := map[string]integrationtest.ComponentState{
 		"filestream-default": {
 			State: integrationtest.NewClientState(client.Healthy),
 			Units: map[integrationtest.ComponentUnitKey]integrationtest.ComponentUnitState{
@@ -412,6 +439,23 @@ agent.internal.runtime.filebeat.filestream: {{ .Runtime }}
 			},
 		},
 	}
+
+	httpjsonAgentCompState := map[string]integrationtest.ComponentState{
+		"httpjson-default": {
+			State: integrationtest.NewClientState(client.Healthy),
+			Units: map[integrationtest.ComponentUnitKey]integrationtest.ComponentUnitState{
+				integrationtest.ComponentUnitKey{UnitType: client.UnitTypeOutput, UnitID: "httpjson-default"}: {
+					State: integrationtest.NewClientState(client.Healthy),
+				},
+				integrationtest.ComponentUnitKey{UnitType: client.UnitTypeInput, UnitID: "httpjson-default-httpjson-trace-test"}: {
+					State: integrationtest.NewClientState(client.Healthy),
+				},
+			},
+		},
+	}
+
+	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	defer cancel()
 	expectedAgentState := integrationtest.NewClientState(client.Healthy)
 
 	testCases := []struct {
@@ -419,6 +463,10 @@ agent.internal.runtime.filebeat.filestream: {{ .Runtime }}
 		runtime                      string
 		monitoringEnabled            bool
 		expectedCompDiagnosticsFiles []string
+		agentCompState               map[string]integrationtest.ComponentState
+		diagCompSetup                map[string]integrationtest.ComponentState
+		configTemplate               string
+		extraPatterns                []filePattern
 	}{
 		{
 			name:              "filebeat process",
@@ -431,6 +479,11 @@ agent.internal.runtime.filebeat.filestream: {{ .Runtime }}
 				"beat-rendered-config.yml",
 				"global_processors.txt",
 			),
+			agentCompState: fileStreamAgentCompState,
+			diagCompSetup: map[string]integrationtest.ComponentState{
+				"filestream-default": {State: integrationtest.NewClientState(client.Healthy)},
+			},
+			configTemplate: fileStreamConfigTemplate,
 		},
 		{
 			name:              "filebeat receiver",
@@ -441,32 +494,65 @@ agent.internal.runtime.filebeat.filestream: {{ .Runtime }}
 				"beat_metrics.json",
 				"input_metrics.json",
 			},
+			agentCompState: fileStreamAgentCompState,
+			diagCompSetup: map[string]integrationtest.ComponentState{
+				"filestream-default": {State: integrationtest.NewClientState(client.Healthy)},
+			},
+			configTemplate: fileStreamConfigTemplate,
+		},
+		{
+			// Verifies that beat receiver trace logs written to {versionedHome}/components/logs/
+			// are included in the diagnostic bundle under logs/<commit>/httpjson/.
+			// Uses httpjson in process mode: the filebeat subprocess sets the global
+			// paths.Paths.Logs so the tracer path validation succeeds, and trace files land in
+			// {versionedHome}/components/logs/httpjson/ — the path the fix now collects.
+			name:    "httpjson trace logs in bundle",
+			runtime: "process",
+			expectedCompDiagnosticsFiles: append(compDiagnosticsFiles,
+				"registry.tar.gz",
+				"input_metrics.json",
+				"beat_metrics.json",
+				"beat-rendered-config.yml",
+				"global_processors.txt",
+			),
+			agentCompState: httpjsonAgentCompState,
+			diagCompSetup: map[string]integrationtest.ComponentState{
+				"httpjson-default": {State: integrationtest.NewClientState(client.Healthy)},
+			},
+			configTemplate: httpjsonTracerConfigTemplate,
+			extraPatterns: []filePattern{
+				{
+					pattern:  path.Join("logs", "*", "httpjson", "http-request-trace-*.ndjson"),
+					optional: false,
+				},
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create the fixture
 			f, err := define.NewFixtureFromLocalBuild(t, define.Version(), integrationtest.WithAllowErrors())
 			require.NoError(t, err)
 			err = f.Prepare(ctx)
 			require.NoError(t, err)
 
-			// Create the data file to ingest.
+			// Create the data file to ingest (used by filestream cases).
 			inputFilePath := filepath.Join(t.TempDir(), "input.txt")
 			err = os.WriteFile(inputFilePath, []byte("hello world\n"), 0o600)
 			require.NoError(t, err, "failed to create input file for ingestion")
 
 			var configBuffer bytes.Buffer
 			require.NoError(t,
-				template.Must(template.New("config").Parse(configTemplate)).Execute(&configBuffer, map[string]any{
+				template.Must(template.New("config").Parse(tc.configTemplate)).Execute(&configBuffer, map[string]any{
 					"Runtime":           tc.runtime,
 					"InputFile":         inputFilePath,
 					"ESHost":            esURL.Host,
 					"MonitoringEnabled": tc.monitoringEnabled,
+					"MockServerURL":     httpjsonServer.URL,
 				}))
+
 			expDiagFiles := append([]string{}, diagnosticsFiles...)
-			var extraPatterns []filePattern
+			extraPatterns := append([]filePattern{}, tc.extraPatterns...)
 			if tc.runtime == "otel" {
 				// EDOT adds these extra files.
 				// TestBeatDiagnostics is quite strict about what it expects to see in the archive.
@@ -491,8 +577,8 @@ agent.internal.runtime.filebeat.filestream: {{ .Runtime }}
 			err = f.Run(ctx, integrationtest.State{
 				Configure:  configBuffer.String(),
 				AgentState: expectedAgentState,
-				Components: expectedComponentState,
-				After:      testDiagnosticsFactory(t, filebeatSetup, expDiagFiles, tc.expectedCompDiagnosticsFiles, f, []string{"diagnostics", "collect"}, extraPatterns...),
+				Components: tc.agentCompState,
+				After:      testDiagnosticsFactory(t, tc.diagCompSetup, expDiagFiles, tc.expectedCompDiagnosticsFiles, f, []string{"diagnostics", "collect"}, extraPatterns...),
 			})
 			assert.NoError(t, err)
 		})


### PR DESCRIPTION
## What does this PR do?

In 9.x, beats run as **in-process OTel receivers** inside `elastic-otel-collector`. Their `path.home` is set to `paths.Components()` (i.e. `{home}/components/`), so their `path.logs` defaults to `{home}/components/logs/`. Input trace logs (e.g. from `httpjson`, `cel`, `http_endpoint`, `entity-analytics`) are written to `{home}/components/logs/{input}/`.

The old `zipLogsWithPath` only walked `{pathsHome}/logs/` — missing `{pathsHome}/components/logs/` entirely.

**Changes:**

- `zipLogsWithPath` now walks both `{pathsHome}/logs/` and `{pathsHome}/components/logs/`, placing trace logs under `logs/{version}/{input}/` in the zip alongside the agent's own logs.
- `collectServiceComponentsLogs` and the `logs/` root header moved out of `zipLogsWithPath` into `zipLogs` so they run once, not once per versioned home.
- Walk logic extracted into `walkLogPath` + `zipLogWalkFunc` helpers so both roots share the same walk callback.
- Three new unit tests: single versioned home, multi versioned home, and container (unversioned) layout.
- Changelog fragment added.

## Why is it important?

Without this fix, `elastic-agent diagnostics` bundles are silently missing the HTTP request trace logs that are essential for debugging `httpjson`, `cel`, and `entity-analytics` integrations.

The root cause is that beats resolve trace log paths via `ResolvePathInLogsFor`, which places files under `{home}/components/logs/{input}/`. The diagnostics code only walked `{pathsHome}/logs/` and never walked `{pathsHome}/components/logs/`.

The regression was introduced by elastic/beats#48909 (merged 2026-02-18), which added `ResolvePathInLogsFor` to fix tracer path validation under managed agents. Before that change, relative tracer paths were resolved against the process CWD, placing files under `{ROOT}/logs/{input}/` which the old diagnostics walk did cover. After it, paths resolve against `path.logs`, placing files under `{home}/components/logs/{input}/` which was never walked. This affects 9.x and later 8.19.x patch releases.

Fixes #14359.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

None. The zip layout for existing log files is unchanged. Trace log files are now present in the bundle where they were previously missing.

## How to test this PR locally

1. Run Elastic Agent 9.x with an `httpjson` input that has `request.tracer.filename` configured.
2. Confirm the file appears on disk under `{home}/components/logs/httpjson/`.
3. Run `elastic-agent diagnostics`.
4. Unzip the bundle and confirm the trace file appears under `logs/{version-hash}/httpjson/`.

Unit tests can be run directly:

```bash
go test ./internal/pkg/diagnostics/... -run TestZipLogs -v
```

## Related issues

- Closes #14359
