### PR TITLE
[chore][coordinator]: give each subtest its own context

### DIFF
--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -1255,8 +1255,6 @@ func TestCoordinatorManagesComponentWorkDirs(t *testing.T) {
 		paths.SetTop(top)
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
 	logger := logp.NewLogger("testing")
 
 	configChan := make(chan ConfigChange, 1)
@@ -1314,6 +1312,8 @@ func TestCoordinatorManagesComponentWorkDirs(t *testing.T) {
 	var workDirCreated time.Time
 
 	t.Run("run in process manager", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 		// Create a policy with one input and one output (no otel configuration)
 		cfg := config.MustNewConfigFrom(`
 agent.internal.runtime.filebeat.filestream: process
@@ -1343,6 +1343,8 @@ inputs:
 	})
 
 	t.Run("run in otel manager", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 		// Create a policy with one input and one output (no otel configuration)
 		cfg := config.MustNewConfigFrom(`
 agent.internal.runtime.filebeat.filestream: otel
@@ -1380,6 +1382,8 @@ inputs:
 		assert.Equal(t, workDirCreated, stat.ModTime(), "component working directory shouldn't have been modified")
 	})
 	t.Run("remove component", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 		// Create a policy with one input and one output (no otel configuration)
 		cfg := config.MustNewConfigFrom(`
 outputs:

--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -1312,8 +1312,8 @@ func TestCoordinatorManagesComponentWorkDirs(t *testing.T) {
 	var workDirCreated time.Time
 
 	t.Run("run in process manager", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		t.Cleanup(cancel)
 		// Create a policy with one input and one output (no otel configuration)
 		cfg := config.MustNewConfigFrom(`
 agent.internal.runtime.filebeat.filestream: process
@@ -1343,8 +1343,8 @@ inputs:
 	})
 
 	t.Run("run in otel manager", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		t.Cleanup(cancel)
 		// Create a policy with one input and one output (no otel configuration)
 		cfg := config.MustNewConfigFrom(`
 agent.internal.runtime.filebeat.filestream: otel
@@ -1382,8 +1382,8 @@ inputs:
 		assert.Equal(t, workDirCreated, stat.ModTime(), "component working directory shouldn't have been modified")
 	})
 	t.Run("remove component", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		t.Cleanup(cancel)
 		// Create a policy with one input and one output (no otel configuration)
 		cfg := config.MustNewConfigFrom(`
 outputs:


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

The test shared a single 1-second context across three sequential subtests. On slow CI (Windows), this context expires often before all subtests completed. When `runLoopIteration` received a cancelled context it returned immediately via `ctx.Done()` without consuming from `configChan`, leaving the buffered channel full. The next subtest's `configChan <- cfgChange` then blocked indefinitely, causing the test to hang until the 10-minute suite timeout killed it.

Fix this issue by giving each subtest its own context.WithTimeout so that context expiry in one subtest cannot starve subsequent ones. The per-subtest timeout is raised to 10s to accommodate slower CI environments while still catching real deadlocks.

This issue was catched in https://buildkite.com/elastic/elastic-agent/builds/41626#019edf97-116a-4035-885e-9e6ba409e614 and blocks https://github.com/elastic/elastic-agent/pull/15012.


<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test
