### PR TITLE
[chore][ci]: pre-warm Go module cache before integration tests

### DIFF
--- a/.buildkite/scripts/buildkite-integration-tests.sh
+++ b/.buildkite/scripts/buildkite-integration-tests.sh
@@ -61,6 +61,14 @@ fully_qualified_group_name="${GROUP_NAME}${root_suffix}_${os_data}"
 outputXML="build/${fully_qualified_group_name}.integration.xml"
 outputJSON="build/${fully_qualified_group_name}.integration.out.json"
 
+echo "~~~ Pre-warming Go module cache"
+# Download all modules declared in go.mod so that the 'go test' compilation step
+# (run by gotestsum below) does not pay the cost of downloading ~100 module zips
+# at test-run time. This is especially important for the integration test packages
+# which import heavy dependencies (testcontainers-go, sarama, mock-es, etc.) that
+# are not compiled by the earlier 'mage build:integrationTestBinaries' step.
+go mod download
+
 echo "~~~ Integration tests: ${GROUP_NAME}"
 # -test.timeout=2h0m0s is set because some tests normally take up to 45 minutes.
 # This 2-hour timeout provides enough room for future, potentially longer tests,


### PR DESCRIPTION
## What does this PR do?
Running 'go mod download' before gotestsum avoids ~47 s of module zip downloads that otherwise happen during 'go test' compilation for every integration test matrix job.

'mage build:integrationTestBinaries' only builds the fake component binary, so the heavy integration-test-only dependencies (testcontainers-go, sarama, mock-es, docker/compose, …) are never pre-fetched before the test run. Adding an explicit 'go mod download' step ensures they are in the local module cache when the compiler needs them.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

