### PR TITLE
Switch auditbeat to run as a receiver by default.

### DIFF
--- a/changelog/fragments/1782497509-run-audit-inputs-as-collector-receivers-by-default,-reducing-steady-state-memory-usage.yaml
+++ b/changelog/fragments/1782497509-run-audit-inputs-as-collector-receivers-by-default,-reducing-steady-state-memory-usage.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Run audit inputs as collector receivers by default, reducing steady state memory usage
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -59,6 +59,7 @@ func DefaultRuntimeConfig() *RuntimeConfig {
 		Default:       string(DefaultRuntimeManager),
 		DynamicInputs: string(ProcessRuntimeManager),
 		Auditbeat: BeatRuntimeConfig{
+			Default: string(OtelRuntimeManager),
 			// go-ucfg sets this while unpacking, having it in the default makes testing easier
 			InputType: make(map[string]string),
 		},

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -4279,7 +4279,7 @@ func TestDefaultRuntimeConfig(t *testing.T) {
 	require.NotNil(t, config)
 	assert.Equal(t, string(DefaultRuntimeManager), config.Default)
 	assert.Equal(t, string(ProcessRuntimeManager), config.DynamicInputs)
-	assert.Equal(t, "", config.Auditbeat.Default)
+	assert.Equal(t, "otel", config.Auditbeat.Default)
 	assert.Empty(t, config.Auditbeat.InputType)
 	assert.Equal(t, "otel", config.Filebeat.Default)
 	assert.Empty(t, config.Filebeat.InputType)

--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -154,25 +154,12 @@ func (runner *AuditDRunner) TestBeatsMetrics() {
 
 	testStart := time.Now()
 
-	// Validate process mode
-	var processDoc mapstr.M
-	t.Run("process", func(t *testing.T) {
-		processDoc = runner.validateAuditdEvents(t, ctx, agentStatus.Info.ID, testStart, "")
-	})
-
-	// Switch to OTel runtime and validate the same data
+	// Validate OTel mode (the default for auditbeat).
 	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
-		otelSince := time.Now()
-		policyRevision := switchPolicyToOtelRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
-
-		// Wait for the agent to apply the new policy revision
-		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
-			5*time.Minute, time.Second)
-
 		// Verify that an audit/auditd component is running as a beats receiver.
-		// The component may not appear immediately after the policy switch, so we
-		// look for it inside the loop rather than capturing its ID up front.
+		// The component may not appear immediately after startup, so we look for
+		// it inside the loop rather than capturing its ID up front.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			status, statusErr := runner.agentFixture.ExecStatus(ctx)
 			require.NoError(collect, statusErr)
@@ -189,28 +176,82 @@ func (runner *AuditDRunner) TestBeatsMetrics() {
 			assert.True(collect, foundReceiver, "expected an audit/auditd component to be running as beats receiver")
 		}, 2*time.Minute, 5*time.Second, "beat component should be running as beats receiver")
 
-		// Use the same event.action as the process document to ensure we compare
+		otelDoc = runner.validateAuditdEvents(t, ctx, agentStatus.Info.ID, testStart, "")
+	})
+
+	// Switch to process runtime and validate the same data.
+	var processDoc mapstr.M
+	t.Run("process", func(t *testing.T) {
+		processSince := time.Now()
+		policyRevision := switchAuditbeatToProcessRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
+
+		// Wait for the agent to apply the new policy revision.
+		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
+			5*time.Minute, time.Second)
+
+		// Verify that the audit/auditd component has switched to process mode.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			status, statusErr := runner.agentFixture.ExecStatus(ctx)
+			require.NoError(collect, statusErr)
+			var foundProcess bool
+			for _, comp := range status.Components {
+				if strings.HasPrefix(comp.ID, "audit/auditd") &&
+					comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.ProcessRuntimeManager) {
+					assert.Equal(collect, int(cproto.State_HEALTHY), comp.State,
+						"expected audit/auditd component to be healthy, got %s", cproto.State(comp.State))
+					foundProcess = true
+					break
+				}
+			}
+			assert.True(collect, foundProcess, "expected an audit/auditd component to be running as a process")
+		}, 2*time.Minute, 5*time.Second, "beat component should be running as a process")
+
+		// Use the same event.action as the OTel document to ensure we compare
 		// semantically equivalent events across runtime modes. auditd.data fields
 		// are excluded from the key comparison because they are audit event type-
 		// specific and vary even within the same event.action depending on kernel
 		// version and PAM configuration (e.g. grantors may or may not be present).
-		var otelEventAction string
-		if processDoc != nil {
-			if v, err := processDoc.GetValue("event.action"); err == nil {
-				otelEventAction, _ = v.(string)
+		var processEventAction string
+		if otelDoc != nil {
+			if v, err := otelDoc.GetValue("event.action"); err == nil {
+				processEventAction, _ = v.(string)
 			}
 		}
-		otelDoc = runner.validateAuditdEvents(t, ctx, agentStatus.Info.ID, otelSince, otelEventAction)
+		processDoc = runner.validateAuditdEvents(t, ctx, agentStatus.Info.ID, processSince, processEventAction)
 	})
 
