### PR TITLE
Disable issue failure reporting from AI workflows

### DIFF
--- a/.github/workflows/sweep-coordinator-status-accuracy.yml
+++ b/.github/workflows/sweep-coordinator-status-accuracy.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-code-quality-audit.lock.yml@v0
     with:
+      report-failure-as-issue: false
       title-prefix: "[coordinator-status-accuracy]"
       severity-threshold: "high"
       setup-commands: |

--- a/.github/workflows/sweep-fleet-enrollment-resilience.yml
+++ b/.github/workflows/sweep-fleet-enrollment-resilience.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-code-quality-audit.lock.yml@v0
     with:
+      report-failure-as-issue: false
       title-prefix: "[fleet-enrollment-resilience]"
       severity-threshold: "high"
       setup-commands: |

--- a/.github/workflows/sweep-otel-collector-integration.yml
+++ b/.github/workflows/sweep-otel-collector-integration.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-code-quality-audit.lock.yml@v0
     with:
+      report-failure-as-issue: false
       title-prefix: "[otel-collector-integration]"
       severity-threshold: "high"
       setup-commands: |

--- a/.github/workflows/sweep-upgrade-lifecycle.yml
+++ b/.github/workflows/sweep-upgrade-lifecycle.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-code-quality-audit.lock.yml@v0
     with:
+      report-failure-as-issue: false
       title-prefix: "[upgrade-lifecycle]"
       severity-threshold: "high"
       setup-commands: |

--- a/.github/workflows/trigger-breaking-change-detect.yml
+++ b/.github/workflows/trigger-breaking-change-detect.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-breaking-change-detect.lock.yml@v0
     with:
+      report-failure-as-issue: false
       setup-commands: |
         sudo apt-get update && sudo apt-get install -y libpcap-dev librpm-dev python3-venv
         export GOTOOLCHAIN=auto

--- a/.github/workflows/trigger-docs-new-contributor-review.yml
+++ b/.github/workflows/trigger-docs-new-contributor-review.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-newbie-contributor-patrol.lock.yml@v0
     with:
+      report-failure-as-issue: false
       setup-commands: |
         sudo apt-get update && sudo apt-get install -y libpcap-dev librpm-dev python3-venv
         export GOTOOLCHAIN=auto

--- a/.github/workflows/trigger-docs-patrol.yml
+++ b/.github/workflows/trigger-docs-patrol.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-patrol.lock.yml@v0
     with:
+      report-failure-as-issue: false
       setup-commands: |
         sudo apt-get update && sudo apt-get install -y libpcap-dev librpm-dev python3-venv
         export GOTOOLCHAIN=auto

--- a/.github/workflows/trigger-duplicate-issue-detector.yml
+++ b/.github/workflows/trigger-duplicate-issue-detector.yml
@@ -17,4 +17,5 @@ jobs:
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-duplicate-issue-detector.lock.yml@v0
     with:
+      report-failure-as-issue: false
       detect-related-issues: false

--- a/.github/workflows/trigger-issue-triage.yml
+++ b/.github/workflows/trigger-issue-triage.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v0
     with:
+      report-failure-as-issue: false
       setup-commands: |
         sudo apt-get update && sudo apt-get install -y libpcap-dev librpm-dev python3-venv
         export GOTOOLCHAIN=auto

--- a/.github/workflows/trigger-mention-in-issue.yml
+++ b/.github/workflows/trigger-mention-in-issue.yml
@@ -18,6 +18,7 @@ jobs:
       (startsWith(github.event.comment.body, '/ai') || contains(github.event.comment.body, '@claude'))
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-issue.lock.yml@v0
     with:
+      report-failure-as-issue: false
       setup-commands: |
         sudo apt-get update && sudo apt-get install -y libpcap-dev librpm-dev python3-venv
         export GOTOOLCHAIN=auto

--- a/.github/workflows/trigger-mention-in-pr.yml
+++ b/.github/workflows/trigger-mention-in-pr.yml
@@ -20,6 +20,7 @@ jobs:
       (github.event.issue.pull_request != null || github.event_name == 'pull_request_review_comment')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-pr.lock.yml@v0
     with:
+      report-failure-as-issue: false
       setup-commands: |
         sudo apt-get update && sudo apt-get install -y libpcap-dev librpm-dev python3-venv
         export GOTOOLCHAIN=auto

--- a/.github/workflows/trigger-pr-actions-detective.yml
+++ b/.github/workflows/trigger-pr-actions-detective.yml
@@ -18,6 +18,7 @@ jobs:
       toJSON(github.event.workflow_run.pull_requests) != '[]'
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-actions-detective.lock.yml@v0
     with:
+      report-failure-as-issue: false
       setup-commands: |
         sudo apt-get update && sudo apt-get install -y libpcap-dev librpm-dev python3-venv
         export GOTOOLCHAIN=auto

--- a/.github/workflows/trigger-pr-buildkite-detective.yml
+++ b/.github/workflows/trigger-pr-buildkite-detective.yml
@@ -16,6 +16,7 @@ jobs:
       contains(github.event.context, 'buildkite')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-estc-pr-buildkite-detective.lock.yml@v0
     with:
+      report-failure-as-issue: false
       additional-instructions: |
         If a step fails, check if the failure is reported as a GitHub issue labeled `flaky-test`. Reference the GitHub issue if so. 
     secrets:

--- a/.github/workflows/trigger-pr-review.yml
+++ b/.github/workflows/trigger-pr-review.yml
@@ -18,6 +18,7 @@ jobs:
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-review.lock.yml@v0
     with:
+      report-failure-as-issue: false
       setup-commands: |
         sudo apt-get update && sudo apt-get install -y libpcap-dev librpm-dev python3-venv
         export GOTOOLCHAIN=auto

--- a/.github/workflows/trigger-stale-issues.yml
+++ b/.github/workflows/trigger-stale-issues.yml
@@ -14,6 +14,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-stale-issues-investigator.lock.yml@v0
     with:
+      report-failure-as-issue: false
       setup-commands: |
         sudo apt-get update && sudo apt-get install -y libpcap-dev librpm-dev python3-venv
         export GOTOOLCHAIN=auto

--- a/.github/workflows/trigger-text-auditor.yml
+++ b/.github/workflows/trigger-text-auditor.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-text-auditor.lock.yml@v0
     with:
+      report-failure-as-issue: false
       setup-commands: |
         sudo apt-get update && sudo apt-get install -y libpcap-dev librpm-dev python3-venv
         export GOTOOLCHAIN=auto


### PR DESCRIPTION
- Relates https://github.com/elastic/beats/pull/51561

The same as https://github.com/elastic/beats/pull/51561, but for agent. We are not actively looking at the failure reports and they create a lot of noise.