### PR TITLE
Add an integration test for synthetics policy with 10k monitors.

### DIFF
--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -791,6 +791,7 @@ steps:
               - "${IMAGE_DEBIAN_13}"
             variant:
               - default
+              - extended
 
       - label: "linux:amd64:tier3:sudo:{{matrix.variant}}:{{matrix.os}}"
         depends_on:

--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -791,7 +791,7 @@ steps:
               - "${IMAGE_DEBIAN_13}"
             variant:
               - default
-              - extended
+              - stress
 
       - label: "linux:amd64:tier3:sudo:{{matrix.variant}}:{{matrix.os}}"
         depends_on:

--- a/pkg/testing/common/stack.go
+++ b/pkg/testing/common/stack.go
@@ -61,6 +61,10 @@ type StackRequest struct {
 
 	// Version is the version of the stack.
 	Version string `yaml:"version"`
+
+	// KibanaMemoryMB overrides the Kibana instance memory (MiB).
+	// When 0 the provisioner default is used.
+	KibanaMemoryMB int `yaml:"kibana_memory_mb,omitempty"`
 }
 
 // StackProvisioner performs the provisioning of stacks.

--- a/pkg/testing/define/batch.go
+++ b/pkg/testing/define/batch.go
@@ -206,6 +206,9 @@ func appendTest(batches []Batch, tar testActionResult, req Requirements) []Batch
 		if req.Stack != nil && batch.Stack == nil {
 			// assign the stack to this batch
 			batch.Stack = copyStack(req.Stack)
+		} else if req.Stack != nil && req.Stack.KibanaMemoryMB > batch.Stack.KibanaMemoryMB {
+			// take the highest KibanaMemoryMB requested by any test in this batch
+			batch.Stack.KibanaMemoryMB = req.Stack.KibanaMemoryMB
 		}
 		if req.Sudo {
 			batch.SudoTests = appendPackageTest(batch.SudoTests, tar.Package, tar.Test, req.Stack != nil)

--- a/pkg/testing/define/batch.go
+++ b/pkg/testing/define/batch.go
@@ -11,10 +11,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"gopkg.in/yaml.v2"
 )
+
+const deploymentCustomizationsFile = "deployment_customizations.yml"
 
 // defaultOS is the set of OS that are used in the case that a requirement doesn't define any
 var defaultOS = []OS{
@@ -51,6 +56,10 @@ type Batch struct {
 
 	// Stack defines the stack required for this batch.
 	Stack *Stack `json:"stack,omitempty"`
+
+	// Customization holds deployment overrides for this batch derived from
+	// deployment_customizations.yml based on the batch group.
+	Customization *GroupCustomization `json:"customization,omitempty"`
 
 	// Tests define the set of packages and tests that do not require sudo
 	// privileges to be performed.
@@ -143,6 +152,14 @@ func DetermineBatches(dir string, testFlags string, buildTags ...string) ([]Batc
 			batches = appendTest(batches, tar, req)
 		}
 	}
+
+	cleanDir := strings.TrimPrefix(dir, "./")
+	customizations, err := readDeploymentCustomizations(filepath.Join(cleanDir, deploymentCustomizationsFile))
+	if err != nil {
+		return nil, fmt.Errorf("reading deployment customizations: %w", err)
+	}
+	applyGroupCustomizations(batches, customizations)
+
 	return batches, nil
 }
 
