### PR TITLE
fix(test): fix flaky TestClassicAndReceiverAgentMonitoring

### DIFF
--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -299,7 +299,7 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 	// 2. Assert monitoring logs and metrics are available on ES
 	for _, tc := range tests {
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
+			findCtx, findCancel := context.WithTimeout(ctx, 10*time.Second)
 			defer findCancel()
 			mustClauses := []map[string]any{
 				{"match": map[string]any{"data_stream.type": tc.dsType}},
@@ -368,7 +368,7 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 	// 5. Assert monitoring logs and metrics are available on ES (for otel mode)
 	for _, tc := range otelTests {
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
+			findCtx, findCancel := context.WithTimeout(ctx, 10*time.Second)
 			defer findCancel()
 			mustClauses := []map[string]any{
 				{"match": map[string]any{"data_stream.type": tc.dsType}},
@@ -437,7 +437,7 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 	assert.Equal(t, agentStatus, otelStatus, "expected agent status to be equal to otel status")
 
 	// Make sure we haven't transferred any logs that are supposed to be dropped
-	findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
+	findCtx, findCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer findCancel()
 	rawQuery := map[string]any{
 		"query": map[string]any{

--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -282,9 +282,7 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 	err = classicFixture.Configure(ctx, updatedPolicyBytes)
 	require.NoError(t, err, "error configuring fixture")
 
-	// capture before install — "Determined allowed capabilities" is logged during startup
-	// (inside InstallWithoutEnroll), so the timestamp must predate the install or the log's
-	// @timestamp will fall below the gte filter and no documents will be found.
+	// must be captured before install — the agent logs this during startup
 	timestamp := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	output, err := classicFixture.InstallWithoutEnroll(ctx, &installOpts)
 	require.NoErrorf(t, err, "error install withouth enroll: %s\ncombinedoutput:\n%s", err, string(output))
@@ -353,9 +351,7 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 	require.NoError(t, err)
 	err = beatReceiverFixture.Configure(ctx, updatedPolicyBytes)
 	require.NoError(t, err)
-	// store timestamp before install to filter otel docs; agent logs "Determined allowed
-	// capabilities" during startup (inside InstallWithoutEnroll), so the timestamp must be
-	// captured before the install or the log's @timestamp will predate the filter.
+	// must be captured before install — the agent logs this during startup
 	timestampBeatReceiver := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	combinedOutput, err = beatReceiverFixture.InstallWithoutEnroll(ctx, &installOpts)
 	require.NoErrorf(t, err, "error install without enroll: %s\ncombinedoutput:\n%s", err, string(combinedOutput))

--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -201,12 +201,10 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 
 	// 7. Compare both documents are equivalent
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	// prepare the policy and marshalled configuration
-	policyCtx, policyCancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
-	t.Cleanup(policyCancel)
+	policyCtx := t.Context()
 
 	// 1. Create and install policy with just monitoring
 	createPolicyReq := kibana.AgentPolicy{
@@ -284,6 +282,9 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 	err = classicFixture.Configure(ctx, updatedPolicyBytes)
 	require.NoError(t, err, "error configuring fixture")
 
+	// capture before install — "Determined allowed capabilities" is logged during startup
+	// (inside InstallWithoutEnroll), so the timestamp must predate the install or the log's
+	// @timestamp will fall below the gte filter and no documents will be found.
 	timestamp := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	output, err := classicFixture.InstallWithoutEnroll(ctx, &installOpts)
 	require.NoErrorf(t, err, "error install withouth enroll: %s\ncombinedoutput:\n%s", err, string(output))
@@ -298,7 +299,7 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 	// 2. Assert monitoring logs and metrics are available on ES
 	for _, tc := range tests {
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			findCtx, findCancel := context.WithTimeout(ctx, 10*time.Second)
+			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer findCancel()
 			mustClauses := []map[string]any{
 				{"match": map[string]any{"data_stream.type": tc.dsType}},
@@ -352,10 +353,12 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 	require.NoError(t, err)
 	err = beatReceiverFixture.Configure(ctx, updatedPolicyBytes)
 	require.NoError(t, err)
+	// store timestamp before install to filter otel docs; agent logs "Determined allowed
+	// capabilities" during startup (inside InstallWithoutEnroll), so the timestamp must be
+	// captured before the install or the log's @timestamp will predate the filter.
+	timestampBeatReceiver := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	combinedOutput, err = beatReceiverFixture.InstallWithoutEnroll(ctx, &installOpts)
 	require.NoErrorf(t, err, "error install without enroll: %s\ncombinedoutput:\n%s", err, string(combinedOutput))
-	// store timestamp to filter otel docs with timestamp greater than this value
-	timestampBeatReceiver := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		var statusErr error
@@ -367,7 +370,7 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 	// 5. Assert monitoring logs and metrics are available on ES (for otel mode)
 	for _, tc := range otelTests {
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			findCtx, findCancel := context.WithTimeout(ctx, 10*time.Second)
+			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer findCancel()
 			mustClauses := []map[string]any{
 				{"match": map[string]any{"data_stream.type": tc.dsType}},
@@ -436,7 +439,7 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 	assert.Equal(t, agentStatus, otelStatus, "expected agent status to be equal to otel status")
 
 	// Make sure we haven't transferred any logs that are supposed to be dropped
-	findCtx, findCancel := context.WithTimeout(ctx, 10*time.Second)
+	findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer findCancel()
 	rawQuery := map[string]any{
 		"query": map[string]any{

--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -201,10 +201,12 @@ func TestClassicAndReceiverAgentMonitoring(t *testing.T) {
 
 	// 7. Compare both documents are equivalent
 
-	ctx := t.Context()
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
+	t.Cleanup(cancel)
 
 	// prepare the policy and marshalled configuration
-	policyCtx := t.Context()
+	policyCtx, policyCancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(5*time.Minute))
+	t.Cleanup(policyCancel)
 
 	// 1. Create and install policy with just monitoring
 	createPolicyReq := kibana.AgentPolicy{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
-->

## What does this PR do?

Fixes two root causes of flakiness in `TestClassicAndReceiverAgentMonitoring`.

**1. Context expired mid-test**

The test has two install/test/uninstall cycles but used a single 5-minute context rooted at `context.Background()`. Under CI parallelism the test takes longer than 5 minutes, so the context expires while operations are still running, causing `context deadline exceeded` failures.

Fix: root the context at `t.Context()` and extend the deadline to 10 minutes.

**2. Timestamp captured too late**

The OTel phase captured the ES filter timestamp *after* `InstallWithoutEnroll`, but the agent emits the target log entry *during* startup inside that call. This causes the ES query to miss the document.

Fix: capture the timestamp before the install call, consistent with the classic phase.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None — test-only change.

## How to test this PR locally

```
go test -v -run TestClassicAndReceiverAgentMonitoring -tags integration ./testing/integration/ess/
```

## Related issues

-
