### PR TITLE
Add warning to release notes to skip Elastic Agent 9.3.4 release

### DIFF
--- a/docs/release-notes/_snippets/9.3.4/index.md
+++ b/docs/release-notes/_snippets/9.3.4/index.md
@@ -1,6 +1,12 @@
 ## 9.3.4 [elastic-agent-release-notes-9.3.4]
 
+:::{warning}
+We recommend that you skip {{agent}} 9.3.4 and upgrade directly to 9.3.5 or later.
 
+A time serialization optimization introduced in {{agent}} 9.3.4 causes timestamp fields sent from Beats-based inputs and {{agent}} integrations to be incorrectly serialized as an empty `{}` JSON object.
+
+As a result, affected documents might be rejected by {{es}} or routed to the Failure Store when it's enabled on the target data stream. For full details, refer to the [known issue](/release-notes/known-issues.md#events-beats-9-3-4-timestamp-empty-object). The optimization has been reverted, and the fix is included in {{agent}} 9.3.5.
+:::
 
 ### Features and enhancements [elastic-agent-9.3.4-features-enhancements]
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -70,6 +70,7 @@ For more information check [Issue #264983](https://github.com/elastic/kibana/iss
 :::
 
 :::{dropdown} Events from Beats based integrations in Elastic Agent 9.3.4 incorrectly convert timestamps to an empty {} JSON object.
+:name: events-beats-9-3-4-timestamp-empty-object
 **Applies to: {{agent}} 9.3.4**
 
 A performance optimization in Elastic Agent 9.3.4 causes timestamp fields sent from Beats based inputs and integrations to be incorrectly serialized to an empty `{}` JSON object. This does not affect the primary `@timestamp` field, only other timestamps fields in the event body.


### PR DESCRIPTION
Docs

## What does this PR do?

This PR adds a warning note to the release notes for 9.3.4, recommending to users to skip this release and upgrade to a later version due to a known issue.

Resolves https://github.com/elastic/docs-content/issues/6955

## Preview

[docs/release-notes/known-issues.md](https://docs-v3-preview.elastic.dev/elastic/elastic-agent/pull/14984/release-notes/known-issues)