### PR TITLE
[mage] Set default package type per platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ To build a local version of the agent for development, run the command below. Th
 # EXTERNAL=true downloads the matching version of the binaries that are packaged with agent, not necessary if only using Beats.
 # SNAPSHOT=true indicates that this is a snapshot version and not a release version.
 # PLATFORMS=linux/amd64 builds an agent that will run on 64 bit X86 Linux systems.
-# PACKAGES is required. Use PACKAGES=all to build all package types, or specify types (e.g. tar.gz,rpm,deb,zip,docker).
+# PACKAGES selects package types; if unset, defaults to tar.gz for non-Windows platforms and zip for Windows.
+# Use PACKAGES=all to build all package types, or specify types (e.g. tar.gz,rpm,deb,zip,docker).
 EXTERNAL=true SNAPSHOT=true PLATFORMS=linux/amd64 PACKAGES=tar.gz mage -v package
 ```
 

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -1886,7 +1886,8 @@ func (s *Settings) GetPlatforms() BuildPlatformList {
 // If SelectedPackageTypes is set in the settings, returns that.
 // Otherwise parses from PACKAGES env var.
 // If PACKAGES is "all", returns all available package types.
-// If PACKAGES is empty, returns nil.
+// If PACKAGES is empty, returns a platform-derived default: tar.gz for non-Windows
+// platforms and zip for Windows platforms.
 func (s *Settings) GetPackageTypes() []PackageType {
 	// Check settings override first
 	if s.SelectedPackageTypes != nil {
@@ -1894,7 +1895,7 @@ func (s *Settings) GetPackageTypes() []PackageType {
 	}
 	// Fall back to env var
 	if s.CrossBuild.Packages == "" {
-		return nil
+		return s.defaultPackageTypesForPlatforms()
 	}
 	if strings.ToLower(s.CrossBuild.Packages) == "all" {
 		return AllPackageTypes
@@ -1905,6 +1906,28 @@ func (s *Settings) GetPackageTypes() []PackageType {
 		if err := p.UnmarshalText([]byte(pkgtype)); err == nil {
 			types = append(types, p)
 		}
+	}
+	return types
+}
+
+// defaultPackageTypesForPlatforms returns the default package types derived from the
+// configured platforms: tar.gz for non-Windows platforms, zip for Windows platforms.
+func (s *Settings) defaultPackageTypesForPlatforms() []PackageType {
+	platforms := s.GetPlatforms()
+	var hasUnix, hasWindows bool
+	for _, p := range platforms {
+		if p.GOOS() == "windows" {
+			hasWindows = true
+		} else {
+			hasUnix = true
+		}
+	}
+	var types []PackageType
+	if hasUnix {
+		types = append(types, TarGz)
+	}
+	if hasWindows {
+		types = append(types, Zip)
 	}
 	return types
 }

--- a/dev-tools/mage/settings_test.go
+++ b/dev-tools/mage/settings_test.go
@@ -349,12 +349,33 @@ func TestSettingsGetPackageTypes(t *testing.T) {
 		assert.Equal(t, []PackageType{TarGz, Zip}, types)
 	})
 
-	t.Run("returns nil when both are empty", func(t *testing.T) {
+	t.Run("returns platform-derived default when both are empty", func(t *testing.T) {
 		s := DefaultSettings()
+		// Default platforms include both Unix and Windows entries, so the derived
+		// default should contain both tar.gz and zip.
+		s.CrossBuild.Platforms = "linux/amd64,windows/amd64"
 
 		types := s.GetPackageTypes()
 
-		assert.Nil(t, types)
+		assert.Equal(t, []PackageType{TarGz, Zip}, types)
+	})
+
+	t.Run("returns only tar.gz for unix-only platforms", func(t *testing.T) {
+		s := DefaultSettings()
+		s.CrossBuild.Platforms = "linux/amd64,darwin/arm64"
+
+		types := s.GetPackageTypes()
+
+		assert.Equal(t, []PackageType{TarGz}, types)
+	})
+
+	t.Run("returns only zip for windows-only platforms", func(t *testing.T) {
+		s := DefaultSettings()
+		s.CrossBuild.Platforms = "windows/amd64"
+
+		types := s.GetPackageTypes()
+
+		assert.Equal(t, []PackageType{Zip}, types)
 	})
 
 	t.Run("returns all package types when PACKAGES is all", func(t *testing.T) {

--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -94,12 +94,13 @@ The packaging process has many leavers that need to be correctly set:
   not set, it defaults to **ALL** platforms. [Selecting specific
   platform](#selecting-specific-platform) contains a list of common
   values. For a full list look at [`elastic-agent/dev-tools/mage/platforms.go`](https://github.com/elastic/elastic-agent/blob/main/dev-tools/mage/platforms.go#L15).
- - `PACKAGES`: **Required.** Comma separated list of packages you want
-  to build. Use `PACKAGES=all` to build all package types.
-  The packages are defined in
+ - `PACKAGES`: Comma separated list of packages you want to build.
+  If not set, defaults to `tar.gz` for non-Windows platforms and `zip`
+  for Windows platforms (based on `PLATFORMS`). Use `PACKAGES=all` to
+  build all package types. The packages are defined in
   [`elastic-agent/dev-tools/mage/pkgtypes.go`](https://github.com/elastic/elastic-agent/blob/main/dev-tools/mage/pkgtypes.go#L72).
-  To run Linux tests you need to package `tar.gz` ,`deb` and `rpm`.
-The possible options are:
+  To run Linux tests you need to package `tar.gz`, `deb` and `rpm`.
+  The possible options are:
     - `tar.gz`
     - `zip` (Windows only)
     - `deb`

--- a/magefile.go
+++ b/magefile.go
@@ -611,14 +611,12 @@ func (Format) License() error {
 // Use SNAPSHOT=true to build snapshots.
 // Use PLATFORMS to control the target platforms.
 // Use VERSION_QUALIFIER to control the version qualifier.
+// Use PACKAGES to override the package types (e.g. PACKAGES=tar.gz,rpm,deb,zip,docker).
+// If PACKAGES is not set, defaults to tar.gz for non-Windows platforms and zip for Windows.
 func Package(ctx context.Context) error {
 	cfg := devtools.SettingsFromContext(ctx)
 	start := time.Now()
 	defer func() { fmt.Println("package ran for", time.Since(start)) }()
-
-	if len(cfg.GetPackageTypes()) == 0 {
-		return fmt.Errorf("PACKAGES env var is required. Set PACKAGES=all to build all package types, or specify types (e.g. PACKAGES=tar.gz,rpm,deb,zip,docker)")
-	}
 
 	if len(cfg.GetPlatforms()) == 0 {
 		panic("elastic-agent package is expected to build at least one platform package")
@@ -1503,10 +1501,6 @@ func PackageUsingDRA(ctx context.Context) error {
 	cfg := devtools.SettingsFromContext(ctx)
 	start := time.Now()
 	defer func() { fmt.Println("package ran for", time.Since(start)) }()
-
-	if len(cfg.GetPackageTypes()) == 0 {
-		return fmt.Errorf("PACKAGES env var is required. Set PACKAGES=all to build all package types, or specify types (e.g. PACKAGES=tar.gz,rpm,deb,zip,docker)")
-	}
 
 	if len(cfg.GetPlatforms()) == 0 {
 		return fmt.Errorf("elastic-agent package is expected to build at least one platform package")


### PR DESCRIPTION
## What does this PR do?

Sets default package types for `mage package` and similar invocations. This only applies if `PACKAGES` is unset. The actual logic is that if we're building for a unix platform, the default package type is `tar.gz`, and for windows - `zip`. If it's both, then we build both. 

## Why is it important?

It makes the build system more ergonomic and easier to use without knowing all the options. Majority of the time, what a user wants when building a package locally is exactly this.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

Run `EXTERNAL=true SNAPSHOT=true PLATFORMS="linux/amd64 windows/amd64" mage package`. You should get a linux `tar.gz` and a Windows `zip` package.

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/14746

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
