### PR TITLE
[8.19] Fix IAR container images

### DIFF
--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -590,7 +590,7 @@ shared:
         source: '{{ elastic_beats_dir }}/dev-tools/packaging/files/linux/metricbeat.sh'
         mode: 0755
       'data/cloud_downloads/agentbeat-{{ agent_package_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz':
-        source: '{{.AgentDropPath}}/archives/{{.GOOS}}-{{.AgentArchName}}.tar.gz/agentbeat-{{ agent_package_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz'
+        source: '{{.AgentDropPath}}/archives/{{.GOOS}}-{{.AgentArchName}}.tar.gz/agentbeat-{{ agent_core_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz'
         mode: 0755
 
   - &agent_docker_cloud_fips_spec
@@ -605,7 +605,7 @@ shared:
         source: '{{ elastic_beats_dir }}/dev-tools/packaging/files/linux/metricbeat.sh'
         mode: 0755
       'data/cloud_downloads/agentbeat-fips-{{ agent_package_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz':
-        source: '{{.AgentDropPath}}/archives/{{.GOOS}}-{{.AgentArchName}}.tar.gz/agentbeat-fips-{{ agent_package_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz'
+        source: '{{.AgentDropPath}}/archives/{{.GOOS}}-{{.AgentArchName}}.tar.gz/agentbeat-fips-{{ agent_core_version }}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.GOOS}}-{{.AgentArchName}}.tar.gz'
         mode: 0755
 
   # service build is based on previous cloud variant


### PR DESCRIPTION
Fix some 8.19-specific Independent Agent Release problems related to recent package version resolution changes. This is more a hacky workaround than a real fix, but I'd like to unblock this first. See failure here: https://buildkite.com/elastic/elastic-agent-package/builds/12919.

As a follow-up, I'll probably introduce a separate `dependencies_version` template variable which will allow these paths to be used unambiguously.