### PR TITLE
fix(test): stabilize TestNetworkTraffic/TestBeatsMetrics/compare

### DIFF
--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -8,7 +8,11 @@ package ess
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
+	"net"
+	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -103,12 +107,14 @@ func (runner *NetworkTrafficRunner) SetupSuite() {
 
 }
 
-// validateNetworkTrafficEvents waits for TLS events in ES and returns one
-// document per destination hostname (SNI).
-func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(t *testing.T, ctx context.Context, agentID string, since time.Time) map[string]mapstr.M {
+// validateNetworkTrafficEvents generates TLS traffic to serverName and waits
+// for the matching event to be available in ES, returning that document. The
+// traffic is generated inside the poll loop so a single missed capture does not
+// fail the test.
+func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(t *testing.T, ctx context.Context, agentID, serverName string, since time.Time) mapstr.M {
 	now := time.Now()
 	var query map[string]any
-	var docsByHost map[string]mapstr.M
+	var doc mapstr.M
 	defer func() {
 		if t.Failed() {
 			bs, err := json.Marshal(query)
@@ -124,9 +130,11 @@ func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(t *testing.T, c
 
 	t.Logf("starting to query ES for network traffic events at %s", now.Format(time.RFC3339Nano))
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		dialTLS(t, serverName)
+
 		query = genESQuery(agentID,
 			[][]string{
-				{"exists", "field", "tls.client.server_name"},
+				{"match", "tls.client.server_name", serverName},
 			})
 		query["query"].(map[string]interface{})["bool"].(map[string]interface{})["filter"] = map[string]any{
 			"range": map[string]any{
@@ -138,21 +146,38 @@ func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(t *testing.T, c
 		res, err := estools.PerformQueryForRawQuery(ctx, query, "logs-network_traffic.tls*", runner.info.ESClient)
 		require.NoError(collect, err)
 		require.NotEmpty(collect, res.Hits.Hits)
-		docs := make(map[string]mapstr.M)
-		for _, hit := range res.Hits.Hits {
-			source := mapstr.M(hit.Source)
-			sn, _ := source.Flatten()["tls.client.server_name"].(string)
-			if sn == "" {
-				continue
-			}
-			if _, exists := docs[sn]; !exists {
-				docs[sn] = source
-			}
-		}
-		require.NotEmpty(collect, docs)
-		docsByHost = docs
-	}, time.Minute*10, time.Second*10, "could not fetch events for network_traffic")
-	return docsByHost
+		doc = mapstr.M(res.Hits.Hits[0].Source)
+	}, time.Minute*10, time.Second*10, "could not fetch events for network_traffic to %s", serverName)
+	return doc
+}
+
+// esServerName returns the hostname of the Elasticsearch endpoint, used as the
+// TLS SNI for the controlled connection the test generates.
+func esServerName(t *testing.T) string {
+	raw := os.Getenv("ELASTICSEARCH_HOST")
+	require.NotEmpty(t, raw, "ELASTICSEARCH_HOST must be set")
+	u, err := url.Parse(raw)
+	require.NoError(t, err, "parsing ELASTICSEARCH_HOST")
+	require.NotEmpty(t, u.Hostname(), "ELASTICSEARCH_HOST has no hostname")
+	return u.Hostname()
+}
+
+// dialTLS opens and closes a TLS connection to host:443 so the packet component
+// captures a fresh handshake with a known SNI. The ClientHello carrying the SNI
+// is sent before any certificate verification, so the captured event is produced
+// even if the handshake does not complete.
+func dialTLS(t *testing.T, host string) {
+	conn, err := tls.DialWithDialer(
+		&net.Dialer{Timeout: 10 * time.Second},
+		"tcp",
+		net.JoinHostPort(host, "443"),
+		&tls.Config{ServerName: host},
+	)
+	if err != nil {
+		t.Logf("TLS dial to %s returned %v (handshake still captured)", host, err)
+		return
+	}
+	_ = conn.Close()
 }
 
 func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
@@ -164,14 +189,17 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 	agentStatus, err := runner.agentFixture.ExecStatus(ctx)
 	require.NoError(t, err, "could not get agent status")
 
-	testStart := time.Now()
+	// Compare the same destination in both runtimes: the test generates its own
+	// TLS traffic to the ES endpoint, so the captured handshake (SNI, extensions,
+	// geo enrichment) is identical by construction.
+	serverName := esServerName(t)
 
-	var processDocs map[string]mapstr.M
+	var processDoc mapstr.M
 	t.Run("process", func(t *testing.T) {
-		processDocs = runner.validateNetworkTrafficEvents(t, ctx, agentStatus.Info.ID, testStart)
+		processDoc = runner.validateNetworkTrafficEvents(t, ctx, agentStatus.Info.ID, serverName, time.Now())
 	})
 
-	var otelDocs map[string]mapstr.M
+	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
 		otelSince := time.Now()
 		policyRevision := switchPolicyToOtelRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
@@ -196,37 +224,13 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 			assert.True(collect, foundReceiver, "expected a packet (network_traffic) component to be running as beats receiver")
 		}, 2*time.Minute, 5*time.Second, "beat component should be running as beats receiver")
 
-		otelDocs = runner.validateNetworkTrafficEvents(t, ctx, agentStatus.Info.ID, otelSince)
+		otelDoc = runner.validateNetworkTrafficEvents(t, ctx, agentStatus.Info.ID, serverName, otelSince)
 	})
 
