### PR TITLE
Use native GO for linux FIPS builds

### DIFF
--- a/changelog/fragments/1781686401-use-native-go-for-linux-fips-builds.yaml
+++ b/changelog/fragments/1781686401-use-native-go-for-linux-fips-builds.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Use native GO for linux FIPS builds
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -110,14 +110,6 @@ func DefaultBuildArgs(cfg *Settings) BuildArgs {
 			for varName, value := range fipsConfig.Compile.Env {
 				args.Env[varName] = value
 			}
-			// windows FIPS builds use the upstream FIPS module
-			if platform.GOOS == "windows" {
-				delete(args.Env, "GOEXPERIMENT")
-				// See https://go.dev/doc/security/fips140#go-cryptographic-module-v100
-				// CMVP Certificate #5247: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247
-				// CAVP Certificate A6650: https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/details?product=19371
-				args.Env["GOFIPS140"] = "v1.0.0"
-			}
 		}
 	}
 

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -213,12 +213,6 @@ func CrossBuildImage(cfg *Settings, platform string) (string, error) {
 
 	goVersion := cfg.GoVersion()
 
-	// FIPS on Linux has to be build using the Go microsoft fork for backwards compatibility reasons.
-	// On Windows, we use the upstream Go mode.
-	if cfg.Build.FIPSBuild && strings.HasPrefix(platform, "linux") {
-		tagSuffix += "-fips"
-	}
-
 	return BeatsCrossBuildImage + ":" + goVersion + "-" + tagSuffix, nil
 }
 

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -40,7 +40,6 @@ packageTypes: &all-package-types
 settings:
   fips:
     compile:
-      cgo: false
       env:
         # See https://go.dev/doc/security/fips140#go-cryptographic-module-v100
         # CMVP Certificate #5247: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -46,7 +46,6 @@ settings:
         # CMVP Certificate #5247: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247
         # CAVP Certificate A6650: https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/details?product=19371
         GOFIPS140: v1.0.0
-        GODEBUG: fips140=on
       tags:
         - requirefips
       platforms:

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -40,10 +40,13 @@ packageTypes: &all-package-types
 settings:
   fips:
     compile:
-      cgo: true
+      cgo: false
       env:
-        GOEXPERIMENT: systemcrypto
-        MS_GOTOOLCHAIN_TELEMETRY_ENABLED: "0"
+        # See https://go.dev/doc/security/fips140#go-cryptographic-module-v100
+        # CMVP Certificate #5247: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247
+        # CAVP Certificate A6650: https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/details?product=19371
+        GOFIPS140: v1.0.0
+        GODEBUG: fips140=on
       tags:
         - requirefips
       platforms:

--- a/dev-tools/packaging/testing/package_test.go
+++ b/dev-tools/packaging/testing/package_test.go
@@ -15,7 +15,6 @@ import (
 	"compress/gzip"
 	"crypto/sha512"
 	"debug/buildinfo"
-	"debug/elf"
 	"encoding/hex"
 	"errors"
 	"flag"
@@ -868,47 +867,29 @@ func checkFIPS(t *testing.T, agentPackageRootDir string) {
 			require.NoError(t, err)
 
 			foundTags := false
-			foundExperiment := false
+			foundFIPS := false
+			foundFIPSDefault := false
 			for _, setting := range info.Settings {
 				switch setting.Key {
 				case "-tags":
 					foundTags = true
 					require.Contains(t, setting.Value, "requirefips")
-
-					// Check if the ms_tls13kdf build tag is set only if the binary was built
-					// with go1.24.x (see https://github.com/microsoft/go/pull/1662).
-					if strings.HasPrefix(info.GoVersion, "go1.24") {
-						require.Contains(t, setting.Value, "ms_tls13kdf")
-					}
 					continue
-				case "GOEXPERIMENT":
-					foundExperiment = true
-					require.Contains(t, setting.Value, "systemcrypto")
+				case "GOFIPS140":
+					foundFIPS = true
+					require.NotEmpty(t, setting.Value, "GOFIPS140 must be set in binary build info")
+					continue
+				case "DefaultGODEBUG":
+					if strings.Contains(setting.Value, "fips140=on") {
+						foundFIPSDefault = true
+					}
 					continue
 				}
 			}
 
 			require.True(t, foundTags, "Did not find -tags within binary version information")
-			require.True(t, foundExperiment, "Did not find GOEXPERIMENT within binary version information")
-
-			// TODO only elf is supported at the moment, in the future we will need to use macho (darwin) and pe (windows)
-			f, err := elf.Open(binary)
-			require.NoError(t, err, "unable to open ELF file")
-
-			symbols, err := f.Symbols()
-			if err != nil {
-				t.Logf("no symbols present in %q: %v", binary, err)
-				return
-			}
-
-			hasOpenSSL := false
-			for _, symbol := range symbols {
-				if strings.Contains(symbol.Name, "OpenSSL_version") {
-					hasOpenSSL = true
-					break
-				}
-			}
-			require.True(t, hasOpenSSL, "unable to find OpenSSL_version symbol")
+			require.True(t, foundFIPS, "Did not find GOFIPS140 within binary version information")
+			require.True(t, foundFIPSDefault, "Did not find fips140=on in DefaultGODEBUG — binary will not enforce FIPS mode at runtime")
 		})
 	}
 }


### PR DESCRIPTION
# Use native Go FIPS for all platforms

## What does this PR do?

Replaces the microsoft-go fork (`GOEXPERIMENT=systemcrypto`) with Go's built-in FIPS support (`GOFIPS140=v1.0.0`) for Linux FIPS builds. Windows was already using the native approach; this aligns Linux with it.

The key changes:

- **`packages.yml`**: swap `GOEXPERIMENT=systemcrypto` for `GOFIPS140=v1.0.0`, drop `cgo: true` (native FIPS is pure Go, no C linking needed)
- **`crossbuild.go`**: remove the `-fips` docker image suffix for Linux — the standard image is now sufficient since it ships upstream Go 1.24+
- **`build.go`**: remove the Windows-specific override that cleaned up `GOEXPERIMENT` (it's no longer set, so there's nothing to clean up)
- **`package_test.go`**: update the FIPS packaging test to check for `GOFIPS140` and `fips140=on` in the binary's default GODEBUG instead of the old `GOEXPERIMENT=systemcrypto` and `OpenSSL_version` ELF symbol

## Why is it important?

Linux and Windows FIPS builds now use the same approach. Before this, Linux required a special microsoft-go Docker image while Windows already used native Go 1.24+ `GOFIPS140`. This PR removes that inconsistency and eliminates the CGO/OpenSSL dependency entirely.

The certified module used is Go Cryptographic Module v1.0.0 (CMVP Certificate #5247).

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None for end users. The resulting binary behaves the same — FIPS mode is on by default when the FIPS package is used. Internally, the binary no longer links OpenSSL, which means the `OpenSSL_version` symbol is no longer present in the ELF.

## How to test this PR locally

Build a FIPS binary for Linux:

```bash
FIPS=true mage build:binary
```

Verify the binary was built with the native FIPS module:

```bash
go version -m ./build/elastic-agent | grep -E "GOFIPS140|DefaultGODEBUG"
```

Expected output:
```
        build   GOFIPS140=v1.0.0
        build   DefaultGODEBUG=fips140=on,...
```

Run FIPS unit tests:

```bash
mage test:fipsOnlyUnit
```
