### PR TITLE
Update kube-stack to 0.15.2

### DIFF
--- a/changelog/fragments/1780667349-Bump-OpenTelemetry-kube-stack-Helm-chart-to-0.15.2.yaml
+++ b/changelog/fragments/1780667349-Bump-OpenTelemetry-kube-stack-Helm-chart-to-0.15.2.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Bump OpenTelemetry kube-stack Helm chart to 0.15.2
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/testing/integration/k8s/k8s.go
+++ b/testing/integration/k8s/k8s.go
@@ -7,7 +7,7 @@ package k8s
 import "path/filepath"
 
 const (
-	KubeStackChartVersion         = "0.14.11"
+	KubeStackChartVersion         = "0.15.2"
 	KubeStackChartName            = "opentelemetry-kube-stack"
 	KubeStackChartNameWithVersion = KubeStackChartName + "-" + KubeStackChartVersion
 	KubeStackChartArchiveName     = KubeStackChartNameWithVersion + ".tgz"

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/Chart.lock
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.0.0
 - name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.105.1
+  version: 0.113.1
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 6.3.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.48.0
-digest: sha256:2ec77416b3a4f1ed3c0cd19512e929b8911fc64e31f5fb909fc50ac61e9c8256
-generated: "2026-02-12T15:44:34.531542519+11:00"
+digest: sha256:0bc649ea2dff6ba5885f295a74847cb477ed71374f15daa40f68d87b01ec82b6
+generated: "2026-05-18T12:13:31.924545+02:00"

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/Chart.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.144.0
+appVersion: 0.151.0
 dependencies:
 - condition: crds.install,crds.installOtel
   name: otel-crds
@@ -12,7 +12,7 @@ dependencies:
 - condition: opentelemetry-operator.enabled
   name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.105.1
+  version: 0.113.1
 - condition: kubeStateMetrics.enabled
   name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
@@ -34,4 +34,4 @@ name: opentelemetry-kube-stack
 sources:
 - https://github.com/open-telemetry/opentelemetry-operator
 type: application
-version: 0.14.11
+version: 0.15.2

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/README.md
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/README.md
@@ -53,7 +53,7 @@ By default, the daemonset collector will load in the daemon_scrape_configs.yaml 
 ## Prerequisites
 
 - Kubernetes 1.24+ is required for OpenTelemetry Operator installation
-- Helm 3.9+
+- Helm 4.0+
 
 ### TLS Certificate Requirement
 

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/Chart.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.144.0
+appVersion: 0.151.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 home: https://opentelemetry.io/
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
@@ -12,4 +12,4 @@ name: opentelemetry-operator
 sources:
 - https://github.com/open-telemetry/opentelemetry-operator
 type: application
-version: 0.105.1
+version: 0.113.1

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/UPGRADING.md
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/UPGRADING.md
@@ -1,5 +1,53 @@
 # Upgrade guidelines
 
+## 0.109.x to 0.110.0
+
+### Migration from kube-rbac-proxy to controller-runtime metrics
+
+The OpenTelemetry Operator (v0.142.0+) has removed its dependency on kube-rbac-proxy. Metrics authentication is now handled by controller-runtime's built-in implementation.
+
+**Breaking Change:** The `kubeRBACProxy` configuration section has been removed. Metrics configuration is now under `manager.metrics` and `manager.ports.metricsPort`.
+
+**Migration Guide:**
+
+If you were using the default configuration (`kubeRBACProxy.enabled: true`), no action is required. The new default (`manager.metrics.secure: true`) provides authenticated metrics on port 8443.
+
+If you need unauthenticated metrics access, update your values.yaml:
+
+```yaml
+# OLD (no longer supported)
+kubeRBACProxy:
+  enabled: true
+  ports:
+    proxyPort: 8443
+
+# NEW
+manager:
+  ports:
+    metricsPort: 8080
+  metrics:
+    secure: false
+```
+
+If you also have the ServiceMonitor enabled, you will need to override the default `metricsEndpoints` to use plain HTTP:
+
+```yaml
+manager:
+  serviceMonitor:
+    enabled: true
+    metricsEndpoints:
+      - port: metrics
+```
+
+**Key Changes:**
+- Deployment now has 1 container (manager only) instead of 2
+- Metrics port configured via `manager.ports.metricsPort` (default: 8443)
+- RBAC: ClusterRole for `/metrics` access only created when `manager.metrics.secure: true`
+- TLS certificates: Auto-generated if not provided when secure mode is enabled
+- ServiceMonitor defaults to HTTPS scraping with bearer token auth to match the secure default
+
+For more details, see [upstream PR #4576](https://github.com/open-telemetry/opentelemetry-operator/pull/4576).
+
 ## 0.86.4 to 0.87.0
 
 In the v0.123.1 Collector release we stopped pushing images to Dockerhub due to how their new rate limit changes affected our CI. If you're using the dockerhub repository (`otel/`) for the image you should switch to `ghcr.io/open-telemetry/opentelemetry-collector-releases/` instead. See https://github.com/open-telemetry/community/issues/2641 for more details.

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_opampbridges.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_opampbridges.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
@@ -1597,6 +1597,10 @@ spec:
                                     type: integer
                                   signerName:
                                     type: string
+                                  userAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
                                 required:
                                 - keyType
                                 - signerName

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_targetallocators.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_targetallocators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
@@ -1334,9 +1334,26 @@ spec:
                 type: string
               global:
                 type: object
+              hostAliases:
+                items:
+                  properties:
+                    hostnames:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    ip:
+                      type: string
+                  required:
+                  - ip
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
               hostNetwork:
                 type: boolean
               hostPID:
+                type: boolean
+              hostUsers:
                 type: boolean
               image:
                 type: string
@@ -2196,6 +2213,87 @@ spec:
                   stopSignal:
                     type: string
                 type: object
+              livenessProbe:
+                properties:
+                  exec:
+                    properties:
+                      command:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  failureThreshold:
+                    format: int32
+                    type: integer
+                  grpc:
+                    properties:
+                      port:
+                        format: int32
+                        type: integer
+                      service:
+                        default: ""
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  httpGet:
+                    properties:
+                      host:
+                        type: string
+                      httpHeaders:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      path:
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    properties:
+                      host:
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  terminationGracePeriodSeconds:
+                    format: int64
+                    type: integer
+                  timeoutSeconds:
+                    format: int32
+                    type: integer
+                type: object
               managementState:
                 default: managed
                 enum:
@@ -2389,7 +2487,65 @@ spec:
                     type: array
                   enabled:
                     type: boolean
+                  evaluationInterval:
+                    default: 30s
+                    format: duration
+                    type: string
+                  podMonitorNamespaceSelector:
+                    default: {}
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
                   podMonitorSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  probeNamespaceSelector:
+                    default: {}
                     properties:
                       matchExpressions:
                         items:
@@ -2447,6 +2603,33 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                     x-kubernetes-preserve-unknown-fields: true
+                  scrapeConfigNamespaceSelector:
+                    default: {}
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
                   scrapeConfigSelector:
                     properties:
                       matchExpressions:
@@ -2477,6 +2660,41 @@ spec:
                     default: 30s
                     format: duration
                     type: string
+                  scrapeProtocols:
+                    items:
+                      type: string
+                    type: array
+                  secretNamespaces:
+                    items:
+                      type: string
+                    type: array
+                  serviceMonitorNamespaceSelector:
+                    default: {}
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
                   serviceMonitorSelector:
                     properties:
                       matchExpressions:
@@ -2503,6 +2721,87 @@ spec:
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
+                type: object
+              readinessProbe:
+                properties:
+                  exec:
+                    properties:
+                      command:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  failureThreshold:
+                    format: int32
+                    type: integer
+                  grpc:
+                    properties:
+                      port:
+                        format: int32
+                        type: integer
+                      service:
+                        default: ""
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  httpGet:
+                    properties:
+                      host:
+                        type: string
+                      httpHeaders:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      path:
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    properties:
+                      host:
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  terminationGracePeriodSeconds:
+                    format: int64
+                    type: integer
+                  timeoutSeconds:
+                    format: int32
+                    type: integer
                 type: object
               replicas:
                 default: 1
@@ -3347,6 +3646,10 @@ spec:
                                     type: integer
                                   signerName:
                                     type: string
+                                  userAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
                                 required:
                                 - keyType
                                 - signerName

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/conf/crds/crd-opentelemetrycollector.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/conf/crds/crd-opentelemetrycollector.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ include "opentelemetry-operator.webhookCertAnnotation" . }}
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
@@ -4501,6 +4501,10 @@ spec:
                                     type: integer
                                   signerName:
                                     type: string
