### PR TITLE
Fix TestFleetDownloadProxyURL and TestFleetDownloadAuthUpgrade timing out in CI

### DIFF
--- a/testing/integration/ess/proxy_url_test.go
+++ b/testing/integration/ess/proxy_url_test.go
@@ -996,17 +996,16 @@ func TestFleetDownloadProxyURL(t *testing.T) {
 	err = fleettools.UpgradeAgent(ctx, kibClient, agentID, endVersionInfo.Binary.String(), true)
 	require.NoError(t, err)
 
-	t.Log("Ensure upgrade starts")
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		status, err := startFixture.ExecStatus(ctx)
-		require.NoError(c, err)
-		require.NotNil(c, status.UpgradeDetails, "Agent status does not contain upgrade_details.")
-	}, time.Minute*5, time.Second, "Unable to verify that upgrade details appear.")
-
-	t.Log("Waiting for upgrade watcher to start...")
-	err = upgradetest.WaitForWatcher(ctx, 5*time.Minute, 10*time.Second)
+	// The prior failed upgrade left a stale UPG_FAILED in status. Wait until
+	// the new upgrade clears it before handing off to WaitForWatchingState,
+	// which treats any UPG_FAILED as a fatal failure.
+	t.Log("Waiting for second upgrade to start...")
+	err = upgradetest.WaitForUpgradeInProgress(ctx, startFixture, 2*time.Minute, 10*time.Second)
 	require.NoError(t, err)
-	t.Log("Upgrade watcher started")
+
+	t.Log("Waiting for upgrade to reach watching state...")
+	err = upgradetest.WaitForWatchingState(ctx, startFixture, 15*time.Minute, 10*time.Second)
+	require.NoError(t, err)
 
 	err = upgradetest.WaitHealthyAndVersion(ctx, startFixture, endVersionInfo.Binary, 2*time.Minute, 10*time.Second, t)
 	require.NoError(t, err)
@@ -1173,17 +1172,9 @@ func TestFleetDownloadAuthUpgrade(t *testing.T) {
 	err = fleettools.UpgradeAgent(t.Context(), kibClient, agentID, endVersionInfo.Binary.String(), true)
 	require.NoError(t, err)
 
-	t.Log("Ensure upgrade starts")
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		status, err := startFixture.ExecStatus(t.Context())
-		require.NoError(c, err)
-		require.NotNil(c, status.UpgradeDetails, "Agent status does not contain upgrade_details.")
-	}, time.Minute*5, time.Second, "Unable to verify that upgrade details appear.")
-
-	t.Log("Waiting for upgrade watcher to start...")
-	err = upgradetest.WaitForWatcher(t.Context(), 5*time.Minute, 10*time.Second)
+	t.Log("Waiting for upgrade to reach watching state...")
+	err = upgradetest.WaitForWatchingState(t.Context(), startFixture, 15*time.Minute, 10*time.Second)
 	require.NoError(t, err)
-	t.Log("Upgrade watcher started")
 
 	err = upgradetest.WaitHealthyAndVersion(t.Context(), startFixture, endVersionInfo.Binary, 2*time.Minute, 10*time.Second, t)
 	require.NoError(t, err)

