### PR TITLE
feat!: remove RollbacksAvailable from upgrade marker

### DIFF
--- a/changelog/fragments/1781185493-remove-rollbacks_available-field-from-upgrade-marker.yaml
+++ b/changelog/fragments/1781185493-remove-rollbacks_available-field-from-upgrade-marker.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: breaking-change
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Remove rollbacks_available field from upgrade marker
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: The rollbacks_available field was introduced in v9.3.0 and is no longer written to the upgrade marker. Upgrading to this version and rolling back is not affected. The only affected case is a Windows rollback after downgrading from this version to an agent in the v9.3.x or v9.4.x range.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+impact: On Windows, rolling back after a downgrade to an agent in the v9.3.x–v9.4.x range will fail.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+action: On Windows, do not downgrade to an agent released between v9.3.0 and v9.4.x.
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/upgrade/manual_rollback.go
+++ b/internal/pkg/agent/application/upgrade/manual_rollback.go
@@ -141,7 +141,7 @@ func rollbackUsingAgentInstalls(log *logger.Logger, watcherHelper WatcherHelper,
 		actionId = action.ActionID
 	}
 	upgradeDetails := details.NewDetails(release.VersionWithSnapshot(), details.StateRequested, actionId)
-	err = markUpgrade(log, paths.DataFrom(topDir), now, curAgentInstall, prevAgentInstall, action, upgradeDetails, nil)
+	err = markUpgrade(log, paths.DataFrom(topDir), now, curAgentInstall, prevAgentInstall, action, upgradeDetails)
 	if err != nil {
 		return "", "", fmt.Errorf("creating upgrade marker: %w", err)
 	}

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -837,7 +837,7 @@ func createUpdateMarker(t *testing.T, log *logger.Logger, topDir, newAgentVersio
 		time.Now(),
 		newAgentInstall,
 		oldAgentInstall,
-		nil, nil, nil)
+		nil, nil)
 	require.NoError(t, err, "error writing fake update marker")
 }
 
@@ -888,7 +888,7 @@ func TestRollbackWithOpts_PreservesInTTLRollbacks(t *testing.T) {
 		time.Now(),
 		agentInstall{version: versionC.version, hash: versionC.hash, versionedHome: relC},
 		agentInstall{version: versionA.version, hash: versionA.hash, versionedHome: relA},
-		nil, nil, nil,
+		nil, nil,
 	)
 	require.NoError(t, err, "writing update marker")
 
@@ -965,7 +965,7 @@ func TestRollbackWithOpts_RemovesMalformedTTLEntries(t *testing.T) {
 		now,
 		agentInstall{version: versionC.version, hash: versionC.hash, versionedHome: relC},
 		agentInstall{version: versionA.version, hash: versionA.hash, versionedHome: relA},
-		nil, nil, nil,
+		nil, nil,
 	)
 	require.NoError(t, err, "writing update marker")
 
@@ -1038,7 +1038,7 @@ func TestRollbackWithOpts_RemovesExpiredTTLEntries(t *testing.T) {
 		now,
 		agentInstall{version: versionC.version, hash: versionC.hash, versionedHome: relC},
 		agentInstall{version: versionA.version, hash: versionA.hash, versionedHome: relA},
-		nil, nil, nil,
+		nil, nil,
 	)
 	require.NoError(t, err, "writing update marker")
 

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -14,7 +14,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/ttl"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 	"github.com/elastic/elastic-agent/pkg/fleetapi"
@@ -48,10 +47,6 @@ type UpdateMarker struct {
 	Action *fleetapi.ActionUpgrade `json:"action" yaml:"action"`
 
 	Details *details.Details `json:"details,omitempty" yaml:"details,omitempty"`
-
-	// Agents older than 9.5.0 read rollback targets from this field on Windows.
-	// TODO: remove once the minimum supported upgrade-from version is 9.5.0.
-	RollbacksAvailable map[string]ttl.TTLMarker `json:"rollbacks_available,omitempty" yaml:"rollbacks_available,omitempty"`
 }
 
 // GetActionID returns the Fleet Action ID associated with the