-	// Compare documents from process and otel modes have the same keys.
+	// Compare documents from otel and process modes have the same keys.
 	// auditd.data fields are excluded because they are audit event type-specific
 	// and can legitimately differ even for the same event.action.
 	t.Run("compare", func(t *testing.T) {
-		if processDoc == nil || otelDoc == nil {
+		if otelDoc == nil || processDoc == nil {
 			t.Skip("skipping comparison because a previous subtest failed")
 		}
 		ignoredFields := append(RuntimeComparisonIgnoredFields, "auditd.data")
-		AssertMapstrKeysEqual(t, processDoc, otelDoc, ignoredFields, "expected auditd document keys to be equal between process and otel modes")
+		AssertMapstrKeysEqual(t, otelDoc, processDoc, ignoredFields, "expected auditd document keys to be equal between otel and process modes")
 	})
+}
+
+// switchAuditbeatToProcessRuntime updates the given policy to override the
+// auditbeat runtime to process and returns the new policy revision.
+func switchAuditbeatToProcessRuntime(ctx context.Context, t testing.TB, kibanaClient *kibana.Client, policyID, policyName, namespace string) int {
+	t.Helper()
+	updateReq := kibana.AgentPolicyUpdateRequest{
+		Name:      policyName,
+		Namespace: namespace,
+		Overrides: map[string]interface{}{
+			"agent": map[string]interface{}{
+				"internal": map[string]interface{}{
+					"runtime": map[string]interface{}{
+						"auditbeat": map[string]interface{}{
+							"default": "process",
+						},
+					},
+				},
+			},
+		},
+	}
+	policyResp, err := kibanaClient.UpdatePolicy(ctx, policyID, updateReq)
+	require.NoError(t, err)
+	return policyResp.Revision
 }


### PR DESCRIPTION
- Closes https://github.com/elastic/elastic-agent/issues/14553
- Closes https://github.com/elastic/ingest-dev/issues/7387

Have auditbeat run as a receiver by default. Installed in a Linux VM and the auditd dashboards lit up as expected.

<img width="2446" height="906" alt="Screenshot 2026-06-26 at 11 32 17 AM" src="https://github.com/user-attachments/assets/329f9eff-b029-4176-8958-52f9f23c4416" />

<img width="2453" height="969" alt="Screenshot 2026-06-26 at 11 32 23 AM" src="https://github.com/user-attachments/assets/130eed3f-b587-4b55-876c-314ad807095d" />

<img width="2462" height="1033" alt="Screenshot 2026-06-26 at 11 32 30 AM" src="https://github.com/user-attachments/assets/54ca7e9e-91c5-4a7a-b660-477eba088e57" />

Using auditbeat as a receiver in a policy with the system integration and monitoring enabled uses ~168M of memory vs ~275M with it as a sub-process.

```
ubuntu@ubuntu:~/elastic-agent-9.5.0-SNAPSHOT-linux-arm64$ sudo systemctl status elastic-agent
● elastic-agent.service - Elastic Agent is a unified agent to observe, monitor and protect your system.
     Loaded: loaded (/etc/systemd/system/elastic-agent.service; enabled; preset: enabled)
     Active: active (running) since Fri 2026-06-26 12:38:03 EDT; 15s ago
   Main PID: 224511 (elastic-agent)
      Tasks: 17 (limit: 1056)
     Memory: 167.8M (peak: 168.1M)
        CPU: 886ms
     CGroup: /system.slice/elastic-agent.service
             ├─224511 /opt/Elastic/Agent/elastic-agent
             └─224526 /opt/Elastic/Agent/data/elastic-agent-9.5.0-SNAPSHOT-7a0aba/components/elastic-ot>

● elastic-agent.service - Elastic Agent is a unified agent to observe, monitor and protect your system.
     Loaded: loaded (/etc/systemd/system/elastic-agent.service; enabled; preset: enabled)
     Active: active (running) since Fri 2026-06-26 14:07:50 EDT; 10s ago
   Main PID: 224867 (elastic-agent)
      Tasks: 25 (limit: 1056)
     Memory: 275.6M (peak: 277.1M)
        CPU: 872ms
     CGroup: /system.slice/elastic-agent.service
             ├─224867 /opt/Elastic/Agent/elastic-agent
             ├─224882 /opt/Elastic/Agent/data/elastic-agent-9.5.0-SNAPSHOT-7a0aba/components/elastic-ot>
             └─224886 /opt/Elastic/Agent/data/elastic-agent-9.5.0-SNAPSHOT-7a0aba/components/elastic-ot>
```