--- a/testing/integration/ess/proxy_url_test.go
+++ b/testing/integration/ess/proxy_url_test.go
@@ -1004,7 +1004,7 @@ func TestFleetDownloadProxyURL(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Waiting for upgrade to reach watching state...")
-	err = upgradetest.WaitForWatchingState(ctx, startFixture, 15*time.Minute, 10*time.Second)
+	err = upgradetest.WaitForWatchingState(ctx, startFixture, 15*time.Minute, 10*time.Second, 2*time.Minute)
 	require.NoError(t, err)
 
 	err = upgradetest.WaitHealthyAndVersion(ctx, startFixture, endVersionInfo.Binary, 2*time.Minute, 10*time.Second, t)
@@ -1173,7 +1173,7 @@ func TestFleetDownloadAuthUpgrade(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Waiting for upgrade to reach watching state...")
-	err = upgradetest.WaitForWatchingState(t.Context(), startFixture, 15*time.Minute, 10*time.Second)
+	err = upgradetest.WaitForWatchingState(t.Context(), startFixture, 15*time.Minute, 10*time.Second, 2*time.Minute)
 	require.NoError(t, err)
 
 	err = upgradetest.WaitHealthyAndVersion(t.Context(), startFixture, endVersionInfo.Binary, 2*time.Minute, 10*time.Second, t)

--- a/testing/integration/ess/proxy_url_test.go
+++ b/testing/integration/ess/proxy_url_test.go
@@ -1172,6 +1172,10 @@ func TestFleetDownloadAuthUpgrade(t *testing.T) {
 	err = fleettools.UpgradeAgent(t.Context(), kibClient, agentID, endVersionInfo.Binary.String(), true)
 	require.NoError(t, err)
 
+	t.Log("Waiting for upgrade to start...")
+	err = upgradetest.WaitForUpgradeInProgress(t.Context(), startFixture, 2*time.Minute, 10*time.Second)
+	require.NoError(t, err)
+
 	t.Log("Waiting for upgrade to reach watching state...")
 	err = upgradetest.WaitForWatchingState(t.Context(), startFixture, 15*time.Minute, 10*time.Second, 2*time.Minute)
 	require.NoError(t, err)

--- a/testing/upgradetest/watcher.go
+++ b/testing/upgradetest/watcher.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
+	"github.com/elastic/elastic-agent/pkg/upgrade/details"
 	"github.com/elastic/elastic-agent/pkg/utils"
 )
 
@@ -31,6 +32,114 @@ agent.upgrade.watcher:
 // watcher stops or is killed before continuing.
 func ConfigureFastWatcher(ctx context.Context, f *atesting.Fixture) error {
 	return f.Configure(ctx, []byte(FastWatcherCfg))
+}
+
+// WaitForWatchingState polls UpgradeDetails.State until the upgrade reaches
+// StateWatching or the timeout is exceeded.
+//
+// It returns immediately on StateFailed or StateRollback so the test does not
+// burn the full timeout when an upgrade genuinely fails. If the test may have
+// a stale UPG_FAILED from a prior upgrade, call WaitForUpgradeInProgress first
+// to confirm the new upgrade has started before calling this function.
+//
+// It also returns nil if UpgradeDetails transitions from an in-progress state
+// to nil, which happens when the watcher finishes its grace period and the
+// coordinator clears UpgradeDetails (StateCompleted maps to nil in status).
+// This prevents a 15-minute hang when the polling interval misses the short
+// StateWatching window between agent restart and watcher completion.
+//
+// Once this returns nil, a separate WaitForWatcher call is not needed.
+//
+// Use a generous timeout: artifact downloads can take 10+ minutes on slow CI
+// links.
+func WaitForWatchingState(ctx context.Context, f *atesting.Fixture, timeout time.Duration, interval time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var lastState details.State
+	var lastErr error
+	var sawInProgress bool
+
+	for {
+		select {
+		case <-ctx.Done():
+			if lastState != "" {
+				return fmt.Errorf("timed out waiting for upgrade to reach %s, last observed state: %s: %w", details.StateWatching, lastState, ctx.Err())
+			}
+			if lastErr != nil {
+				return fmt.Errorf("timed out waiting for upgrade to reach %s: %w", details.StateWatching, lastErr)
+			}
+			return fmt.Errorf("timed out waiting for upgrade to reach %s: %w", details.StateWatching, ctx.Err())
+		case <-ticker.C:
+			status, err := f.ExecStatus(ctx)
+			if err != nil || status.IsZero() {
+				// Status may be briefly unavailable during agent restart; retry.
+				lastErr = err
+				continue
+			}
+			if status.UpgradeDetails == nil {
+				// If the upgrade was previously in progress, nil means the watcher
+				// completed its grace period and the coordinator cleared UpgradeDetails.
+				if sawInProgress {
+					return nil
+				}
+				continue
+			}
+
+			state := status.UpgradeDetails.State
+			lastState = state
+
+			switch state {
+			case details.StateWatching:
+				return nil
+			case details.StateFailed:
+				errMsg := status.UpgradeDetails.Metadata.ErrorMsg
+				if errMsg == "" {
+					errMsg = fmt.Sprintf("failed from state %s", status.UpgradeDetails.Metadata.FailedState)
+				}
+				return fmt.Errorf("upgrade failed while waiting for %s: %s", details.StateWatching, errMsg)
+			case details.StateRollback:
+				errMsg := status.UpgradeDetails.Metadata.ErrorMsg
+				if errMsg == "" {
+					errMsg = fmt.Sprintf("rollback from state %s", status.UpgradeDetails.Metadata.FailedState)
+				}
+				return fmt.Errorf("upgrade watcher triggered rollback while waiting for %s: %s", details.StateWatching, errMsg)
+			default:
+				sawInProgress = true
+			}
+		}
+	}
+}
+
+// WaitForUpgradeInProgress polls until UpgradeDetails.State is non-nil and
+// not StateFailed. Use this before WaitForWatchingState when a prior upgrade
+// may have left a stale UPG_FAILED in the agent status that would otherwise
+// cause WaitForWatchingState to fail immediately.
+func WaitForUpgradeInProgress(ctx context.Context, f *atesting.Fixture, timeout time.Duration, interval time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for upgrade to start: %w", ctx.Err())
+		case <-ticker.C:
+			status, err := f.ExecStatus(ctx)
+			if err != nil || status.IsZero() {
+				continue
+			}
+			if status.UpgradeDetails == nil || status.UpgradeDetails.State == details.StateFailed {
+				continue
+			}
+			return nil
+		}
+	}
 }
 
 // WaitForWatcher loops until a watcher is found running or times out.

