### PR TITLE
ci: add team Slack mention to version bump pipeline notifications

### DIFF
--- a/.buildkite/pipeline.version-bump.yml
+++ b/.buildkite/pipeline.version-bump.yml
@@ -2,11 +2,13 @@ notify:
   - slack:
       channels:
         - "#ingest-notifications"
+      message: "<!subteam^S030QSX59PH|agent-control-plane-team> Version bump to ${NEW_VERSION} — ${BUILDKITE_BUILD_URL}"
     if: (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/) && (build.state == 'passed' || build.state == 'failed')
   - slack:
       channels:
         - "#ingest-notifications"
       message: |
+        <!subteam^S030QSX59PH|agent-control-plane-team>
         🚦 Pipeline waiting to be unblocked 🚦
         Repo: `${REPO}`
 


### PR DESCRIPTION
## Summary

- Add team Slack mention to the blocked-state notification so the team is pinged when the version bump pipeline needs manual approval
- Add team Slack mention to the pass/fail notification so the team is informed of pipeline completion or failure

## Context

Version bump pipelines are triggered centrally by the centralized-version-bump pipeline. Previously, only the release engineer who triggered the pipeline was notified — leaving teams unaware when their pipeline was waiting for approval or had finished.

Feel free to suggest a different Slack handle or a dedicated person to ping if this isn't the right one for your team.

## Test plan

- [ ] Verify Slack notification in the team channel includes the team mention on next version bump run

🤖 Generated with [Claude Code](https://claude.com/claude-code)