### PR TITLE
otel(packetbeat): enable otel as default runtime

### DIFF
--- a/changelog/fragments/1782319332-otel-packetbeat-default-runtime.yaml
+++ b/changelog/fragments/1782319332-otel-packetbeat-default-runtime.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Set OTel as the default runtime for Packetbeat
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/14554

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -80,6 +80,7 @@ func DefaultRuntimeConfig() *RuntimeConfig {
 			InputType: make(map[string]string),
 		},
 		Packetbeat: BeatRuntimeConfig{
+			Default: string(OtelRuntimeManager),
 			// go-ucfg sets this while unpacking, having it in the default makes testing easier
 			InputType: make(map[string]string),
 		},

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -4289,7 +4289,7 @@ func TestDefaultRuntimeConfig(t *testing.T) {
 	assert.Equal(t, map[string]string{}, config.Metricbeat.InputType)
 	assert.Equal(t, "", config.Osquerybeat.Default)
 	assert.Empty(t, config.Osquerybeat.InputType)
-	assert.Equal(t, "", config.Packetbeat.Default)
+	assert.Equal(t, string(OtelRuntimeManager), config.Packetbeat.Default)
 	assert.Empty(t, config.Packetbeat.InputType)
 }
 

--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -186,7 +186,6 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 			assert.True(collect, foundReceiver, "expected a packet (network_traffic) component to be running as beats receiver")
 		}, 2*time.Minute, 5*time.Second, "beat component should be running as beats receiver")
 
-		t.Skip("pbreceiver does not yet produce events, skipping OTel data validation")
 		otelDoc = runner.validateNetworkTrafficEvents(t, ctx, agentStatus.Info.ID, otelSince)
 	})
 


### PR DESCRIPTION
## What does this PR do?

Set Packetbeat.Default to otel in DefaultRuntimeConfig so that packetbeat uses the pbreceiver path by default.

Remove the skip in TestNetworkTraffic/otel to compare documents ingested by process and otel runtimes.


## Why is it important?

Enables packetbeat to use the otel runtime.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## How to test this PR locally

TODO

## Related issues

- For https://github.com/elastic/elastic-agent/issues/14554