--- a/testing/upgradetest/watcher.go
+++ b/testing/upgradetest/watcher.go
@@ -6,7 +6,6 @@ package upgradetest
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -35,41 +34,13 @@ func ConfigureFastWatcher(ctx context.Context, f *atesting.Fixture) error {
 	return f.Configure(ctx, []byte(FastWatcherCfg))
 }
 
-// WaitForWatchingState polls UpgradeDetails.State until the upgrade reaches
-// StateWatching or the timeout is exceeded. Both the start agent and the target
-// agent must be >= 8.12.0 for UpgradeDetails to appear in status; older agents
-// always return nil details and this function will time out.
+// WaitForWatchingState polls UpgradeDetails until the upgrade reaches
+// StateWatching or the coordinator clears the details (upgrade completed).
+// Returns immediately on StateFailed or StateRollback. During StateDownloading,
+// returns an error if DownloadPercent does not advance for stallTimeout.
 //
-// It returns immediately on StateFailed or StateRollback so the test does not
-// burn the full timeout when an upgrade genuinely fails. If the test may have
-// a stale UPG_FAILED from a prior upgrade, call WaitForUpgradeInProgress first
-// to confirm the new upgrade has started before calling this function.
-//
-// It also returns nil if UpgradeDetails transitions from an in-progress state
-// to nil, which happens when the watcher finishes its grace period and the
-// coordinator clears UpgradeDetails (StateCompleted maps to nil in status).
-// This prevents burning the full timeout when the polling interval misses the short
-// StateWatching window between agent restart and watcher grace-period expiry. Note: if
-// a rollback also completes between two polls (StateRollback → nil), this path
-// returns nil as well; WaitHealthyAndVersion and WaitForNoWatcher downstream
-// will catch the wrong version or unexpected watcher state in that case.
-//
-// During StateDownloading, it tracks DownloadPercent and returns an error if
-// the percentage does not advance for stallTimeout. Stalls in other states
-// (extracting, replacing) are not detected and rely on the outer timeout.
-// For larger artifacts, increase stallTimeout accordingly.
-//
-// Once this returns nil, a separate WaitForWatcher call is not needed.
-// WaitForNoWatcher is still needed afterwards to confirm the watcher process
-// has actually exited.
-//
-// Use a generous timeout: artifact downloads can take 10+ minutes on slow CI
-// links.
-//
-// This duplicates the polling pattern in waitUpgradeDetailsState
-// (upgradetest/upgrader.go) on purpose. That helper only waits for a target
-// state; it does not fail fast on StateFailed/StateRollback and has no download
-// stall detection, both of which this function needs.
+// Callers must ensure an upgrade is already in progress before calling this
+// (e.g. via WaitForUpgradeInProgress) — nil details are treated as completion.
 func WaitForWatchingState(ctx context.Context, f *atesting.Fixture, timeout time.Duration, interval time.Duration, stallTimeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -78,8 +49,6 @@ func WaitForWatchingState(ctx context.Context, f *atesting.Fixture, timeout time
 	defer ticker.Stop()
 
 	var lastState details.State
-	var lastErr error
-	var sawInProgress bool
 	var lastPercent float64
 	var lastProgressAt time.Time
 
@@ -87,34 +56,16 @@ func WaitForWatchingState(ctx context.Context, f *atesting.Fixture, timeout time
 		select {
 		case <-ctx.Done():
 			if lastState != "" {
-				return fmt.Errorf("upgrade did not reach %s, last observed state: %s: %w", details.StateWatching, lastState, errors.Join(lastErr, ctx.Err()))
-			}
-			if lastErr != nil {
-				return fmt.Errorf("upgrade did not reach %s: %w", details.StateWatching, errors.Join(lastErr, ctx.Err()))
+				return fmt.Errorf("upgrade did not reach %s, last state: %s: %w", details.StateWatching, lastState, ctx.Err())
 			}
 			return fmt.Errorf("upgrade did not reach %s: %w", details.StateWatching, ctx.Err())
 		case <-ticker.C:
-			// Note: ExecStatus retries internally for up to ~1 minute, so the
-			// effective poll cadence may be longer than interval when the agent
-			// is restarting. Stall timing is based on wall-clock, not tick count.
 			status, err := f.ExecStatus(ctx)
 			if err != nil || status.IsZero() {
-				// Status may be briefly unavailable during agent restart; retry.
-				if err != nil {
-					lastErr = err
-				} else {
-					lastErr = nil // transient zero status; don't carry over a prior error
-				}
 				continue
 			}
-			lastErr = nil
 			if status.UpgradeDetails == nil {
-				// If the upgrade was previously in progress, nil means the watcher
-				// completed its grace period and the coordinator cleared UpgradeDetails.
-				if sawInProgress {
-					return nil
-				}
-				continue
+				return nil // coordinator cleared details: upgrade completed
 			}
 
 			state := status.UpgradeDetails.State
@@ -128,15 +79,14 @@ func WaitForWatchingState(ctx context.Context, f *atesting.Fixture, timeout time
 				if errMsg == "" {
 					errMsg = fmt.Sprintf("failed from state %s", status.UpgradeDetails.Metadata.FailedState)
 				}
-				return fmt.Errorf("upgrade failed while waiting for %s: %s", details.StateWatching, errMsg)
+				return fmt.Errorf("upgrade failed: %s", errMsg)
 			case details.StateRollback:
 				errMsg := status.UpgradeDetails.Metadata.ErrorMsg
 				if errMsg == "" {
 					errMsg = fmt.Sprintf("rollback from state %s", status.UpgradeDetails.Metadata.FailedState)
 				}
-				return fmt.Errorf("upgrade watcher triggered rollback while waiting for %s: %s", details.StateWatching, errMsg)
+				return fmt.Errorf("upgrade rolled back: %s", errMsg)
 			case details.StateDownloading:
-				sawInProgress = true
 				pct := status.UpgradeDetails.Metadata.DownloadPercent
 				if lastProgressAt.IsZero() || pct != lastPercent {
 					lastPercent = pct
@@ -144,26 +94,14 @@ func WaitForWatchingState(ctx context.Context, f *atesting.Fixture, timeout time
 				} else if time.Since(lastProgressAt) > stallTimeout {
 					return fmt.Errorf("download stalled at %.1f%% for %s", lastPercent*100, time.Since(lastProgressAt).Round(time.Second))
 				}
-			default:
-				sawInProgress = true
 			}
 		}
 	}
 }
 
-// WaitForUpgradeInProgress polls until UpgradeDetails.State is non-nil and
-// not StateFailed. Any other state (including StateRollback) is treated as
-// in-progress; WaitForWatchingState will fail fast on StateRollback if the
-// caller invokes it next. Use this before WaitForWatchingState when a prior
-// upgrade may have left a stale UPG_FAILED in the agent status that would
-// otherwise cause WaitForWatchingState to fail immediately. Requires the
-// running agent to be >= 8.12.0 for UpgradeDetails to appear in status.
-//
-// Note: if the new upgrade fails fast (before the poller observes a non-failed
-// state), this function will time out rather than return an error. In that
-// case the failure will only surface as a generic timeout message. Use this
-// function only when a stale UPG_FAILED is expected; otherwise call
-// WaitForWatchingState directly, which fails fast on StateFailed.
+// WaitForUpgradeInProgress polls until UpgradeDetails is non-nil and not
+// StateFailed. Use before WaitForWatchingState when a prior upgrade may have
+// left a stale UPG_FAILED that would otherwise cause an immediate failure.
 func WaitForUpgradeInProgress(ctx context.Context, f *atesting.Fixture, timeout time.Duration, interval time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -171,26 +109,15 @@ func WaitForUpgradeInProgress(ctx context.Context, f *atesting.Fixture, timeout 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	var lastErr error
-
 	for {
 		select {
 		case <-ctx.Done():
-			if lastErr != nil {
-				return fmt.Errorf("upgrade did not start: %w", errors.Join(lastErr, ctx.Err()))
-			}
 			return fmt.Errorf("upgrade did not start: %w", ctx.Err())
 		case <-ticker.C:
 			status, err := f.ExecStatus(ctx)
 			if err != nil || status.IsZero() {
-				if err != nil {
-					lastErr = err
-				} else {
-					lastErr = nil
-				}
 				continue
 			}
-			lastErr = nil
 			if status.UpgradeDetails == nil || status.UpgradeDetails.State == details.StateFailed {
 				continue
 			}

--- a/testing/upgradetest/watcher.go
+++ b/testing/upgradetest/watcher.go
@@ -48,11 +48,16 @@ func ConfigureFastWatcher(ctx context.Context, f *atesting.Fixture) error {
 // This prevents a 15-minute hang when the polling interval misses the short
 // StateWatching window between agent restart and watcher completion.
 //
+// During StateDownloading, it tracks DownloadPercent and returns an error if
+// the percentage does not advance for stallTimeout. This catches a stalled
+// download without waiting for the full timeout. For larger artifacts, increase
+// stallTimeout accordingly.
+//
 // Once this returns nil, a separate WaitForWatcher call is not needed.
 //
 // Use a generous timeout: artifact downloads can take 10+ minutes on slow CI
 // links.
-func WaitForWatchingState(ctx context.Context, f *atesting.Fixture, timeout time.Duration, interval time.Duration) error {
+func WaitForWatchingState(ctx context.Context, f *atesting.Fixture, timeout time.Duration, interval time.Duration, stallTimeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -62,6 +67,8 @@ func WaitForWatchingState(ctx context.Context, f *atesting.Fixture, timeout time
 	var lastState details.State
 	var lastErr error
 	var sawInProgress bool
+	var lastPercent float64
+	var lastProgressAt time.Time
 
 	for {
 		select {
@@ -107,6 +114,15 @@ func WaitForWatchingState(ctx context.Context, f *atesting.Fixture, timeout time
 					errMsg = fmt.Sprintf("rollback from state %s", status.UpgradeDetails.Metadata.FailedState)
 				}
 				return fmt.Errorf("upgrade watcher triggered rollback while waiting for %s: %s", details.StateWatching, errMsg)
+			case details.StateDownloading:
+				sawInProgress = true
+				pct := status.UpgradeDetails.Metadata.DownloadPercent
+				if lastProgressAt.IsZero() || pct > lastPercent {
+					lastPercent = pct
+					lastProgressAt = time.Now()
+				} else if time.Since(lastProgressAt) > stallTimeout {
+					return fmt.Errorf("download stalled at %.1f%% for %s", lastPercent*100, stallTimeout)
+				}
 			default:
 				sawInProgress = true
 			}

--- a/testing/upgradetest/watcher.go
+++ b/testing/upgradetest/watcher.go
@@ -6,6 +6,7 @@ package upgradetest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -35,7 +36,9 @@ func ConfigureFastWatcher(ctx context.Context, f *atesting.Fixture) error {
 }
 
 // WaitForWatchingState polls UpgradeDetails.State until the upgrade reaches
-// StateWatching or the timeout is exceeded.
+// StateWatching or the timeout is exceeded. Both the start agent and the target
+// agent must be >= 8.12.0 for UpgradeDetails to appear in status; older agents
+// always return nil details and this function will time out.
 //
 // It returns immediately on StateFailed or StateRollback so the test does not
 // burn the full timeout when an upgrade genuinely fails. If the test may have
@@ -45,18 +48,28 @@ func ConfigureFastWatcher(ctx context.Context, f *atesting.Fixture) error {
 // It also returns nil if UpgradeDetails transitions from an in-progress state
 // to nil, which happens when the watcher finishes its grace period and the
 // coordinator clears UpgradeDetails (StateCompleted maps to nil in status).
-// This prevents a 15-minute hang when the polling interval misses the short
-// StateWatching window between agent restart and watcher completion.
+// This prevents burning the full timeout when the polling interval misses the short
+// StateWatching window between agent restart and watcher grace-period expiry. Note: if
+// a rollback also completes between two polls (StateRollback → nil), this path
+// returns nil as well; WaitHealthyAndVersion and WaitForNoWatcher downstream
+// will catch the wrong version or unexpected watcher state in that case.
 //
 // During StateDownloading, it tracks DownloadPercent and returns an error if
-// the percentage does not advance for stallTimeout. This catches a stalled
-// download without waiting for the full timeout. For larger artifacts, increase
-// stallTimeout accordingly.
+// the percentage does not advance for stallTimeout. Stalls in other states
+// (extracting, replacing) are not detected and rely on the outer timeout.
+// For larger artifacts, increase stallTimeout accordingly.
 //
 // Once this returns nil, a separate WaitForWatcher call is not needed.
+// WaitForNoWatcher is still needed afterwards to confirm the watcher process
+// has actually exited.
 //
 // Use a generous timeout: artifact downloads can take 10+ minutes on slow CI
 // links.
+//
+// This duplicates the polling pattern in waitUpgradeDetailsState
+// (upgradetest/upgrader.go) on purpose. That helper only waits for a target
+// state; it does not fail fast on StateFailed/StateRollback and has no download
+// stall detection, both of which this function needs.
 func WaitForWatchingState(ctx context.Context, f *atesting.Fixture, timeout time.Duration, interval time.Duration, stallTimeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -74,19 +87,27 @@ func WaitForWatchingState(ctx context.Context, f *atesting.Fixture, timeout time
 		select {
 		case <-ctx.Done():
 			if lastState != "" {
-				return fmt.Errorf("timed out waiting for upgrade to reach %s, last observed state: %s: %w", details.StateWatching, lastState, ctx.Err())
+				return fmt.Errorf("upgrade did not reach %s, last observed state: %s: %w", details.StateWatching, lastState, errors.Join(lastErr, ctx.Err()))
 			}
 			if lastErr != nil {
-				return fmt.Errorf("timed out waiting for upgrade to reach %s: %w", details.StateWatching, lastErr)
+				return fmt.Errorf("upgrade did not reach %s: %w", details.StateWatching, errors.Join(lastErr, ctx.Err()))
 			}
-			return fmt.Errorf("timed out waiting for upgrade to reach %s: %w", details.StateWatching, ctx.Err())
+			return fmt.Errorf("upgrade did not reach %s: %w", details.StateWatching, ctx.Err())
 		case <-ticker.C:
+			// Note: ExecStatus retries internally for up to ~1 minute, so the
+			// effective poll cadence may be longer than interval when the agent
+			// is restarting. Stall timing is based on wall-clock, not tick count.
 			status, err := f.ExecStatus(ctx)
 			if err != nil || status.IsZero() {
 				// Status may be briefly unavailable during agent restart; retry.
-				lastErr = err
+				if err != nil {
+					lastErr = err
+				} else {
+					lastErr = nil // transient zero status; don't carry over a prior error
+				}
 				continue
 			}
+			lastErr = nil
 			if status.UpgradeDetails == nil {
 				// If the upgrade was previously in progress, nil means the watcher
 				// completed its grace period and the coordinator cleared UpgradeDetails.
@@ -117,11 +138,11 @@ func WaitForWatchingState(ctx context.Context, f *atesting.Fixture, timeout time
 			case details.StateDownloading:
 				sawInProgress = true
 				pct := status.UpgradeDetails.Metadata.DownloadPercent
-				if lastProgressAt.IsZero() || pct > lastPercent {
+				if lastProgressAt.IsZero() || pct != lastPercent {
 					lastPercent = pct
 					lastProgressAt = time.Now()
 				} else if time.Since(lastProgressAt) > stallTimeout {
-					return fmt.Errorf("download stalled at %.1f%% for %s", lastPercent*100, stallTimeout)
+					return fmt.Errorf("download stalled at %.1f%% for %s", lastPercent*100, time.Since(lastProgressAt).Round(time.Second))
 				}
 			default:
 				sawInProgress = true
@@ -131,9 +152,18 @@ func WaitForWatchingState(ctx context.Context, f *atesting.Fixture, timeout time
 }
 
 // WaitForUpgradeInProgress polls until UpgradeDetails.State is non-nil and
-// not StateFailed. Use this before WaitForWatchingState when a prior upgrade
-// may have left a stale UPG_FAILED in the agent status that would otherwise
-// cause WaitForWatchingState to fail immediately.
+// not StateFailed. Any other state (including StateRollback) is treated as
+// in-progress; WaitForWatchingState will fail fast on StateRollback if the
+// caller invokes it next. Use this before WaitForWatchingState when a prior
+// upgrade may have left a stale UPG_FAILED in the agent status that would
+// otherwise cause WaitForWatchingState to fail immediately. Requires the
+// running agent to be >= 8.12.0 for UpgradeDetails to appear in status.
+//
+// Note: if the new upgrade fails fast (before the poller observes a non-failed
+// state), this function will time out rather than return an error. In that
+// case the failure will only surface as a generic timeout message. Use this
+// function only when a stale UPG_FAILED is expected; otherwise call
+// WaitForWatchingState directly, which fails fast on StateFailed.
 func WaitForUpgradeInProgress(ctx context.Context, f *atesting.Fixture, timeout time.Duration, interval time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -141,15 +171,26 @@ func WaitForUpgradeInProgress(ctx context.Context, f *atesting.Fixture, timeout 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
+	var lastErr error
+
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("timed out waiting for upgrade to start: %w", ctx.Err())
+			if lastErr != nil {
+				return fmt.Errorf("upgrade did not start: %w", errors.Join(lastErr, ctx.Err()))
+			}
+			return fmt.Errorf("upgrade did not start: %w", ctx.Err())
 		case <-ticker.C:
 			status, err := f.ExecStatus(ctx)
 			if err != nil || status.IsZero() {
+				if err != nil {
+					lastErr = err
+				} else {
+					lastErr = nil
+				}
 				continue
 			}
+			lastErr = nil
 			if status.UpgradeDetails == nil || status.UpgradeDetails.State == details.StateFailed {
 				continue
 			}


### PR DESCRIPTION
## What does this PR do?

Replaces the upgrade-wait logic in two ESS proxy upgrade tests with a state-aware helper that polls the agent's upgrade status instead of checking for an OS process.

The new helper fails fast (~10s) when an upgrade genuinely fails, and uses a 15-minute timeout to give slow downloads enough time to complete.

## Why is it important?

`TestFleetDownloadProxyURL` was failing in CI. The test downloads a ~448 MB artifact through a proxy chain. On a slow CI link the download was still in progress when the old 5-minute wait expired — the test tore down the proxy and killed the download mid-flight.

The old helper had no awareness of download progress, so it could not distinguish "download still running" from "something went wrong." The new helper knows when the upgrade is progressing and when it has actually failed, so it waits longer only when needed.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~ (test-only change)
- ~~I have made corresponding change to the default configuration files~~ (test-only change)
- ~~I have added tests that prove my fix is effective or that my feature works~~ (the change IS the test fix)
- ~~I have added an entry in `./changelog/fragments`~~ (test-only change, skip-changelog)
- ~~I have added an integration test or an E2E test~~ (the change IS in integration tests)

## Disruptive User Impact

None. Changes are confined to integration test helpers and test files.

## How to test this PR locally

Run the affected tests against a Fleet stack:

```
TEST_DEFINE_PREFIX=... mage integration:single TestFleetDownloadProxyURL
TEST_DEFINE_PREFIX=... mage integration:single TestFleetDownloadAuthUpgrade
```

On CI, trigger with `/test extended`.

## Related issues

- Relates to the `TestFleetDownloadProxyURL` CI failure observed on 2026-06-23.
