### PR TITLE
Run generated docs update on release publish

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,6 +1,8 @@
 name: Update documentation
 
 on:
+  release:
+    types: [published]
   schedule:
     # Run weekly on Monday at 8:00 AM UTC
     - cron: '0 8 * * 1'
@@ -30,8 +32,12 @@ jobs:
       - name: Find latest semantic version
         id: get_version
         run: |
-          # Get the latest semantic version tag (excluding pre-release versions)
-          LATEST_VERSION=$(git tag --list | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -1)
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            LATEST_VERSION="${{ github.event.release.tag_name }}"
+          else
+            # Get the latest semantic version tag (excluding pre-release versions)
+            LATEST_VERSION=$(git tag --list | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -1)
+          fi
           echo "Latest version: $LATEST_VERSION"
           echo "version=$LATEST_VERSION" >> $GITHUB_OUTPUT
       
@@ -86,6 +92,8 @@ jobs:
             - **Source go.mod**: https://github.com/elastic/elastic-agent/blob/${{ steps.get_version.outputs.version }}/go.mod
             - **Source components.yaml**: https://github.com/elastic/elastic-agent/blob/${{ steps.get_version.outputs.version }}/internal/edot/components.yaml
             - **Release tag**: https://github.com/elastic/elastic-agent/tree/${{ steps.get_version.outputs.version }}
+            
+            cc @elastic/ingest-docs
             
             This is an automated PR created by the documentation update workflow.
           branch: update-docs-${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
## Summary
- Run the generated documentation update workflow when a GitHub release is published.
- Use the published release tag for release-triggered runs while preserving the existing latest-tag lookup for scheduled and manual runs.
- Mention @elastic/ingest-docs in the generated documentation PR body.

## Test plan
- [x] Ran `actionlint .github/workflows/update-docs.yml`.


Made with [Cursor](https://cursor.com)