### PR TITLE
Use the correct receiver names for auditbeat, heartbeat, packetbeat, and osquerybeat

### DIFF
--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -523,18 +523,8 @@ func getSignalForComponent(comp *component.Component) (pipeline.Signal, error) {
 func getReceiverTypeForComponent(comp *component.Component) (otelcomponent.Type, error) {
 	beatName := comp.BeatName()
 	switch beatName {
-	case "filebeat":
-		return otelcomponent.MustNewType("filebeatreceiver"), nil
-	case "metricbeat":
-		return otelcomponent.MustNewType("metricbeatreceiver"), nil
-	case "auditbeat":
-		return otelcomponent.MustNewType("auditbeatreceiver"), nil
-	case "heartbeat":
-		return otelcomponent.MustNewType("heartbeatreceiver"), nil
-	case "osquerybeat":
-		return otelcomponent.MustNewType("osquerybeatreceiver"), nil
-	case "packetbeat":
-		return otelcomponent.MustNewType("packetbeatreceiver"), nil
+	case "filebeat", "metricbeat", "auditbeat", "heartbeat", "osquerybeat", "packetbeat":
+		return otelcomponent.MustNewType(beatName + "receiver"), nil
 	default:
 		return otelcomponent.Type{}, fmt.Errorf("unknown otel receiver type for input type: %s", comp.InputType)
 	}
@@ -672,15 +662,29 @@ func getInputsForUnit(unit component.Unit, info info.Agent, defaultDataStreamTyp
 	if err != nil {
 		return nil, err
 	}
-	// Add the type to each input. CreateInputsFromStreams doesn't do this, each beat does it on its own in a transform
+	// Handle input types that are namespaced to their component type by either a prefix or suffix.
+	// CreateInputsFromStreams doesn't do this, each beat does it on its own in a transform
 	// function. For filebeat, see: https://github.com/elastic/beats/blob/main/x-pack/filebeat/cmd/agent.go
-
+	inputTypePrefix, inputTypeSuffix, inputTypeHasSlash := strings.Cut(inputType, "/")
 	for _, input := range inputs {
-		// If inputType contains /metrics, use modules to create inputs
-		if strings.Contains(inputType, "/metrics") {
-			input["module"] = strings.TrimSuffix(inputType, "/metrics")
-		} else if _, ok := input["type"]; !ok {
-			input["type"] = inputType
+		switch {
+		case inputTypeHasSlash && inputTypeSuffix == "metrics":
+			// metricbeat: "system/metrics" → "module: system" per https://www.elastic.co/docs/reference/beats/metricbeat/configuration-metricbeat
+			input["module"] = inputTypePrefix
+		case inputTypeHasSlash && inputTypePrefix == "audit":
+			// auditbeat: "audit/auditd" → "module: auditd" per https://www.elastic.co/docs/reference/beats/auditbeat/configuration-auditbeat
+			if _, ok := input["module"]; !ok {
+				input["module"] = inputTypeSuffix
+			}
+		case inputTypeHasSlash && inputTypePrefix == "synthetics":
+			// heartbeat: "synthetics/http" → "type: http" per https://www.elastic.co/docs/reference/beats/heartbeat/configuration-heartbeat-options
+			if _, ok := input["type"]; !ok {
+				input["type"] = inputTypeSuffix
+			}
+		default:
+			if _, ok := input["type"]; !ok {
+				input["type"] = inputType
+			}
 		}
 	}
 

--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -528,13 +528,13 @@ func getReceiverTypeForComponent(comp *component.Component) (otelcomponent.Type,
 	case "metricbeat":
 		return otelcomponent.MustNewType("metricbeatreceiver"), nil
 	case "auditbeat":
-		return otelcomponent.MustNewType("abreceiver"), nil
+		return otelcomponent.MustNewType("auditbeatreceiver"), nil
 	case "heartbeat":
-		return otelcomponent.MustNewType("hbreceiver"), nil
+		return otelcomponent.MustNewType("heartbeatreceiver"), nil
 	case "osquerybeat":
-		return otelcomponent.MustNewType("osqreceiver"), nil
+		return otelcomponent.MustNewType("osquerybeatreceiver"), nil
 	case "packetbeat":
-		return otelcomponent.MustNewType("pbreceiver"), nil
+		return otelcomponent.MustNewType("packetbeatreceiver"), nil
 	default:
 		return otelcomponent.Type{}, fmt.Errorf("unknown otel receiver type for input type: %s", comp.InputType)
 	}

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -2071,7 +2071,7 @@ func TestGetOtelConfig(t *testing.T) {
 					},
 				},
 				"receivers": map[string]any{
-					"abreceiver/_agent-component/auditbeat-default": expectedAuditbeatReceiverConfig("auditbeat-default"),
+					"auditbeatreceiver/_agent-component/auditbeat-default": expectedAuditbeatReceiverConfig("auditbeat-default"),
 				},
 				"service": map[string]any{
 					"extensions": []any{"beatsauth/_agent-component/default"},
@@ -2079,7 +2079,7 @@ func TestGetOtelConfig(t *testing.T) {
 						"logs/_agent-component/auditbeat-default": map[string][]string{
 							"exporters":  {"elasticsearch/_agent-component/default"},
 							"processors": {"beat/_agent-component"},
-							"receivers":  {"abreceiver/_agent-component/auditbeat-default"},
+							"receivers":  {"auditbeatreceiver/_agent-component/auditbeat-default"},
 						},
 					},
 				},
@@ -2130,7 +2130,7 @@ func TestGetOtelConfig(t *testing.T) {
 					},
 				},
 				"receivers": map[string]any{
-					"hbreceiver/_agent-component/heartbeat-default": expectedHeartbeatReceiverConfig("heartbeat-default"),
+					"heartbeatreceiver/_agent-component/heartbeat-default": expectedHeartbeatReceiverConfig("heartbeat-default"),
 				},
 				"service": map[string]any{
 					"extensions": []any{"beatsauth/_agent-component/default"},
@@ -2138,7 +2138,7 @@ func TestGetOtelConfig(t *testing.T) {
 						"logs/_agent-component/heartbeat-default": map[string][]string{
 							"exporters":  {"elasticsearch/_agent-component/default"},
 							"processors": {"beat/_agent-component"},
-							"receivers":  {"hbreceiver/_agent-component/heartbeat-default"},
+							"receivers":  {"heartbeatreceiver/_agent-component/heartbeat-default"},
 						},
 					},
 				},
@@ -2189,7 +2189,7 @@ func TestGetOtelConfig(t *testing.T) {
 					},
 				},
 				"receivers": map[string]any{
-					"osqreceiver/_agent-component/osquerybeat-default": expectedOsquerybeatReceiverConfig("osquerybeat-default"),
+					"osquerybeatreceiver/_agent-component/osquerybeat-default": expectedOsquerybeatReceiverConfig("osquerybeat-default"),
 				},
 				"service": map[string]any{
 					"extensions": []any{"beatsauth/_agent-component/default"},
@@ -2197,7 +2197,7 @@ func TestGetOtelConfig(t *testing.T) {
 						"logs/_agent-component/osquerybeat-default": map[string][]string{
 							"exporters":  {"elasticsearch/_agent-component/default"},
 							"processors": {"beat/_agent-component"},
-							"receivers":  {"osqreceiver/_agent-component/osquerybeat-default"},
+							"receivers":  {"osquerybeatreceiver/_agent-component/osquerybeat-default"},
 						},
 					},
 				},
@@ -2248,7 +2248,7 @@ func TestGetOtelConfig(t *testing.T) {
 					},
 				},
 				"receivers": map[string]any{
-					"pbreceiver/_agent-component/packetbeat-default": expectedPacketbeatReceiverConfig("packetbeat-default"),
+					"packetbeatreceiver/_agent-component/packetbeat-default": expectedPacketbeatReceiverConfig("packetbeat-default"),
 				},
 				"service": map[string]any{
 					"extensions": []any{"beatsauth/_agent-component/default"},
@@ -2256,7 +2256,7 @@ func TestGetOtelConfig(t *testing.T) {
 						"logs/_agent-component/packetbeat-default": map[string][]string{
 							"exporters":  {"elasticsearch/_agent-component/default"},
 							"processors": {"beat/_agent-component"},
-							"receivers":  {"pbreceiver/_agent-component/packetbeat-default"},
+							"receivers":  {"packetbeatreceiver/_agent-component/packetbeat-default"},
 						},
 					},
 				},