+                                  userAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
                                 required:
                                 - keyType
                                 - signerName
@@ -6304,10 +6308,43 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
+              hostAliases:
+                items:
+                  properties:
+                    hostnames:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    ip:
+                      type: string
+                  required:
+                  - ip
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
               hostNetwork:
                 type: boolean
               hostPID:
                 type: boolean
+              hostUsers:
+                type: boolean
+              httpRoute:
+                properties:
+                  enabled:
+                    type: boolean
+                  gateway:
+                    type: string
+                  gatewayNamespace:
+                    type: string
+                  hostnames:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - enabled
+                - gateway
+                type: object
               image:
                 type: string
               imagePullPolicy:
@@ -7319,6 +7356,11 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
+              podManagementPolicy:
+                enum:
+                - OrderedReady
+                - Parallel
+                type: string
               podSecurityContext:
                 properties:
                   appArmorProfile:
@@ -8271,7 +8313,65 @@ spec:
                         type: array
                       enabled:
                         type: boolean
+                      evaluationInterval:
+                        default: 30s
+                        format: duration
+                        type: string
+                      podMonitorNamespaceSelector:
+                        default: {}
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
                       podMonitorSelector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      probeNamespaceSelector:
+                        default: {}
                         properties:
                           matchExpressions:
                             items:
