### PR TITLE
Fix bug where an empty body could be sent after failing over to another Fleet host

### DIFF
--- a/changelog/fragments/1780926122-fix-bug-where-an-empty-request-body-could-be-sent-after-failing-over-to-an-alternate-fleet-host..yaml
+++ b/changelog/fragments/1780926122-fix-bug-where-an-empty-request-body-could-be-sent-after-failing-over-to-an-alternate-fleet-host..yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix bug where an empty request body could be sent after failing over to an alternate fleet host.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/14773

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -59,7 +59,7 @@ func (t *testingClient) Send(
 	_ string,
 	_ url.Values,
 	headers http.Header,
-	body io.Reader,
+	body io.ReadSeeker,
 ) (*http.Response, error) {
 	t.Lock()
 	defer t.Unlock()

--- a/internal/pkg/agent/application/upgrade/upgrade_test.go
+++ b/internal/pkg/agent/application/upgrade/upgrade_test.go
@@ -1966,7 +1966,7 @@ func TestCopyRunDirectory(t *testing.T) {
 
 type mockSender struct{}
 
-func (m *mockSender) Send(ctx context.Context, method, path string, params url.Values, headers http.Header, body io.Reader) (*http.Response, error) {
+func (m *mockSender) Send(ctx context.Context, method, path string, params url.Values, headers http.Header, body io.ReadSeeker) (*http.Response, error) {
 	return nil, nil
 }
 

--- a/internal/pkg/fleetapi/ack_cmd.go
+++ b/internal/pkg/fleetapi/ack_cmd.go
@@ -115,7 +115,7 @@ func (e *AckCmd) Execute(ctx context.Context, r *AckRequest) (_ *AckResponse, er
 	}
 
 	ap := fmt.Sprintf(ackPath, e.info.AgentID())
-	resp, err := e.client.Send(ctx, "POST", ap, nil, nil, bytes.NewBuffer(b))
+	resp, err := e.client.Send(ctx, "POST", ap, nil, nil, bytes.NewReader(b))
 	if err != nil {
 		return nil, errors.New(err,
 			"fail to ack to fleet",

--- a/internal/pkg/fleetapi/acker/fleet/fleet_acker_test.go
+++ b/internal/pkg/fleetapi/acker/fleet/fleet_acker_test.go
@@ -40,7 +40,7 @@ func (s *testSender) Send(
 	path string,
 	params url.Values,
 	headers http.Header,
-	body io.Reader,
+	body io.ReadSeeker,
 ) (*http.Response, error) {
 	d := json.NewDecoder(body)
 	var req ackRequest

--- a/internal/pkg/fleetapi/audit_unenroll_cmd.go
+++ b/internal/pkg/fleetapi/audit_unenroll_cmd.go
@@ -83,7 +83,7 @@ func (e *AuditUnenrollCmd) Execute(ctx context.Context, r *AuditUnenrollRequest)
 		return nil, &ReqError{err}
 	}
 	path := fmt.Sprintf(auditUnenrollPath, e.info.AgentID())
-	resp, err := e.client.Send(ctx, http.MethodPost, path, nil, nil, bytes.NewBuffer(p))
+	resp, err := e.client.Send(ctx, http.MethodPost, path, nil, nil, bytes.NewReader(p))
 	if err != nil {
 		// Invalid credentials should result in no retries
 		if errors.Is(err, client.ErrInvalidAPIKey) {

--- a/internal/pkg/fleetapi/client/client.go
+++ b/internal/pkg/fleetapi/client/client.go
@@ -34,7 +34,7 @@ type Sender interface {
 		path string,
 		params url.Values,
 		headers http.Header,
-		body io.Reader,
+		body io.ReadSeeker,
 	) (*http.Response, error)
 
 	URI() string

--- a/internal/pkg/fleetapi/client/mocks.go
+++ b/internal/pkg/fleetapi/client/mocks.go
@@ -45,7 +45,7 @@ func (_m *MockSender) EXPECT() *MockSender_Expecter {
 }
 
 // Send provides a mock function for the type MockSender
-func (_mock *MockSender) Send(ctx context.Context, method string, path string, params url.Values, headers http.Header, body io.Reader) (*http.Response, error) {
+func (_mock *MockSender) Send(ctx context.Context, method string, path string, params url.Values, headers http.Header, body io.ReadSeeker) (*http.Response, error) {
 	ret := _mock.Called(ctx, method, path, params, headers, body)
 
 	if len(ret) == 0 {
@@ -54,17 +54,17 @@ func (_mock *MockSender) Send(ctx context.Context, method string, path string, p
 
 	var r0 *http.Response
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, url.Values, http.Header, io.Reader) (*http.Response, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, url.Values, http.Header, io.ReadSeeker) (*http.Response, error)); ok {
 		return returnFunc(ctx, method, path, params, headers, body)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, url.Values, http.Header, io.Reader) *http.Response); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, url.Values, http.Header, io.ReadSeeker) *http.Response); ok {
 		r0 = returnFunc(ctx, method, path, params, headers, body)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*http.Response)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, url.Values, http.Header, io.Reader) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, url.Values, http.Header, io.ReadSeeker) error); ok {
 		r1 = returnFunc(ctx, method, path, params, headers, body)
 	} else {
 		r1 = ret.Error(1)
@@ -83,12 +83,12 @@ type MockSender_Send_Call struct {
 //   - path string
 //   - params url.Values
 //   - headers http.Header
-//   - body io.Reader
+//   - body io.ReadSeeker
 func (_e *MockSender_Expecter) Send(ctx interface{}, method interface{}, path interface{}, params interface{}, headers interface{}, body interface{}) *MockSender_Send_Call {
 	return &MockSender_Send_Call{Call: _e.mock.On("Send", ctx, method, path, params, headers, body)}
 }
 
-func (_c *MockSender_Send_Call) Run(run func(ctx context.Context, method string, path string, params url.Values, headers http.Header, body io.Reader)) *MockSender_Send_Call {
+func (_c *MockSender_Send_Call) Run(run func(ctx context.Context, method string, path string, params url.Values, headers http.Header, body io.ReadSeeker)) *MockSender_Send_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -110,9 +110,9 @@ func (_c *MockSender_Send_Call) Run(run func(ctx context.Context, method string,
 		if args[4] != nil {
 			arg4 = args[4].(http.Header)
 		}
-		var arg5 io.Reader
+		var arg5 io.ReadSeeker
 		if args[5] != nil {
-			arg5 = args[5].(io.Reader)
+			arg5 = args[5].(io.ReadSeeker)
 		}
 		run(
 			arg0,
@@ -131,7 +131,7 @@ func (_c *MockSender_Send_Call) Return(response *http.Response, err error) *Mock
 	return _c
 }
 
-func (_c *MockSender_Send_Call) RunAndReturn(run func(ctx context.Context, method string, path string, params url.Values, headers http.Header, body io.Reader) (*http.Response, error)) *MockSender_Send_Call {
+func (_c *MockSender_Send_Call) RunAndReturn(run func(ctx context.Context, method string, path string, params url.Values, headers http.Header, body io.ReadSeeker) (*http.Response, error)) *MockSender_Send_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/pkg/fleetapi/enroll_cmd.go
+++ b/internal/pkg/fleetapi/enroll_cmd.go
@@ -211,7 +211,7 @@ func (e *EnrollCmd) Execute(ctx context.Context, r *EnrollRequest) (*EnrollRespo
 		return nil, errors.New(err, "fail to encode the enrollment request")
 	}
 
-	resp, err := e.client.Send(ctx, "POST", p, nil, headers, bytes.NewBuffer(b))
+	resp, err := e.client.Send(ctx, "POST", p, nil, headers, bytes.NewReader(b))
 	if err != nil {
 		if errors.Is(err, syscall.ECONNREFUSED) {
 			return nil, ErrConnRefused

--- a/internal/pkg/fleetapi/uploader/uploader.go
+++ b/internal/pkg/fleetapi/uploader/uploader.go
@@ -72,23 +72,22 @@ type retrySender struct {
 
 // Send calls the underlying Sender's Send method.
 // If a non context-related error is returned or the 429 status code is returned the request is retried after a backoff period.
-func (r *retrySender) Send(ctx context.Context, method, path string, params url.Values, headers http.Header, body io.Reader) (resp *http.Response, err error) {
+func (r *retrySender) Send(ctx context.Context, method, path string, params url.Values, headers http.Header, body io.ReadSeeker) (resp *http.Response, err error) {
 	r.wait.Reset()
 
-	var b bytes.Buffer
-	tr := io.TeeReader(body, &b)
 	for i := 0; i < r.max; i++ {
-		resp, err = r.c.Send(ctx, method, path, params, headers, tr)
+		if body != nil {
+			_, _ = body.Seek(0, io.SeekStart)
+		}
+		resp, err = r.c.Send(ctx, method, path, params, headers, body)
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return resp, err
 			}
-			tr = bytes.NewReader(b.Bytes())
 			r.wait.Wait()
 			continue
 		}
 		if resp.StatusCode == http.StatusTooManyRequests {
-			tr = bytes.NewReader(b.Bytes())
 			r.wait.Wait()
 			continue
 		}
@@ -131,7 +130,7 @@ func (c *Client) New(ctx context.Context, r *NewUploadRequest) (*NewUploadRespon
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.c.Send(ctx, http.MethodPost, PathNewUpload, nil, nil, bytes.NewBuffer(b))
+	resp, err := c.c.Send(ctx, http.MethodPost, PathNewUpload, nil, nil, bytes.NewReader(b))
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +149,7 @@ func (c *Client) New(ctx context.Context, r *NewUploadRequest) (*NewUploadRespon
 }
 
 // Chunk uploads a file chunk to fleet-server.
-func (c *Client) Chunk(ctx context.Context, uploadID string, chunkID int, sha256Hash []byte, r io.Reader) error {
+func (c *Client) Chunk(ctx context.Context, uploadID string, chunkID int, sha256Hash []byte, r io.ReadSeeker) error {
 	h := http.Header{"X-Chunk-Sha2": {fmt.Sprintf("%x", sha256Hash)}}
 	resp, err := c.c.Send(ctx, "PUT", fmt.Sprintf(PathChunk, uploadID, chunkID), nil, h, r)
 	if err != nil {
@@ -171,7 +170,7 @@ func (c *Client) Finish(ctx context.Context, id string, r *FinishRequest) error 
 		return err
 	}
 
-	resp, err := c.c.Send(ctx, "POST", fmt.Sprintf(PathFinishUpload, id), nil, nil, bytes.NewBuffer(b))
+	resp, err := c.c.Send(ctx, "POST", fmt.Sprintf(PathFinishUpload, id), nil, nil, bytes.NewReader(b))
 	if err != nil {
 		return err
 	}
@@ -209,7 +208,10 @@ func (c *Client) UploadDiagnostics(ctx context.Context, actionId string, timesta
 		var data bytes.Buffer
 		io.CopyN(&data, r, chunkSize) //nolint:errcheck // copy chunkSize bytes to a buffer so we can get the checksum
 		hash := sha256.Sum256(data.Bytes())
-		err := c.Chunk(ctx, uploadID, chunk, hash[:], &data) // hash[:] uses the array as a slice
+		// bytes.NewReader references the existing buffer without copying and
+		// implements io.ReadSeeker, so retrySender can rewind on retry rather
+		// than buffering a second copy of the chunk.
+		err := c.Chunk(ctx, uploadID, chunk, hash[:], bytes.NewReader(data.Bytes()))
 		if err != nil {
 			return uploadID, err
 		}

--- a/internal/pkg/fleetapi/uploader/uploader_test.go
+++ b/internal/pkg/fleetapi/uploader/uploader_test.go
@@ -42,7 +42,7 @@ type mockSender struct {
 	mock.Mock
 }
 
-func (m *mockSender) Send(ctx context.Context, method, path string, params url.Values, headers http.Header, body io.Reader) (*http.Response, error) {
+func (m *mockSender) Send(ctx context.Context, method, path string, params url.Values, headers http.Header, body io.ReadSeeker) (*http.Response, error) {
 	args := m.Called(ctx, method, path, params, headers, body)
 	return args.Get(0).(*http.Response), args.Error(1)
 }

--- a/internal/pkg/remote/client.go
+++ b/internal/pkg/remote/client.go
@@ -165,7 +165,7 @@ func (c *Client) Send(
 	method, path string,
 	params url.Values,
 	headers http.Header,
-	body io.Reader,
+	body io.ReadSeeker,
 ) (*http.Response, error) {
 	// Generate a request ID for tracking
 	var reqID string
@@ -181,6 +181,9 @@ func (c *Client) Send(
 	clients := c.sortClients()
 
 	for i, requester := range clients {
+		if body != nil {
+			_, _ = body.Seek(0, io.SeekStart)
+		}
 		req, err := requester.newRequest(method, path, params, body)
 		if err != nil {
 			return nil, fmt.Errorf(

--- a/internal/pkg/remote/client_test.go
+++ b/internal/pkg/remote/client_test.go
@@ -544,6 +544,80 @@ func withServer(m func(t *testing.T) *http.ServeMux, test func(t *testing.T, hos
 	}
 }
 
+// TestSendRetriesAcrossHosts reproduces the bug described in
+// https://github.com/elastic/elastic-agent/issues/14773: Client.Send passes the
+// same io.Reader to every host attempt, so after the first host consumes the body
+// the remaining hosts receive an empty body and fail even though they are healthy.
+func TestSendRetriesAcrossHosts(t *testing.T) {
+	ctx := context.Background()
+	l, err := logger.New("", false)
+	require.NoError(t, err)
+
+	const payload = `{"agent_id":"test-agent"}`
+
+	// secondBodyReceived is populated by the second server's handler.
+	var secondBodyReceived []byte
+
+	// Second server: records the body it receives and returns 200 only when
+	// the body matches the expected payload.
+	secondServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, readErr := io.ReadAll(r.Body)
+		if readErr != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		secondBodyReceived = b
+		if string(b) != payload {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"status":"ok"}`)
+	}))
+	defer secondServer.Close()
+
+	// First host transport: reads (consumes) the request body then returns a
+	// transport-level error, simulating a connection reset after bytes were sent.
+	firstTransport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Body != nil {
+			_, _ = io.ReadAll(req.Body)
+			_ = req.Body.Close()
+		}
+		return nil, fmt.Errorf("connection reset by peer")
+	})
+
+	firstRequester := &requestClient{
+		// lastUsed is zero (never used) so sortClients picks it first.
+		host:   "not a real URL",
+		client: http.Client{Transport: firstTransport},
+	}
+	secondRequester := &requestClient{
+		// lastUsed is non-zero so sortClients places it after firstRequester.
+		host:     fmt.Sprintf("http://%s/", secondServer.Listener.Addr().String()),
+		lastUsed: time.Now().UTC(),
+	}
+
+	c := &Client{
+		log:     l,
+		clients: []*requestClient{firstRequester, secondRequester},
+	}
+
+	resp, err := c.Send(ctx, http.MethodPost, "/checkin", nil, nil, bytes.NewBufferString(payload))
+	require.NoError(t, err, "Send should succeed when the second host is healthy")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"second host returned non-200; body it received: %q", secondBodyReceived)
+	assert.Equal(t, payload, string(secondBodyReceived),
+		"second host must receive the full request body, not an empty or truncated one")
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 type debugStack struct {
 	sync.Mutex
 	messages []string

--- a/internal/pkg/remote/client_test.go
+++ b/internal/pkg/remote/client_test.go
@@ -328,7 +328,7 @@ func TestHTTPClient(t *testing.T) {
 			})
 
 			require.NoError(t, err)
-			resp, err := client.Send(ctx, http.MethodGet, "/echo-hello", nil, nil, bytes.NewBuffer([]byte("hello")))
+			resp, err := client.Send(ctx, http.MethodGet, "/echo-hello", nil, nil, bytes.NewReader([]byte("hello")))
 			require.NoError(t, err)
 
 			body, err := io.ReadAll(resp.Body)
@@ -602,7 +602,7 @@ func TestSendRetriesAcrossHosts(t *testing.T) {
 		clients: []*requestClient{firstRequester, secondRequester},
 	}
 
-	resp, err := c.Send(ctx, http.MethodPost, "/checkin", nil, nil, bytes.NewBufferString(payload))
+	resp, err := c.Send(ctx, http.MethodPost, "/checkin", nil, nil, bytes.NewReader([]byte(payload)))
 	require.NoError(t, err, "Send should succeed when the second host is healthy")
 	defer resp.Body.Close()
 

--- a/pkg/fleetapi/checkin_cmd.go
+++ b/pkg/fleetapi/checkin_cmd.go
@@ -35,7 +35,7 @@ type Sender interface {
 		path string,
 		params url.Values,
 		headers http.Header,
-		body io.Reader,
+		body io.ReadSeeker,
 	) (*http.Response, error)
 }
 
@@ -150,7 +150,7 @@ func (e *CheckinCmd) Execute(ctx context.Context, r *CheckinRequest) (*CheckinRe
 	}
 
 	requestHeaders := http.Header{}
-	requestBody := bytes.NewBuffer(b)
+	var requestBody io.ReadSeeker = bytes.NewReader(b)
 	if e.compression == "gzip" {
 		requestBody, err = gzipEncodeCheckinRequestBody(b)
 		if err != nil {
@@ -220,9 +220,9 @@ func extractError(resp io.Reader) error {
 	return fmt.Errorf("could not decode the response, raw response: %s", string(data))
 }
 
-func gzipEncodeCheckinRequestBody(body []byte) (*bytes.Buffer, error) {
-	compressedBody := bytes.NewBuffer(nil)
-	gzipWriter := gzip.NewWriter(compressedBody)
+func gzipEncodeCheckinRequestBody(body []byte) (*bytes.Reader, error) {
+	var compressedBody bytes.Buffer
+	gzipWriter := gzip.NewWriter(&compressedBody)
 	if _, err := gzipWriter.Write(body); err != nil {
 		return nil, err
 	}
@@ -231,5 +231,5 @@ func gzipEncodeCheckinRequestBody(body []byte) (*bytes.Buffer, error) {
 		return nil, err
 	}
 
-	return compressedBody, nil
+	return bytes.NewReader(compressedBody.Bytes()), nil
 }

--- a/testing/fleetservertest/fleetserver_test.go
+++ b/testing/fleetservertest/fleetserver_test.go
@@ -848,7 +848,7 @@ func (s sender) Send(
 	path string,
 	params url.Values,
 	headers http.Header,
-	body io.Reader) (*http.Response, error) {
+	body io.ReadSeeker) (*http.Response, error) {
 
 	r, err := http.NewRequest(method, s.url+path, body) //nolint:noctx // it's a test
 	if err != nil {


### PR DESCRIPTION
- Closes https://github.com/elastic/elastic-agent/issues/14773

The previous Fleet client failover logic reused a consumed `io.Reader`, leading to an empty body being sent after the first failed call.

Switch from `io.Reader` to [io.ReadSeeker](https://pkg.go.dev/io#ReadSeeker) which allows seeking to 0 to re-reading the body in multiple attempts. Makes the same change to the file uploader to avoiding have to copy each chunk via [io.TeeReader](https://pkg.go.dev/io#TeeReader) to allow re-sending on retry.