### PR TITLE
fix(otel): route native OTel component debug logs to the events file

### DIFF
--- a/changelog/fragments/1782391711-otel-native-component-logs-to-events.yaml
+++ b/changelog/fragments/1782391711-otel-native-component-logs-to-events.yaml
@@ -1,0 +1,55 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user's deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Route native OTel component debug logs to the events file
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  When running with native OTel components (such as the Elasticsearch exporter),
+  debug-level log lines were written to the main agent log file and could be
+  picked up by Fleet monitoring and shipped to Elasticsearch. These lines can
+  contain customer data — for example, when log_failed_docs_input is enabled,
+  the full document body appears in debug logs.
+
+  Debug-level logs from native OTel components are now written to the events
+  log file instead, which is not collected by Fleet monitoring. Info, warn, and
+  error lines from the same components continue to go to the main log file as
+  before.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/pkg/component/runtime/log_writer.go
+++ b/pkg/component/runtime/log_writer.go
@@ -157,6 +157,12 @@ func (r *logWriter) handleJSON(line string) bool {
 		}
 	}
 	if allowedLvl.Enabled(lvl) {
+		// Unlike beats, native OTel components have no built-in way to distinguish
+		// control plane from data plane logs, so we use log level as a heuristic
+		// where debug lines may contain customer data and info/warn/error are operational.
+		if lvl == zapcore.DebugLevel && isNonBeatsOtelComponentLine(evt) {
+			fields = append(fields, zap.String("log.type", "event"))
+		}
 		_ = r.loggerCore.Write(zapcore.Entry{
 			Level:   lvl,
 			Time:    ts,
@@ -254,4 +260,14 @@ func getUnitId(evt map[string]interface{}) string {
 		}
 	}
 	return ""
+}
+
+func isNonBeatsOtelComponentLine(evt map[string]interface{}) bool {
+	if getStrVal(evt, "otelcol.component.id") == "" {
+		return false
+	}
+	// The "component" field is injected into every beat receiver log line via logging.with_fields
+	// (see internal/pkg/otel/translate/otelconfig.go).
+	_, hasComponent := evt["component"]
+	return !hasComponent
 }

--- a/pkg/component/runtime/log_writer_test.go
+++ b/pkg/component/runtime/log_writer_test.go
@@ -327,6 +327,138 @@ func TestLogWriter(t *testing.T) {
 	}
 }
 