@@ -8329,6 +8429,33 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                         x-kubernetes-preserve-unknown-fields: true
+                      scrapeConfigNamespaceSelector:
+                        default: {}
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
                       scrapeConfigSelector:
                         properties:
                           matchExpressions:
@@ -8359,6 +8486,41 @@ spec:
                         default: 30s
                         format: duration
                         type: string
+                      scrapeProtocols:
+                        items:
+                          type: string
+                        type: array
+                      secretNamespaces:
+                        items:
+                          type: string
+                        type: array
+                      serviceMonitorNamespaceSelector:
+                        default: {}
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
                       serviceMonitorSelector:
                         properties:
                           matchExpressions:
@@ -9480,6 +9642,10 @@ spec:
                                     type: integer
                                   signerName:
                                     type: string
+                                  userAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
                                 required:
                                 - keyType
                                 - signerName

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/conf/crds/crd-opentelemetryinstrumentation.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/conf/crds/crd-opentelemetryinstrumentation.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
@@ -131,6 +131,8 @@ spec:
                       type: object
                     type: array
                   configPath:
+                    maxLength: 256
+                    pattern: ^[A-Za-z0-9._/-]*$
                     type: string
                   env:
                     items:
@@ -836,6 +838,78 @@ spec:
                           x-kubernetes-int-or-string: true
                         type: object
                     type: object
+                  securityContext:
+                    properties:
+                      allowPrivilegeEscalation:
+                        type: boolean
+                      appArmorProfile:
+                        properties:
+                          localhostProfile:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      capabilities:
+                        properties:
+                          add:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          drop:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      privileged:
+                        type: boolean
+                      procMount:
+                        type: string
+                      readOnlyRootFilesystem:
+                        type: boolean
+                      runAsGroup:
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        type: boolean
+                      runAsUser:
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        properties:
+                          level:
+                            type: string
+                          role:
+                            type: string
+                          type:
+                            type: string
+                          user:
+                            type: string
+                        type: object
+                      seccompProfile:
+                        properties:
+                          localhostProfile:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        properties:
+                          gmsaCredentialSpec:
+                            type: string
+                          gmsaCredentialSpecName:
+                            type: string
+                          hostProcess:
+                            type: boolean
+                          runAsUserName:
+                            type: string
+                        type: object
+                    type: object
                   volumeClaimTemplate:
                     properties:
                       metadata:
@@ -957,6 +1031,78 @@ spec:
                 type: object
               imagePullPolicy:
                 type: string
+              initContainerSecurityContext:
+                properties:
+                  allowPrivilegeEscalation:
+                    type: boolean
+                  appArmorProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  capabilities:
+                    properties:
+                      add:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      drop:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  privileged:
+                    type: boolean
+                  procMount:
+                    type: string
+                  readOnlyRootFilesystem:
+                    type: boolean
+                  runAsGroup:
+                    format: int64
+                    type: integer
+                  runAsNonRoot:
+                    type: boolean
+                  runAsUser:
+                    format: int64
+                    type: integer
+                  seLinuxOptions:
+                    properties:
+                      level:
+                        type: string
+                      role:
+                        type: string
+                      type:
+                        type: string
+                      user:
+                        type: string
+                    type: object
+                  seccompProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  windowsOptions:
+                    properties:
+                      gmsaCredentialSpec:
+                        type: string
+                      gmsaCredentialSpecName:
+                        type: string
+                      hostProcess:
+                        type: boolean
+                      runAsUserName:
+                        type: string
+                    type: object
+                type: object
               java:
                 properties:
                   env:
@@ -1294,6 +1440,8 @@ spec:
                       type: object
                     type: array
                   configFile:
+                    maxLength: 256
+                    pattern: ^[A-Za-z0-9._/-]*$
                     type: string
                   env:
                     items:
@@ -2050,6 +2198,11 @@ spec:
                 type: object
             type: object
           status:
+            properties:
+              upgradeBlockedVersions:
+                additionalProperties:
+                  type: string
+                type: object
             type: object
         type: object
     served: true

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
@@ -184,7 +184,11 @@ rules:
   - apiGroups:
       - ""
     resources:
+{{- if semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version }}
+      - nodes/pods
+{{- else }}
       - nodes/proxy
+{{- end }}
     verbs:
       - get
   - apiGroups:
@@ -212,11 +216,32 @@ rules:
       - list
       - update
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - events.k8s.io
     resources:
       - events
     verbs:
+      - create
       - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
       - watch
   - apiGroups:
       - monitoring.coreos.com