-	// Compare per host: for the same destination the two modes must produce identical fields.
 	t.Run("compare", func(t *testing.T) {
-		require.NotNil(t, processDocs, "process subtest did not produce documents")
-		require.NotNil(t, otelDocs, "otel subtest did not produce documents")
-		var commonHosts []string
-		for host := range processDocs {
-			if _, ok := otelDocs[host]; ok {
-				commonHosts = append(commonHosts, host)
-			}
-		}
-		require.NotEmpty(t, commonHosts,
-			"no common tls.client.server_name found between process and otel phases; process=%v otel=%v",
-			hostKeys(processDocs), hostKeys(otelDocs))
-		for _, host := range commonHosts {
-			host := host
-			t.Run(host, func(t *testing.T) {
-				AssertMapstrKeysEqual(t, processDocs[host], otelDocs[host], RuntimeComparisonIgnoredFields,
-					"expected network_traffic document keys to be equal between process and otel modes")
-			})
-		}
+		require.NotNil(t, processDoc, "process subtest did not produce a document")
+		require.NotNil(t, otelDoc, "otel subtest did not produce a document")
+		AssertMapstrKeysEqual(t, processDoc, otelDoc, RuntimeComparisonIgnoredFields,
+			"expected network_traffic document keys to be equal between process and otel modes")
 	})
-}
-
-// hostKeys returns the hostnames from a per-host document map, for use in error messages.
-func hostKeys(m map[string]mapstr.M) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
 }

--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -107,10 +107,9 @@ func (runner *NetworkTrafficRunner) SetupSuite() {
 
 }
 