@@ -98,32 +93,30 @@ func convertToActionUpgrade(a *MarkerActionUpgrade) *fleetapi.ActionUpgrade {
 }
 
 type updateMarkerSerializer struct {
-	Version            string                   `yaml:"version"`
-	Hash               string                   `yaml:"hash"`
-	VersionedHome      string                   `yaml:"versioned_home"`
-	UpdatedOn          time.Time                `yaml:"updated_on"`
-	PrevVersion        string                   `yaml:"prev_version"`
-	PrevHash           string                   `yaml:"prev_hash"`
-	PrevVersionedHome  string                   `yaml:"prev_versioned_home"`
-	Acked              bool                     `yaml:"acked"`
-	Action             *MarkerActionUpgrade     `yaml:"action"`
-	Details            *details.Details         `yaml:"details"`
-	RollbacksAvailable map[string]ttl.TTLMarker `yaml:"rollbacks_available,omitempty"`
+	Version           string               `yaml:"version"`
+	Hash              string               `yaml:"hash"`
+	VersionedHome     string               `yaml:"versioned_home"`
+	UpdatedOn         time.Time            `yaml:"updated_on"`
+	PrevVersion       string               `yaml:"prev_version"`
+	PrevHash          string               `yaml:"prev_hash"`
+	PrevVersionedHome string               `yaml:"prev_versioned_home"`
+	Acked             bool                 `yaml:"acked"`
+	Action            *MarkerActionUpgrade `yaml:"action"`
+	Details           *details.Details     `yaml:"details"`
 }
 
 func newMarkerSerializer(m *UpdateMarker) *updateMarkerSerializer {
 	return &updateMarkerSerializer{
-		Version:            m.Version,
-		Hash:               m.Hash,
-		VersionedHome:      m.VersionedHome,
-		UpdatedOn:          m.UpdatedOn,
-		PrevVersion:        m.PrevVersion,
-		PrevHash:           m.PrevHash,
-		PrevVersionedHome:  m.PrevVersionedHome,
-		Acked:              m.Acked,
-		Action:             convertToMarkerAction(m.Action),
-		Details:            m.Details,
-		RollbacksAvailable: m.RollbacksAvailable,
+		Version:           m.Version,
+		Hash:              m.Hash,
+		VersionedHome:     m.VersionedHome,
+		UpdatedOn:         m.UpdatedOn,
+		PrevVersion:       m.PrevVersion,
+		PrevHash:          m.PrevHash,
+		PrevVersionedHome: m.PrevVersionedHome,
+		Acked:             m.Acked,
+		Action:            convertToMarkerAction(m.Action),
+		Details:           m.Details,
 	}
 }
 
