### PR TITLE
[logging] fix event logging

### DIFF
--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -109,19 +109,12 @@ func (h *PolicyChangeHandler) Handle(ctx context.Context, a fleetapi.Action, ack
 	}
 
 	h.log.Debugf("handlerPolicyChange: emit configuration for action %+v", a)
-	err = h.handlePolicyChange(ctx, c)
+	err = h.handlePolicyChange(ctx, c, action)
 	if err != nil {
 		return err
 	}
 
-	if h.stateStore != nil {
-		h.stateStore.SetAction(action)
-		if err := h.stateStore.Save(); err != nil {
-			h.log.Warnf("failed to persist policy action to state store: %v", err)
-		}
-	}
-
-	h.ch <- newPolicyChange(ctx, h.log, c, a, acker, false, h.stateStore, h.disableAckFn())
+	h.ch <- newPolicyChange(ctx, h.log, c, a, acker, false, h.disableAckFn())
 	return nil
 }
 
@@ -243,7 +236,7 @@ func emptyCertificateConfig() tlscommon.CertificateConfig {
 	return tlscommon.CertificateConfig{}
 }
 
-func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.Config) error {
+func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.Config, action *fleetapi.ActionPolicyChange) error {
 	partialCfg, err := configuration.NewPartialFromConfigNoDefaults(c)
 	if err != nil {
 		return fmt.Errorf("parsing fleet config: %w", err)
@@ -308,15 +301,22 @@ func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.
 			runtimeErr = goerrors.Join(runtimeErr, fmt.Errorf("failed to set runtime log level: %w", err))
 		}
 	}
+	if runtimeErr != nil {
+		return runtimeErr
+	}
+
+	// Now, we can safely store the action as we can't have any more errors after this point.
+	if h.stateStore != nil && action != nil {
+		h.stateStore.SetAction(action)
+		if err := h.stateStore.Save(); err != nil {
+			h.log.Warnf("failed to persist policy action to state store: %v", err)
+		}
+	}
 
 	// If the event logging output has changed, re-exec the agent so it picks up
 	// the newly-persisted logging config on startup.
 	if hasEventLoggingChanged {
 		h.runtimeLogLevelSetter.ReExec(nil)
-	}
-
-	if runtimeErr != nil {
-		return runtimeErr
 	}
 
 	return nil
@@ -471,7 +471,6 @@ type policyChange struct {
 	action     fleetapi.Action
 	acker      acker.Acker
 	ackWatcher chan struct{}
-	stateStore stateStore
 	disableAck bool
 }
 
@@ -482,7 +481,6 @@ func newPolicyChange(
 	action fleetapi.Action,
 	acker acker.Acker,
 	makeCh bool,
-	stateStore stateStore,
 	disableAck bool) *policyChange {
 	var ackWatcher chan struct{}
 	if makeCh {
@@ -496,7 +494,6 @@ func newPolicyChange(
 		action:     action,
 		acker:      acker,
 		ackWatcher: ackWatcher,
-		stateStore: stateStore,
 		disableAck: disableAck,
 	}
 }

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -114,6 +114,18 @@ func (h *PolicyChangeHandler) Handle(ctx context.Context, a fleetapi.Action, ack
 		return err
 	}
 
+	// Persist the action before the async Ack() path. A re-exec triggered by
+	// handlePolicyChange can shut the agent down before Ack() updates the store,
+	// leaving the previous policy persisted. On restart, the stale action is
+	// replayed, causing another re-exec and an endless flip-flop. Writing here,
+	// in the dispatcher goroutine, keeps the state store consistent with fleet.enc
+	// before exit. Ack() will write the same action again, but duplicate IDs are
+	// safely deduplicated.
+	h.stateStore.SetAction(action)
+	if err := h.stateStore.Save(); err != nil {
+		h.log.Warnf("failed to persist policy action to state store: %v", err)
+	}
+
 	h.ch <- newPolicyChange(ctx, h.log, c, a, acker, false, h.stateStore, h.disableAckFn())
 	return nil
 }

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -262,30 +262,15 @@ func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.
 		return fmt.Errorf("failed to parse policy configuration: %w", err)
 	}
 
+	// Step 3: Set the policy log level, the runtime step below reads it back.
 	policyLogLevel := logger.DefaultLogLevel.String()
 	if loggingConfig != nil {
 		policyLogLevel = loggingConfig.Level.String()
 	}
