### PR TITLE
Fix Windows upgrade hang caused by an infinite loop scanning the Uninstall registry key

### DIFF
--- a/changelog/fragments/1780533768-fix-msi-uninstall-registry-infinite-loop.yaml
+++ b/changelog/fragments/1780533768-fix-msi-uninstall-registry-infinite-loop.yaml
@@ -1,0 +1,37 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix Windows upgrade hang caused by an infinite loop scanning the Uninstall registry key
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  FindMSIProductCodes used registry.Key.ReadSubKeyNames(100) in a loop that only
+  exited on a non-nil error. That call does not paginate and returns a nil error
+  whenever the Uninstall key has at least 100 subkeys, so on Windows hosts with
+  100 or more Add/Remove Programs entries the agent spun forever during startup
+  when upgrading from a pre-9.4.0 version, causing the upgrade watcher to roll
+  back. The function now reads all subkey names in a single call.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/14764

--- a/internal/pkg/agent/install/registry_windows.go
+++ b/internal/pkg/agent/install/registry_windows.go
@@ -127,30 +127,40 @@ func FindMSIProductCodes() []string {
 	}
 	defer k.Close()
 
-	var guids []string
-	for {
-		names, err := k.ReadSubKeyNames(100)
-		for _, name := range names {
-			// The Elastic Agent MSI ProductCode varies per version but
-			// it always starts with "{E550A894-5C44-5BEF-9967-".
-			// See: https://github.com/elastic/elastic-stack-installers/blob/main/src/shared/Uuid5.cs
-			if !strings.HasPrefix(strings.ToUpper(name), "{E550A894-5C44-5BEF-9967-") {
-				continue
-			}
-			subKey, subErr := registry.OpenKey(registry.LOCAL_MACHINE, UninstallKeyPath+`\`+name, registry.QUERY_VALUE)
-			if subErr != nil {
-				continue
-			}
-			displayName, _, _ := subKey.GetStringValue("DisplayName")
-			winInstaller, _, _ := subKey.GetIntegerValue("WindowsInstaller")
-			subKey.Close()
+	return findMSIProductCodes(k)
+}
 
-			if strings.HasPrefix(displayName, "Elastic Agent") && winInstaller == 1 {
-				guids = append(guids, name)
-			}
+// findMSIProductCodes enumerates the subkeys of the given open Uninstall key
+// and returns the names of the Elastic Agent MSI entries.
+func findMSIProductCodes(k registry.Key) []string {
+	// Pass -1 to read all subkey names in a single call. Passing a positive
+	// count (e.g. 100) does not paginate: ReadSubKeyNames always enumerates
+	// from index 0 and returns a nil error whenever the key has at least that
+	// many subkeys, so looping on a non-nil error spins forever on hosts with
+	// many Add/Remove Programs entries.
+	names, err := k.ReadSubKeyNames(-1)
+	if err != nil {
+		return nil
+	}
+
+	var guids []string
+	for _, name := range names {
+		// The Elastic Agent MSI ProductCode varies per version but
+		// it always starts with "{E550A894-5C44-5BEF-9967-".
+		// See: https://github.com/elastic/elastic-stack-installers/blob/main/src/shared/Uuid5.cs
+		if !strings.HasPrefix(strings.ToUpper(name), "{E550A894-5C44-5BEF-9967-") {
+			continue
 		}
-		if err != nil {
-			break
+		subKey, subErr := registry.OpenKey(k, name, registry.QUERY_VALUE)
+		if subErr != nil {
+			continue
+		}
+		displayName, _, _ := subKey.GetStringValue("DisplayName")
+		winInstaller, _, _ := subKey.GetIntegerValue("WindowsInstaller")
+		subKey.Close()
+
+		if strings.HasPrefix(displayName, "Elastic Agent") && winInstaller == 1 {
+			guids = append(guids, name)
 		}
 	}
 	return guids

--- a/internal/pkg/agent/install/registry_windows_test.go
+++ b/internal/pkg/agent/install/registry_windows_test.go
@@ -1,0 +1,108 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build windows
+
+package install
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows/registry"
+)
+
+// newTestUninstallKey creates a temporary, isolated key under HKCU that
+// mimics the Uninstall key structure, populated with the requested number of
+// non-MSI filler subkeys. It returns the open key; cleanup is registered via
+// t.Cleanup.
+func newTestUninstallKey(t *testing.T, fillerSubKeys int) registry.Key {
+	t.Helper()
+
+	// Use a unique path under HKCU so tests don't require admin rights and
+	// don't collide with real Add/Remove Programs entries.
+	root := fmt.Sprintf(`Software\ElasticAgentTest\%d\Uninstall`, time.Now().UnixNano())
+	k, _, err := registry.CreateKey(registry.CURRENT_USER, root, registry.CREATE_SUB_KEY|registry.ENUMERATE_SUB_KEYS)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		// Best-effort recursive cleanup of the test tree.
+		_ = deleteKeyRecursive(registry.CURRENT_USER, root)
+		k.Close()
+	})
+
+	for i := 0; i < fillerSubKeys; i++ {
+		sub, _, err := registry.CreateKey(k, fmt.Sprintf("filler-%d", i), registry.SET_VALUE)
+		require.NoError(t, err)
+		sub.Close()
+	}
+
+	return k
+}
+
+// addMSIEntry creates a subkey under k that looks like an Elastic Agent MSI
+// Add/Remove Programs entry.
+func addMSIEntry(t *testing.T, k registry.Key, guid string) {
+	t.Helper()
+	sub, _, err := registry.CreateKey(k, guid, registry.SET_VALUE)
+	require.NoError(t, err)
+	defer sub.Close()
+	require.NoError(t, sub.SetStringValue("DisplayName", "Elastic Agent"))
+	require.NoError(t, sub.SetDWordValue("WindowsInstaller", 1))
+}
+
+func deleteKeyRecursive(root registry.Key, path string) error {
+	k, err := registry.OpenKey(root, path, registry.ENUMERATE_SUB_KEYS)
+	if err != nil {
+		return err
+	}
+	names, _ := k.ReadSubKeyNames(-1)
+	k.Close()
+	for _, name := range names {
+		_ = deleteKeyRecursive(root, path+`\`+name)
+	}
+	return registry.DeleteKey(root, path)
+}
+
+// TestFindMSIProductCodesManySubKeys is a regression test for the infinite
+// loop that occurred when the Uninstall key had >=100 subkeys. With the old
+// ReadSubKeyNames(100) pagination bug this test would hang forever.
+func TestFindMSIProductCodesManySubKeys(t *testing.T) {
+	const guid = "{E550A894-5C44-5BEF-9967-0123456789AB}"
+
+	// 150 filler subkeys (well over the 100 threshold) plus one real MSI entry.
+	k := newTestUninstallKey(t, 150)
+	addMSIEntry(t, k, guid)
+
+	done := make(chan []string, 1)
+	go func() {
+		done <- findMSIProductCodes(k)
+	}()
+
+	select {
+	case guids := <-done:
+		require.Equal(t, []string{guid}, guids)
+	case <-time.After(30 * time.Second):
+		t.Fatal("findMSIProductCodes did not return; likely stuck in the pagination loop")
+	}
+}
+
+// TestFindMSIProductCodesFewSubKeys verifies the function still works when the
+// key has fewer than 100 subkeys (the previously-working path).
+func TestFindMSIProductCodesFewSubKeys(t *testing.T) {
+	const guid = "{E550A894-5C44-5BEF-9967-FEDCBA987654}"
+
+	k := newTestUninstallKey(t, 5)
+	addMSIEntry(t, k, guid)
+
+	require.Equal(t, []string{guid}, findMSIProductCodes(k))
+}
+
+// TestFindMSIProductCodesNoMatches verifies non-Elastic entries are ignored.
+func TestFindMSIProductCodesNoMatches(t *testing.T) {
+	k := newTestUninstallKey(t, 120)
+	require.Empty(t, findMSIProductCodes(k))
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fixes Windows startup issue that would hang caused by an infinite loop scanning the Uninstall registry key.

## Why is it important?

Any machine with more than 100 Add/Remove Program entries would result in the Elastic Agent being stuck in an infinite loop looking for the entry for Elastic Agent.

These conditions had to be occur for it to happen:

1. the running binary is 9.4.x
2. an upgrade marker is present (LoadMarker != nil)
3. the host has ≥100 uninstall subkeys.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Rather hard to test. Need a Windows machine with 100 Add/Remove program entries and then upgrade the Elastic Agent to a 9.4.x+ version. Unit test verifies it and this issue was identified from a crash dump of a stuck Elastic Agent upgrade.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #14764