@@ -374,13 +399,19 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
       - authorization.k8s.io
     resources:
       - subjectaccessreviews
     verbs:
       - create
 
-{{ if .Values.kubeRBACProxy.enabled }}
+{{ if .Values.manager.metrics.secure }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -394,20 +425,5 @@ rules:
       - /metrics
     verbs:
       - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    {{- include "opentelemetry-operator.labels" . | nindent 4 }}
-    app.kubernetes.io/component: controller-manager
-  name: {{ template "opentelemetry-operator.fullname" . }}-proxy
-rules:
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
 {{- end }}
 {{ end }}

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
@@ -14,23 +14,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "opentelemetry-operator.serviceAccountName" . }}
     namespace: {{ template "opentelemetry-operator.namespace" . }}
-
-{{ if .Values.kubeRBACProxy.enabled }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    {{- include "opentelemetry-operator.labels" . | nindent 4 }}
-    app.kubernetes.io/component: controller-manager
-  name: {{ template "opentelemetry-operator.fullname" . }}-proxy
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "opentelemetry-operator.fullname" . }}-proxy
-subjects:
-  - kind: ServiceAccount
-    name: {{ template "opentelemetry-operator.serviceAccountName" . }}
-    namespace: {{ template "opentelemetry-operator.namespace" . }}
-{{- end }}
 {{ end }}

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/deployment.yaml
@@ -14,6 +14,9 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- if .Values.minReadySeconds }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "opentelemetry-operator.selectorLabels" . | nindent 6 }}
@@ -46,6 +49,7 @@ spec:
       containers:
         - args:
             - --metrics-addr=0.0.0.0:{{ .Values.manager.ports.metricsPort }}
+            - --metrics-secure={{ .Values.manager.metrics.secure }}
             {{- if .Values.manager.leaderElection.enabled }}
             - --enable-leader-election
             {{- end }}
@@ -154,33 +158,6 @@ spec:
           {{- with .Values.manager.securityContext }}
           securityContext: {{ toYaml . | nindent 12 }}
           {{- end }}
-        {{ if .Values.kubeRBACProxy.enabled }}
-        - args:
-            - --secure-listen-address=0.0.0.0:{{ .Values.kubeRBACProxy.ports.proxyPort }}
-            - --upstream=http://127.0.0.1:{{ .Values.manager.ports.metricsPort }}/
-            - --v=0
-            {{-  if .Values.kubeRBACProxy.extraArgs  }}
-            {{- .Values.kubeRBACProxy.extraArgs | toYaml | nindent 12 }}
-            {{-  end  }}
-          image: "{{ .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}"
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: {{ .Values.kubeRBACProxy.ports.proxyPort }}
-              name: https
-              protocol: TCP
-          {{- with .Values.kubeRBACProxy.resources }}
-          resources: {{ toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.kubeRBACProxy.securityContext }}
-          securityContext: {{ toYaml . | nindent 12 }}
-          {{- end }}
-          {{- if $explicitMount }}
-          volumeMounts:
-            - name: access-token
-              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-              readOnly: true
-          {{- end }}
-        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/extramanifests.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/extramanifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/service.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/service.yaml
@@ -12,12 +12,6 @@ metadata:
   namespace: {{ template "opentelemetry-operator.namespace" . }}
 spec:
   ports:
-    {{- if .Values.kubeRBACProxy.enabled }}
-    - name: https
-      port: {{ .Values.kubeRBACProxy.ports.proxyPort }}
-      protocol: TCP
-      targetPort: https
-    {{- end }}
     - name: metrics
       port: {{ .Values.manager.ports.metricsPort }}
       protocol: TCP

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/tests/test-service-connection.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/tests/test-service-connection.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.kubeRBACProxy.enabled }}
 ---
 apiVersion: v1
 kind: Pod
@@ -18,7 +17,7 @@ spec:
         - name: MANAGER_METRICS_SERVICE_CLUSTERIP
           value: "{{ include "opentelemetry-operator.fullname" . }}"
         - name: MANAGER_METRICS_SERVICE_PORT
-          value: "{{ .Values.kubeRBACProxy.ports.proxyPort }}"
+          value: "{{ .Values.manager.ports.metricsPort }}"
       command:
         - sh
         - -c
@@ -52,7 +51,6 @@ spec:
   {{- end }}
   securityContext:
 {{ toYaml .Values.securityContext | indent 4 }}
-{{- end }}
 ---
 apiVersion: v1
 kind: Pod

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/verticalpodautoscaler.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/templates/verticalpodautoscaler.yaml
@@ -16,7 +16,8 @@ spec:
     containerPolicies:
     - containerName: manager
       {{- if .Values.manager.verticalPodAutoscaler.controlledResources }}
