### PR TITLE
Fix TestFQDN flakiness

### DIFF
--- a/pkg/testing/tools/tools.go
+++ b/pkg/testing/tools/tools.go
@@ -32,7 +32,7 @@ func IsPolicyRevision(ctx context.Context, t *testing.T, client *kibana.Client, 
 			return false
 		}
 
-		return updatedPolicyAgent.PolicyRevision == policyRevision
+		return updatedPolicyAgent.PolicyRevision >= policyRevision
 	}
 }
 

--- a/pkg/testing/tools/tools.go
+++ b/pkg/testing/tools/tools.go
@@ -20,10 +20,28 @@ import (
 )
 
 // IsPolicyRevision returns a niladic function that returns true if the
-// given agent's policy revision has reached the given policy revision; false
-// otherwise. The returned function is intended
+// given agent's policy revision matches the given policy revision exactly;
+// false otherwise. The returned function is intended
 // for use with assert.Eventually or require.Eventually.
 func IsPolicyRevision(ctx context.Context, t *testing.T, client *kibana.Client, agentID string, policyRevision int) func() bool {
+	return func() bool {
+		getAgentReq := kibana.GetAgentRequest{ID: agentID}
+		updatedPolicyAgent, err := client.GetAgent(ctx, getAgentReq)
+		if err != nil {
+			t.Logf("failed to get agent document to check policy revision: %v", err)
+			return false
+		}
+
+		return updatedPolicyAgent.PolicyRevision == policyRevision
+	}
+}
+
+// IsMinPolicyRevision returns a niladic function that returns true if the
+// given agent's policy revision is at least the given policy revision; false
+// otherwise. Use this instead of IsPolicyRevision when intermediate revisions
+// may occur between computing the expected value and the agent applying it.
+// The returned function is intended for use with assert.Eventually or require.Eventually.
+func IsMinPolicyRevision(ctx context.Context, t *testing.T, client *kibana.Client, agentID string, policyRevision int) func() bool {
 	return func() bool {
 		getAgentReq := kibana.GetAgentRequest{ID: agentID}
 		updatedPolicyAgent, err := client.GetAgent(ctx, getAgentReq)

--- a/testing/integration/ess/fqdn_test.go
+++ b/testing/integration/ess/fqdn_test.go
@@ -135,7 +135,7 @@ func TestFQDN(t *testing.T) {
 	t.Log("Wait until policy has been applied by Agent")
 	require.Eventually(
 		t,
-		tools.IsPolicyRevision(ctx, t, kibClient, agent.ID, updatedPolicy.Revision),
+		tools.IsMinPolicyRevision(ctx, t, kibClient, agent.ID, updatedPolicy.Revision),
 		2*time.Minute,
 		1*time.Second,
 	)
@@ -165,7 +165,7 @@ func TestFQDN(t *testing.T) {
 	t.Log("Wait until policy has been applied by Agent")
 	require.Eventually(
 		t,
-		tools.IsPolicyRevision(ctx, t, kibClient, agent.ID, updatedPolicy.Revision),
+		tools.IsMinPolicyRevision(ctx, t, kibClient, agent.ID, updatedPolicy.Revision),
 		2*time.Minute,
 		1*time.Second,
 	)

--- a/testing/integration/ess/fqdn_test.go
+++ b/testing/integration/ess/fqdn_test.go
@@ -129,14 +129,13 @@ func TestFQDN(t *testing.T) {
 		Namespace:     info.Namespace,
 		AgentFeatures: policy.AgentFeatures,
 	}
-	_, err = kibClient.UpdatePolicy(ctx, policy.ID, updatePolicyReq)
+	updatedPolicy, err := kibClient.UpdatePolicy(ctx, policy.ID, updatePolicyReq)
 	require.NoError(t, err)
 
 	t.Log("Wait until policy has been applied by Agent")
-	expectedAgentPolicyRevision := agent.PolicyRevision + 1
 	require.Eventually(
 		t,
-		tools.IsPolicyRevision(ctx, t, kibClient, agent.ID, expectedAgentPolicyRevision),
+		tools.IsPolicyRevision(ctx, t, kibClient, agent.ID, updatedPolicy.Revision),
 		2*time.Minute,
 		1*time.Second,
 	)
@@ -160,14 +159,13 @@ func TestFQDN(t *testing.T) {
 		Namespace:     info.Namespace,
 		AgentFeatures: policy.AgentFeatures,
 	}
-	_, err = kibClient.UpdatePolicy(ctx, policy.ID, updatePolicyReq)
+	updatedPolicy, err = kibClient.UpdatePolicy(ctx, policy.ID, updatePolicyReq)
 	require.NoError(t, err)
 
 	t.Log("Wait until policy has been applied by Agent")
-	expectedAgentPolicyRevision++
 	require.Eventually(
 		t,
-		tools.IsPolicyRevision(ctx, t, kibClient, agent.ID, expectedAgentPolicyRevision),
+		tools.IsPolicyRevision(ctx, t, kibClient, agent.ID, updatedPolicy.Revision),
 		2*time.Minute,
 		1*time.Second,
 	)


### PR DESCRIPTION
## What does this PR do?

Fix TestFQDN flakiness by capturing the revision returned directly by UpdatePolicy and switching to >= so the check is resilient to any further bumps that occur between policy application and the polling interval catching up.

## Why is it important?

IsPolicyRevision used strict equality against agent.PolicyRevision+1, which is computed from a snapshot taken before UpdatePolicy is called. If Fleet bumped the policy revision between that snapshot and the UpdatePolicy call (e.g. due to UpdateESOutputPreset introduced in #14705), the expected revision was one too low and the check could never pass.

Honestly, I'm not sure how this can happen, exactly, but this test definitely became flaky with #14705. It doesn't look like there's an actual bug in play, just a small race condition against Fleet. @cmacknz as the author of that PR, can you think of a way for this to happen? Is the update non-idempotent, maybe?

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
