### PR TITLE
Ignore late checkins in the command runtime

### DIFF
--- a/changelog/fragments/1780533768-fix-command-runtime-late-checkin-resurrect.yaml
+++ b/changelog/fragments/1780533768-fix-command-runtime-late-checkin-resurrect.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Ignore late component check-ins after a command runtime has stopped
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/14298

--- a/pkg/component/runtime/command.go
+++ b/pkg/component/runtime/command.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/pkg/component"
@@ -212,40 +213,7 @@ func (c *commandRuntime) Run(ctx context.Context, comm Communicator) error {
 				c.sendObserved()
 			}
 		case checkin := <-comm.CheckinObserved():
-			sendExpected := false
-			changed := false
-			if c.state.State == client.UnitStateStarting {
-				// first observation after start set component to healthy
-				c.state.State = client.UnitStateHealthy
-				c.state.Message = fmt.Sprintf("Healthy: communicating with pid '%d'", c.proc.PID)
-				changed = true
-			}
-			if c.lastCheckin.IsZero() {
-				// first check-in
-				sendExpected = true
-			}
-			// Warning lastCheckin must contain a
-			// monotonic clock.  Functions like Local(),
-			// UTC(), Round(), AddDate(), etc. remove the
-			// monotonic clock.  See
-			// https://pkg.go.dev/time
-			c.lastCheckin = time.Now()
-			if c.state.syncCheckin(checkin) {
-				changed = true
-			}
-			if c.state.unsettled() {
-				sendExpected = true
-			}
-			if sendExpected {
-				checkinExpected := c.state.toCheckinExpected()
-				comm.CheckinExpected(checkinExpected, checkin)
-			}
-			if changed {
-				c.sendObserved()
-			}
-			if c.state.cleanupStopped() {
-				c.sendObserved()
-			}
+			c.processCheckin(checkin, comm)
 		case <-t.C:
 			t.Reset(checkinPeriod)
 			if c.actionState == actionStart {
@@ -374,6 +342,56 @@ func (c *commandRuntime) compState(state client.UnitState) {
 
 func (c *commandRuntime) sendObserved() {
 	c.ch <- c.state.Copy()
+}
+
+// processCheckin handles an observed check-in message from the running process.
+func (c *commandRuntime) processCheckin(checkin *proto.CheckinObserved, comm Communicator) {
+	// Ignore late check-ins once the component is no longer meant to be
+	// running. The checkinObserved channel is unbuffered, so a final check-in
+	// emitted by a dying process can be parked on it while stop() blocks the
+	// Run() loop reaping the process, then delivered after stop() has already
+	// forced UnitStateStopped. Processing it would resurrect non-stopped unit
+	// states via syncCheckin and emit a state update after the terminal
+	// Stopped state, re-broadcasting stale health for a component that has
+	// been removed. This mirrors serviceRuntime's isRunning() guard in its
+	// own processCheckin.
+	if c.actionState != actionStart || c.state.State == client.UnitStateStopping || c.state.State == client.UnitStateStopped {
+		return
+	}
+	sendExpected := false
+	changed := false
+	if c.state.State == client.UnitStateStarting {
+		// first observation after start set component to healthy
+		c.state.State = client.UnitStateHealthy
+		c.state.Message = fmt.Sprintf("Healthy: communicating with pid '%d'", c.proc.PID)
+		changed = true
+	}
+	if c.lastCheckin.IsZero() {
+		// first check-in
+		sendExpected = true
+	}
+	// Warning lastCheckin must contain a
+	// monotonic clock.  Functions like Local(),
+	// UTC(), Round(), AddDate(), etc. remove the
+	// monotonic clock.  See
+	// https://pkg.go.dev/time
+	c.lastCheckin = time.Now()
+	if c.state.syncCheckin(checkin) {
+		changed = true
+	}
+	if c.state.unsettled() {
+		sendExpected = true
+	}
+	if sendExpected {
+		checkinExpected := c.state.toCheckinExpected()
+		comm.CheckinExpected(checkinExpected, checkin)
+	}
+	if changed {
+		c.sendObserved()
+	}
+	if c.state.cleanupStopped() {
+		c.sendObserved()
+	}
 }
 
 func (c *commandRuntime) start(comm Communicator) error {

--- a/pkg/component/runtime/command_test.go
+++ b/pkg/component/runtime/command_test.go
@@ -212,6 +212,94 @@ func TestSyncExpected(t *testing.T) {
 
 }
 
+// TestProcessCheckinIgnoredAfterStop verifies that a late observed check-in is
+// dropped once the component is no longer meant to be running, so it cannot
+// resurrect non-stopped unit states or emit an observed update after the
+// terminal Stopped state. See https://github.com/elastic/elastic-agent/issues/14298
+func TestProcessCheckinIgnoredAfterStop(t *testing.T) {
+	comp := component.Component{
+		ID: "test-component",
+		Units: []component.Unit{
+			{
+				ID:   "test-unit",
+				Type: client.UnitTypeInput,
+			},
+		},
+	}
+
+	// A check-in reporting the unit as healthy. Processing it would change the
+	// observed state and trigger sendObserved if not ignored.
+	checkin := &proto.CheckinObserved{
+		Units: []*proto.UnitObserved{
+			{
+				Id:      "test-unit",
+				Type:    proto.UnitType_INPUT,
+				State:   proto.State_HEALTHY,
+				Message: "Healthy",
+			},
+		},
+	}
+
+	t.Run("dropped after Stopped", func(t *testing.T) {
+		state := newComponentState(&comp)
+		state.forceState(client.UnitStateStopped, "Stopped")
+		c := &commandRuntime{
+			ch:          make(chan ComponentState, 1),
+			state:       state,
+			actionState: actionStop,
+		}
+
+		c.processCheckin(checkin, newMockCommunicator(""))
+
+		select {
+		case s := <-c.ch:
+			t.Fatalf("expected no observed state after Stopped, got %+v", s)
+		default:
+		}
+	})
+
+	t.Run("dropped while Stopping", func(t *testing.T) {
+		state := newComponentState(&comp)
+		state.forceState(client.UnitStateStopping, "Stopping")
+		c := &commandRuntime{
+			ch:          make(chan ComponentState, 1),
+			state:       state,
+			actionState: actionStop,
+		}
+
+		c.processCheckin(checkin, newMockCommunicator(""))
+
+		select {
+		case s := <-c.ch:
+			t.Fatalf("expected no observed state while Stopping, got %+v", s)
+		default:
+		}
+	})
+
+	t.Run("processed while running", func(t *testing.T) {
+		state := newComponentState(&comp)
+		// Force a starting-ish message that differs from the check-in below so
+		// syncCheckin observes a change and emits an observed state.
+		state.forceState(client.UnitStateHealthy, "starting up")
+		c := &commandRuntime{
+			ch:          make(chan ComponentState, 1),
+			state:       state,
+			actionState: actionStart,
+		}
+
+		c.processCheckin(checkin, newMockCommunicator(""))
+
+		select {
+		case s := <-c.ch:
+			unit, ok := s.Units[ComponentUnitKey{UnitType: client.UnitTypeInput, UnitID: "test-unit"}]
+			require.True(t, ok, "expected the test unit in the observed state")
+			assert.Equal(t, client.UnitStateHealthy, unit.State)
+		default:
+			t.Fatal("expected an observed state to be emitted while running")
+		}
+	})
+}
+
 func TestCreateLogWriterJSONEncoder(t *testing.T) {
 	componentType := "test-type"
 	componentBinary := "test-binary"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Ignores late checkins in the command runtime.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Prevents the case where a delayed checkin message for a command that is already Stopping or Stopped will bring it back in the status output.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #14298
