### PR TITLE
Fix potential sources of flakiness in integration tests

### DIFF
--- a/testing/integration/ess/agent_start_shutdown_test.go
+++ b/testing/integration/ess/agent_start_shutdown_test.go
@@ -57,6 +57,7 @@ inputs:
 	require.NoError(t, fixture.Configure(ctx, []byte(config)))
 	var wg sync.WaitGroup
 	wg.Add(1)
+	t.Cleanup(wg.Wait)
 	go func() {
 		defer wg.Done()
 		assert.NoError(t, fixture.Run(ctx))

--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -1321,14 +1321,17 @@ agent.monitoring.enabled: false
 	var componentID, componentWorkDir string
 	var workDirCreated time.Time
 
-	// wait for component to appear in status and be healthy
+	// wait for component to appear in status and be healthy or degraded
+	// (output points at localhost:9200 which is unreachable, so DEGRADED is expected)
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		var statusErr error
 		status, statusErr := fixture.ExecStatus(ctx)
 		require.NoError(collect, statusErr)
 		require.Equal(collect, 1, len(status.Components))
 		componentStatus := status.Components[0]
-		assert.Equal(collect, cproto.State_HEALTHY, cproto.State(componentStatus.State))
+		componentState := cproto.State(componentStatus.State)
+		assert.Truef(collect, componentState == cproto.State_HEALTHY || componentState == cproto.State_DEGRADED,
+			"component state should be HEALTHY or DEGRADED, got %s", componentState.String())
 		componentID = componentStatus.ID
 	}, 2*time.Minute, 5*time.Second)
 

--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -1479,17 +1479,14 @@ func TestSensitiveLogsESExporter(t *testing.T) {
 	tmpDir := t.TempDir()
 	numEvents := 50
 	// Create the data file to ingest
-	inputFile, err := os.CreateTemp(tmpDir, "input.txt")
-	require.NoError(t, err, "failed to create temp file to hold data to ingest")
-	inputFilePath := inputFile.Name()
-
+	inputFilePath := filepath.Join(tmpDir, "input.txt")
+	var inputContent bytes.Buffer
 	// these messages will fail to index as message is expected to be of integer type
 	for i := 0; i < numEvents; i++ {
-		_, err = inputFile.Write([]byte(fmt.Sprintf("Line %d\n", i)))
-		require.NoErrorf(t, err, "failed to write line %d to temp file", i)
+		fmt.Fprintf(&inputContent, "Line %d\n", i)
 	}
-	err = inputFile.Close()
-	require.NoError(t, err, "failed to close data temp file")
+	err := os.WriteFile(inputFilePath, inputContent.Bytes(), 0o600)
+	require.NoError(t, err, "failed to write data to temp file")
 
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
@@ -1661,17 +1658,14 @@ func TestSensitiveIncludeSourceOnError(t *testing.T) {
 	tmpDir := t.TempDir()
 	numEvents := 50
 	// Create the data file to ingest
-	inputFile, err := os.CreateTemp(tmpDir, "input.txt")
-	require.NoError(t, err, "failed to create temp file to hold data to ingest")
-	inputFilePath := inputFile.Name()
-
+	inputFilePath := filepath.Join(tmpDir, "input.txt")
+	var inputContent bytes.Buffer
 	// these messages will fail to index as message is expected to be of integer type
 	for i := 0; i < numEvents; i++ {
-		_, err = inputFile.Write([]byte(fmt.Sprintf("Line %d\n", i)))
-		require.NoErrorf(t, err, "failed to write line %d to temp file", i)
+		fmt.Fprintf(&inputContent, "Line %d\n", i)
 	}
-	err = inputFile.Close()
-	require.NoError(t, err, "failed to close data temp file")
+	err := os.WriteFile(inputFilePath, inputContent.Bytes(), 0o600)
+	require.NoError(t, err, "failed to write data to temp file")
 
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)

--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -1937,8 +1937,8 @@ func TestMonitoringNoDuplicates(t *testing.T) {
 			assert.NoError(collect, statusErr)
 			assertBeatsHealthy(collect, &status, runtime, componentCount)
 		}, 1*time.Minute, 1*time.Second)