-      controlledResources: {{ .Values.manager.verticalPodAutoscaler.controlledResources }}
+      controlledResources:
+        {{- toYaml .Values.manager.verticalPodAutoscaler.controlledResources | nindent 8 }}
       {{- end }}
       {{- if .Values.manager.verticalPodAutoscaler.maxAllowed }}
       maxAllowed:
@@ -33,7 +34,7 @@ spec:
   {{- if .Values.manager.verticalPodAutoscaler.updatePolicy }}
   updatePolicy:
     {{- if .Values.manager.verticalPodAutoscaler.updatePolicy.updateMode }}
-    updateMode: {{ .Values.manager.verticalPodAutoscaler.updatePolicy.updateMode }}
+    updateMode: {{ .Values.manager.verticalPodAutoscaler.updatePolicy.updateMode | quote }}
     {{- end }}
     {{- if .Values.manager.verticalPodAutoscaler.updatePolicy.minReplicas }}
     minReplicas: {{ .Values.manager.verticalPodAutoscaler.updatePolicy.minReplicas }}

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/values.schema.json
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/values.schema.json
@@ -12,7 +12,6 @@
     "clusterDomain",
     "pdb",
     "manager",
-    "kubeRBACProxy",
     "admissionWebhooks",
     "crds",
     "role",
@@ -47,6 +46,16 @@
       "title": "The revisionHistoryLimit Schema",
       "examples": [
         1
+      ]
+    },
+    "minReadySeconds": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "title": "The minReadySeconds Schema",
+      "examples": [
+        0,
+        30
       ]
     },
     "nameOverride": {
@@ -174,7 +183,8 @@
         "rolling",
         "securityContext",
         "ignoreMissingCollectorCRDs",
-        "autoInstrumentation"
+        "autoInstrumentation",
+        "metrics"
       ],
       "additionalProperties": false,
       "properties": {
@@ -703,7 +713,7 @@
           },
           "examples": [
             {
-              "metricsPort": 8080,
+              "metricsPort": 8443,
               "webhookPort": 9443,
               "healthzPort": 8081
             }
@@ -1266,6 +1276,72 @@
               "additionalProperties": false
             }
           }
+        },
+        "metrics": {
+          "type": "object",
+          "default": {},
+          "title": "Metrics server configuration",
+          "required": [
+            "secure",
+            "tls"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "secure": {
+              "type": "boolean",
+              "default": true,
+              "title": "Enable authentication and authorization for metrics",
+              "description": "Corresponds to --metrics-secure flag in the operator",
+              "examples": [
+                true
+              ]
+            },
+            "tls": {
+              "type": "object",
+              "default": {},
+              "title": "TLS configuration for metrics server",
+              "required": [
+                "certFile",
+                "keyFile"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "certFile": {
+                  "type": "string",
+                  "default": "",
+                  "title": "Path to TLS certificate file",
+                  "description": "Corresponds to --metrics-tls-cert-file flag",
+                  "examples": [
+                    ""
+                  ]
+                },
+                "keyFile": {
+                  "type": "string",
+                  "default": "",
+                  "title": "Path to TLS private key file",
+                  "description": "Corresponds to --metrics-tls-key-file flag",
+                  "examples": [
+                    ""
+                  ]
+                }
+              },
+              "examples": [
+                {
+                  "certFile": "",
+                  "keyFile": ""
+                }
+              ]
+            }
+          },
+          "examples": [
+            {
+              "secure": true,
+              "tls": {
+                "certFile": "",
+                "keyFile": ""
+              }
+            }
+          ]
         }
       },
       "examples": [
@@ -1314,7 +1390,7 @@
           },
           "featureGates": "",
           "ports": {
-            "metricsPort": 8080,
+            "metricsPort": 8443,
             "webhookPort": 9443,
             "healthzPort": 8081
           },
@@ -1373,214 +1449,14 @@
             }
           },
           "rolling": false,