@@ -2542,28 +2542,28 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 			name:                 "auditbeat component",
 			component:            auditbeatComponent,
 			outputQueueConfig:    nil,
-			expectedReceiverType: "abreceiver",
+			expectedReceiverType: "auditbeatreceiver",
 			expectedBeatName:     "auditbeat",
 		},
 		{
 			name:                 "heartbeat component",
 			component:            heartbeatComponent,
 			outputQueueConfig:    nil,
-			expectedReceiverType: "hbreceiver",
+			expectedReceiverType: "heartbeatreceiver",
 			expectedBeatName:     "heartbeat",
 		},
 		{
 			name:                 "osquerybeat component",
 			component:            osquerybeatComponent,
 			outputQueueConfig:    nil,
-			expectedReceiverType: "osqreceiver",
+			expectedReceiverType: "osquerybeatreceiver",
 			expectedBeatName:     "osquerybeat",
 		},
 		{
 			name:                 "packetbeat component",
 			component:            packetbeatComponent,
 			outputQueueConfig:    nil,
-			expectedReceiverType: "pbreceiver",
+			expectedReceiverType: "packetbeatreceiver",
 			expectedBeatName:     "packetbeat",
 		},
 		{

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -543,8 +543,8 @@ func TestGetOtelConfig(t *testing.T) {
 					},
 					"audit_rules": "-a exit,always -F arch=b64 -S open",
 					"index":       "logs-generic-1-default",
+					"module":      "auditd",
 					"processors":  defaultInputProcessors("test-1", "generic-1", "logs"),
-					"type":        "audit/auditd",
 				},
 			},
 		}
