### PR TITLE
Move metrics conversion to connector

### DIFF
--- a/internal/edot/connectors/elasticmonitoring/connector.go
+++ b/internal/edot/connectors/elasticmonitoring/connector.go
@@ -1,0 +1,137 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package elasticmonitoring
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/elastic/beats/v7/libbeat/otel/otelmap"
+	"github.com/elastic/elastic-agent-libs/mapstr"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/connector"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+type monitoringConnector struct {
+	logger   *zap.Logger
+	config   *Config
+	consumer consumer.Logs
+}
+
+func createConnector(
+	_ context.Context,
+	set connector.Settings,
+	baseCfg component.Config,
+	next consumer.Logs,
+) (connector.Metrics, error) {
+	cfg := baseCfg.(*Config)
+	return &monitoringConnector{
+		logger:   set.Logger,
+		config:   cfg,
+		consumer: next,
+	}, nil
+}
+
+func (c *monitoringConnector) Start(_ context.Context, _ component.Host) error { return nil }
+func (c *monitoringConnector) Shutdown(_ context.Context) error                { return nil }
+
+func (c *monitoringConnector) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
+func (c *monitoringConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	exporterMetricsMap := convertScopeMetrics(md)
+	for exporter, metrics := range exporterMetricsMap {
+		componentID, ok := c.config.ExporterNames[exporter]
+		if !ok {
+			c.logger.Warn("Reporting metrics for exporter with no specified component name", zap.String("exporter_id", exporter))
+			componentID = exporter
+		}
+		c.sendExporterMetricsEvent(ctx, componentID, metrics)
+	}
+
+	componentMetrics := collectComponentInputMetrics(md)
+	for compID, compData := range componentMetrics {
+		if compData.beatType != "filebeat" {
+			continue
+		}
+		for _, inputMetrics := range compData.inputs {
+			c.sendInputMetricsEvent(ctx, compID, compData.beatType, inputMetrics)
+		}
+	}
+
+	receiverPipelineMetrics := collectReceiverMetrics(md)
+	for compID, fields := range receiverPipelineMetrics {
+		c.sendReceiverPipelineMetricsEvent(ctx, compID, fields)
+	}
+
+	return nil
+}
+
+func (c *monitoringConnector) sendExporterMetricsEvent(ctx context.Context, componentID string, metrics exporterMetrics) {
+	beatEvent := mapstr.M(c.config.EventTemplate.Fields).Clone()
+	addMetricsToEventFields(c.logger, metrics, &beatEvent)
+	_, _ = beatEvent.Put("component.id", componentID)
+	c.sendLogRecord(ctx, beatEvent, componentID)
+}
+
+func (c *monitoringConnector) sendReceiverPipelineMetricsEvent(ctx context.Context, componentID string, fields map[string]any) {
+	beatEvent := mapstr.M(c.config.EventTemplate.Fields).Clone()
+	_, _ = beatEvent.Put("component.id", componentID)
+	for k, v := range fields {
+		_, _ = beatEvent.Put(k, v)
+	}
+	c.sendLogRecord(ctx, beatEvent, componentID)
+}
+
+func (c *monitoringConnector) sendInputMetricsEvent(ctx context.Context, componentID string, beatType string, inputMetrics map[string]any) {
+	beatEvent := mapstr.M(c.config.InputEventTemplate.Fields).Clone()
+	_, _ = beatEvent.Put("component.id", componentID)
+	namespace := beatType + "_input"
+	for k, v := range inputMetrics {
+		_, _ = beatEvent.Put(namespace+"."+k, v)
+	}
+	c.sendLogRecord(ctx, beatEvent, componentID)
+}
+
+func (c *monitoringConnector) sendLogRecord(ctx context.Context, beatEvent mapstr.M, componentID string) {
+	pLogs := plog.NewLogs()
+	resourceLogs := pLogs.ResourceLogs().AppendEmpty()
+	sourceLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	logRecords := sourceLogs.LogRecords()
+	logRecord := logRecords.AppendEmpty()
+
+	sourceLogs.Scope().Attributes().PutStr("elastic.mapping.mode", "bodymap")
+
+	now := time.Now()
+	beatEvent["@timestamp"] = now
+	timestamp := pcommon.NewTimestampFromTime(now)
+	logRecord.SetTimestamp(timestamp)
+	logRecord.SetObservedTimestamp(timestamp)
+
+	if val, _ := beatEvent.GetValue("data_stream"); val != nil {
+		for _, subField := range []string{"dataset", "namespace", "type"} {
+			value, err := beatEvent.GetValue("data_stream." + subField)
+			if vStr, ok := value.(string); ok && err == nil {
+				logRecord.Attributes().PutStr("data_stream."+subField, vStr)
+			}
+		}
+	}
+
+	if err := otelmap.FromMapstr(logRecord.Body().SetEmptyMap(), beatEvent); err != nil {
+		c.logger.Error("couldn't convert map to plog.Log, some fields might be missing", zap.Error(err))
+	}
+
+	if err := c.consumer.ConsumeLogs(ctx, pLogs); err != nil {
+		c.logger.Error("error sending internal telemetry log record", zap.String("component.id", componentID), zap.Error(err))
+	}
+}

--- a/internal/edot/connectors/elasticmonitoring/convert.go
+++ b/internal/edot/connectors/elasticmonitoring/convert.go
@@ -1,0 +1,435 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package elasticmonitoring
+
+import (
+	"strings"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+
+	"github.com/elastic/elastic-agent-libs/mapstr"
+)
+
+// exporterMetrics summarises current metric values for a particular exporter.
+type exporterMetrics struct {
+	queueSize     *int64
+	queueCapacity *int64
+
+	sentLogs    *int64
+	sentSpans   *int64
+	sentMetrics *int64
+
+	failedLogs    *int64
+	failedSpans   *int64
+	failedMetrics *int64
+
+	docsProcessed *int64
+	docsRetried   *int64
+	bulkRequests  *int64
+	flushedBytes  *int64
+}
+
+const (
+	beatsQueueFilledEventsKey   = "beat.stats.libbeat.pipeline.queue.filled.events"
+	beatsQueueMaxEventsKey      = "beat.stats.libbeat.pipeline.queue.max_events"
+	beatsQueueFilledPctKey      = "beat.stats.libbeat.pipeline.queue.filled.pct"
+	beatsOutputEventsTotalKey   = "beat.stats.libbeat.output.events.total"
+	beatsOutputEventsActiveKey  = "beat.stats.libbeat.output.events.active"
+	beatsOutputEventsAckedKey   = "beat.stats.libbeat.output.events.acked"
+	beatsOutputEventsDroppedKey = "beat.stats.libbeat.output.events.dropped"
+	beatsOutputEventsFailedKey  = "beat.stats.libbeat.output.events.failed"
+	beatsOutputEventsBatchesKey = "beat.stats.libbeat.output.events.batches"
+	beatsOutputWriteBytesKey    = "beat.stats.libbeat.output.write.bytes"
+
+	otelQueueCapacityKey       = "otelcol_exporter_queue_capacity"
+	otelQueueSizeKey           = "otelcol_exporter_queue_size"
+	otelSentLogsKey            = "otelcol_exporter_sent_log_records"
+	otelSentSpansKey           = "otelcol_exporter_sent_spans"
+	otelSentMetricsKey         = "otelcol_exporter_sent_metric_points"
+	otelFailedLogsKey          = "otelcol_exporter_send_failed_log_records"
+	otelFailedSpansKey         = "otelcol_exporter_send_failed_spans"
+	otelFailedMetricsKey       = "otelcol_exporter_send_failed_metric_points"
+	otelDocsProcessedKey       = "otelcol.elasticsearch.docs.processed"
+	otelDocsRetriedKey         = "otelcol.elasticsearch.docs.retried"
+	otelDocsRetriedHTTPRequest = "otelcol.elasticsearch.docs.retried_http_request"
+	otelBulkRequestsKey        = "otelcol.elasticsearch.bulk_requests.count"
+	otelFlushedBytesKey        = "otelcol.elasticsearch.flushed.bytes"
+
+	otelComponentIDKey   = "otelcol.component.id"
+	otelComponentKindKey = "otelcol.component.kind"
+
+	otelInputIDKey   = "input_id"
+	otelInputTypeKey = "input_type"
+
+	// registryBridgeScopeName is the instrumentation scope name used by the
+	// RegistryBridge in beats, which bridges Beats monitoring registries into
+	// OTel async instruments. Metrics from this scope carry a "receiver"
+	// data point attribute containing the OTel component ID.
+	registryBridgeScopeName = "github.com/elastic/beats/v7/x-pack/otel/telemetry"
+	// registryBridgeReceiverKey is the data point attribute key set by the
+	// RegistryBridge to identify which Beat receiver emitted the metric.
+	registryBridgeReceiverKey = "receiver"
+)
+
+// componentInputData holds the per-input metrics for a single agent component,
+// along with the beat type derived from the OTel receiver component ID.
+type componentInputData struct {
+	beatType string
+	inputs   map[string]map[string]any // inputID -> fields
+}
+
+// add adds the integer referenced by value, if it isn't nil, to the given
+// referenced sum, initialising the sum if needed.
+func add(target **int64, value *int64) {
+	if value != nil {
+		if *target != nil {
+			**target += *value
+		} else {
+			v := *value
+			*target = &v
+		}
+	}
+}
+
+// set sets the referenced pointer to contain the given value, if it isn't nil.
+func set(target **int64, value *int64) {
+	if value != nil {
+		v := *value
+		*target = &v
+	}
+}
+
+// addValue records the named OTel Collector internal telemetry variable into em.
+func addValue(em *exporterMetrics, name string, value int64) {
+	switch name {
+	case otelQueueSizeKey:
+		add(&em.queueSize, &value)
+	case otelQueueCapacityKey:
+		set(&em.queueCapacity, &value)
+	case otelSentLogsKey:
+		add(&em.sentLogs, &value)
+	case otelSentSpansKey:
+		add(&em.sentSpans, &value)
+	case otelSentMetricsKey:
+		add(&em.sentMetrics, &value)
+	case otelFailedLogsKey:
+		add(&em.failedLogs, &value)
+	case otelFailedSpansKey:
+		add(&em.failedSpans, &value)
+	case otelFailedMetricsKey:
+		add(&em.failedMetrics, &value)
+	case otelDocsProcessedKey:
+		add(&em.docsProcessed, &value)
+	case otelDocsRetriedKey, otelDocsRetriedHTTPRequest:
+		add(&em.docsRetried, &value)
+	case otelBulkRequestsKey:
+		add(&em.bulkRequests, &value)
+	case otelFlushedBytesKey:
+		add(&em.flushedBytes, &value)
+	}
+}
+
+// agentComponentID extracts the agent component ID from an OTel component ID.
+// OTel component IDs follow the pattern "{type}/_agent-component/{compID}".
+//
+// TODO(blakerouse): move the "_agent-component/" naming convention to a shared
+// module so this package does not duplicate knowledge from the config translation layer.
+func agentComponentID(otelComponentID string) string {
+	const prefix = "_agent-component/"
+	_, after, ok := strings.Cut(otelComponentID, prefix)
+	if !ok {
+		return ""
+	}
+	return after
+}
+
+// beatTypeFromOtelID extracts the beat type from an OTel component ID by
+// stripping the "receiver" suffix from the component type
+// (e.g. "filebeatreceiver" → "filebeat").
+func beatTypeFromOtelID(otelComponentID string) string {
+	var id component.ID
+	if err := id.UnmarshalText([]byte(otelComponentID)); err != nil {
+		return ""
+	}
+	return strings.TrimSuffix(id.Type().String(), "receiver")
+}
+
+func mapstrSetWithErrorLog(logger *zap.Logger, event *mapstr.M, key string, value any) {
+	_, err := event.Put(key, value)
+	if err != nil {
+		logger.Error("Couldn't set key while generating metrics event",
+			zap.String("key", key), zap.Error(err))
+	}
+}
+
+// addMetricsToEventFields writes exporterMetrics values as fields on the event,
+// using the legacy schema for Beats metrics.
+func addMetricsToEventFields(logger *zap.Logger, em exporterMetrics, event *mapstr.M) {
+	if em.queueSize != nil {
+		mapstrSetWithErrorLog(logger, event, beatsQueueFilledEventsKey, *em.queueSize)
+	}
+	if em.queueCapacity != nil {
+		mapstrSetWithErrorLog(logger, event, beatsQueueMaxEventsKey, *em.queueCapacity)
+	}
+	if em.queueSize != nil && em.queueCapacity != nil && *em.queueCapacity > 0 {
+		filled := float64(*em.queueSize) / float64(*em.queueCapacity)
+		mapstrSetWithErrorLog(logger, event, beatsQueueFilledPctKey, filled)
+	}
+	var sentTotal int64
+	if em.sentLogs != nil {
+		sentTotal += *em.sentLogs
+	}
+	if em.sentSpans != nil {
+		sentTotal += *em.sentSpans
+	}
+	if em.sentMetrics != nil {
+		sentTotal += *em.sentMetrics
+	}
+	mapstrSetWithErrorLog(logger, event, beatsOutputEventsAckedKey, sentTotal)
+
+	var failedTotal int64
+	if em.failedLogs != nil {
+		failedTotal += *em.failedLogs
+	}
+	if em.failedSpans != nil {
+		failedTotal += *em.failedSpans
+	}
+	if em.failedMetrics != nil {
+		failedTotal += *em.failedMetrics
+	}
+	mapstrSetWithErrorLog(logger, event, beatsOutputEventsDroppedKey, failedTotal)
+
+	if em.docsProcessed != nil {
+		mapstrSetWithErrorLog(logger, event, beatsOutputEventsTotalKey, *em.docsProcessed)
+
+		active := *em.docsProcessed - sentTotal - failedTotal
+		mapstrSetWithErrorLog(logger, event, beatsOutputEventsActiveKey, active)
+	}
+	if em.docsRetried != nil {
+		mapstrSetWithErrorLog(logger, event, beatsOutputEventsFailedKey, *em.docsRetried)
+	}
+	if em.bulkRequests != nil {
+		mapstrSetWithErrorLog(logger, event, beatsOutputEventsBatchesKey, *em.bulkRequests)
+	}
+	if em.flushedBytes != nil {
+		mapstrSetWithErrorLog(logger, event, beatsOutputWriteBytesKey, *em.flushedBytes)
+	}
+}
+
+// componentIDForScope returns the otelcol.component.id from the scope attributes
+// if its otelcol.component.kind matches kind, or empty string otherwise.
+func componentIDForScope(sm pmetric.ScopeMetrics, kind string) string {
+	attrs := sm.Scope().Attributes()
+	kindVal, ok := attrs.Get(otelComponentKindKey)
+	if !ok || kindVal.Str() != kind {
+		return ""
+	}
+	id, ok := attrs.Get(otelComponentIDKey)
+	if !ok {
+		return ""
+	}
+	return id.Str()
+}
+
+// numberDataPointValue extracts the numeric value from a data point as any,
+// returning false for unset or unknown value types.
+func numberDataPointValue(dp pmetric.NumberDataPoint) (any, bool) {
+	switch dp.ValueType() {
+	case pmetric.NumberDataPointValueTypeInt:
+		return dp.IntValue(), true
+	case pmetric.NumberDataPointValueTypeDouble:
+		return dp.DoubleValue(), true
+	}
+	return nil, false
+}
+
+// addMetric adds a pmetric.Metric's integer data points into em. Only Gauge
+// and Sum metrics with integer values are processed; all currently tracked
+// exporter metrics are integer sums or gauges.
+func addMetric(em *exporterMetrics, m pmetric.Metric) {
+	switch m.Type() {
+	case pmetric.MetricTypeGauge:
+		dps := m.Gauge().DataPoints()
+		for i := 0; i < dps.Len(); i++ {
+			dp := dps.At(i)
+			if dp.ValueType() == pmetric.NumberDataPointValueTypeInt {
+				addValue(em, m.Name(), dp.IntValue())
+			}
+		}
+	case pmetric.MetricTypeSum:
+		dps := m.Sum().DataPoints()
+		for i := 0; i < dps.Len(); i++ {
+			dp := dps.At(i)
+			if dp.ValueType() == pmetric.NumberDataPointValueTypeInt {
+				addValue(em, m.Name(), dp.IntValue())
+			}
+		}
+	}
+}
+
+// convertScopeMetrics builds a map from elasticsearch exporter component ID to
+// its aggregated exporterMetrics from the given pmetric.Metrics.
+func convertScopeMetrics(md pmetric.Metrics) map[string]exporterMetrics {
+	const elasticsearchPrefix = "elasticsearch/"
+	exporters := map[string]exporterMetrics{}
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			exporterID := componentIDForScope(sm, "exporter")
+			if !strings.HasPrefix(exporterID, elasticsearchPrefix) {
+				continue
+			}
+			metrics := exporters[exporterID]
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				addMetric(&metrics, sm.Metrics().At(k))
+			}
+			exporters[exporterID] = metrics
+		}
+	}
+	return exporters
+}
+
+// addInputDataPoint records a single data point into the inputs map keyed by
+// its input_id attribute. Data points without an input_id are ignored.
+func addInputDataPoint(dataset map[string]map[string]any, metricName string, dp pmetric.NumberDataPoint) {
+	inputIDVal, ok := dp.Attributes().Get(otelInputIDKey)
+	if !ok {
+		return
+	}
+	inputID := inputIDVal.Str()
+
+	entry, exists := dataset[inputID]
+	if !exists {
+		entry = map[string]any{"id": inputID}
+	}
+
+	if inputTypeVal, ok := dp.Attributes().Get(otelInputTypeKey); ok {
+		entry["input"] = inputTypeVal.Str()
+	}
+
+	if val, ok := numberDataPointValue(dp); ok {
+		entry[metricName] = val
+	}
+
+	dataset[inputID] = entry
+}
+
+// collectComponentInputMetrics iterates all scope metrics and aggregates data
+// points that carry an input_id attribute, grouped by the agent component they
+// belong to (extracted from the scope's otelcol.component.id).
+func collectComponentInputMetrics(md pmetric.Metrics) map[string]componentInputData {
+	components := map[string]componentInputData{}
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+
+			// Prefer receiver kind, but fall back to any component ID present
+			// (e.g. beat bridge metrics that may not carry a component kind).
+			otelID := componentIDForScope(sm, "receiver")
+			if otelID == "" {
+				idVal, ok := sm.Scope().Attributes().Get(otelComponentIDKey)
+				if !ok {
+					continue
+				}
+				otelID = idVal.Str()
+			}
+
+			compID := agentComponentID(otelID)
+			if compID == "" {
+				continue
+			}
+
+			data, exists := components[compID]
+			if !exists {
+				data = componentInputData{
+					beatType: beatTypeFromOtelID(otelID),
+					inputs:   map[string]map[string]any{},
+				}
+			}
+
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				m := sm.Metrics().At(k)
+				switch m.Type() {
+				case pmetric.MetricTypeGauge:
+					dps := m.Gauge().DataPoints()
+					for l := 0; l < dps.Len(); l++ {
+						addInputDataPoint(data.inputs, m.Name(), dps.At(l))
+					}
+				case pmetric.MetricTypeSum:
+					dps := m.Sum().DataPoints()
+					for l := 0; l < dps.Len(); l++ {
+						addInputDataPoint(data.inputs, m.Name(), dps.At(l))
+					}
+				}
+			}
+
+			components[compID] = data
+		}
+	}
+	return components
+}
+
+// addReceiverDataPoint records a single data point from a RegistryBridge metric
+// into the components map. otelID is the receiver's OTel component ID.
+func addReceiverDataPoint(components map[string]map[string]any, dp pmetric.NumberDataPoint, otelID string, metricName string) {
+	compID := agentComponentID(otelID)
+	if compID == "" {
+		return
+	}
+	field := "beat.stats." + beatTypeFromOtelID(otelID) + "." + metricName
+	if _, exists := components[compID]; !exists {
+		components[compID] = map[string]any{}
+	}
+	if val, ok := numberDataPointValue(dp); ok {
+		components[compID][field] = val
+	}
+}
+
+// collectReceiverMetrics collects all metrics emitted by the RegistryBridge
+// (scope name: registryBridgeScopeName). Each data point carries a "receiver"
+// attribute containing the OTel component ID. Metrics are mapped to fields as
+// "beat.stats.{beatType}.{metricName}", matching the standard Beats monitoring schema.
+func collectReceiverMetrics(md pmetric.Metrics) map[string]map[string]any {
+	components := map[string]map[string]any{}
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			if sm.Scope().Name() != registryBridgeScopeName {
+				continue
+			}
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				m := sm.Metrics().At(k)
+				switch m.Type() {
+				case pmetric.MetricTypeGauge:
+					dps := m.Gauge().DataPoints()
+					for l := 0; l < dps.Len(); l++ {
+						dp := dps.At(l)
+						receiverVal, ok := dp.Attributes().Get(registryBridgeReceiverKey)
+						if !ok {
+							continue
+						}
+						addReceiverDataPoint(components, dp, receiverVal.Str(), m.Name())
+					}
+				case pmetric.MetricTypeSum:
+					dps := m.Sum().DataPoints()
+					for l := 0; l < dps.Len(); l++ {
+						dp := dps.At(l)
+						receiverVal, ok := dp.Attributes().Get(registryBridgeReceiverKey)
+						if !ok {
+							continue
+						}
+						addReceiverDataPoint(components, dp, receiverVal.Str(), m.Name())
+					}
+				}
+			}
+		}
+	}
+	return components
+}