@@ -139,22 +132,21 @@ type updateActiveCommitFunc func(log *logger.Logger, topDirPath, hash string, wr
 // writeUpgradeMarkerProvider returns a function that writes the upgrade marker file.
 // It does not update active.commit; use it to protect the target directory before unpacking starts.
 func writeUpgradeMarkerProvider() writeUpgradeMarkerFunc {
-	return func(log *logger.Logger, dataDirPath string, updatedOn time.Time, agent, previousAgent agentInstall, action *fleetapi.ActionUpgrade, upgradeDetails *details.Details, availableRollbacks map[string]ttl.TTLMarker) error {
+	return func(log *logger.Logger, dataDirPath string, updatedOn time.Time, agent, previousAgent agentInstall, action *fleetapi.ActionUpgrade, upgradeDetails *details.Details) error {
 		if len(previousAgent.hash) > HashLen {
 			previousAgent.hash = previousAgent.hash[:HashLen]
 		}
 
 		marker := &UpdateMarker{
-			Version:            agent.version,
-			Hash:               agent.hash,
-			VersionedHome:      agent.versionedHome,
-			UpdatedOn:          updatedOn,
-			PrevVersion:        previousAgent.version,
-			PrevHash:           previousAgent.hash,
-			PrevVersionedHome:  previousAgent.versionedHome,
-			Action:             action,
-			Details:            upgradeDetails,
-			RollbacksAvailable: availableRollbacks,
+			Version:           agent.version,
+			Hash:              agent.hash,
+			VersionedHome:     agent.versionedHome,
+			UpdatedOn:         updatedOn,
+			PrevVersion:       previousAgent.version,
+			PrevHash:          previousAgent.hash,
+			PrevVersionedHome: previousAgent.versionedHome,
+			Action:            action,
+			Details:           upgradeDetails,
 		}
 
 		markerBytes, err := yaml.Marshal(newMarkerSerializer(marker))
@@ -176,8 +168,8 @@ func writeUpgradeMarkerProvider() writeUpgradeMarkerFunc {
 // Use it after the symlink has been flipped to the new binary.
 func markUpgradeProvider(updateActiveCommit updateActiveCommitFunc, writeFile writeFileFunc) markUpgradeFunc {
 	writeMarker := writeUpgradeMarkerProvider()
-	return func(log *logger.Logger, dataDirPath string, updatedOn time.Time, agent, previousAgent agentInstall, action *fleetapi.ActionUpgrade, upgradeDetails *details.Details, availableRollbacks map[string]ttl.TTLMarker) error {
-		if err := writeMarker(log, dataDirPath, updatedOn, agent, previousAgent, action, upgradeDetails, availableRollbacks); err != nil {
+	return func(log *logger.Logger, dataDirPath string, updatedOn time.Time, agent, previousAgent agentInstall, action *fleetapi.ActionUpgrade, upgradeDetails *details.Details) error {
+		if err := writeMarker(log, dataDirPath, updatedOn, agent, previousAgent, action, upgradeDetails); err != nil {
 			return err
 		}
 		return updateActiveCommit(log, paths.Top(), agent.hash, writeFile)
@@ -289,17 +281,16 @@ func loadMarker(markerFile string) (*UpdateMarker, error) {
 	}
 
 	return &UpdateMarker{
-		Version:            marker.Version,
-		Hash:               marker.Hash,
-		VersionedHome:      marker.VersionedHome,
-		UpdatedOn:          marker.UpdatedOn,
-		PrevVersion:        marker.PrevVersion,
-		PrevHash:           marker.PrevHash,
-		PrevVersionedHome:  marker.PrevVersionedHome,
-		Acked:              marker.Acked,
-		Action:             convertToActionUpgrade(marker.Action),
-		Details:            marker.Details,
-		RollbacksAvailable: marker.RollbacksAvailable,
+		Version:           marker.Version,
+		Hash:              marker.Hash,
+		VersionedHome:     marker.VersionedHome,
+		UpdatedOn:         marker.UpdatedOn,
+		PrevVersion:       marker.PrevVersion,
+		PrevHash:          marker.PrevHash,
+		PrevVersionedHome: marker.PrevVersionedHome,
+		Acked:             marker.Acked,
+		Action:            convertToActionUpgrade(marker.Action),
+		Details:           marker.Details,
 	}, nil
 }
 
@@ -312,17 +303,16 @@ func SaveMarker(dataDirPath string, marker *UpdateMarker, shouldFsync bool) erro
 
 func saveMarkerToPath(marker *UpdateMarker, markerFile string, shouldFsync bool) error {
 	makerSerializer := &updateMarkerSerializer{
-		Version:            marker.Version,
-		Hash:               marker.Hash,
-		VersionedHome:      marker.VersionedHome,
-		UpdatedOn:          marker.UpdatedOn,
-		PrevVersion:        marker.PrevVersion,
-		PrevHash:           marker.PrevHash,
-		PrevVersionedHome:  marker.PrevVersionedHome,
-		Acked:              marker.Acked,
-		Action:             convertToMarkerAction(marker.Action),
-		Details:            marker.Details,
-		RollbacksAvailable: marker.RollbacksAvailable,
+		Version:           marker.Version,
+		Hash:              marker.Hash,
+		VersionedHome:     marker.VersionedHome,
+		UpdatedOn:         marker.UpdatedOn,
+		PrevVersion:       marker.PrevVersion,
+		PrevHash:          marker.PrevHash,
+		PrevVersionedHome: marker.PrevVersionedHome,
+		Acked:             marker.Acked,
+		Action:            convertToMarkerAction(marker.Action),
+		Details:           marker.Details,
 	}
 	markerBytes, err := yaml.Marshal(makerSerializer)
 	if err != nil {

--- a/internal/pkg/agent/application/upgrade/step_mark_test.go
+++ b/internal/pkg/agent/application/upgrade/step_mark_test.go
@@ -232,7 +232,7 @@ func TestMarkUpgrade(t *testing.T) {
 				tc.setupBeforeMark(t, dataDir)
 			}
 
-			err := markUpgrade(log, dataDir, tc.args.updatedOn, tc.args.currentAgent, tc.args.previousAgent, tc.args.action, tc.args.details, nil)
+			err := markUpgrade(log, dataDir, tc.args.updatedOn, tc.args.currentAgent, tc.args.previousAgent, tc.args.action, tc.args.details)
 			tc.wantErr(t, err)
 			if tc.assertAfterMark != nil {
 				tc.assertAfterMark(t, dataDir)

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -81,8 +81,8 @@ type unpackHandler interface {
 type copyActionStoreFunc func(log *logger.Logger, newHome string) error
 type copyRunDirectoryFunc func(log *logger.Logger, oldRunPath, newRunPath string) error
 type fileDirCopyFunc func(from, to string, opts ...filecopy.Options) error
-type markUpgradeFunc func(log *logger.Logger, dataDirPath string, updatedOn time.Time, agent, previousAgent agentInstall, action *fleetapi.ActionUpgrade, upgradeDetails *details.Details, availableRollbacks map[string]ttl.TTLMarker) error
-type writeUpgradeMarkerFunc func(log *logger.Logger, dataDirPath string, updatedOn time.Time, agent, previousAgent agentInstall, action *fleetapi.ActionUpgrade, upgradeDetails *details.Details, availableRollbacks map[string]ttl.TTLMarker) error
+type markUpgradeFunc func(log *logger.Logger, dataDirPath string, updatedOn time.Time, agent, previousAgent agentInstall, action *fleetapi.ActionUpgrade, upgradeDetails *details.Details) error
+type writeUpgradeMarkerFunc func(log *logger.Logger, dataDirPath string, updatedOn time.Time, agent, previousAgent agentInstall, action *fleetapi.ActionUpgrade, upgradeDetails *details.Details) error
 type changeSymlinkFunc func(log *logger.Logger, topDirPath, symlinkPath, newTarget string) error
 type rollbackInstallFunc func(ctx context.Context, log *logger.Logger, topDirPath, versionedHome, oldVersionedHome string, rollbackSource ttl.Source) error
 
@@ -471,8 +471,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, rollback bool, s
 	availableRollbacks := getAvailableRollbacks(rollbackWindow, time.Now(), previous, current)
 
 	// Write the marker before unpacking so newVersionedHome is protected from cleanup during the upgrade.
-	// RollbacksAvailable is nil here: TTL entries are written after the symlink flips, and previous rollbacks were already removed at the start of Upgrade().
-	if err = u.writeUpgradeMarker(u.log, paths.Data(), time.Now(), current, previous, action, det, nil); err != nil {
+	if err = u.writeUpgradeMarker(u.log, paths.Data(), time.Now(), current, previous, action, det); err != nil {
 		return nil, fmt.Errorf("writing upgrade marker: %w", err)
 	}
 	markerWritten = true
@@ -566,7 +565,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, version string, rollback bool, s
 	// Write the marker with the post-symlink timestamp so the watcher's grace period starts at the moment the symlink flipped.
 	// markUpgrade also calls updateActiveCommit; track this so the defer restores active.commit on any subsequent failure.
 	activeCommitModified = true
-	if err = u.markUpgrade(u.log, paths.Data(), time.Now(), current, previous, action, det, availableRollbacks); err != nil {
+	if err = u.markUpgrade(u.log, paths.Data(), time.Now(), current, previous, action, det); err != nil {
 		u.log.Errorw("Rolling back: refreshing upgrade marker failed", "error.message", err)
 		rollbackErr := u.rollbackInstall(ctx, u.log, paths.Top(), newVersionedHome, currentVersionedHome, u.availableRollbacksSource)
 		return nil, goerrors.Join(err, rollbackErr)

--- a/internal/pkg/agent/application/upgrade/upgrade_test.go
+++ b/internal/pkg/agent/application/upgrade/upgrade_test.go
@@ -1319,7 +1319,7 @@ func TestUpgradeErrorHandling(t *testing.T) {
 						hash:     "abc123",
 					},
 				}
-				upgrader.writeUpgradeMarker = func(log *logger.Logger, dataDirPath string, updatedOn time.Time, agent, previousAgent agentInstall, action *fleetapi.ActionUpgrade, upgradeDetails *details.Details, availableRollbacks map[string]ttl.TTLMarker) error {
+				upgrader.writeUpgradeMarker = func(log *logger.Logger, dataDirPath string, updatedOn time.Time, agent, previousAgent agentInstall, action *fleetapi.ActionUpgrade, upgradeDetails *details.Details) error {
 					return testError
 				}
 			},
@@ -1553,7 +1553,7 @@ func TestUpgradeSelfHealsCorruptLiveTTL(t *testing.T) {
 	upgrader.copyActionStore = func(_ *logger.Logger, _ string) error { return nil }
 	upgrader.copyRunDirectory = func(_ *logger.Logger, _, _ string) error { return nil }
 	upgrader.changeSymlink = func(_ *logger.Logger, _, _, _ string) error { return nil }
-	upgrader.markUpgrade = func(_ *logger.Logger, _ string, _ time.Time, _, _ agentInstall, _ *fleetapi.ActionUpgrade, _ *details.Details, _ map[string]ttl.TTLMarker) error {
+	upgrader.markUpgrade = func(_ *logger.Logger, _ string, _ time.Time, _, _ agentInstall, _ *fleetapi.ActionUpgrade, _ *details.Details) error {
 		return nil
 	}
 
@@ -1628,8 +1628,8 @@ func TestUpgrade_RestoresActiveCommitAfterPostSymlinkFailure(t *testing.T) {
 	// assertion below can confirm the restore is meaningful (not a no-op).
 	var activeCommitDuringUpgrade string
 	realMarkUpgrade := upgrader.markUpgrade
-	upgrader.markUpgrade = func(log *logger.Logger, dataDirPath string, updatedOn time.Time, agent, prev agentInstall, action *fleetapi.ActionUpgrade, det *details.Details, rollbacks map[string]ttl.TTLMarker) error {
-		err := realMarkUpgrade(log, dataDirPath, updatedOn, agent, prev, action, det, rollbacks)
+	upgrader.markUpgrade = func(log *logger.Logger, dataDirPath string, updatedOn time.Time, agent, prev agentInstall, action *fleetapi.ActionUpgrade, det *details.Details) error {
+		err := realMarkUpgrade(log, dataDirPath, updatedOn, agent, prev, action, det)
 		if err == nil {
 			got, _ := os.ReadFile(activeCommitPath)
 			activeCommitDuringUpgrade = string(got)


### PR DESCRIPTION
## What does this PR do?

Removes the `rollbacks_available` field from the upgrade marker file and the `UpdateMarker` struct.

The field was a compatibility shim added in v9.3.0 so that Windows agents older than v9.5.0 could find rollback targets. Since v9.5.0, rollback targets are stored in separate TTL files and the marker field is no longer read by any code path.

I marked it as breaking change, as technically it is breaking change, but the scope is super narrow. It fires only when the three following condition are met together:

- we are on Windows
- we downgraded from >=9.5.0
- we do rollback (by default the windows is 7 days only)

## Why is it important?

The information in marker is duplication of TTL files, and unfrtunately has been required on Windows rollback path. We should clean this technical debt as soon as possible

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~ (no new logic)
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~ (only signature cleanup — existing tests updated)
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

On Windows, if an agent running this version is downgraded to a version in the v9.3.x–v9.4.x range, rolling back after that downgrade will fail. The downgrade target will not find `rollbacks_available` in the marker and cannot identify the rollback target.

Agents on v9.5.0+ and agents older than v9.3.0 are not affected.

## How to test this PR locally

```
go test ./internal/pkg/agent/application/upgrade/...
```

To verify backward compatibility (reading old markers that still contain `rollbacks_available`):
The test fixtures in `manual_rollback_test.go` include markers with the old field. Verify they decode without error.

## Related issues

- https://github.com/elastic/elastic-agent/pull/14543
