### PR TITLE
Fix packaging bug that incorrectly included cloud-defend in the Linux .tar.gz

### DIFF
--- a/changelog/fragments/1780517113-fix-accidental-inclusion-of-cloud-defend-in-linux-.tar.gz-saving-151m.yaml
+++ b/changelog/fragments/1780517113-fix-accidental-inclusion-of-cloud-defend-in-linux-.tar.gz-saving-151m.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix accidental inclusion of cloud-defend in the Linux .tar.gz saving 151 MB of disk space.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -703,12 +703,18 @@ func PackageTarGz(spec PackageSpec) error {
 	// 	spec.Files = newFiles
 	// }
 
+	// When building multiple package types simultaneously (e.g. PACKAGES=all),
+	// components that only support Docker may land in the shared drop path.
+	// Derive the exclusion list from the spec's component definitions so any
+	// future Docker-only component is also excluded without a code change.
+	excludedFromTar := componentFilesNotSupportingPackageType(spec.Components, pkgcommon.TarGz)
+
 	// Add files to tar (dirs before files so explicit entries take precedence).
 	for _, pkgFile := range dirsFirst(spec.Files) {
 		if pkgFile.Symlink {
 			continue
 		}
-		if err := addFileToTar(w, baseDir, pkgFile); err != nil {
+		if err := addFileToTar(w, baseDir, pkgFile, excludedFromTar); err != nil {
 			return fmt.Errorf("failed adding file=%+v to tar: %w", pkgFile, err)
 		}
 	}
@@ -990,10 +996,22 @@ func addFileToZip(ar *zip.Writer, baseDir string, pkgFile PackageFile) error {
 	})
 }
 
-// addFileToTar adds a file (or directory) to a tar archive.
-func addFileToTar(ar *tar.Writer, baseDir string, pkgFile PackageFile) error {
-	excludedFiles := []string{}
+// componentFilesNotSupportingPackageType returns the binary names and spec
+// filenames of components whose packageTypes field does not include pkgType.
+// These files should be excluded when assembling an archive of that type.
+func componentFilesNotSupportingPackageType(components []packaging.BinarySpec, pkgType pkgcommon.PackageType) []string {
+	var excluded []string
+	for _, comp := range components {
+		if !comp.SupportsPackageType(pkgType) {
+			excluded = append(excluded, comp.BinaryName, comp.BinaryName+".spec.yml")
+		}
+	}
+	return excluded
+}
 
+// addFileToTar adds a file (or directory) to a tar archive.
+// excludedFiles is a list of base filenames (not paths) to skip during the walk.
+func addFileToTar(ar *tar.Writer, baseDir string, pkgFile PackageFile, excludedFiles []string) error {
 	return filepath.WalkDir(pkgFile.Source, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			if pkgFile.SkipOnMissing && os.IsNotExist(err) {

--- a/dev-tools/packaging/testing/package_test.go
+++ b/dev-tools/packaging/testing/package_test.go
@@ -66,6 +66,7 @@ var (
 	otelSamplesFilePattern      = regexp.MustCompile(`otel_samples/.+[^/]$`)
 	otelCollectorSpecPattern    = regexp.MustCompile(`elastic-otel-collector\.spec\.yml$`)
 	endpointResourcesZipPattern = regexp.MustCompile(`endpoint-security-resources\.zip$`)
+	cloudDefendPattern          = regexp.MustCompile(`/cloud-defend(\.spec\.yml)?$`)
 
 	licenseFiles = []string{"LICENSE.txt", "NOTICE.txt"}
 )
@@ -248,6 +249,7 @@ func checkTar(t *testing.T, file string, fipsCheck bool) {
 	checkFilePermissions(t, p, otelCollectorSpecPattern, expectedManifestMode)
 	checkFilePermissions(t, p, endpointResourcesZipPattern, expectedManifestMode)
 	checkLicensesPresent(t, "", p)
+	checkCloudDefendNotPresent(t, p)
 
 	// extract archive in a temporary directory
 	tempExtractionPath := t.TempDir()
@@ -638,6 +640,18 @@ func checkModulesOwner(t *testing.T, p *packageFile, expectRoot bool) {
 		for _, entry := range p.Contents {
 			if modulesDFilePattern.MatchString(entry.File) || modulesDDirPattern.MatchString(entry.File) {
 				checkOwner(t, entry, expectRoot)
+			}
+		}
+	})
+}
+
+// checkCloudDefendNotPresent verifies cloud-defend is absent from tar.gz packages.
+// Cloud Defend is only supported in Docker images.
+func checkCloudDefendNotPresent(t *testing.T, p *packageFile) {
+	t.Run("cloud-defend not present", func(t *testing.T) {
+		for name := range p.Contents {
+			if cloudDefendPattern.MatchString(name) {
+				t.Errorf("cloud-defend must not be included in tar.gz packages, found: %s", name)
 			}
 		}
 	})


### PR DESCRIPTION
Fixes a packaging bug where components like cloud-defend that only support Docker are incorrectly included in the Linux .tar.gz. Cloud Defend is a 151M binary and unnecessarily inflates the size on disk.

```
du -h elastic-agent-9.4.2-linux-x86_64/data/elastic-agent-dd9ee6/components/cloud-defend
151M	elastic-agent-9.4.2-linux-x86_64/data/elastic-agent-dd9ee6/components/cloud-defend
```

Cloud Defend was originally excluded from the Linux .tar.gz in https://github.com/elastic/elastic-agent/pull/4584, then removed completely, and then brought back in https://github.com/elastic/elastic-agent/pull/11450.

The PR restoring cloud-defend correctly declares that it only supports the Docker package type, and if you build with `PACKAGES=targz PLATFORMS=linux/amd64 mage package` it is indeed excluded.

However, if you build with `PACKAGES=all` as CI does or more specifically `PACKAGES=docker,targz` such that the supported package type is included then cloud-defend would be included in the Linux .tar.gz package because there is nothing in the packaging code to remove it from the linux/amd64 drop path.

This PR adds the necessary exclusion logic and adds a basic packaging test that cloud-defend is actually excluded to prevent this bug from coming back.