### PR TITLE
test: fix flaky TestOtelAPMIngestion

### DIFF
--- a/testing/integration/ess/otel_test.go
+++ b/testing/integration/ess/otel_test.go
@@ -62,6 +62,7 @@ const apmProcessingContent = `2023-06-19 05:20:50 ERROR This is a test error mes
 const apmOtelConfig = `receivers:
   filelog:
     include: [ %s ]
+    start_at: beginning  # read apm logs even if otel starts after they are written
     operators:
       - type: regex_parser
         regex: '^(?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) (?P<sev>[A-Z]*) (?P<msg>.*)$'
@@ -734,7 +735,7 @@ func TestOtelAPMIngestion(t *testing.T) {
 	}()
 
 	// wait for apm to start
-	err = logWatcher.WaitForKeys(context.Background(),
+	err = logWatcher.WaitForKeys(ctx,
 		10*time.Minute,
 		500*time.Millisecond,
 		apmReadyLog,
@@ -769,7 +770,7 @@ func TestOtelAPMIngestion(t *testing.T) {
 				return true
 			}
 
-			findCtx, findCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer findCancel()
 			docs, err := estools.GetLogsForIndexWithContext(findCtx, esClient, "logs-apm*", match)
 			if err != nil {


### PR DESCRIPTION
<!-- Bug -->

## What does this PR do?

Fixes the flaky `TestOtelAPMIngestion` test.

The filelog receiver was missing `start_at: beginning`, so if the OTel agent started after the test had already written the log file, it would silently skip all existing content. Two small context fixes are included: the APM-ready wait now uses the test context instead of `context.Background()`, and the ES query inside the assertion loop uses `t.Context()`.

## Why is it important?

The test has been intermittently failing in CI since it was introduced. Every other filelog-based test in the file already has `start_at: beginning` — this was the only exception.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None — test-only change.

## How to test this PR locally

```
go test -v -tags integration -run TestOtelAPMIngestion ./testing/integration/ess/
```

## Related issues

- Closes #4148