-
-	// Step 3: Update in-memory caches.
-	if validatedFleetConfig != nil {
-		h.config.Fleet.Client = *validatedFleetConfig
-	}
-	if loggingConfig != nil {
-		h.config.Settings.LoggingConfig.Level = loggingConfig.Level
-	}
-	h.config.Settings.MonitoringConfig.HTTP = cfg.Settings.MonitoringConfig.HTTP
-	h.config.Settings.MonitoringConfig.Pprof = cfg.Settings.MonitoringConfig.Pprof
 	h.agentInfo.SetLogLevelPolicy(policyLogLevel)
 
-	hasEventLoggingChanged := h.applyEventLoggingOutputChange(partialCfg)
-
-	// Step 4: Persist the updated configuration to disk.
-	if err := saveConfig(h.agentInfo, h.config, h.store, h.log); err != nil {
-		return fmt.Errorf("failed to persist policy config: %w", err)
-	}
-
-	// Step 5: Apply runtime changes.
+	// Step 4: Apply runtime changes before persisting, so a failure leaves
+	// fleet.enc and the state store untouched.
 	var runtimeErr error
 	if err := h.applyFleetClientConfig(validatedFleetConfig); err != nil {
 		runtimeErr = goerrors.Join(runtimeErr, fmt.Errorf("failed to apply Fleet client config: %w", err))
@@ -305,7 +290,25 @@ func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.
 		return runtimeErr
 	}
 
-	// Now, we can safely store the action as we can't have any more errors after this point.
+	// Step 5: Commit. Nothing below can fail so we update the caches, persist the
+	// config and the action and then re-exec.
+	//
+	// The caches are updated here, not earlier, because they are the baseline we
+	// compare the next policy against. If we updated them before a failure, the
+	// resent policy would look unchanged and we would skip re-applying it.
+	hasEventLoggingChanged := h.applyEventLoggingOutputChange(partialCfg)
+	if validatedFleetConfig != nil {
+		h.config.Fleet.Client = *validatedFleetConfig
+	}
+	if loggingConfig != nil {
+		h.config.Settings.LoggingConfig.Level = loggingConfig.Level
+	}
+	h.config.Settings.MonitoringConfig.HTTP = cfg.Settings.MonitoringConfig.HTTP
+	h.config.Settings.MonitoringConfig.Pprof = cfg.Settings.MonitoringConfig.Pprof
+
+	if err := saveConfig(h.agentInfo, h.config, h.store, h.log); err != nil {
+		return fmt.Errorf("failed to persist policy config: %w", err)
+	}
 	if h.stateStore != nil && action != nil {
 		h.stateStore.SetAction(action)
 		if err := h.stateStore.Save(); err != nil {
@@ -313,8 +316,7 @@ func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.
 		}
 	}
 
-	// If the event logging output has changed, re-exec the agent so it picks up
-	// the newly-persisted logging config on startup.
+	// Re-exec so the new event logging output is applied on restart.
 	if hasEventLoggingChanged {
 		h.runtimeLogLevelSetter.ReExec(nil)
 	}

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -114,13 +114,6 @@ func (h *PolicyChangeHandler) Handle(ctx context.Context, a fleetapi.Action, ack
 		return err
 	}
 
