### PR TITLE
Test new crossbuild images

### DIFF
--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -38,7 +38,7 @@ const (
 	// Docker images. See https://github.com/elastic/golang-crossbuild.
 	beatsFPMImage = "docker.elastic.co/beats-dev/fpm"
 	// BeatsCrossBuildImage is the image used for crossbuilding Beats.
-	BeatsCrossBuildImage = "docker.elastic.co/beats-dev/golang-crossbuild"
+	BeatsCrossBuildImage = "docker.elastic.co/observability-ci/golang-crossbuild"
 
 	elasticAgentImportPath = "github.com/elastic/elastic-agent"
 


### PR DESCRIPTION
Test the new crossbuild images built from https://github.com/elastic/golang-crossbuild/pull/735.