### PR TITLE
Fix merge issues and clean up Otel configuration options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	go.opentelemetry.io/collector/connector v0.154.0 // indirect
 	go.opentelemetry.io/collector/exporter v1.60.0
 	go.opentelemetry.io/collector/extension v1.60.0
-	go.opentelemetry.io/collector/featuregate v1.60.0 // indirect
+	go.opentelemetry.io/collector/featuregate v1.60.0
 	go.opentelemetry.io/collector/otelcol v0.154.0
 	go.opentelemetry.io/collector/processor v1.60.0 // indirect
 	go.opentelemetry.io/collector/receiver v1.60.0 // indirect

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -19,7 +19,6 @@ import (
 	"go.opentelemetry.io/collector/component/componentstatus"
 
 	"github.com/elastic/elastic-agent/internal/pkg/composable"
-	"github.com/elastic/go-ucfg"
 
 	"github.com/elastic/elastic-agent/internal/pkg/otel/translate"
 	"github.com/elastic/elastic-agent/internal/pkg/release"
@@ -1883,10 +1882,7 @@ func applyPersistedConfig(logger *logger.Logger, cfg *config.Config, configFile 
 		return fmt.Errorf("parsing persisted config: %w", err)
 	}
 
-	err = cfg.Merge(persisted,
-		ucfg.FieldPrependValues("extensions"),
-		ucfg.FieldPrependValues("service.extensions"),
-	)
+	err = cfg.Merge(persisted)
 	if err != nil {
 		return fmt.Errorf("merging persisted config: %w", err)
 	}

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/collector/component/componentstatus"
 
 	"github.com/elastic/elastic-agent/internal/pkg/composable"
+	"github.com/elastic/go-ucfg"
 
 	"github.com/elastic/elastic-agent/internal/pkg/otel/translate"
 	"github.com/elastic/elastic-agent/internal/pkg/release"
@@ -1882,7 +1883,10 @@ func applyPersistedConfig(logger *logger.Logger, cfg *config.Config, configFile 
 		return fmt.Errorf("parsing persisted config: %w", err)
 	}
 
-	err = cfg.Merge(persisted)
+	err = cfg.Merge(persisted,
+		ucfg.FieldPrependValues("extensions"),
+		ucfg.FieldPrependValues("service.extensions"),
+	)
 	if err != nil {
 		return fmt.Errorf("merging persisted config: %w", err)
 	}

--- a/internal/pkg/agent/application/coordinator/coordinator_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_test.go
@@ -1190,9 +1190,9 @@ func TestExtensionsAreMerged(t *testing.T) {
 	testLogger, _ := loggertest.New("")
 
 	registry := featuregate.GlobalRegistry()
-	registry.Set("confmap.enableMergeAppendOption", true)
+	require.NoError(t, registry.Set("confmap.enableMergeAppendOption", true))
 	t.Cleanup(func() {
-		registry.Set("confmap.enableMergeAppendOption", false)
+		_ = registry.Set("confmap.enableMergeAppendOption", false)
 	})
 
 	err = applyPersistedConfig(testLogger, fleetCfg, filepath.Join(".", "testdata", "service_populated.yaml"))

--- a/internal/pkg/agent/application/coordinator/coordinator_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.elastic.co/apm/v2/apmtest"
 	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/featuregate"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -1165,6 +1166,90 @@ func Test_ApplyPersistedConfig(t *testing.T) {
 			assert.Equal(t, tc.expectedOutputType, outputType, "output type should be %s, got %s", tc.expectedOutputType, outputType)
 		})
 	}
