### PR TITLE
[mage] Set PLATFORMS to the host platform by default

### DIFF
--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -1843,7 +1843,11 @@ func (s *Settings) BuildDateString() string {
 }
 
 // GetPlatforms returns the parsed platform list from PLATFORMS env var.
-// If PLATFORMS is empty, returns the default platform list.
+// If PLATFORMS is empty, returns the host platform (runtime.GOOS/runtime.GOARCH)
+// when that platform is known, or BuildPlatforms.Defaults() as a fallback for
+// exotic hosts. This makes `mage package` produce host-only artifacts by
+// default; callers that want a broader matrix (CI cross-builds) set PLATFORMS
+// explicitly.
 // Platform filters from the settings' PlatformFilters are applied to the result.
 // Note: linux/386 and windows/386 are always filtered out as they are not supported.
 func (s *Settings) GetPlatforms() BuildPlatformList {
@@ -1851,7 +1855,12 @@ func (s *Settings) GetPlatforms() BuildPlatformList {
 	if s.CrossBuild.Platforms != "" {
 		platforms = NewPlatformList(s.CrossBuild.Platforms)
 	} else {
-		platforms = BuildPlatforms.Defaults()
+		hostName := runtime.GOOS + "/" + runtime.GOARCH
+		if bp, ok := BuildPlatforms.Get(hostName); ok {
+			platforms = BuildPlatformList{bp}
+		} else {
+			platforms = BuildPlatforms.Defaults()
+		}
 	}
 
 	// Filter out unsupported platforms

--- a/dev-tools/mage/settings_test.go
+++ b/dev-tools/mage/settings_test.go
@@ -469,6 +469,9 @@ func TestSettingsGetDockerVariants(t *testing.T) {
 func TestSettingsIsPackageTypeSelected(t *testing.T) {
 	t.Run("returns true when no types selected", func(t *testing.T) {
 		s := DefaultSettings()
+		// Simulate a cross-platform build so defaultPackageTypesForPlatforms
+		// produces both TarGz (Unix) and Zip (Windows).
+		s.CrossBuild.Platforms = "linux/amd64 windows/amd64"
 
 		assert.True(t, s.IsPackageTypeSelected(TarGz))
 		assert.True(t, s.IsPackageTypeSelected(Zip))

--- a/dev-tools/mage/settings_test.go
+++ b/dev-tools/mage/settings_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -285,6 +286,45 @@ func TestSettingsPlatform(t *testing.T) {
 
 	assert.Equal(t, "linux", platform.GOOS)
 	assert.Equal(t, "amd64", platform.Arch)
+}
+
+func TestSettingsGetPlatforms(t *testing.T) {
+	t.Run("returns host platform when PLATFORMS is unset", func(t *testing.T) {
+		s := DefaultSettings()
+		// CrossBuild.Platforms is "" by default — simulates no PLATFORMS env var.
+
+		platforms := s.GetPlatforms()
+
+		hostName := runtime.GOOS + "/" + runtime.GOARCH
+		if _, known := BuildPlatforms.Get(hostName); known {
+			require.Len(t, platforms, 1)
+			assert.Equal(t, hostName, platforms[0].Name)
+		} else {
+			// Exotic host not in BuildPlatforms: falls back to Defaults().
+			assert.Equal(t, BuildPlatforms.Defaults(), platforms)
+		}
+	})
+
+	t.Run("returns specified platforms when PLATFORMS is set", func(t *testing.T) {
+		s := DefaultSettings()
+		s.CrossBuild.Platforms = "linux/amd64,darwin/arm64"
+
+		platforms := s.GetPlatforms()
+
+		assert.ElementsMatch(t, []string{"linux/amd64", "darwin/arm64"}, platforms.Names())
+	})
+
+	t.Run("always filters linux/386 and windows/386", func(t *testing.T) {
+		s := DefaultSettings()
+		s.CrossBuild.Platforms = "linux/386 windows/386 linux/amd64"
+
+		platforms := s.GetPlatforms()
+
+		names := platforms.Names()
+		assert.NotContains(t, names, "linux/386")
+		assert.NotContains(t, names, "windows/386")
+		assert.Contains(t, names, "linux/amd64")
+	})
 }
 
 func TestSettingsTestTagsWithFIPS(t *testing.T) {

--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -91,7 +91,7 @@ The packaging process has many leavers that need to be correctly set:
    use snapshot versions. That is required to package from the `main`
    branch with `EXTERNAL=true`.
  - `PLATFORMS`: Comma separated list of platforms you want to build. If
-  not set, it defaults to **ALL** platforms. [Selecting specific
+  not set, it defaults to the **host platform** only. [Selecting specific
   platform](#selecting-specific-platform) contains a list of common
   values. For a full list look at [`elastic-agent/dev-tools/mage/platforms.go`](https://github.com/elastic/elastic-agent/blob/main/dev-tools/mage/platforms.go#L15).
  - `PACKAGES`: Comma separated list of packages you want to build.

--- a/magefile.go
+++ b/magefile.go
@@ -3809,7 +3809,7 @@ func restoreBeatsSubmodule() error {
 	return nil
 }
 
-func (Otel) OsquerybeatCrossBuildExt() error {
+func (Otel) OsquerybeatCrossBuildExt(ctx context.Context) error {
 	mg.Deps(Otel.PrepareBeats)
 	defer func() {
 		if err := restoreBeatsSubmodule(); err != nil {
@@ -3818,8 +3818,16 @@ func (Otel) OsquerybeatCrossBuildExt() error {
 	}()
 	fmt.Println("--- CrossBuild osquery-extension")
 	osquerybeatDir := filepath.Join("beats", "x-pack", "osquerybeat")
-	err := sh.RunV("mage", "-d", osquerybeatDir, "crossBuildExt")
-	if err != nil {
+
+	// The child mage process runs in the beats submodule, which has its own
+	// magefile and its own default platform list. Without an explicit
+	// PLATFORMS it would rebuild the osquery extension for every default
+	// platform, not the host-only set our own magefile computed.
+	cfg := devtools.SettingsFromContext(ctx)
+	env := map[string]string{
+		"PLATFORMS": strings.Join(cfg.GetPlatforms().Names(), " "),
+	}
+	if _, err := sh.Exec(env, os.Stdout, os.Stderr, "mage", "-d", osquerybeatDir, "crossBuildExt"); err != nil {
 		return fmt.Errorf("failed to run mage -d %s crossBuildExt: %w", osquerybeatDir, err)
 	}
 	return nil


### PR DESCRIPTION
## What does this PR do?

Sets the PLATFORMS environment variable controlling the build and packaging mage targets to use the host platform, rather than all supported platforms, by default.

## Why is it important?

This is a better default for local dev work, and all the CI workflows already explicitly set it to what they want.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

This may bite anyone who depends on the current default in theory, but I doubt anyone does. It's very unusual to build against all platforms in a single invocation.

## How to test this PR locally

Run `EXTERNAL=true SNAPSHOT=true mage package`. You should get a package for your host platform only.

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/14746


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
