### PR TITLE
ci: pass stack_build_id to ess_up in all callers

### DIFF
--- a/.buildkite/scripts/steps/ess.ps1
+++ b/.buildkite/scripts/steps/ess.ps1
@@ -1,6 +1,6 @@
 function ess_up {
   param (
-      [string]$StackVersion
+      [string]$StackVersion,
       [string]$StackBuildId
   )
 
@@ -196,7 +196,7 @@ function Retry-Command {
 
 function Get-Ess-Stack {
   param (
-      [string]$StackVersion
+      [string]$StackVersion,
       [string]$StackBuildId
   )
 

--- a/.buildkite/scripts/steps/ess.ps1
+++ b/.buildkite/scripts/steps/ess.ps1
@@ -1,12 +1,18 @@
 function ess_up {
   param (
       [string]$StackVersion
+      [string]$StackBuildId
   )
 
   Write-Output "~~~ Starting ESS Stack"
 
   if (-not $StackVersion) {
-      Write-Error "Error: Specify stack version: ess_up [stack_version]"
+      Write-Error "Error: Specify stack version: ess_up [stack_version] [stack_build_id]"
+      return 1
+  }
+
+  if (-not $StackBuildId) {
+      Write-Error "Error: Specify stack build ID: ess_up [stack_build_id]"
       return 1
   }
 
@@ -24,6 +30,9 @@ function ess_up {
   if ($Env:INTEGRATION_SERVER_DOCKER_IMAGE) {
       $params.ElasticAgentDockerImage = $Env:INTEGRATION_SERVER_DOCKER_IMAGE
   }
+
+  $params.ElasticsearchDockerImage = "docker.elastic.co/cloud-release/elasticsearch-cloud-ess:$StackBuildId"
+  $params.KibanaDockerImage = "docker.elastic.co/cloud-release/kibana-cloud:$StackBuildId"
 
   $params | ConvertTo-Json -Compress | Set-Content -Path $paramsPath -Encoding ASCII
 
@@ -188,10 +197,11 @@ function Retry-Command {
 function Get-Ess-Stack {
   param (
       [string]$StackVersion
+      [string]$StackBuildId
   )
 
   if ($Env:BUILDKITE_RETRY_COUNT -gt 0) {
       Write-Output "The step is retried, starting the ESS stack again"
-      ess_up $StackVersion
+      ess_up $StackVersion $StackBuildId
   }
 }

--- a/.buildkite/scripts/steps/ess.ps1
+++ b/.buildkite/scripts/steps/ess.ps1
@@ -12,7 +12,7 @@ function ess_up {
   }
 
   if (-not $StackBuildId) {
-      Write-Error "Error: Specify stack build ID: ess_up [stack_build_id]"
+      Write-Error "Error: Specify stack build id: ess_up [stack_version] [stack_build_id]"
       return 1
   }
 

--- a/.buildkite/scripts/steps/ess_oblt-cli.sh
+++ b/.buildkite/scripts/steps/ess_oblt-cli.sh
@@ -2,13 +2,12 @@
 set -euo pipefail
 
 function ess_up() {
+  : "${1:?Error: Specify stack version: ess_up [stack_version] [stack_build_id]}"
+  : "${2:?Error: Specify stack build version: ess_up [stack_version] [stack_build_id]}"
+
   echo "~~~ Starting ESS Stack"
   local STACK_VERSION=$1
-
-  if [ -z "$STACK_VERSION" ]; then
-    echo "Error: Specify stack version: ess_up [stack_version]" >&2
-    return 1
-  fi
+  local STACK_BUILD_ID=$2
 
   # Build the oblt-cli command with conditional ElasticAgentDockerImage parameter
   local oblt_cmd=(
@@ -17,7 +16,7 @@ function ess_up() {
     --cluster-name-prefix hosted
     --output-file="${PWD}/cluster-info.json"
     --wait 20
-    --parameter "StackVersion=$STACK_VERSION"
+    --parameter "StackVersion=$STACK_BUILD_ID"
     --parameter "ExpireInHours=2"
   )
 

--- a/.buildkite/scripts/steps/ess_oblt-cli.sh
+++ b/.buildkite/scripts/steps/ess_oblt-cli.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 function ess_up() {
   : "${1:?Error: Specify stack version: ess_up [stack_version] [stack_build_id]}"
-  : "${2:?Error: Specify stack build version: ess_up [stack_version] [stack_build_id]}"
+  : "${2:?Error: Specify stack build id: ess_up [stack_version] [stack_build_id]}"
 
   echo "~~~ Starting ESS Stack"
   local STACK_VERSION=$1

--- a/.buildkite/scripts/steps/ess_oblt-cli.sh
+++ b/.buildkite/scripts/steps/ess_oblt-cli.sh
@@ -16,9 +16,12 @@ function ess_up() {
     --cluster-name-prefix hosted
     --output-file="${PWD}/cluster-info.json"
     --wait 20
-    --parameter "StackVersion=$STACK_BUILD_ID"
+    --parameter "StackVersion=$STACK_VERSION"
     --parameter "ExpireInHours=2"
   )
+
+  oblt_cmd+=(--parameter "ElasticsearchDockerImage=docker.elastic.co/elasticsearch/elasticsearch-cloud:${STACK_BUILD_ID}")
+  oblt_cmd+=(--parameter "KibanaDockerImage=docker.elastic.co/elasticsearch/kibana-cloud:${STACK_BUILD_ID}")
 
   if [ -n "${INTEGRATION_SERVER_DOCKER_IMAGE:-}" ]; then
     oblt_cmd+=(--parameter "ElasticAgentDockerImage=${INTEGRATION_SERVER_DOCKER_IMAGE}")

--- a/.buildkite/scripts/steps/ess_oblt-cli.sh
+++ b/.buildkite/scripts/steps/ess_oblt-cli.sh
@@ -20,8 +20,9 @@ function ess_up() {
     --parameter "ExpireInHours=2"
   )
 
-  oblt_cmd+=(--parameter "ElasticsearchDockerImage=docker.elastic.co/elasticsearch/elasticsearch-cloud:${STACK_BUILD_ID}")
-  oblt_cmd+=(--parameter "KibanaDockerImage=docker.elastic.co/elasticsearch/kibana-cloud:${STACK_BUILD_ID}")
+  # TODO: use the new template parameter to pass the stack build id, and simplify how to use this.
+  oblt_cmd+=(--parameter "ElasticsearchDockerImage=docker.elastic.co/cloud-release/elasticsearch-cloud-ess:${STACK_BUILD_ID}")
+  oblt_cmd+=(--parameter "KibanaDockerImage=docker.elastic.co/cloud-release/kibana-cloud:${STACK_BUILD_ID}")
 
   if [ -n "${INTEGRATION_SERVER_DOCKER_IMAGE:-}" ]; then
     oblt_cmd+=(--parameter "ElasticAgentDockerImage=${INTEGRATION_SERVER_DOCKER_IMAGE}")

--- a/.buildkite/scripts/steps/ess_start_oblt-cli.sh
+++ b/.buildkite/scripts/steps/ess_start_oblt-cli.sh
@@ -5,6 +5,7 @@ source .buildkite/scripts/steps/ess_oblt-cli.sh
 source .buildkite/scripts/steps/fleet.sh
 
 STACK_VERSION="$(jq -r '.stack_version' .package-version)"
+STACK_BUILD_ID="$(jq -r '.stack_build_id' .package-version)"
 
 METADATA_PREFIX=""
 if [[ "${FIPS:-false}" == "true" ]]; then
@@ -13,7 +14,7 @@ if [[ "${FIPS:-false}" == "true" ]]; then
 fi
 export METADATA_PREFIX
 
-ess_up "$STACK_VERSION"
+ess_up "$STACK_VERSION" "$STACK_BUILD_ID"
 
 # Publish the shared cluster name via meta-data so the global cleanup step
 # (ess_down_oblt-cli.sh) can find and destroy it. Per-step retries intentionally

--- a/.buildkite/scripts/steps/integration_tests_oblt-cli.sh
+++ b/.buildkite/scripts/steps/integration_tests_oblt-cli.sh
@@ -24,6 +24,7 @@ fi
 # There is a time when the current snapshot is not available on cloud yet, so we cannot use the latest version automatically
 # This file is managed by an automation (mage integration:UpdateAgentPackageVersion) that check if the snapshot is ready.
 STACK_VERSION="$(jq -r '.stack_version' .package-version)"
+STACK_BUILD_ID="$(jq -r '.stack_build_id' .package-version)"
 
 METADATA_PREFIX=""
 if [[ "${FIPS:-false}" == "true" ]]; then
@@ -38,7 +39,7 @@ export METADATA_PREFIX
 if [[ "${BUILDKITE_RETRY_COUNT}" -gt 0 || "${FORCE_ESS_CREATE:-false}" == "true" ]]; then
   echo "~~~ The steps is retried, starting the ESS stack again"
   trap 'ess_down' EXIT
-  ess_up "$STACK_VERSION"
+  ess_up "$STACK_VERSION" "$STACK_BUILD_ID"
 fi
 
 ess_load_secrets

--- a/.buildkite/scripts/steps/integration_tests_tf.ps1
+++ b/.buildkite/scripts/steps/integration_tests_tf.ps1
@@ -15,6 +15,7 @@ $PSVersionTable.PSVersion
 $packageVersionContent = Get-Content .package-version -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json
 if ($packageVersionContent -and $packageVersionContent.stack_version ) {
     $STACK_VERSION = $packageVersionContent.stack_version
+    $STACK_BUILD_ID = $packageVersionContent.stack_build_id
 }
 
 Write-Output "~~~ Building test binaries"
@@ -29,7 +30,8 @@ $TestsExitCode = 0
 try {
     Write-Output "~~~ Running integration tests"
     # Get-Ess-Stack will start the ESS stack if it is a BK retry
-    Get-Ess-Stack -StackVersion $STACK_VERSION
+    Get-Ess-Stack -StackVersion $STACK_VERSION -StackBuildId $STACK_BUILD_ID
+
     # Load secrets from GCP Secret Manager via oblt-cli
     $result = ess_load_secrets
     if ($result -ne 0) {


### PR DESCRIPTION
The `ess_up` function signature was updated to require `stack_build_id`, but the `integration_tests_oblt-cli.sh` retry path and PowerShell parameter declarations were not updated accordingly.

**Changes:**

- **`.buildkite/scripts/steps/integration_tests_oblt-cli.sh`**: Read `STACK_BUILD_ID` from `.package-version` and pass to `ess_up` in retry path (line 41)
- **`.buildkite/scripts/steps/ess.ps1`**: Add missing commas in `param()` blocks for `ess_up` and `Get-Ess-Stack` functions

```bash
# Before
ess_up "$STACK_VERSION"

# After
STACK_BUILD_ID="$(jq -r '.stack_build_id' .package-version)"
ess_up "$STACK_VERSION" "$STACK_BUILD_ID"
```

```powershell
# Before
param (
    [string]$StackVersion
    [string]$StackBuildId
)

# After
param (
    [string]$StackVersion,
    [string]$StackBuildId
)
```