@@ -205,11 +222,7 @@ func appendTest(batches []Batch, tar testActionResult, req Requirements) []Batch
 			batch.OS.DockerVariant = o.DockerVariant
 		}
 		if req.Stack != nil && batch.Stack == nil {
-			// assign the stack to this batch
 			batch.Stack = copyStack(req.Stack)
-		} else if req.Stack != nil && req.Stack.KibanaMemoryMB > batch.Stack.KibanaMemoryMB {
-			// take the highest KibanaMemoryMB requested by any test in this batch
-			batch.Stack.KibanaMemoryMB = req.Stack.KibanaMemoryMB
 		}
 		if req.Sudo {
 			batch.SudoTests = appendPackageTest(batch.SudoTests, tar.Package, tar.Test, req.Stack != nil)
@@ -308,4 +321,50 @@ type testActionResult struct {
 	Package string `json:"Package"`
 	Test    string `json:"Test"`
 	Output  string `json:"Output"`
+}
+
+// deploymentCustomizations holds per-group deployment overrides loaded from a
+// deployment_customizations.yml file in the test directory.
+type deploymentCustomizations struct {
+	Groups map[string]GroupCustomization `yaml:"groups"`
+}
+
+// GroupCustomization holds deployment overrides for a test group.
+type GroupCustomization struct {
+	KibanaMemoryMB int `yaml:"kibana_memory_mb" json:"kibana_memory_mb,omitempty"`
+}
+
+// readDeploymentCustomizations loads the deployment customizations file at the
+// given path. Returns nil without error when the file does not exist.
+func readDeploymentCustomizations(file string) (*deploymentCustomizations, error) {
+	data, err := os.ReadFile(file)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var c deploymentCustomizations
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// applyGroupCustomizations sets KibanaMemoryMB on each batch that has a Stack,
+// using the group-level override from the customizations file.
+// Batches without a Stack are left unchanged.
+func applyGroupCustomizations(batches []Batch, c *deploymentCustomizations) {
+	if c == nil {
+		return
+	}
+	for i, b := range batches {
+		if b.Stack == nil {
+			continue
+		}
+		if gc, ok := c.Groups[b.Group]; ok {
+			gc := gc
+			batches[i].Customization = &gc
+		}
+	}
 }

--- a/pkg/testing/define/batch.go
+++ b/pkg/testing/define/batch.go
@@ -338,7 +338,7 @@ type GroupCustomization struct {
 // given path. Returns nil without error when the file does not exist.
 func readDeploymentCustomizations(file string) (*deploymentCustomizations, error) {
 	data, err := os.ReadFile(file)
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}
 	if err != nil {

--- a/pkg/testing/define/batch.go
+++ b/pkg/testing/define/batch.go
@@ -7,6 +7,7 @@ package define
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -102,7 +103,7 @@ func DetermineBatches(dir string, testFlags string, buildTags ...string) ([]Batc
 	}
 
 	cmdArgs = append(cmdArgs, dir)
-	testCmd := exec.Command("go", cmdArgs...)
+	testCmd := exec.CommandContext(context.Background(), "go", cmdArgs...)
 	output, err := testCmd.Output()
 	if err != nil {
 		// format cmdArgs to make the error message more coherent

--- a/pkg/testing/define/requirements.go
+++ b/pkg/testing/define/requirements.go
@@ -89,6 +89,11 @@ type Stack struct {
 	// In the case that no version is provided the same version being used for
 	// the current test execution is used.
 	Version string `json:"version"`
+
+	// KibanaMemoryMB overrides the Kibana instance memory (MiB) for the stack
+	// provisioned for this test. When 0 the provisioner default (1024 MiB) is
+	// used. Tests that share a stack version get the maximum requested value.
+	KibanaMemoryMB int `json:"kibana_memory_mb,omitempty"`
 }
 
 // Requirements defines the testing requirements for the test to run.

--- a/pkg/testing/define/requirements.go
+++ b/pkg/testing/define/requirements.go
@@ -90,10 +90,6 @@ type Stack struct {
 	// the current test execution is used.
 	Version string `json:"version"`
 
-	// KibanaMemoryMB overrides the Kibana instance memory (MiB) for the stack
-	// provisioned for this test. When 0 the provisioner default (1024 MiB) is
-	// used. Tests that share a stack version get the maximum requested value.
-	KibanaMemoryMB int `json:"kibana_memory_mb,omitempty"`
 }
 
 // Requirements defines the testing requirements for the test to run.

--- a/pkg/testing/define/requirements.go
+++ b/pkg/testing/define/requirements.go
@@ -89,7 +89,6 @@ type Stack struct {
 	// In the case that no version is provided the same version being used for
 	// the current test execution is used.
 	Version string `json:"version"`
-
 }
 
 // Requirements defines the testing requirements for the test to run.

--- a/pkg/testing/ess/create_deployment_request.tmpl.json
+++ b/pkg/testing/ess/create_deployment_request.tmpl.json
@@ -82,7 +82,7 @@
               "zone_count": 1,
               "size": {
                 "resource": "memory",
-                "value": 1024
+                "value": {{ if .request.KibanaMemoryMB }}{{ .request.KibanaMemoryMB }}{{ else }}1024{{ end }}
               }
             }
           ],

--- a/pkg/testing/ess/deployment.go
+++ b/pkg/testing/ess/deployment.go
@@ -27,10 +27,11 @@ type Tag struct {
 }
 
 type CreateDeploymentRequest struct {
-	Name    string `json:"name"`
-	Region  string `json:"region"`
-	Version string `json:"version"`
-	Tags    []Tag  `json:"tags"`
+	Name           string `json:"name"`
+	Region         string `json:"region"`
+	Version        string `json:"version"`
+	Tags           []Tag  `json:"tags"`
+	KibanaMemoryMB int    `json:"kibana_memory_mb,omitempty"`
 }
 
 type CreateDeploymentResponse struct {

--- a/pkg/testing/ess/statful_provisioner.go
+++ b/pkg/testing/ess/statful_provisioner.go
@@ -225,10 +225,11 @@ func (p *StatefulProvisioner) createDeployment(ctx context.Context, r common.Sta
 	}
 
 	createDeploymentRequest := CreateDeploymentRequest{
-		Name:    name,
-		Region:  p.cfg.Region,
-		Version: r.Version,
-		Tags:    tagArray,
+		Name:           name,
+		Region:         p.cfg.Region,
+		Version:        r.Version,
+		Tags:           tagArray,
+		KibanaMemoryMB: r.KibanaMemoryMB,
 	}
 
 	resp, err := p.client.CreateDeployment(ctx, createDeploymentRequest)

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -621,6 +621,7 @@ func (r *Runner) createRepoArchive(ctx context.Context, repoDir string, dir stri
 func (r *Runner) startStacks(ctx context.Context) error {
 	var versions []string
 	batchToVersion := make(map[string]string)
+	versionToKibanaMemory := make(map[string]int)
 	for _, lb := range r.batches {
 		if !lb.Skip && lb.Batch.Stack != nil {
 			if lb.Batch.Stack.Version == "" {
@@ -631,6 +632,9 @@ func (r *Runner) startStacks(ctx context.Context) error {
 				versions = append(versions, lb.Batch.Stack.Version)
 			}
 			batchToVersion[lb.ID] = lb.Batch.Stack.Version
+			if lb.Batch.Stack.KibanaMemoryMB > versionToKibanaMemory[lb.Batch.Stack.Version] {
+				versionToKibanaMemory[lb.Batch.Stack.Version] = lb.Batch.Stack.KibanaMemoryMB
+			}
 		}
 	}
 
@@ -638,8 +642,12 @@ func (r *Runner) startStacks(ctx context.Context) error {
 	for _, version := range versions {
 		id := strings.ReplaceAll(version, ".", "")
 		requests = append(requests, stackReq{
-			request: common.StackRequest{ID: id, Version: version},
-			stack:   r.findStack(id),
+			request: common.StackRequest{
+				ID:             id,
+				Version:        version,
+				KibanaMemoryMB: versionToKibanaMemory[version],
+			},
+			stack: r.findStack(id),
 		})
 	}
 

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -632,8 +632,8 @@ func (r *Runner) startStacks(ctx context.Context) error {
 				versions = append(versions, lb.Batch.Stack.Version)
 			}
 			batchToVersion[lb.ID] = lb.Batch.Stack.Version
-			if lb.Batch.Stack.KibanaMemoryMB > versionToKibanaMemory[lb.Batch.Stack.Version] {
-				versionToKibanaMemory[lb.Batch.Stack.Version] = lb.Batch.Stack.KibanaMemoryMB
+			if lb.Batch.Customization != nil && lb.Batch.Customization.KibanaMemoryMB > versionToKibanaMemory[lb.Batch.Stack.Version] {
+				versionToKibanaMemory[lb.Batch.Stack.Version] = lb.Batch.Customization.KibanaMemoryMB
 			}
 		}
 	}

--- a/testing/integration/ess/deployment_customizations.yml
+++ b/testing/integration/ess/deployment_customizations.yml
@@ -1,0 +1,5 @@
+# deployment_customizations.yml maps test groups to ESS deployment settings.
+# Groups not listed here use the provisioner default (1 GB Kibana).
+groups:
+  stress:
+    kibana_memory_mb: 4096

--- a/testing/integration/ess/large_synthetics_policy_test.go
+++ b/testing/integration/ess/large_synthetics_policy_test.go
@@ -1,0 +1,318 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build integration
+
+package ess
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/kibana"
+	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
+	atesting "github.com/elastic/elastic-agent/pkg/testing"
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+	"github.com/elastic/elastic-agent/pkg/testing/tools"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/check"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/testcontext"
+	"github.com/elastic/elastic-agent/testing/integration"
+)
+
+const (
+	// syntheticsBatchSize is intentionally larger than the @elastic/synthetics CLI
+	// default of 250 (src/push/kibana_api.ts) to reduce the number of round-trips
+	// when seeding 10 000 monitors. The Kibana project API accepts up to 1 500
+	// lightweight monitors per request.
+	syntheticsBatchSize = 1000
+
+	numHTTPMonitors = 8000
+	numICMPMonitors = 1000
+	numTCPMonitors  = 1000
+)
+
+// TestLargeSyntheticsPolicy verifies that an elastic-agent can enroll into and
+// stay healthy under a Fleet policy that contains 10 000 synthetic monitors
+// (8 000 HTTP + 1 000 TCP + 1 000 ICMP) on a single private location.
+func TestLargeSyntheticsPolicy(t *testing.T) {
+	info := define.Require(t, define.Requirements{
+		Group: integration.Fleet,
+		Stack: &define.Stack{
+			KibanaMemoryMB: 4096,
+		},
+		Local: false,
+		Sudo:  true,
+	})
+
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(30*time.Minute))
+	defer cancel()
+
+	// 1. Start a local HTTP server. All three monitor types target it so it must
+	//    remain alive for the duration of the test.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "Hello, World!")
+	}))
+	t.Cleanup(ts.Close)
+
+	tsURL, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	tsHost := tsURL.Hostname()
+	tsPort := tsURL.Port()
+
+	// 2. Create a Fleet agent policy.
+	uid := uuid.Must(uuid.NewV4()).String()
+	policyResp, err := info.KibanaClient.CreatePolicy(ctx, kibana.AgentPolicy{
+		Name:        fmt.Sprintf("test-large-synthetics-%s", uid),
+		Namespace:   info.Namespace,
+		Description: "large synthetics policy test",
+		MonitoringEnabled: []kibana.MonitoringEnabledOption{
+			kibana.MonitoringEnabledLogs,
+			kibana.MonitoringEnabledMetrics,
+		},
+	})
+	require.NoError(t, err)
+	t.Logf("created Fleet policy %s", policyResp.ID)
+
+	// 3. Create a Synthetics private location backed by the Fleet policy.
+	locationLabel := fmt.Sprintf("test-location-%s", uid)
+	privLocID, err := createSyntheticsPrivateLocation(ctx, info.KibanaClient, locationLabel, policyResp.ID)
+	require.NoError(t, err)
+	t.Logf("created private location %s (label: %s)", privLocID, locationLabel)
+
+	// 4. Push 10 000 monitors to the private location in batches.
+	projectName := fmt.Sprintf("large-policy-test-%s", uid)
+	monitors := buildSyntheticsMonitors(tsHost, tsPort, locationLabel)
+	t.Logf("pushing %d monitors in batches of %d", len(monitors), syntheticsBatchSize)
+	require.NoError(t, bulkPushSyntheticsMonitors(ctx, t, info.KibanaClient, projectName, monitors))
+	t.Logf("pushed %d monitors", len(monitors))
+
+	// 5. Install the agent enrolled into the policy.
+	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
+	require.NoError(t, err)
+
+	agentID, err := tools.InstallAgentForPolicy(ctx, t, atesting.InstallOpts{
+		NonInteractive: true,
+		Force:          true,
+		Privileged:     true,
+	}, agentFixture, info.KibanaClient, policyResp.ID)
+	require.NoError(t, err)
+	t.Logf("enrolled agent %s", agentID)
+
+	// 6. Wait for the agent to connect to Fleet and for every component to
+	//    reach the HEALTHY state.
+	check.ConnectedToFleet(ctx, t, agentFixture, 10*time.Minute)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		status, err := agentFixture.ExecStatus(ctx)
+		require.NoError(c, err)
+		require.NotEmpty(c, status.Components, "expected at least one component")
+		for _, comp := range status.Components {
+			assert.Equalf(c, int(cproto.State_HEALTHY), comp.State, "component %s not healthy", comp.Name)
+		}
+		t.Logf("agent healthy with %d components", len(status.Components))
+	}, 10*time.Minute, 10*time.Second, "agent did not reach fully healthy state")
+}
+
+// --- Kibana Synthetics API helpers ---
+
+type syntheticsPrivateLocationResp struct {
+	ID            string `json:"id"`
+	Label         string `json:"label"`
+	AgentPolicyID string `json:"agentPolicyId"`
+}
+
+func createSyntheticsPrivateLocation(ctx context.Context, client *kibana.Client, label, policyID string) (string, error) {
+	body, err := json.Marshal(map[string]string{
+		"label":         label,
+		"agentPolicyId": policyID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshaling private location request: %w", err)
+	}
+
+	headers := http.Header{"Content-Type": []string{"application/json"}}
+	resp, err := client.SendWithContext(ctx, http.MethodPost, "/api/synthetics/private_locations", nil, headers, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("sending private location request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading private location response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("private location API returned %d: %s", resp.StatusCode, respBody)
+	}
+
+	var loc syntheticsPrivateLocationResp
+	if err := json.Unmarshal(respBody, &loc); err != nil {
+		return "", fmt.Errorf("decoding private location response: %w", err)
+	}
+	return loc.ID, nil
+}
+
+type syntheticsMonitorSchema struct {
+	ID               string   `json:"id"`
+	Type             string   `json:"type"`
+	Name             string   `json:"name"`
+	Enabled          bool     `json:"enabled"`
+	Schedule         int      `json:"schedule"` // minutes; project API accepts a plain integer
+	PrivateLocations []string `json:"privateLocations"`
+	URLs             string   `json:"urls,omitempty"`
+	Hosts            string   `json:"hosts,omitempty"`
+}
+
+type syntheticsBulkPutRequest struct {
+	Monitors []syntheticsMonitorSchema `json:"monitors"`
+}
+
+type syntheticsBulkPutResponse struct {
+	CreatedMonitors []any `json:"createdMonitors"`
+	UpdatedMonitors []any `json:"updatedMonitors"`
+	FailedMonitors  []struct {
+		ID      string          `json:"id"`
+		Reason  string          `json:"reason"`
+		Details string          `json:"details"`
+		Payload json.RawMessage `json:"payload,omitempty"`
+	} `json:"failedMonitors"`
+}
+
+func buildSyntheticsMonitors(host, port, locationLabel string) []syntheticsMonitorSchema {
+	total := numHTTPMonitors + numICMPMonitors + numTCPMonitors
+	monitors := make([]syntheticsMonitorSchema, 0, total)
+
+	for i := range numHTTPMonitors {
+		path := uuid.Must(uuid.NewV4()).String()
+		monitors = append(monitors, syntheticsMonitorSchema{
+			ID:               fmt.Sprintf("http-monitor-%d", i),
+			Type:             "http",
+			Name:             fmt.Sprintf("HTTP Monitor %d", i),
+			Enabled:          true,
+			Schedule:         1,
+			PrivateLocations: []string{locationLabel},
+			URLs:             fmt.Sprintf("http://%s:%s/%s", host, port, path),
+		})
+	}
+
+	for i := range numTCPMonitors {
+		monitors = append(monitors, syntheticsMonitorSchema{
+			ID:               fmt.Sprintf("tcp-monitor-%d", i),
+			Type:             "tcp",
+			Name:             fmt.Sprintf("TCP Monitor %d", i),
+			Enabled:          true,
+			Schedule:         1,
+			PrivateLocations: []string{locationLabel},
+			Hosts:            fmt.Sprintf("%s:%s", host, port),
+		})
+	}
+
+	for i := range numICMPMonitors {
+		monitors = append(monitors, syntheticsMonitorSchema{
+			ID:               fmt.Sprintf("icmp-monitor-%d", i),
+			Type:             "icmp",
+			Name:             fmt.Sprintf("ICMP Monitor %d", i),
+			Enabled:          true,
+			Schedule:         1,
+			PrivateLocations: []string{locationLabel},
+			Hosts:            host,
+		})
+	}
+
+	return monitors
+}
+
+// bulkPushSyntheticsMonitors uploads monitors to the Synthetics project API in
+// batches of syntheticsBatchSize with a short inter-batch pause to avoid
+// overwhelming the server.
+func bulkPushSyntheticsMonitors(ctx context.Context, t *testing.T, client *kibana.Client, projectName string, monitors []syntheticsMonitorSchema) error {
+	apiURL := fmt.Sprintf("/api/synthetics/project/%s/monitors/_bulk_update", projectName)
+	headers := http.Header{"Content-Type": []string{"application/json"}}
+
+	for start := 0; start < len(monitors); start += syntheticsBatchSize {
+		end := min(start+syntheticsBatchSize, len(monitors))
+		batchNum := start / syntheticsBatchSize
+
+		reqBody, err := json.Marshal(syntheticsBulkPutRequest{Monitors: monitors[start:end]})
+		if err != nil {
+			return fmt.Errorf("marshaling batch %d: %w", batchNum, err)
+		}
+
+		t.Logf("pushing batch %d (%d-%d of %d)", batchNum, start, end, len(monitors))
+		if err := sendBatchWithRetry(ctx, t, client, apiURL, headers, reqBody, batchNum); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// sendBatchWithRetry sends a single batch to the Kibana Synthetics API. On
+// transient failures (network error, 429, 5xx) it retries with exponential
+// backoff (15s base, 2× multiplier, 5 min cap, 10 attempts).
+func sendBatchWithRetry(ctx context.Context, t *testing.T, client *kibana.Client, apiURL string, headers http.Header, reqBody []byte, batchNum int) error {
+	const (
+		maxAttempts = 10
+		baseDelay   = 15 * time.Second
+		maxDelay    = 5 * time.Minute
+	)
+	var lastErr error
+	delay := baseDelay
+	for attempt := range maxAttempts {
+		if attempt > 0 {
+			t.Logf("batch %d: attempt %d failed (%v); backing off %s", batchNum, attempt, lastErr, delay)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+			delay = min(delay*2, maxDelay)
+		}
+
+		resp, err := client.SendWithContext(ctx, http.MethodPut, apiURL, nil, headers, bytes.NewReader(reqBody))
+		if err != nil {
+			lastErr = fmt.Errorf("network error: %w", err)
+			continue
+		}
+
+		respBody, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			lastErr = fmt.Errorf("reading response: %w", err)
+			continue
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			lastErr = fmt.Errorf("status %d: %s", resp.StatusCode, respBody)
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("batch %d returned %d: %s", batchNum, resp.StatusCode, respBody)
+		}
+
+		var putResp syntheticsBulkPutResponse
+		if err := json.Unmarshal(respBody, &putResp); err != nil {
+			return fmt.Errorf("decoding batch %d response: %w", batchNum, err)
+		}
+		if len(putResp.FailedMonitors) > 0 {
+			first := putResp.FailedMonitors[0]
+			return fmt.Errorf("batch %d: %d monitors failed; first: id=%s reason=%q details=%q",
+				batchNum, len(putResp.FailedMonitors), first.ID, first.Reason, first.Details)
+		}
+		return nil
+	}
+	return fmt.Errorf("batch %d: max retries exceeded; last error: %w", batchNum, lastErr)
+}

--- a/testing/integration/ess/large_synthetics_policy_test.go
+++ b/testing/integration/ess/large_synthetics_policy_test.go
@@ -49,7 +49,7 @@ const (
 // (8 000 HTTP + 1 000 TCP + 1 000 ICMP) on a single private location.
 func TestLargeSyntheticsPolicy(t *testing.T) {
 	info := define.Require(t, define.Requirements{
-		Group: integration.Fleet,
+		Group: integration.Extended,
 		Stack: &define.Stack{
 			KibanaMemoryMB: 4096,
 		},

--- a/testing/integration/ess/large_synthetics_policy_test.go
+++ b/testing/integration/ess/large_synthetics_policy_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -57,23 +58,69 @@ func TestLargeSyntheticsPolicy(t *testing.T) {
 		Sudo:  true,
 	})
 
-	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(30*time.Minute))
-	defer cancel()
+	t.Run("all monitors succeed", func(t *testing.T) {
+		ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(30*time.Minute))
+		defer cancel()
 
-	// 1. Start a local HTTP server. All three monitor types target it so it must
-	//    remain alive for the duration of the test.
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "Hello, World!")
-	}))
-	t.Cleanup(ts.Close)
+		// Start a local HTTP server that always returns 200.
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "Hello, World!")
+		}))
+		t.Cleanup(ts.Close)
 
