### PR TITLE
Fix duplicate entries and empty unit dirs in OTel diagnostics ZIP

### DIFF
--- a/changelog/fragments/1782214855-fix-duplicate-entries-and-empty-unit-dirs-in-otel-diagnostics-zip.yaml
+++ b/changelog/fragments/1782214855-fix-duplicate-entries-and-empty-unit-dirs-in-otel-diagnostics-zip.yaml
@@ -13,12 +13,16 @@ kind: bug-fix
 
 # REQUIRED for all kinds
 # Change summary; a 80ish characters long description of the change.
-summary: Fix duplicate entries and empty unit subdirectories in OTel diagnostics ZIP
+summary: Fix duplicate entries, empty unit dirs, and EDOT error handling in OTel diagnostics
 
 # REQUIRED for breaking-change, deprecation, known-issue
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
-description:
+description: >
+  The OTel diagnostics ZIP no longer contains duplicate entries and no longer creates empty unit
+  subdirectories. Components with no EDOT diagnostics no longer produce a spurious error in the archive.
+  Also, an unexpected EDOT error used to abort the whole component-diagnostics request; now it is
+  recorded per component so the diagnostics archive is still produced.
 
 # REQUIRED for breaking-change, deprecation, known-issue
 # impact:

--- a/changelog/fragments/1782214855-fix-duplicate-entries-and-empty-unit-dirs-in-otel-diagnostics-zip.yaml
+++ b/changelog/fragments/1782214855-fix-duplicate-entries-and-empty-unit-dirs-in-otel-diagnostics-zip.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix duplicate entries and empty unit subdirectories in OTel diagnostics ZIP
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -282,6 +282,9 @@ func ZipArchive(
 			// check for component-level errors
 			// create unit diags
 			for _, ud := range units {
+				if ud.Err == nil && len(ud.Results) == 0 {
+					continue
+				}
 				unitDir := strings.ReplaceAll(strings.TrimPrefix(ud.UnitID, ud.ComponentID+"-"), "/", "-")
 				_, err := zw.CreateHeader(&zip.FileHeader{
 					Name:     fmt.Sprintf("components/%s/%s/", dirName, unitDir),

--- a/internal/pkg/diagnostics/diagnostics_test.go
+++ b/internal/pkg/diagnostics/diagnostics_test.go
@@ -440,6 +440,7 @@ func TestZipArchiveUnitDirSkip(t *testing.T) {
 			expectedPaths: []string{
 				"components/",
 				"components/my-component/",
+				"logs/",
 			},
 		},
 		{
@@ -452,6 +453,7 @@ func TestZipArchiveUnitDirSkip(t *testing.T) {
 				"components/my-component/",
 				"components/my-component/input/",
 				"components/my-component/input/error.txt",
+				"logs/",
 			},
 		},
 		{
@@ -470,6 +472,7 @@ func TestZipArchiveUnitDirSkip(t *testing.T) {
 				"components/my-component/",
 				"components/my-component/input/",
 				"components/my-component/input/beat_metrics.json",
+				"logs/",
 			},
 		},
 	}
@@ -487,6 +490,7 @@ func TestZipArchiveUnitDirSkip(t *testing.T) {
 			r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
 			require.NoError(t, err)
 
+			// One component per case, so the zip entry order is deterministic and safe to assert.
 			var paths []string
 			for _, f := range r.File {
 				paths = append(paths, f.Name)

--- a/internal/pkg/diagnostics/diagnostics_test.go
+++ b/internal/pkg/diagnostics/diagnostics_test.go
@@ -423,6 +423,79 @@ type zippedItem struct {
 	IsDir bool
 }
 
+func TestZipArchiveUnitDirSkip(t *testing.T) {
+	compID := "my-component"
+	compDiags := []client.DiagnosticComponentResult{{ComponentID: compID}}
+
+	tests := []struct {
+		name          string
+		unitDiags     []client.DiagnosticUnitResult
+		expectedPaths []string
+	}{
+		{
+			name: "unit with no results and no error is skipped",
+			unitDiags: []client.DiagnosticUnitResult{
+				{ComponentID: compID, UnitID: compID + "-input"},
+			},
+			expectedPaths: []string{
+				"components/",
+				"components/my-component/",
+			},
+		},
+		{
+			name: "unit with error creates dir and error.txt",
+			unitDiags: []client.DiagnosticUnitResult{
+				{ComponentID: compID, UnitID: compID + "-input", Err: errors.New("something failed")},
+			},
+			expectedPaths: []string{
+				"components/",
+				"components/my-component/",
+				"components/my-component/input/",
+				"components/my-component/input/error.txt",
+			},
+		},
+		{
+			name: "unit with results creates dir and file",
+			unitDiags: []client.DiagnosticUnitResult{
+				{
+					ComponentID: compID,
+					UnitID:      compID + "-input",
+					Results: []client.DiagnosticFileResult{
+						{Filename: "beat_metrics.json", ContentType: "application/json", Content: []byte(`{}`)},
+					},
+				},
+			},
+			expectedPaths: []string{
+				"components/",
+				"components/my-component/",
+				"components/my-component/input/",
+				"components/my-component/input/beat_metrics.json",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			topPath := t.TempDir()
+			// zipLogs opens topPath/data; create it so ZipArchive doesn't fail
+			require.NoError(t, os.MkdirAll(filepath.Join(topPath, "data"), 0o700))
+
+			buf := new(bytes.Buffer)
+			err := ZipArchive(io.Discard, buf, topPath, nil, tc.unitDiags, compDiags, true)
+			require.NoError(t, err)
+
+			r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+			require.NoError(t, err)
+
+			var paths []string
+			for _, f := range r.File {
+				paths = append(paths, f.Name)
+			}
+			assert.Equal(t, tc.expectedPaths, paths)
+		})
+	}
+}
+
 func TestZipLogs(t *testing.T) {
 	topPath := t.TempDir()
 	dir := filepath.Join(paths.HomeFrom(topPath), "logs", "sub-dir")

--- a/internal/pkg/otel/manager/diagnostics.go
+++ b/internal/pkg/otel/manager/diagnostics.go
@@ -126,28 +126,29 @@ func (m *OTelManager) PerformComponentDiagnostics(
 		return diagnostics, nil
 	}
 
-	// Beat receivers register hooks under the OTel receiver instance ID, which has the form
-	// "<receiverType>/_agent-component/<comp.ID>/<streamID>". The "<receiverType>/" prefix is the
-	// string representation produced by otelcomponent.ID.String(); the "_agent-component/" segment
-	// is translate.OtelNamePrefix.
-	// Match on the segment "_agent-component/<comp.ID>/" to avoid false positives from
-	// component IDs that are prefixes of other component IDs.
-	compSegment := make(map[string]int) // "_agent-component/<comp.ID>/" -> index in diagnostics
+	// Receiver names have the form "<receiverType>/_agent-component/<comp.ID>/<streamID>".
+	// All "/" characters are literal string delimiters, not filesystem path separators,
+	// so this is consistent across platforms including Windows.
+	// We extract comp.ID as the segment between OtelNamePrefix and the next "/". This is
+	// exact and unambiguous for normal IDs. Both comp.ID and streamID are user-supplied
+	// (from the policy input "id" field), so either could contain "/" — making the format
+	// ambiguous in that case. The warning below flags such IDs. A proper fix requires
+	// escaping "/" in IDs at the source in the beat receiver.
+	diagIdxByCompID := make(map[string]int)
 	for idx, diag := range diagnostics {
-		compSegment[translate.OtelNamePrefix+diag.Component.ID+"/"] = idx
+		if strings.Contains(diag.Component.ID, "/") {
+			m.managerLogger.Warnf("component ID %q contains '/', its EDOT diagnostics will be missing from the archive", diag.Component.ID)
+		}
+		diagIdxByCompID[diag.Component.ID] = idx
 	}
 	for _, extDiag := range extDiagnostics.ComponentDiagnostics {
-		// For standard component IDs the "_agent-component/<comp.ID>/" framing is unambiguous:
-		// such IDs are built by joining parts with "-", so "/" only appears as the prefix and
-		// suffix delimiter and one ID cannot be a substring of another in this framing. We assume
-		// this holds, so at most one segment matches a given name and the map iteration order does
-		// not affect correctness. A policy input id that itself contains "/" could break the
-		// assumption, but normal IDs do not.
-		for segment, idx := range compSegment {
-			if strings.Contains(extDiag.Name, segment) {
-				diagnostics[idx].Results = append(diagnostics[idx].Results, extDiag)
-				break
-			}
+		parts := strings.SplitN(extDiag.Name, translate.OtelNamePrefix, 2)
+		if len(parts) != 2 {
+			continue
+		}
+		compID, _, _ := strings.Cut(parts[1], "/")
+		if idx, ok := diagIdxByCompID[compID]; ok {
+			diagnostics[idx].Results = append(diagnostics[idx].Results, extDiag)
 		}
 	}
 

--- a/internal/pkg/otel/manager/diagnostics.go
+++ b/internal/pkg/otel/manager/diagnostics.go
@@ -23,6 +23,8 @@ import (
 // PerformDiagnostics executes the diagnostic action for the provided units. If no units are provided then
 // it performs diagnostics for all current units. If a given unit does not exist in the manager, then a warning
 // is logged.
+// Note: this function returns unit-level diagnostics only. EDOT groups beat receiver results at the
+// component level, so they are not included here.
 func (m *OTelManager) PerformDiagnostics(ctx context.Context, req ...runtime.ComponentUnitDiagnosticRequest) []runtime.ComponentUnitDiagnostic {
 	var diagnostics []runtime.ComponentUnitDiagnostic
 	m.mx.RLock()
@@ -39,40 +41,37 @@ func (m *OTelManager) PerformDiagnostics(ctx context.Context, req ...runtime.Com
 				})
 			}
 		}
-	} else {
-		// create a map of unit by component and unit id, this is used to filter out units that
-		// do not exist in the manager
-		unitByID := make(map[string]map[string]*component.Unit)
-		for _, r := range req {
-			if unitByID[r.Component.ID] == nil {
-				unitByID[r.Component.ID] = make(map[string]*component.Unit)
-			}
-			unitByID[r.Component.ID][r.Unit.ID] = &r.Unit
-		}
+		return diagnostics
+	}
 
-		// create empty diagnostics for units that exist in the manager
-		for _, existingComp := range currentComponents {
-			inputComp, ok := unitByID[existingComp.ID]
-			if !ok {
-				m.managerLogger.Warnf("requested diagnostics for component %s, but it does not exist in the manager", existingComp.ID)
-				continue
-			}
-			for _, unit := range existingComp.Units {
-				if _, ok := inputComp[unit.ID]; ok {
-					diagnostics = append(diagnostics, runtime.ComponentUnitDiagnostic{
-						Component: existingComp,
-						Unit:      unit,
-					})
-				} else {
-					m.managerLogger.Warnf("requested diagnostics for unit %s, but it does not exist in the manager", unit.ID)
-				}
+	// create a map of unit by component and unit id, this is used to filter out units that
+	// do not exist in the manager
+	unitByID := make(map[string]map[string]*component.Unit)
+	for _, r := range req {
+		if unitByID[r.Component.ID] == nil {
+			unitByID[r.Component.ID] = make(map[string]*component.Unit)
+		}
+		unitByID[r.Component.ID][r.Unit.ID] = &r.Unit
+	}
+
+	// create empty diagnostics for units that exist in the manager
+	for _, existingComp := range currentComponents {
+		inputComp, ok := unitByID[existingComp.ID]
+		if !ok {
+			m.managerLogger.Warnf("requested diagnostics for component %s, but it does not exist in the manager", existingComp.ID)
+			continue
+		}
+		for _, unit := range existingComp.Units {
+			if _, ok := inputComp[unit.ID]; ok {
+				diagnostics = append(diagnostics, runtime.ComponentUnitDiagnostic{
+					Component: existingComp,
+					Unit:      unit,
+				})
+			} else {
+				m.managerLogger.Warnf("requested diagnostics for unit %s, but it does not exist in the manager", unit.ID)
 			}
 		}
 	}
-
-	// Beat receivers register diagnostic hooks per input stream (one receiver per input/stream),
-	// but the results are grouped at the component level in the diagnostics archive. So EDOT
-	// results are fetched and assigned in PerformComponentDiagnostics, not here.
 	return diagnostics
 }
 

--- a/internal/pkg/otel/manager/diagnostics.go
+++ b/internal/pkg/otel/manager/diagnostics.go
@@ -141,7 +141,7 @@ func (m *OTelManager) PerformComponentDiagnostics(
 	for _, extDiag := range extDiagnostics.ComponentDiagnostics {
 		parts := strings.SplitN(extDiag.Name, translate.OtelNamePrefix, 2)
 		if len(parts) != 2 {
-			m.managerLogger.Debugf("skipping EDOT diagnostic %q: receiver name does not contain expected prefix %q", extDiag.Name, translate.OtelNamePrefix)
+			m.managerLogger.Debugf("skipping EDOT diagnostic %q: diagnostic name does not contain expected prefix %q", extDiag.Name, translate.OtelNamePrefix)
 			continue
 		}
 		compID, _, _ := strings.Cut(parts[1], "/")

--- a/internal/pkg/otel/manager/diagnostics.go
+++ b/internal/pkg/otel/manager/diagnostics.go
@@ -141,6 +141,7 @@ func (m *OTelManager) PerformComponentDiagnostics(
 	for _, extDiag := range extDiagnostics.ComponentDiagnostics {
 		parts := strings.SplitN(extDiag.Name, translate.OtelNamePrefix, 2)
 		if len(parts) != 2 {
+			m.managerLogger.Debugf("skipping EDOT diagnostic %q: receiver name does not contain expected prefix %q", extDiag.Name, translate.OtelNamePrefix)
 			continue
 		}
 		compID, _, _ := strings.Cut(parts[1], "/")

--- a/internal/pkg/otel/manager/diagnostics.go
+++ b/internal/pkg/otel/manager/diagnostics.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"strings"
 	"syscall"
 
@@ -69,8 +70,9 @@ func (m *OTelManager) PerformDiagnostics(ctx context.Context, req ...runtime.Com
 		}
 	}
 
-	// Beat receivers register diagnostic hooks at the component level (one receiver per component),
-	// so EDOT results are fetched and assigned in PerformComponentDiagnostics, not here.
+	// Beat receivers register diagnostic hooks per input stream (one receiver per input/stream),
+	// but the results are grouped at the component level in the diagnostics archive. So EDOT
+	// results are fetched and assigned in PerformComponentDiagnostics, not here.
 	return diagnostics
 }
 
@@ -107,8 +109,16 @@ func (m *OTelManager) PerformComponentDiagnostics(
 
 	extDiagnostics, err := otel.PerformDiagnosticsExt(ctx, false)
 	if err != nil {
-		m.managerLogger.Debugf("Couldn't fetch diagnostics from EDOT: %v", err)
-		if !errors.Is(err, syscall.ENOENT) && !errors.Is(err, syscall.ECONNREFUSED) {
+		// These three errors mean EDOT is not running, which is expected.
+		// fs.ErrNotExist: the socket file is missing (POSIX ENOENT / Windows ERROR_FILE_NOT_FOUND).
+		// syscall.ECONNREFUSED: the socket file exists but nothing is listening (EDOT crashed or mid-restart).
+		// context.DeadlineExceeded: a Windows pipe-busy dial timed out. This is defensive: production does not
+		// set a dial deadline, so this only fires if the caller passes a deadline.
+		// Any other error is unexpected, so surface it on each component so it ends up in the diagnostics archive.
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, context.DeadlineExceeded) {
+			m.managerLogger.Debugf("EDOT not reachable, no diagnostics available: %v", err)
+		} else {
+			m.managerLogger.Warnf("failed to fetch diagnostics from EDOT: %v", err)
 			for idx := range diagnostics {
 				diagnostics[idx].Err = fmt.Errorf("error fetching otel diagnostics: %w", err)
 			}
@@ -117,16 +127,24 @@ func (m *OTelManager) PerformComponentDiagnostics(
 	}
 
 	// Beat receivers register hooks under the OTel receiver instance ID, which has the form
-	// "<receiverType>/_agent-component/<comp.ID>" (see translate.OtelNamePrefix).
-	// Use HasSuffix on the name suffix "_agent-component/<comp.ID>" for an exact component match
-	// that avoids false positives from substring overlap between component IDs.
-	compSuffix := make(map[string]int) // "_agent-component/<comp.ID>" → index in diagnostics
+	// "<receiverType>/_agent-component/<comp.ID>/<streamID>". The "<receiverType>/" prefix is the
+	// string representation produced by otelcomponent.ID.String(); the "_agent-component/" segment
+	// is translate.OtelNamePrefix.
+	// Match on the segment "_agent-component/<comp.ID>/" to avoid false positives from
+	// component IDs that are prefixes of other component IDs.
+	compSegment := make(map[string]int) // "_agent-component/<comp.ID>/" -> index in diagnostics
 	for idx, diag := range diagnostics {
-		compSuffix[translate.OtelNamePrefix+diag.Component.ID] = idx
+		compSegment[translate.OtelNamePrefix+diag.Component.ID+"/"] = idx
 	}
 	for _, extDiag := range extDiagnostics.ComponentDiagnostics {
-		for suffix, idx := range compSuffix {
-			if strings.HasSuffix(extDiag.Name, suffix) {
+		// For standard component IDs the "_agent-component/<comp.ID>/" framing is unambiguous:
+		// such IDs are built by joining parts with "-", so "/" only appears as the prefix and
+		// suffix delimiter and one ID cannot be a substring of another in this framing. We assume
+		// this holds, so at most one segment matches a given name and the map iteration order does
+		// not affect correctness. A policy input id that itself contains "/" could break the
+		// assumption, but normal IDs do not.
+		for segment, idx := range compSegment {
+			if strings.Contains(extDiag.Name, segment) {
 				diagnostics[idx].Results = append(diagnostics[idx].Results, extDiag)
 				break
 			}

--- a/internal/pkg/otel/manager/diagnostics.go
+++ b/internal/pkg/otel/manager/diagnostics.go
@@ -23,8 +23,6 @@ import (
 // PerformDiagnostics executes the diagnostic action for the provided units. If no units are provided then
 // it performs diagnostics for all current units. If a given unit does not exist in the manager, then a warning
 // is logged.
-// Note: this function returns unit-level diagnostics only. EDOT groups beat receiver results at the
-// component level, so they are not included here.
 func (m *OTelManager) PerformDiagnostics(ctx context.Context, req ...runtime.ComponentUnitDiagnosticRequest) []runtime.ComponentUnitDiagnostic {
 	var diagnostics []runtime.ComponentUnitDiagnostic
 	m.mx.RLock()

--- a/internal/pkg/otel/manager/diagnostics.go
+++ b/internal/pkg/otel/manager/diagnostics.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 
 	"github.com/elastic/elastic-agent/internal/pkg/otel"
+	"github.com/elastic/elastic-agent/internal/pkg/otel/translate"
 
 	"github.com/elastic/elastic-agent/pkg/component"
 	"github.com/elastic/elastic-agent/pkg/component/runtime"
@@ -37,38 +38,39 @@ func (m *OTelManager) PerformDiagnostics(ctx context.Context, req ...runtime.Com
 				})
 			}
 		}
-		return diagnostics
-	}
-
-	// create a map of unit by component and unit id, this is used to filter out units that
-	// do not exist in the manager
-	unitByID := make(map[string]map[string]*component.Unit)
-	for _, r := range req {
-		if unitByID[r.Component.ID] == nil {
-			unitByID[r.Component.ID] = make(map[string]*component.Unit)
+	} else {
+		// create a map of unit by component and unit id, this is used to filter out units that
+		// do not exist in the manager
+		unitByID := make(map[string]map[string]*component.Unit)
+		for _, r := range req {
+			if unitByID[r.Component.ID] == nil {
+				unitByID[r.Component.ID] = make(map[string]*component.Unit)
+			}
+			unitByID[r.Component.ID][r.Unit.ID] = &r.Unit
 		}
-		unitByID[r.Component.ID][r.Unit.ID] = &r.Unit
-	}
 
-	// create empty diagnostics for units that exist in the manager
-	for _, existingComp := range currentComponents {
-		inputComp, ok := unitByID[existingComp.ID]
-		if !ok {
-			m.managerLogger.Warnf("requested diagnostics for component %s, but it does not exist in the manager", existingComp.ID)
-			continue
-		}
-		for _, unit := range existingComp.Units {
-			if _, ok := inputComp[unit.ID]; ok {
-				diagnostics = append(diagnostics, runtime.ComponentUnitDiagnostic{
-					Component: existingComp,
-					Unit:      unit,
-				})
-			} else {
-				m.managerLogger.Warnf("requested diagnostics for unit %s, but it does not exist in the manager", unit.ID)
+		// create empty diagnostics for units that exist in the manager
+		for _, existingComp := range currentComponents {
+			inputComp, ok := unitByID[existingComp.ID]
+			if !ok {
+				m.managerLogger.Warnf("requested diagnostics for component %s, but it does not exist in the manager", existingComp.ID)
+				continue
+			}
+			for _, unit := range existingComp.Units {
+				if _, ok := inputComp[unit.ID]; ok {
+					diagnostics = append(diagnostics, runtime.ComponentUnitDiagnostic{
+						Component: existingComp,
+						Unit:      unit,
+					})
+				} else {
+					m.managerLogger.Warnf("requested diagnostics for unit %s, but it does not exist in the manager", unit.ID)
+				}
 			}
 		}
 	}
 
+	// Beat receivers register diagnostic hooks at the component level (one receiver per component),
+	// so EDOT results are fetched and assigned in PerformComponentDiagnostics, not here.
 	return diagnostics
 }
 
@@ -93,7 +95,6 @@ func (m *OTelManager) PerformComponentDiagnostics(
 		compByID[comp.ID] = comp
 	}
 
-	// create empty diagnostics for components that exist in the manager
 	for _, existingComp := range currentComponents {
 		if inputComp, ok := compByID[existingComp.ID]; ok {
 			diagnostics = append(diagnostics, runtime.ComponentDiagnostic{
@@ -105,28 +106,30 @@ func (m *OTelManager) PerformComponentDiagnostics(
 	}
 
 	extDiagnostics, err := otel.PerformDiagnosticsExt(ctx, false)
-
-	// We're not running the EDOT if:
-	//  1. Either the socket doesn't exist
-	//	2. It is refusing the connections.
-	// Return error for any other scenario.
 	if err != nil {
 		m.managerLogger.Debugf("Couldn't fetch diagnostics from EDOT: %v", err)
 		if !errors.Is(err, syscall.ENOENT) && !errors.Is(err, syscall.ECONNREFUSED) {
-			return nil, fmt.Errorf("error fetching otel diagnostics: %w", err)
-		}
-	}
-
-	for idx, diag := range diagnostics {
-		found := false
-		for _, extDiag := range extDiagnostics.ComponentDiagnostics {
-			if strings.Contains(extDiag.Name, diag.Component.ID) {
-				found = true
-				diagnostics[idx].Results = append(diagnostics[idx].Results, extDiag)
+			for idx := range diagnostics {
+				diagnostics[idx].Err = fmt.Errorf("error fetching otel diagnostics: %w", err)
 			}
 		}
-		if !found {
-			diagnostics[idx].Err = fmt.Errorf("failed to get diagnostics for %s", diag.Component.ID)
+		return diagnostics, nil
+	}
+
+	// Beat receivers register hooks under the OTel receiver instance ID, which has the form
+	// "<receiverType>/_agent-component/<comp.ID>" (see translate.OtelNamePrefix).
+	// Use HasSuffix on the name suffix "_agent-component/<comp.ID>" for an exact component match
+	// that avoids false positives from substring overlap between component IDs.
+	compSuffix := make(map[string]int) // "_agent-component/<comp.ID>" → index in diagnostics
+	for idx, diag := range diagnostics {
+		compSuffix[translate.OtelNamePrefix+diag.Component.ID] = idx
+	}
+	for _, extDiag := range extDiagnostics.ComponentDiagnostics {
+		for suffix, idx := range compSuffix {
+			if strings.HasSuffix(extDiag.Name, suffix) {
+				diagnostics[idx].Results = append(diagnostics[idx].Results, extDiag)
+				break
+			}
 		}
 	}
 

--- a/internal/pkg/otel/manager/diagnostics_test.go
+++ b/internal/pkg/otel/manager/diagnostics_test.go
@@ -6,12 +6,12 @@ package manager
 
 import (
 	"encoding/json"
-	"fmt"
 	"runtime"
 	"testing"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 	"github.com/elastic/elastic-agent/internal/pkg/otel/extension/elasticdiagnostics"
+	"github.com/elastic/elastic-agent/internal/pkg/otel/translate"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/actions/handlers"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
@@ -41,21 +41,17 @@ func TestPerformComponentDiagnostics(t *testing.T) {
 	}
 
 	expectedDiags := []componentruntime.ComponentDiagnostic{
-		{
-			Component: filebeatComp,
-		},
-		{
-			Component: otherComp,
-		},
+		{Component: filebeatComp},
+		{Component: otherComp},
 	}
 
 	diags, err := m.PerformComponentDiagnostics(t.Context(), nil)
 	require.NoError(t, err)
+	require.Len(t, diags, len(expectedDiags))
 	for i, d := range diags {
 		assert.Equal(t, expectedDiags[i].Component.ID, d.Component.ID)
-		// we should have errors set about not being able to connect to diagnostics extension
-		require.NotNil(t, d.Err)
-		assert.ErrorContains(t, d.Err, fmt.Sprintf("failed to get diagnostics for %s", d.Component.ID))
+		assert.Nil(t, d.Err)
+		assert.Empty(t, d.Results)
 	}
 }
 
@@ -122,10 +118,13 @@ func TestBeatMetrics(t *testing.T) {
 	}
 	setTemporaryAgentPath(t)
 	logger, obs := loggertest.New("test")
-	compID := "filebeat-comp-1"
 
-	filebeatComp := testComponent(compID)
+	filebeatComp := testComponent("filebeat-comp-1")
 	filebeatComp.InputSpec.Spec.Command.Args = []string{"filebeat"}
+
+	// Beat receivers register hooks under the OTel receiver instance ID, which has the form
+	// "<receiverType>/_agent-component/<comp.ID>" (see translate.OtelNamePrefix).
+	receiverName := "filebeatreceiver/" + translate.OtelNamePrefix + filebeatComp.ID
 
 	m := &OTelManager{
 		managerLogger: logger,
@@ -137,14 +136,14 @@ func TestBeatMetrics(t *testing.T) {
 	expectedResponse := elasticdiagnostics.Response{
 		ComponentDiagnostics: []*proto.ActionDiagnosticUnitResult{
 			{
-				Name:        compID,
+				Name:        receiverName,
 				Filename:    "beat_metrics.json",
 				ContentType: "application/json",
 				Description: "Metrics from the default monitoring namespace and expvar.",
 				Content:     expectedMetricData,
 			},
 			{
-				Name:        compID,
+				Name:        receiverName,
 				Filename:    "input_metrics.json",
 				ContentType: "application/json",
 				Description: "Metrics from active inputs.",
@@ -161,19 +160,19 @@ func TestBeatMetrics(t *testing.T) {
 	})
 
 	diags, err := m.PerformComponentDiagnostics(t.Context(), nil)
-	require.NoError(t, err)
 	assert.Len(t, obs.All(), 0)
+	require.NoError(t, err)
 	require.Len(t, diags, 1)
 	require.True(t, called)
 
-	diag := diags[0]
-	assert.Equal(t, filebeatComp, diag.Component)
-	// two metrics diagnostics and one filebeat registry
-	require.Len(t, diag.Results, 2, "expected 2 diagnostics, got error: %w", diag.Err)
+	compDiag := diags[0]
+	assert.Equal(t, filebeatComp, compDiag.Component)
+	require.Nil(t, compDiag.Err)
+	require.Len(t, compDiag.Results, 2)
 
 	t.Run("stats beat metrics", func(t *testing.T) {
-		beatMetrics := diag.Results[0]
-		assert.Equal(t, compID, beatMetrics.Name)
+		beatMetrics := compDiag.Results[0]
+		assert.Equal(t, receiverName, beatMetrics.Name)
 		assert.Equal(t, "Metrics from the default monitoring namespace and expvar.", beatMetrics.Description)
 		assert.Equal(t, "beat_metrics.json", beatMetrics.Filename)
 		assert.Equal(t, "application/json", beatMetrics.ContentType)
@@ -181,8 +180,8 @@ func TestBeatMetrics(t *testing.T) {
 	})
 
 	t.Run("input beat metrics", func(t *testing.T) {
-		inputMetrics := diag.Results[1]
-		assert.Equal(t, compID, inputMetrics.Name)
+		inputMetrics := compDiag.Results[1]
+		assert.Equal(t, receiverName, inputMetrics.Name)
 		assert.Equal(t, "Metrics from active inputs.", inputMetrics.Description)
 		assert.Equal(t, "input_metrics.json", inputMetrics.Filename)
 		assert.Equal(t, "application/json", inputMetrics.ContentType)

--- a/internal/pkg/otel/manager/diagnostics_test.go
+++ b/internal/pkg/otel/manager/diagnostics_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	otelcomponent "go.opentelemetry.io/collector/component"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 	"github.com/elastic/elastic-agent/internal/pkg/otel/extension/elasticdiagnostics"
@@ -300,7 +301,7 @@ func TestPerformComponentDiagnosticsUnexpectedError(t *testing.T) {
 		assert.Empty(t, d.Results)
 	}
 
-	assert.NotEmpty(t, obs.FilterMessageSnippet("failed to fetch diagnostics from EDOT").All(), "unexpected EDOT error should be logged at warn level")
+	assert.NotEmpty(t, obs.FilterLevelExact(zapcore.WarnLevel).FilterMessageSnippet("failed to fetch diagnostics from EDOT").All(), "unexpected EDOT error should be logged at warn level")
 }
 
 func setTemporaryAgentPath(t *testing.T) {

--- a/internal/pkg/otel/manager/diagnostics_test.go
+++ b/internal/pkg/otel/manager/diagnostics_test.go
@@ -6,8 +6,12 @@ package manager
 
 import (
 	"encoding/json"
+	"net/http"
 	"runtime"
 	"testing"
+
+	otelcomponent "go.opentelemetry.io/collector/component"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 	"github.com/elastic/elastic-agent/internal/pkg/otel/extension/elasticdiagnostics"
@@ -17,7 +21,9 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 
 	componentruntime "github.com/elastic/elastic-agent/pkg/component/runtime"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
 	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
+	"github.com/elastic/elastic-agent/pkg/ipc"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +32,7 @@ import (
 )
 
 func TestPerformComponentDiagnostics(t *testing.T) {
+	setTemporaryAgentPath(t)
 	logger, _ := loggertest.New("test")
 	compID := "filebeat-comp-1"
 
@@ -122,9 +129,9 @@ func TestBeatMetrics(t *testing.T) {
 	filebeatComp := testComponent("filebeat-comp-1")
 	filebeatComp.InputSpec.Spec.Command.Args = []string{"filebeat"}
 
-	// Beat receivers register hooks under the OTel receiver instance ID, which has the form
-	// "<receiverType>/_agent-component/<comp.ID>" (see translate.OtelNamePrefix).
-	receiverName := "filebeatreceiver/" + translate.OtelNamePrefix + filebeatComp.ID
+	// The receiver name format must match what EDOT registers, otherwise the segment match in
+	// production would not find this result.
+	receiverName := translate.GetReceiverID(otelcomponent.MustNewType("filebeatreceiver"), filebeatComp.ID+"/stream-1").String()
 
 	m := &OTelManager{
 		managerLogger: logger,
@@ -160,8 +167,8 @@ func TestBeatMetrics(t *testing.T) {
 	})
 
 	diags, err := m.PerformComponentDiagnostics(t.Context(), nil)
-	assert.Len(t, obs.All(), 0)
 	require.NoError(t, err)
+	assert.Len(t, obs.All(), 0)
 	require.Len(t, diags, 1)
 	require.True(t, called)
 
@@ -187,6 +194,122 @@ func TestBeatMetrics(t *testing.T) {
 		assert.Equal(t, "application/json", inputMetrics.ContentType)
 		assert.Equal(t, expectedMetricData, inputMetrics.Content)
 	})
+}
+
+// TestBeatMetricsPrefixOverlap guards that each EDOT result is assigned to exactly one component:
+// the one whose receiver ID contains the result's name segment. When one component ID is a prefix
+// of another (e.g. "filebeat" and "filebeat-2"), the prefix component must not receive the result
+// of the component whose ID it is a prefix of.
+func TestBeatMetricsPrefixOverlap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skip test on Windows.",
+			"It's technically cumbersome to set up an npipe http server.",
+			"And it doesn't have anything to do with the code paths being tested.",
+		)
+	}
+	setTemporaryAgentPath(t)
+	logger, _ := loggertest.New("test")
+
+	shortComp := testComponent("filebeat")
+	shortComp.InputSpec.Spec.Command.Args = []string{"filebeat"}
+	longComp := testComponent("filebeat-2")
+	longComp.InputSpec.Spec.Command.Args = []string{"filebeat"}
+
+	shortReceiver := translate.GetReceiverID(otelcomponent.MustNewType("filebeatreceiver"), shortComp.ID+"/stream-1").String()
+	longReceiver := translate.GetReceiverID(otelcomponent.MustNewType("filebeatreceiver"), longComp.ID+"/stream-1").String()
+
+	metricData, err := json.MarshalIndent(map[string]any{"test": "test"}, "", "  ")
+	require.NoError(t, err)
+
+	expectedResponse := elasticdiagnostics.Response{
+		ComponentDiagnostics: []*proto.ActionDiagnosticUnitResult{
+			{Name: shortReceiver, Filename: "beat_metrics.json", ContentType: "application/json", Content: metricData},
+			{Name: longReceiver, Filename: "beat_metrics.json", ContentType: "application/json", Content: metricData},
+		},
+	}
+
+	m := &OTelManager{
+		managerLogger: logger,
+		components:    []component.Component{shortComp, longComp},
+	}
+
+	called := false
+	server := handlers.NewMockServer(t, paths.DiagnosticsExtensionSocket(), &called, &expectedResponse)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close())
+	})
+
+	diags, err := m.PerformComponentDiagnostics(t.Context(), nil)
+	require.NoError(t, err)
+	require.True(t, called)
+	require.Len(t, diags, 2)
+
+	// find results by component ID to avoid order dependence
+	resultsByComp := make(map[string][]string)
+	for _, d := range diags {
+		for _, r := range d.Results {
+			resultsByComp[d.Component.ID] = append(resultsByComp[d.Component.ID], r.Name)
+		}
+	}
+
+	assert.Equal(t, []string{shortReceiver}, resultsByComp[shortComp.ID], "short comp must get only its own result")
+	assert.Equal(t, []string{longReceiver}, resultsByComp[longComp.ID], "long comp must get only its own result")
+}
+
+// TestPerformComponentDiagnosticsUnexpectedError verifies that when EDOT returns an error other than
+// "not running" (ENOENT/ECONNREFUSED), the error is recorded on each component and the call itself
+// still returns nil so the rest of the diagnostics archive is produced.
+func TestPerformComponentDiagnosticsUnexpectedError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skip test on Windows.",
+			"It's technically cumbersome to set up an npipe http server.",
+			"And it doesn't have anything to do with the code paths being tested.",
+		)
+	}
+	setTemporaryAgentPath(t)
+	managerLogger, obs := loggertest.New("test")
+
+	filebeatComp := testComponent("filebeat-comp-1")
+	filebeatComp.InputSpec.Spec.Command.Args = []string{"filebeat"}
+	otherComp := testComponent("other-comp")
+	otherComp.InputSpec.Spec.Command.Args = []string{"metricbeat"}
+
+	m := &OTelManager{
+		managerLogger: managerLogger,
+		components:    []component.Component{filebeatComp, otherComp},
+	}
+
+	// A reachable socket that returns a non-JSON body makes PerformDiagnosticsExt fail while
+	// unmarshalling. That error is neither ENOENT nor ECONNREFUSED, so it hits the unexpected path.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/diagnostics", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	})
+	l, err := ipc.CreateListener(logger.NewWithoutConfig(""), paths.DiagnosticsExtensionSocket())
+	require.NoError(t, err)
+	server := &http.Server{Handler: mux} //nolint:gosec // This is a test
+	go func() {
+		assert.ErrorIs(t, server.Serve(l), http.ErrServerClosed)
+	}()
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close())
+	})
+
+	diags, err := m.PerformComponentDiagnostics(t.Context(), nil)
+	require.NoError(t, err)
+	require.Len(t, diags, 2)
+	for _, d := range diags {
+		assert.Error(t, d.Err)
+		assert.Empty(t, d.Results)
+	}
+
+	var loggedWarn bool
+	for _, e := range obs.All() {
+		if e.Level == zapcore.WarnLevel {
+			loggedWarn = true
+		}
+	}
+	assert.True(t, loggedWarn, "unexpected EDOT error should be logged")
 }
 
 func setTemporaryAgentPath(t *testing.T) {

--- a/internal/pkg/otel/manager/diagnostics_test.go
+++ b/internal/pkg/otel/manager/diagnostics_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	otelcomponent "go.opentelemetry.io/collector/component"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 	"github.com/elastic/elastic-agent/internal/pkg/otel/extension/elasticdiagnostics"
@@ -21,7 +20,6 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 
 	componentruntime "github.com/elastic/elastic-agent/pkg/component/runtime"
-	"github.com/elastic/elastic-agent/pkg/core/logger"
 	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
 	"github.com/elastic/elastic-agent/pkg/ipc"
 
@@ -284,7 +282,7 @@ func TestPerformComponentDiagnosticsUnexpectedError(t *testing.T) {
 	mux.HandleFunc("/diagnostics", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("not json"))
 	})
-	l, err := ipc.CreateListener(logger.NewWithoutConfig(""), paths.DiagnosticsExtensionSocket())
+	l, err := ipc.CreateListener(managerLogger, paths.DiagnosticsExtensionSocket())
 	require.NoError(t, err)
 	server := &http.Server{Handler: mux} //nolint:gosec // This is a test
 	go func() {
@@ -302,13 +300,7 @@ func TestPerformComponentDiagnosticsUnexpectedError(t *testing.T) {
 		assert.Empty(t, d.Results)
 	}
 
-	var loggedWarn bool
-	for _, e := range obs.All() {
-		if e.Level == zapcore.WarnLevel {
-			loggedWarn = true
-		}
-	}
-	assert.True(t, loggedWarn, "unexpected EDOT error should be logged")
+	assert.NotEmpty(t, obs.FilterMessageSnippet("failed to fetch diagnostics from EDOT").All(), "unexpected EDOT error should be logged at warn level")
 }
 
 func setTemporaryAgentPath(t *testing.T) {

--- a/internal/pkg/otel/manager/diagnostics_test.go
+++ b/internal/pkg/otel/manager/diagnostics_test.go
@@ -129,8 +129,8 @@ func TestBeatMetrics(t *testing.T) {
 	filebeatComp := testComponent("filebeat-comp-1")
 	filebeatComp.InputSpec.Spec.Command.Args = []string{"filebeat"}
 
-	// The receiver name format must match what EDOT registers, otherwise the segment match in
-	// production would not find this result.
+	// The receiver name format must match what EDOT registers, otherwise the comp.ID extraction
+	// in production would not find this result.
 	receiverName := translate.GetReceiverID(otelcomponent.MustNewType("filebeatreceiver"), filebeatComp.ID+"/stream-1").String()
 
 	m := &OTelManager{
@@ -196,10 +196,9 @@ func TestBeatMetrics(t *testing.T) {
 	})
 }
 
-// TestBeatMetricsPrefixOverlap guards that each EDOT result is assigned to exactly one component:
-// the one whose receiver ID contains the result's name segment. When one component ID is a prefix
-// of another (e.g. "filebeat" and "filebeat-2"), the prefix component must not receive the result
-// of the component whose ID it is a prefix of.
+// TestBeatMetricsPrefixOverlap guards that each EDOT result is assigned to exactly one component.
+// When one component ID is a prefix of another (e.g. "filebeat" and "filebeat-2"), the prefix
+// component must not receive the result of the longer one.
 func TestBeatMetricsPrefixOverlap(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skip test on Windows.",

--- a/testing/integration/ess/diagnostics_test.go
+++ b/testing/integration/ess/diagnostics_test.go
@@ -494,6 +494,9 @@ agent.internal.runtime.filebeat.httpjson: process
 			configTemplate: fileStreamConfigTemplate,
 		},
 		{
+			// Beat receivers register diagnostic hooks at the component level via the OTel
+			// receiver instance ID ("_agent-component/<comp.ID>"). Files land under the
+			// component directory, same as for process-runtime beats.
 			name:              "filebeat receiver",
 			runtime:           "otel",
 			monitoringEnabled: true,
@@ -661,6 +664,9 @@ agent.internal.runtime.filebeat.filestream: otel
 
 	extractZipArchive(t, diagZip, extractionDir)
 
+	// Beat receivers register diagnostic hooks at the component level via the OTel
+	// receiver instance ID ("_agent-component/<comp.ID>"). Files land under the
+	// component directory, same as for process-runtime beats.
 	expectedFiles := []string{
 		"edot/otel-merged-actual.yaml",
 		"edot/allocs.profile.gz",

--- a/testing/integration/ess/diagnostics_test.go
+++ b/testing/integration/ess/diagnostics_test.go
@@ -494,9 +494,9 @@ agent.internal.runtime.filebeat.httpjson: process
 			configTemplate: fileStreamConfigTemplate,
 		},
 		{
-			// Beat receivers register diagnostic hooks at the component level via the OTel
-			// receiver instance ID ("_agent-component/<comp.ID>"). Files land under the
-			// component directory, same as for process-runtime beats.
+			// Beat receivers register diagnostic hooks per input stream via the OTel receiver
+			// instance ID ("<receiverType>/_agent-component/<comp.ID>/<streamID>"). Results are grouped
+			// at the component level and land under the component directory, same as for process-runtime beats.
 			name:              "filebeat receiver",
 			runtime:           "otel",
 			monitoringEnabled: true,
@@ -664,9 +664,9 @@ agent.internal.runtime.filebeat.filestream: otel
 
 	extractZipArchive(t, diagZip, extractionDir)
 
-	// Beat receivers register diagnostic hooks at the component level via the OTel
-	// receiver instance ID ("_agent-component/<comp.ID>"). Files land under the
-	// component directory, same as for process-runtime beats.
+	// Beat receivers register diagnostic hooks per input stream via the OTel receiver
+	// instance ID ("<receiverType>/_agent-component/<comp.ID>/<streamID>"). Results are grouped
+	// at the component level and land under the component directory, same as for process-runtime beats.
 	expectedFiles := []string{
 		"edot/otel-merged-actual.yaml",
 		"edot/allocs.profile.gz",


### PR DESCRIPTION
<!-- Type of change: Bug -->

## What does this PR do?

Fixes three bugs in the diagnostics ZIP produced by agents running in OTel mode.

**Duplicate files in the archive**

When an agent ran with multiple OTel beat components (e.g. `filebeat` and `filebeat-2`), diagnostic files like `beat_metrics.json` appeared under both components — even when they belonged to only one. The root cause was a substring match: `"filebeat"` is contained in `"filebeat-2"`, so the wrong component claimed the result. The fix uses exact extraction of the component ID from the receiver name, so each result lands in exactly one place.

**Empty subdirectories**

Output units (e.g. the output side of a filestream component) always got their own subdirectory in the archive even though they never produce any diagnostic files. This left empty dirs like `components/filestream-monitoring/filestream-monitoring/`. The fix skips creating a directory when there is nothing to write.

**EDOT errors aborting the whole request**

If the EDOT collector returned an unexpected error, the entire diagnostics call failed and no archive was produced at all. The fix records the error on the affected components and continues, so the rest of the archive is still collected.

## Before / after

```
# Before
components/filebeat/beat_metrics.json    ← correct
components/filebeat-2/beat_metrics.json  ← duplicate of filebeat's result
components/filebeat/filebeat/            ← empty output unit dir
components/filebeat-2/filebeat-2/        ← empty output unit dir

# After
components/filebeat/beat_metrics.json
components/filebeat-2/beat_metrics.json
```

## Known limitation

If a policy input `id` field contains `/`, the component ID extraction may not work correctly — both `comp.ID` and `streamID` are user-supplied strings, and `/` is also the delimiter in the receiver name format, making it ambiguous. The agent logs a warning when it detects such an ID. A proper fix would require escaping `/` in IDs at the source (in the beat receiver, which is outside this repo).

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## How to test this PR locally

**Unit tests:**
```bash
go test ./internal/pkg/otel/manager/ -run "TestPerformComponentDiagnostics|TestPerformDiagnostics|TestBeatMetrics|TestBeatMetricsPrefixOverlap|TestPerformComponentDiagnosticsUnexpectedError" -v
go test ./internal/pkg/diagnostics/ -run TestZipArchiveUnitDirSkip -v
```

**Integration tests (requires a full integration environment):**
```bash
mage integration:single TestEDOTDiagnostics
mage integration:single TestBeatDiagnostics
```

Extract the resulting diagnostics ZIP and verify:
- No duplicate entries (`unzip -l` lists each path exactly once)
- No empty unit subdirectories

## Related issues

-
