### PR TITLE
Export enrollment and ack backoff constants from pkg/fleetapi

### DIFF
--- a/internal/pkg/agent/application/enroll/enroll.go
+++ b/internal/pkg/agent/application/enroll/enroll.go
@@ -34,11 +34,10 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/remote"
 	"github.com/elastic/elastic-agent/pkg/backoff"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
+	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 )
 
 const (
-	EnrollBackoffInit      = time.Second * 5
-	EnrollBackoffMax       = time.Minute * 10
 	EnrollInfiniteAttempts = -1
 
 	maxRetriesstoreAgentInfo       = 5
@@ -64,7 +63,7 @@ func EnrollWithBackoff(
 ) error {
 	if backoffFactory == nil {
 		backoffFactory = func(done <-chan struct{}) backoff.Backoff {
-			return backoff.NewEqualJitterBackoff(done, EnrollBackoffInit, EnrollBackoffMax)
+			return backoff.NewEqualJitterBackoff(done, pkgfleetapi.EnrollBackoffInit, pkgfleetapi.EnrollBackoffMax)
 		}
 	}
 	delay(ctx, enrollDelay)
@@ -91,7 +90,7 @@ func EnrollWithBackoff(
 		return nil
 	}
 
-	log.Infof("1st enrollment attempt failed, retrying enrolling to URL: %s with exponential backoff (init %s, max %s)", client.URI(), EnrollBackoffInit, EnrollBackoffMax)
+	log.Infof("1st enrollment attempt failed, retrying enrolling to URL: %s with exponential backoff (init %s, max %s)", client.URI(), pkgfleetapi.EnrollBackoffInit, pkgfleetapi.EnrollBackoffMax)
 
 	signal := make(chan struct{})
 	defer close(signal)

--- a/internal/pkg/agent/cmd/enroll_cmd.go
+++ b/internal/pkg/agent/cmd/enroll_cmd.go
@@ -32,6 +32,7 @@ import (
 	"github.com/elastic/elastic-agent/pkg/control/v2/client/wait"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 	"github.com/elastic/elastic-agent/pkg/core/process"
+	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/pkg/utils"
 )
 
@@ -78,7 +79,7 @@ func newEnrollCmd(
 ) (*enrollCmd, error) {
 	if backoffFactory == nil {
 		backoffFactory = func(done <-chan struct{}) backoff.Backoff {
-			return backoff.NewEqualJitterBackoff(done, enroll.EnrollBackoffInit, enroll.EnrollBackoffMax)
+			return backoff.NewEqualJitterBackoff(done, pkgfleetapi.EnrollBackoffInit, pkgfleetapi.EnrollBackoffMax)
 		}
 	}
 	return &enrollCmd{

--- a/internal/pkg/fleetapi/acker/retrier/retrier.go
+++ b/internal/pkg/fleetapi/acker/retrier/retrier.go
@@ -13,14 +13,10 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/pkg/backoff"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
+	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 )
 
-const (
-	defaultMaxRetries = 5
-
-	defaultInitialRetryInterval = 1 * time.Minute
-	defaultMaxRetryInterval     = 5 * time.Minute
-)
+const defaultMaxRetries = 5
 
 // BatchAcker provider interface, implemented by fleet acker
 type BatchAcker interface {
@@ -52,8 +48,8 @@ func New(acker BatchAcker, log *logger.Logger, opts ...Option) *Retrier {
 	r := &Retrier{
 		acker:                acker,
 		log:                  log,
-		initialRetryInterval: defaultInitialRetryInterval,
-		maxRetryInterval:     defaultMaxRetryInterval,
+		initialRetryInterval: pkgfleetapi.AckBackoffInit,
+		maxRetryInterval:     pkgfleetapi.AckBackoffMax,
 		maxRetries:           defaultMaxRetries,
 		kickCh:               make(chan struct{}, 1),
 		doneCh:               make(chan struct{}, 1),

--- a/pkg/fleetapi/backoff.go
+++ b/pkg/fleetapi/backoff.go
@@ -1,0 +1,22 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package fleetapi
+
+import "time"
+
+// Backoff constants for Fleet Server client operations. Exported so external
+// consumers (e.g. Horde) can use the same values and avoid drift.
+
+// EnrollBackoffInit is the initial backoff duration for enrollment retries.
+const EnrollBackoffInit = 5 * time.Second
+
+// EnrollBackoffMax is the maximum backoff duration for enrollment retries.
+const EnrollBackoffMax = 10 * time.Minute
+
+// AckBackoffInit is the initial backoff duration for action-ack retries.
+const AckBackoffInit = 1 * time.Minute
+
+// AckBackoffMax is the maximum backoff duration for action-ack retries.
+const AckBackoffMax = 5 * time.Minute


### PR DESCRIPTION
## What does this PR do?

Adds four backoff constants to `pkg/fleetapi`:

- `EnrollBackoffInit` (5s) — initial backoff for enrollment retries
- `EnrollBackoffMax` (10m) — max backoff for enrollment retries
- `AckBackoffInit` (1m) — initial backoff for action-ack retries
- `AckBackoffMax` (5m) — max backoff for action-ack retries

Internal callers (`enroll.go`, `enroll_cmd.go`, `acker/retrier`) are updated to reference these constants directly instead of defining their own.

## Why is it important?

External consumers (Horde) need to import the same backoff values to stay consistent with Agent and avoid silent drift. Since `pkg/fleetapi` is already imported by Horde for `CheckinCmd` types, adding the constants here avoids introducing a new package dependency.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] No behavior change — values are identical to what was previously hardcoded

## Related issues

- Relates elastic/ingest-dev#7601 (item 13)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)