-	tsURL, err := url.Parse(ts.URL)
+		agentFixture := setupMonitorsAndAgent(t, ctx, info, ts.URL)
+
+		// ensure all components are healthy
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			status, err := agentFixture.ExecStatus(ctx)
+			require.NoError(c, err)
+			require.NotEmpty(c, status.Components, "expected at least one component")
+			for _, comp := range status.Components {
+				assert.Equalf(c, int(cproto.State_HEALTHY), comp.State, "component %s not healthy", comp.Name)
+			}
+			require.Equal(c, int(cproto.State_HEALTHY), status.State, "expected agent status to be healthy")
+			require.Equal(c, int(cproto.State_HEALTHY), status.FleetState, "expected fleet status to be healthy")
+			t.Logf("agent healthy with %d components", len(status.Components))
+		}, 10*time.Minute, 10*time.Second, "agent did not reach fully healthy state")
+	})
+
+	// Test where all monitors fail - payload information may be different then success case causing even larger checkin bodies.
+	t.Run("all monitors fail", func(t *testing.T) {
+		ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(30*time.Minute))
+		defer cancel()
+
+		// Start a local listener that closes all incoming connections immediatly.
+		l, err := net.Listen("tcp", "localhost:0")
+		require.NoError(t, err)
+		cl := &closeListener{l}
+		t.Cleanup(func() {
+			cl.Close()
+		})
+
+		agentFixture := setupMonitorsAndAgent(t, ctx, info, "http://"+cl.Addr().String())
+
+		// Ensure agent is not healthy
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			status, err := agentFixture.ExecStatus(ctx)
+			require.NoError(c, err)
+			require.NotEmpty(c, status.Components, "expected at least one component")
+			require.Equal(c, int(cproto.State_DEGRADED), status.State, "expected agent status to be degraded")
+			require.Equal(c, int(cproto.State_HEALTHY), status.FleetState, "expected fleet status to be healthy")
+		}, 10*time.Minute, 10*time.Second, "expected agent to be unhealthy")
+	})
+}
+
+// setupMonitorsAndAgent creates a policy and uses it as a synthetics private location for 10k monitors directed to testURL.
+// then install an agent with that policy and ensures the agent is connected to fleet.
+func setupMonitorsAndAgent(t *testing.T, ctx context.Context, info *define.Info, testURL string) *atesting.Fixture {
+	t.Helper()
+	tsURL, err := url.Parse(testURL)
 	require.NoError(t, err)
 	tsHost := tsURL.Hostname()
 	tsPort := tsURL.Port()
 
-	// 2. Create a Fleet agent policy.
+	// Create a Fleet agent policy.
 	uid := uuid.Must(uuid.NewV4()).String()
 	policyResp, err := info.KibanaClient.CreatePolicy(ctx, kibana.AgentPolicy{
 		Name:        fmt.Sprintf("test-large-synthetics-%s", uid),
@@ -87,20 +134,20 @@ func TestLargeSyntheticsPolicy(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("created Fleet policy %s", policyResp.ID)
 
-	// 3. Create a Synthetics private location backed by the Fleet policy.
+	// Create a Synthetics private location backed by the created Fleet policy.
 	locationLabel := fmt.Sprintf("test-location-%s", uid)
 	privLocID, err := createSyntheticsPrivateLocation(ctx, info.KibanaClient, locationLabel, policyResp.ID)
 	require.NoError(t, err)
 	t.Logf("created private location %s (label: %s)", privLocID, locationLabel)
 
-	// 4. Push 10 000 monitors to the private location in batches.
+	// Push 10 000 monitors to the private location in batches.
 	projectName := fmt.Sprintf("large-policy-test-%s", uid)
 	monitors := buildSyntheticsMonitors(tsHost, tsPort, locationLabel)
 	t.Logf("pushing %d monitors in batches of %d", len(monitors), syntheticsBatchSize)
 	require.NoError(t, bulkPushSyntheticsMonitors(ctx, t, info.KibanaClient, projectName, monitors))
 	t.Logf("pushed %d monitors", len(monitors))
 
-	// 5. Install the agent enrolled into the policy.
+	// Install an agent enrolled into the policy.
 	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
@@ -112,29 +159,21 @@ func TestLargeSyntheticsPolicy(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("enrolled agent %s", agentID)
 
-	// 6. Wait for the agent to connect to Fleet and for every component to
-	//    reach the HEALTHY state.
+	// Wait for the agent to connect to Fleet.
 	check.ConnectedToFleet(ctx, t, agentFixture, 10*time.Minute)
-
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		status, err := agentFixture.ExecStatus(ctx)
-		require.NoError(c, err)
-		require.NotEmpty(c, status.Components, "expected at least one component")
-		for _, comp := range status.Components {
-			assert.Equalf(c, int(cproto.State_HEALTHY), comp.State, "component %s not healthy", comp.Name)
-		}
-		t.Logf("agent healthy with %d components", len(status.Components))
-	}, 10*time.Minute, 10*time.Second, "agent did not reach fully healthy state")
+	return agentFixture
 }
 
 // --- Kibana Synthetics API helpers ---
 
+// syntheticsPrivateLocationResp is the response when defining a fleet policy as a private_location
 type syntheticsPrivateLocationResp struct {
 	ID            string `json:"id"`
 	Label         string `json:"label"`
 	AgentPolicyID string `json:"agentPolicyId"`
 }
 
+// createSyntheticsPriveLocation creates a private_location associated with the passed policyID and label.
 func createSyntheticsPrivateLocation(ctx context.Context, client *kibana.Client, label, policyID string) (string, error) {
 	body, err := json.Marshal(map[string]string{
 		"label":         label,
@@ -192,6 +231,11 @@ type syntheticsBulkPutResponse struct {
 	} `json:"failedMonitors"`
 }
 
+// buildSyntheticsMonitors creates 10k monitors for the passed host:port for the private_location specified by locationLabel.
+//
+// 8k http monitors are created - each with a different path (generated by random uuids)
+// 1k tcp monitors are created
+// 1k icmp monitors are created
 func buildSyntheticsMonitors(host, port, locationLabel string) []syntheticsMonitorSchema {
 	total := numHTTPMonitors + numICMPMonitors + numTCPMonitors
 	monitors := make([]syntheticsMonitorSchema, 0, total)
@@ -236,9 +280,8 @@ func buildSyntheticsMonitors(host, port, locationLabel string) []syntheticsMonit
 	return monitors
 }
 
-// bulkPushSyntheticsMonitors uploads monitors to the Synthetics project API in
-// batches of syntheticsBatchSize with a short inter-batch pause to avoid
-// overwhelming the server.
+// bulkPushSyntheticsMonitors uploads monitors to the Synthetics project API in batches.
+// If a batch fails it is retried with exponential backoff to avoid overwhelming the Kibana instance.
 func bulkPushSyntheticsMonitors(ctx context.Context, t *testing.T, client *kibana.Client, projectName string, monitors []syntheticsMonitorSchema) error {
 	apiURL := fmt.Sprintf("/api/synthetics/project/%s/monitors/_bulk_update", projectName)
 	headers := http.Header{"Content-Type": []string{"application/json"}}
@@ -260,9 +303,9 @@ func bulkPushSyntheticsMonitors(ctx context.Context, t *testing.T, client *kiban
 	return nil
 }
 
-// sendBatchWithRetry sends a single batch to the Kibana Synthetics API. On
-// transient failures (network error, 429, 5xx) it retries with exponential
-// backoff (15s base, 2× multiplier, 5 min cap, 10 attempts).
+// sendBatchWithRetry sends a single batch to the Kibana Synthetics API.
+// On transient failures (network error, 429, 5xx) it retries with exponential backoff.
+// (15s base, 2× multiplier, 5 min cap, 10 attempts)
 func sendBatchWithRetry(ctx context.Context, t *testing.T, client *kibana.Client, apiURL string, headers http.Header, reqBody []byte, batchNum int) error {
 	const (
 		maxAttempts = 10
@@ -315,4 +358,18 @@ func sendBatchWithRetry(ctx context.Context, t *testing.T, client *kibana.Client
 		return nil
 	}
 	return fmt.Errorf("batch %d: max retries exceeded; last error: %w", batchNum, lastErr)
+}
+
+// closeListener is a net.Listener that closes any accepted connections.
+type closeListener struct {
+	net.Listener
+}
+
+// Accept will accept a connction from the underlying listener and close it.
+func (c *closeListener) Accept() (net.Conn, error) {
+	conn, err := c.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	return nil, conn.Close()
 }

--- a/testing/integration/ess/large_synthetics_policy_test.go
+++ b/testing/integration/ess/large_synthetics_policy_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -24,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/kibana"
+	"github.com/elastic/elastic-agent/pkg/backoff"
 	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
@@ -46,17 +46,30 @@ const (
 )
 
 // TestLargeSyntheticsPolicy verifies that an elastic-agent can enroll into and
-// stay healthy under a Fleet policy that contains 10 000 synthetic monitors
+// connected to Fleet with a policy that contains 10 000 synthetic monitors
 // (8 000 HTTP + 1 000 TCP + 1 000 ICMP) on a single private location.
+// There are subtests for healthy, and unhealthy monitors.
 func TestLargeSyntheticsPolicy(t *testing.T) {
 	info := define.Require(t, define.Requirements{
-		Group: integration.Extended,
-		Stack: &define.Stack{
-			KibanaMemoryMB: 4096,
-		},
+		Group: integration.Stress,
+		Stack: &define.Stack{},
 		Local: false,
 		Sudo:  true,
 	})
+
+	validateSyntheticsHealthy := func(t *testing.T, ctx context.Context, agentFixture *atesting.Fixture) func(c *assert.CollectT) {
+		return func(c *assert.CollectT) {
+			status, err := agentFixture.ExecStatus(ctx)
+			require.NoError(c, err)
+			require.NotEmpty(c, status.Components, "expected at least one component")
+			for _, comp := range status.Components {
+				assert.Equalf(c, int(cproto.State_HEALTHY), comp.State, "component %s not healthy", comp.Name)
+			}
+			assert.Equal(c, int(cproto.State_HEALTHY), status.State, "expected agent status to be healthy")
+			assert.Equal(c, int(cproto.State_HEALTHY), status.FleetState, "expected fleet status to be healthy")
+			t.Logf("agent healthy with %d components", len(status.Components))
+		}
+	}
 
 	t.Run("all monitors succeed", func(t *testing.T) {
 		ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(30*time.Minute))
@@ -72,17 +85,7 @@ func TestLargeSyntheticsPolicy(t *testing.T) {
 		agentFixture := setupMonitorsAndAgent(t, ctx, info, ts.URL)
 
 		// ensure all components are healthy
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			status, err := agentFixture.ExecStatus(ctx)
-			require.NoError(c, err)
-			require.NotEmpty(c, status.Components, "expected at least one component")
-			for _, comp := range status.Components {
-				assert.Equalf(c, int(cproto.State_HEALTHY), comp.State, "component %s not healthy", comp.Name)
-			}
-			require.Equal(c, int(cproto.State_HEALTHY), status.State, "expected agent status to be healthy")
-			require.Equal(c, int(cproto.State_HEALTHY), status.FleetState, "expected fleet status to be healthy")
-			t.Logf("agent healthy with %d components", len(status.Components))
-		}, 10*time.Minute, 10*time.Second, "agent did not reach fully healthy state")
+		require.EventuallyWithT(t, validateSyntheticsHealthy(t, ctx, agentFixture), 10*time.Minute, 10*time.Second, "agent did not reach fully healthy state")
 	})
 
 	// Test where all monitors fail - payload information may be different then success case causing even larger checkin bodies.
@@ -90,24 +93,10 @@ func TestLargeSyntheticsPolicy(t *testing.T) {
 		ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(30*time.Minute))
 		defer cancel()
 
-		// Start a local listener that closes all incoming connections immediatly.
-		l, err := net.Listen("tcp", "localhost:0")
-		require.NoError(t, err)
-		cl := &closeListener{l}
-		t.Cleanup(func() {
-			cl.Close()
-		})
+		agentFixture := setupMonitorsAndAgent(t, ctx, info, "http://fake.internal:8080")
 
-		agentFixture := setupMonitorsAndAgent(t, ctx, info, "http://"+cl.Addr().String())
-
-		// Ensure agent is not healthy
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			status, err := agentFixture.ExecStatus(ctx)
-			require.NoError(c, err)
-			require.NotEmpty(c, status.Components, "expected at least one component")
-			require.Equal(c, int(cproto.State_DEGRADED), status.State, "expected agent status to be degraded")
-			require.Equal(c, int(cproto.State_HEALTHY), status.FleetState, "expected fleet status to be healthy")
-		}, 10*time.Minute, 10*time.Second, "expected agent to be unhealthy")
+		// even though the monitor fails - all componets and agent status is healthy
+		require.EventuallyWithT(t, validateSyntheticsHealthy(t, ctx, agentFixture), 10*time.Minute, 10*time.Second, "agent did not reach fully healthy state")
 	})
 }
 
