### PR TITLE
Enable dependabot for all Go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,9 +35,27 @@ updates:
           - "golang.org/x/*"
       tooling-test:
         patterns:
-          - "github.com/magefile/*"
+          # Test frameworks and helpers
           - "github.com/stretchr/*"
           - "github.com/testcontainers/*"
+          # Helm: only used in k8s integration tests
+          - "helm.sh/helm/*"
+          # Only used in *_test.go files
+          - "github.com/google/pprof"
+          - "github.com/google/go-containerregistry"
+          - "github.com/cavaliergopher/*"
+          - "github.com/blakesmith/*"
+          # Only used in pkg/testing/
+          - "github.com/sajari/*"
+          - "github.com/moby/*"
+      packaging:
+        patterns:
+          # Build tooling: only used in magefile.go, dev-tools/, or tools/tools.go
+          - "github.com/magefile/*"
+          - "github.com/Jeffail/gabs/*"
+          - "github.com/josephspurrier/goversioninfo"
+          - "github.com/rednafi/link-patrol"
+          - "gotest.tools/*"
       misc:
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,20 +12,35 @@ updates:
       - skip-changelog
       - Team:Elastic-Agent-Control-Plane
       - backport-active-all
-    allow:
-      - dependency-name: "github.com/elastic/*"
-      - dependency-name: "helm.sh/helm/*"
-    groups:
-      go-dependencies:
-        patterns:
-          - "github.com/elastic/*"
-          - "helm.sh/helm/*"
     ignore:
+      # beats is a git submodule; bumped separately
       - dependency-name: "github.com/elastic/beats/*"
-      # Otel dependency updates are done in lock-step with Otel core framework updates
-      - dependency-name: "github.com/elastic/opentelemetry-collector-components/*"
-      # elastic/sarama fork should be managed manually to avoid path mismatch issues
+      # elastic/sarama fork must be managed manually to avoid module path mismatch issues
       - dependency-name: "github.com/elastic/sarama"
+      # Otel dependency updates are done in lock-step with the upstream Otel release cycle
+      - dependency-name: "go.opentelemetry.io/*"
+      - dependency-name: "github.com/open-telemetry/*"
+      - dependency-name: "github.com/elastic/opentelemetry-collector-components/*"
+      # k8s dependencies are bumped transitively by Otel dependency updates; do not update independently
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "sigs.k8s.io/*"
+    groups:
+      elastic:
+        patterns:
+          # github.com/elastic/* and go.elastic.co/* cover all Elastic and APM Go packages
+          - "github.com/elastic/*"
+          - "go.elastic.co/*"
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+      tooling-test:
+        patterns:
+          - "github.com/magefile/*"
+          - "github.com/stretchr/*"
+          - "github.com/testcontainers/*"
+      misc:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## What does this PR do?

Enables dependabot for all Go dependencies. Updates run weekly on Mondays and are divided into groups:

### `elastic`
All Elastic and APM Go packages: `github.com/elastic/*` and `go.elastic.co/*`. Excludes `beats` (managed as a git submodule), `elastic/sarama` (requires manualhandling due to module path issues), and `elastic/opentelemetry-collector-components` (see OTel below).

### `golang-x`
The `golang.org/x/*` extended standard library packages.

### `tooling-test`
Dependencies used exclusively in tests or test infrastructure (`*_test.go`, `testing/`, `pkg/testing/`):
- `github.com/stretchr/*` - testify and related assertion libraries                                                                     
- `github.com/testcontainers/*` - Docker-based integration test containers
- `helm.sh/helm/*` - used only in Kubernetes integration tests
- `github.com/google/pprof`, `github.com/google/go-containerregistry` - test-only helpers
- `github.com/cavaliergopher/*`, `github.com/blakesmith/*` - RPM/ar package format tests
- `github.com/sajari/*`, `github.com/moby/*` - `pkg/testing/` utilities

### `packaging`
Dependencies used exclusively in `magefile.go`, `dev-tools/`, or `tools/tools.go`:
- `github.com/magefile/*` - the Mage build tool itself
- `github.com/Jeffail/gabs/*` - JSON parsing in mage download helpers
- `github.com/josephspurrier/goversioninfo` - Windows PE resource generation
- `github.com/rednafi/link-patrol` - link-checking dev tool
- `gotest.tools/*` (gotestsum) - test runner invoked by mage

### `misc`
Catch-all for all other Go dependencies not covered by the groups above.

### Ignored (not updated by Dependabot)
- **OTel** (`go.opentelemetry.io/*`, `github.com/open-telemetry/*`, `github.com/elastic/opentelemetry-collector-components/*`) - updated in lock-step with the
upstream OTel release cycle
- **k8s** (`k8s.io/*`, `sigs.k8s.io/*`) - bumped transitively by OTel dependency updates; updating independently would cause version skew


## Why is it important?

Dependencies should be kept up to date. 

## Related issues

- Closes #14908