-          "securityContext": {}
-        }
-      ]
-    },
-    "kubeRBACProxy": {
-      "type": "object",
-      "default": {},
-      "title": "The kubeRBACProxy Schema",
-      "required": [
-        "enabled",
-        "image",
-        "ports",
-        "extraArgs",
-        "securityContext"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "default": false,
-          "title": "The enabled Schema",
-          "examples": [
-            true
-          ]
-        },
-        "image": {
-          "type": "object",
-          "default": {},
-          "title": "The image Schema",
-          "required": [
-            "repository",
-            "tag"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "repository": {
-              "type": "string",
-              "default": "",
-              "title": "The repository Schema",
-              "examples": [
-                "quay.io/brancz/kube-rbac-proxy"
-              ]
-            },
-            "tag": {
-              "type": "string",
-              "default": "",
-              "title": "The tag Schema",
-              "examples": [
-                "v0.15.0"
-              ]
+          "securityContext": {},
+          "metrics": {
+            "secure": true,
+            "tls": {
+              "certFile": "",
+              "keyFile": ""
             }
-          },
-          "examples": [
-            {
-              "repository": "quay.io/brancz/kube-rbac-proxy",
-              "tag": "v0.15.0"
-            }
-          ]
-        },
-        "ports": {
-          "type": "object",
-          "default": {},
-          "title": "The ports Schema",
-          "required": [
-            "proxyPort"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "proxyPort": {
-              "type": "integer",
-              "default": 0,
-              "title": "The proxyPort Schema",
-              "examples": [
-                8443
-              ]
-            }
-          },
-          "examples": [
-            {
-              "proxyPort": 8443
-            }
-          ]
-        },
-        "resources": {
-          "type": "object",
-          "default": {},
-          "title": "The resources Schema",
-          "required": [],
-          "additionalProperties": false,
-          "properties": {
-            "limits": {
-              "type": "object",
-              "default": {},
-              "title": "The limits Schema",
-              "required": [],
-              "additionalProperties": true,
-              "properties": {
-                "cpu": {
-                  "type": "string",
-                  "default": "",
-                  "title": "The cpu Schema",
-                  "examples": [
-                    "500m"
-                  ]
-                },
-                "memory": {
-                  "type": "string",
-                  "default": "",
-                  "title": "The memory Schema",
-                  "examples": [
-                    "128Mi"
-                  ]
-                }
-              },
-              "examples": [
-                {
-                  "cpu": "500m",
-                  "memory": "128Mi"
-                }
-              ]
-            },
-            "requests": {
-              "type": "object",
-              "default": {},
-              "title": "The requests Schema",
-              "required": [],
-              "additionalProperties": true,
-              "properties": {
-                "cpu": {
-                  "type": "string",
-                  "default": "",
-                  "title": "The cpu Schema",
-                  "examples": [
-                    "5m"
-                  ]
-                },
-                "memory": {
-                  "type": "string",
-                  "default": "",
-                  "title": "The memory Schema",
-                  "examples": [
-                    "64Mi"
-                  ]
-                }
-              },
-              "examples": [
-                {
-                  "cpu": "5m",
-                  "memory": "64Mi"
-                }
-              ]
-            }
-          },
-          "examples": [
-            {
-              "limits": {
-                "cpu": "500m",
-                "memory": "128Mi"
-              },
-              "requests": {
-                "cpu": "5m",
-                "memory": "64Mi"
-              }
-            }
-          ]
-        },
-        "extraArgs": {
-          "type": "array",
-          "default": [],
-          "title": "The extraArgs Schema",
-          "items": {},
-          "examples": [
-            []
-          ]
-        },
-        "securityContext": {
-          "type": "object",
-          "default": {},
-          "title": "The securityContext Schema",
-          "required": [],
-          "properties": {},
-          "examples": [
-            {}
-          ]
-        }
-      },
-      "examples": [
-        {
-          "enabled": true,
-          "image": {
-            "repository": "quay.io/brancz/kube-rbac-proxy",
-            "tag": "v0.15.0"
-          },
-          "ports": {
-            "proxyPort": 8443
-          },
-          "resources": {
-            "limits": {
-              "cpu": "500m",
-              "memory": "128Mi"
-            },
-            "requests": {
-              "cpu": "5m",
-              "memory": "64Mi"
-            }
-          },
-          "extraArgs": [],
-          "securityContext": {}
+          }
         }
       ]
     },
@@ -2137,6 +2013,14 @@
       "examples": [
         false
       ]
+    },
+    "extraObjects": {
+      "type": "array",
+      "default": [],
+      "title": "Extra manifests to deploy as an array",
+      "items": {
+        "type": "object"
+      }
     }
   },
   "examples": [
@@ -2198,7 +2082,7 @@
         },
         "featureGates": "",
         "ports": {
-          "metricsPort": 8080,
+          "metricsPort": 8443,
           "webhookPort": 9443,
           "healthzPort": 8081
         },
@@ -2257,28 +2141,6 @@
           }
         },
         "rolling": false,