@@ -312,19 +301,12 @@ func sendBatchWithRetry(ctx context.Context, t *testing.T, client *kibana.Client
 		baseDelay   = 15 * time.Second
 		maxDelay    = 5 * time.Minute
 	)
+	done := make(chan struct{})
+	defer close(done)
+	bo := backoff.NewExpBackoff(done, baseDelay, maxDelay)
 	var lastErr error
-	delay := baseDelay
-	for attempt := range maxAttempts {
-		if attempt > 0 {
-			t.Logf("batch %d: attempt %d failed (%v); backing off %s", batchNum, attempt, lastErr, delay)
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(delay):
-			}
-			delay = min(delay*2, maxDelay)
-		}
-
+	for range maxAttempts {
+		bo.Wait()
 		resp, err := client.SendWithContext(ctx, http.MethodPut, apiURL, nil, headers, bytes.NewReader(reqBody))
 		if err != nil {
 			lastErr = fmt.Errorf("network error: %w", err)
@@ -358,18 +340,4 @@ func sendBatchWithRetry(ctx context.Context, t *testing.T, client *kibana.Client
 		return nil
 	}
 	return fmt.Errorf("batch %d: max retries exceeded; last error: %w", batchNum, lastErr)
-}
-
-// closeListener is a net.Listener that closes any accepted connections.
-type closeListener struct {
-	net.Listener
-}
-
-// Accept will accept a connction from the underlying listener and close it.
-func (c *closeListener) Accept() (net.Conn, error) {
-	conn, err := c.Listener.Accept()
-	if err != nil {
-		return nil, err
-	}
-	return nil, conn.Close()
 }

--- a/testing/integration/ess/large_synthetics_policy_test.go
+++ b/testing/integration/ess/large_synthetics_policy_test.go
@@ -296,48 +296,39 @@ func bulkPushSyntheticsMonitors(ctx context.Context, t *testing.T, client *kiban
 // On transient failures (network error, 429, 5xx) it retries with exponential backoff.
 // (15s base, 2× multiplier, 5 min cap, 10 attempts)
 func sendBatchWithRetry(ctx context.Context, t *testing.T, client *kibana.Client, apiURL string, headers http.Header, reqBody []byte, batchNum int) error {
-	const (
-		maxAttempts = 10
-		baseDelay   = 15 * time.Second
-		maxDelay    = 5 * time.Minute
-	)
 	done := make(chan struct{})
 	defer close(done)
-	bo := backoff.NewExpBackoff(done, baseDelay, maxDelay)
-	var lastErr error
-	for range maxAttempts {
-		bo.Wait()
-		resp, err := client.SendWithContext(ctx, http.MethodPut, apiURL, nil, headers, bytes.NewReader(reqBody))
-		if err != nil {
-			lastErr = fmt.Errorf("network error: %w", err)
-			continue
-		}
-
-		respBody, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			lastErr = fmt.Errorf("reading response: %w", err)
-			continue
-		}
-
-		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
-			lastErr = fmt.Errorf("status %d: %s", resp.StatusCode, respBody)
-			continue
-		}
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("batch %d returned %d: %s", batchNum, resp.StatusCode, respBody)
-		}
-
-		var putResp syntheticsBulkPutResponse
-		if err := json.Unmarshal(respBody, &putResp); err != nil {
-			return fmt.Errorf("decoding batch %d response: %w", batchNum, err)
-		}
-		if len(putResp.FailedMonitors) > 0 {
-			first := putResp.FailedMonitors[0]
-			return fmt.Errorf("batch %d: %d monitors failed; first: id=%s reason=%q details=%q",
-				batchNum, len(putResp.FailedMonitors), first.ID, first.Reason, first.Details)
-		}
-		return nil
+	bo := backoff.NewExpBackoff(done, 15*time.Second, 5*time.Minute)
+	client.Retry = kibana.RetryConfig{
+		MaxRetries:    10,
+		RetryOnStatus: []int{http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout},
+		RetryBackoff: func(_ int) time.Duration {
+			return bo.NextWait()
+		},
 	}
-	return fmt.Errorf("batch %d: max retries exceeded; last error: %w", batchNum, lastErr)
+	resp, err := client.SendWithContext(ctx, http.MethodPut, apiURL, nil, headers, bytes.NewReader(reqBody))
+	if err != nil {
+		return err
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("batch %d returned %d: %s", batchNum, resp.StatusCode, respBody)
+	}
+
+	var putResp syntheticsBulkPutResponse
+	if err := json.Unmarshal(respBody, &putResp); err != nil {
+		return fmt.Errorf("decoding batch %d response: %w", batchNum, err)
+	}
+	if len(putResp.FailedMonitors) > 0 {
+		first := putResp.FailedMonitors[0]
+		return fmt.Errorf("batch %d: %d monitors failed; first: id=%s reason=%q details=%q",
+			batchNum, len(putResp.FailedMonitors), first.ID, first.Reason, first.Details)
+	}
+	return nil
 }

