### PR TITLE
remove upgrade marker on all platforms after a successful upgrade

### DIFF
--- a/changelog/fragments/1781622285-upgrade-marker-is-now-removed-on-all-platforms-after-a-successful-upgrade.yaml
+++ b/changelog/fragments/1781622285-upgrade-marker-is-now-removed-on-all-platforms-after-a-successful-upgrade.yaml
@@ -1,0 +1,47 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: upgrade marker is now removed on all platforms after a successful upgrade
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+issue: https://github.com/elastic/elastic-agent/issues/14668
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -377,6 +377,10 @@ type Coordinator struct {
 	// SetUpgradeDetails helper to the Coordinator goroutine.
 	upgradeDetailsChan chan *details.Details
 
+	// upgradeMarkerCleanCh receives a signal when a StateCompleted checkin has been confirmed, triggering upgrade marker cleanup.
+	// The send side is exposed via UpgradeMarkerCleanCh; the receive-only view is wired into managerChans.
+	upgradeMarkerCleanCh chan struct{}
+
 	// loglevelCh forwards log level changes from the public API (SetLogLevel)
 	// to the run loop in Coordinator's main goroutine.
 	logLevelCh chan logp.Level
@@ -484,8 +488,8 @@ type managerChans struct {
 
 	upgradeMarkerUpdate <-chan upgrade.UpdateMarker
 
-	// upgradeMarkerCleanCh receives a signal when a StateCompleted checkin has been confirmed, triggering upgrade marker cleanup.
-	upgradeMarkerCleanCh chan struct{}
+	// upgradeMarkerCleanCh is the receive side of Coordinator.upgradeMarkerCleanCh.
+	upgradeMarkerCleanCh <-chan struct{}
 }
 
 // diffCheck is a container used by checkAndLogUpdate()
@@ -626,7 +630,8 @@ func New(
 	if upgradeMgr != nil && upgradeMgr.MarkerWatcher() != nil {
 		c.managerChans.upgradeMarkerUpdate = upgradeMgr.MarkerWatcher().Watch()
 	}
-	c.managerChans.upgradeMarkerCleanCh = make(chan struct{}, 1)
+	c.upgradeMarkerCleanCh = make(chan struct{}, 1)
+	c.managerChans.upgradeMarkerCleanCh = c.upgradeMarkerCleanCh
 	return c
 }
 
@@ -1001,7 +1006,7 @@ func (c *Coordinator) logUpgradeDetails(details *details.Details) {
 
 // UpgradeMarkerCleanCh returns the send side of the channel used to signal that a StateCompleted checkin was confirmed and the upgrade marker can be deleted.
 func (c *Coordinator) UpgradeMarkerCleanCh() chan<- struct{} {
-	return c.managerChans.upgradeMarkerCleanCh
+	return c.upgradeMarkerCleanCh
 }
 
 // AckUpgrade is the method used on startup to ack a previously successful upgrade action.
@@ -1715,18 +1720,24 @@ func (c *Coordinator) runLoopIteration(ctx context.Context) {
 			if !c.isManaged &&
 				upgradeMarker.Details != nil &&
 				upgradeMarker.Details.State == details.StateCompleted {
-				if err := upgrade.CleanMarker(c.logger, paths.Data()); err != nil {
-					c.logger.Warnw("failed to clean upgrade marker", "error.message", err)
-				}
+				log, dataDir := c.logger, paths.Data()
+				go func() {
+					if err := upgrade.CleanMarker(log, dataDir); err != nil {
+						log.Warnw("failed to clean upgrade marker", "error.message", err)
+					}
+				}()
 				c.setUpgradeDetails(nil)
 			}
 		}
 
 	case <-c.managerChans.upgradeMarkerCleanCh:
-		if ctx.Err() == nil && c.state.UpgradeDetails != nil {
-			if err := upgrade.CleanMarker(c.logger, paths.Data()); err != nil {
-				c.logger.Warnw("failed to clean upgrade marker after Fleet confirmation", "error.message", err)
-			}
+		if ctx.Err() == nil && c.state.UpgradeDetails != nil && c.state.UpgradeDetails.State == details.StateCompleted {
+			log, dataDir := c.logger, paths.Data()
+			go func() {
+				if err := upgrade.CleanMarker(log, dataDir); err != nil {
+					log.Warnw("failed to clean upgrade marker after Fleet confirmation", "error.message", err)
+				}
+			}()
 			c.setUpgradeDetails(nil)
 		}
 	}

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -1723,7 +1723,7 @@ func (c *Coordinator) runLoopIteration(ctx context.Context) {
 		}
 
 	case <-c.managerChans.upgradeMarkerCleanCh:
-		if ctx.Err() == nil {
+		if ctx.Err() == nil && c.state.UpgradeDetails != nil {
 			if err := upgrade.CleanMarker(c.logger, paths.Data()); err != nil {
 				c.logger.Warnw("failed to clean upgrade marker after Fleet confirmation", "error.message", err)
 			}

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -484,9 +484,7 @@ type managerChans struct {
 
 	upgradeMarkerUpdate <-chan upgrade.UpdateMarker
 
-	// upgradeMarkerCleanCh is sent to by the Fleet gateway after a checkin
-	// carrying StateCompleted returns successfully, signalling the coordinator
-	// to delete the upgrade marker. Buffered size 1; gateway sends non-blocking.
+	// upgradeMarkerCleanCh receives a signal when a StateCompleted checkin has been confirmed, triggering upgrade marker cleanup.
 	upgradeMarkerCleanCh chan struct{}
 }
 
@@ -1001,10 +999,7 @@ func (c *Coordinator) logUpgradeDetails(details *details.Details) {
 	c.logger.Infow("updated upgrade details", "upgrade_details", details)
 }
 
-// UpgradeMarkerCleanCh returns the send side of the upgrade marker clean channel.
-// The Fleet gateway sends to this channel (non-blocking) after a checkin carrying
-// StateCompleted returns successfully, signalling the coordinator to delete the marker.
-// Called from external goroutines.
+// UpgradeMarkerCleanCh returns the send side of the channel used to signal that a StateCompleted checkin was confirmed and the upgrade marker can be deleted.
 func (c *Coordinator) UpgradeMarkerCleanCh() chan<- struct{} {
 	return c.managerChans.upgradeMarkerCleanCh
 }

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -1697,6 +1697,14 @@ func (c *Coordinator) runLoopIteration(ctx context.Context) {
 	case upgradeMarker := <-c.managerChans.upgradeMarkerUpdate:
 		if ctx.Err() == nil {
 			c.setUpgradeDetails(upgradeMarker.Details)
+			if !c.isManaged &&
+				upgradeMarker.Details != nil &&
+				upgradeMarker.Details.State == details.StateCompleted {
+				if err := upgrade.CleanMarker(c.logger, paths.Data()); err != nil {
+					c.logger.Warnw("failed to clean upgrade marker", "error.message", err)
+				}
+				c.setUpgradeDetails(nil)
+			}
 		}
 	}
 

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -1659,7 +1659,13 @@ func (c *Coordinator) runLoopIteration(ctx context.Context) {
 		c.setOverrideState(overrideState)
 
 	case upgradeDetails := <-c.upgradeDetailsChan:
-		c.setUpgradeDetails(upgradeDetails)
+		// StateCompleted on this channel means the upgrade was handled entirely
+		// within this process and is already resolved; clear the details.
+		if upgradeDetails != nil && upgradeDetails.State == details.StateCompleted {
+			c.setUpgradeDetails(nil)
+		} else {
+			c.setUpgradeDetails(upgradeDetails)
+		}
 
 	case c.heartbeatChan <- struct{}{}:
 

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -1721,8 +1721,9 @@ func (c *Coordinator) runLoopIteration(ctx context.Context) {
 				upgradeMarker.Details != nil &&
 				upgradeMarker.Details.State == details.StateCompleted {
 				log, dataDir := c.logger, paths.Data()
+				completedVersion := upgradeMarker.Details.TargetVersion
 				go func() {
-					if err := upgrade.CleanMarker(log, dataDir); err != nil {
+					if err := upgrade.CleanMarkerIfCompleted(log, dataDir, completedVersion); err != nil {
 						log.Warnw("failed to clean upgrade marker", "error.message", err)
 					}
 				}()
@@ -1733,8 +1734,9 @@ func (c *Coordinator) runLoopIteration(ctx context.Context) {
 	case <-c.managerChans.upgradeMarkerCleanCh:
 		if ctx.Err() == nil && c.state.UpgradeDetails != nil && c.state.UpgradeDetails.State == details.StateCompleted {
 			log, dataDir := c.logger, paths.Data()
+			completedVersion := c.state.UpgradeDetails.TargetVersion
 			go func() {
-				if err := upgrade.CleanMarker(log, dataDir); err != nil {
+				if err := upgrade.CleanMarkerIfCompleted(log, dataDir, completedVersion); err != nil {
 					log.Warnw("failed to clean upgrade marker after Fleet confirmation", "error.message", err)
 				}
 			}()

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -483,6 +483,11 @@ type managerChans struct {
 	otelManagerError           <-chan error
 
 	upgradeMarkerUpdate <-chan upgrade.UpdateMarker
+
+	// upgradeMarkerCleanCh is sent to by the Fleet gateway after a checkin
+	// carrying StateCompleted returns successfully, signalling the coordinator
+	// to delete the upgrade marker. Buffered size 1; gateway sends non-blocking.
+	upgradeMarkerCleanCh chan struct{}
 }
 
 // diffCheck is a container used by checkAndLogUpdate()
@@ -623,6 +628,7 @@ func New(
 	if upgradeMgr != nil && upgradeMgr.MarkerWatcher() != nil {
 		c.managerChans.upgradeMarkerUpdate = upgradeMgr.MarkerWatcher().Watch()
 	}
+	c.managerChans.upgradeMarkerCleanCh = make(chan struct{}, 1)
 	return c
 }
 
@@ -993,6 +999,14 @@ func (c *Coordinator) Upgrade(ctx context.Context, version string, sourceURI str
 
 func (c *Coordinator) logUpgradeDetails(details *details.Details) {
 	c.logger.Infow("updated upgrade details", "upgrade_details", details)
+}
+
+// UpgradeMarkerCleanCh returns the send side of the upgrade marker clean channel.
+// The Fleet gateway sends to this channel (non-blocking) after a checkin carrying
+// StateCompleted returns successfully, signalling the coordinator to delete the marker.
+// Called from external goroutines.
+func (c *Coordinator) UpgradeMarkerCleanCh() chan<- struct{} {
+	return c.managerChans.upgradeMarkerCleanCh
 }
 
 // AckUpgrade is the method used on startup to ack a previously successful upgrade action.
@@ -1705,6 +1719,14 @@ func (c *Coordinator) runLoopIteration(ctx context.Context) {
 				}
 				c.setUpgradeDetails(nil)
 			}
+		}
+
+	case <-c.managerChans.upgradeMarkerCleanCh:
+		if ctx.Err() == nil {
+			if err := upgrade.CleanMarker(c.logger, paths.Data()); err != nil {
+				c.logger.Warnw("failed to clean upgrade marker after Fleet confirmation", "error.message", err)
+			}
+			c.setUpgradeDetails(nil)
 		}
 	}
 

--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -2811,7 +2811,7 @@ func TestCoordinatorCleansMarkerOnStateCompletedStandalone(t *testing.T) {
 	// Write a marker file so we can verify it gets cleaned.
 	require.NoError(t, os.MkdirAll(paths.Data(), 0o750))
 	det := details.NewDetails("9.5.0", details.StateCompleted, "test-action-id")
-	marker := upgrade.UpdateMarker{Details: det}
+	marker := upgrade.UpdateMarker{Version: "9.5.0", Details: det}
 	require.NoError(t, upgrade.SaveMarker(paths.Data(), &marker, false))
 
 	// Send StateCompleted through the marker update channel.
@@ -2862,7 +2862,7 @@ func TestCoordinatorDoesNotCleanMarkerOnStateCompletedManaged(t *testing.T) {
 	// Write a marker file — it must survive this iteration.
 	require.NoError(t, os.MkdirAll(paths.Data(), 0o750))
 	det := details.NewDetails("9.5.0", details.StateCompleted, "test-action-id")
-	marker := upgrade.UpdateMarker{Details: det}
+	marker := upgrade.UpdateMarker{Version: "9.5.0", Details: det}
 	require.NoError(t, upgrade.SaveMarker(paths.Data(), &marker, false))
 
 	markerChan <- marker
@@ -2908,7 +2908,7 @@ func TestCoordinatorCleansMarkerOnFleetConfirmation(t *testing.T) {
 	}
 
 	require.NoError(t, os.MkdirAll(paths.Data(), 0o750))
-	marker := upgrade.UpdateMarker{}
+	marker := upgrade.UpdateMarker{Version: "9.5.0", Details: details.NewDetails("9.5.0", details.StateCompleted, "test-action-id")}
 	require.NoError(t, upgrade.SaveMarker(paths.Data(), &marker, false))
 	det := details.NewDetails("9.5.0", details.StateCompleted, "test-action-id")
 	coord.state.UpgradeDetails = det
@@ -2923,4 +2923,54 @@ func TestCoordinatorCleansMarkerOnFleetConfirmation(t *testing.T) {
 		_, err := os.Stat(filepath.Join(paths.Data(), ".update-marker"))
 		return os.IsNotExist(err)
 	}, time.Second, time.Millisecond, "upgrade marker must be removed after Fleet confirmation")
+}
+
+func TestCoordinatorDoesNotCleanMarkerOnVersionMismatch(t *testing.T) {
+	top := paths.Top()
+	paths.SetTop(t.TempDir())
+	t.Cleanup(func() { paths.SetTop(top) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	log, _ := loggertest.New("coordinator-marker-test")
+	stateChan := make(chan State, 1)
+	cleanCh := make(chan struct{}, 1)
+
+	coord := &Coordinator{
+		isManaged: true,
+		logger:    log,
+		state: State{
+			CoordinatorState:   agentclient.Healthy,
+			CoordinatorMessage: "Running",
+		},
+		stateBroadcaster: &broadcaster.Broadcaster[State]{
+			InputChan: stateChan,
+		},
+		managerChans: managerChans{
+			upgradeMarkerCleanCh: cleanCh,
+		},
+		componentPIDTicker: func() *time.Ticker {
+			tk := time.NewTicker(time.Second * 30)
+			t.Cleanup(tk.Stop)
+			return tk
+		}(),
+	}
+
+	// The marker on disk points at 9.5.0, but the confirmed upgrade targets
+	// 9.6.0; the cleanup must leave the marker alone when versions mismatch.
+	require.NoError(t, os.MkdirAll(paths.Data(), 0o750))
+	marker := upgrade.UpdateMarker{Version: "9.5.0", Details: details.NewDetails("9.5.0", details.StateCompleted, "test-action-id")}
+	require.NoError(t, upgrade.SaveMarker(paths.Data(), &marker, false))
+	coord.state.UpgradeDetails = details.NewDetails("9.6.0", details.StateCompleted, "test-action-id")
+
+	cleanCh <- struct{}{}
+	coord.runLoopIteration(ctx)
+
+	// Marker removal runs in a goroutine; give it time to run, then confirm it
+	// stayed in place because of the version mismatch.
+	assert.Never(t, func() bool {
+		_, err := os.Stat(filepath.Join(paths.Data(), ".update-marker"))
+		return os.IsNotExist(err)
+	}, 200*time.Millisecond, time.Millisecond, "upgrade marker must not be removed when versions mismatch")
 }

--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -2775,3 +2775,91 @@ func TestGetDynamicInputs(t *testing.T) {
 		assert.False(t, result["env-input"], "env-input should not be marked as dynamic")
 	})
 }
+
+func TestCoordinatorCleansMarkerOnStateCompletedStandalone(t *testing.T) {
+	top := paths.Top()
+	paths.SetTop(t.TempDir())
+	t.Cleanup(func() { paths.SetTop(top) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	log, _ := loggertest.New("coordinator-marker-test")
+	stateChan := make(chan State, 1)
+	markerChan := make(chan upgrade.UpdateMarker, 1)
+
+	coord := &Coordinator{
+		isManaged: false,
+		logger:    log,
+		state: State{
+			CoordinatorState:   agentclient.Healthy,
+			CoordinatorMessage: "Running",
+		},
+		stateBroadcaster: &broadcaster.Broadcaster[State]{
+			InputChan: stateChan,
+		},
+		managerChans: managerChans{
+			upgradeMarkerUpdate: markerChan,
+		},
+		componentPIDTicker: time.NewTicker(time.Second * 30),
+	}
+
+	// Write a marker file so we can verify it gets cleaned.
+	require.NoError(t, os.MkdirAll(paths.Data(), 0o750))
+	det := details.NewDetails("8.99.0", details.StateCompleted, "test-action-id")
+	marker := upgrade.UpdateMarker{Details: det}
+	require.NoError(t, upgrade.SaveMarker(paths.Data(), &marker, false))
+
+	// Send StateCompleted through the marker update channel.
+	markerChan <- marker
+	coord.runLoopIteration(ctx)
+
+	// Marker file must be gone.
+	assert.NoFileExists(t, filepath.Join(paths.Data(), ".update-marker"))
+	// Coordinator state must have UpgradeDetails cleared.
+	assert.Nil(t, coord.state.UpgradeDetails)
+}
+
+func TestCoordinatorDoesNotCleanMarkerOnStateCompletedManaged(t *testing.T) {
+	top := paths.Top()
+	paths.SetTop(t.TempDir())
+	t.Cleanup(func() { paths.SetTop(top) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	log, _ := loggertest.New("coordinator-marker-test")
+	stateChan := make(chan State, 1)
+	markerChan := make(chan upgrade.UpdateMarker, 1)
+
+	coord := &Coordinator{
+		isManaged: true,
+		logger:    log,
+		state: State{
+			CoordinatorState:   agentclient.Healthy,
+			CoordinatorMessage: "Running",
+		},
+		stateBroadcaster: &broadcaster.Broadcaster[State]{
+			InputChan: stateChan,
+		},
+		managerChans: managerChans{
+			upgradeMarkerUpdate: markerChan,
+		},
+		componentPIDTicker: time.NewTicker(time.Second * 30),
+	}
+
+	// Write a marker file — it must survive this iteration.
+	require.NoError(t, os.MkdirAll(paths.Data(), 0o750))
+	det := details.NewDetails("8.99.0", details.StateCompleted, "test-action-id")
+	marker := upgrade.UpdateMarker{Details: det}
+	require.NoError(t, upgrade.SaveMarker(paths.Data(), &marker, false))
+
+	markerChan <- marker
+	coord.runLoopIteration(ctx)
+
+	// Marker file must still be present — coordinator waits for Fleet confirmation.
+	assert.FileExists(t, filepath.Join(paths.Data(), ".update-marker"))
+	// Coordinator state must carry StateCompleted so future checkins include it.
+	require.NotNil(t, coord.state.UpgradeDetails)
+	assert.Equal(t, details.StateCompleted, coord.state.UpgradeDetails.State)
+}

--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -2863,3 +2863,49 @@ func TestCoordinatorDoesNotCleanMarkerOnStateCompletedManaged(t *testing.T) {
 	require.NotNil(t, coord.state.UpgradeDetails)
 	assert.Equal(t, details.StateCompleted, coord.state.UpgradeDetails.State)
 }
+
+func TestCoordinatorCleansMarkerOnFleetConfirmation(t *testing.T) {
+	top := paths.Top()
+	paths.SetTop(t.TempDir())
+	t.Cleanup(func() { paths.SetTop(top) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	log, _ := loggertest.New("coordinator-marker-test")
+	stateChan := make(chan State, 1)
+	cleanCh := make(chan struct{}, 1)
+
+	coord := &Coordinator{
+		isManaged: true,
+		logger:    log,
+		state: State{
+			CoordinatorState:   agentclient.Healthy,
+			CoordinatorMessage: "Running",
+		},
+		stateBroadcaster: &broadcaster.Broadcaster[State]{
+			InputChan: stateChan,
+		},
+		managerChans: managerChans{
+			upgradeMarkerCleanCh: cleanCh,
+		},
+		componentPIDTicker: time.NewTicker(time.Second * 30),
+	}
+
+	// Write a marker file and pre-load StateCompleted into coordinator state
+	// as the gateway would have observed it from the checkin.
+	require.NoError(t, os.MkdirAll(paths.Data(), 0o750))
+	marker := upgrade.UpdateMarker{}
+	require.NoError(t, upgrade.SaveMarker(paths.Data(), &marker, false))
+	det := details.NewDetails("8.99.0", details.StateCompleted, "test-action-id")
+	coord.state.UpgradeDetails = det
+
+	// Simulate the Fleet gateway signalling successful StateCompleted checkin.
+	cleanCh <- struct{}{}
+	coord.runLoopIteration(ctx)
+
+	// Marker file must be gone.
+	assert.NoFileExists(t, filepath.Join(paths.Data(), ".update-marker"))
+	// Coordinator state must have UpgradeDetails cleared.
+	assert.Nil(t, coord.state.UpgradeDetails)
+}

--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -2820,9 +2820,12 @@ func TestCoordinatorCleansMarkerOnStateCompletedStandalone(t *testing.T) {
 
 	// Coordinator state must have UpgradeDetails cleared synchronously.
 	assert.Nil(t, coord.state.UpgradeDetails)
+	// Capture before the async callback: paths.Data() must not be called from a
+	// polling goroutine while t.Cleanup may concurrently restore paths.Top().
+	markerPath := filepath.Join(paths.Data(), ".update-marker")
 	// Marker file removal runs in a goroutine; wait for it.
 	assert.Eventually(t, func() bool {
-		_, err := os.Stat(filepath.Join(paths.Data(), ".update-marker"))
+		_, err := os.Stat(markerPath)
 		return os.IsNotExist(err)
 	}, time.Second, time.Millisecond, "upgrade marker must be removed after standalone upgrade completes")
 }
@@ -2918,9 +2921,10 @@ func TestCoordinatorCleansMarkerOnFleetConfirmation(t *testing.T) {
 
 	// Coordinator state must have UpgradeDetails cleared synchronously.
 	assert.Nil(t, coord.state.UpgradeDetails)
+	markerPath := filepath.Join(paths.Data(), ".update-marker")
 	// Marker file removal runs in a goroutine; wait for it.
 	assert.Eventually(t, func() bool {
-		_, err := os.Stat(filepath.Join(paths.Data(), ".update-marker"))
+		_, err := os.Stat(markerPath)
 		return os.IsNotExist(err)
 	}, time.Second, time.Millisecond, "upgrade marker must be removed after Fleet confirmation")
 }
@@ -2967,10 +2971,11 @@ func TestCoordinatorDoesNotCleanMarkerOnVersionMismatch(t *testing.T) {
 	cleanCh <- struct{}{}
 	coord.runLoopIteration(ctx)
 
+	markerPath := filepath.Join(paths.Data(), ".update-marker")
 	// Marker removal runs in a goroutine; give it time to run, then confirm it
 	// stayed in place because of the version mismatch.
 	assert.Never(t, func() bool {
-		_, err := os.Stat(filepath.Join(paths.Data(), ".update-marker"))
+		_, err := os.Stat(markerPath)
 		return os.IsNotExist(err)
 	}, 200*time.Millisecond, time.Millisecond, "upgrade marker must not be removed when versions mismatch")
 }

--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -2857,7 +2857,7 @@ func TestCoordinatorDoesNotCleanMarkerOnStateCompletedManaged(t *testing.T) {
 	markerChan <- marker
 	coord.runLoopIteration(ctx)
 
-	// Marker file must still be present — coordinator waits for Fleet confirmation.
+	// Marker file must still be present.
 	assert.FileExists(t, filepath.Join(paths.Data(), ".update-marker"))
 	// Coordinator state must carry StateCompleted so future checkins include it.
 	require.NotNil(t, coord.state.UpgradeDetails)
@@ -2892,15 +2892,12 @@ func TestCoordinatorCleansMarkerOnFleetConfirmation(t *testing.T) {
 		componentPIDTicker: time.NewTicker(time.Second * 30),
 	}
 
-	// Write a marker file and pre-load StateCompleted into coordinator state
-	// as the gateway would have observed it from the checkin.
 	require.NoError(t, os.MkdirAll(paths.Data(), 0o750))
 	marker := upgrade.UpdateMarker{}
 	require.NoError(t, upgrade.SaveMarker(paths.Data(), &marker, false))
 	det := details.NewDetails("8.99.0", details.StateCompleted, "test-action-id")
 	coord.state.UpgradeDetails = det
 
-	// Simulate the Fleet gateway signalling successful StateCompleted checkin.
 	cleanCh <- struct{}{}
 	coord.runLoopIteration(ctx)
 

--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -2801,12 +2801,16 @@ func TestCoordinatorCleansMarkerOnStateCompletedStandalone(t *testing.T) {
 		managerChans: managerChans{
 			upgradeMarkerUpdate: markerChan,
 		},
-		componentPIDTicker: time.NewTicker(time.Second * 30),
+		componentPIDTicker: func() *time.Ticker {
+			tk := time.NewTicker(time.Second * 30)
+			t.Cleanup(tk.Stop)
+			return tk
+		}(),
 	}
 
 	// Write a marker file so we can verify it gets cleaned.
 	require.NoError(t, os.MkdirAll(paths.Data(), 0o750))
-	det := details.NewDetails("8.99.0", details.StateCompleted, "test-action-id")
+	det := details.NewDetails("9.5.0", details.StateCompleted, "test-action-id")
 	marker := upgrade.UpdateMarker{Details: det}
 	require.NoError(t, upgrade.SaveMarker(paths.Data(), &marker, false))
 
@@ -2814,10 +2818,13 @@ func TestCoordinatorCleansMarkerOnStateCompletedStandalone(t *testing.T) {
 	markerChan <- marker
 	coord.runLoopIteration(ctx)
 
-	// Marker file must be gone.
-	assert.NoFileExists(t, filepath.Join(paths.Data(), ".update-marker"))
-	// Coordinator state must have UpgradeDetails cleared.
+	// Coordinator state must have UpgradeDetails cleared synchronously.
 	assert.Nil(t, coord.state.UpgradeDetails)
+	// Marker file removal runs in a goroutine; wait for it.
+	assert.Eventually(t, func() bool {
+		_, err := os.Stat(filepath.Join(paths.Data(), ".update-marker"))
+		return os.IsNotExist(err)
+	}, time.Second, time.Millisecond, "upgrade marker must be removed after standalone upgrade completes")
 }
 
 func TestCoordinatorDoesNotCleanMarkerOnStateCompletedManaged(t *testing.T) {
@@ -2845,12 +2852,16 @@ func TestCoordinatorDoesNotCleanMarkerOnStateCompletedManaged(t *testing.T) {
 		managerChans: managerChans{
 			upgradeMarkerUpdate: markerChan,
 		},
-		componentPIDTicker: time.NewTicker(time.Second * 30),
+		componentPIDTicker: func() *time.Ticker {
+			tk := time.NewTicker(time.Second * 30)
+			t.Cleanup(tk.Stop)
+			return tk
+		}(),
 	}
 
 	// Write a marker file — it must survive this iteration.
 	require.NoError(t, os.MkdirAll(paths.Data(), 0o750))
-	det := details.NewDetails("8.99.0", details.StateCompleted, "test-action-id")
+	det := details.NewDetails("9.5.0", details.StateCompleted, "test-action-id")
 	marker := upgrade.UpdateMarker{Details: det}
 	require.NoError(t, upgrade.SaveMarker(paths.Data(), &marker, false))
 
@@ -2889,20 +2900,27 @@ func TestCoordinatorCleansMarkerOnFleetConfirmation(t *testing.T) {
 		managerChans: managerChans{
 			upgradeMarkerCleanCh: cleanCh,
 		},
-		componentPIDTicker: time.NewTicker(time.Second * 30),
+		componentPIDTicker: func() *time.Ticker {
+			tk := time.NewTicker(time.Second * 30)
+			t.Cleanup(tk.Stop)
+			return tk
+		}(),
 	}
 
 	require.NoError(t, os.MkdirAll(paths.Data(), 0o750))
 	marker := upgrade.UpdateMarker{}
 	require.NoError(t, upgrade.SaveMarker(paths.Data(), &marker, false))
-	det := details.NewDetails("8.99.0", details.StateCompleted, "test-action-id")
+	det := details.NewDetails("9.5.0", details.StateCompleted, "test-action-id")
 	coord.state.UpgradeDetails = det
 
 	cleanCh <- struct{}{}
 	coord.runLoopIteration(ctx)
 
-	// Marker file must be gone.
-	assert.NoFileExists(t, filepath.Join(paths.Data(), ".update-marker"))
-	// Coordinator state must have UpgradeDetails cleared.
+	// Coordinator state must have UpgradeDetails cleared synchronously.
 	assert.Nil(t, coord.state.UpgradeDetails)
+	// Marker file removal runs in a goroutine; wait for it.
+	assert.Eventually(t, func() bool {
+		_, err := os.Stat(filepath.Join(paths.Data(), ".update-marker"))
+		return os.IsNotExist(err)
+	}, time.Second, time.Millisecond, "upgrade marker must be removed after Fleet confirmation")
 }

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -98,7 +98,7 @@ type FleetGateway struct {
 	actionCh           chan []fleetapi.Action
 	rollbackSource     ttl.ReadOnlySource
 	compression        string
-	// onUpgradeCompleted is called after a checkin with StateCompleted returns successfully, so the coordinator can clean up the upgrade marker. Nil when not set.
+	// onUpgradeCompleted is called when a checkin carrying StateCompleted returns successfully. Nil when not set.
 	onUpgradeCompleted func()
 }
 

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -32,6 +32,7 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/pkg/scheduler"
+	"github.com/elastic/elastic-agent/pkg/upgrade/details"
 )
 
 // Max number of times an invalid API Key is checked
@@ -97,6 +98,8 @@ type FleetGateway struct {
 	actionCh           chan []fleetapi.Action
 	rollbackSource     ttl.ReadOnlySource
 	compression        string
+	// onUpgradeCompleted is called after a checkin with StateCompleted returns successfully, so the coordinator can clean up the upgrade marker. Nil when not set.
+	onUpgradeCompleted func()
 }
 
 // New creates a new fleet gateway
@@ -109,6 +112,7 @@ func New(
 	stateFetcher StateFetcher,
 	cfg *configuration.FleetCheckin,
 	source ttl.ReadOnlySource,
+	onUpgradeCompleted func(),
 ) (*FleetGateway, error) {
 	scheduler := scheduler.NewPeriodicJitter(defaultGatewaySettings.Duration, defaultGatewaySettings.Jitter)
 	st := defaultGatewaySettings
@@ -123,6 +127,7 @@ func New(
 		stateStore,
 		stateFetcher,
 		source,
+		onUpgradeCompleted,
 	)
 	if err != nil {
 		return nil, err
@@ -141,19 +146,21 @@ func newFleetGatewayWithScheduler(
 	stateStore stateStore,
 	stateFetcher StateFetcher,
 	source ttl.ReadOnlySource,
+	onUpgradeCompleted func(),
 ) (*FleetGateway, error) {
 	return &FleetGateway{
-		log:            log,
-		client:         client,
-		settings:       settings,
-		agentInfo:      agentInfo,
-		scheduler:      scheduler,
-		acker:          acker,
-		stateFetcher:   stateFetcher,
-		stateStore:     stateStore,
-		errCh:          make(chan error),
-		actionCh:       make(chan []fleetapi.Action, 1),
-		rollbackSource: source,
+		log:                log,
+		client:             client,
+		settings:           settings,
+		agentInfo:          agentInfo,
+		scheduler:          scheduler,
+		acker:              acker,
+		stateFetcher:       stateFetcher,
+		stateStore:         stateStore,
+		errCh:              make(chan error),
+		actionCh:           make(chan []fleetapi.Action, 1),
+		rollbackSource:     source,
+		onUpgradeCompleted: onUpgradeCompleted,
 	}, nil
 }
 
@@ -483,6 +490,12 @@ func (f *FleetGateway) execute(ctx context.Context) (*pkgfleetapi.CheckinRespons
 		if serr != nil {
 			f.log.Errorf("failed to save the ack token, err: %v", serr)
 		}
+	}
+
+	if f.onUpgradeCompleted != nil &&
+		req.UpgradeDetails != nil &&
+		req.UpgradeDetails.State == details.StateCompleted {
+		f.onUpgradeCompleted()
 	}
 
 	return resp, took, nil

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -96,7 +96,7 @@ func withGateway(agentInfo agentInfo, settings *fleetGatewaySettings, fn withGat
 		mockRollbacksSrc := ttl.NewMockReadOnlySource(t)
 		mockRollbacksSrc.EXPECT().GetAll().Return(nil, nil, nil)
 
-		gateway, err := newFleetGatewayWithScheduler(log, settings, agentInfo, client, scheduler, noop.New(), stateStore, NewCheckinStateFetcher(emptyStateFetcher), mockRollbacksSrc)
+		gateway, err := newFleetGatewayWithScheduler(log, settings, agentInfo, client, scheduler, noop.New(), stateStore, NewCheckinStateFetcher(emptyStateFetcher), mockRollbacksSrc, nil)
 
 		require.NoError(t, err)
 
@@ -229,7 +229,7 @@ func TestFleetGateway(t *testing.T) {
 		mockRollbacksSrc := ttl.NewMockReadOnlySource(t)
 		mockRollbacksSrc.EXPECT().GetAll().Return(nil, nil, nil)
 
-		gateway, err := newFleetGatewayWithScheduler(log, settings, agentInfo, client, scheduler, noop.New(), stateStore, NewCheckinStateFetcher(emptyStateFetcher), mockRollbacksSrc)
+		gateway, err := newFleetGatewayWithScheduler(log, settings, agentInfo, client, scheduler, noop.New(), stateStore, NewCheckinStateFetcher(emptyStateFetcher), mockRollbacksSrc, nil)
 		require.NoError(t, err)
 
 		waitFn := ackSeq(
@@ -275,7 +275,7 @@ func TestFleetGateway(t *testing.T) {
 		gateway, err := newFleetGatewayWithScheduler(log, &fleetGatewaySettings{
 			Duration: d,
 			Backoff:  &backoffSettings{Init: 1 * time.Second, Max: 30 * time.Second},
-		}, agentInfo, client, scheduler, noop.New(), stateStore, NewCheckinStateFetcher(emptyStateFetcher), mockRollbacksSrc)
+		}, agentInfo, client, scheduler, noop.New(), stateStore, NewCheckinStateFetcher(emptyStateFetcher), mockRollbacksSrc, nil)
 		require.NoError(t, err)
 
 		ch2 := client.Answer(func(_ context.Context, headers http.Header, body io.Reader) (*http.Response, error) {
@@ -328,7 +328,7 @@ func TestFleetGateway(t *testing.T) {
 		mockRollbacksSrc := ttl.NewMockReadOnlySource(t)
 		mockRollbacksSrc.EXPECT().GetAll().Return(nil, nil, nil)
 
-		gateway, err := newFleetGatewayWithScheduler(log, settings, agentInfo, client, scheduler, noop.New(), stateStore, NewCheckinStateFetcher(stateFetcher), mockRollbacksSrc)
+		gateway, err := newFleetGatewayWithScheduler(log, settings, agentInfo, client, scheduler, noop.New(), stateStore, NewCheckinStateFetcher(stateFetcher), mockRollbacksSrc, nil)
 
 		require.NoError(t, err)
 
@@ -391,7 +391,7 @@ func TestFleetGateway(t *testing.T) {
 		mockRollbacksSrc := ttl.NewMockReadOnlySource(t)
 		mockRollbacksSrc.EXPECT().GetAll().Return(nil, nil, nil)
 
-		gateway, err := newFleetGatewayWithScheduler(log, settings, agentInfo, client, scheduler, noop.New(), stateStore, NewCheckinStateFetcher(emptyStateFetcher), mockRollbacksSrc)
+		gateway, err := newFleetGatewayWithScheduler(log, settings, agentInfo, client, scheduler, noop.New(), stateStore, NewCheckinStateFetcher(emptyStateFetcher), mockRollbacksSrc, nil)
 		require.NoError(t, err)
 
 		waitFn := ackSeq(
@@ -446,7 +446,7 @@ func TestFleetGateway(t *testing.T) {
 		gateway, err := newFleetGatewayWithScheduler(log, &fleetGatewaySettings{
 			Duration: 5 * time.Second,
 			Backoff:  &backoffSettings{Init: 10 * time.Millisecond, Max: 30 * time.Second},
-		}, agentInfo, client, scheduler, noop.New(), stateStore, stateFetcher, mockRollbacksSrc)
+		}, agentInfo, client, scheduler, noop.New(), stateStore, stateFetcher, mockRollbacksSrc, nil)
 		require.NoError(t, err)
 
 		requestSent := make(chan struct{}, 10)
@@ -1214,7 +1214,7 @@ func TestAvailableRollbacks(t *testing.T) {
 
 			tc.setup(t, mockRollbacksSrc, testClient)
 
-			gateway, err := newFleetGatewayWithScheduler(log, defaultGatewaySettings, mockAgentInfo, testClient, stepperScheduler, noop.New(), stateStore, NewCheckinStateFetcher(emptyStateFetcher), mockRollbacksSrc)
+			gateway, err := newFleetGatewayWithScheduler(log, defaultGatewaySettings, mockAgentInfo, testClient, stepperScheduler, noop.New(), stateStore, NewCheckinStateFetcher(emptyStateFetcher), mockRollbacksSrc, nil)
 			require.NoError(t, err, "error creating gateway")
 			checkinResponse, _, err := gateway.execute(t.Context())
 			tc.wantErr(t, err)
@@ -1222,5 +1222,160 @@ func TestAvailableRollbacks(t *testing.T) {
 				tc.assertCheckinResponse(t, checkinResponse)
 			}
 		})
+	}
+}
+
+func TestOnUpgradeCompletedCallback(t *testing.T) {
+	log, _ := logger.New("fleet_gateway_test", false)
+	stateStore := newStateStore(t, log)
+	mockRollbacksSrc := ttl.NewMockReadOnlySource(t)
+	mockRollbacksSrc.EXPECT().GetAll().Return(nil, nil, nil)
+
+	called := make(chan struct{}, 1)
+	onUpgradeCompleted := func() {
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+	}
+
+	det := details.NewDetails("8.99.0", details.StateCompleted, "test-action-id")
+	stateFetcherFn := func() coordinator.State {
+		return coordinator.State{UpgradeDetails: det}
+	}
+
+	client := newTestingClient()
+	client.Answer(func(_ context.Context, _ http.Header, _ io.Reader) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"actions":[]}`)),
+		}, nil
+	})
+
+	gw, err := newFleetGatewayWithScheduler(
+		log,
+		defaultGatewaySettings,
+		&testAgentInfo{},
+		client,
+		scheduler.NewStepper(),
+		noop.New(),
+		stateStore,
+		NewCheckinStateFetcher(stateFetcherFn),
+		mockRollbacksSrc,
+		onUpgradeCompleted,
+	)
+	require.NoError(t, err)
+
+	_, _, err = gw.execute(t.Context())
+	require.NoError(t, err)
+
+	select {
+	case <-called:
+		// callback fired as expected
+	default:
+		t.Fatal("onUpgradeCompleted was not called after StateCompleted checkin")
+	}
+}
+
+func TestOnUpgradeCompletedCallbackNotCalledOnCheckinError(t *testing.T) {
+	log, _ := logger.New("fleet_gateway_test", false)
+	stateStore := newStateStore(t, log)
+	mockRollbacksSrc := ttl.NewMockReadOnlySource(t)
+	mockRollbacksSrc.EXPECT().GetAll().Return(nil, nil, nil)
+
+	called := make(chan struct{}, 1)
+	onUpgradeCompleted := func() {
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+	}
+
+	// StateCompleted in the state, but the checkin HTTP call fails.
+	det := details.NewDetails("8.99.0", details.StateCompleted, "test-action-id")
+	stateFetcherFn := func() coordinator.State {
+		return coordinator.State{UpgradeDetails: det}
+	}
+
+	client := newTestingClient()
+	client.Answer(func(_ context.Context, _ http.Header, _ io.Reader) (*http.Response, error) {
+		return nil, fmt.Errorf("network error")
+	})
+
+	gw, err := newFleetGatewayWithScheduler(
+		log,
+		defaultGatewaySettings,
+		&testAgentInfo{},
+		client,
+		scheduler.NewStepper(),
+		noop.New(),
+		stateStore,
+		NewCheckinStateFetcher(stateFetcherFn),
+		mockRollbacksSrc,
+		onUpgradeCompleted,
+	)
+	require.NoError(t, err)
+
+	_, _, err = gw.execute(t.Context())
+	require.Error(t, err)
+
+	select {
+	case <-called:
+		t.Fatal("onUpgradeCompleted must not be called when checkin fails")
+	default:
+		// correct — callback not fired
+	}
+}
+
+func TestOnUpgradeCompletedCallbackNotCalledWithoutStateCompleted(t *testing.T) {
+	log, _ := logger.New("fleet_gateway_test", false)
+	stateStore := newStateStore(t, log)
+	mockRollbacksSrc := ttl.NewMockReadOnlySource(t)
+	mockRollbacksSrc.EXPECT().GetAll().Return(nil, nil, nil)
+
+	called := make(chan struct{}, 1)
+	onUpgradeCompleted := func() {
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+	}
+
+	// StateWatching — not StateCompleted
+	det := details.NewDetails("8.99.0", details.StateWatching, "test-action-id")
+	stateFetcherFn := func() coordinator.State {
+		return coordinator.State{UpgradeDetails: det}
+	}
+
+	client := newTestingClient()
+	client.Answer(func(_ context.Context, _ http.Header, _ io.Reader) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"actions":[]}`)),
+		}, nil
+	})
+
+	gw, err := newFleetGatewayWithScheduler(
+		log,
+		defaultGatewaySettings,
+		&testAgentInfo{},
+		client,
+		scheduler.NewStepper(),
+		noop.New(),
+		stateStore,
+		NewCheckinStateFetcher(stateFetcherFn),
+		mockRollbacksSrc,
+		onUpgradeCompleted,
+	)
+	require.NoError(t, err)
+
+	_, _, err = gw.execute(t.Context())
+	require.NoError(t, err)
+
+	select {
+	case <-called:
+		t.Fatal("onUpgradeCompleted must not be called when state is not StateCompleted")
+	default:
+		// correct — callback not fired
 	}
 }

--- a/internal/pkg/agent/application/managed_mode.go
+++ b/internal/pkg/agent/application/managed_mode.go
@@ -164,6 +164,13 @@ func (m *managedConfigManager) Run(ctx context.Context) error {
 	}
 	m.log.Infof("running managed config manager with checkin mode: %s", m.cfg.Fleet.Checkin.GetMode())
 
+	upgradeMarkerCleanCh := m.coord.UpgradeMarkerCleanCh()
+	onUpgradeCompleted := func() {
+		select {
+		case upgradeMarkerCleanCh <- struct{}{}:
+		default:
+		}
+	}
 	gateway, err := fleetgateway.New(
 		m.log,
 		m.agentInfo,
@@ -173,6 +180,7 @@ func (m *managedConfigManager) Run(ctx context.Context) error {
 		stateFetcher,
 		m.cfg.Fleet.Checkin,
 		m.availableRollbacksSource,
+		onUpgradeCompleted,
 	)
 	if err != nil {
 		return err

--- a/internal/pkg/agent/application/upgrade/manual_rollback.go
+++ b/internal/pkg/agent/application/upgrade/manual_rollback.go
@@ -58,7 +58,10 @@ func (u *Upgrader) rollbackToPreviousVersion(ctx context.Context, topDir string,
 			} else {
 				u.log.Infow("upgrade watcher is still running cleanup, waiting before starting rollback watcher")
 				if tErr := withTakeOverWatcher(ctx, u.log, topDir, u.watcherHelper, func() error { return nil }); tErr != nil {
-					u.log.Warnw("failed to acquire watcher lock before rollback", "error.message", tErr)
+					if cleanErr := os.Remove(updateMarkerPath); cleanErr != nil {
+						u.log.Errorf("Error cleaning up fake upgrade marker: %v", cleanErr)
+					}
+					return nil, fmt.Errorf("waiting for upgrade watcher to release lock before rollback: %w", tErr)
 				}
 			}
 		}

--- a/internal/pkg/agent/application/upgrade/manual_rollback.go
+++ b/internal/pkg/agent/application/upgrade/manual_rollback.go
@@ -46,6 +46,22 @@ func (u *Upgrader) rollbackToPreviousVersion(ctx context.Context, topDir string,
 		// there is no upgrade marker (the rollback was requested after the watcher grace period had elapsed), we need
 		// to extract available rollbacks from agent installs
 		watcherExecutable, versionedHomeToRollbackTo, err = rollbackUsingAgentInstalls(u.log, u.watcherHelper, u.availableRollbacksSource, topDir, now, version, u.markUpgrade, action)
+		if err == nil {
+			// The coordinator may have removed the marker while the upgrade watcher is still
+			// in its cleanup phase (holding watcher.lock). The rollback watcher would exit
+			// immediately if it cannot acquire the lock.
+			// Check whether a watcher is still running and, if so, wait for it (or stop it).
+			quickLocker := filelock.NewAppLocker(topDir, watcherApplockerFileName)
+			if lockErr := quickLocker.TryLock(); lockErr == nil {
+				u.log.Debugw("no lingering upgrade watcher, proceeding with rollback")
+				_ = quickLocker.Unlock()
+			} else {
+				u.log.Infow("upgrade watcher is still running cleanup, waiting before starting rollback watcher")
+				if tErr := withTakeOverWatcher(ctx, u.log, topDir, u.watcherHelper, func() error { return nil }); tErr != nil {
+					u.log.Warnw("failed to acquire watcher lock before rollback", "error.message", tErr)
+				}
+			}
+		}
 	} else {
 		// If upgrade marker is available, we need to gracefully stop any watcher process, read the available rollbacks from
 		// the TTL registry and then proceed with rollback

--- a/internal/pkg/agent/application/upgrade/manual_rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/manual_rollback_test.go
@@ -676,6 +676,10 @@ func TestManualRollback(t *testing.T) {
 				locker := filelock.NewAppLocker(topDir, "watcher.lock")
 				err := locker.TryLock()
 				require.NoError(t, err, "error locking watcher AppLocker")
+				t.Cleanup(func() {
+					unlockErr := locker.Unlock()
+					assert.NoError(t, unlockErr, "error unlocking watcher AppLocker")
+				})
 				watcherHelper.EXPECT().TakeOverWatcher(t.Context(), mock.Anything, topDir).Return(nil, errors.New("error taking over watcher"))
 				// InvokeWatcher must NOT be called.
 			},

--- a/internal/pkg/agent/application/upgrade/manual_rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/manual_rollback_test.go
@@ -480,6 +480,11 @@ func TestManualRollback(t *testing.T) {
 				}, nil, nil)
 				newerWatcherExecutable := filepath.Join(topDir, "data", fmt.Sprintf("elastic-agent-%s-%s", release.VersionWithSnapshot(), release.ShortCommit()), "elastic-agent")
 				watcherHelper.EXPECT().SelectWatcherExecutable(topDir, agentInstall123, agentInstallCurrent).Return(newerWatcherExecutable)
+				// TakeOverWatcher is called to drain any lingering upgrade watcher before starting the rollback watcher.
+				locker := filelock.NewAppLocker(topDir, "watcher.lock")
+				err := locker.TryLock()
+				require.NoError(t, err, "error locking watcher AppLocker")
+				watcherHelper.EXPECT().TakeOverWatcher(t.Context(), mock.Anything, topDir).Return(locker, nil)
 				watcherHelper.EXPECT().InvokeWatcher(mock.Anything, newerWatcherExecutable, "--rollback", filepath.Join("data", "elastic-agent-1.2.3-oldver")).
 					Return(&exec.Cmd{Path: newerWatcherExecutable, Args: []string{"watch", "for rollbacksies"}, Process: &os.Process{Pid: 123}}, nil)
 			},
@@ -607,6 +612,11 @@ func TestManualRollback(t *testing.T) {
 				)
 				newerWatcherExecutable := filepath.Join(topDir, "data", fmt.Sprintf("elastic-agent-%s-%s", release.VersionWithSnapshot(), release.ShortCommit()), "elastic-agent")
 				watcherHelper.EXPECT().SelectWatcherExecutable(topDir, agentInstall123, agentInstallCurrent).Return(newerWatcherExecutable)
+				// TakeOverWatcher is called to drain any lingering upgrade watcher before starting the rollback watcher.
+				locker := filelock.NewAppLocker(topDir, "watcher.lock")
+				err := locker.TryLock()
+				require.NoError(t, err, "error locking watcher AppLocker")
+				watcherHelper.EXPECT().TakeOverWatcher(t.Context(), mock.Anything, topDir).Return(locker, nil)
 				watcherHelper.EXPECT().InvokeWatcher(mock.Anything, newerWatcherExecutable, "--rollback", filepath.Join("data", "elastic-agent-1.2.3-oldver")).
 					Return(nil, errors.New("error invoking watcher"))
 			},

--- a/internal/pkg/agent/application/upgrade/manual_rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/manual_rollback_test.go
@@ -634,6 +634,65 @@ func TestManualRollback(t *testing.T) {
 				require.NoFileExists(t, actualMarkerFilePath, "marker file must have been created")
 			},
 		},
+		{
+			name: "no update marker, no lingering watcher - rollback proceeds without TakeOverWatcher",
+			setup: func(t *testing.T, topDir string, agent *info.MockAgent, watcherHelper *MockWatcherHelper, rollbacksSource *ttl.MockSource) {
+				rollbacksSource.EXPECT().GetAll().Return(map[string]ttl.TTLMarker{
+					filepath.Join("data", "elastic-agent-1.2.3-oldver"): {
+						Version:    "1.2.3",
+						Hash:       "oldver",
+						ValidUntil: aMomentTomorrow,
+					},
+				}, nil, nil)
+				newerWatcherExecutable := filepath.Join(topDir, "data", fmt.Sprintf("elastic-agent-%s-%s", release.VersionWithSnapshot(), release.ShortCommit()), "elastic-agent")
+				watcherHelper.EXPECT().SelectWatcherExecutable(topDir, agentInstall123, agentInstallCurrent).Return(newerWatcherExecutable)
+				// watcher.lock is free: TryLock succeeds, TakeOverWatcher is NOT called.
+				watcherHelper.EXPECT().InvokeWatcher(mock.Anything, newerWatcherExecutable, "--rollback", filepath.Join("data", "elastic-agent-1.2.3-oldver")).
+					Return(&exec.Cmd{Path: newerWatcherExecutable, Args: []string{"watch", "for rollbacksies"}, Process: &os.Process{Pid: 123}}, nil)
+			},
+			artifactSettings: artifact.DefaultConfig(),
+			upgradeSettings: &configuration.UpgradeConfig{
+				Rollback: &configuration.UpgradeRollbackConfig{
+					Window: 24 * time.Hour,
+				},
+			},
+			now:     aMomentInTime,
+			version: "1.2.3",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "no update marker, TakeOverWatcher fails - error, marker cleaned up",
+			setup: func(t *testing.T, topDir string, agent *info.MockAgent, watcherHelper *MockWatcherHelper, rollbacksSource *ttl.MockSource) {
+				rollbacksSource.EXPECT().GetAll().Return(map[string]ttl.TTLMarker{
+					filepath.Join("data", "elastic-agent-1.2.3-oldver"): {
+						Version:    "1.2.3",
+						Hash:       "oldver",
+						ValidUntil: aMomentTomorrow,
+					},
+				}, nil, nil)
+				newerWatcherExecutable := filepath.Join(topDir, "data", fmt.Sprintf("elastic-agent-%s-%s", release.VersionWithSnapshot(), release.ShortCommit()), "elastic-agent")
+				watcherHelper.EXPECT().SelectWatcherExecutable(topDir, agentInstall123, agentInstallCurrent).Return(newerWatcherExecutable)
+				// Pre-lock watcher.lock so TryLock fails, then simulate TakeOverWatcher failing.
+				locker := filelock.NewAppLocker(topDir, "watcher.lock")
+				err := locker.TryLock()
+				require.NoError(t, err, "error locking watcher AppLocker")
+				watcherHelper.EXPECT().TakeOverWatcher(t.Context(), mock.Anything, topDir).Return(nil, errors.New("error taking over watcher"))
+				// InvokeWatcher must NOT be called.
+			},
+			artifactSettings: artifact.DefaultConfig(),
+			upgradeSettings: &configuration.UpgradeConfig{
+				Rollback: &configuration.UpgradeRollbackConfig{
+					Window: 24 * time.Hour,
+				},
+			},
+			now:     aMomentInTime,
+			version: "1.2.3",
+			wantErr: assert.Error,
+			additionalAsserts: func(t *testing.T, topDir string) {
+				actualMarkerFilePath := filepath.Join(topDir, "data", markerFilename)
+				require.NoFileExists(t, actualMarkerFilePath, "fake upgrade marker must be cleaned up on error")
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/internal/pkg/agent/application/upgrade/marker_access_other.go
+++ b/internal/pkg/agent/application/upgrade/marker_access_other.go
@@ -20,6 +20,9 @@ func readMarkerFile(markerFile string) ([]byte, error) {
 		// marker doesn't exist, nothing to do
 		return nil, nil
 	}
+	if err != nil {
+		return nil, err
+	}
 	return markerFileBytes, nil
 }
 
@@ -31,8 +34,8 @@ func writeMarkerFile(markerFile string, markerBytes []byte, shouldFsync bool) er
 
 // On non-Windows platforms, removeMarkerFile simply removes the marker file.
 // See marker_access_windows.go for behavior on Windows platforms.
-// Unlike the Windows version, this may return os.ErrNotExist; callers such as
-// CleanMarker filter that out and treat it as success.
+// Unlike the Windows version, this may return os.ErrNotExist; callers must
+// handle it (the Windows version swallows it).
 func removeMarkerFile(markerFile string) error {
 	return os.Remove(markerFile)
 }

--- a/internal/pkg/agent/application/upgrade/marker_access_other.go
+++ b/internal/pkg/agent/application/upgrade/marker_access_other.go
@@ -28,3 +28,9 @@ func readMarkerFile(markerFile string) ([]byte, error) {
 func writeMarkerFile(markerFile string, markerBytes []byte, shouldFsync bool) error {
 	return writeMarkerFileCommon(markerFile, markerBytes, shouldFsync)
 }
+
+// On non-Windows platforms, removeMarkerFile simply removes the marker file.
+// See marker_access_windows.go for behavior on Windows platforms.
+func removeMarkerFile(markerFile string) error {
+	return os.Remove(markerFile)
+}

--- a/internal/pkg/agent/application/upgrade/marker_access_other.go
+++ b/internal/pkg/agent/application/upgrade/marker_access_other.go
@@ -31,6 +31,8 @@ func writeMarkerFile(markerFile string, markerBytes []byte, shouldFsync bool) er
 
 // On non-Windows platforms, removeMarkerFile simply removes the marker file.
 // See marker_access_windows.go for behavior on Windows platforms.
+// Unlike the Windows version, this may return os.ErrNotExist; callers such as
+// CleanMarker filter that out and treat it as success.
 func removeMarkerFile(markerFile string) error {
 	return os.Remove(markerFile)
 }

--- a/internal/pkg/agent/application/upgrade/marker_access_windows.go
+++ b/internal/pkg/agent/application/upgrade/marker_access_windows.go
@@ -62,6 +62,23 @@ func writeMarkerFile(markerFile string, markerBytes []byte, shouldFsync bool) er
 	return nil
 }
 
+// On Windows, removeMarkerFile tries to remove the marker file, retrying with
+// randomized exponential backoff up to markerAccessTimeout duration. This retry
+// mechanism is necessary since the marker file could be accessed by multiple
+// processes (the Upgrade Watcher and the main Agent process) at the same time,
+// which could fail on Windows.
+func removeMarkerFile(markerFile string) error {
+	removeFn := func() error {
+		return os.Remove(markerFile)
+	}
+
+	if err := accessMarkerFileWithRetries(removeFn); err != nil {
+		return fmt.Errorf("failed to remove upgrade marker file [%s] despite retrying: %w", markerFile, err)
+	}
+
+	return nil
+}
+
 func accessMarkerFileWithRetries(accessFn func() error) error {
 	expBackoff := backoff.NewExponentialBackOff()
 	expBackoff.InitialInterval = markerAccessBackoffInitialInterval

--- a/internal/pkg/agent/application/upgrade/marker_access_windows.go
+++ b/internal/pkg/agent/application/upgrade/marker_access_windows.go
@@ -71,7 +71,7 @@ func removeMarkerFile(markerFile string) error {
 	removeFn := func() error {
 		err := os.Remove(markerFile)
 		if errors.Is(err, os.ErrNotExist) {
-			// Already gone — treat as success, same as readMarkerFile.
+			// Already gone; treat as success, same as readMarkerFile.
 			return nil
 		}
 		return err

--- a/internal/pkg/agent/application/upgrade/marker_access_windows.go
+++ b/internal/pkg/agent/application/upgrade/marker_access_windows.go
@@ -69,7 +69,12 @@ func writeMarkerFile(markerFile string, markerBytes []byte, shouldFsync bool) er
 // which could fail on Windows.
 func removeMarkerFile(markerFile string) error {
 	removeFn := func() error {
-		return os.Remove(markerFile)
+		err := os.Remove(markerFile)
+		if errors.Is(err, os.ErrNotExist) {
+			// Already gone — treat as success, same as readMarkerFile.
+			return nil
+		}
+		return err
 	}
 
 	if err := accessMarkerFileWithRetries(removeFn); err != nil {
@@ -108,6 +113,6 @@ func accessMarkerFileWithRetries(accessFn func() error) error {
 		count++
 	}
 
-	return fmt.Errorf("could not write narker after %s and %d retries. Last error: %w",
+	return fmt.Errorf("could not access marker file after %s and %d retries. Last error: %w",
 		time.Since(start), count, err)
 }

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -23,6 +24,13 @@ import (
 )
 
 const markerFilename = ".update-marker"
+
+// markerMu guards marker reads and writes in this package. Its purpose is to
+// prevent a concurrent cleanup from deleting a marker that a new upgrade just
+// wrote.
+//
+// CleanMarker does not hold this lock; see its doc for why that is safe.
+var markerMu sync.RWMutex
 
 // UpdateMarker is a marker holding necessary information about ongoing upgrade.
 type UpdateMarker struct {
@@ -164,7 +172,12 @@ func writeUpgradeMarkerProvider() writeUpgradeMarkerFunc {
 
 		markerPath := markerFilePath(dataDirPath)
 		log.Infow("Writing upgrade marker file", "file.path", markerPath, "hash", marker.Hash, "prev_hash", marker.PrevHash)
-		if err := writeMarkerFile(markerPath, markerBytes, true); err != nil {
+		err = func() error {
+			markerMu.Lock()
+			defer markerMu.Unlock()
+			return writeMarkerFile(markerPath, markerBytes, true)
+		}()
+		if err != nil {
 			return goerrors.Join(err, errors.New(errors.TypeFilesystem, "failed to create update marker file", errors.M(errors.MetaKeyPath, markerPath)))
 		}
 
@@ -227,7 +240,15 @@ func MarkUpgradeFailed(dataDirPath string, det *details.Details, cause error) er
 	return nil
 }
 
-// CleanMarker removes a marker from disk.
+// CleanMarker removes a marker from disk. It does not hold markerMu, so callers
+// must ensure no concurrent upgrade can write a marker at the same time.
+//
+// The two call-sites are safe for different reasons:
+//
+//   - coordinator process: a process-wide guard prevents a second upgrade from
+//     starting while the first is still in cleanup, so no concurrent writer exists.
+//   - upgrade-watcher process: markerMu is process-local and cannot guard
+//     cross-process writes anyway; the watcher is the sole writer in that process.
 func CleanMarker(log *logger.Logger, dataDirPath string) error {
 	markerFile := markerFilePath(dataDirPath)
 	log.Infow("Removing marker file", "file.path", markerFile)
@@ -241,6 +262,69 @@ func CleanMarker(log *logger.Logger, dataDirPath string) error {
 	}
 
 	return nil
+}
+
+// CleanMarkerIfCompleted removes the marker only when it still describes the
+// expected upgrade and that upgrade has reached a terminal state. The whole
+// read-verify-delete sequence runs under the marker write lock so it cannot
+// race with a new upgrade writing a fresh marker. If the marker is missing,
+// points at a different version, or is not in a terminal state, it is left
+// untouched and the function returns nil.
+func CleanMarkerIfCompleted(log *logger.Logger, dataDirPath string, expectedVersion string) error {
+	markerMu.Lock()
+	defer markerMu.Unlock()
+
+	markerFile := markerFilePath(dataDirPath)
+	marker, err := loadMarkerLocked(markerFile)
+	if err != nil {
+		return err
+	}
+
+	if marker == nil || !versionsMatch(log, marker.Version, expectedVersion) || !IsTerminalState(marker) {
+		return nil
+	}
+
+	log.Infow("Removing marker file", "file.path", markerFile)
+	if err := removeMarkerFile(markerFile); err != nil && !goerrors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+
+	return nil
+}
+
+// versionsMatch reports whether the marker version and the expected version
+// describe the same release.
+//
+// In production both strings always come from the same source expression, so
+// they are byte-identical and always match. The parsed-semver comparison is
+// kept as defense for future callers that might pass differently-formatted
+// strings; if parsing fails for either string we fall back to raw equality.
+//
+// SNAPSHOT suffixes are part of the comparison and must match. Build metadata
+// is handled in two ways: generic metadata (e.g. +abc123) is ignored, so
+// differences there do not cause a mismatch; independent-release metadata (the
+// +buildNNNNNNNNNNNN form) is compared, so two strings that differ only in
+// that field compare as not-equal.
+//
+// A mismatch is logged at info level: it is a normal, benign condition (a
+// leftover marker from a prior upgrade pointing at a different version), not an
+// error, so the marker is simply left in place.
+func versionsMatch(log *logger.Logger, markerVersion, expectedVersion string) bool {
+	markerParsed, markerErr := version.ParseVersion(markerVersion)
+	expectedParsed, expectedErr := version.ParseVersion(expectedVersion)
+
+	var match bool
+	if markerErr != nil || expectedErr != nil {
+		match = markerVersion == expectedVersion
+	} else {
+		match = markerParsed.Equal(*expectedParsed)
+	}
+
+	if !match {
+		log.Infof("upgrade marker version %q does not match expected completed version %q; leaving marker in place",
+			markerVersion, expectedVersion)
+	}
+	return match
 }
 
 // LoadMarker loads the update marker. If the file does not exist it returns nil
@@ -274,6 +358,14 @@ func TryLoadMarker(log *logger.Logger, dataDirPath string) (*UpdateMarker, error
 }
 
 func loadMarker(markerFile string) (*UpdateMarker, error) {
+	markerMu.RLock()
+	defer markerMu.RUnlock()
+	return loadMarkerLocked(markerFile)
+}
+
+// loadMarkerLocked reads and parses the marker without taking markerMu. Callers
+// must already hold markerMu (read or write).
+func loadMarkerLocked(markerFile string) (*UpdateMarker, error) {
 	markerBytes, err := readMarkerFile(markerFile)
 	if err != nil {
 		return nil, err
@@ -329,6 +421,8 @@ func saveMarkerToPath(marker *UpdateMarker, markerFile string, shouldFsync bool)
 		return err
 	}
 
+	markerMu.Lock()
+	defer markerMu.Unlock()
 	return writeMarkerFile(markerFile, markerBytes, shouldFsync)
 }
 

--- a/internal/pkg/agent/application/upgrade/step_mark.go
+++ b/internal/pkg/agent/application/upgrade/step_mark.go
@@ -236,7 +236,7 @@ func CleanMarker(log *logger.Logger, dataDirPath string) error {
 	// (err == nil) to also enter the return branch. Currently harmless
 	// because there's no work after this block, but brittle to future
 	// additions; keep the guard.
-	if err := os.Remove(markerFile); err != nil && !goerrors.Is(err, fs.ErrNotExist) {
+	if err := removeMarkerFile(markerFile); err != nil && !goerrors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 

--- a/internal/pkg/agent/application/upgrade/step_mark_test.go
+++ b/internal/pkg/agent/application/upgrade/step_mark_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
@@ -239,6 +240,99 @@ func TestMarkUpgrade(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCleanMarkerIfCompleted(t *testing.T) {
+	testcases := []struct {
+		name            string
+		marker          *UpdateMarker
+		expectedVersion string
+		wantDeleted     bool
+		wantMismatchLog bool
+	}{
+		{
+			name: "version matches and terminal state - deleted",
+			marker: &UpdateMarker{
+				Version: "9.5.0",
+				Details: details.NewDetails("9.5.0", details.StateCompleted, ""),
+			},
+			expectedVersion: "9.5.0",
+			wantDeleted:     true,
+		},
+		{
+			name: "version mismatch - not deleted",
+			marker: &UpdateMarker{
+				Version: "9.5.0",
+				Details: details.NewDetails("9.5.0", details.StateCompleted, ""),
+			},
+			expectedVersion: "9.6.0",
+			wantDeleted:     false,
+			wantMismatchLog: true,
+		},
+		{
+			name: "non-terminal state - not deleted",
+			marker: &UpdateMarker{
+				Version: "9.5.0",
+				Details: details.NewDetails("9.5.0", details.StateReplacing, ""),
+			},
+			expectedVersion: "9.5.0",
+			wantDeleted:     false,
+		},
+		{
+			name: "snapshot suffix differs - not deleted",
+			marker: &UpdateMarker{
+				Version: "9.5.0-SNAPSHOT",
+				Details: details.NewDetails("9.5.0-SNAPSHOT", details.StateCompleted, ""),
+			},
+			expectedVersion: "9.5.0",
+			wantDeleted:     false,
+			wantMismatchLog: true,
+		},
+		{
+			name: "unparseable but identical - deleted via raw equality",
+			marker: &UpdateMarker{
+				Version: "not-a-version",
+				Details: details.NewDetails("not-a-version", details.StateCompleted, ""),
+			},
+			expectedVersion: "not-a-version",
+			wantDeleted:     true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			log, observed := loggertest.New(t.Name())
+
+			require.NoError(t, SaveMarker(dataDir, tc.marker, false), "seed marker")
+
+			err := CleanMarkerIfCompleted(log, dataDir, tc.expectedVersion)
+			require.NoError(t, err)
+
+			if tc.wantDeleted {
+				require.NoFileExists(t, markerFilePath(dataDir))
+			} else {
+				require.FileExists(t, markerFilePath(dataDir))
+			}
+
+			mismatchLogs := observed.FilterMessageSnippet("does not match expected completed version").TakeAll()
+			if tc.wantMismatchLog {
+				require.Len(t, mismatchLogs, 1, "expected exactly one version-mismatch log entry")
+				require.Equal(t, zapcore.InfoLevel, mismatchLogs[0].Level)
+			} else {
+				require.Empty(t, mismatchLogs, "did not expect a version-mismatch log entry")
+			}
+		})
+	}
+
+	t.Run("nil marker - no error and no delete", func(t *testing.T) {
+		dataDir := t.TempDir()
+		log, _ := loggertest.New(t.Name())
+
+		err := CleanMarkerIfCompleted(log, dataDir, "9.5.0")
+		require.NoError(t, err)
+		require.NoFileExists(t, markerFilePath(dataDir))
+	})
 }
 
 func TestMarkUpgradeFailed(t *testing.T) {

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -72,6 +72,8 @@ var (
 	Version_9_3_0_SNAPSHOT = agtversion.NewParsedSemVer(9, 3, 0, "SNAPSHOT", "")
 	// Version_9_4_0_SNAPSHOT is the minimum version that manages the Windows Add/Remove Programs registry entry
 	Version_9_4_0_SNAPSHOT = agtversion.NewParsedSemVer(9, 4, 0, "SNAPSHOT", "")
+	// Version_9_5_0_SNAPSHOT is the minimum version where the coordinator owns upgrade marker cleanup after a successful upgrade.
+	Version_9_5_0_SNAPSHOT = agtversion.NewParsedSemVer(9, 5, 0, "SNAPSHOT", "")
 )
 
 func init() {

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -274,8 +274,12 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 	// watch succeeded - upgrade was successful!
 	upgradeDetails.SetState(details.StateCompleted)
 
-	// cleanup older versions
-	removeMarker := false
+	// For agents predating the coordinator-owned marker cleanup (< 9.5.0), the
+	// running agent after this upgrade has no upgradeMarkerCleanCh. The watcher
+	// removes the marker so the old coordinator receives nil via the fsnotify
+	// Remove path. For 9.5.0+ the coordinator handles cleanup itself.
+	targetVersion, targetVersionErr := semver.ParseVersion(marker.Version)
+	removeMarker := targetVersionErr != nil || targetVersion.Less(*upgrade.Version_9_5_0_SNAPSHOT)
 	newVersionedHome := marker.VersionedHome
 	if newVersionedHome == "" {
 		// the upgrade marker may have been created by an older version of agent where the versionedHome is always `data/elastic-agent-<shortHash>`

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -275,13 +274,9 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 	// watch succeeded - upgrade was successful!
 	upgradeDetails.SetState(details.StateCompleted)
 
-	// cleanup older versions,
-	// in windows it might leave self untouched, this will get cleaned up
-	// later at the start, because for windows we leave marker untouched.
-	//
-	// Why is this being skipped on Windows? The comment above is not clear.
-	// issue: https://github.com/elastic/elastic-agent/issues/3027
-	removeMarker := !isWindows()
+	// cleanup older versions; the coordinator removes the upgrade marker after
+	// confirming the completed state with Fleet (or immediately for standalone).
+	removeMarker := false
 	newVersionedHome := marker.VersionedHome
 	if newVersionedHome == "" {
 		// the upgrade marker may have been created by an older version of agent where the versionedHome is always `data/elastic-agent-<shortHash>`
@@ -347,10 +342,6 @@ func rollback(log *logp.Logger, topDir string, client client.Client, installModi
 	}
 
 	return nil
-}
-
-func isWindows() bool {
-	return runtime.GOOS == "windows"
 }
 
 // gracePeriod returns true if it is within grace period and time until grace period ends.

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -274,8 +274,7 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 	// watch succeeded - upgrade was successful!
 	upgradeDetails.SetState(details.StateCompleted)
 
-	// cleanup older versions; the coordinator removes the upgrade marker after
-	// confirming the completed state with Fleet (or immediately for standalone).
+	// cleanup older versions; the upgrade marker is removed separately after the completed state is confirmed.
 	removeMarker := false
 	newVersionedHome := marker.VersionedHome
 	if newVersionedHome == "" {

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -236,7 +236,9 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 		// coordinator may not understand StateCompleted and would get stuck.
 		// Fall back to old protocol: skip writing StateCompleted and let the
 		// watcher remove the marker so the coordinator receives nil instead.
-		removeMarker = targetVersion.Less(*version.GetParsedAgentPackageVersion())
+		// If the watcher version is unknown, fall back to old protocol as well.
+		watcherVersion := version.GetParsedAgentPackageVersion()
+		removeMarker = watcherVersion == nil || targetVersion.Less(*watcherVersion)
 	}
 
 	upgradeDetails := initUpgradeDetails(marker, saveMarkerFunc, log, removeMarker)
@@ -287,9 +289,10 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 	// watch succeeded - upgrade was successful!
 	upgradeDetails.SetState(details.StateCompleted)
 
-	// removeMarker was computed before the watch started (see above).
-	// When true, the watcher deletes the marker so the coordinator receives nil
-	// via the fsnotify Remove event. When false, the coordinator handles cleanup.
+	// When removeMarker is true the watcher deletes the marker; the coordinator receives
+	// nil from the fsnotify Remove event.
+	// When false (9.5.0+ target), the coordinator handles cleanup: via upgradeMarkerCleanCh
+	// in managed mode, or on StateCompleted in standalone mode.
 	newVersionedHome := marker.VersionedHome
 	if newVersionedHome == "" {
 		// the upgrade marker may have been created by an older version of agent where the versionedHome is always `data/elastic-agent-<shortHash>`

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -226,7 +226,20 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 	saveMarkerFunc := func(marker *upgrade.UpdateMarker, b bool) error {
 		return upgrade.SaveMarker(dataDir, marker, b)
 	}
-	upgradeDetails := initUpgradeDetails(marker, saveMarkerFunc, log)
+
+	// Determine whether the watcher should remove the marker on success (old protocol)
+	// or leave it for the coordinator to clean up (new protocol, coordinator >= 9.5.0).
+	targetVersion, targetVersionErr := semver.ParseVersion(marker.Version)
+	removeMarker := targetVersionErr != nil || targetVersion.Less(*upgrade.Version_9_5_0_SNAPSHOT)
+	if !removeMarker && targetVersionErr == nil {
+		// When the watcher binary is newer than the upgrade target, the target
+		// coordinator may not understand StateCompleted and would get stuck.
+		// Fall back to old protocol: skip writing StateCompleted and let the
+		// watcher remove the marker so the coordinator receives nil instead.
+		removeMarker = targetVersion.Less(*version.GetParsedAgentPackageVersion())
+	}
+
+	upgradeDetails := initUpgradeDetails(marker, saveMarkerFunc, log, removeMarker)
 
 	errorCheckInterval := cfg.ErrorCheck.Interval
 	ctx := context.Background()
@@ -274,12 +287,9 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 	// watch succeeded - upgrade was successful!
 	upgradeDetails.SetState(details.StateCompleted)
 
-	// For agents predating the coordinator-owned marker cleanup (< 9.5.0), the
-	// running agent after this upgrade has no upgradeMarkerCleanCh. The watcher
-	// removes the marker so the old coordinator receives nil via the fsnotify
-	// Remove path. For 9.5.0+ the coordinator handles cleanup itself.
-	targetVersion, targetVersionErr := semver.ParseVersion(marker.Version)
-	removeMarker := targetVersionErr != nil || targetVersion.Less(*upgrade.Version_9_5_0_SNAPSHOT)
+	// removeMarker was computed before the watch started (see above).
+	// When true, the watcher deletes the marker so the coordinator receives nil
+	// via the fsnotify Remove event. When false, the coordinator handles cleanup.
 	newVersionedHome := marker.VersionedHome
 	if newVersionedHome == "" {
 		// the upgrade marker may have been created by an older version of agent where the versionedHome is always `data/elastic-agent-<shortHash>`
@@ -397,13 +407,19 @@ func getConfig(streams *cli.IOStreams) *configuration.Configuration {
 	return cfg
 }
 
-func initUpgradeDetails(marker *upgrade.UpdateMarker, saveMarker func(*upgrade.UpdateMarker, bool) error, log *logp.Logger) *details.Details {
+func initUpgradeDetails(marker *upgrade.UpdateMarker, saveMarker func(*upgrade.UpdateMarker, bool) error, log *logp.Logger, removeMarker bool) *details.Details {
 	upgradeDetails := details.NewDetails(version.GetAgentPackageVersion(), details.StateWatching, marker.GetActionID())
-	upgradeDetails.RegisterObserver(func(details *details.Details) {
-		marker.Details = details
+	upgradeDetails.RegisterObserver(func(d *details.Details) {
+		// When the watcher will remove the marker on success, skip writing
+		// StateCompleted. The coordinator will receive nil from the Remove
+		// fsnotify event, which works for both old and new coordinators.
+		if removeMarker && d != nil && d.State == details.StateCompleted {
+			return
+		}
+		marker.Details = d
 		if err := saveMarker(marker, true); err != nil {
-			if details != nil {
-				log.Errorf("unable to save upgrade marker after setting upgrade details (state = %s): %s", details.State, err.Error())
+			if d != nil {
+				log.Errorf("unable to save upgrade marker after setting upgrade details (state = %s): %s", d.State, err.Error())
 			} else {
 				log.Errorf("unable to save upgrade marker after clearing upgrade details: %s", err.Error())
 			}

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -289,15 +289,15 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 	// watch succeeded - upgrade was successful!
 	upgradeDetails.SetState(details.StateCompleted)
 
-	// When removeMarker is true the watcher deletes the marker; the coordinator receives
-	// nil from the fsnotify Remove event.
-	// When false (9.5.0+ target), the coordinator handles cleanup: via upgradeMarkerCleanCh
-	// in managed mode, or on StateCompleted in standalone mode.
 	newVersionedHome := marker.VersionedHome
 	if newVersionedHome == "" {
 		// the upgrade marker may have been created by an older version of agent where the versionedHome is always `data/elastic-agent-<shortHash>`
 		newVersionedHome = filepath.Join("data", fmt.Sprintf("elastic-agent-%s", marker.Hash[:6]))
 	}
+	// When removeMarker is true the watcher deletes the marker; the coordinator receives
+	// nil from the fsnotify Remove event.
+	// When false (9.5.0+ target), the coordinator handles cleanup: via upgradeMarkerCleanCh
+	// in managed mode, or on StateCompleted in standalone mode.
 	// Only newVersionedHome is explicitly kept here; rollback candidates are preserved by
 	// cleanupAgentDirectories reading the TTL registry and retaining unexpired entries.
 	err = installModifier.Cleanup(log, topDir, removeMarker, false /* keepLogs */, newVersionedHome)

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -274,7 +274,7 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 	// watch succeeded - upgrade was successful!
 	upgradeDetails.SetState(details.StateCompleted)
 
-	// cleanup older versions; the upgrade marker is removed separately after the completed state is confirmed.
+	// cleanup older versions
 	removeMarker := false
 	newVersionedHome := marker.VersionedHome
 	if newVersionedHome == "" {

--- a/internal/pkg/agent/cmd/watch_test.go
+++ b/internal/pkg/agent/cmd/watch_test.go
@@ -142,7 +142,41 @@ func Test_watchCmd(t *testing.T) {
 					Return(nil)
 
 				installModifier.EXPECT().
-					Cleanup(mock.Anything, topDir, false, false, filepath.Join("data", "elastic-agent-4.5.6-newver")).
+					Cleanup(mock.Anything, topDir, true, false, filepath.Join("data", "elastic-agent-4.5.6-newver")).
+					Return(nil)
+			},
+			args: args{
+				cfg: configuration.DefaultUpgradeConfig().Watcher,
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "happy path: target version >= 9.5.0, coordinator owns marker cleanup",
+			setupUpgradeMarker: func(t *testing.T, topDir string, watcher *mockAgentWatcher, installModifier *mockInstallationModifier) {
+				dataDirPath := paths.DataFrom(topDir)
+				err := os.MkdirAll(dataDirPath, 0755)
+				require.NoError(t, err)
+				err = upgrade.SaveMarker(
+					dataDirPath,
+					&upgrade.UpdateMarker{
+						Version:           "9.5.0",
+						Hash:              "newver",
+						VersionedHome:     filepath.Join("data", "elastic-agent-9.5.0-newver"),
+						UpdatedOn:         time.Now(),
+						PrevVersion:       "9.4.0",
+						PrevHash:          "prvver",
+						PrevVersionedHome: filepath.Join("data", "elastic-agent-prvver"),
+					},
+					true,
+				)
+				require.NoError(t, err)
+
+				watcher.EXPECT().
+					Watch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(nil)
+
+				installModifier.EXPECT().
+					Cleanup(mock.Anything, topDir, false, false, filepath.Join("data", "elastic-agent-9.5.0-newver")).
 					Return(nil)
 			},
 			args: args{
@@ -460,7 +494,7 @@ func Test_watchCmd_MarkerPointsToSelf(t *testing.T) {
 
 	loaded, loadErr := upgrade.LoadMarker(dataDir)
 	require.NoError(t, loadErr)
-	assert.NotNil(t, loaded, "marker should be preserved after successful watch")
+	assert.Nil(t, loaded, "marker should be removed after successful watch")
 }
 
 // writeFakeInstallForWatcherTest builds the on-disk shape that step_unpack

--- a/internal/pkg/agent/cmd/watch_test.go
+++ b/internal/pkg/agent/cmd/watch_test.go
@@ -139,7 +139,6 @@ func Test_watchCmd(t *testing.T) {
 					Watch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
 
-				// marker removal is not the watcher's responsibility
 				installModifier.EXPECT().
 					Cleanup(mock.Anything, topDir, false, false, filepath.Join("data", "elastic-agent-4.5.6-newver")).
 					Return(nil)
@@ -457,7 +456,6 @@ func Test_watchCmd_MarkerPointsToSelf(t *testing.T) {
 		paths.BinaryPath(filepath.Join(topDir, liveHome), binName),
 		"live agent binary must survive cleanup")
 
-	// The watcher does not remove the marker on success; it is removed later after the completed state is confirmed.
 	loaded, loadErr := upgrade.LoadMarker(dataDir)
 	require.NoError(t, loadErr)
 	assert.NotNil(t, loaded, "marker should be preserved after successful watch")

--- a/internal/pkg/agent/cmd/watch_test.go
+++ b/internal/pkg/agent/cmd/watch_test.go
@@ -34,61 +34,82 @@ import (
 )
 
 func TestInitUpgradeDetails(t *testing.T) {
-	testMarker := &upgrade.UpdateMarker{
-		Action: &fleetapi.ActionUpgrade{
-			ActionID: "foobar",
-		},
-	}
+	t.Run("removeMarker=false: StateCompleted is written to marker", func(t *testing.T) {
+		testMarker := &upgrade.UpdateMarker{
+			Action: &fleetapi.ActionUpgrade{ActionID: "foobar"},
+		}
 
-	saveCount := 0
-	mockSaveMarker := func(marker *upgrade.UpdateMarker, _ bool) error {
-		saveCount++
-		if saveCount <= 3 {
-			testMarker = marker
+		saveCount := 0
+		mockSaveMarker := func(marker *upgrade.UpdateMarker, _ bool) error {
+			saveCount++
+			if saveCount <= 3 {
+				testMarker = marker
+				return nil
+			}
+			return errors.New("some error")
+		}
+
+		log, obs := loggertest.New("initUpgradeDetails")
+		upgradeDetails := initUpgradeDetails(testMarker, mockSaveMarker, log, false)
+
+		require.NotNil(t, testMarker.Details)
+		require.Equal(t, details.StateWatching, testMarker.Details.State)
+		require.Equal(t, 0, obs.Len())
+
+		upgradeDetails.SetState(details.StateRollback)
+		require.Equal(t, details.StateRollback, testMarker.Details.State)
+		require.Equal(t, 0, obs.Len())
+
+		// StateCompleted must be written so the coordinator can detect and clean the marker.
+		upgradeDetails.SetState(details.StateCompleted)
+		require.NotNil(t, testMarker.Details)
+		require.Equal(t, details.StateCompleted, testMarker.Details.State)
+		require.Equal(t, 0, obs.Len())
+
+		upgradeDetails.SetState(details.StateRollback)
+		require.Equal(t, 1, obs.Len())
+		logs := obs.TakeAll()
+		require.Equal(t, zapcore.ErrorLevel, logs[0].Level)
+		require.Equal(t, `unable to save upgrade marker after setting upgrade details (state = UPG_ROLLBACK): some error`, logs[0].Message)
+
+		upgradeDetails.SetState(details.StateCompleted)
+		require.NotNil(t, testMarker.Details)
+		require.Equal(t, details.StateCompleted, testMarker.Details.State)
+		require.Equal(t, 1, obs.Len())
+		logs = obs.TakeAll()
+		require.Equal(t, zapcore.ErrorLevel, logs[0].Level)
+		require.Equal(t, `unable to save upgrade marker after setting upgrade details (state = UPG_COMPLETED): some error`, logs[0].Message)
+	})
+
+	t.Run("removeMarker=true: StateCompleted is not written to marker", func(t *testing.T) {
+		testMarker := &upgrade.UpdateMarker{
+			Action: &fleetapi.ActionUpgrade{ActionID: "foobar"},
+		}
+
+		var lastSavedMarker *upgrade.UpdateMarker
+		mockSaveMarker := func(marker *upgrade.UpdateMarker, _ bool) error {
+			lastSavedMarker = marker
 			return nil
 		}
-		return errors.New("some error")
-	}
 
-	log, obs := loggertest.New("initUpgradeDetails")
+		log, _ := loggertest.New("initUpgradeDetails")
+		upgradeDetails := initUpgradeDetails(testMarker, mockSaveMarker, log, true)
 
-	upgradeDetails := initUpgradeDetails(testMarker, mockSaveMarker, log)
+		// Initial StateWatching must still be saved.
+		require.NotNil(t, lastSavedMarker)
+		require.Equal(t, details.StateWatching, lastSavedMarker.Details.State)
 
-	// Verify initial state
-	require.NotNil(t, testMarker.Details)
-	require.Equal(t, details.StateWatching, testMarker.Details.State)
-	require.Equal(t, 0, obs.Len())
+		// StateCompleted must be skipped: the watcher will remove the marker,
+		// so writing StateCompleted would leave old coordinators stuck at UPG_COMPLETED.
+		lastSavedMarker = nil
+		upgradeDetails.SetState(details.StateCompleted)
+		require.Nil(t, lastSavedMarker, "observer must not write StateCompleted when removeMarker=true")
 
-	// Verify state after changing details state
-	upgradeDetails.SetState(details.StateRollback)
-	require.NotNil(t, testMarker.Details)
-	require.Equal(t, details.StateRollback, testMarker.Details.State)
-	require.Equal(t, 0, obs.Len())
-
-	// Verify state after StateCompleted: observer must write StateCompleted explicitly
-	// (not nil) so the coordinator can detect it and remove the marker file.
-	upgradeDetails.SetState(details.StateCompleted)
-	require.NotNil(t, testMarker.Details)
-	require.Equal(t, details.StateCompleted, testMarker.Details.State)
-	require.Equal(t, 0, obs.Len())
-
-	// Verify state after changing details state and there's an
-	// error saving the marker
-	upgradeDetails.SetState(details.StateRollback)
-	require.NotNil(t, testMarker.Details)
-	require.Equal(t, 1, obs.Len())
-	logs := obs.TakeAll()
-	require.Equal(t, zapcore.ErrorLevel, logs[0].Level)
-	require.Equal(t, `unable to save upgrade marker after setting upgrade details (state = UPG_ROLLBACK): some error`, logs[0].Message)
-
-	// Verify state after StateCompleted and there's an error saving the marker
-	upgradeDetails.SetState(details.StateCompleted)
-	require.NotNil(t, testMarker.Details)
-	require.Equal(t, details.StateCompleted, testMarker.Details.State)
-	require.Equal(t, 1, obs.Len())
-	logs = obs.TakeAll()
-	require.Equal(t, zapcore.ErrorLevel, logs[0].Level)
-	require.Equal(t, `unable to save upgrade marker after setting upgrade details (state = UPG_COMPLETED): some error`, logs[0].Message)
+		// Other state transitions must still be saved.
+		upgradeDetails.SetState(details.StateRollback)
+		require.NotNil(t, lastSavedMarker)
+		require.Equal(t, details.StateRollback, lastSavedMarker.Details.State)
+	})
 }
 
 func Test_watchCmd(t *testing.T) {

--- a/internal/pkg/agent/cmd/watch_test.go
+++ b/internal/pkg/agent/cmd/watch_test.go
@@ -65,9 +65,11 @@ func TestInitUpgradeDetails(t *testing.T) {
 	require.Equal(t, details.StateRollback, testMarker.Details.State)
 	require.Equal(t, 0, obs.Len())
 
-	// Verify state after clearing details state
+	// Verify state after StateCompleted: observer must write StateCompleted explicitly
+	// (not nil) so the coordinator can detect it and remove the marker file.
 	upgradeDetails.SetState(details.StateCompleted)
-	require.Nil(t, testMarker.Details)
+	require.NotNil(t, testMarker.Details)
+	require.Equal(t, details.StateCompleted, testMarker.Details.State)
 	require.Equal(t, 0, obs.Len())
 
 	// Verify state after changing details state and there's an
@@ -79,14 +81,14 @@ func TestInitUpgradeDetails(t *testing.T) {
 	require.Equal(t, zapcore.ErrorLevel, logs[0].Level)
 	require.Equal(t, `unable to save upgrade marker after setting upgrade details (state = UPG_ROLLBACK): some error`, logs[0].Message)
 
-	// Verify state after clearing details state and there's an
-	// error saving the marker
+	// Verify state after StateCompleted and there's an error saving the marker
 	upgradeDetails.SetState(details.StateCompleted)
-	require.Nil(t, testMarker.Details)
+	require.NotNil(t, testMarker.Details)
+	require.Equal(t, details.StateCompleted, testMarker.Details.State)
 	require.Equal(t, 1, obs.Len())
 	logs = obs.TakeAll()
 	require.Equal(t, zapcore.ErrorLevel, logs[0].Level)
-	require.Equal(t, `unable to save upgrade marker after clearing upgrade details: some error`, logs[0].Message)
+	require.Equal(t, `unable to save upgrade marker after setting upgrade details (state = UPG_COMPLETED): some error`, logs[0].Message)
 }
 
 func Test_watchCmd(t *testing.T) {

--- a/internal/pkg/agent/cmd/watch_test.go
+++ b/internal/pkg/agent/cmd/watch_test.go
@@ -139,11 +139,9 @@ func Test_watchCmd(t *testing.T) {
 					Watch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
 
-				// on windows the marker is not removed immediately to allow for cleanup on restart
-				expectedRemoveMarkerFlag := runtime.GOOS != "windows"
-
+				// the coordinator owns marker removal; watcher always passes false here
 				installModifier.EXPECT().
-					Cleanup(mock.Anything, topDir, expectedRemoveMarkerFlag, false, filepath.Join("data", "elastic-agent-4.5.6-newver")).
+					Cleanup(mock.Anything, topDir, false, false, filepath.Join("data", "elastic-agent-4.5.6-newver")).
 					Return(nil)
 			},
 			args: args{
@@ -459,16 +457,11 @@ func Test_watchCmd_MarkerPointsToSelf(t *testing.T) {
 		paths.BinaryPath(filepath.Join(topDir, liveHome), binName),
 		"live agent binary must survive cleanup")
 
-	// Sanity: watchCmd sets removeMarker = !isWindows() for the success
-	// branch, so the marker should be gone on non-Windows and preserved
-	// on Windows.
+	// The watcher no longer removes the marker on success; the coordinator does.
+	// The marker must still be present on disk after watchCmd returns.
 	loaded, loadErr := upgrade.LoadMarker(dataDir)
 	require.NoError(t, loadErr)
-	if runtime.GOOS == "windows" {
-		assert.NotNil(t, loaded, "marker should be preserved after successful watch on windows")
-	} else {
-		assert.Nil(t, loaded, "marker should be cleaned up after successful watch on non-windows")
-	}
+	assert.NotNil(t, loaded, "marker should be preserved after successful watch — coordinator removes it later")
 }
 
 // writeFakeInstallForWatcherTest builds the on-disk shape that step_unpack

--- a/internal/pkg/agent/cmd/watch_test.go
+++ b/internal/pkg/agent/cmd/watch_test.go
@@ -139,7 +139,7 @@ func Test_watchCmd(t *testing.T) {
 					Watch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
 
-				// the coordinator owns marker removal; watcher always passes false here
+				// marker removal is not the watcher's responsibility
 				installModifier.EXPECT().
 					Cleanup(mock.Anything, topDir, false, false, filepath.Join("data", "elastic-agent-4.5.6-newver")).
 					Return(nil)
@@ -457,11 +457,10 @@ func Test_watchCmd_MarkerPointsToSelf(t *testing.T) {
 		paths.BinaryPath(filepath.Join(topDir, liveHome), binName),
 		"live agent binary must survive cleanup")
 
-	// The watcher no longer removes the marker on success; the coordinator does.
-	// The marker must still be present on disk after watchCmd returns.
+	// The watcher does not remove the marker on success; it is removed later after the completed state is confirmed.
 	loaded, loadErr := upgrade.LoadMarker(dataDir)
 	require.NoError(t, loadErr)
-	assert.NotNil(t, loaded, "marker should be preserved after successful watch — coordinator removes it later")
+	assert.NotNil(t, loaded, "marker should be preserved after successful watch")
 }
 
 // writeFakeInstallForWatcherTest builds the on-disk shape that step_unpack

--- a/internal/pkg/agent/cmd/watch_test.go
+++ b/internal/pkg/agent/cmd/watch_test.go
@@ -206,6 +206,43 @@ func Test_watchCmd(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			// When marker.Version is unparseable, targetVersionErr != nil → removeMarker=true.
+			// The watcher falls back to old protocol regardless of versions.
+			name: "happy path: unparseable marker version falls back to old protocol (removeMarker=true)",
+			setupUpgradeMarker: func(t *testing.T, topDir string, watcher *mockAgentWatcher, installModifier *mockInstallationModifier) {
+				dataDirPath := paths.DataFrom(topDir)
+				err := os.MkdirAll(dataDirPath, 0755)
+				require.NoError(t, err)
+				err = upgrade.SaveMarker(
+					dataDirPath,
+					&upgrade.UpdateMarker{
+						Version:           "", // unparseable: triggers targetVersionErr != nil branch
+						Hash:              "newver",
+						VersionedHome:     filepath.Join("data", "elastic-agent-newver"),
+						UpdatedOn:         time.Now(),
+						PrevVersion:       "9.4.0",
+						PrevHash:          "prvver",
+						PrevVersionedHome: filepath.Join("data", "elastic-agent-prvver"),
+					},
+					true,
+				)
+				require.NoError(t, err)
+
+				watcher.EXPECT().
+					Watch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(nil)
+
+				// removeMarker=true: unparseable target version falls back to old protocol.
+				installModifier.EXPECT().
+					Cleanup(mock.Anything, topDir, true, false, filepath.Join("data", "elastic-agent-newver")).
+					Return(nil)
+			},
+			args: args{
+				cfg: configuration.DefaultUpgradeConfig().Watcher,
+			},
+			wantErr: assert.NoError,
+		},
+		{
 			// The watcher binary version (version.GetParsedAgentPackageVersion(), which
 			// defaults to 9.5.0 in tests) is newer than the target SNAPSHOT. The watcher
 			// falls back to old protocol: it removes the marker so the coordinator sees nil

--- a/internal/pkg/agent/cmd/watch_test.go
+++ b/internal/pkg/agent/cmd/watch_test.go
@@ -206,6 +206,45 @@ func Test_watchCmd(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			// The watcher binary version (version.GetParsedAgentPackageVersion(), which
+			// defaults to 9.5.0 in tests) is newer than the target SNAPSHOT. The watcher
+			// falls back to old protocol: it removes the marker so the coordinator sees nil
+			// rather than StateCompleted.
+			name: "happy path: watcher newer than target SNAPSHOT, falls back to old protocol (removeMarker=true)",
+			setupUpgradeMarker: func(t *testing.T, topDir string, watcher *mockAgentWatcher, installModifier *mockInstallationModifier) {
+				dataDirPath := paths.DataFrom(topDir)
+				err := os.MkdirAll(dataDirPath, 0755)
+				require.NoError(t, err)
+				err = upgrade.SaveMarker(
+					dataDirPath,
+					&upgrade.UpdateMarker{
+						Version:           "9.5.0-SNAPSHOT",
+						Hash:              "newver",
+						VersionedHome:     filepath.Join("data", "elastic-agent-9.5.0-SNAPSHOT-newver"),
+						UpdatedOn:         time.Now(),
+						PrevVersion:       "9.4.0",
+						PrevHash:          "prvver",
+						PrevVersionedHome: filepath.Join("data", "elastic-agent-prvver"),
+					},
+					true,
+				)
+				require.NoError(t, err)
+
+				watcher.EXPECT().
+					Watch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(nil)
+
+				// removeMarker=true: watcher removes the marker (old protocol).
+				installModifier.EXPECT().
+					Cleanup(mock.Anything, topDir, true, false, filepath.Join("data", "elastic-agent-9.5.0-SNAPSHOT-newver")).
+					Return(nil)
+			},
+			args: args{
+				cfg: configuration.DefaultUpgradeConfig().Watcher,
+			},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "unhappy path: error watching, rollback to previous install, leaving the upgrade marker",
 			setupUpgradeMarker: func(t *testing.T, topDir string, watcher *mockAgentWatcher, installModifier *mockInstallationModifier) {
 				dataDirPath := paths.DataFrom(topDir)

--- a/pkg/upgrade/details/details.go
+++ b/pkg/upgrade/details/details.go
@@ -176,6 +176,9 @@ func (d *Details) Fail(err error) {
 // RegisterObserver allows an interested consumer of Details to register
 // themselves as an Observer. The registered observer is immediately notified
 // of the current upgrade details.
+// Observers always receive a non-nil copy of the current details, including
+// when the state is StateCompleted. Observers must not rely on receiving nil
+// to detect completion; check d.State == StateCompleted instead.
 func (d *Details) RegisterObserver(observer Observer) {
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/pkg/upgrade/details/details.go
+++ b/pkg/upgrade/details/details.go
@@ -209,17 +209,13 @@ func (d *Details) notifyObservers() {
 }
 
 func (d *Details) notifyObserver(observer Observer) {
-	if d.State == StateCompleted {
-		observer(nil)
-	} else {
-		dCopy := Details{
-			TargetVersion: d.TargetVersion,
-			State:         d.State,
-			ActionID:      d.ActionID,
-			Metadata:      d.Metadata,
-		}
-		observer(&dCopy)
+	dCopy := Details{
+		TargetVersion: d.TargetVersion,
+		State:         d.State,
+		ActionID:      d.ActionID,
+		Metadata:      d.Metadata,
 	}
+	observer(&dCopy)
 }
 
 func (m Metadata) Equals(otherM Metadata) bool {

--- a/pkg/upgrade/details/details_test.go
+++ b/pkg/upgrade/details/details_test.go
@@ -75,7 +75,8 @@ func TestDetailsObserver(t *testing.T) {
 
 	det.SetState(StateCompleted)
 	require.Equal(t, StateCompleted, det.State)
-	require.Nil(t, nil, observedDetails)
+	require.NotNil(t, observedDetails)
+	require.Equal(t, StateCompleted, observedDetails.State)
 }
 
 func TestDetailsDownloadRateJSON(t *testing.T) {

--- a/testing/integration/ess/upgrade_rollback_test.go
+++ b/testing/integration/ess/upgrade_rollback_test.go
@@ -408,6 +408,10 @@ func TestFleetManagedUpgradeRollback(t *testing.T) {
 		}
 	}, 5*time.Minute, 15*time.Second)
 
+	// Fleet confirmed the completed state, so the marker must be gone now on all platforms.
+	assert.NoFileExists(t, filepath.Join(startFixture.WorkDir(), "data", ".update-marker"),
+		"upgrade marker must be removed after Fleet confirms StateCompleted")
+
 	// 3. Request rollback via Fleet API
 	t.Logf("Requesting rollback via Fleet API for agent %s", agentID)
 	err = fleettools.RollbackAgent(ctx, kibClient, agentID)

--- a/testing/integration/ess/upgrade_rollback_test.go
+++ b/testing/integration/ess/upgrade_rollback_test.go
@@ -406,10 +406,9 @@ func TestFleetManagedUpgradeRollback(t *testing.T) {
 			assert.Nil(ct, agentResp.UpgradeDetails,
 				"Fleet upgrade_details should be nil after upgrade completes")
 		}
+		assert.NoFileExists(ct, filepath.Join(startFixture.WorkDir(), "data", ".update-marker"),
+			"upgrade marker must be removed after upgrade completes")
 	}, 5*time.Minute, 15*time.Second)
-
-	assert.NoFileExists(t, filepath.Join(startFixture.WorkDir(), "data", ".update-marker"),
-		"upgrade marker must be removed after upgrade completes")
 
 	// 3. Request rollback via Fleet API
 	t.Logf("Requesting rollback via Fleet API for agent %s", agentID)

--- a/testing/integration/ess/upgrade_rollback_test.go
+++ b/testing/integration/ess/upgrade_rollback_test.go
@@ -528,10 +528,8 @@ func TestStandaloneUpgradeManualRollback(t *testing.T) {
 					assert.Equal(t, cproto.State_HEALTHY, state.State)
 					assert.Equal(collect, expectedVersion, state.Info.Version)
 					assert.Equal(collect, expectedSnapshot, state.Info.Snapshot)
-					if runtime.GOOS != "windows" {
-						// on windows the update marker is not removed when cleaning up
-						assert.NoFileExists(collect, filepath.Join(startFixture.WorkDir(), "data", ".update-marker"))
-					}
+					// coordinator removes the marker on all platforms after StateCompleted
+					assert.NoFileExists(collect, filepath.Join(startFixture.WorkDir(), "data", ".update-marker"))
 				}, 4*time.Minute, 10*time.Second)
 				t.Log("elastic agent is out of grace period.")
 				t.Logf("sending version=%s rollback=%v upgrade to agent", startFixture.Version(), true)

--- a/testing/integration/ess/upgrade_rollback_test.go
+++ b/testing/integration/ess/upgrade_rollback_test.go
@@ -408,9 +408,8 @@ func TestFleetManagedUpgradeRollback(t *testing.T) {
 		}
 	}, 5*time.Minute, 15*time.Second)
 
-	// Fleet confirmed the completed state, so the marker must be gone now on all platforms.
 	assert.NoFileExists(t, filepath.Join(startFixture.WorkDir(), "data", ".update-marker"),
-		"upgrade marker must be removed after Fleet confirms StateCompleted")
+		"upgrade marker must be removed after upgrade completes")
 
 	// 3. Request rollback via Fleet API
 	t.Logf("Requesting rollback via Fleet API for agent %s", agentID)
@@ -532,7 +531,6 @@ func TestStandaloneUpgradeManualRollback(t *testing.T) {
 					assert.Equal(t, cproto.State_HEALTHY, state.State)
 					assert.Equal(collect, expectedVersion, state.Info.Version)
 					assert.Equal(collect, expectedSnapshot, state.Info.Snapshot)
-					// marker is removed after StateCompleted is confirmed, on all platforms
 					assert.NoFileExists(collect, filepath.Join(startFixture.WorkDir(), "data", ".update-marker"))
 				}, 4*time.Minute, 10*time.Second)
 				t.Log("elastic agent is out of grace period.")

--- a/testing/integration/ess/upgrade_rollback_test.go
+++ b/testing/integration/ess/upgrade_rollback_test.go
@@ -528,7 +528,7 @@ func TestStandaloneUpgradeManualRollback(t *testing.T) {
 					assert.Equal(t, cproto.State_HEALTHY, state.State)
 					assert.Equal(collect, expectedVersion, state.Info.Version)
 					assert.Equal(collect, expectedSnapshot, state.Info.Snapshot)
-					// coordinator removes the marker on all platforms after StateCompleted
+					// marker is removed after StateCompleted is confirmed, on all platforms
 					assert.NoFileExists(collect, filepath.Join(startFixture.WorkDir(), "data", ".update-marker"))
 				}, 4*time.Minute, 10*time.Second)
 				t.Log("elastic agent is out of grace period.")


### PR DESCRIPTION
## What does this PR do?

Moves ownership of the upgrade marker (`.update-marker`) from the watcher to the coordinator, and makes cleanup consistent across Linux and Windows.

The coordinator now removes the marker:
- in **standalone mode** — when it reads `StateCompleted` from the marker file
- in **Fleet-managed mode** — after a `StateCompleted` checkin is confirmed by Fleet Server

The watcher no longer touches the marker on the success path.

**TOCTOU protection:** the coordinator calls `CleanMarkerIfCompleted` instead of `CleanMarker`. It holds a package-level `sync.RWMutex` across the entire read-verify-delete sequence, so a concurrent `writeUpgradeMarker` call (e.g. a new upgrade action arriving from Fleet before the previous marker is cleaned up) cannot have its marker silently deleted. The delete is skipped if the on-disk marker version no longer matches the completed upgrade.

**Backward compatibility:** if the target agent is older than 9.5.0, the watcher still removes the marker as before — old coordinators are not affected.

**Rollback fix:** if a manual rollback is requested after the grace period, the upgrade watcher may still hold `watcher.lock`. The PR checks for this and waits for the watcher to finish before starting the rollback watcher.

This PR is a prerequisite for #14903 (removing `rollbacks_available` from the marker).

## Why is it important?

The marker cleanup was inconsistent: on Linux the watcher removed it, on Windows it was never removed. The coordinator is the right owner — it knows both the upgrade state and the Fleet confirmation result.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

None. Agents upgrading from < 9.5.0 use the existing protocol unchanged.

## How to test this PR locally

**Unit tests:**
```bash
go test ./internal/pkg/agent/application/coordinator/... -run "TestCoordinatorCleansMarker|TestCoordinatorDoesNot" -v
go test ./internal/pkg/agent/application/gateway/fleet/... -run "TestOnUpgradeCompleted" -v
go test ./internal/pkg/agent/application/upgrade/... -run "TestManualRollback|TestCleanMarkerIfCompleted" -v
go test ./internal/pkg/agent/cmd/... -run "Test_watchCmd|TestInitUpgradeDetails" -v
```

**Integration tests:**
```bash
mage integration:single TestStandaloneUpgradeManualRollback
mage integration:single TestFleetManagedUpgradeRollback
```

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/14668
- Enables https://github.com/elastic/elastic-agent/pull/14903