+func TestLogWriterOtelRouting(t *testing.T) {
+	cfg := component.CommandLogSpec{
+		LevelKey:   "log.level",
+		TimeKey:    "@timestamp",
+		TimeFormat: time.RFC3339Nano,
+		MessageKey: "message",
+	}
+	scenarios := []struct {
+		Name  string
+		Line  string
+		Wrote []wrote
+	}{
+		{
+			Name: "native OTel component debug line gets log.type event injected",
+			Line: `{"@timestamp": "2009-11-10T23:00:00Z", "log.level": "debug", "message": "failed to index document", "otelcol.component.id": "elasticsearchexporter"}` + "\n",
+			Wrote: []wrote{
+				{
+					entry: zapcore.Entry{
+						Level:   zapcore.DebugLevel,
+						Time:    parseTime("2009-11-10T23:00:00Z", time.RFC3339Nano),
+						Message: "failed to index document",
+					},
+					fields: []zapcore.Field{
+						zap.String("log.type", "event"),
+						zap.String("otelcol.component.id", "elasticsearchexporter"),
+					},
+				},
+			},
+		},
+		{
+			Name: "native OTel component info line does not get log.type event injected",
+			Line: `{"@timestamp": "2009-11-10T23:00:00Z", "log.level": "info", "message": "Extension is starting", "otelcol.component.id": "elasticsearchexporter"}` + "\n",
+			Wrote: []wrote{
+				{
+					entry: zapcore.Entry{
+						Level:   zapcore.InfoLevel,
+						Time:    parseTime("2009-11-10T23:00:00Z", time.RFC3339Nano),
+						Message: "Extension is starting",
+					},
+					fields: []zapcore.Field{
+						zap.String("otelcol.component.id", "elasticsearchexporter"),
+					},
+				},
+			},
+		},
+		{
+			Name: "native OTel component error line does not get log.type event injected",
+			Line: `{"@timestamp": "2009-11-10T23:00:00Z", "log.level": "error", "message": "bulk indexer flush error", "otelcol.component.id": "elasticsearchexporter"}` + "\n",
+			Wrote: []wrote{
+				{
+					entry: zapcore.Entry{
+						Level:   zapcore.ErrorLevel,
+						Time:    parseTime("2009-11-10T23:00:00Z", time.RFC3339Nano),
+						Message: "bulk indexer flush error",
+					},
+					fields: []zapcore.Field{
+						zap.String("otelcol.component.id", "elasticsearchexporter"),
+					},
+				},
+			},
+		},
+		{
+			Name: "beat-managed OTel component debug line does not get log.type event injected",
+			Line: `{"@timestamp": "2009-11-10T23:00:00Z", "log.level": "debug", "message": "harvester started", "otelcol.component.id": "filebeatreceiver/_agent-component/filestream-default", "component": {"binary": "filebeat", "id": "filestream-default"}}` + "\n",
+			Wrote: []wrote{
+				{
+					entry: zapcore.Entry{
+						Level:   zapcore.DebugLevel,
+						Time:    parseTime("2009-11-10T23:00:00Z", time.RFC3339Nano),
+						Message: "harvester started",
+					},
+					fields: []zapcore.Field{
+						zap.Any("component", map[string]interface{}{"binary": "filebeat", "id": "filestream-default"}),
+						zap.String("otelcol.component.id", "filebeatreceiver/_agent-component/filestream-default"),
+					},
+				},
+			},
+		},
+		{
+			Name: "beat-managed OTel component debug line preserves existing log.type event",
+			Line: `{"@timestamp": "2009-11-10T23:00:00Z", "log.level": "debug", "message": "Publish event", "otelcol.component.id": "filebeatreceiver/_agent-component/filestream-default", "component": {"binary": "filebeat", "id": "filestream-default"}, "log.type": "event"}` + "\n",
+			Wrote: []wrote{
+				{
+					entry: zapcore.Entry{
+						Level:   zapcore.DebugLevel,
+						Time:    parseTime("2009-11-10T23:00:00Z", time.RFC3339Nano),
+						Message: "Publish event",
+					},
+					fields: []zapcore.Field{
+						zap.Any("component", map[string]interface{}{"binary": "filebeat", "id": "filestream-default"}),
+						zap.String("log.type", "event"),
+						zap.String("otelcol.component.id", "filebeatreceiver/_agent-component/filestream-default"),
+					},
+				},
+			},
+		},
+		{
+			Name: "line without otelcol.component.id at debug level does not get log.type event injected",
+			Line: `{"@timestamp": "2009-11-10T23:00:00Z", "log.level": "debug", "message": "some agent debug message"}` + "\n",
+			Wrote: []wrote{
+				{
+					entry: zapcore.Entry{
+						Level:   zapcore.DebugLevel,
+						Time:    parseTime("2009-11-10T23:00:00Z", time.RFC3339Nano),
+						Message: "some agent debug message",
+					},
+					fields: []zapcore.Field{},
+				},
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			c := &captureCore{}
+			w := newLogWriter(c, cfg, zapcore.DebugLevel, nil, logSourceStdout)
+			n, err := w.Write([]byte(scenario.Line))
+			require.NoError(t, err)
+			require.Equal(t, len([]byte(scenario.Line)), n)
+			require.Len(t, c.wrote, len(scenario.Wrote))
+			for i := 0; i < len(scenario.Wrote); i++ {
+				e := scenario.Wrote[i]
+				o := c.wrote[i]
+				assert.Equal(t, e.entry, o.entry)
+				sortFields(e.fields)
+				sortFields(o.fields)
+				assert.EqualValues(t, e.fields, o.fields)
+			}
+		})
+	}
+}
+
 type captureCore struct {
 	wrote []wrote
 }