-        "securityContext": {}
-      },
-      "kubeRBACProxy": {
-        "enabled": true,
-        "image": {
-          "repository": "quay.io/brancz/kube-rbac-proxy",
-          "tag": "v0.15.0"
-        },
-        "ports": {
-          "proxyPort": 8443
-        },
-        "resources": {
-          "limits": {
-            "cpu": "500m",
-            "memory": "128Mi"
-          },
-          "requests": {
-            "cpu": "5m",
-            "memory": "64Mi"
-          }
-        },
-        "extraArgs": [],
         "securityContext": {}
       },
       "admissionWebhooks": {

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/values.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/charts/opentelemetry-operator/values.yaml
@@ -11,6 +11,11 @@ replicaCount: 1
 ##
 revisionHistoryLimit: 10
 
+## Minimum number of seconds for which a newly created pod should be ready
+## without any of its container crashing, for it to be considered available.
+##
+minReadySeconds: 0
+
 ## Provide a name in place of opentelemetry-operator (includes the chart's release name).
 ##
 nameOverride: ""
@@ -50,7 +55,7 @@ manager:
     imagePullPolicy: IfNotPresent
   collectorImage:
     repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s
-    tag: 0.144.0
+    tag: 0.151.0
   opampBridgeImage:
     repository: ""
     tag: ""
@@ -104,9 +109,23 @@ manager:
   # operator.golang.flags: false
   # operator.collector.default.config: false
   ports:
-    metricsPort: 8080
+    metricsPort: 8443
     webhookPort: 9443
     healthzPort: 8081
+  ## Metrics server configuration
+  ## The operator uses controller-runtime built-in auth for the metrics server
+  metrics:
+    # Enable authentication and authorization for the metrics server
+    # Corresponds to --metrics-secure flag in the operator
+    secure: true
+
+    # TLS configuration (optional, self-signed certs generated if not provided)
+    # Corresponds to --metrics-tls-cert-file and --metrics-tls-key-file flags
+    tls:
+      # Path to TLS certificate file (optional)
+      certFile: ""
+      # Path to TLS private key file (optional)
+      keyFile: ""
   resources: {}
   # resources:
   #   limits:
@@ -147,6 +166,10 @@ manager:
     annotations: {}
     metricsEndpoints:
       - port: metrics
+        scheme: https
+        bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+        tlsConfig:
+          insecureSkipVerify: true
     # Used to set relabeling and metricRelabeling configs on the ServiceMonitor
     # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
     relabelings: []
@@ -224,39 +247,6 @@ manager:
       minReplicas: 2
   # Enable manager pod automatically rolling
   rolling: false
-
-  ## Container specific securityContext
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
-
-## Provide OpenTelemetry Operator kube-rbac-proxy container image.
-##
-kubeRBACProxy:
-  enabled: true
-  image:
-    repository: quay.io/brancz/kube-rbac-proxy
-    tag: v0.20.0
-  ports:
-    proxyPort: 8443
-  resources: {}
-  # resources:
-  #   limits:
-  #     cpu: 500m
-  #     memory: 128Mi
-  #   requests:
-  #     cpu: 5m
-  #     memory: 64Mi
-
-  ## List of additional cli arguments to configure the kube-rbac-proxy
-  ## for example: --tls-cipher-suites, --tls-min-version, etc.
-  extraArgs: []
 
   ## Container specific securityContext
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
@@ -416,3 +406,13 @@ testFramework:
   #   requests:
   #     cpu: 10m
   #     memory: 64Mi
+
+## Extra manifests to deploy as an array
+## Supports tpl syntax for templating
+extraObjects: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: '{{ include "opentelemetry-operator.fullname" . }}-extra'
+  #   data:
+  #     key: value

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/ci/daemonset-ta-no-scrape-config-file.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/ci/daemonset-ta-no-scrape-config-file.yaml
@@ -1,0 +1,20 @@
+collectors:
+  daemon:
+    # no prometheus scrape config file
+    scrape_configs_file: ""
+    presets:
+      kubeletMetrics:
+        enabled: true
+      hostMetrics:
+        enabled: true
+      kubernetesAttributes:
+        enabled: true
+      clusterMetrics:
+        enabled: true
+    # target allocator configuration to discover ServiceMonitor resources and distribute scrape targets across the DaemonSet pods
+    targetAllocator:
+      enabled: true
+      allocationStrategy: per-node
+      prometheusCR:
+        enabled: true
+        serviceMonitorSelector: {}

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/templates/_config.tpl
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/templates/_config.tpl
@@ -4,6 +4,10 @@ Constructs the final config for the given collector
 This allows a user to supply a scrape_configs_file. This file is templated and loaded as a yaml array.
 If a user has already supplied a prometheus receiver config, the file's config is appended. Finally,
 the config is written as YAML.
+
+When no scrape_configs_file is supplied but the targetAllocator is enabled, a minimal prometheus
+receiver (with an empty scrape_configs list) is injected if one isn't already defined, so the
+target allocator has a receiver to populate.
 */}}
 {{- define "opentelemetry-kube-stack.config" -}}
 {{- $collector := .collector }}
@@ -11,6 +15,15 @@ the config is written as YAML.
 {{- if .collector.scrape_configs_file }}
 {{- $config = (include "opentelemetry-kube-stack.collector.appendPrometheusScrapeFile" . | fromYaml) }}
 {{- $_ := set $collector "config" $config }}