--- a/testing/integration/groups.go
+++ b/testing/integration/groups.go
@@ -58,4 +58,7 @@ const (
 
 	// ECHDeployment group of tests. Used for tests that orchestrate ECH deployments.
 	ECHDeployment = "ech-deployment"
+
+	// Extended test suite that contains tests that do not need to run on each PR.
+	Extended = "extended"
 )

--- a/testing/integration/groups.go
+++ b/testing/integration/groups.go
@@ -59,6 +59,6 @@ const (
 	// ECHDeployment group of tests. Used for tests that orchestrate ECH deployments.
 	ECHDeployment = "ech-deployment"
 
-	// Extended test suite that contains tests that do not need to run on each PR.
-	Extended = "extended"
+	// Stress test suite that contains tests that do not need to run on each PR.
+	Stress = "stress"
 )


### PR DESCRIPTION
## What does this PR do?

Add a new integration test that creates a policy with 10k lightweight synthetics monitors (1k tcp, 1k icmp, 8k http) associated with a private location (the test policy). Monitors all point at a local test server. The goal of this test is to ensure that very large checkins, with a lot of components succeed. Extended testing scaffolding to allow tests to request larger kibana instances as the 1GB instance was failing to properly create all monitors.

## Why is it important?

Customers have experienced issues in policies where a lot of monitors have been deployed in a policy.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

N/A test only

## Related issues

- Closes: https://github.com/elastic/elastic-agent/issues/11981