--- a/internal/edot/connectors/elasticmonitoring/convert_test.go
+++ b/internal/edot/connectors/elasticmonitoring/convert_test.go
@@ -1,0 +1,401 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package elasticmonitoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+
+	"github.com/elastic/elastic-agent-libs/mapstr"
+)
+
+const (
+	fbreceiverScopeName = "github.com/elastic/beats/v7/x-pack/filebeat/fbreceiver"
+	mbreceiverScopeName = "github.com/elastic/beats/v7/x-pack/metricbeat/mbreceiver"
+)
+
+// newMetrics returns a Metrics with one ResourceMetrics and one ScopeMetrics
+// pre-configured with the given scope name and attributes (key-value pairs).
+func newMetricsWithScope(scopeName string, attrs ...string) (pmetric.Metrics, pmetric.ScopeMetrics) {
+	md := pmetric.NewMetrics()
+	sm := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+	sm.Scope().SetName(scopeName)
+	for i := 0; i+1 < len(attrs); i += 2 {
+		sm.Scope().Attributes().PutStr(attrs[i], attrs[i+1])
+	}
+	return md, sm
+}
+
+func newMetricsWithExporterScope(exporterID string) (pmetric.Metrics, pmetric.ScopeMetrics) {
+	return newMetricsWithScope(
+		"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter",
+		otelComponentKindKey, "exporter",
+		otelComponentIDKey, exporterID,
+	)
+}
+
+func newMetricsWithReceiverScope(scopeName, receiverID string) (pmetric.Metrics, pmetric.ScopeMetrics) {
+	return newMetricsWithScope(scopeName,
+		otelComponentKindKey, "receiver",
+		otelComponentIDKey, receiverID,
+	)
+}
+
+func newMetricsWithRegistryBridgeScope() (pmetric.Metrics, pmetric.ScopeMetrics) {
+	return newMetricsWithScope(registryBridgeScopeName)
+}
+
+// appendScopeToMetrics adds an additional ScopeMetrics to an existing Metrics value,
+// reusing the first (and only) ResourceMetrics.
+func appendScopeToMetrics(md pmetric.Metrics, scopeName string, attrs ...string) pmetric.ScopeMetrics {
+	sm := md.ResourceMetrics().At(0).ScopeMetrics().AppendEmpty()
+	sm.Scope().SetName(scopeName)
+	for i := 0; i+1 < len(attrs); i += 2 {
+		sm.Scope().Attributes().PutStr(attrs[i], attrs[i+1])
+	}
+	return sm
+}
+
+func appendGaugeInt(sm pmetric.ScopeMetrics, name string, value int64) {
+	m := sm.Metrics().AppendEmpty()
+	m.SetName(name)
+	m.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(value)
+}
+
+func appendSumInt(sm pmetric.ScopeMetrics, name string, values ...int64) {
+	m := sm.Metrics().AppendEmpty()
+	m.SetName(name)
+	g := m.SetEmptySum()
+	for _, v := range values {
+		g.DataPoints().AppendEmpty().SetIntValue(v)
+	}
+}
+
+func appendGaugeIntWithAttrs(sm pmetric.ScopeMetrics, name string, value int64, kvs ...string) {
+	m := sm.Metrics().AppendEmpty()
+	m.SetName(name)
+	dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.SetIntValue(value)
+	for i := 0; i+1 < len(kvs); i += 2 {
+		dp.Attributes().PutStr(kvs[i], kvs[i+1])
+	}
+}
+
+func appendSumIntWithAttrs(sm pmetric.ScopeMetrics, name string, value int64, kvs ...string) {
+	m := sm.Metrics().AppendEmpty()
+	m.SetName(name)
+	dp := m.SetEmptySum().DataPoints().AppendEmpty()
+	dp.SetIntValue(value)
+	for i := 0; i+1 < len(kvs); i += 2 {
+		dp.Attributes().PutStr(kvs[i], kvs[i+1])
+	}
+}
+
+func appendGaugeFloat64WithAttrs(sm pmetric.ScopeMetrics, name string, value float64, kvs ...string) {
+	m := sm.Metrics().AppendEmpty()
+	m.SetName(name)
+	dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.SetDoubleValue(value)
+	for i := 0; i+1 < len(kvs); i += 2 {
+		dp.Attributes().PutStr(kvs[i], kvs[i+1])
+	}
+}
+
+func TestConvertAllMetrics(t *testing.T) {
+	const exporterID = "elasticsearch/_agent-component/monitoring"
+	const (
+		queueCapacity = int64(1000)
+		queueSize     = int64(500)
+		sentLogs      = int64(1)
+		sentSpans     = int64(2)
+		sentMetrics   = int64(3)
+		failedLogs    = int64(4)
+		failedSpans   = int64(5)
+		failedMetrics = int64(6)
+		docsProcessed = int64(100)
+		docsRetried   = int64(8)
+		bulkRequests  = int64(9)
+		flushedBytes  = int64(10)
+	)
+
+	md, sm := newMetricsWithExporterScope(exporterID)
+	appendGaugeInt(sm, otelQueueCapacityKey, queueCapacity)
+	appendGaugeInt(sm, otelQueueSizeKey, queueSize)
+	appendSumInt(sm, otelSentLogsKey, sentLogs)
+	appendSumInt(sm, otelSentSpansKey, sentSpans)
+	appendSumInt(sm, otelSentMetricsKey, sentMetrics)
+	appendSumInt(sm, otelFailedLogsKey, failedLogs)
+	appendSumInt(sm, otelFailedSpansKey, failedSpans)
+	appendSumInt(sm, otelFailedMetricsKey, failedMetrics)
+	appendSumInt(sm, otelDocsProcessedKey, docsProcessed)
+	appendSumInt(sm, otelDocsRetriedKey, docsRetried)
+	appendSumInt(sm, otelFlushedBytesKey, flushedBytes)
+	appendSumInt(sm, otelBulkRequestsKey, bulkRequests)
+
+	result := convertScopeMetrics(md)
+	assert.Equal(t, 1, len(result), "scope metrics contain one exporter")
+
+	metrics, ok := result[exporterID]
+	require.Truef(t, ok, "exporter metrics should contain metrics for id %q", exporterID)
+
+	beatEvent := mapstr.M{}
+	addMetricsToEventFields(zap.NewNop(), metrics, &beatEvent)
+
+	maxEvents, err := beatEvent.GetValue(beatsQueueMaxEventsKey)
+	assert.NoError(t, err)
+	assert.Equal(t, queueCapacity, maxEvents)
+
+	filledEvents, err := beatEvent.GetValue(beatsQueueFilledEventsKey)
+	assert.NoError(t, err)
+	assert.Equal(t, queueSize, filledEvents)
+
+	filledPct, err := beatEvent.GetValue(beatsQueueFilledPctKey)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(queueSize)/float64(queueCapacity), filledPct)
+
+	expectedSent := sentLogs + sentSpans + sentMetrics
+	eventsAcked, err := beatEvent.GetValue(beatsOutputEventsAckedKey)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedSent, eventsAcked)
+
+	expectedFailed := failedLogs + failedSpans + failedMetrics
+	eventsDropped, err := beatEvent.GetValue(beatsOutputEventsDroppedKey)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedFailed, eventsDropped)
+
+	eventsTotal, err := beatEvent.GetValue(beatsOutputEventsTotalKey)
+	assert.NoError(t, err)
+	assert.Equal(t, docsProcessed, eventsTotal)
+
+	eventsFailed, err := beatEvent.GetValue(beatsOutputEventsFailedKey)
+	assert.NoError(t, err)
+	assert.Equal(t, docsRetried, eventsFailed)
+
+	writeBytes, err := beatEvent.GetValue(beatsOutputWriteBytesKey)
+	assert.NoError(t, err)
+	assert.Equal(t, flushedBytes, writeBytes)
+
+	expectedActive := docsProcessed - expectedSent - expectedFailed
+	active, err := beatEvent.GetValue(beatsOutputEventsActiveKey)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedActive, active)
+
+	batches, err := beatEvent.GetValue(beatsOutputEventsBatchesKey)
+	assert.NoError(t, err)
+	assert.Equal(t, bulkRequests, batches)
+}
+
+func TestCollectComponentInputMetrics_Basic(t *testing.T) {
+	md, sm := newMetricsWithReceiverScope(fbreceiverScopeName, "filebeatreceiver/_agent-component/filebeat-default")
+	appendGaugeIntWithAttrs(sm, "beat.input.events.published", int64(42), otelInputIDKey, "logs.my-input")
+
+	result := collectComponentInputMetrics(md)
+	require.Len(t, result, 1)
+	compData, ok := result["filebeat-default"]
+	require.True(t, ok)
+	assert.Equal(t, "filebeat", compData.beatType)
+	entry, ok := compData.inputs["logs.my-input"]
+	require.True(t, ok)
+	assert.Equal(t, "logs.my-input", entry["id"])
+	assert.Equal(t, int64(42), entry["beat.input.events.published"])
+}
+
+func TestCollectComponentInputMetrics_WithInputType(t *testing.T) {
+	md, sm := newMetricsWithReceiverScope(fbreceiverScopeName, "filebeatreceiver/_agent-component/filebeat-default")
+	appendGaugeIntWithAttrs(sm, "beat.input.events.published", int64(10),
+		otelInputIDKey, "my-input", otelInputTypeKey, "log")
+
+	result := collectComponentInputMetrics(md)
+	require.Len(t, result, 1)
+	entry := result["filebeat-default"].inputs["my-input"]
+	assert.Equal(t, "log", entry["input"])
+}
+
+func TestCollectComponentInputMetrics_DotInInputID(t *testing.T) {
+	md, sm := newMetricsWithReceiverScope(fbreceiverScopeName, "filebeatreceiver/_agent-component/filebeat-default")
+	appendGaugeIntWithAttrs(sm, "some.metric", int64(1), otelInputIDKey, "logs.my-input")
+
+	result := collectComponentInputMetrics(md)
+	require.Len(t, result, 1)
+	inputs := result["filebeat-default"].inputs
+	entry, ok := inputs["logs.my-input"]
+	require.True(t, ok, "input ID with dots should be used as-is")
+	assert.Equal(t, "logs.my-input", entry["id"])
+}
+
+func TestCollectComponentInputMetrics_NoInputID(t *testing.T) {
+	md, sm := newMetricsWithReceiverScope(fbreceiverScopeName, "filebeatreceiver/_agent-component/filebeat-default")
+	appendGaugeInt(sm, "beat.input.events.published", int64(5))
+
+	result := collectComponentInputMetrics(md)
+	if compData, ok := result["filebeat-default"]; ok {
+		assert.Empty(t, compData.inputs)
+	}
+}
+
+func TestCollectComponentInputMetrics_MultipleInputsSameComponent(t *testing.T) {
+	md, sm := newMetricsWithReceiverScope(fbreceiverScopeName, "filebeatreceiver/_agent-component/filebeat-default")
+	appendSumIntWithAttrs(sm, "beat.input.events.published", int64(7), otelInputIDKey, "input-a")
+	appendSumIntWithAttrs(sm, "beat.input.events.published", int64(3), otelInputIDKey, "input-b")
+
+	result := collectComponentInputMetrics(md)
+	require.Len(t, result, 1)
+	inputs := result["filebeat-default"].inputs
+	require.Len(t, inputs, 2)
+	assert.Equal(t, "input-a", inputs["input-a"]["id"])
+	assert.Equal(t, "input-b", inputs["input-b"]["id"])
+	assert.Equal(t, int64(7), inputs["input-a"]["beat.input.events.published"])
+	assert.Equal(t, int64(3), inputs["input-b"]["beat.input.events.published"])
+}
+
+func TestCollectComponentInputMetrics_AcrossScopes(t *testing.T) {
+	md, sm1 := newMetricsWithReceiverScope(fbreceiverScopeName, "filebeatreceiver/_agent-component/filebeat-default")
+	appendGaugeIntWithAttrs(sm1, "metric.one", int64(11), otelInputIDKey, "shared-input")
+
+	sm2 := appendScopeToMetrics(md, fbreceiverScopeName,
+		otelComponentKindKey, "receiver",
+		otelComponentIDKey, "filebeatreceiver/_agent-component/filebeat-default",
+	)
+	appendGaugeIntWithAttrs(sm2, "metric.two", int64(22), otelInputIDKey, "shared-input")
+
+	result := collectComponentInputMetrics(md)
+	require.Len(t, result, 1)
+	entry := result["filebeat-default"].inputs["shared-input"]
+	assert.Equal(t, int64(11), entry["metric.one"])
+	assert.Equal(t, int64(22), entry["metric.two"])
+}
+
+func TestCollectComponentInputMetrics_DifferentComponents(t *testing.T) {
+	md, sm1 := newMetricsWithReceiverScope(fbreceiverScopeName, "filebeatreceiver/_agent-component/filebeat-default")
+	appendGaugeIntWithAttrs(sm1, "beat.input.events.published", int64(10), otelInputIDKey, "input-fb")
+
+	sm2 := appendScopeToMetrics(md, mbreceiverScopeName,
+		otelComponentKindKey, "receiver",
+		otelComponentIDKey, "metricbeatreceiver/_agent-component/metricbeat-default",
+	)
+	appendGaugeIntWithAttrs(sm2, "beat.input.events.published", int64(20), otelInputIDKey, "input-mb")
+
+	result := collectComponentInputMetrics(md)
+	require.Len(t, result, 2)
+
+	fbData := result["filebeat-default"]
+	assert.Equal(t, "filebeat", fbData.beatType)
+	require.Len(t, fbData.inputs, 1)
+	assert.Equal(t, int64(10), fbData.inputs["input-fb"]["beat.input.events.published"])
+
+	mbData := result["metricbeat-default"]
+	assert.Equal(t, "metricbeat", mbData.beatType)
+	require.Len(t, mbData.inputs, 1)
+	assert.Equal(t, int64(20), mbData.inputs["input-mb"]["beat.input.events.published"])
+}
+
+func TestBeatTypeFromOtelID(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"filebeatreceiver/_agent-component/filebeat-default", "filebeat"},
+		{"metricbeatreceiver/_agent-component/metricbeat-default", "metricbeat"},
+		{"elasticsearch/_agent-component/monitoring", "elasticsearch"},
+		{"filebeatreceiver/no-agent-component", "filebeat"},
+		{"filebeatreceiver", "filebeat"},
+		{"somecomponent", "somecomponent"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, beatTypeFromOtelID(tt.input))
+		})
+	}
+}
+
+func TestCollectReceiverPipelineMetrics_Basic(t *testing.T) {
+	const receiverID = "filebeatreceiver/_agent-component/filebeat-default"
+	md, sm := newMetricsWithRegistryBridgeScope()
+	appendGaugeIntWithAttrs(sm, "pipeline.clients", int64(3), registryBridgeReceiverKey, receiverID)
+	appendSumIntWithAttrs(sm, "pipeline.events.published", int64(42), registryBridgeReceiverKey, receiverID)
+
+	result := collectReceiverMetrics(md)
+	require.Len(t, result, 1)
+	fields, ok := result["filebeat-default"]
+	require.True(t, ok)
+	assert.Equal(t, int64(3), fields["beat.stats.filebeat.pipeline.clients"])
+	assert.Equal(t, int64(42), fields["beat.stats.filebeat.pipeline.events.published"])
+}
+
+func TestCollectReceiverPipelineMetrics_FloatGauge(t *testing.T) {
+	const receiverID = "filebeatreceiver/_agent-component/filebeat-default"
+	md, sm := newMetricsWithRegistryBridgeScope()
+	appendGaugeFloat64WithAttrs(sm, "pipeline.queue.filled.pct", float64(0.42), registryBridgeReceiverKey, receiverID)
+
+	result := collectReceiverMetrics(md)
+	require.Len(t, result, 1)
+	fields := result["filebeat-default"]
+	assert.Equal(t, float64(0.42), fields["beat.stats.filebeat.pipeline.queue.filled.pct"])
+}
+
+func TestCollectReceiverMetrics_AllMetricsCollected(t *testing.T) {
+	const receiverID = "filebeatreceiver/_agent-component/filebeat-default"
+	md, sm := newMetricsWithRegistryBridgeScope()
+	appendGaugeIntWithAttrs(sm, "output.events.active", int64(5), registryBridgeReceiverKey, receiverID)
+	appendGaugeIntWithAttrs(sm, "harvester.running", int64(3), registryBridgeReceiverKey, receiverID)
+	appendGaugeIntWithAttrs(sm, "pipeline.clients", int64(2), registryBridgeReceiverKey, receiverID)
+
+	result := collectReceiverMetrics(md)
+	require.Len(t, result, 1)
+	fields := result["filebeat-default"]
+	assert.Equal(t, int64(2), fields["beat.stats.filebeat.pipeline.clients"])
+	assert.Equal(t, int64(5), fields["beat.stats.filebeat.output.events.active"])
+	assert.Equal(t, int64(3), fields["beat.stats.filebeat.harvester.running"])
+}
+
+func TestCollectReceiverPipelineMetrics_WrongScopeSkipped(t *testing.T) {
+	md, sm := newMetricsWithExporterScope("elasticsearch/_agent-component/monitoring")
+	appendGaugeInt(sm, "pipeline.clients", int64(1))
+
+	result := collectReceiverMetrics(md)
+	assert.Empty(t, result)
+}
+
+func TestCollectReceiverPipelineMetrics_NoReceiverAttr(t *testing.T) {
+	md, sm := newMetricsWithRegistryBridgeScope()
+	appendGaugeInt(sm, "pipeline.clients", int64(1))
+
+	result := collectReceiverMetrics(md)
+	assert.Empty(t, result)
+}
+
+func TestCollectReceiverPipelineMetrics_MultipleReceivers(t *testing.T) {
+	const fbReceiverID = "filebeatreceiver/_agent-component/filebeat-default"
+	const mbReceiverID = "metricbeatreceiver/_agent-component/metricbeat-default"
+	md, sm := newMetricsWithRegistryBridgeScope()
+	appendGaugeIntWithAttrs(sm, "pipeline.clients", int64(2), registryBridgeReceiverKey, fbReceiverID)
+	appendGaugeIntWithAttrs(sm, "pipeline.clients", int64(5), registryBridgeReceiverKey, mbReceiverID)
+
+	result := collectReceiverMetrics(md)
+	require.Len(t, result, 2)
+	assert.Equal(t, int64(2), result["filebeat-default"]["beat.stats.filebeat.pipeline.clients"])
+	assert.Equal(t, int64(5), result["metricbeat-default"]["beat.stats.metricbeat.pipeline.clients"])
+}
+
+func TestAgentComponentID(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"filebeatreceiver/_agent-component/filebeat-default", "filebeat-default"},
+		{"elasticsearch/_agent-component/monitoring", "monitoring"},
+		{"filebeatreceiver/some-other-prefix", ""},
+		{"no-prefix-at-all", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, agentComponentID(tt.input))
+		})
+	}
+}