+{{- else if (dig "targetAllocator" "enabled" false .collector) }}
+{{- $receivers := (dig "receivers" dict $config) }}
+{{- if not (hasKey $receivers "prometheus") }}
+{{- $config = (mustMergeOverwrite $config (dict "receivers" (dict "prometheus" (dict "config" (dict "scrape_configs" list))))) }}
+{{- $_ := set $collector "config" $config }}
+{{- end }}
+{{- if and (dig "service" "pipelines" "metrics" false $config) (not (has "prometheus" (dig "service" "pipelines" "metrics" "receivers" list $config))) }}
+{{- $_ := set $config.service.pipelines.metrics "receivers" (append ($config.service.pipelines.metrics.receivers | default list) "prometheus" | uniq) }}
+{{- end }}
 {{- end }}
 {{- if .collector.presets.logsCollection.enabled }}
 {{- $_ := set $collector "exclude" (list (printf "/var/log/pods/%s_%s*_*/otc-container/*.log" .namespace (include "opentelemetry-kube-stack.collectorFullname" .))) }}

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/templates/_helpers.tpl
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/templates/_helpers.tpl
@@ -75,7 +75,7 @@ Render a deduped list of environment variables and 'extraEnvs'
 {{- end }}
 {{- range $key, $value := $envMap }}
 - name: {{ $key }}
-  value: {{ $value }}
+  value: {{ $value | quote }}
 {{- end }}
 {{- range $key, $value := $valueFromMap }}
 - name: {{ $key }}

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/templates/hooks.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/templates/hooks.yaml
@@ -62,12 +62,20 @@ spec:
       {{- else}}
       serviceAccountName: {{ .Values.cleanupJob.existingServiceAccount }}
       {{- end}}
+      {{- with .Values.cleanupJob.podSecurityContext }}
+      securityContext:
+{{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: delete-resources
         {{- if $.Values.cleanupJob.image.digest }}
         image: "{{ $.Values.cleanupJob.image.repository }}@{{ $.Values.cleanupJob.image.digest }}"
         {{- else }}
         image: "{{ $.Values.cleanupJob.image.repository }}:{{ $.Values.cleanupJob.image.tag }}"
+        {{- end }}
+        {{- with $.Values.cleanupJob.securityContext }}
+        securityContext:
+{{- toYaml . | nindent 10 }}
         {{- end }}
         args:
           - "delete"

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/values.schema.json
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/values.schema.json
@@ -566,7 +566,10 @@
           "type": "string"
         },
         "value": {
-          "type": "string"
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "valueFrom": {
           "$ref": "#/$defs/EnvVarSource"
@@ -4221,6 +4224,29 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "digest": {
+              "type": "string"
+            }
+          }
+        },
+        "existingServiceAccount": {
+          "type": "string"
+        },
+        "podSecurityContext": {
+          "$ref": "#/$defs/PodSecurityContext"
+        },
+        "securityContext": {
+          "$ref": "#/$defs/SecurityContext"
         }
       }
     },

--- a/testing/integration/k8s/testdata/opentelemetry-kube-stack/values.yaml
+++ b/testing/integration/k8s/testdata/opentelemetry-kube-stack/values.yaml
@@ -26,6 +26,22 @@ cleanupJob:
   # To use the existingServiceAccount
   existingServiceAccount: ""
 
+  # Pod-level securityContext for the cleanup Job (Pod spec field name; PSA restricted needs seccomp).
+  podSecurityContext: {}
+  #   runAsNonRoot: true
+  #   seccompProfile:
+  #     type: RuntimeDefault
+
+  # Container security context for the cleanup Job.
+  securityContext: {}
+  #   allowPrivilegeEscalation: false
+  #   capabilities:
+  #     drop:
+  #       - ALL
+  #   readOnlyRootFilesystem: true
+  #   runAsNonRoot: true
+  #   runAsUser: 65534
+
 # Should the CRDs be installed by this chart.
 crds:
   # Control whether the opentelemetry.io CRDS should be installed.


### PR DESCRIPTION
## What does this PR do?

Bumps the kube-stack version to 0.15.2 which is the latest upstream

**Note:** I was not able to repro the issue mentioned in PR #14464 regarding the quotations marks locally with this version. Raising the PR to check if ci/cd pipeline also passes.

Will raise a PR later for Kibana to also update the version so both PRs can be merged in sync. (Investigation required to check what it would be required to automate this)


## Why is it important?

Bring the latest features from upstream kube-stack 


## How to test this PR locally


```
helm upgrade --install opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack \                                                     
  --namespace opentelemetry-operator-system \
  --values 'kube-stack/managed_otlp/values.yaml' \
  --version '0.15.2' \
  --set 'collectors.daemon.config.processors.resource\/onboarding_id.attributes[0].action=upsert' \
  --set 'collectors.daemon.config.processors.resource\/onboarding_id.attributes[0].key=onboarding.id' \
  --set 'collectors.daemon.config.processors.resource\/onboarding_id.attributes[0].value=placeholder' \
  --set 'collectors.daemon.config.service.pipelines.logs\/node.processors[8]=resource/onboarding_id' \
  --set 'collectors.daemon.config.service.pipelines.metrics\/node\/otel.processors[8]=resource/onboarding_id'
```

-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
