### PR TITLE
Don't check out beats submodule in updatecli CI

### DIFF
--- a/.ci/updatecli/ironbank-dockerfile.yaml
+++ b/.ci/updatecli/ironbank-dockerfile.yaml
@@ -1,0 +1,51 @@
+---
+# Runs separately from the compose policy; submodules: false avoids go-git/go-git#872.
+name: 'deps: Bump ironbank Dockerfile version'
+pipelineid: ironbank/dockerfile
+
+sources:
+  ubi_version:
+    name: 'Get ubi version from ironbank'
+    kind: yaml
+    spec:
+      file: 'https://repo1.dso.mil/dsop/redhat/ubi/10.x/ubi10/-/raw/master/hardening_manifest.yaml?ref_type=heads'
+      key: "$.labels.'org.opencontainers.image.version'"
+    transformers:
+      - trimprefix: '"'
+      - trimsuffix: '"'
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: 'github-actions[bot]'
+      owner: elastic
+      repository: elastic-agent
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ env "GITHUB_ACTOR" }}'
+      branch: main
+      commitusingapi: true
+      submodules: false
+
+targets:
+  dockerfile_ironbank:
+    scmid: default
+    name: 'deps(ironbank): Bump ubi version to {{ source "ubi_version" }}'
+    kind: dockerfile
+    sourceid: ubi_version
+    spec:
+      file: dev-tools/packaging/templates/ironbank/Dockerfile.tmpl
+      instruction:
+        keyword: "ARG"
+        matcher: "BASE_TAG"
+
+actions:
+  default:
+    title: 'deps: Bump ironbank Dockerfile version to {{ source "ubi_version" }}'
+    kind: github/pullrequest
+    spec:
+      automerge: false
+      labels:
+        - dependencies
+        - backport-active-all
+    scmid: default

--- a/.ci/updatecli/values.d/ironbank.yml
+++ b/.ci/updatecli/values.d/ironbank.yml
@@ -2,6 +2,9 @@ config:
   - path: dev-tools/packaging/templates/ironbank
     dockerfile: Dockerfile.tmpl
     manifest: hardening_manifest.yaml.tmpl
+    # kind: dockerfile checks git cleanliness via go-git, which fails with the beats submodule
+    # (go-git/go-git#872). Handled separately in .ci/updatecli/ironbank-dockerfile.yaml.
+    skip_dockerfile: true
 
 pull_request:
   labels:

--- a/.github/workflows/updatecli-compose.yml
+++ b/.github/workflows/updatecli-compose.yml
@@ -18,6 +18,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: true
 
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:

--- a/.github/workflows/updatecli-compose.yml
+++ b/.github/workflows/updatecli-compose.yml
@@ -18,8 +18,6 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:

--- a/.github/workflows/updatecli-compose.yml
+++ b/.github/workflows/updatecli-compose.yml
@@ -41,6 +41,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Ironbank Dockerfile update runs separately with submodules: false (go-git/go-git#872).
+      - uses: elastic/oblt-actions/updatecli/run@v1
+        with:
+          command: diff --config .ci/updatecli/ironbank-dockerfile.yaml
+          version-file: .updatecli-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: elastic/oblt-actions/updatecli/run@v1
+        with:
+          command: apply --config .ci/updatecli/ironbank-dockerfile.yaml
+          version-file: .updatecli-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - if: ${{ failure()  }}
         uses: elastic/oblt-actions/slack/send@v1
         env:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "beats"]
 	path = beats
 	url = https://github.com/elastic/beats.git
+	ignore = all


### PR DESCRIPTION
The beats submodule causes git status to appear dirty to updatecli's internal git operations (policy v0.6.0+ added a cleanliness check to the dockerfile_ironbank target). updatecli reads files via the GitHub API (commitusingapi: true) and doesn't need the local submodule checkout.

Fixes daily CI failure since 2026-02-04. See https://github.com/elastic/elastic-agent/actions/runs/27532657511/job/81374279413 for example. Successful run on this PR branch: https://github.com/elastic/elastic-agent/actions/runs/27549905814/job/81433095298.