--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -1632,15 +1632,42 @@ agent.logging.stderr: true
 		},
 	}
 
-	findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
-	defer findCancel()
+	require.Never(t,
+		func() bool {
+			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer findCancel()
 
-	docs, err := estools.GetLogsForIndexWithContext(findCtx, info.ESClient, "logs-elastic_agent*", map[string]any{
-		"log.type": "event",
-	})
+			docs, err := estools.PerformQueryForRawQuery(findCtx, rawQuery, "logs-elastic_agent*", info.ESClient)
+			if err != nil {
+				t.Logf("error querying for event logs in ES: %v", err)
+				return false
+			}
+			return docs.Hits.Total.Value > 0
+		},
+		1*time.Minute, 5*time.Second,
+		"expected no event logs to be shipped to ES")
 
-	assert.NoError(t, err)
-	assert.Zero(t, docs.Hits.Total.Value)
+	// Check 3:
+	// Ensure debug logs from the elasticsearch exporter are captured in the events log file.
+	foundESExporterDebugLine := false
+	for _, line := range strings.Split(readEventLogFile(t, fixture), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		componentID, _ := entry["otelcol.component.id"].(string)
+		if componentID != "elasticsearch/_agent-component/default" {
+			continue
+		}
+		if level, _ := entry["log.level"].(string); level == "debug" {
+			foundESExporterDebugLine = true
+			break
+		}
+	}
+	assert.True(t, foundESExporterDebugLine, "expected elasticsearch exporter debug lines in events log file")
 }
 
 func TestSensitiveIncludeSourceOnError(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Native (non-Beats) OTel components can't distinguish operational logs from logs that may contain customer data. As a heuristic, the agent now routes their debug-level lines to the events log file (not collected by Fleet) instead of the main log. Info, warn and error lines continue to go to the main log as before.

Without the fix, all lines from native OTel components go to the main log and get shipped:
```
# logs/elastic-agent-20260625.ndjson
{"log.level":"debug","otelcol.component.id":"filebeatreceiver/_agent-component/filestream-default/e2e","component":{"binary":"filebeat","id":"filestream-default"},"log.type":"event","message":"Publish event: {...}"}
{"log.level":"debug","otelcol.component.id":"elasticsearch/_agent-component/default","message":"failed to index document; input: {\"message\":\"sensitive customer data\"}"}
{"log.level":"warn","otelcol.component.id":"elasticsearch/_agent-component/default","message":"telemetry::log_failed_docs_input is enabled, and may expose sensitive data in logs"}
```

With the fix, beat receiver event lines and native OTel debug lines go to the events file; operational lines stay in the main log:
```
# logs/events/elastic-agent-event-log-20260625.ndjson
{"log.level":"debug","otelcol.component.id":"filebeatreceiver/_agent-component/filestream-default/e2e","component":{"binary":"filebeat","id":"filestream-default"},"log.type":"event","message":"Publish event: {...}"}
{"log.level":"debug","log.type":"event","otelcol.component.id":"elasticsearch/_agent-component/default","message":"failed to index document; input: {\"message\":\"sensitive customer data\"}"}

# logs/elastic-agent-20260625.ndjson
{"log.level":"warn","otelcol.component.id":"elasticsearch/_agent-component/default","message":"telemetry::log_failed_docs_input is enabled, and may expose sensitive data in logs"}
```

## Why is it important?

Debug logs from native OTel components can contain customer data (e.g. document bodies on indexing failure). Without this fix they are shipped to Fleet monitoring.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

None.

## How to test this PR locally
Run the following integration tests:
```
SNAPSHOT=true mage -v integration:single TestSensitiveLogsESExporter
SNAPSHOT=true mage -v integration:single TestEventLogOutputConfiguredViaFleet
```

## Related issues

- Relates to #8845
