### PR TITLE
[8.19] nit: use new(false) instead of temp variable for CertificateReload default

### DIFF
--- a/internal/pkg/agent/configuration/fleet_server.go
+++ b/internal/pkg/agent/configuration/fleet_server.go
@@ -28,8 +28,7 @@ func (c *FleetServerConfig) Validate() error {
 	// by default so it does not land silently in a patch release. Operators who
 	// want it can set ssl.certificate_reload.enabled: true in their config.
 	if c.TLS != nil && c.TLS.CertificateReload.Enabled == nil {
-		enabled := false
-		c.TLS.CertificateReload.Enabled = &enabled
+		c.TLS.CertificateReload.Enabled = new(false)
 	}
 	return nil
 }
@@ -71,8 +70,7 @@ func (c *Elasticsearch) Validate() error {
 	// by default so it does not land silently in a patch release. Operators who
 	// want it can set ssl.certificate_reload.enabled: true in their config.
 	if c.TLS != nil && c.TLS.CertificateReload.Enabled == nil {
-		enabled := false
-		c.TLS.CertificateReload.Enabled = &enabled
+		c.TLS.CertificateReload.Enabled = new(false)
 	}
 	return nil
 }

--- a/internal/pkg/remote/config.go
+++ b/internal/pkg/remote/config.go
@@ -75,8 +75,7 @@ func (c *Config) Validate() error {
 		// by default so it does not land silently in a patch release. Operators who
 		// want it can set ssl.certificate_reload.enabled: true in their config.
 		if c.Transport.TLS.CertificateReload.Enabled == nil {
-			enabled := false
-			c.Transport.TLS.CertificateReload.Enabled = &enabled
+			c.Transport.TLS.CertificateReload.Enabled = new(false)
 		}
 		return c.Transport.TLS.Validate()
 	}


### PR DESCRIPTION
## What does this PR do?

Applies the suggestion from https://github.com/elastic/elastic-agent/pull/14597#discussion_r3342004680 to the 8.19 branch.

Replaces the two-line `enabled := false; ... = &enabled` pattern with the more concise `new(false)` in the `CertificateReload` nil-guard added by #14599.

## Why is it important?

Cleaner code, fewer temporary variables.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Disruptive User Impact

None — behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)