-		require.Eventuallyf(t,
-			func() bool {
+		require.EventuallyWithT(t,
+			func(collect *assert.CollectT) {
 				findCtx, findCancel := context.WithTimeout(ctx, 10*time.Second)
 				defer findCancel()
 				mustClauses := []map[string]any{
@@ -1959,8 +1959,8 @@ func TestMonitoringNoDuplicates(t *testing.T) {
 					},
 				}
 				docs, err := estools.PerformQueryForRawQuery(findCtx, rawQuery, "logs-*", info.ESClient)
-				require.NoError(t, err)
-				return docs.Hits.Total.Value > 0
+				require.NoError(collect, err)
+				assert.Greater(collect, docs.Hits.Total.Value, 0)
 			},
 			4*time.Minute, 5*time.Second,
 			"health check failed: timestamp: %s", timestamp)
@@ -1994,10 +1994,10 @@ func TestMonitoringNoDuplicates(t *testing.T) {
 
 	// wait until policy is applied
 	policyCheck := func(expectedRevision int) {
-		require.Eventually(t, func() bool {
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			inspectOutput, err := fut.ExecInspect(ctx)
-			require.NoError(t, err)
-			return expectedRevision == inspectOutput.Revision
+			require.NoError(collect, err)
+			assert.Equal(collect, expectedRevision, inspectOutput.Revision)
 		}, 3*time.Minute, 1*time.Second)
 	}
 	policyCheck(otelMonResp.Revision)

--- a/testing/integration/ess/container_cmd_test.go
+++ b/testing/integration/ess/container_cmd_test.go
@@ -348,7 +348,7 @@ func TestContainerCMDEventToStderr(t *testing.T) {
 	reqBody := fmt.Sprintf(`
 {
   "name": "%s",
-  "namespace": "default",
+  "namespace": "%s",
   "overrides": {
     "agent": {
       "internal": {
@@ -361,7 +361,7 @@ func TestContainerCMDEventToStderr(t *testing.T) {
     }
   }
 }
-`, policyName)
+`, policyName, info.Namespace)
 
 	status, result, err := info.KibanaClient.Request(
 		http.MethodPut,
@@ -820,7 +820,7 @@ func setAgentMonitoringRuntime(t *testing.T, info *define.Info, policyID string,
 	reqBody := fmt.Sprintf(`
 {
   "name": "%s",
-  "namespace": "default",
+  "namespace": "%s",
   "overrides": {
     "agent": {
       "monitoring": {
@@ -829,7 +829,7 @@ func setAgentMonitoringRuntime(t *testing.T, info *define.Info, policyID string,
     }
   }
 }
-`, policyName, runtime)
+`, policyName, info.Namespace, runtime)
 
 	status, result, err := info.KibanaClient.Request(
 		http.MethodPut,

--- a/testing/integration/ess/event_logging_test.go
+++ b/testing/integration/ess/event_logging_test.go
@@ -295,7 +295,7 @@ func addOverwriteToPolicy(t *testing.T, info *define.Info, policyName, policyID 
 	body := fmt.Sprintf(`
 {
   "name": "%s",
-  "namespace": "default",
+  "namespace": "%s",
   "overrides": {
     "agent": {
       "logging": {
@@ -314,7 +314,7 @@ func addOverwriteToPolicy(t *testing.T, info *define.Info, policyName, policyID 
 	  }
     }
   }
-}`, policyName)
+}`, policyName, info.Namespace)
 	sendPolicyUpdate(t, info, policyID, body)
 }
 

--- a/testing/integration/ess/fqdn_test.go
+++ b/testing/integration/ess/fqdn_test.go
@@ -229,9 +229,9 @@ func verifyHostNameInIndices(t *testing.T, indices, hostname, namespace string, 
 
 	search := esClient.Search
 
-	require.Eventually(
+	require.EventuallyWithT(
 		t,
-		func() bool {
+		func(collect *assert.CollectT) {
 			resp, err := search(
 				search.WithIndex(indices),
 				search.WithSort("@timestamp:desc"),
@@ -239,8 +239,8 @@ func verifyHostNameInIndices(t *testing.T, indices, hostname, namespace string, 
 				search.WithSize(1),
 				search.WithBody(&buf),
 			)
-			require.NoError(t, err)
-			require.False(t, resp.IsError())
+			require.NoError(collect, err)
+			require.False(collect, resp.IsError())
 			defer resp.Body.Close()
 
 			var body struct {
@@ -256,9 +256,9 @@ func verifyHostNameInIndices(t *testing.T, indices, hostname, namespace string, 
 			}
 			decoder := json.NewDecoder(resp.Body)
 			err = decoder.Decode(&body)
-			require.NoError(t, err)
+			require.NoError(collect, err)
 
-			return len(body.Hits.Hits) == 1
+			assert.Len(collect, body.Hits.Hits, 1)
 		},
 		2*time.Minute,
 		5*time.Second,

--- a/testing/integration/ess/metrics_monitoring_test.go
+++ b/testing/integration/ess/metrics_monitoring_test.go
@@ -204,18 +204,15 @@ func (runner *MetricsRunner) TestBeatsMetrics() {
 	}()
 
 	t.Logf("starting to query ES for metrics at %s", now.Format(time.RFC3339Nano))
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		for _, check := range componentChecks {
 			query = genESQuery(agentStatus.Info.ID, check.fields)
 			now = time.Now()
 			res, err := estools.PerformQueryForRawQuery(ctx, query, "metrics-elastic_agent*", runner.info.ESClient)
-			require.NoError(t, err)
+			require.NoError(collect, err)
 			t.Logf("Fetched metrics for %s, got %d hits", check.name, res.Hits.Total.Value)
-			if res.Hits.Total.Value < 1 {
-				return false
-			}
+			assert.GreaterOrEqual(collect, res.Hits.Total.Value, 1)
 		}
-		return true
 	}, time.Minute*10, time.Second*10, "could not fetch metrics for all known components in default install")
 
 	query = genESQuery(agentStatus.Info.ID,
@@ -236,12 +233,12 @@ func (runner *MetricsRunner) TestBeatsMetrics() {
 			{"exists", "field", "metricset.name"},
 			{"exists", "field", "host.hostname"},
 		})
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		now = time.Now()
 		res, err := estools.PerformQueryForRawQuery(ctx, query, "metrics-elastic_agent*", runner.info.ESClient)
-		require.NoError(t, err)
+		require.NoError(collect, err)
 		t.Logf("Fetched monitoring metrics with event template fields, got %d hits", res.Hits.Total.Value)
-		return res.Hits.Total.Value >= 1
+		assert.GreaterOrEqual(collect, res.Hits.Total.Value, 1)
 	}, time.Minute*10, time.Second*10, "monitoring metrics missing expected event template fields")
 
 	// Add a policy overwrite to change the agent monitoring to use Otel runtime
@@ -257,15 +254,12 @@ func (runner *MetricsRunner) TestBeatsMetrics() {
 			{"exists", "field", "system.process.memory.size"},
 		})
 
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		now = time.Now()
 		res, err := estools.PerformQueryForRawQuery(ctx, query, "metrics-elastic_agent*", runner.info.ESClient)
-		require.NoError(t, err)
+		require.NoError(collect, err)
 		t.Logf("Fetched metrics for %s, got %d hits", edotCollectorComponentID, res.Hits.Total.Value)
-		if res.Hits.Total.Value < 1 {
-			return false
-		}
-		return true
+		assert.GreaterOrEqual(collect, res.Hits.Total.Value, 1)
 	}, time.Minute*10, time.Second*10, "could not fetch metrics for edot collector")
 
 	if runtime.GOOS == "windows" {

--- a/testing/integration/ess/metrics_monitoring_test.go
+++ b/testing/integration/ess/metrics_monitoring_test.go
@@ -106,7 +106,7 @@ func (runner *MetricsRunner) addMonitoringToOtelRuntimeOverwrite() {
 	addMonitoringOverwriteBody := fmt.Sprintf(`
 {
   "name": "%s",
-  "namespace": "default",
+  "namespace": "%s",
   "overrides": {
     "agent": {
       "monitoring": {
@@ -115,7 +115,7 @@ func (runner *MetricsRunner) addMonitoringToOtelRuntimeOverwrite() {
     }
   }
 }
-`, runner.policyName)
+`, runner.policyName, runner.info.Namespace)
 	resp, err := runner.info.KibanaClient.Send(
 		http.MethodPut,
 		fmt.Sprintf("/api/fleet/agent_policies/%s", runner.policyID),

--- a/testing/integration/ess/otel_test.go
+++ b/testing/integration/ess/otel_test.go
@@ -139,6 +139,7 @@ service:
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
+	t.Cleanup(wg.Wait)
 	go func() {
 		defer wg.Done()
 		assert.NoError(t, fixture.RunOtelWithClient(ctx))

--- a/testing/integration/ess/otel_test.go
+++ b/testing/integration/ess/otel_test.go
@@ -1348,19 +1348,19 @@ service:
 	actualHits := &struct {
 		Hits int
 	}{}
-	require.Eventually(t,
-		func() bool {
+	require.EventuallyWithT(t,
+		func(collect *assert.CollectT) {
 			findCtx, findCancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer findCancel()
 
 			docs, err = estools.GetLogsForIndexWithContext(findCtx, info.ESClient, ".ds-"+fbIndex+"*", map[string]interface{}{
 				"log.file.path": inputFilePath,
 			})
-			require.NoError(t, err)
+			require.NoError(collect, err)
 
 			actualHits.Hits = docs.Hits.Total.Value
 
-			return actualHits.Hits == numEvents*2 // filebeat + fbreceiver
+			assert.Equal(collect, numEvents*2, actualHits.Hits) // filebeat + fbreceiver
 		},
 		1*time.Minute, 1*time.Second,
 		"Expected %d logs in elasticsearch, got: %v", numEvents, actualHits)
@@ -1531,19 +1531,19 @@ processors:
 	actualHits := &struct {
 		Hits int
 	}{}
-	require.Eventually(t,
-		func() bool {
+	require.EventuallyWithT(t,
+		func(collect *assert.CollectT) {
 			findCtx, findCancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer findCancel()
 
 			docs, err = estools.GetLogsForIndexWithContext(findCtx, info.ESClient, ".ds-"+fbIndex+"*", map[string]interface{}{
 				"log.file.path": inputFilePath,
 			})
-			require.NoError(t, err)
+			require.NoError(collect, err)
 
 			actualHits.Hits = docs.Hits.Total.Value
 
-			return actualHits.Hits == numEvents
+			assert.Equal(collect, numEvents, actualHits.Hits)
 		},
 		1*time.Minute, 1*time.Second,
 		"Expected %d logs in elasticsearch, got: %v", numEvents, actualHits)
@@ -1916,18 +1916,18 @@ service:
 
 	// Make sure find the logs
 	actualHits := &struct{ Hits int }{}
-	require.Eventually(t,
-		func() bool {
+	require.EventuallyWithT(t,
+		func(collect *assert.CollectT) {
 			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer findCancel()
 
 			docs, err := estools.GetLogsForIndexWithContext(findCtx, info.ESClient, ".ds-"+index+"*", map[string]interface{}{
 				"metricset.name": "cpu",
 			})
-			require.NoError(t, err)
+			require.NoError(collect, err)
 
 			actualHits.Hits = docs.Hits.Total.Value
-			return actualHits.Hits >= 1
+			assert.GreaterOrEqual(collect, actualHits.Hits, 1)
 		},
 		2*time.Minute, 1*time.Second,
 		"Expected at least %d logs, got %v", 1, actualHits)

--- a/testing/integration/ess/otel_test.go
+++ b/testing/integration/ess/otel_test.go
@@ -364,6 +364,9 @@ service:
         - filelog
       exporters:
         - file
+  telemetry:
+    metrics:
+      level: none
 `
 	var otelConfigBuffer bytes.Buffer
 	require.NoError(t,
@@ -1272,6 +1275,9 @@ service:
       exporters:
         - elasticsearch/log
         - debug
+  telemetry:
+    metrics:
+      level: none
 `
 
 	beatsApiKey, err := getDecodedApiKey(esApiKey)
@@ -1857,6 +1863,9 @@ service:
         - metricbeatreceiver
       exporters:
         - elasticsearch/log
+  telemetry:
+    metrics:
+      level: none
 `
 	var otelConfigBuffer bytes.Buffer
 	require.NoError(t,
@@ -1997,6 +2006,9 @@ service:
         - metricbeatreceiver
       exporters:
         - elasticsearch/log
+  telemetry:
+    metrics:
+      level: none
 `
 	var otelConfigBuffer bytes.Buffer
 	require.NoError(t,

--- a/testing/integration/ess/otel_test.go
+++ b/testing/integration/ess/otel_test.go
@@ -185,15 +185,13 @@ func TestOtelFileProcessing(t *testing.T) {
 	tmpDir := t.TempDir()
 	// create input file
 	numEvents := 50
-	inputFile, err := os.CreateTemp(tmpDir, "input.txt")
-	require.NoError(t, err, "failed to create temp file to hold data to ingest")
-	inputFilePath := inputFile.Name()
+	inputFilePath := filepath.Join(tmpDir, "input.txt")
+	var inputContent bytes.Buffer
 	for i := 0; i < numEvents; i++ {
-		_, err = inputFile.Write([]byte(fmt.Sprintf("Line %d\n", i)))
-		require.NoErrorf(t, err, "failed to write line %d to temp file", i)
+		fmt.Fprintf(&inputContent, "Line %d\n", i)
 	}
-	err = inputFile.Close()
-	require.NoError(t, err, "failed to close data temp file")
+	err := os.WriteFile(inputFilePath, inputContent.Bytes(), 0o600)
+	require.NoError(t, err, "failed to write data to temp file")
 	t.Cleanup(func() {
 		if t.Failed() {
 			contents, err := os.ReadFile(inputFilePath)
@@ -316,15 +314,13 @@ func TestOtelHybridFileProcessing(t *testing.T) {
 	tmpDir := t.TempDir()
 	// create input file
 	numEvents := 50
-	inputFile, err := os.CreateTemp(tmpDir, "input.txt")
-	require.NoError(t, err, "failed to create temp file to hold data to ingest")
-	inputFilePath := inputFile.Name()
+	inputFilePath := filepath.Join(tmpDir, "input.txt")
+	var inputContent bytes.Buffer
 	for i := 0; i < numEvents; i++ {
-		_, err = inputFile.Write([]byte(fmt.Sprintf("Line %d\n", i)))
-		require.NoErrorf(t, err, "failed to write line %d to temp file", i)
+		fmt.Fprintf(&inputContent, "Line %d\n", i)
 	}
-	err = inputFile.Close()
-	require.NoError(t, err, "failed to close data temp file")
+	err := os.WriteFile(inputFilePath, inputContent.Bytes(), 0o600)
+	require.NoError(t, err, "failed to write data to temp file")
 	t.Cleanup(func() {
 		if t.Failed() {
 			contents, err := os.ReadFile(inputFilePath)
@@ -878,15 +874,13 @@ func TestOtelFilestreamInput(t *testing.T) {
 	tmpDir := t.TempDir()
 	numEvents := 50
 	// Create the data file to ingest
-	inputFile, err := os.CreateTemp(tmpDir, "input.txt")
-	require.NoError(t, err, "failed to create temp file to hold data to ingest")
-	inputFilePath := inputFile.Name()
+	inputFilePath := filepath.Join(tmpDir, "input.txt")
+	var inputContent bytes.Buffer
 	for i := 0; i < numEvents; i++ {
-		_, err = inputFile.Write([]byte(fmt.Sprintf("Line %d\n", i)))
-		require.NoErrorf(t, err, "failed to write line %d to temp file", i)
+		fmt.Fprintf(&inputContent, "Line %d\n", i)
 	}
-	err = inputFile.Close()
-	require.NoError(t, err, "failed to close data temp file")
+	err := os.WriteFile(inputFilePath, inputContent.Bytes(), 0o600)
+	require.NoError(t, err, "failed to write data to temp file")
 	t.Cleanup(func() {
 		if t.Failed() {
 			contents, err := os.ReadFile(inputFilePath)
@@ -1173,18 +1167,13 @@ func TestHybridAgentE2E(t *testing.T) {
 	fbIndex := "logs-generic-default"
 	fbReceiverIndex := "logs-generic-default"
 
-	inputFile, err := os.CreateTemp(tmpDir, "input-*.log")
-	require.NoError(t, err, "failed to create input log file")
-	inputFilePath := inputFile.Name()
+	inputFilePath := filepath.Join(tmpDir, "input.log")
+	var inputContent bytes.Buffer
 	for i := 0; i < numEvents; i++ {
-		_, err = inputFile.Write([]byte(fmt.Sprintf("Line %d", i)))
-		require.NoErrorf(t, err, "failed to write line %d to temp file", i)
-		_, err = inputFile.Write([]byte("\n"))
-		require.NoErrorf(t, err, "failed to write newline to input file")
-		time.Sleep(100 * time.Millisecond)
+		fmt.Fprintf(&inputContent, "Line %d\n", i)
 	}
-	err = inputFile.Close()
-	require.NoError(t, err, "failed to close data input file")
+	err := os.WriteFile(inputFilePath, inputContent.Bytes(), 0o600)
+	require.NoError(t, err, "failed to write data to temp file")
 
 	t.Cleanup(func() {
 		if t.Failed() {
@@ -1394,18 +1383,13 @@ func TestHybridAgentGlobalProcessors(t *testing.T) {
 	numEvents := 1
 	fbIndex := "logs-generic-default"
 
-	inputFile, err := os.CreateTemp(tmpDir, "input-*.log")
-	require.NoError(t, err, "failed to create input log file")
-	inputFilePath := inputFile.Name()
+	inputFilePath := filepath.Join(tmpDir, "input.log")
+	var inputContent bytes.Buffer
 	for i := 0; i < numEvents; i++ {
-		_, err = inputFile.Write([]byte(fmt.Sprintf("Line %d", i)))
-		require.NoErrorf(t, err, "failed to write line %d to temp file", i)
-		_, err = inputFile.Write([]byte("\n"))
-		require.NoErrorf(t, err, "failed to write newline to input file")
-		time.Sleep(100 * time.Millisecond)
+		fmt.Fprintf(&inputContent, "Line %d\n", i)
 	}
-	err = inputFile.Close()
-	require.NoError(t, err, "failed to close data input file")
+	err := os.WriteFile(inputFilePath, inputContent.Bytes(), 0o600)
+	require.NoError(t, err, "failed to write data to temp file")
 
 	t.Cleanup(func() {
 		if t.Failed() {


### PR DESCRIPTION
## What does this PR do?

Fix some test issues I discovered doing discovery for https://github.com/elastic/elastic-agent/issues/14958.

One commit per category:

  1. **`require.EventuallyWithT` instead of `require.Eventually`**
  ([9aea55f](https://github.com/elastic/elastic-agent/commit/9aea55f8d5ae1bb35f948a1b4354230b07f5e158)) - `require.X(t, ...)` inside an `Eventually` closure calls
  `t.FailNow()` from a goroutine, which panics or silently aborts. Converted to `require.EventuallyWithT` with `*assert.CollectT`, which defers failure to the
  next retry via `runtime.Goexit()`. Affected: `fqdn_test.go`, `metrics_monitoring_test.go`, `beat_receivers_test.go`, `otel_test.go`.

  2. **`t.Cleanup(wg.Wait)` to join goroutines** ([b352423](https://github.com/elastic/elastic-agent/commit/b35242364da85b17c563025f0bc2eb0852e9d187)) - `go
  func() { assert.NoError(t, fixture.Run(ctx)) }()` was never joined on test failure, leaking the goroutine. Added `t.Cleanup(wg.Wait)` so the goroutine is always
  joined regardless of exit path. Affected: `agent_start_shutdown_test.go`, `otel_test.go`.
  
  3. **Use `info.Namespace` instead of hardcoded `"default"`**
  ([15261f9](https://github.com/elastic/elastic-agent/commit/15261f9e90f25c8323edfd024e869482c5664af5)) - Fleet policy update bodies were sending `"namespace":
  "default"` regardless of the test-provisioned namespace, causing 400s on stacks where the namespace differs. Affected: `event_logging_test.go`,
  `container_cmd_test.go`, `metrics_monitoring_test.go`.

  4. **Accept `DEGRADED` in `TestComponentWorkDir`** ([385bad7](https://github.com/elastic/elastic-agent/commit/385bad7459afe53fe4a5e5a5cbc4f2b17bd2abef)) - The
  test installs a component with `hosts: [http://localhost:9200]` and a placeholder API key, so the ES output is always unreachable and the component is
  `DEGRADED`, not `HEALTHY`. Changed the health check to accept either state.
  
  5. **`os.WriteFile` instead of `os.CreateTemp`** ([ad3af65](https://github.com/elastic/elastic-agent/commit/ad3af65b5e2b9f107a14c8c9efb46ac7f2d783dc)) - On
  Windows, `os.CreateTemp` opens the file without `FILE_SHARE_DELETE`, causing `t.TempDir()` cleanup to fail while the handle is held. `os.WriteFile` opens,
  writes, and closes atomically. Affected: `beat_receivers_test.go`, `otel_test.go` (excluding `TestFBOtelRestartE2E` which intentionally holds an open handle for
  continuous writes).

  6. **Suppress OTel default Prometheus metrics endpoint** ([3d85eac](https://github.com/elastic/elastic-agent/commit/3d85eacd175e18082c7cd475a356c4f7bcaa103d)) -
  Several tests start an OTel collector that binds port 8888 by default for Prometheus metrics. When multiple tests run in parallel this causes port conflicts.
  Added `service.telemetry.metrics.level: none` to the affected service blocks in `otel_test.go`.
  
  ## Why is it important?

  These are root causes of observed flakiness in the ESS integration test suite. No functional behaviour changes - test correctness only.

  ## Checklist
  
  - [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of
  this project.
  - [x] My code follows the style guidelines of this project
  - ~~I have commented my code, particularly in hard-to-understand areas~~
  - ~~I have made corresponding changes to the documentation~~
  - ~~I have made corresponding change to the default configuration files~~
  - ~~I have added tests that prove my fix is effective or that my feature works~~
  - ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
  - ~~I have added an integration test or an E2E test~~

  ## Disruptive User Impact

  None - test-only changes.

  ## How to test this PR locally

  Run the affected ESS integration tests against a live stack. The easiest signal is reduced flakiness on re-runs.

  ## Related issues
  
  - Relates https://github.com/elastic/elastic-agent/issues/14958

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