-	// Persist the action before the async Ack() path. A re-exec triggered by
-	// handlePolicyChange can shut the agent down before Ack() updates the store,
-	// leaving the previous policy persisted. On restart, the stale action is
-	// replayed, causing another re-exec and an endless flip-flop. Writing here,
-	// in the dispatcher goroutine, keeps the state store consistent with fleet.enc
-	// before exit. Ack() will write the same action again, but duplicate IDs are
-	// safely deduplicated.
 	if h.stateStore != nil {
 		h.stateStore.SetAction(action)
 		if err := h.stateStore.Save(); err != nil {

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -278,6 +278,8 @@ func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.
 	h.config.Settings.MonitoringConfig.Pprof = cfg.Settings.MonitoringConfig.Pprof
 	h.agentInfo.SetLogLevelPolicy(policyLogLevel)
 
+	hasEventLoggingChanged := h.applyEventLoggingOutputChange(partialCfg)
+
 	// Step 4: Persist the updated configuration to disk.
 	if err := saveConfig(h.agentInfo, h.config, h.store, h.log); err != nil {
 		return fmt.Errorf("failed to persist policy config: %w", err)
@@ -302,7 +304,7 @@ func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.
 
 	// If the event logging output has changed, re-exec the agent so it picks up
 	// the newly-persisted logging config on startup.
-	if h.applyEventLoggingOutputChange(partialCfg) {
+	if hasEventLoggingChanged {
 		h.runtimeLogLevelSetter.ReExec(nil)
 	}
 

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -121,9 +121,11 @@ func (h *PolicyChangeHandler) Handle(ctx context.Context, a fleetapi.Action, ack
 	// in the dispatcher goroutine, keeps the state store consistent with fleet.enc
 	// before exit. Ack() will write the same action again, but duplicate IDs are
 	// safely deduplicated.
-	h.stateStore.SetAction(action)
-	if err := h.stateStore.Save(); err != nil {
-		h.log.Warnf("failed to persist policy action to state store: %v", err)
+	if h.stateStore != nil {
+		h.stateStore.SetAction(action)
+		if err := h.stateStore.Save(); err != nil {
+			h.log.Warnf("failed to persist policy action to state store: %v", err)
+		}
 	}
 
 	h.ch <- newPolicyChange(ctx, h.log, c, a, acker, false, h.stateStore, h.disableAckFn())
@@ -524,13 +526,6 @@ func (l *policyChange) Config() *config.Config {
 //     propagates so the coordinator can retry.
 //  3. Commit the ack batch. Failures propagate.
 func (l *policyChange) Ack() error {
-	if pc, ok := l.action.(*fleetapi.ActionPolicyChange); ok && pc != nil && l.stateStore != nil {
-		l.stateStore.SetAction(pc)
-		if err := l.stateStore.Save(); err != nil && l.log != nil {
-			return fmt.Errorf("failed to perist policy change action to state store: %w", err)
-		}
-	}
-
 	if !l.disableAck && l.action != nil {
 		if err := l.acker.Ack(l.ctx, l.action); err != nil {
 			return err

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_nofips_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_nofips_test.go
@@ -219,7 +219,7 @@ func Test_Handler_SSL_Passphrase(t *testing.T) {
 
 			cfg := config.MustNewConfigFrom(tc.newCfg)
 
-			err := h.handlePolicyChange(context.Background(), cfg)
+			err := h.handlePolicyChange(context.Background(), cfg, nil)
 			tc.assertErr(t, err)
 
 			assert.Equal(t, tc.setterCalledCount, setterCalledCount,

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
@@ -265,7 +265,7 @@ func TestPolicyChangeHandler_handlePolicyChange_FleetClientSettings(t *testing.T
 						"fleet.proxy_url": "http://some.proxy",
 					})
 
-				err := h.handlePolicyChange(context.Background(), cfg)
+				err := h.handlePolicyChange(context.Background(), cfg, nil)
 				assert.ErrorContains(t, err, "fail to create API client with updated config")
 
 				// h.config must be unchanged since the error originated in validation, before any mutation.
@@ -323,7 +323,7 @@ func TestPolicyChangeHandler_handlePolicyChange_FleetClientSettings(t *testing.T
 						"fleet.proxy_url": "http://some.proxy",
 					})
 
-				err := h.handlePolicyChange(context.Background(), cfg)
+				err := h.handlePolicyChange(context.Background(), cfg, nil)
 				assert.ErrorContains(t, err, "fail to communicate with Fleet Server API client hosts")
 
 				// h.config must be unchanged since the error originated in validation, before any mutation.
@@ -372,7 +372,7 @@ func TestPolicyChangeHandler_handlePolicyChange_FleetClientSettings(t *testing.T
 				map[string]interface{}{
 					"fleet.hosts": fleetServer.URL})
 
-			err := h.handlePolicyChange(context.Background(), cfg)
+			err := h.handlePolicyChange(context.Background(), cfg, nil)
 			require.NoError(t, err)
 
 			assert.Equal(t, 1, setterCalledCount)
@@ -421,7 +421,7 @@ func TestPolicyChangeHandler_handlePolicyChange_FleetClientSettings(t *testing.T
 					"fleet.proxy_url": mockProxy.URL,
 					"fleet.host":      fleetServer.URL})
 
-			err := h.handlePolicyChange(context.Background(), cfg)
+			err := h.handlePolicyChange(context.Background(), cfg, nil)
 			require.NoError(t, err)
 
 			assert.Equal(t, 1, setterCalledCount)
@@ -475,7 +475,7 @@ func TestPolicyChangeHandler_handlePolicyChange_FleetClientSettings(t *testing.T
 						"fleet.proxy_url": "",
 						"fleet.host":      fleetServer.URL})
 
-				err = h.handlePolicyChange(context.Background(), cfg)
+				err = h.handlePolicyChange(context.Background(), cfg, nil)
 				require.NoError(t, err)
 
 				assert.Equal(t, 1, setterCalledCount)
@@ -532,7 +532,7 @@ func TestPolicyChangeHandler_handlePolicyChange_FleetClientSettings(t *testing.T
 						"fleet.hosts":     []string{alwaysErroringServer.URL},
 					})
 
-				err = h.handlePolicyChange(context.Background(), cfg)
+				err = h.handlePolicyChange(context.Background(), cfg, nil)
 				if assert.Error(t, err, "action policy change handler should return an error if new fleet server sends back a bad status code") {
 					// check that we have the correct error contents
 					assert.ErrorContains(t, err, fmt.Sprintf("fleet server ping returned a bad status code: %d", httpStatusCode))
@@ -938,7 +938,7 @@ func TestPolicyChangeHandler_handlePolicyChange_FleetClientSettings(t *testing.T
 
 				cfg := config.MustNewConfigFrom(tc.newCfg)
 
-				err := h.handlePolicyChange(context.Background(), cfg)
+				err := h.handlePolicyChange(context.Background(), cfg, nil)
 				tc.assertErr(t, err)
 
 				assert.Equal(t, tc.setterCalledCount, setterCalledCount,
@@ -1116,7 +1116,7 @@ func TestPolicyChangeHandler_handlePolicyChange_LogLevelSet(t *testing.T) {
 				runtimeLogLevelSetter: mockLogSetter,
 			}
 
-			tt.wantErr(t, h.handlePolicyChange(context.Background(), config.MustNewConfigFrom(tt.args.c)), fmt.Sprintf("handlePolicyChange(ctx, %v)", tt.args.c))
+			tt.wantErr(t, h.handlePolicyChange(context.Background(), config.MustNewConfigFrom(tt.args.c), nil), fmt.Sprintf("handlePolicyChange(ctx, %v)", tt.args.c))
 		})
 	}
 }
@@ -1178,7 +1178,7 @@ func TestPolicyChangeHandler_handlePolicyChange_LogLevelPersistedToConfig(t *tes
 			cfg := config.MustNewConfigFrom(map[string]interface{}{
 				"agent.logging.level": tt.policyLevel,
 			})
-			err := h.handlePolicyChange(context.Background(), cfg)
+			err := h.handlePolicyChange(context.Background(), cfg, nil)
 			require.NoError(t, err)
 
 			var policyLvl logp.Level

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
@@ -120,9 +120,6 @@ func TestPolicyAcked(t *testing.T) {
 			},
 		}
 		mockSaver := newStateStoreMock()
-		mockSaver.On("SetAction", mock.Anything).Return(nil).Once()
-		mockSaver.On("Save").Return(nil).Once()
-
 		// Test default FF value
 		cfg := configuration.DefaultConfiguration()
 		handler := NewPolicyChangeHandler(log, agentInfo, cfg, nullStore, mockSaver, ch, defaultLogLevelSet(t))
@@ -152,8 +149,6 @@ func TestPolicyAcked(t *testing.T) {
 			},
 		}
 		mockSaver := newStateStoreMock()
-		mockSaver.On("SetAction", mock.Anything).Return(nil).Once()
-		mockSaver.On("Save").Return(nil).Once()
 
 		cfg := configuration.DefaultConfiguration()
 		handler := NewPolicyChangeHandler(log, agentInfo, cfg, nullStore, mockSaver, ch, defaultLogLevelSet(t))
@@ -184,8 +179,6 @@ func TestPolicyAcked(t *testing.T) {
 			},
 		}
 		mockSaver := newStateStoreMock()
-		mockSaver.On("SetAction", mock.Anything).Return(nil).Once()
-		mockSaver.On("Save").Return(nil).Once()
 
 		cfg := configuration.DefaultConfiguration()
 		handler := NewPolicyChangeHandler(log, agentInfo, cfg, nullStore, mockSaver, ch, defaultLogLevelSet(t))

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
@@ -62,7 +62,7 @@ func TestPolicyChange(t *testing.T) {
 		}
 
 		cfg := configuration.DefaultConfiguration()
-		handler := NewPolicyChangeHandler(log, agentInfo, cfg, nullStore, &mockStateStore{}, ch, defaultLogLevelSet(t))
+		handler := NewPolicyChangeHandler(log, agentInfo, cfg, nullStore, newStateStoreMock(), ch, defaultLogLevelSet(t))
 
 		err := handler.Handle(context.Background(), action, ack)
 		require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestPolicyChange(t *testing.T) {
 		}
 
 		cfg := configuration.DefaultConfiguration()
-		handler := NewPolicyChangeHandler(log, agentInfo, cfg, nullStore, &mockStateStore{}, ch, defaultLogLevelSet(t))
+		handler := NewPolicyChangeHandler(log, agentInfo, cfg, nullStore, newStateStoreMock(), ch, defaultLogLevelSet(t))
 
 		err := handler.Handle(context.Background(), action, ack)
 		require.NoError(t, err)
@@ -120,6 +120,8 @@ func TestPolicyAcked(t *testing.T) {
 			},
 		}
 		mockSaver := newStateStoreMock()
+		mockSaver.On("SetAction", mock.Anything).Return(nil).Once()
+		mockSaver.On("Save").Return(nil).Once()
 
 		// Test default FF value
 		cfg := configuration.DefaultConfiguration()
@@ -150,6 +152,8 @@ func TestPolicyAcked(t *testing.T) {
 			},
 		}
 		mockSaver := newStateStoreMock()
+		mockSaver.On("SetAction", mock.Anything).Return(nil).Once()
+		mockSaver.On("Save").Return(nil).Once()
 
 		cfg := configuration.DefaultConfiguration()
 		handler := NewPolicyChangeHandler(log, agentInfo, cfg, nullStore, mockSaver, ch, defaultLogLevelSet(t))
@@ -180,6 +184,8 @@ func TestPolicyAcked(t *testing.T) {
 			},
 		}
 		mockSaver := newStateStoreMock()
+		mockSaver.On("SetAction", mock.Anything).Return(nil).Once()
+		mockSaver.On("Save").Return(nil).Once()
 
 		cfg := configuration.DefaultConfiguration()
 		handler := NewPolicyChangeHandler(log, agentInfo, cfg, nullStore, mockSaver, ch, defaultLogLevelSet(t))

--- a/internal/pkg/agent/application/actions/handlers/handler_helpers.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_helpers.go
@@ -46,7 +46,7 @@ type unitWithComponent struct {
 }
 
 func stopComponents(ctx context.Context, ch chan coordinator.ConfigChange, a fleetapi.Action, acker acker.Acker, backupCallback func()) {
-	unenrollPolicy := newPolicyChange(ctx, nil, config.New(), a, acker, true, nil, false)
+	unenrollPolicy := newPolicyChange(ctx, nil, config.New(), a, acker, true, false)
 	ch <- unenrollPolicy
 
 	if backupCallback != nil {

--- a/internal/pkg/agent/configuration/configuration.go
+++ b/internal/pkg/agent/configuration/configuration.go
@@ -57,7 +57,7 @@ func NewFromConfig(cfg *config.Config) (*Configuration, error) {
 func NewPartialFromConfigNoDefaults(cfg *config.Config) (*Configuration, error) {
 	c := new(Configuration)
 	// Validator tag set to "validate_disable" is a hack to avoid validation errors on a partial config
-	if err := cfg.UnpackTo(c, ucfg.ValidatorTag("validate_disable")); err != nil {
+	if err := cfg.UnpackTo(c, ucfg.ValidatorTag("validate_disable"), ucfg.PathSep(".")); err != nil {
 		return nil, errors.New(err, errors.TypeConfig)
 	}
 

--- a/testing/integration/ess/event_logging_test.go
+++ b/testing/integration/ess/event_logging_test.go
@@ -8,9 +8,12 @@ package ess
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httputil"
 	"os"
 	"path"
 	"path/filepath"
@@ -429,4 +432,28 @@ func getLogFilenames(
 	}
 
 	return logFiles, eventLogFiles
+}
+
+func sendPolicyUpdate(t *testing.T, info *define.Info, policyID, body string) {
+	t.Helper()
+
+	resp, err := info.KibanaClient.Send(
+		http.MethodPut,
+		fmt.Sprintf("/api/fleet/agent_policies/%s", policyID),
+		nil,
+		nil,
+		bytes.NewBufferString(body),
+	)
+	if err != nil {
+		t.Fatalf("could not execute request to Kibana/Fleet: %s", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		respDump, dumpErr := httputil.DumpResponse(resp, true)
+		if dumpErr != nil {
+			t.Fatalf("could not dump Kibana error response: %s", dumpErr)
+		}
+		t.Log("Kibana error response:")
+		t.Log(string(respDump))
+		t.Fatalf("received non-200 status when updating Fleet policy: %d", resp.StatusCode)
+	}
 }

--- a/testing/integration/ess/event_logging_test.go
+++ b/testing/integration/ess/event_logging_test.go
@@ -8,12 +8,9 @@ package ess
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httputil"
 	"os"
 	"path"
 	"path/filepath"
@@ -25,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/elastic-agent-libs/kibana"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools/fleettools"
@@ -166,7 +164,6 @@ func TestEventLogOutputConfiguredViaFleet(t *testing.T) {
 		},
 		Group: "container",
 	})
-	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/5159")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -182,6 +179,29 @@ func TestEventLogOutputConfiguredViaFleet(t *testing.T) {
 		info,
 		policyName,
 		outputID)
+
+	// Switch to process monitoring, as event logging is not yet supported for otel.
+	// https://github.com/elastic/elastic-agent/issues/8845
+	processMonUpdateReq := kibana.AgentPolicyUpdateRequest{
+		Name:      policyName,
+		Namespace: info.Namespace,
+		Overrides: map[string]any{
+			"agent": map[string]any{
+				"internal": map[string]any{
+					"runtime": map[string]any{
+						"default": "process",
+						"filebeat": map[string]any{
+							"default": "process",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = info.KibanaClient.UpdatePolicy(ctx,
+		policyID, processMonUpdateReq)
+	require.NoError(t, err)
 
 	fleetURL, err := fleettools.DefaultURL(ctx, info.KibanaClient)
 	if err != nil {
@@ -267,7 +287,8 @@ func TestEventLogOutputConfiguredViaFleet(t *testing.T) {
 }
 
 func addOverwriteToPolicy(t *testing.T, info *define.Info, policyName, policyID string) {
-	addLoggingOverwriteBody := fmt.Sprintf(`
+	t.Helper()
+	body := fmt.Sprintf(`
 {
   "name": "%s",
   "namespace": "default",
@@ -281,33 +302,8 @@ func addOverwriteToPolicy(t *testing.T, info *define.Info, policyName, policyID 
       }
     }
   }
-}
-`, policyName)
-	resp, err := info.KibanaClient.Send(
-		http.MethodPut,
-		fmt.Sprintf("/api/fleet/agent_policies/%s", policyID),
-		nil,
-		nil,
-		bytes.NewBufferString(addLoggingOverwriteBody),
-	)
-	if err != nil {
-		t.Fatalf("could not execute request to Kibana/Fleet: %s", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		// On error dump the whole request response so we can easily spot
-		// what went wrong.
-		t.Errorf("received a non 200-OK when adding overwrite to policy. "+
-			"Status code: %d", resp.StatusCode)
-		respDump, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			t.Fatalf("could not dump error response from Kibana: %s", err)
-		}
-		// Make debugging as easy as possible
-		t.Log("================================================================================")
-		t.Log("Kibana error response:")
-		t.Log(string(respDump))
-		t.FailNow()
-	}
+}`, policyName)
+	sendPolicyUpdate(t, info, policyID, body)
 }
 
 func readEventLogFile(t *testing.T, agentFixture *atesting.Fixture) string {
@@ -327,7 +323,7 @@ func readEventLogFile(t *testing.T, agentFixture *atesting.Fixture) string {
 			t.Fatalf("could not scan for the events log file: %s", err)
 		}
 
-		if len(files) == 1 {
+		if len(files) >= 1 {
 			logFileName = files[0]
 			return true
 		}
@@ -372,7 +368,7 @@ func requireEventLogFileExistsWithData(t *testing.T, agentFixture *atesting.Fixt
 	logEntry := readEventLogFile(t, agentFixture)
 	// That's part of the generated event that is logged by the 'processor'
 	// logger at level debug
-	expectedStr := "TestEventLogFile"
+	expectedStr := "Cannot index event"
 	if !strings.Contains(logEntry, expectedStr) {
 		t.Errorf(
 			"did not find the expected log entry ('%s') in the events log file",

--- a/testing/integration/ess/event_logging_test.go
+++ b/testing/integration/ess/event_logging_test.go
@@ -129,7 +129,7 @@ func TestEventLogFile(t *testing.T) {
 	})
 
 	// Now the Elastic-Agent is running, so validate the Event log file.
-	requireEventLogFileExistsWithData(t, agentFixture)
+	requireEventLogFileExistsWithData(t, agentFixture, "Publish event: ")
 	requireNoCopyProcessorError(t, agentFixture)
 
 	// The diagnostics command is already tested by another test,
@@ -254,7 +254,8 @@ func TestEventLogOutputConfiguredViaFleet(t *testing.T) {
 
 	// The default behaviour is to log events to the events log file
 	// so ensure this is happening
-	requireEventLogFileExistsWithData(t, agentFixture)
+	// As the mockEs returns indexing failures, we should see "Cannot index event" in the events log file
+	requireEventLogFileExistsWithData(t, agentFixture, "Cannot index event")
 
 	// Add a policy overwrite to change the events output to stderr
 	addOverwriteToPolicy(t, info, policyName, policyID)
@@ -302,7 +303,15 @@ func addOverwriteToPolicy(t *testing.T, info *define.Info, policyName, policyID 
           "to_stderr": true,
           "to_files": false
         }
-      }
+      },
+	  "internal": {
+		"runtime": {
+		  "default": "process",
+  		  "filebeat": {
+	  		"default": "process"
+		  }
+		}
+	  }
     }
   }
 }`, policyName)
@@ -367,11 +376,10 @@ func requireNoCopyProcessorError(t *testing.T, agentFixture *atesting.Fixture) {
 	}
 }
 
-func requireEventLogFileExistsWithData(t *testing.T, agentFixture *atesting.Fixture) {
+func requireEventLogFileExistsWithData(t *testing.T, agentFixture *atesting.Fixture, expectedStr string) {
 	logEntry := readEventLogFile(t, agentFixture)
 	// That's part of the generated event that is logged by the 'processor'
 	// logger at level debug
-	expectedStr := "Cannot index event"
 	if !strings.Contains(logEntry, expectedStr) {
 		t.Errorf(
 			"did not find the expected log entry ('%s') in the events log file",

--- a/testing/integration/ess/event_logging_test.go
+++ b/testing/integration/ess/event_logging_test.go
@@ -166,7 +166,7 @@ func TestEventLogOutputConfiguredViaFleet(t *testing.T) {
 		},
 		Group: "container",
 	})
-
+	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/5159")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 

--- a/testing/integration/ess/event_logging_test.go
+++ b/testing/integration/ess/event_logging_test.go
@@ -166,7 +166,7 @@ func TestEventLogOutputConfiguredViaFleet(t *testing.T) {
 		},
 		Group: "container",
 	})
-	t.Skip("Flaky test: https://github.com/elastic/elastic-agent/issues/5159")
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 


### PR DESCRIPTION
## What does this PR do?

It looks like this [PR broke](https://github.com/elastic/elastic-agent/pull/14408) event logging update via fleet. `logging.event_data` fields is not mapped correctly, because `NewPartialFromConfigNoDefaults` lacks the correct path separator option.

This PR fixes following things:
1. Adds `PathSep(".")` option, so the config is correctly unpacked. 
2. Moves `applyEventLoggingOutputChange` before we persist the configuration. As of now, we're updating the in-memory configuration after persisting it, which is incorrect and we'll hit a reexec loop. 
3. Save action synchronously, as a reexec can lead to early shutdown and stored action can be out-of-date with latest `fleet.enc`.
4. Uncomments the integration test that was skipped. It should work now.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

IMO this is a regression and given that 9.3.6 and 9.4.3 FF on 16th June, we should fix this.
