### PR TITLE
add system.cpu.cores field to monitoring

### DIFF
--- a/changelog/fragments/1781273333-add-system.cpu.cores-field-to-self-monitoring-data.yaml
+++ b/changelog/fragments/1781273333-add-system.cpu.cores-field-to-self-monitoring-data.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Adds system.cpu.cores field to self monitoring data
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/elastic-agent/pull/14885
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/14862

--- a/internal/pkg/agent/application/monitoring/component/testdata/monitoring_config_full_otel.yaml
+++ b/internal/pkg/agent/application/monitoring/component/testdata/monitoring_config_full_otel.yaml
@@ -181,6 +181,8 @@ inputs:
           to: apm-server
         - from: http.filebeat_input
           to: filebeat_input
+        - from: http.agent.system.cpu.cores
+          to: system.cpu.cores
         ignore_missing: true
     - drop_fields:
         fields:
@@ -225,6 +227,8 @@ inputs:
           to: apm-server
         - from: http.filebeat_input
           to: filebeat_input
+        - from: http.agent.system.cpu.cores
+          to: system.cpu.cores
         ignore_missing: true
     - drop_fields:
         fields:
@@ -273,6 +277,8 @@ inputs:
           to: apm-server
         - from: http.filebeat_input
           to: filebeat_input
+        - from: http.agent.system.cpu.cores
+          to: system.cpu.cores
         ignore_missing: true
     - drop_fields:
         fields:
@@ -322,6 +328,8 @@ inputs:
           to: apm-server
         - from: http.filebeat_input
           to: filebeat_input
+        - from: http.agent.system.cpu.cores
+          to: system.cpu.cores
         ignore_missing: true
     - drop_fields:
         fields:

--- a/internal/pkg/agent/application/monitoring/component/testdata/monitoring_config_full_process.yaml
+++ b/internal/pkg/agent/application/monitoring/component/testdata/monitoring_config_full_process.yaml
@@ -247,6 +247,8 @@ inputs:
           to: apm-server
         - from: http.filebeat_input
           to: filebeat_input
+        - from: http.agent.system.cpu.cores
+          to: system.cpu.cores
         ignore_missing: true
     - drop_fields:
         fields:
@@ -291,6 +293,8 @@ inputs:
           to: apm-server
         - from: http.filebeat_input
           to: filebeat_input
+        - from: http.agent.system.cpu.cores
+          to: system.cpu.cores
         ignore_missing: true
     - drop_fields:
         fields:
@@ -339,6 +343,8 @@ inputs:
           to: apm-server
         - from: http.filebeat_input
           to: filebeat_input
+        - from: http.agent.system.cpu.cores
+          to: system.cpu.cores
         ignore_missing: true
     - drop_fields:
         fields:
@@ -387,6 +393,8 @@ inputs:
           to: apm-server
         - from: http.filebeat_input
           to: filebeat_input
+        - from: http.agent.system.cpu.cores
+          to: system.cpu.cores
         ignore_missing: true
     - drop_fields:
         fields:
@@ -436,6 +444,8 @@ inputs:
           to: apm-server
         - from: http.filebeat_input
           to: filebeat_input
+        - from: http.agent.system.cpu.cores
+          to: system.cpu.cores
         ignore_missing: true
     - drop_fields:
         fields:
@@ -484,6 +494,8 @@ inputs:
           to: apm-server
         - from: http.filebeat_input
           to: filebeat_input
+        - from: http.agent.system.cpu.cores
+          to: system.cpu.cores
         ignore_missing: true
     - drop_fields:
         fields:
@@ -533,6 +545,8 @@ inputs:
           to: apm-server
         - from: http.filebeat_input
           to: filebeat_input
+        - from: http.agent.system.cpu.cores
+          to: system.cpu.cores
         ignore_missing: true
     - drop_fields:
         fields:
@@ -581,6 +595,8 @@ inputs:
           to: apm-server
         - from: http.filebeat_input
           to: filebeat_input
+        - from: http.agent.system.cpu.cores
+          to: system.cpu.cores
         ignore_missing: true
     - drop_fields:
         fields:

--- a/internal/pkg/agent/application/monitoring/component/v1_monitor.go
+++ b/internal/pkg/agent/application/monitoring/component/v1_monitor.go
@@ -1285,6 +1285,12 @@ func httpCopyRules() []any {
 			"from": "http.filebeat_input",
 			"to":   "filebeat_input",
 		},
+
+		// System CPU core count
+		map[string]any{
+			"from": "http.agent.system.cpu.cores",
+			"to":   "system.cpu.cores",
+		},
 	}
 
 	return fromToMap


### PR DESCRIPTION
## What does this PR do?

Adds the `system.cpu.cores` field to Elastic Agent self-monitoring data. The field is sourced from the agent's internal HTTP metrics endpoint (`http.agent.system.cpu.cores`) and is remapped to `system.cpu.cores` via a copy rule in the monitoring configuration pipeline. This affects both the process-based and OTel monitoring config paths.

## Why is it important?

Necessary to normalize the cpu utilization per cpu.

## Checklist

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

This is an additive change — a new field is emitted in self-monitoring data. Existing dashboards and queries are unaffected.

This will result in a small increase in the storage cost of monitoring data.


## How to test this PR locally

Run Elastic Agent with self-monitoring enabled and query the monitoring index. Verify that documents include a system.cpu.cores field with the expected integer value for the host.


Kibana Dev-tools
```
# Build and run with monitoring enabled, then check:
GET .monitoring-*/_search
{
  "query": { "exists": { "field": "system.cpu.cores" } }
}
```

Unit tests covering the monitoring config generation can be run with:

```shell

go test ./internal/pkg/agent/application/monitoring/component/...
```

## Related issues

- Closes #14862

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