+}
+
+func TestExtensionsAreMerged(t *testing.T) {
+	// this test loads config from service_populated.yaml and verifies that the extensions are merged
+	// with already prepopulated extensions in agent configuration
+	// we are testing extensions, processors, pipelines, exporters
+	// those coming from file are named type/persisted those from config type/fleet
+	// test passes when all extensions, processors, pipelines, exporters are present in the merged config
+	// single test for all of those
+	// we're testing these keys:
+	// - extensions
+	// - service.extensions
+	// - service.pipelines
+	// - processors
+	// - pipelines
+	// - exporters
+	// - receivers
+
+	fleetCfg, err := config.LoadFile(filepath.Join(".", "testdata", "config_fleet.yaml"))
+	require.NoError(t, err)
+
+	testLogger, _ := loggertest.New("")
+
+	registry := featuregate.GlobalRegistry()
+	registry.Set("confmap.enableMergeAppendOption", true)
+	t.Cleanup(func() {
+		registry.Set("confmap.enableMergeAppendOption", false)
+	})
+
+	err = applyPersistedConfig(testLogger, fleetCfg, filepath.Join(".", "testdata", "service_populated.yaml"))
+	require.NoError(t, err)
+
+	// verify extensions contain both values
+	extensions, ok := fleetCfg.OTel.Get("extensions").(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, 2, len(extensions))
+	_, ok = extensions["headers_setter/persisted"]
+	require.True(t, ok)
+	_, ok = extensions["headers_setter/fleet"]
+	require.True(t, ok)
+
+	// verify service contains both values in service.extensions array
+
+	serviceExtensions, ok := fleetCfg.OTel.Get("service::extensions").([]any)
+	require.True(t, ok)
+	require.Equal(t, 2, len(serviceExtensions))
+	require.Equal(t, "headers_setter/fleet", serviceExtensions[0].(string))
+	require.Equal(t, "headers_setter/persisted", serviceExtensions[1].(string))
+
+	// verify processors contain both values
+	processors, ok := fleetCfg.OTel.Get("processors").(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, 2, len(processors))
+	_, ok = processors["batch/persisted"]
+	require.True(t, ok)
+	_, ok = processors["batch/fleet"]
+	require.True(t, ok)
+
+	// verify service contains both values in service.pipelines map
+	pipelines, ok := fleetCfg.OTel.Get("service::pipelines").(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, 2, len(pipelines))
+	_, ok = pipelines["logs/persisted"]
+	require.True(t, ok)
+	_, ok = pipelines["logs/fleet"]
+	require.True(t, ok)
+
+	// verify exporters contain both values
+	exporters, ok := fleetCfg.OTel.Get("exporters").(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, 2, len(exporters))
+	_, ok = exporters["nop/persisted"]
+	require.True(t, ok)
+	_, ok = exporters["nop/fleet"]
+	require.True(t, ok)
+
+	// verify receivers contain both values
+	receivers, ok := fleetCfg.OTel.Get("receivers").(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, 2, len(receivers))
+	_, ok = receivers["nop/persisted"]
+	require.True(t, ok)
+	_, ok = receivers["nop/fleet"]
+	require.True(t, ok)
 }
 
 // Test_Coordinator_OTelManagerReceivesPersistedConfig verifies that the OTel manager

--- a/internal/pkg/agent/application/coordinator/coordinator_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_test.go
@@ -1168,7 +1168,73 @@ func Test_ApplyPersistedConfig(t *testing.T) {
 	}
 }
 