-// validateNetworkTrafficEvents generates TLS traffic to serverName and waits
-// for the matching event to be available in ES, returning that document. The
-// traffic is generated inside the poll loop so a single missed capture does not
-// fail the test.
+// validateNetworkTrafficEvents generates TLS traffic to serverName and returns
+// the captured event for it. Traffic is generated on every poll so a missed
+// capture is retried rather than failing the test.
 func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(t *testing.T, ctx context.Context, agentID, serverName string, since time.Time) mapstr.M {
 	now := time.Now()
 	var query map[string]any
@@ -151,8 +150,7 @@ func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(t *testing.T, c
 	return doc
 }
 
-// esServerName returns the hostname of the Elasticsearch endpoint, used as the
-// TLS SNI for the controlled connection the test generates.
+// esServerName returns the Elasticsearch hostname, used as the TLS SNI.
 func esServerName(t *testing.T) string {
 	raw := os.Getenv("ELASTICSEARCH_HOST")
 	require.NotEmpty(t, raw, "ELASTICSEARCH_HOST must be set")
@@ -162,10 +160,8 @@ func esServerName(t *testing.T) string {
 	return u.Hostname()
 }
 
-// dialTLS opens and closes a TLS connection to host:443 so the packet component
-// captures a fresh handshake with a known SNI. The ClientHello carrying the SNI
-// is sent before any certificate verification, so the captured event is produced
-// even if the handshake does not complete.
+// dialTLS triggers a TLS handshake to host:443 for the packet component to
+// capture. A dial error is fine: the SNI is sent before cert verification.
 func dialTLS(t *testing.T, host string) {
 	conn, err := tls.DialWithDialer(
 		&net.Dialer{Timeout: 10 * time.Second},
@@ -189,9 +185,8 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 	agentStatus, err := runner.agentFixture.ExecStatus(ctx)
 	require.NoError(t, err, "could not get agent status")
 
-	// Compare the same destination in both runtimes: the test generates its own
-	// TLS traffic to the ES endpoint, so the captured handshake (SNI, extensions,
-	// geo enrichment) is identical by construction.
+	// Use one fixed destination for both runtimes so the captured handshakes are
+	// directly comparable.
 	serverName := esServerName(t)
 
 	var processDoc mapstr.M

--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -103,10 +103,12 @@ func (runner *NetworkTrafficRunner) SetupSuite() {
 
 }
 
-func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(t *testing.T, ctx context.Context, agentID string, since time.Time) mapstr.M {
+// validateNetworkTrafficEvents waits for TLS events in ES and returns one
+// document per destination hostname (SNI).
+func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(t *testing.T, ctx context.Context, agentID string, since time.Time) map[string]mapstr.M {
 	now := time.Now()
 	var query map[string]any
-	var doc mapstr.M
+	var docsByHost map[string]mapstr.M
 	defer func() {
 		if t.Failed() {
 			bs, err := json.Marshal(query)
@@ -131,13 +133,26 @@ func (runner *NetworkTrafficRunner) validateNetworkTrafficEvents(t *testing.T, c
 				"@timestamp": map[string]any{"gte": since.UTC().Format("2006-01-02T15:04:05.000Z")},
 			},
 		}
+		query["sort"] = []map[string]any{{"@timestamp": map[string]any{"order": "asc"}}}
 		now = time.Now()
 		res, err := estools.PerformQueryForRawQuery(ctx, query, "logs-network_traffic.tls*", runner.info.ESClient)
 		require.NoError(collect, err)
 		require.NotEmpty(collect, res.Hits.Hits)
-		doc = res.Hits.Hits[0].Source
+		docs := make(map[string]mapstr.M)
+		for _, hit := range res.Hits.Hits {
+			source := mapstr.M(hit.Source)
+			sn, _ := source.Flatten()["tls.client.server_name"].(string)
+			if sn == "" {
+				continue
+			}
+			if _, exists := docs[sn]; !exists {
+				docs[sn] = source
+			}
+		}
+		require.NotEmpty(collect, docs)
+		docsByHost = docs
 	}, time.Minute*10, time.Second*10, "could not fetch events for network_traffic")
-	return doc
+	return docsByHost
 }
 
 func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
@@ -151,25 +166,20 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 
 	testStart := time.Now()
 
-	// Validate process mode
-	var processDoc mapstr.M
+	var processDocs map[string]mapstr.M
 	t.Run("process", func(t *testing.T) {
-		processDoc = runner.validateNetworkTrafficEvents(t, ctx, agentStatus.Info.ID, testStart)
+		processDocs = runner.validateNetworkTrafficEvents(t, ctx, agentStatus.Info.ID, testStart)
 	})
 
-	// Switch to OTel runtime and validate the same data
-	var otelDoc mapstr.M
+	var otelDocs map[string]mapstr.M
 	t.Run("otel", func(t *testing.T) {
 		otelSince := time.Now()
 		policyRevision := switchPolicyToOtelRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
 
-		// Wait for the agent to apply the new policy revision
 		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
 			5*time.Minute, time.Second)
 
-		// Verify that a packet (network_traffic) component is running as a beats receiver.
-		// The component may not appear immediately after the policy switch, so we
-		// look for it inside the loop rather than capturing its ID up front.
+		// The packet component may take a moment to appear after the policy switch.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			status, statusErr := runner.agentFixture.ExecStatus(ctx)
 			require.NoError(collect, statusErr)
@@ -186,14 +196,37 @@ func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 			assert.True(collect, foundReceiver, "expected a packet (network_traffic) component to be running as beats receiver")
 		}, 2*time.Minute, 5*time.Second, "beat component should be running as beats receiver")
 
-		otelDoc = runner.validateNetworkTrafficEvents(t, ctx, agentStatus.Info.ID, otelSince)
+		otelDocs = runner.validateNetworkTrafficEvents(t, ctx, agentStatus.Info.ID, otelSince)
 	})
 
-	// Compare documents from process and otel modes have the same keys
+	// Compare per host: for the same destination the two modes must produce identical fields.
 	t.Run("compare", func(t *testing.T) {
-		if processDoc == nil || otelDoc == nil {
-			t.Skip("skipping comparison because a previous subtest failed")
+		require.NotNil(t, processDocs, "process subtest did not produce documents")
+		require.NotNil(t, otelDocs, "otel subtest did not produce documents")
+		var commonHosts []string
+		for host := range processDocs {
+			if _, ok := otelDocs[host]; ok {
+				commonHosts = append(commonHosts, host)
+			}
 		}
-		AssertMapstrKeysEqual(t, processDoc, otelDoc, RuntimeComparisonIgnoredFields, "expected network_traffic document keys to be equal between process and otel modes")
+		require.NotEmpty(t, commonHosts,
+			"no common tls.client.server_name found between process and otel phases; process=%v otel=%v",
+			hostKeys(processDocs), hostKeys(otelDocs))
+		for _, host := range commonHosts {
+			host := host
+			t.Run(host, func(t *testing.T) {
+				AssertMapstrKeysEqual(t, processDocs[host], otelDocs[host], RuntimeComparisonIgnoredFields,
+					"expected network_traffic document keys to be equal between process and otel modes")
+			})
+		}
 	})
+}
+
+// hostKeys returns the hostnames from a per-host document map, for use in error messages.
+func hostKeys(m map[string]mapstr.M) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }


### PR DESCRIPTION
<!-- Bug -->

## What does this PR do?

Makes `TestNetworkTraffic/TestBeatsMetrics/compare` deterministic by generating its own TLS connection to the Elasticsearch endpoint in both the process and OTel phases, then comparing the captured document for that exact host.

## Why is it important?

The test compared two TLS documents captured from whatever traffic happened to be on the host, so the two phases often saw different destinations (e.g. the ES endpoint vs `logging.googleapis.com`) with legitimately different fields — and failed even though both runtimes worked.

A previous attempt compared per host and only used hosts seen in both phases, but in practice the phases sometimes shared no common host, so it still failed.

By generating a controlled connection to the same host with the same TLS stack in both phases, the captured handshake is identical by construction and the comparison checks the only thing that matters: that both runtimes produce the same document shape.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None — test-only change.

## How to test this PR locally

```
go test -v -tags integration -run TestNetworkTraffic ./testing/integration/ess/
```

## Related issues

- Closes #15197