--- a/internal/edot/connectors/elasticmonitoring/factory.go
+++ b/internal/edot/connectors/elasticmonitoring/factory.go
@@ -1,0 +1,48 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package elasticmonitoring
+
+import (
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/connector"
+)
+
+const (
+	Name = "elasticmonitoringconnector"
+)
+
+// Config holds the configuration for the elasticmonitoringconnector.
+// The polling interval lives in the upstream elasticmonitoringreceiver; this
+// connector is stateless and only handles the metric-to-log conversion.
+type Config struct {
+	// EventTemplate provides the static fields included in every generated
+	// exporter/pipeline metrics event. If data_stream.* is present those fields
+	// are set as log record attributes so the elasticsearch exporter routes the
+	// event to the correct datastream.
+	EventTemplate struct {
+		Fields map[string]any `mapstructure:",remain"`
+	} `mapstructure:"event_template"`
+
+	// InputEventTemplate provides the static fields for per-input events.
+	InputEventTemplate struct {
+		Fields map[string]any `mapstructure:",remain"`
+	} `mapstructure:"input_event_template"`
+
+	// ExporterNames maps OTel exporter component IDs to the agent component name
+	// that should appear in the generated log record.
+	ExporterNames map[string]string `mapstructure:"exporter_names"`
+}
+
+func NewFactory() connector.Factory {
+	return connector.NewFactory(
+		component.MustNewType(Name),
+		createDefaultConfig,
+		connector.WithMetricsToLogs(createConnector, component.StabilityLevelAlpha),
+	)
+}
+
+func createDefaultConfig() component.Config {
+	return &Config{}
+}

