### PR TITLE
Use the checkin on state change mode in integration tests

### DIFF
--- a/internal/pkg/agent/application/enroll/enroll.go
+++ b/internal/pkg/agent/application/enroll/enroll.go
@@ -187,7 +187,7 @@ func enroll(
 			errors.TypeNetwork)
 	}
 
-	fleetConfig, err := createFleetConfigFromEnroll(resp.Item.AccessAPIKey, options.EnrollAPIKey, options.ReplaceToken, remoteConfig)
+	fleetConfig, err := createFleetConfigFromEnroll(resp.Item.AccessAPIKey, options.EnrollAPIKey, options.ReplaceToken, remoteConfig, options.CheckinOnStateChange)
 	if err != nil {
 		return err
 	}
@@ -505,12 +505,15 @@ func storeAgentInfo(s saver, reader io.Reader) error {
 	return nil
 }
 
-func createFleetConfigFromEnroll(accessAPIKey string, enrollmentToken string, replaceToken string, cli remote.Config) (*configuration.FleetAgentConfig, error) {
+func createFleetConfigFromEnroll(accessAPIKey string, enrollmentToken string, replaceToken string, cli remote.Config, checkinOnStateChange bool) (*configuration.FleetAgentConfig, error) {
 	var err error
 	cfg := configuration.DefaultFleetAgentConfig()
 	cfg.Enabled = true
 	cfg.AccessAPIKey = accessAPIKey
 	cfg.Client = cli
+	if checkinOnStateChange {
+		cfg.Checkin.Mode = configuration.FleetCheckinModeOnStateChange
+	}
 	cfg.EnrollmentTokenHash, err = fleetHashToken(enrollmentToken)
 	if err != nil {
 		return nil, errors.New(err, "failed to generate enrollment hash", errors.TypeConfig)

--- a/internal/pkg/agent/application/enroll/options.go
+++ b/internal/pkg/agent/application/enroll/options.go
@@ -45,6 +45,7 @@ type EnrollOptions struct {
 	SkipCreateSecret     bool                       `yaml:"-" json:"-"`
 	SkipDaemonRestart    bool                       `yaml:"-" json:"-"`
 	Tags                 []string                   `yaml:"tags,omitempty" json:"tags,omitempty"`
+	CheckinOnStateChange bool                       `yaml:"-" json:"-"`
 }
 
 // EnrollCmdFleetServerOption define all the supported enrollment options for bootstrapping with Fleet Server.

--- a/internal/pkg/agent/cmd/enroll.go
+++ b/internal/pkg/agent/cmd/enroll.go
@@ -105,8 +105,10 @@ func addEnrollFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceP("tag", "", []string{}, "User-set tags")
 	cmd.Flags().Bool("checkin-on-state-change", false, "Use on_state_change Fleet checkin mode so the agent checks in immediately on state changes (speeds up integration tests)")
 
-	cmd.Flags().MarkHidden("skip-daemon-reload")         //nolint:errcheck // an error is only returned if the flag does not exist.
-	cmd.Flags().MarkHidden("checkin-on-state-change")    //nolint:errcheck // an error is only returned if the flag does not exist.
+	// Hide the checkin-on-state-change flag, it's used to speed up tests and in agentless only.
+	// Faster checkins affects Fleet scalability by lowering the maximum agents that can be managed due to increased authentication load.
+	cmd.Flags().MarkHidden("checkin-on-state-change") //nolint:errcheck // an error is only returned if the flag does not exist.
+	cmd.Flags().MarkHidden("skip-daemon-reload")      //nolint:errcheck // an error is only returned if the flag does not exist.
 }
 
 func validateEnrollFlags(cmd *cobra.Command) error {

--- a/internal/pkg/agent/cmd/enroll.go
+++ b/internal/pkg/agent/cmd/enroll.go
@@ -103,8 +103,10 @@ func addEnrollFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationP("fleet-server-timeout", "", 0, "When bootstrapping Fleet Server, timeout waiting for Fleet Server to be ready to start enrollment")
 	cmd.Flags().Bool("skip-daemon-reload", false, "Skip daemon reload after enrolling")
 	cmd.Flags().StringSliceP("tag", "", []string{}, "User-set tags")
+	cmd.Flags().Bool("checkin-on-state-change", false, "Use on_state_change Fleet checkin mode so the agent checks in immediately on state changes (speeds up integration tests)")
 
-	cmd.Flags().MarkHidden("skip-daemon-reload") //nolint:errcheck // an error is only returned if the flag does not exist.
+	cmd.Flags().MarkHidden("skip-daemon-reload")         //nolint:errcheck // an error is only returned if the flag does not exist.
+	cmd.Flags().MarkHidden("checkin-on-state-change")    //nolint:errcheck // an error is only returned if the flag does not exist.
 }
 
 func validateEnrollFlags(cmd *cobra.Command) error {
@@ -214,6 +216,7 @@ func buildEnrollmentFlags(cmd *cobra.Command, url string, token string) []string
 	fTimeout, _ := cmd.Flags().GetDuration("fleet-server-timeout")
 	skipDaemonReload, _ := cmd.Flags().GetBool("skip-daemon-reload")
 	fTags, _ := cmd.Flags().GetStringSlice("tag")
+	checkinOnStateChange, _ := cmd.Flags().GetBool("checkin-on-state-change")
 	args := []string{}
 	if url != "" {
 		args = append(args, "--url")
@@ -363,6 +366,9 @@ func buildEnrollmentFlags(cmd *cobra.Command, url string, token string) []string
 	for _, v := range fTags {
 		args = append(args, "--tag", v)
 	}
+	if checkinOnStateChange {
+		args = append(args, "--checkin-on-state-change")
+	}
 	return args
 }
 
@@ -491,6 +497,7 @@ func doEnroll(streams *cli.IOStreams, cmd *cobra.Command) error {
 	fTimeout, _ := cmd.Flags().GetDuration("fleet-server-timeout")
 	skipDaemonReload, _ := cmd.Flags().GetBool("skip-daemon-reload")
 	tags, _ := cmd.Flags().GetStringSlice("tag")
+	checkinOnStateChange, _ := cmd.Flags().GetBool("checkin-on-state-change")
 
 	caStr, _ := cmd.Flags().GetString("certificate-authorities")
 	CAs := cli.StringToSlice(caStr)
@@ -540,6 +547,7 @@ func doEnroll(streams *cli.IOStreams, cmd *cobra.Command) error {
 		DaemonTimeout:        daemonTimeout,
 		SkipDaemonRestart:    skipDaemonReload,
 		Tags:                 tags,
+		CheckinOnStateChange: checkinOnStateChange,
 		FleetServer: enroll.EnrollCmdFleetServerOption{
 			ConnStr:               fServer,
 			ElasticsearchCA:       fElasticSearchCA,

--- a/internal/pkg/agent/cmd/enroll_cmd_test.go
+++ b/internal/pkg/agent/cmd/enroll_cmd_test.go
@@ -542,6 +542,123 @@ func TestEnroll(t *testing.T) {
 			assert.Equal(t, host, config.Client.Host)
 		},
 	))
+
+	t.Run("default fleet checkin mode is the standard mode", withServer(
+		func(t *testing.T) *http.ServeMux {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`
+{
+    "action": "created",
+    "item": {
+        "id": "a9328860-ec54-11e9-93c4-d72ab8a69391",
+        "active": true,
+        "policy_id": "69f3f5a0-ec52-11e9-93c4-d72ab8a69391",
+        "type": "PERMANENT",
+        "enrolled_at": "2019-10-11T18:26:37.158Z",
+        "user_provided_metadata": {},
+        "local_metadata": {
+            "platform": "linux",
+            "version": "8.0.0"
+        },
+        "actions": [],
+        "access_api_key": "my-access-api-key"
+    }
+}`))
+			})
+			return mux
+		}, func(t *testing.T, host string) {
+			url := "http://" + host
+			store := &mockStore{}
+			cmd, err := newEnrollCmd(
+				log,
+				&enroll.EnrollOptions{
+					URL:               url,
+					CAs:               []string{},
+					EnrollAPIKey:      "my-enrollment-api-key",
+					Insecure:          true,
+					SkipCreateSecret:  skipCreateSecret,
+					SkipDaemonRestart: true,
+				},
+				"",
+				store,
+				nil,
+			)
+			require.NoError(t, err)
+
+			streams, _, _, _ := cli.NewTestingIOStreams()
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			defer cancel()
+			err = cmd.Execute(ctx, streams)
+			require.NoError(t, err, "enroll command should return no error")
+
+			assert.True(t, store.Called, "the store should have been called")
+			cfg, err := readConfig(store.Content)
+			require.NoError(t, err)
+			require.Equal(t, configuration.FleetCheckinModeStandard, cfg.Checkin.GetMode())
+		},
+	))
+
+	t.Run("checkin-on-state-change flag configures on_state_change checkin mode", withServer(
+		func(t *testing.T) *http.ServeMux {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/fleet/agents/enroll", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`
+{
+    "action": "created",
+    "item": {
+        "id": "a9328860-ec54-11e9-93c4-d72ab8a69391",
+        "active": true,
+        "policy_id": "69f3f5a0-ec52-11e9-93c4-d72ab8a69391",
+        "type": "PERMANENT",
+        "enrolled_at": "2019-10-11T18:26:37.158Z",
+        "user_provided_metadata": {},
+        "local_metadata": {
+            "platform": "linux",
+            "version": "8.0.0"
+        },
+        "actions": [],
+        "access_api_key": "my-access-api-key"
+    }
+}`))
+			})
+			return mux
+		}, func(t *testing.T, host string) {
+			url := "http://" + host
+			store := &mockStore{}
+			cmd, err := newEnrollCmd(
+				log,
+				&enroll.EnrollOptions{
+					URL:                  url,
+					CAs:                  []string{},
+					EnrollAPIKey:         "my-enrollment-api-key",
+					Insecure:             true,
+					SkipCreateSecret:     skipCreateSecret,
+					SkipDaemonRestart:    true,
+					CheckinOnStateChange: true,
+				},
+				"",
+				store,
+				nil,
+			)
+			require.NoError(t, err)
+
+			streams, _, _, _ := cli.NewTestingIOStreams()
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			defer cancel()
+			err = cmd.Execute(ctx, streams)
+			require.NoError(t, err, "enroll command should return no error")
+
+			assert.True(t, store.Called, "the store should have been called")
+			cfg, err := readConfig(store.Content)
+			require.NoError(t, err)
+			require.NotNil(t, cfg.Checkin)
+			assert.Equal(t, configuration.FleetCheckinModeOnStateChange, cfg.Checkin.Mode)
+			assert.Equal(t, configuration.CheckinCompressionGzip, cfg.Checkin.GetCompression())
+		},
+	))
 }
 
 func TestValidateArgs(t *testing.T) {

--- a/internal/pkg/agent/configuration/fleet.go
+++ b/internal/pkg/agent/configuration/fleet.go
@@ -19,11 +19,7 @@ const (
 
 	defaultCompression = CheckinCompressionGzip
 
-	FleetCheckinModeStandard = "standard"
-
-	// FleetCheckinModeOnStateChange is the checkin mode that causes the agent to
-	// check in with Fleet immediately when its state changes, rather than waiting
-	// for the full polling interval. Useful for speeding up integration tests.
+	FleetCheckinModeStandard      = "standard"
 	FleetCheckinModeOnStateChange = "on_state_change"
 )
 

--- a/internal/pkg/agent/configuration/fleet.go
+++ b/internal/pkg/agent/configuration/fleet.go
@@ -19,7 +19,7 @@ const (
 
 	defaultCompression = CheckinCompressionGzip
 
-	fleetCheckinModeStandard = "standard"
+	FleetCheckinModeStandard = "standard"
 
 	// FleetCheckinModeOnStateChange is the checkin mode that causes the agent to
 	// check in with Fleet immediately when its state changes, rather than waiting
@@ -96,7 +96,7 @@ func (f *FleetCheckin) IsModeOnStateChanged() bool {
 
 func (f *FleetCheckin) GetMode() string {
 	if f == nil || f.Mode == "" {
-		return fleetCheckinModeStandard
+		return FleetCheckinModeStandard
 	}
 
 	return f.Mode
@@ -107,7 +107,7 @@ func (f *FleetCheckin) Validate() error {
 		return nil
 	}
 
-	if f.Mode != "" && f.Mode != fleetCheckinModeStandard && f.Mode != FleetCheckinModeOnStateChange {
+	if f.Mode != "" && f.Mode != FleetCheckinModeStandard && f.Mode != FleetCheckinModeOnStateChange {
 		return errors.New("checkin.mode must be either 'standard' or 'on_state_change'")
 	}
 

--- a/internal/pkg/agent/configuration/fleet.go
+++ b/internal/pkg/agent/configuration/fleet.go
@@ -19,8 +19,12 @@ const (
 
 	defaultCompression = CheckinCompressionGzip
 
-	fleetCheckinModeStandard       = "standard"
-	fleetCheckinModeOnStateChanged = "on_state_change"
+	fleetCheckinModeStandard = "standard"
+
+	// FleetCheckinModeOnStateChange is the checkin mode that causes the agent to
+	// check in with Fleet immediately when its state changes, rather than waiting
+	// for the full polling interval. Useful for speeding up integration tests.
+	FleetCheckinModeOnStateChange = "on_state_change"
 )
 
 // FleetAgentConfig is the internal configuration of the agent after the enrollment is done,
@@ -87,7 +91,7 @@ func DefaultFleetCheckin() *FleetCheckin {
 }
 
 func (f *FleetCheckin) IsModeOnStateChanged() bool {
-	return f != nil && f.Mode == fleetCheckinModeOnStateChanged
+	return f != nil && f.Mode == FleetCheckinModeOnStateChange
 }
 
 func (f *FleetCheckin) GetMode() string {
@@ -103,7 +107,7 @@ func (f *FleetCheckin) Validate() error {
 		return nil
 	}
 
-	if f.Mode != "" && f.Mode != fleetCheckinModeStandard && f.Mode != fleetCheckinModeOnStateChanged {
+	if f.Mode != "" && f.Mode != fleetCheckinModeStandard && f.Mode != FleetCheckinModeOnStateChange {
 		return errors.New("checkin.mode must be either 'standard' or 'on_state_change'")
 	}
 

--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -57,6 +57,10 @@ type Fixture struct {
 	fipsArtifact    bool
 	cmdOutput       io.Writer
 
+	// useStandardCheckinMode disables the on_state_change Fleet checkin
+	// mode used in tests by default.
+	useStandardCheckinMode bool
+
 	srcPackage string
 	workDir    string
 	extractDir string
@@ -174,6 +178,15 @@ func WithAdditionalArgs(args []string) FixtureOpt {
 func WithFIPSArtifact() FixtureOpt {
 	return func(f *Fixture) {
 		f.fipsArtifact = true
+	}
+}
+
+// WithStandardCheckinMode opts the fixture out of the default on_state_change
+// Fleet checkin mode. Use this when a test specifically requires standard
+// checkin behavior where changes can take up to 5 minutes to be reported to Fleet.
+func WithStandardCheckinMode() FixtureOpt {
+	return func(f *Fixture) {
+		f.useStandardCheckinMode = true
 	}
 }
 

--- a/pkg/testing/fixture_install.go
+++ b/pkg/testing/fixture_install.go
@@ -244,6 +244,15 @@ func (f *Fixture) installNoPkgManager(ctx context.Context, installOpts *InstallO
 	}
 
 	installArgs = append(installArgs, installOpts.ToCmdArgs()...)
+
+	// Speed up integration tests by having the agent check in with Fleet on
+	// state changes rather than waiting the full polling interval. Tests that
+	// need the standard poll-based mode should pass WithStandardCheckinMode()
+	// when creating their fixture.
+	if !f.useStandardCheckinMode {
+		installArgs = append(installArgs, "--checkin-on-state-change")
+	}
+
 	out, err := f.Exec(ctx, installArgs, opts...)
 	if err != nil {
 		f.DumpProcesses("-install")

--- a/pkg/testing/fixture_install.go
+++ b/pkg/testing/fixture_install.go
@@ -29,6 +29,7 @@ import (
 	"github.com/elastic/elastic-agent/pkg/control"
 	"github.com/elastic/elastic-agent/pkg/control/v2/client"
 	"github.com/elastic/elastic-agent/pkg/core/process"
+	agentversion "github.com/elastic/elastic-agent/pkg/version"
 )
 
 // ErrNotInstalled is returned in cases where Agent isn't installed
@@ -249,7 +250,9 @@ func (f *Fixture) installNoPkgManager(ctx context.Context, installOpts *InstallO
 	// state changes rather than waiting the full polling interval. Tests that
 	// need the standard poll-based mode should pass WithStandardCheckinMode()
 	// when creating their fixture.
-	if !f.useStandardCheckinMode && shouldEnroll {
+	// Gate on the fixture version: the flag was introduced in 9.5.0-SNAPSHOT, so
+	// older binaries (e.g. the start agent in upgrade tests) would reject it.
+	if !f.useStandardCheckinMode && supportsCheckinOnStateChange(f.version) {
 		installArgs = append(installArgs, "--checkin-on-state-change")
 	}
 
@@ -908,4 +911,16 @@ func KeepInstalledFlag() bool {
 	// failure reports false (ignore error)
 	v, _ := strconv.ParseBool(os.Getenv("AGENT_KEEP_INSTALLED"))
 	return v
+}
+
+// supportsCheckinOnStateChange returns true when the given version string is new enough
+// to support the --checkin-on-state-change install/enroll flag.
+func supportsCheckinOnStateChange(versionStr string) bool {
+	parsed, err := agentversion.ParseVersion(versionStr)
+	if err != nil {
+		return false
+	}
+
+	// The --checkin-on-state-change flag is currently only available in 9.5.0-SNAPSHOT.
+	return !parsed.Less(*agentversion.NewParsedSemVer(9, 5, 0, "SNAPSHOT", ""))
 }

--- a/pkg/testing/fixture_install.go
+++ b/pkg/testing/fixture_install.go
@@ -249,7 +249,7 @@ func (f *Fixture) installNoPkgManager(ctx context.Context, installOpts *InstallO
 	// state changes rather than waiting the full polling interval. Tests that
 	// need the standard poll-based mode should pass WithStandardCheckinMode()
 	// when creating their fixture.
-	if !f.useStandardCheckinMode {
+	if !f.useStandardCheckinMode && shouldEnroll {
 		installArgs = append(installArgs, "--checkin-on-state-change")
 	}
 

--- a/testing/integration/ess/log_level_test.go
+++ b/testing/integration/ess/log_level_test.go
@@ -142,7 +142,7 @@ func TestSetLogLevelFleetManagedSurvivesRestart(t *testing.T) {
 		}
 		t.Logf("Fleet metadata log level: %q (want %q)", fleetLevel, policyLogLevel)
 		return fleetLevel == policyLogLevel.String()
-	}, 6*time.Minute, 30*time.Second, "agent never reported policy log level %q to Fleet", policyLogLevel)
+	}, 6*time.Minute, time.Second, "agent never reported policy log level %q to Fleet", policyLogLevel)
 
 	// Step 3: restart the agent service.
 	topPath := paths.Top()
@@ -191,7 +191,7 @@ func TestSetLogLevelFleetManagedSurvivesRestart(t *testing.T) {
 		}
 		t.Logf("Fleet metadata log level after restart: %q (want %q)", fleetLevel, policyLogLevel)
 		return fleetLevel == policyLogLevel.String()
-	}, 6*time.Minute, 30*time.Second,
+	}, 6*time.Minute, time.Second,
 		"agent did not report policy log level %q to Fleet after restart", policyLogLevel)
 
 	// Step 6: apply a per-agent log level override after restart and validate it in Fleet metadata.
@@ -211,7 +211,7 @@ func TestSetLogLevelFleetManagedSurvivesRestart(t *testing.T) {
 		}
 		t.Logf("Fleet metadata log level after override: %q (want %q)", fleetLevel, overrideLogLevel)
 		return fleetLevel == overrideLogLevel.String()
-	}, 6*time.Minute, 30*time.Second,
+	}, 6*time.Minute, time.Second,
 		"agent did not apply per-agent log level override %q after restart", overrideLogLevel)
 
 	// Step 7: clear the per-agent override and validate the policy log level is restored.
@@ -227,7 +227,7 @@ func TestSetLogLevelFleetManagedSurvivesRestart(t *testing.T) {
 		}
 		t.Logf("Fleet metadata log level after clearing override: %q (want %q)", fleetLevel, policyLogLevel)
 		return fleetLevel == policyLogLevel.String()
-	}, 6*time.Minute, 30*time.Second,
+	}, 6*time.Minute, time.Second,
 		"agent did not revert to policy log level %q after clearing override", policyLogLevel)
 }
 
@@ -258,7 +258,7 @@ func testLogLevelSetViaFleet(ctx context.Context, f *atesting.Fixture, agentID s
 	//	}
 	//	t.Logf("Agent log level: %q policy log level: %q", agentLogLevel, policyLogLevel)
 	//	return agentLogLevel == policyLogLevel.String()
-	//}, 30*time.Second, time.Second, "agent never received expected log level %q", policyLogLevel)
+	//}, time.Second, time.Second, "agent never received expected log level %q", policyLogLevel)
 
 	// assert Fleet eventually receives the new log level from agent through checkin
 	assert.Eventuallyf(t, func() bool {
@@ -269,7 +269,7 @@ func testLogLevelSetViaFleet(ctx context.Context, f *atesting.Fixture, agentID s
 		}
 		t.Logf("Fleet metadata log level for agent %q: %q policy log level: %q", agentID, fleetMetadataLogLevel, policyLogLevel)
 		return fleetMetadataLogLevel == policyLogLevel.String()
-	}, 6*time.Minute, 30*time.Second, "agent never communicated policy log level %q to Fleet", policyLogLevel)
+	}, 6*time.Minute, time.Second, "agent never communicated policy log level %q to Fleet", policyLogLevel)
 
 	// Step 2: set a different log level for the specific agent using Settings action
 	// set agent log level and verify that it takes precedence over the policy one
@@ -300,7 +300,7 @@ func testLogLevelSetViaFleet(ctx context.Context, f *atesting.Fixture, agentID s
 		}
 		t.Logf("Fleet metadata log level for agent %q: %q agent log level: %q", agentID, fleetMetadataLogLevel, agentLogLevel)
 		return fleetMetadataLogLevel == agentLogLevel
-	}, 6*time.Minute, 30*time.Second, "agent never communicated agent-specific log level %q to Fleet", agentLogLevel)
+	}, 6*time.Minute, time.Second, "agent never communicated agent-specific log level %q to Fleet", agentLogLevel)
 
 	// Step 3: Clear the agent-specific log level override, verify that we revert to policy log level
 	t.Logf("Clearing agent log level, expecting log level to revert back to %q", policyLogLevel)
@@ -317,7 +317,7 @@ func testLogLevelSetViaFleet(ctx context.Context, f *atesting.Fixture, agentID s
 	//	}
 	//	t.Logf("Agent log level: %q policy log level: %q", actualAgentLogLevel, policyLogLevel)
 	//	return actualAgentLogLevel == policyLogLevel.String()
-	//}, 30*time.Second, time.Second, "agent never reverted to policy log level %q", policyLogLevel)
+	//}, time.Second, time.Second, "agent never reverted to policy log level %q", policyLogLevel)
 
 	// assert Fleet eventually receives the new log level from agent through checkin
 	assert.Eventuallyf(t, func() bool {
@@ -328,7 +328,7 @@ func testLogLevelSetViaFleet(ctx context.Context, f *atesting.Fixture, agentID s
 		}
 		t.Logf("Fleet metadata log level for agent %q: %q policy log level: %q", agentID, fleetMetadataLogLevel, policyLogLevel)
 		return fleetMetadataLogLevel == policyLogLevel.String()
-	}, 6*time.Minute, 30*time.Second, "agent never communicated reverting to policy log level %q to Fleet", policyLogLevel)
+	}, 6*time.Minute, time.Second, "agent never communicated reverting to policy log level %q to Fleet", policyLogLevel)
 
 	// Step 4: Clear the log level in policy and verify that agent reverts to the initial log level
 	t.Logf("Clearing policy log level, expecting log level to revert back to %q", initialLogLevel)
@@ -356,7 +356,7 @@ func testLogLevelSetViaFleet(ctx context.Context, f *atesting.Fixture, agentID s
 		}
 		t.Logf("Fleet metadata log level for agent %q: %q initial log level: %q", agentID, fleetMetadataLogLevel, initialLogLevel)
 		return fleetMetadataLogLevel == initialLogLevel
-	}, 6*time.Minute, 30*time.Second, "agent never communicated initial log level %q to Fleet", initialLogLevel)
+	}, 6*time.Minute, time.Second, "agent never communicated initial log level %q to Fleet", initialLogLevel)
 }
 
 func waitForAgentAndFleetHealthy(ctx context.Context, t *testing.T, f *atesting.Fixture) bool {


### PR DESCRIPTION
- Relates https://github.com/elastic/elastic-agent/pull/9982

Uses the checkin on state change mode in integration tests, to speed up tests that poll for the agent status to change in Fleet. This makes a few test significantly faster, like the log level related tests.

https://github.com/elastic/elastic-agent/blob/94308667cac4c8b439e2dfceb3aece9fc85dd4f9/testing/integration/ess/log_level_test.go#L263-L272
e 
The impact on test execution overall is not that big because these tests weren't on the critical path. It's also bypassed in several of the upgrade tests until I backport this and come back and change the version guard.