@@ -565,7 +565,7 @@ func TestGetOtelConfig(t *testing.T) {
 					"schedule":   "@every 5s",
 					"index":      "logs-generic-1-default",
 					"processors": defaultInputProcessors("test-1", "generic-1", "logs"),
-					"type":       "synthetics/http",
+					"type":       "http",
 				},
 			},
 		}
@@ -2520,6 +2520,7 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 		expectedError        string
 		expectedReceiverType string
 		expectedBeatName     string
+		verifyBeatConfig     func(t *testing.T, beatConfig map[string]any)
 	}{
 		{
 			name:                 "filebeat component",
@@ -2544,6 +2545,14 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 			outputQueueConfig:    nil,
 			expectedReceiverType: "auditbeatreceiver",
 			expectedBeatName:     "auditbeat",
+			verifyBeatConfig: func(t *testing.T, beatConfig map[string]any) {
+				modules, ok := beatConfig["modules"].([]map[string]any)
+				require.True(t, ok, "auditbeat modules should be a slice of maps")
+				require.NotEmpty(t, modules, "auditbeat modules should not be empty")
+				for i, mod := range modules {
+					assert.Equal(t, "auditd", mod["module"], "auditbeat module[%d] must have module=auditd", i)
+				}
+			},
 		},
 		{
 			name:                 "heartbeat component",
@@ -2648,6 +2657,13 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 			httpConfig, ok := receiverConfig["http"].(map[string]any)
 			require.True(t, ok, "http config should be a map")
 			assert.Equal(t, false, httpConfig["enabled"], "http monitoring should be disabled for OTel-managed components")
+
+			// Run any beat-specific assertions
+			if tt.verifyBeatConfig != nil {
+				beatConfig, ok := receiverConfig[tt.expectedBeatName].(map[string]any)
+				require.True(t, ok, "%s config should be a map", tt.expectedBeatName)
+				tt.verifyBeatConfig(t, beatConfig)
+			}
 		})
 	}
 }

--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/testing/estools"
 	"github.com/elastic/elastic-agent/pkg/component"
+	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
@@ -171,6 +172,8 @@ func (runner *AuditDRunner) TestBeatsMetrics() {
 			for _, comp := range status.Components {
 				if strings.HasPrefix(comp.ID, "audit/auditd") &&
 					comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
+					assert.Equal(collect, int(cproto.State_HEALTHY), comp.State,
+						"expected audit/auditd component to be healthy, got %s", cproto.State(comp.State))
 					foundReceiver = true
 					break
 				}

--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/testing/estools"
 	"github.com/elastic/elastic-agent/pkg/component"
+	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
@@ -176,6 +177,8 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 			for _, comp := range status.Components {
 				if strings.HasPrefix(comp.ID, "packet") &&
 					comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
+					assert.Equal(collect, int(cproto.State_HEALTHY), comp.State,
+						"expected packet component to be healthy, got %s", cproto.State(comp.State))
 					foundReceiver = true
 					break
 				}

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/testing/estools"
 	"github.com/elastic/elastic-agent/pkg/component"
+	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools"
@@ -169,6 +170,8 @@ func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 			for _, comp := range status.Components {
 				if strings.HasPrefix(comp.ID, "osquery") &&
 					comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
+					assert.Equal(collect, int(cproto.State_HEALTHY), comp.State,
+						"expected osquery component to be healthy, got %s", cproto.State(comp.State))
 					foundReceiver = true
 					break
 				}


### PR DESCRIPTION
- https://github.com/elastic/elastic-agent/issues/14552
- https://github.com/elastic/elastic-agent/issues/14553
- https://github.com/elastic/elastic-agent/issues/14554
- https://github.com/elastic/elastic-agent/issues/14555

The first phase of fixing these receivers, we used the package name instead of the receiver name setup in the component factory when translating their configuration.

For osquery at least, we also additionally did not bring over some osquery specific configuration translation from the control protocol handling in beats. Likely this will be similar for the other beats. The tests still fail, but this is the first step to get the receivers to actually run. I added a check that the component is healthy in the integration tests that catches this issue, without this check the tests just time out.