### PR TITLE
fix: tolerate transient recoverable degraded state in TestHandleLeak

### DIFF
--- a/pkg/testing/consecutive_health_checker.go
+++ b/pkg/testing/consecutive_health_checker.go
@@ -1,0 +1,44 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package testing
+
+import (
+	"context"
+	"fmt"
+)
+
+// ConsecutiveHealthChecker wraps IsHealthy for use in long-running polling loops.
+// It returns nil until the agent has been unhealthy for maxConsecutive checks in a row,
+// then returns the error. The counter resets on any healthy response.
+//
+// Use this instead of bare IsHealthy + require.NoError in custom polling loops.
+// For one-shot health checks after an operation, use IsHealthy inside require.Eventually instead.
+type ConsecutiveHealthChecker struct {
+	fixture     *Fixture
+	max         int
+	consecutive int
+}
+
+// NewConsecutiveHealthChecker returns a checker that tolerates up to maxConsecutive
+// consecutive unhealthy responses before reporting an error.
+func NewConsecutiveHealthChecker(fixture *Fixture, maxConsecutive int) *ConsecutiveHealthChecker {
+	return &ConsecutiveHealthChecker{fixture: fixture, max: maxConsecutive}
+}
+
+// Check calls IsHealthy and returns nil as long as the agent has not been
+// unhealthy for maxConsecutive consecutive calls. It resets the counter on
+// any healthy response.
+func (c *ConsecutiveHealthChecker) Check(ctx context.Context) error {
+	err := c.fixture.IsHealthy(ctx)
+	if err != nil {
+		c.consecutive++
+		if c.consecutive >= c.max {
+			return fmt.Errorf("unhealthy for %d consecutive checks: %w", c.consecutive, err)
+		}
+		return nil
+	}
+	c.consecutive = 0
+	return nil
+}

--- a/testing/integration/leak/long_running_test.go
+++ b/testing/integration/leak/long_running_test.go
@@ -170,14 +170,17 @@ func (runner *ExtendedRunner) TestHandleLeak() {
 	ticker := time.NewTicker(time.Second * 10)
 	defer ticker.Stop()
 
+	// Use a consecutive health checker so that transient recoverable degraded
+	// states (e.g. system.cpu on Windows) do not immediately fail the test.
+	healthChecker := atesting.NewConsecutiveHealthChecker(runner.agentFixture, 3)
+
 	done := false
 	for !done {
 		select {
 		case <-timer.C:
 			done = true
 		case <-ticker.C:
-			err := runner.agentFixture.IsHealthy(ctx)
-			require.NoError(runner.T(), err)
+			require.NoError(runner.T(), healthChecker.Check(ctx))
 			// iterate through our watchers, update them
 			for _, mon := range runner.resourceWatchers {
 				mon.Update(runner.T(), runner.agentFixture)


### PR DESCRIPTION
## What does this PR do?

`TestHandleLeak` polls agent health every 10 seconds and used to fail immediately on a single non-healthy response. It now requires **3 consecutive unhealthy ticks (~20 seconds)** before failing.

Attaching the run I spotted it:

- https://github.com/elastic/elastic-agent/pull/14953#issuecomment-4729437196
- https://buildkite.com/elastic/elastic-agent/builds/41494/list?jid=019ed501-bbee-4e7e-9bf6-da4a85fd0499&tab=output

## Why is it important?

The test was flaky on Windows. The `system.cpu` metricset can transiently report DEGRADED with `previous sample is newer than current sample` — a recoverable timing issue that self-heals within seconds. The old single-snapshot check would catch the agent mid-recovery and fail the test.

The health check here is a sanity guard for the resource-leak measurements, not the primary assertion. A short transient degradation does not invalidate those measurements.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None. Test-only change.

## How to test this PR locally

```bash
LONG_TEST_RUNTIME=15m go test -v -tags integration ./testing/integration/leak/... -run TestLongRunningAgentForLeaks
```