-func TestExtensionsAreMerged(t *testing.T) {
+func TestExtensionsAreMergedInOrder(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		fleetFile               string
+		persistedFile           string
+		expectedExtensionsOrder []string
+	}{
+		{
+			name:          "extensions are merged in the order of the source file",
+			fleetFile:     filepath.Join(".", "testdata", "config_fleet.yaml"),
+			persistedFile: filepath.Join(".", "testdata", "service_populated.yaml"),
+			expectedExtensionsOrder: []string{
+				"headers_setter/fleet",
+				"headers_setter/api_key",
+				"headers_setter/persisted",
+			},
+		},
+		{
+			name:          "extensions are merged in the order of the source file",
+			fleetFile:     filepath.Join(".", "testdata", "config_fleet.yaml"),
+			persistedFile: filepath.Join(".", "testdata", "service_populated_with_dup.yaml"),
+			expectedExtensionsOrder: []string{
+				"headers_setter/fleet",
+				"headers_setter/api_key",
+				"headers_setter/persisted",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fleetCfg, err := config.LoadFile(tc.fleetFile)
+			require.NoError(t, err)
+
+			testLogger, _ := loggertest.New("")
+
+			registry := featuregate.GlobalRegistry()
+			require.NoError(t, registry.Set("confmap.enableMergeAppendOption", true))
+			t.Cleanup(func() {
+				_ = registry.Set("confmap.enableMergeAppendOption", false)
+			})
+
+			err = applyPersistedConfig(testLogger, fleetCfg, tc.persistedFile)
+			require.NoError(t, err)
+
+			// verify extensions contain both values
+			extensions, ok := fleetCfg.OTel.Get("extensions").(map[string]interface{})
+			require.True(t, ok)
+			require.Equal(t, len(tc.expectedExtensionsOrder), len(extensions))
+			for _, ext := range tc.expectedExtensionsOrder {
+				_, ok = extensions[ext]
+				require.True(t, ok)
+			}
+
+			// verify service contains both values in service.extensions array
+
+			serviceExtensions, ok := fleetCfg.OTel.Get("service::extensions").([]any)
+			require.True(t, ok)
+			require.Equal(t, len(tc.expectedExtensionsOrder), len(serviceExtensions))
+			for i := range len(tc.expectedExtensionsOrder) {
+				require.Equal(t, tc.expectedExtensionsOrder[i], serviceExtensions[i].(string))
+			}
+		})
+	}
+}
+
+func TestOtelConfigIsMerged(t *testing.T) {
 	// this test loads config from service_populated.yaml and verifies that the extensions are merged
 	// with already prepopulated extensions in agent configuration
 	// we are testing extensions, processors, pipelines, exporters
@@ -1201,8 +1267,10 @@ func TestExtensionsAreMerged(t *testing.T) {
 	// verify extensions contain both values
 	extensions, ok := fleetCfg.OTel.Get("extensions").(map[string]interface{})
 	require.True(t, ok)
-	require.Equal(t, 2, len(extensions))
+	require.Equal(t, 3, len(extensions))
 	_, ok = extensions["headers_setter/persisted"]
+	require.True(t, ok)
+	_, ok = extensions["headers_setter/api_key"]
 	require.True(t, ok)
 	_, ok = extensions["headers_setter/fleet"]
 	require.True(t, ok)
@@ -1211,9 +1279,10 @@ func TestExtensionsAreMerged(t *testing.T) {
 
 	serviceExtensions, ok := fleetCfg.OTel.Get("service::extensions").([]any)
 	require.True(t, ok)
-	require.Equal(t, 2, len(serviceExtensions))
+	require.Equal(t, 3, len(serviceExtensions))
 	require.Equal(t, "headers_setter/fleet", serviceExtensions[0].(string))
-	require.Equal(t, "headers_setter/persisted", serviceExtensions[1].(string))
+	require.Equal(t, "headers_setter/api_key", serviceExtensions[1].(string))
+	require.Equal(t, "headers_setter/persisted", serviceExtensions[2].(string))
 
 	// verify processors contain both values
 	processors, ok := fleetCfg.OTel.Get("processors").(map[string]interface{})
@@ -1250,6 +1319,7 @@ func TestExtensionsAreMerged(t *testing.T) {
 	require.True(t, ok)
 	_, ok = receivers["nop/fleet"]
 	require.True(t, ok)
+
 }
 
 // Test_Coordinator_OTelManagerReceivesPersistedConfig verifies that the OTel manager

--- a/internal/pkg/agent/application/coordinator/testdata/config_fleet.yaml
+++ b/internal/pkg/agent/application/coordinator/testdata/config_fleet.yaml
@@ -1,0 +1,54 @@
+outputs:
+    es-default-output-internal:
+        type: elasticsearch
+        ssl:
+            verification_mode: none
+agent:
+    monitoring:
+        enabled: true
+        http:
+            enabled: true
+            host: 0.0.0.0
+            port: 1234
+        logs: false
+        metrics: false
+    logging:
+        level: info
+        to_stderr: true
+        rotateeverybytes: 1
+    providers:
+        initial_default: false
+    internal:
+        runtime:
+            filebeat:
+                default: otel
+            metricbeat:
+                default: otel
+fleet:
+    enabled: true
+providers:
+    local:
+        enabled: true
+receivers:
+    nop/fleet: null
+extensions:
+    headers_setter/fleet:
+        headers:
+            - action: upsert
+              key: User-Agent
+              value: Elastic-edot agentless
+exporters:
+    nop/fleet: null
+processors:
+    batch/fleet:
+        type: batch
+        timeout: 1s
+service:
+    extensions:
+        - headers_setter/fleet
+    pipelines:
+        logs/fleet:
+            receivers:
+                - nop
+            exporters:
+                - nop

--- a/internal/pkg/agent/application/coordinator/testdata/config_fleet.yaml
+++ b/internal/pkg/agent/application/coordinator/testdata/config_fleet.yaml
@@ -37,6 +37,11 @@ extensions:
             - action: upsert
               key: User-Agent
               value: Elastic-edot agentless
+    headers_setter/api_key:
+        headers:
+            - action: upsert
+              key: APIKEY
+              value: SECRET_API_KEY
 exporters:
     nop/fleet: null
 processors:
@@ -46,6 +51,7 @@ processors:
 service:
     extensions:
         - headers_setter/fleet
+        - headers_setter/api_key
     pipelines:
         logs/fleet:
             receivers:

--- a/internal/pkg/agent/application/coordinator/testdata/service_populated.yaml
+++ b/internal/pkg/agent/application/coordinator/testdata/service_populated.yaml
@@ -1,0 +1,30 @@
+
+providers:
+    local:
+        enabled: true
+receivers:
+    nop/persisted: null
+extensions:
+    headers_setter/persisted:
+        headers:
+            - action: upsert
+              key: User-Agent
+              value: Elastic-edot agentless
+exporters:
+    nop/persisted: null
+processors:
+    batch/persisted:
+        type: batch
+        timeout: 1s
+service:
+    extensions:
+        - headers_setter/persisted
+    pipelines:
+        logs/persisted:
+            receivers:
+                - nop
+            exporters:
+                - nop
+agent:
+    logging:
+        rotateeverybytes: 1

--- a/internal/pkg/agent/application/coordinator/testdata/service_populated_with_dup.yaml
+++ b/internal/pkg/agent/application/coordinator/testdata/service_populated_with_dup.yaml
@@ -1,0 +1,36 @@
+
+providers:
+    local:
+        enabled: true
+receivers:
+    nop/persisted: null
+extensions:
+    headers_setter/persisted:
+        headers:
+            - action: upsert
+              key: User-Agent
+              value: Elastic-edot agentless
+    headers_setter/api_key:
+        headers:
+            - action: upsert
+              key: APIKEY
+              value: SECRET_API_KEY_2
+exporters:
+    nop/persisted: null
+processors:
+    batch/persisted:
+        type: batch
+        timeout: 1s
+service:
+    extensions:
+        - headers_setter/persisted
+        - headers_setter/api_key
+    pipelines:
+        logs/persisted:
+            receivers:
+                - nop
+            exporters:
+                - nop
+agent:
+    logging:
+        rotateeverybytes: 1

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -196,7 +196,8 @@ func runElasticAgentCritical(
 	}
 
 	// enabled feature gate for merging configuration, important for merging persisted configuration with fleet configuration
-	featuregate.GlobalRegistry().Set("confmap.enableMergeAppendOption", true)
+	// no need to check for error, this is guarded in tests
+	_ = featuregate.GlobalRegistry().Set("confmap.enableMergeAppendOption", true)
 
 	// try load config, but don't error yet
 	cfg, err := configuration.LoadConfig(ctx, override)

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -197,6 +197,9 @@ func runElasticAgentCritical(
 
 	// enabled feature gate for merging configuration, important for merging persisted configuration with fleet configuration
 	// no need to check for error, this is guarded in tests
+	// agentless controller needs this feature gate to be enabled to merge persisted configuration with fleet configuration
+	// we inject some common extensions and processors in the persisted configuration that are overriding
+	// the ones from the fleet configuration in case this feature is disabled.
 	_ = featuregate.GlobalRegistry().Set("confmap.enableMergeAppendOption", true)
 
 	// try load config, but don't error yet

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -22,6 +22,7 @@ import (
 	fleetgateway "github.com/elastic/elastic-agent/internal/pkg/agent/application/gateway/fleet"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/ttl"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/perms"
+	"go.opentelemetry.io/collector/featuregate"
 
 	"go.elastic.co/apm/v2"
 	apmtransport "go.elastic.co/apm/v2/transport"
@@ -192,6 +193,9 @@ func runElasticAgentCritical(
 			errs = append(errs, fmt.Errorf("failed to restore configuration: %w", err))
 		}
 	}
+
+	// enabled feature gate for merging configuration, important for merging persisted configuration with fleet configuration
+	featuregate.GlobalRegistry().Set("confmap.enableMergeAppendOption", true)
 
 	// try load config, but don't error yet
 	cfg, err := configuration.LoadConfig(ctx, override)

--- a/internal/pkg/agent/cmd/run.go
+++ b/internal/pkg/agent/cmd/run.go
@@ -18,11 +18,12 @@ import (
 	"syscall"
 	"time"
 
+	"go.opentelemetry.io/collector/featuregate"
+
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/enroll"
 	fleetgateway "github.com/elastic/elastic-agent/internal/pkg/agent/application/gateway/fleet"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/ttl"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/perms"
-	"go.opentelemetry.io/collector/featuregate"
 
 	"go.elastic.co/apm/v2"
 	apmtransport "go.elastic.co/apm/v2/transport"


### PR DESCRIPTION
This pull request enhances the configuration merging logic for the Elastic Agent, specifically improving how persisted and Fleet configurations are combined. It introduces support for appending values to certain configuration fields (like extensions and service extensions) using the `go-ucfg` library and OpenTelemetry Collector feature gates. Comprehensive tests have also been added to ensure correct merging behavior.

Configuration merging improvements:

* Updated `applyPersistedConfig` in `coordinator.go` to use `ucfg.FieldPrependValues` for `extensions` and `service.extensions`, ensuring values from both persisted and Fleet configs are combined rather than overwritten.
* Enabled the OpenTelemetry Collector feature gate `confmap.enableMergeAppendOption` globally to support advanced merging behavior.

Dependency and import updates:

* Added imports for `go-ucfg` and OpenTelemetry Collector's `featuregate` in relevant files to support new merging logic and feature gate management.

Testing enhancements:

* Added a comprehensive test `TestExtensionsAreMerged` in `coordinator_test.go` to verify that extensions, processors, pipelines, exporters, and receivers from both persisted and Fleet configurations are present in the merged result.
* Added new test data files `config_fleet.yaml` and `service_populated.yaml` to support the new test scenarios. 