--- a/internal/edot/otelcol/components/default.go
+++ b/internal/edot/otelcol/components/default.go
@@ -131,6 +131,7 @@ import (
 	forwardconnector "go.opentelemetry.io/collector/connector/forwardconnector"
 
 	"github.com/elastic/beats/v7/x-pack/otel/extension/beatsauthextension"
+	elasticmonitoringconnector "github.com/elastic/elastic-agent/internal/edot/connectors/elasticmonitoring"
 	elasticapmconnector "github.com/elastic/opentelemetry-collector-components/connector/elasticapmconnector"
 	profilingmetricsconnector "github.com/elastic/opentelemetry-collector-components/connector/profilingmetricsconnector"
 
@@ -261,6 +262,7 @@ func Default(extensionFactories ...extension.Factory) func() (otelcol.Factories,
 			elasticapmconnector.NewFactory(),
 			profilingmetricsconnector.NewFactory(),
 			forwardconnector.NewFactory(),
+			elasticmonitoringconnector.NewFactory(),
 		)
 		if err != nil {
 			return otelcol.Factories{}, err

--- a/internal/edot/otelcol/monitoring_test.go
+++ b/internal/edot/otelcol/monitoring_test.go
@@ -30,6 +30,8 @@ func TestMonitoringReceiver(t *testing.T) {
 	cfg := `receivers:
   elasticmonitoringreceiver:
     interval: 1s
+connectors:
+  elasticmonitoringconnector: {}
 exporters:
   elasticsearch/1:
     endpoints:
@@ -54,8 +56,11 @@ exporters:
 
 service:
   pipelines:
-    logs:
+    metrics:
       receivers: [elasticmonitoringreceiver]
+      exporters: [elasticmonitoringconnector]
+    logs:
+      receivers: [elasticmonitoringconnector]
       exporters:
         - elasticsearch/1
 `
@@ -150,6 +155,8 @@ func TestMonitoringReceiverRequestLevelErrors(t *testing.T) {
 	cfg := `receivers:
   elasticmonitoringreceiver:
     interval: 1s
+connectors:
+  elasticmonitoringconnector: {}
 exporters:
   elasticsearch/1:
     endpoints:
@@ -175,8 +182,11 @@ exporters:
 
 service:
   pipelines:
-    logs:
+    metrics:
       receivers: [elasticmonitoringreceiver]
+      exporters: [elasticmonitoringconnector]
+    logs:
+      receivers: [elasticmonitoringconnector]
       exporters:
         - elasticsearch/1
 `

--- a/internal/edot/receivers/elasticmonitoring/convert.go
+++ b/internal/edot/receivers/elasticmonitoring/convert.go
@@ -5,420 +5,114 @@
 package elasticmonitoring
 
 import (
-	"strings"
-
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	"go.uber.org/zap"
 
-	"github.com/elastic/elastic-agent-libs/mapstr"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-// A summary of current metrics values for a particular exporter
-type exporterMetrics struct {
-	queueSize     *int64
-	queueCapacity *int64
+// metricdataToPdata converts an OTel SDK ResourceMetrics (from the internal
+// telemetry ManualReader) into a pdata.Metrics, preserving scope names, scope
+// attributes, metric names/units, and all data point values and attributes.
+// Resource attributes are not currently emitted by the internal telemetry
+// reader so they are not copied.
+func metricdataToPdata(rm *metricdata.ResourceMetrics) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	pRM := md.ResourceMetrics().AppendEmpty()
 
-	sentLogs    *int64
-	sentSpans   *int64
-	sentMetrics *int64
+	for _, sm := range rm.ScopeMetrics {
+		pSM := pRM.ScopeMetrics().AppendEmpty()
+		pSM.Scope().SetName(sm.Scope.Name)
+		pSM.Scope().SetVersion(sm.Scope.Version)
 
-	failedLogs    *int64
-	failedSpans   *int64
-	failedMetrics *int64
+		iter := sm.Scope.Attributes.Iter()
+		for iter.Next() {
+			kv := iter.Attribute()
+			setAttrValue(pSM.Scope().Attributes(), string(kv.Key), kv.Value)
+		}
 
-	docsProcessed *int64
-	docsRetried   *int64
-	bulkRequests  *int64
-	flushedBytes  *int64
-}
-
-const (
-	beatsQueueFilledEventsKey   = "beat.stats.libbeat.pipeline.queue.filled.events"
-	beatsQueueMaxEventsKey      = "beat.stats.libbeat.pipeline.queue.max_events"
-	beatsQueueFilledPctKey      = "beat.stats.libbeat.pipeline.queue.filled.pct"
-	beatsOutputEventsTotalKey   = "beat.stats.libbeat.output.events.total"
-	beatsOutputEventsActiveKey  = "beat.stats.libbeat.output.events.active"
-	beatsOutputEventsAckedKey   = "beat.stats.libbeat.output.events.acked"
-	beatsOutputEventsDroppedKey = "beat.stats.libbeat.output.events.dropped"
-	beatsOutputEventsFailedKey  = "beat.stats.libbeat.output.events.failed"
-	beatsOutputEventsBatchesKey = "beat.stats.libbeat.output.events.batches"
-	beatsOutputWriteBytesKey    = "beat.stats.libbeat.output.write.bytes"
-
-	otelQueueCapacityKey       = "otelcol_exporter_queue_capacity"
-	otelQueueSizeKey           = "otelcol_exporter_queue_size"
-	otelSentLogsKey            = "otelcol_exporter_sent_log_records"
-	otelSentSpansKey           = "otelcol_exporter_sent_spans"
-	otelSentMetricsKey         = "otelcol_exporter_sent_metric_points"
-	otelFailedLogsKey          = "otelcol_exporter_send_failed_log_records"
-	otelFailedSpansKey         = "otelcol_exporter_send_failed_spans"
-	otelFailedMetricsKey       = "otelcol_exporter_send_failed_metric_points"
-	otelDocsProcessedKey       = "otelcol.elasticsearch.docs.processed"
-	otelDocsRetriedKey         = "otelcol.elasticsearch.docs.retried"
-	otelDocsRetriedHTTPRequest = "otelcol.elasticsearch.docs.retried_http_request"
-	otelBulkRequestsKey        = "otelcol.elasticsearch.bulk_requests.count"
-	otelFlushedBytesKey        = "otelcol.elasticsearch.flushed.bytes"
-
-	otelComponentIDKey   = "otelcol.component.id"
-	otelComponentKindKey = "otelcol.component.kind"
-
-	otelInputIDKey   = "input_id"
-	otelInputTypeKey = "input_type"
-
-	// registryBridgeScopeName is the instrumentation scope name used by the
-	// RegistryBridge in beats, which bridges Beats monitoring registries into
-	// OTel async instruments. Metrics from this scope carry a "receiver"
-	// data point attribute containing the OTel component ID.
-	registryBridgeScopeName = "github.com/elastic/beats/v7/x-pack/otel/telemetry"
-	// registryBridgeReceiverKey is the data point attribute key set by the
-	// RegistryBridge to identify which Beat receiver emitted the metric.
-	registryBridgeReceiverKey = "receiver"
-)
-
-// Add the integer referenced by value, if it isn't nil, to the given
-// referenced sum, initializing the sum if needed.
-func add(target **int64, value *int64) {
-	if value != nil {
-		if *target != nil {
-			**target += *value
-		} else {
-			v := *value
-			*target = &v
+		for _, m := range sm.Metrics {
+			pM := pSM.Metrics().AppendEmpty()
+			pM.SetName(m.Name)
+			pM.SetDescription(m.Description)
+			pM.SetUnit(m.Unit)
+			convertMetricData(pM, m.Data)
 		}
 	}
+	return md
 }
 
-// Set the referenced pointer to contain the given value, if it
-// isn't nil. (Like "add" but for gauges instead of sums.)
-func set(target **int64, value *int64) {
-	if value != nil {
-		v := *value
-		*target = &v
-	}
-}
-
-// Given the name and value of an OTel Collector internal telemetry variable,
-// add it to the given metrics struct.
-func addValue(metrics *exporterMetrics, name string, value int64) {
-	switch name {
-	case otelQueueSizeKey:
-		add(&metrics.queueSize, &value)
-	case otelQueueCapacityKey:
-		set(&metrics.queueCapacity, &value)
-	case otelSentLogsKey:
-		add(&metrics.sentLogs, &value)
-	case otelSentSpansKey:
-		add(&metrics.sentSpans, &value)
-	case otelSentMetricsKey:
-		add(&metrics.sentMetrics, &value)
-	case otelFailedLogsKey:
-		add(&metrics.failedLogs, &value)
-	case otelFailedSpansKey:
-		add(&metrics.failedSpans, &value)
-	case otelFailedMetricsKey:
-		add(&metrics.failedMetrics, &value)
-	case otelDocsProcessedKey:
-		add(&metrics.docsProcessed, &value)
-	case otelDocsRetriedKey, otelDocsRetriedHTTPRequest:
-		add(&metrics.docsRetried, &value)
-	case otelBulkRequestsKey:
-		add(&metrics.bulkRequests, &value)
-	case otelFlushedBytesKey:
-		add(&metrics.flushedBytes, &value)
-	}
-}
-
-// Returns the datapoints for the given aggregation, or an empty list if
-// the aggregation is not a gauge or sum over integer data (all currently
-// tracked metrics are integer sums or gauges, though this will change in
-// the future).
-func getDataPoints(data metricdata.Aggregation) []metricdata.DataPoint[int64] {
+func convertMetricData(pM pmetric.Metric, data metricdata.Aggregation) {
 	switch v := data.(type) {
 	case metricdata.Gauge[int64]:
-		return v.DataPoints
+		g := pM.SetEmptyGauge()
+		for _, dp := range v.DataPoints {
+			appendIntDataPoint(g.DataPoints().AppendEmpty(), dp)
+		}
+	case metricdata.Gauge[float64]:
+		g := pM.SetEmptyGauge()
+		for _, dp := range v.DataPoints {
+			appendFloatDataPoint(g.DataPoints().AppendEmpty(), dp)
+		}
 	case metricdata.Sum[int64]:
-		return v.DataPoints
-	}
-	return nil
-}
-
-func addMetric(metrics *exporterMetrics, met metricdata.Metrics) {
-	for _, dp := range getDataPoints(met.Data) {
-		addValue(metrics, met.Name, dp.Value)
-	}
-}
-
-// componentIDForScope returns the otelcol.component.id from the scope
-// attributes if it matches the given kind, or empty string otherwise.
-func componentIDForScope(scope instrumentation.Scope, kind string) string {
-	kindVal, ok := scope.Attributes.Value(otelComponentKindKey)
-	if !ok || kindVal.AsString() != kind {
-		return ""
-	}
-	id, ok := scope.Attributes.Value(otelComponentIDKey)
-	if !ok {
-		return ""
-	}
-	return id.AsString()
-}
-
-// agentComponentID extracts the agent component ID from an OTel component ID.
-// OTel component IDs follow the pattern "{type}/_agent-component/{compID}".
-// Returns the compID portion, or empty string if the pattern doesn't match.
-//
-// TODO(blakerouse): move the "_agent-component/" naming convention to a shared module so
-// this package does not duplicate knowledge that originates in the agent's
-// config translation layer.
-func agentComponentID(otelComponentID string) string {
-	const prefix = "_agent-component/"
-	idx := strings.Index(otelComponentID, prefix)
-	if idx < 0 {
-		return ""
-	}
-	return otelComponentID[idx+len(prefix):]
-}
-
-func convertScopeMetrics(scopeMetrics []metricdata.ScopeMetrics) map[string]exporterMetrics {
-	const elasticsearchPrefix = "elasticsearch/"
-	exporters := map[string]exporterMetrics{}
-
-	for _, sm := range scopeMetrics {
-		exporterID := componentIDForScope(sm.Scope, "exporter")
-		if !strings.HasPrefix(exporterID, elasticsearchPrefix) {
-			// Only handle metrics corresponding to exporter state we know how
-			// to monitor (just elasticsearch for now)
-			continue
+		s := pM.SetEmptySum()
+		s.SetIsMonotonic(v.IsMonotonic)
+		s.SetAggregationTemporality(convertTemporality(v.Temporality))
+		for _, dp := range v.DataPoints {
+			appendIntDataPoint(s.DataPoints().AppendEmpty(), dp)
 		}
-
-		// The same exporter can appear many times in different metrics
-		// blocks and we want to aggregate all of them, so load the existing
-		// values first.
-		metrics := exporters[exporterID]
-		for _, met := range sm.Metrics {
-			addMetric(&metrics, met)
-		}
-		exporters[exporterID] = metrics
-	}
-	return exporters
-}
-
-func mapstrSetWithErrorLog(logger *zap.Logger, event *mapstr.M, key string, value interface{}) {
-	_, err := event.Put(key, value)
-	if err != nil {
-		logger.Error("Couldn't set key while generating metrics event",
-			zap.String("key", key), zap.Error(err))
-	}
-}
-
-// componentInputData holds the per-input metrics for a single agent component,
-// along with the beat type derived from the OTel receiver component ID
-// (e.g. "filebeat" for a filebeatreceiver component).
-type componentInputData struct {
-	beatType string
-	inputs   map[string]map[string]any // sanitizedInputID -> fields
-}
-
-// beatTypeFromOtelID extracts the beat type from an OTel component ID.
-// It parses the ID using component.ID.UnmarshalText to extract the type
-// portion (e.g. "filebeatreceiver"), then strips the "receiver" suffix to
-// get the beat type (e.g. "filebeat").
-func beatTypeFromOtelID(otelComponentID string) string {
-	var id component.ID
-	if err := id.UnmarshalText([]byte(otelComponentID)); err != nil {
-		return ""
-	}
-	return strings.TrimSuffix(id.Type().String(), "receiver")
-}
-
-// collectComponentInputMetrics iterates all scope metrics and aggregates data
-// points that carry an "input_id" attribute, grouped by the agent component
-// they belong to (extracted from the scope's otelcol.component.id).
-// Returns a map from agent component ID to componentInputData, which holds
-// the beat type and a map keyed by sanitized input ID. Each input entry
-// contains "id" (original input_id), optionally "input" (input_type), and
-// the raw metric name/value pairs.
-func collectComponentInputMetrics(scopeMetrics []metricdata.ScopeMetrics) map[string]componentInputData {
-	components := map[string]componentInputData{}
-	for _, sm := range scopeMetrics {
-		// Resolve the full OTel component ID for this scope, preferring the
-		// receiver kind but falling back to any component ID present (e.g.
-		// beat bridge metrics that may not carry a component kind attribute).
-		otelID := componentIDForScope(sm.Scope, "receiver")
-		if otelID == "" {
-			id, ok := sm.Scope.Attributes.Value(otelComponentIDKey)
-			if !ok {
-				continue
-			}
-			otelID = id.AsString()
-		}
-
-		compID := agentComponentID(otelID)
-		if compID == "" {
-			continue
-		}
-
-		data, exists := components[compID]
-		if !exists {
-			data = componentInputData{
-				beatType: beatTypeFromOtelID(otelID),
-				inputs:   map[string]map[string]any{},
-			}
-		}
-
-		for _, met := range sm.Metrics {
-			switch v := met.Data.(type) {
-			case metricdata.Gauge[int64]:
-				for _, dp := range v.DataPoints {
-					addInputDataPoint(data.inputs, met.Name, dp.Attributes, dp.Value)
-				}
-			case metricdata.Sum[int64]:
-				for _, dp := range v.DataPoints {
-					addInputDataPoint(data.inputs, met.Name, dp.Attributes, dp.Value)
-				}
-			case metricdata.Gauge[float64]:
-				for _, dp := range v.DataPoints {
-					addInputDataPoint(data.inputs, met.Name, dp.Attributes, dp.Value)
-				}
-			case metricdata.Sum[float64]:
-				for _, dp := range v.DataPoints {
-					addInputDataPoint(data.inputs, met.Name, dp.Attributes, dp.Value)
-				}
-			}
-		}
-
-		components[compID] = data
-	}
-	return components
-}
-
-func addInputDataPoint[N int64 | float64](dataset map[string]map[string]any, name string, attrs attribute.Set, value N) {
-	inputIDVal, ok := attrs.Value(otelInputIDKey)
-	if !ok {
-		return
-	}
-	inputID := inputIDVal.AsString()
-
-	entry, exists := dataset[inputID]
-	if !exists {
-		entry = map[string]any{"id": inputID}
-	}
-
-	if inputTypeVal, ok := attrs.Value(otelInputTypeKey); ok {
-		entry["input"] = inputTypeVal.AsString()
-	}
-
-	entry[name] = value
-	dataset[inputID] = entry
-}
-
-// collectReceiverMetrics collects all metrics emitted by the RegistryBridge
-// (scope name: github.com/elastic/beats/v7/x-pack/otel/telemetry).
-// Each data point carries a "receiver" attribute containing the OTel component ID.
-// Metrics are mapped to fields as "beat.stats.{beatType}.{metricName}", where
-// beatType is derived from the receiver OTel component ID (e.g. "filebeat").
-// This matches the standard Beats monitoring schema
-// (e.g. "beat.stats.filebeat.harvester.running", "beat.stats.filebeat.registrar.states.current").
-// Returns a map from agent component ID to a map of field names to values,
-// one entry per receiver.
-func collectReceiverMetrics(scopeMetrics []metricdata.ScopeMetrics) map[string]map[string]any {
-	components := map[string]map[string]any{}
-	for _, sm := range scopeMetrics {
-		if sm.Scope.Name != registryBridgeScopeName {
-			continue
-		}
-		for _, met := range sm.Metrics {
-			switch v := met.Data.(type) {
-			case metricdata.Gauge[int64]:
-				for _, dp := range v.DataPoints {
-					addReceiverDataPoint(components, dp.Attributes, met.Name, dp.Value)
-				}
-			case metricdata.Sum[int64]:
-				for _, dp := range v.DataPoints {
-					addReceiverDataPoint(components, dp.Attributes, met.Name, dp.Value)
-				}
-			case metricdata.Gauge[float64]:
-				for _, dp := range v.DataPoints {
-					addReceiverDataPoint(components, dp.Attributes, met.Name, dp.Value)
-				}
-			case metricdata.Sum[float64]:
-				for _, dp := range v.DataPoints {
-					addReceiverDataPoint(components, dp.Attributes, met.Name, dp.Value)
-				}
-			}
+	case metricdata.Sum[float64]:
+		s := pM.SetEmptySum()
+		s.SetIsMonotonic(v.IsMonotonic)
+		s.SetAggregationTemporality(convertTemporality(v.Temporality))
+		for _, dp := range v.DataPoints {
+			appendFloatDataPoint(s.DataPoints().AppendEmpty(), dp)
 		}
 	}
-	return components
 }
 
-func addReceiverDataPoint[N int64 | float64](components map[string]map[string]any, attrs attribute.Set, metricName string, value N) {
-	receiverVal, ok := attrs.Value(registryBridgeReceiverKey)
-	if !ok {
-		return
+func appendIntDataPoint(pDP pmetric.NumberDataPoint, dp metricdata.DataPoint[int64]) {
+	pDP.SetIntValue(dp.Value)
+	pDP.SetStartTimestamp(pcommon.NewTimestampFromTime(dp.StartTime))
+	pDP.SetTimestamp(pcommon.NewTimestampFromTime(dp.Time))
+	iter := dp.Attributes.Iter()
+	for iter.Next() {
+		kv := iter.Attribute()
+		setAttrValue(pDP.Attributes(), string(kv.Key), kv.Value)
 	}
-	otelID := receiverVal.AsString()
-	compID := agentComponentID(otelID)
-	if compID == "" {
-		return
-	}
-	field := "beat.stats." + beatTypeFromOtelID(otelID) + "." + metricName
-	if _, exists := components[compID]; !exists {
-		components[compID] = map[string]any{}
-	}
-	components[compID][field] = value
 }
 
-// Add the given metrics as fields on the event, with field names following
-// the legacy schema for Beats metrics.
-func addMetricsToEventFields(logger *zap.Logger, em exporterMetrics, event *mapstr.M) {
-	if em.queueSize != nil {
-		mapstrSetWithErrorLog(logger, event, beatsQueueFilledEventsKey, *em.queueSize)
+func appendFloatDataPoint(pDP pmetric.NumberDataPoint, dp metricdata.DataPoint[float64]) {
+	pDP.SetDoubleValue(dp.Value)
+	pDP.SetStartTimestamp(pcommon.NewTimestampFromTime(dp.StartTime))
+	pDP.SetTimestamp(pcommon.NewTimestampFromTime(dp.Time))
+	iter := dp.Attributes.Iter()
+	for iter.Next() {
+		kv := iter.Attribute()
+		setAttrValue(pDP.Attributes(), string(kv.Key), kv.Value)
 	}
-	if em.queueCapacity != nil {
-		mapstrSetWithErrorLog(logger, event, beatsQueueMaxEventsKey, *em.queueCapacity)
-	}
-	if em.queueSize != nil && em.queueCapacity != nil && *em.queueCapacity > 0 {
-		filled := float64(*em.queueSize) / float64(*em.queueCapacity)
-		mapstrSetWithErrorLog(logger, event, beatsQueueFilledPctKey, filled)
-	}
-	var sentTotal int64
-	if em.sentLogs != nil {
-		sentTotal += *em.sentLogs
-	}
-	if em.sentSpans != nil {
-		sentTotal += *em.sentSpans
-	}
-	if em.sentMetrics != nil {
-		sentTotal += *em.sentMetrics
-	}
-	mapstrSetWithErrorLog(logger, event, beatsOutputEventsAckedKey, sentTotal)
+}
 
-	var failedTotal int64
-	if em.failedLogs != nil {
-		failedTotal += *em.failedLogs
+func setAttrValue(attrs pcommon.Map, key string, val attribute.Value) {
+	switch val.Type() {
+	case attribute.STRING:
+		attrs.PutStr(key, val.AsString())
+	case attribute.INT64:
+		attrs.PutInt(key, val.AsInt64())
+	case attribute.FLOAT64:
+		attrs.PutDouble(key, val.AsFloat64())
+	case attribute.BOOL:
+		attrs.PutBool(key, val.AsBool())
 	}
-	if em.failedSpans != nil {
-		failedTotal += *em.failedSpans
-	}
-	if em.failedMetrics != nil {
-		failedTotal += *em.failedMetrics
-	}
-	mapstrSetWithErrorLog(logger, event, beatsOutputEventsDroppedKey, failedTotal)
+}
 
-	if em.docsProcessed != nil {
-		mapstrSetWithErrorLog(logger, event, beatsOutputEventsTotalKey, *em.docsProcessed)
-
-		active := *em.docsProcessed - sentTotal - failedTotal
-		mapstrSetWithErrorLog(logger, event, beatsOutputEventsActiveKey, active)
+func convertTemporality(t metricdata.Temporality) pmetric.AggregationTemporality {
+	switch t {
+	case metricdata.CumulativeTemporality:
+		return pmetric.AggregationTemporalityCumulative
+	case metricdata.DeltaTemporality:
+		return pmetric.AggregationTemporalityDelta
 	}
-	if em.docsRetried != nil {
-		mapstrSetWithErrorLog(logger, event, beatsOutputEventsFailedKey, *em.docsRetried)
-	}
-	if em.bulkRequests != nil {
-		mapstrSetWithErrorLog(logger, event, beatsOutputEventsBatchesKey, *em.bulkRequests)
-	}
-	if em.flushedBytes != nil {
-		mapstrSetWithErrorLog(logger, event, beatsOutputWriteBytesKey, *em.flushedBytes)
-	}
+	return pmetric.AggregationTemporalityUnspecified
 }

--- a/internal/edot/receivers/elasticmonitoring/convert_test.go
+++ b/internal/edot/receivers/elasticmonitoring/convert_test.go
@@ -6,456 +6,293 @@ package elasticmonitoring
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	"go.uber.org/zap"
+	"go.opentelemetry.io/otel/sdk/resource"
 
-	"github.com/elastic/elastic-agent-libs/mapstr"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-const (
-	fbreceiverScopeName = "github.com/elastic/beats/v7/x-pack/filebeat/fbreceiver"
-	mbreceiverScopeName = "github.com/elastic/beats/v7/x-pack/metricbeat/mbreceiver"
-)
-
-func esExporterScope(exporterID string) instrumentation.Scope {
-	return instrumentation.Scope{
-		Name: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter",
-		Attributes: attribute.NewSet(
-			attribute.String(otelComponentKindKey, "exporter"),
-			attribute.String(otelComponentIDKey, exporterID),
-		),
+func makeResourceMetrics(scopes []metricdata.ScopeMetrics) *metricdata.ResourceMetrics {
+	return &metricdata.ResourceMetrics{
+		Resource:     resource.NewSchemaless(),
+		ScopeMetrics: scopes,
 	}
 }
 
-func receiverScope(scopeName string, receiverID string) instrumentation.Scope {
+func scopeWithAttrs(name string, attrs ...attribute.KeyValue) instrumentation.Scope {
 	return instrumentation.Scope{
-		Name: scopeName,
-		Attributes: attribute.NewSet(
-			attribute.String(otelComponentKindKey, "receiver"),
-			attribute.String(otelComponentIDKey, receiverID),
-		),
+		Name:       name,
+		Attributes: attribute.NewSet(attrs...),
 	}
 }
 
-func gaugeMetricWithAttrs[N int64 | float64](name string, value N, attrs ...attribute.KeyValue) metricdata.Metrics {
-	return metricdata.Metrics{
-		Name: name,
-		Data: metricdata.Gauge[N]{
-			DataPoints: []metricdata.DataPoint[N]{
-				{Value: value, Attributes: attribute.NewSet(attrs...)},
+func TestMetricdataToPdata_ScopeNameAndAttributes(t *testing.T) {
+	rm := makeResourceMetrics([]metricdata.ScopeMetrics{
+		{
+			Scope: scopeWithAttrs("my/scope",
+				attribute.String("otelcol.component.id", "elasticsearch/foo"),
+				attribute.String("otelcol.component.kind", "exporter"),
+			),
+			Metrics: []metricdata.Metrics{},
+		},
+	})
+
+	md := metricdataToPdata(rm)
+
+	require.Equal(t, 1, md.ResourceMetrics().Len())
+	sms := md.ResourceMetrics().At(0).ScopeMetrics()
+	require.Equal(t, 1, sms.Len())
+
+	sm := sms.At(0)
+	assert.Equal(t, "my/scope", sm.Scope().Name())
+
+	id, ok := sm.Scope().Attributes().Get("otelcol.component.id")
+	require.True(t, ok)
+	assert.Equal(t, "elasticsearch/foo", id.Str())
+
+	kind, ok := sm.Scope().Attributes().Get("otelcol.component.kind")
+	require.True(t, ok)
+	assert.Equal(t, "exporter", kind.Str())
+}
+
+func TestMetricdataToPdata_Int64Gauge(t *testing.T) {
+	ts := time.Now()
+	rm := makeResourceMetrics([]metricdata.ScopeMetrics{
+		{
+			Scope: scopeWithAttrs("test"),
+			Metrics: []metricdata.Metrics{
+				{
+					Name: "otelcol_exporter_queue_size",
+					Data: metricdata.Gauge[int64]{
+						DataPoints: []metricdata.DataPoint[int64]{
+							{
+								Value:     42,
+								StartTime: ts.Add(-time.Second),
+								Time:      ts,
+								Attributes: attribute.NewSet(
+									attribute.String("exporter", "elasticsearch"),
+								),
+							},
+						},
+					},
+				},
 			},
 		},
-	}
+	})
+
+	md := metricdataToPdata(rm)
+
+	sm := md.ResourceMetrics().At(0).ScopeMetrics().At(0)
+	require.Equal(t, 1, sm.Metrics().Len())
+	m := sm.Metrics().At(0)
+	assert.Equal(t, "otelcol_exporter_queue_size", m.Name())
+	assert.Equal(t, pmetric.MetricTypeGauge, m.Type())
+
+	dps := m.Gauge().DataPoints()
+	require.Equal(t, 1, dps.Len())
+	dp := dps.At(0)
+	assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+	assert.Equal(t, int64(42), dp.IntValue())
+
+	v, ok := dp.Attributes().Get("exporter")
+	require.True(t, ok)
+	assert.Equal(t, "elasticsearch", v.Str())
 }
 
-func sumMetricWithAttrs[N int64 | float64](name string, value N, attrs ...attribute.KeyValue) metricdata.Metrics {
-	return metricdata.Metrics{
-		Name: name,
-		Data: metricdata.Sum[N]{
-			DataPoints: []metricdata.DataPoint[N]{
-				{Value: value, Attributes: attribute.NewSet(attrs...)},
+func TestMetricdataToPdata_Float64Gauge(t *testing.T) {
+	ts := time.Now()
+	rm := makeResourceMetrics([]metricdata.ScopeMetrics{
+		{
+			Scope: scopeWithAttrs("test"),
+			Metrics: []metricdata.Metrics{
+				{
+					Name: "some.float.metric",
+					Data: metricdata.Gauge[float64]{
+						DataPoints: []metricdata.DataPoint[float64]{
+							{Value: 3.14, Time: ts},
+						},
+					},
+				},
 			},
 		},
-	}
+	})
+
+	md := metricdataToPdata(rm)
+
+	m := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+	assert.Equal(t, pmetric.MetricTypeGauge, m.Type())
+	dp := m.Gauge().DataPoints().At(0)
+	assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+	assert.InDelta(t, 3.14, dp.DoubleValue(), 1e-9)
 }
 
-func gaugeMetric[N int64 | float64](name string, value N) metricdata.Metrics {
-	return metricdata.Metrics{
-		Name: name,
-		Data: metricdata.Gauge[N]{
-			DataPoints: []metricdata.DataPoint[N]{
-				{Value: value},
+func TestMetricdataToPdata_Int64Sum(t *testing.T) {
+	ts := time.Now()
+	rm := makeResourceMetrics([]metricdata.ScopeMetrics{
+		{
+			Scope: scopeWithAttrs("test"),
+			Metrics: []metricdata.Metrics{
+				{
+					Name: "otelcol_exporter_sent_log_records",
+					Data: metricdata.Sum[int64]{
+						IsMonotonic: true,
+						Temporality: metricdata.CumulativeTemporality,
+						DataPoints: []metricdata.DataPoint[int64]{
+							{Value: 100, Time: ts},
+						},
+					},
+				},
 			},
 		},
-	}
+	})
+
+	md := metricdataToPdata(rm)
+
+	m := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+	assert.Equal(t, pmetric.MetricTypeSum, m.Type())
+	assert.True(t, m.Sum().IsMonotonic())
+	assert.Equal(t, pmetric.AggregationTemporalityCumulative, m.Sum().AggregationTemporality())
+	assert.Equal(t, int64(100), m.Sum().DataPoints().At(0).IntValue())
 }
 
-func sumMetric[N int64 | float64](name string, values ...N) metricdata.Metrics {
-	var dataPoints []metricdata.DataPoint[N]
-	for _, v := range values {
-		dataPoints = append(dataPoints, metricdata.DataPoint[N]{Value: v})
-	}
-	return metricdata.Metrics{
-		Name: name,
-		Data: metricdata.Sum[N]{DataPoints: dataPoints},
-	}
-}
-
-func TestConvertAllMetrics(t *testing.T) {
-	const exporterID = "elasticsearch/_agent-component/monitoring"
-	// Test values here are mostly arbitrary except that no two are the same.
-	const (
-		queueCapacity = int64(1000)
-		queueSize     = int64(500)
-		sentLogs      = int64(1)
-		sentSpans     = int64(2)
-		sentMetrics   = int64(3)
-		failedLogs    = int64(4)
-		failedSpans   = int64(5)
-		failedMetrics = int64(6)
-		docsProcessed = int64(100)
-		docsRetried   = int64(8)
-		bulkRequests  = int64(9)
-		flushedBytes  = int64(10)
-	)
-	scopeMetrics := metricdata.ScopeMetrics{
-		Scope: esExporterScope(exporterID),
-		Metrics: []metricdata.Metrics{
-			gaugeMetric(otelQueueCapacityKey, queueCapacity),
-			gaugeMetric(otelQueueSizeKey, queueSize),
-			sumMetric(otelSentLogsKey, sentLogs),
-			sumMetric(otelSentSpansKey, sentSpans),
-			sumMetric(otelSentMetricsKey, sentMetrics),
-			sumMetric(otelFailedLogsKey, failedLogs),
-			sumMetric(otelFailedSpansKey, failedSpans),
-			sumMetric(otelFailedMetricsKey, failedMetrics),
-			sumMetric(otelDocsProcessedKey, docsProcessed),
-			sumMetric(otelDocsRetriedKey, docsRetried),
-			sumMetric(otelFlushedBytesKey, flushedBytes),
-			sumMetric(otelBulkRequestsKey, bulkRequests),
+func TestMetricdataToPdata_Float64Sum(t *testing.T) {
+	ts := time.Now()
+	rm := makeResourceMetrics([]metricdata.ScopeMetrics{
+		{
+			Scope: scopeWithAttrs("test"),
+			Metrics: []metricdata.Metrics{
+				{
+					Name: "some.float.sum",
+					Data: metricdata.Sum[float64]{
+						IsMonotonic: false,
+						Temporality: metricdata.DeltaTemporality,
+						DataPoints: []metricdata.DataPoint[float64]{
+							{Value: 2.718, Time: ts},
+						},
+					},
+				},
+			},
 		},
-	}
-	result := convertScopeMetrics([]metricdata.ScopeMetrics{scopeMetrics})
-	assert.Equal(t, 1, len(result), "The scope metrics contain one exporter")
+	})
 
-	metrics, ok := result[exporterID]
-	require.Truef(t, ok, "Exporter metrics should contain metrics for the id '%v'", exporterID)
+	md := metricdataToPdata(rm)
 
-	beatEvent := mapstr.M{}
-	addMetricsToEventFields(zap.NewNop(), metrics, &beatEvent)
-
-	maxEvents, err := beatEvent.GetValue(beatsQueueMaxEventsKey)
-	assert.NoError(t, err)
-	assert.Equal(t, queueCapacity, maxEvents)
-
-	filledEvents, err := beatEvent.GetValue(beatsQueueFilledEventsKey)
-	assert.NoError(t, err)
-	assert.Equal(t, queueSize, filledEvents)
-
-	filledPct, err := beatEvent.GetValue(beatsQueueFilledPctKey)
-	assert.NoError(t, err)
-	assert.Equal(t, float64(queueSize)/float64(queueCapacity), filledPct)
-
-	expectedSent := sentLogs + sentSpans + sentMetrics
-	eventsAcked, err := beatEvent.GetValue(beatsOutputEventsAckedKey)
-	assert.NoError(t, err)
-	assert.Equal(t, expectedSent, eventsAcked)
-
-	// Subtlety: what beats calls "dropped", OTel calls "failed."
-	expectedFailed := failedLogs + failedSpans + failedMetrics
-	eventsDropped, err := beatEvent.GetValue(beatsOutputEventsDroppedKey)
-	assert.NoError(t, err)
-	assert.Equal(t, expectedFailed, eventsDropped)
-
-	eventsTotal, err := beatEvent.GetValue(beatsOutputEventsTotalKey)
-	assert.NoError(t, err)
-	assert.Equal(t, eventsTotal, docsProcessed)
-
-	// Subtlety: what beats calls "failed", OTel calls "retried."
-	eventsFailed, err := beatEvent.GetValue(beatsOutputEventsFailedKey)
-	assert.NoError(t, err)
-	assert.Equal(t, docsRetried, eventsFailed)
-
-	writeBytes, err := beatEvent.GetValue(beatsOutputWriteBytesKey)
-	assert.NoError(t, err)
-	assert.Equal(t, flushedBytes, writeBytes)
-
-	expectedActive := docsProcessed - expectedSent - expectedFailed
-	active, err := beatEvent.GetValue(beatsOutputEventsActiveKey)
-	assert.NoError(t, err)
-	assert.Equal(t, expectedActive, active)
-
-	// The ES exporter doesn't have a concept of batches that is semantically
-	// identical to Beats, but bulk requests are a close analogue.
-	batches, err := beatEvent.GetValue(beatsOutputEventsBatchesKey)
-	assert.NoError(t, err)
-	assert.Equal(t, bulkRequests, batches)
+	m := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+	assert.Equal(t, pmetric.MetricTypeSum, m.Type())
+	assert.False(t, m.Sum().IsMonotonic())
+	assert.Equal(t, pmetric.AggregationTemporalityDelta, m.Sum().AggregationTemporality())
+	assert.InDelta(t, 2.718, m.Sum().DataPoints().At(0).DoubleValue(), 1e-9)
 }
 
-func TestCollectComponentInputMetrics_Basic(t *testing.T) {
-	sm := metricdata.ScopeMetrics{
-		Scope: receiverScope(fbreceiverScopeName, "filebeatreceiver/_agent-component/filebeat-default"),
-		Metrics: []metricdata.Metrics{
-			gaugeMetricWithAttrs("beat.input.events.published", int64(42),
-				attribute.String(otelInputIDKey, "logs.my-input"),
-			),
+func TestMetricdataToPdata_DataPointAttributes(t *testing.T) {
+	ts := time.Now()
+	rm := makeResourceMetrics([]metricdata.ScopeMetrics{
+		{
+			Scope: scopeWithAttrs("test"),
+			Metrics: []metricdata.Metrics{
+				{
+					Name: "some.metric",
+					Data: metricdata.Gauge[int64]{
+						DataPoints: []metricdata.DataPoint[int64]{
+							{
+								Value: 7,
+								Time:  ts,
+								Attributes: attribute.NewSet(
+									attribute.String("input_id", "my-input"),
+									attribute.String("input_type", "log"),
+									attribute.Int64("count", 99),
+									attribute.Bool("active", true),
+								),
+							},
+						},
+					},
+				},
+			},
 		},
-	}
-	result := collectComponentInputMetrics([]metricdata.ScopeMetrics{sm})
-	require.Len(t, result, 1)
-	compData, ok := result["filebeat-default"]
+	})
+
+	md := metricdataToPdata(rm)
+
+	dp := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0)
+
+	v, ok := dp.Attributes().Get("input_id")
 	require.True(t, ok)
-	assert.Equal(t, "filebeat", compData.beatType)
-	entry, ok := compData.inputs["logs.my-input"]
+	assert.Equal(t, "my-input", v.Str())
+
+	v, ok = dp.Attributes().Get("input_type")
 	require.True(t, ok)
-	assert.Equal(t, "logs.my-input", entry["id"])
-	assert.Equal(t, int64(42), entry["beat.input.events.published"])
-}
+	assert.Equal(t, "log", v.Str())
 
-func TestCollectComponentInputMetrics_WithInputType(t *testing.T) {
-	sm := metricdata.ScopeMetrics{
-		Scope: receiverScope(fbreceiverScopeName, "filebeatreceiver/_agent-component/filebeat-default"),
-		Metrics: []metricdata.Metrics{
-			gaugeMetricWithAttrs("beat.input.events.published", int64(10),
-				attribute.String(otelInputIDKey, "my-input"),
-				attribute.String(otelInputTypeKey, "log"),
-			),
-		},
-	}
-	result := collectComponentInputMetrics([]metricdata.ScopeMetrics{sm})
-	require.Len(t, result, 1)
-	compData := result["filebeat-default"]
-	entry := compData.inputs["my-input"]
-	assert.Equal(t, "log", entry["input"])
-}
-
-func TestCollectComponentInputMetrics_DotInInputID(t *testing.T) {
-	sm := metricdata.ScopeMetrics{
-		Scope: receiverScope(fbreceiverScopeName, "filebeatreceiver/_agent-component/filebeat-default"),
-		Metrics: []metricdata.Metrics{
-			gaugeMetricWithAttrs("some.metric", int64(1),
-				attribute.String(otelInputIDKey, "logs.my-input"),
-			),
-		},
-	}
-	result := collectComponentInputMetrics([]metricdata.ScopeMetrics{sm})
-	require.Len(t, result, 1)
-	inputs := result["filebeat-default"].inputs
-	entry, ok := inputs["logs.my-input"]
-	require.True(t, ok, "input ID with dots should be used as-is")
-	assert.Equal(t, "logs.my-input", entry["id"])
-}
-
-func TestCollectComponentInputMetrics_NoInputID(t *testing.T) {
-	sm := metricdata.ScopeMetrics{
-		Scope: receiverScope(fbreceiverScopeName, "filebeatreceiver/_agent-component/filebeat-default"),
-		Metrics: []metricdata.Metrics{
-			gaugeMetric("beat.input.events.published", int64(5)),
-		},
-	}
-	result := collectComponentInputMetrics([]metricdata.ScopeMetrics{sm})
-	// Component is created but inputs should be empty (no input_id on data points)
-	if compData, ok := result["filebeat-default"]; ok {
-		assert.Empty(t, compData.inputs)
-	}
-}
-
-func TestCollectComponentInputMetrics_MultipleInputsSameComponent(t *testing.T) {
-	sm := metricdata.ScopeMetrics{
-		Scope: receiverScope(fbreceiverScopeName, "filebeatreceiver/_agent-component/filebeat-default"),
-		Metrics: []metricdata.Metrics{
-			sumMetricWithAttrs("beat.input.events.published", int64(7),
-				attribute.String(otelInputIDKey, "input-a"),
-			),
-			sumMetricWithAttrs("beat.input.events.published", int64(3),
-				attribute.String(otelInputIDKey, "input-b"),
-			),
-		},
-	}
-	result := collectComponentInputMetrics([]metricdata.ScopeMetrics{sm})
-	require.Len(t, result, 1)
-	inputs := result["filebeat-default"].inputs
-	require.Len(t, inputs, 2)
-	assert.Equal(t, "input-a", inputs["input-a"]["id"])
-	assert.Equal(t, "input-b", inputs["input-b"]["id"])
-	assert.Equal(t, int64(7), inputs["input-a"]["beat.input.events.published"])
-	assert.Equal(t, int64(3), inputs["input-b"]["beat.input.events.published"])
-}
-
-func TestCollectComponentInputMetrics_AcrossScopes(t *testing.T) {
-	sm1 := metricdata.ScopeMetrics{
-		Scope: receiverScope(fbreceiverScopeName, "filebeatreceiver/_agent-component/filebeat-default"),
-		Metrics: []metricdata.Metrics{
-			gaugeMetricWithAttrs("metric.one", int64(11),
-				attribute.String(otelInputIDKey, "shared-input"),
-			),
-		},
-	}
-	sm2 := metricdata.ScopeMetrics{
-		Scope: receiverScope(fbreceiverScopeName, "filebeatreceiver/_agent-component/filebeat-default"),
-		Metrics: []metricdata.Metrics{
-			gaugeMetricWithAttrs("metric.two", int64(22),
-				attribute.String(otelInputIDKey, "shared-input"),
-			),
-		},
-	}
-	result := collectComponentInputMetrics([]metricdata.ScopeMetrics{sm1, sm2})
-	require.Len(t, result, 1)
-	entry := result["filebeat-default"].inputs["shared-input"]
-	assert.Equal(t, int64(11), entry["metric.one"])
-	assert.Equal(t, int64(22), entry["metric.two"])
-}
-
-func TestCollectComponentInputMetrics_DifferentComponents(t *testing.T) {
-	sm1 := metricdata.ScopeMetrics{
-		Scope: receiverScope(fbreceiverScopeName, "filebeatreceiver/_agent-component/filebeat-default"),
-		Metrics: []metricdata.Metrics{
-			gaugeMetricWithAttrs("beat.input.events.published", int64(10),
-				attribute.String(otelInputIDKey, "input-fb"),
-			),
-		},
-	}
-	sm2 := metricdata.ScopeMetrics{
-		Scope: receiverScope(mbreceiverScopeName, "metricbeatreceiver/_agent-component/metricbeat-default"),
-		Metrics: []metricdata.Metrics{
-			gaugeMetricWithAttrs("beat.input.events.published", int64(20),
-				attribute.String(otelInputIDKey, "input-mb"),
-			),
-		},
-	}
-	result := collectComponentInputMetrics([]metricdata.ScopeMetrics{sm1, sm2})
-	require.Len(t, result, 2)
-
-	fbData := result["filebeat-default"]
-	assert.Equal(t, "filebeat", fbData.beatType)
-	require.Len(t, fbData.inputs, 1)
-	assert.Equal(t, int64(10), fbData.inputs["input-fb"]["beat.input.events.published"])
-
-	mbData := result["metricbeat-default"]
-	assert.Equal(t, "metricbeat", mbData.beatType)
-	require.Len(t, mbData.inputs, 1)
-	assert.Equal(t, int64(20), mbData.inputs["input-mb"]["beat.input.events.published"])
-}
-
-func TestBeatTypeFromOtelID(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"filebeatreceiver/_agent-component/filebeat-default", "filebeat"},
-		{"metricbeatreceiver/_agent-component/metricbeat-default", "metricbeat"},
-		{"elasticsearch/_agent-component/monitoring", "elasticsearch"},
-		{"filebeatreceiver/no-agent-component", "filebeat"},
-		{"filebeatreceiver", "filebeat"},
-		{"somecomponent", "somecomponent"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			assert.Equal(t, tt.expected, beatTypeFromOtelID(tt.input))
-		})
-	}
-}
-
-func registryBridgeScope(receiverID string) instrumentation.Scope {
-	return instrumentation.Scope{
-		Name: registryBridgeScopeName,
-		// RegistryBridge sets no scope attributes; receiver identity is on data points.
-	}
-}
-
-func gaugeMetricWithReceiverAttr[N int64 | float64](name string, value N, receiverID string) metricdata.Metrics {
-	return gaugeMetricWithAttrs(name, value, attribute.String(registryBridgeReceiverKey, receiverID))
-}
-
-func TestCollectReceiverPipelineMetrics_Basic(t *testing.T) {
-	const receiverID = "filebeatreceiver/_agent-component/filebeat-default"
-	sm := metricdata.ScopeMetrics{
-		Scope: registryBridgeScope(receiverID),
-		Metrics: []metricdata.Metrics{
-			gaugeMetricWithReceiverAttr("pipeline.clients", int64(3), receiverID),
-			sumMetricWithAttrs("pipeline.events.published", int64(42),
-				attribute.String(registryBridgeReceiverKey, receiverID),
-			),
-		},
-	}
-	result := collectReceiverMetrics([]metricdata.ScopeMetrics{sm})
-	require.Len(t, result, 1)
-	fields, ok := result["filebeat-default"]
+	v, ok = dp.Attributes().Get("count")
 	require.True(t, ok)
-	assert.Equal(t, int64(3), fields["beat.stats.filebeat.pipeline.clients"])
-	assert.Equal(t, int64(42), fields["beat.stats.filebeat.pipeline.events.published"])
+	assert.Equal(t, int64(99), v.Int())
+
+	v, ok = dp.Attributes().Get("active")
+	require.True(t, ok)
+	assert.True(t, v.Bool())
 }
 
-func TestCollectReceiverPipelineMetrics_FloatGauge(t *testing.T) {
-	const receiverID = "filebeatreceiver/_agent-component/filebeat-default"
-	sm := metricdata.ScopeMetrics{
-		Scope: registryBridgeScope(receiverID),
-		Metrics: []metricdata.Metrics{
-			gaugeMetricWithReceiverAttr("pipeline.queue.filled.pct", float64(0.42), receiverID),
+func TestMetricdataToPdata_MultipleScopes(t *testing.T) {
+	ts := time.Now()
+	rm := makeResourceMetrics([]metricdata.ScopeMetrics{
+		{
+			Scope:   scopeWithAttrs("scope-a"),
+			Metrics: []metricdata.Metrics{{Name: "metric.a", Data: metricdata.Gauge[int64]{DataPoints: []metricdata.DataPoint[int64]{{Value: 1, Time: ts}}}}},
 		},
-	}
-	result := collectReceiverMetrics([]metricdata.ScopeMetrics{sm})
-	require.Len(t, result, 1)
-	fields := result["filebeat-default"]
-	assert.Equal(t, float64(0.42), fields["beat.stats.filebeat.pipeline.queue.filled.pct"])
-}
-
-func TestCollectReceiverMetrics_AllMetricsCollected(t *testing.T) {
-	const receiverID = "filebeatreceiver/_agent-component/filebeat-default"
-	sm := metricdata.ScopeMetrics{
-		Scope: registryBridgeScope(receiverID),
-		Metrics: []metricdata.Metrics{
-			gaugeMetricWithReceiverAttr("output.events.active", int64(5), receiverID),
-			gaugeMetricWithReceiverAttr("harvester.running", int64(3), receiverID),
-			gaugeMetricWithReceiverAttr("pipeline.clients", int64(2), receiverID),
+		{
+			Scope:   scopeWithAttrs("scope-b"),
+			Metrics: []metricdata.Metrics{{Name: "metric.b", Data: metricdata.Gauge[int64]{DataPoints: []metricdata.DataPoint[int64]{{Value: 2, Time: ts}}}}},
 		},
-	}
-	result := collectReceiverMetrics([]metricdata.ScopeMetrics{sm})
-	require.Len(t, result, 1)
-	fields := result["filebeat-default"]
-	assert.Equal(t, int64(2), fields["beat.stats.filebeat.pipeline.clients"])
-	assert.Equal(t, int64(5), fields["beat.stats.filebeat.output.events.active"])
-	assert.Equal(t, int64(3), fields["beat.stats.filebeat.harvester.running"])
+	})
+
+	md := metricdataToPdata(rm)
+
+	sms := md.ResourceMetrics().At(0).ScopeMetrics()
+	require.Equal(t, 2, sms.Len())
+	assert.Equal(t, "scope-a", sms.At(0).Scope().Name())
+	assert.Equal(t, "scope-b", sms.At(1).Scope().Name())
+	assert.Equal(t, "metric.a", sms.At(0).Metrics().At(0).Name())
+	assert.Equal(t, "metric.b", sms.At(1).Metrics().At(0).Name())
 }
 
-func TestCollectReceiverPipelineMetrics_WrongScopeSkipped(t *testing.T) {
-	// A scope from the OTel collector (not RegistryBridge) should be ignored.
-	sm := metricdata.ScopeMetrics{
-		Scope: esExporterScope("elasticsearch/_agent-component/monitoring"),
-		Metrics: []metricdata.Metrics{
-			gaugeMetric("pipeline.clients", int64(1)),
+func TestMetricdataToPdata_RegistryBridgeReceiverAttr(t *testing.T) {
+	// Verify that the "receiver" data point attribute is preserved, since the
+	// connector's collectReceiverMetrics depends on it.
+	ts := time.Now()
+	otelID := "filebeatreceiver/_agent-component/filebeat-0"
+	rm := makeResourceMetrics([]metricdata.ScopeMetrics{
+		{
+			Scope: scopeWithAttrs("github.com/elastic/beats/v7/x-pack/otel/telemetry"),
+			Metrics: []metricdata.Metrics{
+				{
+					Name: "harvester.running",
+					Data: metricdata.Gauge[int64]{
+						DataPoints: []metricdata.DataPoint[int64]{
+							{
+								Value: 5,
+								Time:  ts,
+								Attributes: attribute.NewSet(
+									attribute.String("receiver", otelID),
+								),
+							},
+						},
+					},
+				},
+			},
 		},
-	}
-	result := collectReceiverMetrics([]metricdata.ScopeMetrics{sm})
-	assert.Empty(t, result)
-}
+	})
 
-func TestCollectReceiverPipelineMetrics_NoReceiverAttr(t *testing.T) {
-	// Data points without a "receiver" attribute should be skipped.
-	sm := metricdata.ScopeMetrics{
-		Scope: registryBridgeScope(""),
-		Metrics: []metricdata.Metrics{
-			gaugeMetric("pipeline.clients", int64(1)),
-		},
-	}
-	result := collectReceiverMetrics([]metricdata.ScopeMetrics{sm})
-	assert.Empty(t, result)
-}
+	md := metricdataToPdata(rm)
 
-func TestCollectReceiverPipelineMetrics_MultipleReceivers(t *testing.T) {
-	const fbReceiverID = "filebeatreceiver/_agent-component/filebeat-default"
-	const mbReceiverID = "metricbeatreceiver/_agent-component/metricbeat-default"
-	sm := metricdata.ScopeMetrics{
-		Scope: registryBridgeScope(""),
-		Metrics: []metricdata.Metrics{
-			gaugeMetricWithReceiverAttr("pipeline.clients", int64(2), fbReceiverID),
-			gaugeMetricWithReceiverAttr("pipeline.clients", int64(5), mbReceiverID),
-		},
-	}
-	result := collectReceiverMetrics([]metricdata.ScopeMetrics{sm})
-	require.Len(t, result, 2)
-	assert.Equal(t, int64(2), result["filebeat-default"]["beat.stats.filebeat.pipeline.clients"])
-	assert.Equal(t, int64(5), result["metricbeat-default"]["beat.stats.metricbeat.pipeline.clients"])
-}
-
-func TestAgentComponentID(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"filebeatreceiver/_agent-component/filebeat-default", "filebeat-default"},
-		{"elasticsearch/_agent-component/monitoring", "monitoring"},
-		{"filebeatreceiver/some-other-prefix", ""},
-		{"no-prefix-at-all", ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			assert.Equal(t, tt.expected, agentComponentID(tt.input))
-		})
-	}
+	dp := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0)
+	v, ok := dp.Attributes().Get("receiver")
+	require.True(t, ok)
+	assert.Equal(t, otelID, v.Str())
 }

--- a/internal/edot/receivers/elasticmonitoring/factory.go
+++ b/internal/edot/receivers/elasticmonitoring/factory.go
@@ -15,35 +15,19 @@ const (
 	Name = "elasticmonitoringreceiver"
 )
 
+// Config holds the configuration for the elasticmonitoringreceiver.
+// Event templates, exporter name mappings, and datastream routing live in the
+// downstream elasticmonitoringconnector; this receiver is only responsible for
+// polling interval.
 type Config struct {
-	// EventTemplate provides the static fields that will be included in every
-	// generated event. If data_stream.* is present, these fields will be set
-	// as attributes on the resulting log record, so the elasticsearch
-	// exporter will route it to the correct datastream.
-	EventTemplate struct {
-		Fields map[string]interface{} `mapstructure:",remain"`
-	} `mapstructure:"event_template"`
-
-	// InputEventTemplate provides the static fields for per-input events.
-	// If unset, per-input events are emitted without base fields (no datastream
-	// routing). When set, data_stream.* should be configured to route input
-	// events to the correct datastream (e.g. elastic_agent.filebeat_input).
-	InputEventTemplate struct {
-		Fields map[string]interface{} `mapstructure:",remain"`
-	} `mapstructure:"input_event_template"`
-
 	Interval time.Duration `mapstructure:"interval"`
-
-	// A map from OTel exporter IDs to the component name that should be used
-	// when reporting their metrics.
-	ExporterNames map[string]string `mapstructure:"exporter_names"`
 }
 
 func NewFactory() receiver.Factory {
 	return receiver.NewFactory(
 		component.MustNewType(Name),
 		createDefaultConfig,
-		receiver.WithLogs(createReceiver, component.StabilityLevelAlpha))
+		receiver.WithMetrics(createReceiver, component.StabilityLevelAlpha))
 }
 
 func createDefaultConfig() component.Config {

--- a/internal/edot/receivers/elasticmonitoring/receiver.go
+++ b/internal/edot/receivers/elasticmonitoring/receiver.go
@@ -10,21 +10,17 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/elastic/beats/v7/libbeat/otel/otelmap"
-	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent/internal/edot/internaltelemetry"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/pdata/pcommon"
-	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver"
 )
 
 type monitoringReceiver struct {
 	logger   *zap.Logger
 	config   *Config
-	consumer consumer.Logs
+	consumer consumer.Metrics
 
 	runCtx context.Context
 	cancel context.CancelFunc
@@ -36,11 +32,11 @@ type monitoringReceiver struct {
 }
 
 func createReceiver(
-	ctx context.Context,
+	_ context.Context,
 	set receiver.Settings,
 	baseCfg component.Config,
-	consumer consumer.Logs,
-) (receiver.Logs, error) {
+	next consumer.Metrics,
+) (receiver.Metrics, error) {
 	cfg := baseCfg.(*Config)
 
 	runCtx, cancel := context.WithCancel(context.Background())
@@ -48,14 +44,14 @@ func createReceiver(
 	return &monitoringReceiver{
 		logger:   set.Logger,
 		config:   cfg,
-		consumer: consumer,
+		consumer: next,
 		runCtx:   runCtx,
 		cancel:   cancel,
 		done:     make(chan struct{}),
 	}, nil
 }
 
-func (mr *monitoringReceiver) Start(ctx context.Context, _ component.Host) error {
+func (mr *monitoringReceiver) Start(_ context.Context, _ component.Host) error {
 	go func() {
 		defer close(mr.done)
 		mr.run()
@@ -93,99 +89,9 @@ func (mr *monitoringReceiver) updateMetrics() {
 		mr.logger.Info("couldn't collect metrics", zap.Error(err))
 		return
 	}
-	exporterMetrics := convertScopeMetrics(resourceMetrics.ScopeMetrics)
-	for exporter, metrics := range exporterMetrics {
-		componentID, ok := mr.config.ExporterNames[exporter]
-		if !ok {
-			mr.logger.Warn("Reporting metrics for exporter with no specified component name", zap.String("exporter_id", exporter))
-			componentID = exporter
-		}
-		mr.sendExporterMetricsEvent(componentID, metrics)
-	}
-
-	// Send per-input metrics, one document per input, for filebeat only.
-	// Metricbeat has no per-input monitoring equivalent; other beat types are
-	// not expected to have a corresponding *_input datastream.
-	componentMetrics := collectComponentInputMetrics(resourceMetrics.ScopeMetrics)
-	for compID, compData := range componentMetrics {
-		if compData.beatType != "filebeat" {
-			continue
-		}
-		for _, inputMetrics := range compData.inputs {
-			mr.sendInputMetricsEvent(compID, compData.beatType, inputMetrics)
-		}
-	}
-
-	// Send per-receiver pipeline metrics, one document per Beat receiver.
-	// The pipeline runs internally within each Beat receiver, so separate
-	// events allow visibility into which receiver's pipeline may be backed up.
-	receiverPipelineMetrics := collectReceiverMetrics(resourceMetrics.ScopeMetrics)
-	for compID, fields := range receiverPipelineMetrics {
-		mr.sendReceiverPipelineMetricsEvent(compID, fields)
-	}
-}
-
-func (mr *monitoringReceiver) sendExporterMetricsEvent(componentID string, metrics exporterMetrics) {
-	beatEvent := mapstr.M(mr.config.EventTemplate.Fields).Clone()
-	addMetricsToEventFields(mr.logger, metrics, &beatEvent)
-	_, _ = beatEvent.Put("component.id", componentID)
-	mr.sendLogRecord(beatEvent, componentID)
-}
-
-func (mr *monitoringReceiver) sendReceiverPipelineMetricsEvent(componentID string, fields map[string]any) {
-	beatEvent := mapstr.M(mr.config.EventTemplate.Fields).Clone()
-	_, _ = beatEvent.Put("component.id", componentID)
-	for k, v := range fields {
-		_, _ = beatEvent.Put(k, v)
-	}
-	mr.sendLogRecord(beatEvent, componentID)
-}
-
-func (mr *monitoringReceiver) sendInputMetricsEvent(componentID string, beatType string, inputMetrics map[string]any) {
-	beatEvent := mapstr.M(mr.config.InputEventTemplate.Fields).Clone()
-	_, _ = beatEvent.Put("component.id", componentID)
-	namespace := beatType + "_input"
-	for k, v := range inputMetrics {
-		_, _ = beatEvent.Put(namespace+"."+k, v)
-	}
-	mr.sendLogRecord(beatEvent, componentID)
-}
-
-func (mr *monitoringReceiver) sendLogRecord(beatEvent mapstr.M, componentID string) {
-	pLogs := plog.NewLogs()
-	resourceLogs := pLogs.ResourceLogs().AppendEmpty()
-	sourceLogs := resourceLogs.ScopeLogs().AppendEmpty()
-	logRecords := sourceLogs.LogRecords()
-	logRecord := logRecords.AppendEmpty()
-
-	sourceLogs.Scope().Attributes().PutStr("elastic.mapping.mode", "bodymap")
-
-	// Set timestamp
-	now := time.Now()
-	beatEvent["@timestamp"] = now
-	timestamp := pcommon.NewTimestampFromTime(now)
-	logRecord.SetTimestamp(timestamp)
-	logRecord.SetObservedTimestamp(timestamp)
-
-	// Add data_stream metadata to the log record attributes
-	if val, _ := beatEvent.GetValue("data_stream"); val != nil {
-		for _, subField := range []string{"dataset", "namespace", "type"} {
-			value, err := beatEvent.GetValue("data_stream." + subField)
-			if vStr, ok := value.(string); ok && err == nil {
-				// set log record attribute only if value is non empty
-				logRecord.Attributes().PutStr("data_stream."+subField, vStr)
-			}
-		}
-	}
-
-	// Set log record body to computed fields
-	if err := otelmap.FromMapstr(logRecord.Body().SetEmptyMap(), beatEvent); err != nil {
-		mr.logger.Error("couldn't convert map to plog.Log, some fields might be missing", zap.Error(err))
-	}
-
-	err := mr.consumer.ConsumeLogs(mr.runCtx, pLogs)
-	if err != nil && mr.runCtx.Err() == nil {
+	md := metricdataToPdata(resourceMetrics)
+	if err := mr.consumer.ConsumeMetrics(mr.runCtx, md); err != nil && mr.runCtx.Err() == nil {
 		// Don't log an error if the context is cancelled, that's just a normal shutdown
-		mr.logger.Error("error sending internal telemetry log record", zap.String("component.id", componentID), zap.Error(err))
+		mr.logger.Error("error sending internal telemetry metrics", zap.Error(err))
 	}
 }

--- a/internal/pkg/otel/manager/manager.go
+++ b/internal/pkg/otel/manager/manager.go
@@ -47,6 +47,9 @@ const (
 
 	// elasticMonitoringReceiverName is the component type name for the elastic monitoring receiver.
 	elasticMonitoringReceiverName = "elasticmonitoringreceiver"
+	// elasticMonitoringConnectorName is the component type name for the elastic monitoring connector.
+	// The connector receives pdata.Metrics from the receiver and converts them to Beats-format pdata.Logs.
+	elasticMonitoringConnectorName = "elasticmonitoringconnector"
 )
 
 type collectorRecoveryTimer interface {
@@ -655,37 +658,40 @@ func injectMonitoringReceiver(
 	}
 
 	receiverType := otelcomponent.MustNewType(elasticMonitoringReceiverName)
+	connectorType := otelcomponent.MustNewType(elasticMonitoringConnectorName)
 	receiverName := "internal-telemetry-monitoring"
 	receiverID := translate.GetReceiverID(receiverType, receiverName).String()
 	processorID := translate.GetProcessorID().String()
-	pipelineID := "logs/" + translate.OtelNamePrefix + receiverName
+
+	diagName := translate.OtelNamePrefix + receiverName
+	connectorID := otelcomponent.NewIDWithName(connectorType, diagName).String()
+	metricsPipelineID := "metrics/" + translate.OtelNamePrefix + receiverName
+	logsPipelineID := "logs/" + translate.OtelNamePrefix + receiverName
 
 	// Build a file exporter for writing internal telemetry to disk as a diagnostics
 	// artifact. The file is written to the default logs directory.
 	// Records are written as plain OTLP JSON (one record per line). No compression.
 	// This data format compresses very well, so impact on diagnostics is minimal.
-	diagName := translate.OtelNamePrefix + receiverName
 	fileExporterID := otelcomponent.NewIDWithName(otelcomponent.MustNewType("file"), diagName).String()
 	diagFilePath := filepath.Join(paths.Home(), "logs", internalTelemetryDiagnosticsFileName)
 
-	// The pipeline always writes to the file exporter (for diagnostics). When
-	// OTel-based monitoring is also configured, the ES monitoring exporter is
-	// included too so that the data flows to Elasticsearch as well.
-	pipelineExporters := []string{fileExporterID}
+	// The metrics pipeline always writes to the file exporter (for diagnostics in
+	// proper OTel metrics format). When OTel-based monitoring is also configured,
+	// the connector is included as an additional exporter so that metrics are
+	// converted to Beats-format logs and forwarded to Elasticsearch.
+	metricsPipelineExporters := []string{fileExporterID}
 	if monitoringExporterFound {
-		pipelineExporters = append(pipelineExporters, exporterID)
+		metricsPipelineExporters = append(metricsPipelineExporters, connectorID)
 	}
-	pipelineCfg := map[string]any{
+	metricsPipelineCfg := map[string]any{
 		"receivers": []string{receiverID},
-		"exporters": pipelineExporters,
+		"exporters": metricsPipelineExporters,
 	}
+
 	collectorCfg := map[string]any{
 		"receivers": map[string]any{
 			receiverID: map[string]any{
-				"event_template":       monitoringEventTemplate(monitoring, agentInfo, logger),
-				"input_event_template": monitoringInputEventTemplate(monitoring, agentInfo, logger),
-				"interval":             monitoring.MetricsPeriod,
-				"exporter_names":       outputNameLookup,
+				"interval": monitoring.MetricsPeriod,
 			},
 		},
 		"exporters": map[string]any{
@@ -700,20 +706,38 @@ func injectMonitoringReceiver(
 		},
 		"service": map[string]any{
 			"pipelines": map[string]any{
-				pipelineID: pipelineCfg,
+				metricsPipelineID: metricsPipelineCfg,
 			},
 		},
 	}
-	if features.DefaultProcessors() {
-		// If default processors are enabled, reference the shared beat processor.
-		// The processor definition is the same as the one added in GetOtelConfig,
-		// so upon merge one replaces the other with identical content.
-		collectorCfg["processors"] = map[string]any{
-			processorID: map[string]any{
-				"processors": translate.GetDefaultProcessors(),
+
+	// When OTel-based monitoring is configured, add the connector and a logs
+	// pipeline so that metrics are converted to Beats-format monitoring events
+	// and forwarded to Elasticsearch.
+	if monitoringExporterFound {
+		logsPipelineCfg := map[string]any{
+			"receivers": []string{connectorID},
+			"exporters": []string{exporterID},
+		}
+		if features.DefaultProcessors() {
+			// If default processors are enabled, reference the shared beat processor.
+			// The processor definition is the same as the one added in GetOtelConfig,
+			// so upon merge one replaces the other with identical content.
+			collectorCfg["processors"] = map[string]any{
+				processorID: map[string]any{
+					"processors": translate.GetDefaultProcessors(),
+				},
+			}
+			logsPipelineCfg["processors"] = []string{processorID}
+		}
+		collectorCfg["connectors"] = map[string]any{
+			connectorID: map[string]any{
+				"event_template":       monitoringEventTemplate(monitoring, agentInfo, logger),
+				"input_event_template": monitoringInputEventTemplate(monitoring, agentInfo, logger),
+				"exporter_names":       outputNameLookup,
 			},
 		}
-		pipelineCfg["processors"] = []string{processorID}
+		collectorCfg["service"].(map[string]any)["pipelines"].(map[string]any)[logsPipelineID] = logsPipelineCfg
 	}
 
 	return mergeWithExtensions(config, confmap.NewFromStringMap(collectorCfg))

--- a/internal/pkg/otel/manager/manager_test.go
+++ b/internal/pkg/otel/manager/manager_test.go
@@ -2522,7 +2522,9 @@ func TestAddCollectorMetricsPort(t *testing.T) {
 func TestMonitoringReceiverProcessors(t *testing.T) {
 	exporterName := "elasticsearch/" + translate.OtelNamePrefix + "monitoring"
 	procName := translate.GetProcessorID().String()
-	pipelineName := "logs/" + translate.OtelNamePrefix + "internal-telemetry-monitoring"
+	// Processors are injected on the logs pipeline (connector → ES), which is only
+	// created when an OTel-based monitoring exporter is present.
+	logsPipelineName := "logs/" + translate.OtelNamePrefix + "internal-telemetry-monitoring"
 	baseConfig := map[string]any{
 		"exporters": map[string]any{
 			exporterName: nil,
@@ -2544,19 +2546,24 @@ func TestMonitoringReceiverProcessors(t *testing.T) {
 	}
 
 	expectedPipelineProcessors := []string{procName}
-	actualPipelineProcessors := result["service.pipelines."+pipelineName+".processors"]
-	assert.NotNil(t, actualPipelineProcessors, "processors for monitoring receiver pipeline should not be nil")
-	assert.ElementsMatch(t, expectedPipelineProcessors, actualPipelineProcessors, "monitoring receiver pipeline processors should match default")
+	actualPipelineProcessors := result["service.pipelines."+logsPipelineName+".processors"]
+	assert.NotNil(t, actualPipelineProcessors, "processors for monitoring logs pipeline should not be nil")
+	assert.ElementsMatch(t, expectedPipelineProcessors, actualPipelineProcessors, "monitoring logs pipeline processors should match default")
 }
 
 func TestMonitoringReceiverFileExporter(t *testing.T) {
-	pipelineName := "logs/" + translate.OtelNamePrefix + "internal-telemetry-monitoring"
 	receiverName := "internal-telemetry-monitoring"
+	// The file exporter is on the metrics pipeline, which always exists.
+	metricsPipelineName := "metrics/" + translate.OtelNamePrefix + receiverName
+	// The logs pipeline (connector → ES) only exists when ES monitoring is configured.
+	logsPipelineName := "logs/" + translate.OtelNamePrefix + receiverName
 	fileExporterName := "file/" + translate.OtelNamePrefix + receiverName
+	connectorName := elasticMonitoringConnectorName + "/" + translate.OtelNamePrefix + receiverName
 
 	t.Run("with OTel monitoring exporter", func(t *testing.T) {
-		// When an OTel-based monitoring exporter is present, the pipeline should
-		// export to both the file and the ES monitoring exporter.
+		// When an OTel-based monitoring exporter is present:
+		// - metrics pipeline: receiver → [file exporter, connector]
+		// - logs pipeline:    connector → ES monitoring exporter
 		exporterName := "elasticsearch/" + translate.OtelNamePrefix + "monitoring"
 		baseConfig := map[string]any{
 			"exporters": map[string]any{
@@ -2568,31 +2575,48 @@ func TestMonitoringReceiverFileExporter(t *testing.T) {
 		require.NoError(t, err, "injectMonitoringReceiver should succeed")
 		result := mapstr.M(cfg.ToStringMap()).Flatten()
 
-		pipelineExporters := result["service.pipelines."+pipelineName+".exporters"]
-		require.NotNil(t, pipelineExporters, "pipeline exporters should not be nil")
+		// Metrics pipeline exports to file and to the connector.
+		metricsExporters := result["service.pipelines."+metricsPipelineName+".exporters"]
+		require.NotNil(t, metricsExporters, "metrics pipeline exporters should not be nil")
 		assert.ElementsMatch(t,
-			[]string{exporterName, fileExporterName},
-			pipelineExporters,
-			"pipeline should export to both elasticsearch and the diagnostics file exporter",
+			[]string{fileExporterName, connectorName},
+			metricsExporters,
+			"metrics pipeline should export to the file exporter and the connector",
+		)
+
+		// Logs pipeline (connector output) exports to ES.
+		logsExporters := result["service.pipelines."+logsPipelineName+".exporters"]
+		require.NotNil(t, logsExporters, "logs pipeline exporters should not be nil")
+		assert.ElementsMatch(t,
+			[]string{exporterName},
+			logsExporters,
+			"logs pipeline should export to the elasticsearch monitoring exporter",
 		)
 	})
 
 	t.Run("without OTel monitoring exporter", func(t *testing.T) {
 		// When no OTel-based monitoring exporter exists (e.g. classic HTTP-based
-		// monitoring is in use), the pipeline should still be injected so that
-		// internal telemetry is captured in the diagnostics file.
+		// monitoring is in use), the metrics pipeline is still injected so that
+		// internal telemetry is captured in the diagnostics file. No connector or
+		// logs pipeline is added since there is no ES output to send logs to.
 		cfg := confmap.NewFromStringMap(map[string]any{})
 		err := injectMonitoringReceiver(cfg, &config.MonitoringConfig{}, &info.AgentInfo{}, []component.Component{}, logp.NewNopLogger())
 		require.NoError(t, err, "injectMonitoringReceiver should succeed without monitoring exporter")
 		result := mapstr.M(cfg.ToStringMap()).Flatten()
 
-		pipelineExporters := result["service.pipelines."+pipelineName+".exporters"]
-		require.NotNil(t, pipelineExporters, "pipeline should still be created with file-only exporters")
+		metricsExporters := result["service.pipelines."+metricsPipelineName+".exporters"]
+		require.NotNil(t, metricsExporters, "metrics pipeline should still be created with file-only exporters")
 		assert.ElementsMatch(t,
 			[]string{fileExporterName},
-			pipelineExporters,
-			"pipeline should export only to the diagnostics file exporter when no OTel monitoring exporter is present",
+			metricsExporters,
+			"metrics pipeline should export only to the diagnostics file exporter when no OTel monitoring exporter is present",
 		)
+
+		// No connector, no logs pipeline.
+		assert.Nil(t, result["connectors."+connectorName],
+			"connector should not be injected when no OTel monitoring exporter is present")
+		assert.Nil(t, result["service.pipelines."+logsPipelineName],
+			"logs pipeline should not be created when no OTel monitoring exporter is present")
 	})
 
 	t.Run("file exporter config", func(t *testing.T) {
@@ -2607,8 +2631,8 @@ func TestMonitoringReceiverFileExporter(t *testing.T) {
 		assert.Equal(t, expectedPath, result["exporters."+fileExporterName+".path"],
 			"file exporter path should be in paths.Home()/logs/")
 
-		// Records are written as OTLP JSON — format: json uses the same plog.JSONMarshaler
-		// as the otlp_encoding extension, without needing a separate extension component.
+		// Records are written as OTLP JSON metrics — format: json uses the same metrics
+		// marshaler as the otlp_encoding extension, without needing a separate extension component.
 		assert.Equal(t, "json", result["exporters."+fileExporterName+".format"])
 
 		// Rotation settings: 10 MB cap with one backup.

--- a/testing/integration/ess/otel_test.go
+++ b/testing/integration/ess/otel_test.go
@@ -2348,6 +2348,8 @@ agent.logging.to_stderr: true
 receivers:
   elasticmonitoringreceiver:
     interval: 3s
+connectors:
+  elasticmonitoringconnector: {}
 exporters:
   elasticsearch/1:
     endpoints:
@@ -2378,8 +2380,11 @@ processors:
 
 service:
   pipelines:
-    logs:
+    metrics:
       receivers: [elasticmonitoringreceiver]
+      exporters: [elasticmonitoringconnector]
+    logs:
+      receivers: [elasticmonitoringconnector]
       processors: [beat/1]
       exporters:
         - elasticsearch/1


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Moves conversion of beats metrics from otel pdata metrics to ECS-in-bodymap logs from the `elasticmonitoring` receiver to a new `elasticmonitoring` connector. The receiver now emits pdata metrics, and the connector consumes pdata metrics and emits pdata logs.

As a consequence, our file exporter writing metrics data to disk can emit native otel metrics, which makes them consumable via a variety of upstream otel tooling. 

The pipeline used to look like:

```
elasticmonitoringreceiver -> beatsprocessor -> elasticsearchexporter
                                            -> fileexporter
```

Now it's:

```
elasticmonitoringreceiver -> elasticmonitoringconnector -> beatsprocessor -> elasticsearchexporter
                          -> fileexporter
```

## Why is it important?

Having the metrics in an easily consumable format in diagnostics will let us get rid of metrics snapshots in logs, which are quite expensive with each stream running in its own receiver. See https://github.com/elastic/beats/issues/51459.

This will also let us replace the elasticmonitoringreceiver with an otlpreceiver and drop out invasive customizations of the otel collector telemetry stack completely.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

None, this is changing behavior that hasn't been released yet.

## How to test this PR locally

Build agent locally, start it, then go to the logs directory and inspect the `elastic-agent-metrics.ndjson` file. I used `otel-tui`.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/15159

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
