### PR TITLE
Allow spec files to indicate streams should run in one receiver and fix osquerybeat as a receiver

### DIFF
--- a/internal/edot/spec.yml
+++ b/internal/edot/spec.yml
@@ -581,7 +581,7 @@ inputs:
     description: "Osquery"
     platforms: *platforms
     outputs: *outputs
-    # Ensure there is only a single osquerd daemon to manage by using a single receiver.
+    # Ensure there is only a single osqueryd daemon to manage by using a single receiver.
     single_receiver: true
     command:
       restart_monitoring_period: 5s

--- a/internal/edot/spec.yml
+++ b/internal/edot/spec.yml
@@ -581,6 +581,7 @@ inputs:
     description: "Osquery"
     platforms: *platforms
     outputs: *outputs
+    single_receiver: true
     command:
       restart_monitoring_period: 5s
       maximum_restarts_per_period: 1

--- a/internal/edot/spec.yml
+++ b/internal/edot/spec.yml
@@ -581,6 +581,7 @@ inputs:
     description: "Osquery"
     platforms: *platforms
     outputs: *outputs
+    # Ensure there is only a single osquerd daemon to manage by using a single receiver.
     single_receiver: true
     command:
       restart_monitoring_period: 5s

--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -357,7 +357,8 @@ func getCollectorConfigForComponent(
 }
 
 // getReceiversConfigForComponent returns the receivers configuration for a component.
-// Each input produces its own receiver, so a component with N inputs will have N receivers.
+// By default each input stream produces its own receiver. When the component's InputSpec has
+// SingleReceiver set, all streams are merged into one receiver keyed by component ID alone.
 func getReceiversConfigForComponent(
 	comp *component.Component,
 	info info.Agent,
@@ -435,7 +436,23 @@ func getReceiversConfigForComponent(
 	// indicate that beat receivers are managed by the elastic-agent
 	sharedConfig["management.otel.enabled"] = true
 
-	// Create one receiver per input
+	// When SingleReceiver is set, merge all stream inputs into one receiver keyed by
+	// component ID instead of creating one receiver per stream. Some components have
+	// shared state that cannot easily be split across receivers.
+	if comp.InputSpec != nil && comp.InputSpec.Spec.SingleReceiver {
+		allInputConfigs := make([]map[string]any, 0, len(inputs))
+		for _, ri := range inputs {
+			allInputConfigs = append(allInputConfigs, ri.config)
+		}
+		receiverID := GetReceiverID(receiverType, comp.ID)
+		receiverConfig := maps.Clone(sharedConfig)
+		receiverConfig[beatName] = map[string]any{
+			beatInputsKey(beatName): allInputConfigs,
+		}
+		return map[string]any{receiverID.String(): receiverConfig}, nil
+	}
+
+	// Create one receiver per input stream.
 	receiversConfig := make(map[string]any, len(inputs))
 	for _, ri := range inputs {
 		if ri.streamID == "" {
@@ -446,10 +463,7 @@ func getReceiversConfigForComponent(
 		// Create a new config map for this receiver, copying shared config entries.
 		// This is a shallow copy — nested map values (path, logging, http) are shared
 		// across receivers. This is safe because nothing mutates them after construction.
-		receiverConfig := make(map[string]any, len(sharedConfig)+1)
-		for k, v := range sharedConfig {
-			receiverConfig[k] = v
-		}
+		receiverConfig := maps.Clone(sharedConfig)
 		receiverConfig[beatName] = map[string]any{
 			beatInputsKey(beatName): []map[string]any{ri.config},
 		}

--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -378,7 +378,7 @@ func getReceiversConfigForComponent(
 	var inputs []receiverInput
 	for _, unit := range comp.Units {
 		if unit.Type == client.UnitTypeInput {
-			unitInputs, err := getInputsForUnit(unit, info, defaultDataStreamType, comp.InputType)
+			unitInputs, err := getInputsForUnit(unit, info, defaultDataStreamType, comp)
 			if err != nil {
 				return nil, err
 			}
@@ -686,7 +686,7 @@ func resolveStreamID(streamID string, streamSource map[string]any, unitID string
 	return fmt.Sprintf("%s-%d", unitID, index)
 }
 
-func getInputsForUnit(unit component.Unit, info info.Agent, defaultDataStreamType string, inputType string) ([]receiverInput, error) {
+func getInputsForUnit(unit component.Unit, info info.Agent, defaultDataStreamType string, comp *component.Component) ([]receiverInput, error) {
 	agentInfo := &client.AgentInfo{
 		ID:           info.AgentID(),
 		Version:      info.Version(),
@@ -706,7 +706,7 @@ func getInputsForUnit(unit component.Unit, info info.Agent, defaultDataStreamTyp
 	// Handle input types that are namespaced to their component type by either a prefix or suffix.
 	// CreateInputsFromStreams doesn't do this, each beat does it on its own in a transform
 	// function. For filebeat, see: https://github.com/elastic/beats/blob/main/x-pack/filebeat/cmd/agent.go
-	inputTypePrefix, inputTypeSuffix, inputTypeHasSlash := strings.Cut(inputType, "/")
+	inputTypePrefix, inputTypeSuffix, inputTypeHasSlash := strings.Cut(comp.InputType, "/")
 	result := make([]receiverInput, len(inputs))
 	for i, input := range inputs {
 		switch {
@@ -725,7 +725,7 @@ func getInputsForUnit(unit component.Unit, info info.Agent, defaultDataStreamTyp
 			}
 		default:
 			if _, ok := input["type"]; !ok {
-				input["type"] = inputType
+				input["type"] = comp.InputType
 			}
 		}
 
@@ -737,18 +737,12 @@ func getInputsForUnit(unit component.Unit, info info.Agent, defaultDataStreamTyp
 		result[i] = receiverInput{streamID: streamID, config: input}
 	}
 
-	if inputType == "osquery" {
+	if comp.InputSpec != nil && comp.InputSpec.Spec.SingleReceiver && comp.InputType == "osquery" {
 		result = injectOsqueryConfig(result, unit)
 	}
 
 	return result, nil
 }
-
-const (
-	// osqueryResultDataset is the dataset of the stream that carries osquery scheduled
-	// query results and must receive the input-level osquery configuration.
-	osqueryResultDataset = "osquery_manager.result"
-)
 
 // injectOsqueryConfig replicates what osquerybeatCfgFromStreams does in process
 // mode: it attaches the input-level "osquery" field (schedule, packs, decorators,
@@ -757,17 +751,25 @@ const (
 // beat startup.
 func injectOsqueryConfig(result []receiverInput, unit component.Unit) []receiverInput {
 	// Mirror the implementation from https://github.com/elastic/beats/blob/7764586737b76758db262a06fb3c594c52185c48/x-pack/osquerybeat/cmd/root.go#L92
-	osqVal := unit.Config.GetSource().AsMap()["osquery"]
-	if osqVal == nil {
+	osqMap, ok := unit.Config.GetSource().AsMap()["osquery"].(map[string]any)
+	if !ok {
 		return result
 	}
 	for i, ri := range result {
-		ds, ok := ri.config["data_stream"].(map[string]any)
-		if !ok || ds["dataset"] != osqueryResultDataset {
+		// "osquery_manager.result" is the dataset of the stream that carries osquery
+		// scheduled query results and must receive the input-level osquery configuration.
+		datastream, ok := ri.config["data_stream"].(map[string]any)
+		if !ok {
+			continue
+		}
+		dataset, _ := datastream["dataset"].(string)
+		if dataset != "osquery_manager.result" {
 			continue
 		}
 		if _, exists := result[i].config["osquery"]; !exists {
-			result[i].config["osquery"] = osqVal
+			// Clone before mutating so we don't modify the map returned by CreateInputsFromStreamsForReceiver.
+			result[i].config = maps.Clone(result[i].config)
+			result[i].config["osquery"] = osqMap
 		}
 		// Place the result stream first so inputs[0].Osquery is set.
 		result[0], result[i] = result[i], result[0]

--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -737,7 +737,43 @@ func getInputsForUnit(unit component.Unit, info info.Agent, defaultDataStreamTyp
 		result[i] = receiverInput{streamID: streamID, config: input}
 	}
 
+	if inputType == "osquery" {
+		result = injectOsqueryConfig(result, unit)
+	}
+
 	return result, nil
+}
+
+const (
+	// osqueryResultDataset is the dataset of the stream that carries osquery scheduled
+	// query results and must receive the input-level osquery configuration.
+	osqueryResultDataset = "osquery_manager.result"
+)
+
+// injectOsqueryConfig replicates what osquerybeatCfgFromStreams does in process
+// mode: it attaches the input-level "osquery" field (schedule, packs, decorators,
+// etc.) to the osquery_manager.result stream and moves that stream to position 0
+// so that inputs[0].Osquery is non-nil when config_plugin.Set() reads it at
+// beat startup.
+func injectOsqueryConfig(result []receiverInput, unit component.Unit) []receiverInput {
+	// Mirror the implementation from https://github.com/elastic/beats/blob/7764586737b76758db262a06fb3c594c52185c48/x-pack/osquerybeat/cmd/root.go#L92
+	osqVal := unit.Config.GetSource().AsMap()["osquery"]
+	if osqVal == nil {
+		return result
+	}
+	for i, ri := range result {
+		ds, ok := ri.config["data_stream"].(map[string]any)
+		if !ok || ds["dataset"] != osqueryResultDataset {
+			continue
+		}
+		if _, exists := result[i].config["osquery"]; !exists {
+			result[i].config["osquery"] = osqVal
+		}
+		// Place the result stream first so inputs[0].Osquery is set.
+		result[0], result[i] = result[i], result[0]
+		break
+	}
+	return result
 }
 
 // extractOtelProcessors extracts the processor IDs from the output configuration.

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -2646,6 +2646,105 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 			},
 		},
 		{
+			// single_receiver with input-level osquery schedule: the osquery field lives at
+			// the fleet policy input level (not stream level), so getInputsForUnit must inject
+			// it into each stream config so the beat can read its scheduled queries.
+			name: "osquerybeat single_receiver injects input-level schedule into streams",
+			component: &component.Component{
+				ID:        "osquerybeat-test-id",
+				InputType: "osquery",
+				InputSpec: &component.InputRuntimeSpec{
+					BinaryName: "elastic-otel-collector",
+					Spec: component.InputSpec{
+						Name: "osquery",
+						Command: &component.CommandSpec{
+							Args: []string{"osquerybeat"},
+						},
+						SingleReceiver: true,
+					},
+				},
+				Units: []component.Unit{
+					{
+						ID:   "osquerybeat-test-id-unit",
+						Type: client.UnitTypeInput,
+						Config: component.MustExpectedConfig(map[string]any{
+							"id":         "test",
+							"use_output": "default",
+							"type":       "osquery",
+							"streams": []any{
+								map[string]any{
+									"id": "action-responses",
+									"data_stream": map[string]any{
+										"dataset": "osquery_manager.action.responses",
+									},
+									"query": nil,
+								},
+								map[string]any{
+									"id": "results",
+									"data_stream": map[string]any{
+										"dataset": "osquery_manager.result",
+									},
+									"query":    "SELECT * FROM processes",
+									"interval": "3600",
+								},
+							},
+							// osquery.schedule is a map from query name to query definition,
+						// matching the real fleet policy structure (same as pre-config.yaml).
+						"osquery": map[string]any{
+							"schedule": map[string]any{
+								"system_info": map[string]any{
+									"query":    "SELECT hostname FROM system_info",
+									"interval": 60,
+								},
+							},
+							"decorators": map[string]any{
+								"load": []any{
+									"SELECT uuid AS host_uuid FROM system_info;",
+								},
+							},
+						},
+					}),
+				},
+			},
+		},
+		outputQueueConfig:  nil,
+		expectedReceiverID: "osquerybeatreceiver/_agent-component/osquerybeat-test-id",
+		expectedBeatName:   "osquerybeat",
+		verifyBeatConfig: func(t *testing.T, beatConfig map[string]any) {
+			inputs, ok := beatConfig["inputs"].([]map[string]any)
+			require.True(t, ok, "osquerybeat inputs should be a slice of maps")
+			require.Len(t, inputs, 2, "both streams must be merged into the single receiver")
+
+			// The result stream must be placed first (matching osquerybeatCfgFromStreams
+			// which "set it as a first stream"), so inputs[0].Osquery is non-nil when
+			// config_plugin reads it at beat startup.
+			assert.Equal(t, "results", inputs[0]["id"], "osquery_manager.result stream must be first")
+
+			// Only the result stream gets the osquery section injected from the input
+			// level — not the action-responses stream. This is equivalent to what
+			// osquerybeatCfgFromStreams does: "Attach osquery configuration to the
+			// osquery_manager.result stream and set it as a first stream".
+			resultInput := inputs[0]
+			osquery, ok := resultInput["osquery"]
+			require.True(t, ok, "inputs[0] (result stream) must have osquery section injected from input level")
+			osqueryMap, ok := osquery.(map[string]any)
+			require.True(t, ok, "inputs[0].osquery must be a map")
+			// schedule must be present and contain the named query
+			schedule, ok := osqueryMap["schedule"]
+			assert.True(t, ok, "inputs[0].osquery must have schedule")
+			scheduleMap, ok := schedule.(map[string]any)
+			assert.True(t, ok, "inputs[0].osquery.schedule must be a map (query name → definition)")
+			assert.Contains(t, scheduleMap, "system_info", "inputs[0].osquery.schedule must have system_info query")
+			// decorators must also be present
+			assert.Contains(t, osqueryMap, "decorators", "inputs[0].osquery must have decorators")
+
+			// The action-responses stream must NOT have osquery injected.
+			actionInput := inputs[1]
+			_, hasOsquery := actionInput["osquery"]
+			assert.False(t, hasOsquery, "action-responses stream must not have osquery injected")
+		},
+	},
+		{
 			name:               "packetbeat component",
 			component:          packetbeatComponent,
 			outputQueueConfig:  nil,

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -2534,6 +2534,19 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 							"interval": "3600",
 						},
 					},
+					"osquery": map[string]any{
+						"schedule": map[string]any{
+							"system_info": map[string]any{
+								"query":    "SELECT hostname FROM system_info",
+								"interval": 60,
+							},
+						},
+						"decorators": map[string]any{
+							"load": []any{
+								"SELECT uuid AS host_uuid FROM system_info;",
+							},
+						},
+					},
 				}),
 			},
 		},
@@ -2631,7 +2644,10 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 		{
 			// single_receiver: true collapses all streams into one receiver keyed by component
 			// ID only (no stream suffix). This prevents osquery from launching two competing
-			// osqueryd processes that would fight over the same Unix socket.
+			// osqueryd processes that would fight over the same Unix socket. The input-level
+			// osquery field (schedule, decorators) is injected into the result stream only,
+			// matching osquerybeatCfgFromStreams: "Attach osquery configuration to the
+			// osquery_manager.result stream and set it as a first stream".
 			name:               "osquerybeat component with single_receiver merges streams",
 			component:          osquerybeatSingleReceiverComponent,
 			outputQueueConfig:  nil,
@@ -2640,110 +2656,31 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 			verifyBeatConfig: func(t *testing.T, beatConfig map[string]any) {
 				inputs, ok := beatConfig["inputs"].([]map[string]any)
 				require.True(t, ok, "osquerybeat inputs should be a slice of maps")
-				assert.Len(t, inputs, 2, "both streams must be merged into the single receiver")
-				assert.Equal(t, "action-responses", inputs[0]["id"])
-				assert.Equal(t, "results", inputs[1]["id"])
+				require.Len(t, inputs, 2, "both streams must be merged into the single receiver")
+
+				// The result stream must be placed first so inputs[0].Osquery is non-nil
+				// when config_plugin reads it at beat startup.
+				assert.Equal(t, "results", inputs[0]["id"], "osquery_manager.result stream must be first")
+
+				// Only the result stream gets the osquery section injected from the input level.
+				resultInput := inputs[0]
+				osquery, ok := resultInput["osquery"]
+				require.True(t, ok, "inputs[0] (result stream) must have osquery section injected from input level")
+				osqueryMap, ok := osquery.(map[string]any)
+				require.True(t, ok, "inputs[0].osquery must be a map")
+				schedule, ok := osqueryMap["schedule"]
+				assert.True(t, ok, "inputs[0].osquery must have schedule")
+				scheduleMap, ok := schedule.(map[string]any)
+				assert.True(t, ok, "inputs[0].osquery.schedule must be a map (query name → definition)")
+				assert.Contains(t, scheduleMap, "system_info", "inputs[0].osquery.schedule must have system_info query")
+				assert.Contains(t, osqueryMap, "decorators", "inputs[0].osquery must have decorators")
+
+				// The action-responses stream must NOT have osquery injected.
+				actionInput := inputs[1]
+				_, hasOsquery := actionInput["osquery"]
+				assert.False(t, hasOsquery, "action-responses stream must not have osquery injected")
 			},
 		},
-		{
-			// single_receiver with input-level osquery schedule: the osquery field lives at
-			// the fleet policy input level (not stream level), so getInputsForUnit must inject
-			// it into each stream config so the beat can read its scheduled queries.
-			name: "osquerybeat single_receiver injects input-level schedule into streams",
-			component: &component.Component{
-				ID:        "osquerybeat-test-id",
-				InputType: "osquery",
-				InputSpec: &component.InputRuntimeSpec{
-					BinaryName: "elastic-otel-collector",
-					Spec: component.InputSpec{
-						Name: "osquery",
-						Command: &component.CommandSpec{
-							Args: []string{"osquerybeat"},
-						},
-						SingleReceiver: true,
-					},
-				},
-				Units: []component.Unit{
-					{
-						ID:   "osquerybeat-test-id-unit",
-						Type: client.UnitTypeInput,
-						Config: component.MustExpectedConfig(map[string]any{
-							"id":         "test",
-							"use_output": "default",
-							"type":       "osquery",
-							"streams": []any{
-								map[string]any{
-									"id": "action-responses",
-									"data_stream": map[string]any{
-										"dataset": "osquery_manager.action.responses",
-									},
-									"query": nil,
-								},
-								map[string]any{
-									"id": "results",
-									"data_stream": map[string]any{
-										"dataset": "osquery_manager.result",
-									},
-									"query":    "SELECT * FROM processes",
-									"interval": "3600",
-								},
-							},
-							// osquery.schedule is a map from query name to query definition,
-						// matching the real fleet policy structure (same as pre-config.yaml).
-						"osquery": map[string]any{
-							"schedule": map[string]any{
-								"system_info": map[string]any{
-									"query":    "SELECT hostname FROM system_info",
-									"interval": 60,
-								},
-							},
-							"decorators": map[string]any{
-								"load": []any{
-									"SELECT uuid AS host_uuid FROM system_info;",
-								},
-							},
-						},
-					}),
-				},
-			},
-		},
-		outputQueueConfig:  nil,
-		expectedReceiverID: "osquerybeatreceiver/_agent-component/osquerybeat-test-id",
-		expectedBeatName:   "osquerybeat",
-		verifyBeatConfig: func(t *testing.T, beatConfig map[string]any) {
-			inputs, ok := beatConfig["inputs"].([]map[string]any)
-			require.True(t, ok, "osquerybeat inputs should be a slice of maps")
-			require.Len(t, inputs, 2, "both streams must be merged into the single receiver")
-
-			// The result stream must be placed first (matching osquerybeatCfgFromStreams
-			// which "set it as a first stream"), so inputs[0].Osquery is non-nil when
-			// config_plugin reads it at beat startup.
-			assert.Equal(t, "results", inputs[0]["id"], "osquery_manager.result stream must be first")
-
-			// Only the result stream gets the osquery section injected from the input
-			// level — not the action-responses stream. This is equivalent to what
-			// osquerybeatCfgFromStreams does: "Attach osquery configuration to the
-			// osquery_manager.result stream and set it as a first stream".
-			resultInput := inputs[0]
-			osquery, ok := resultInput["osquery"]
-			require.True(t, ok, "inputs[0] (result stream) must have osquery section injected from input level")
-			osqueryMap, ok := osquery.(map[string]any)
-			require.True(t, ok, "inputs[0].osquery must be a map")
-			// schedule must be present and contain the named query
-			schedule, ok := osqueryMap["schedule"]
-			assert.True(t, ok, "inputs[0].osquery must have schedule")
-			scheduleMap, ok := schedule.(map[string]any)
-			assert.True(t, ok, "inputs[0].osquery.schedule must be a map (query name → definition)")
-			assert.Contains(t, scheduleMap, "system_info", "inputs[0].osquery.schedule must have system_info query")
-			// decorators must also be present
-			assert.Contains(t, osqueryMap, "decorators", "inputs[0].osquery must have decorators")
-
-			// The action-responses stream must NOT have osquery injected.
-			actionInput := inputs[1]
-			_, hasOsquery := actionInput["osquery"]
-			assert.False(t, hasOsquery, "action-responses stream must not have osquery injected")
-		},
-	},
 		{
 			name:               "packetbeat component",
 			component:          packetbeatComponent,

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -271,6 +271,30 @@ func TestGetOtelConfig(t *testing.T) {
 		},
 	}
 
+	// osquerybeat with two streams (action responses + results), as deployed by osquery_manager.
+	osquerybeatMultiStreamInputConfig := map[string]any{
+		"id":         "test",
+		"use_output": "default",
+		"type":       "osquery",
+		"streams": []any{
+			map[string]any{
+				"id": "action-responses",
+				"data_stream": map[string]any{
+					"dataset": "osquery_manager.action.responses",
+				},
+				"query": nil,
+			},
+			map[string]any{
+				"id": "results",
+				"data_stream": map[string]any{
+					"dataset": "osquery_manager.result",
+				},
+				"query":    "SELECT * FROM processes",
+				"interval": "3600",
+			},
+		},
+	}
+
 	packetbeatInputConfig := map[string]any{
 		"id":         "test",
 		"use_output": "default",
@@ -586,6 +610,38 @@ func TestGetOtelConfig(t *testing.T) {
 					"interval":   "3600",
 					"index":      "logs-generic-1-default",
 					"processors": defaultInputProcessors("test-1", "generic-1", "logs"),
+					"type":       "osquery",
+				},
+			},
+		}
+		return cfg
+	}
+
+	// expectedOsquerybeatSingleReceiverConfig is the expected config for an osquery component
+	// with single_receiver: true and two streams merged into one receiver.
+	expectedOsquerybeatSingleReceiverConfig := func(id string) map[string]any {
+		cfg := beatReceiverBaseConfig(id, "osquerybeat", "osquery")
+		cfg["osquerybeat"] = map[string]any{
+			"inputs": []map[string]any{
+				{
+					"id": "action-responses",
+					"data_stream": map[string]any{
+						"dataset": "osquery_manager.action.responses",
+					},
+					"query":      nil,
+					"index":      "logs-osquery_manager.action.responses-default",
+					"processors": defaultInputProcessors("action-responses", "osquery_manager.action.responses", "logs"),
+					"type":       "osquery",
+				},
+				{
+					"id": "results",
+					"data_stream": map[string]any{
+						"dataset": "osquery_manager.result",
+					},
+					"query":      "SELECT * FROM processes",
+					"interval":   "3600",
+					"index":      "logs-osquery_manager.result-default",
+					"processors": defaultInputProcessors("results", "osquery_manager.result", "logs"),
 					"type":       "osquery",
 				},
 			},
@@ -2107,6 +2163,67 @@ func TestGetOtelConfig(t *testing.T) {
 			}),
 		},
 		{
+			name: "osquerybeat with single_receiver merges all streams into one receiver",
+			model: &component.Model{
+				Components: []component.Component{
+					{
+						ID:         "osquerybeat-default",
+						InputType:  "osquery",
+						OutputType: "elasticsearch",
+						OutputName: "default",
+						InputSpec: &component.InputRuntimeSpec{
+							BinaryName: "elastic-otel-collector",
+							Spec: component.InputSpec{
+								Command: &component.CommandSpec{
+									Args: []string{"osquerybeat"},
+								},
+								SingleReceiver: true,
+							},
+						},
+						Units: []component.Unit{
+							{
+								ID:     "osquerybeat-unit",
+								Type:   client.UnitTypeInput,
+								Config: component.MustExpectedConfig(osquerybeatMultiStreamInputConfig),
+							},
+							{
+								ID:     "osquerybeat-default",
+								Type:   client.UnitTypeOutput,
+								Config: component.MustExpectedConfig(esOutputConfig()),
+							},
+						},
+					},
+				},
+			},
+			expectedConfig: confmap.NewFromStringMap(map[string]any{
+				"exporters": map[string]any{
+					"elasticsearch/_agent-component/default": expectedESConfig("default"),
+				},
+				"extensions": map[string]any{
+					"beatsauth/_agent-component/default": expectedExtensionConfig(),
+				},
+				"processors": map[string]any{
+					"beat/_agent-component": map[string]any{
+						"processors": defaultGlobalProcessors,
+					},
+				},
+				"receivers": map[string]any{
+					// Single receiver keyed by component ID only — no stream suffix.
+					"osquerybeatreceiver/_agent-component/osquerybeat-default": expectedOsquerybeatSingleReceiverConfig("osquerybeat-default"),
+				},
+				"service": map[string]any{
+					"extensions": []any{"beatsauth/_agent-component/default"},
+					"pipelines": map[string]any{
+						"logs/_agent-component/osquerybeat-default": map[string][]string{
+							"exporters":  {"elasticsearch/_agent-component/default"},
+							"processors": {"beat/_agent-component"},
+							"receivers":  {"osquerybeatreceiver/_agent-component/osquerybeat-default"},
+						},
+					},
+				},
+			}),
+		},
+		{
 			name: "packetbeat",
 			model: &component.Model{
 				Components: []component.Component{
@@ -2378,6 +2495,50 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 		},
 	}
 
+	// osquerybeat with two streams and single_receiver: true, matching the real osquery_manager setup.
+	osquerybeatSingleReceiverComponent := &component.Component{
+		ID:        "osquerybeat-test-id",
+		InputType: "osquery",
+		InputSpec: &component.InputRuntimeSpec{
+			BinaryName: "elastic-otel-collector",
+			Spec: component.InputSpec{
+				Name: "osquery",
+				Command: &component.CommandSpec{
+					Args: []string{"osquerybeat"},
+				},
+				SingleReceiver: true,
+			},
+		},
+		Units: []component.Unit{
+			{
+				ID:   "osquerybeat-test-id-unit",
+				Type: client.UnitTypeInput,
+				Config: component.MustExpectedConfig(map[string]any{
+					"id":         "test",
+					"use_output": "default",
+					"type":       "osquery",
+					"streams": []any{
+						map[string]any{
+							"id": "action-responses",
+							"data_stream": map[string]any{
+								"dataset": "osquery_manager.action.responses",
+							},
+							"query": nil,
+						},
+						map[string]any{
+							"id": "results",
+							"data_stream": map[string]any{
+								"dataset": "osquery_manager.result",
+							},
+							"query":    "SELECT * FROM processes",
+							"interval": "3600",
+						},
+					},
+				}),
+			},
+		},
+	}
+
 	packetbeatComponent := &component.Component{
 		ID:        "packetbeat-test-id",
 		InputType: "packet",
@@ -2466,6 +2627,23 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 			outputQueueConfig:  nil,
 			expectedReceiverID: "osquerybeatreceiver/_agent-component/osquerybeat-test-id/test-1",
 			expectedBeatName:   "osquerybeat",
+		},
+		{
+			// single_receiver: true collapses all streams into one receiver keyed by component
+			// ID only (no stream suffix). This prevents osquery from launching two competing
+			// osqueryd processes that would fight over the same Unix socket.
+			name:               "osquerybeat component with single_receiver merges streams",
+			component:          osquerybeatSingleReceiverComponent,
+			outputQueueConfig:  nil,
+			expectedReceiverID: "osquerybeatreceiver/_agent-component/osquerybeat-test-id",
+			expectedBeatName:   "osquerybeat",
+			verifyBeatConfig: func(t *testing.T, beatConfig map[string]any) {
+				inputs, ok := beatConfig["inputs"].([]map[string]any)
+				require.True(t, ok, "osquerybeat inputs should be a slice of maps")
+				assert.Len(t, inputs, 2, "both streams must be merged into the single receiver")
+				assert.Equal(t, "action-responses", inputs[0]["id"])
+				assert.Equal(t, "results", inputs[1]["id"])
+			},
 		},
 		{
 			name:               "packetbeat component",

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -2642,12 +2642,6 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 			expectedBeatName:   "osquerybeat",
 		},
 		{
-			// single_receiver: true collapses all streams into one receiver keyed by component
-			// ID only (no stream suffix). This prevents osquery from launching two competing
-			// osqueryd processes that would fight over the same Unix socket. The input-level
-			// osquery field (schedule, decorators) is injected into the result stream only,
-			// matching osquerybeatCfgFromStreams: "Attach osquery configuration to the
-			// osquery_manager.result stream and set it as a first stream".
 			name:               "osquerybeat component with single_receiver merges streams",
 			component:          osquerybeatSingleReceiverComponent,
 			outputQueueConfig:  nil,

--- a/internal/pkg/otel/translate/status.go
+++ b/internal/pkg/otel/translate/status.go
@@ -285,13 +285,37 @@ func getComponentState(pipelineStatus *status.AggregateStatus, comp component.Co
 		return runtime.ComponentComponentState{}, err
 	}
 
-	// Build a map from input ID to receiver status. Each receiver corresponds to one input,
-	// and its otel component ID encodes the input ID as compID/inputID.
+	// Build a map from input ID to receiver status.
 	receiverByInputID := make(map[string]*status.AggregateStatus)
-	receiverPrefix := OtelNamePrefix + comp.ID + "/"
-	for receiverOtelID, rs := range receiverStatuses {
-		if inputID, found := strings.CutPrefix(receiverOtelID.Name(), receiverPrefix); found {
-			receiverByInputID[inputID] = rs
+	if comp.InputSpec != nil && comp.InputSpec.Spec.SingleReceiver {
+		// single_receiver: true means all streams share one receiver named after the
+		// component ID only (no stream suffix). Map every stream's resolved ID to it.
+		singleReceiverName := OtelNamePrefix + comp.ID
+		for receiverOtelID, rs := range receiverStatuses {
+			if receiverOtelID.Name() != singleReceiverName {
+				continue
+			}
+			for _, u := range comp.Units {
+				if u.Type != client.UnitTypeInput || u.Config == nil {
+					continue
+				}
+				for i, stream := range u.Config.Streams {
+					var src map[string]any
+					if s := stream.GetSource(); s != nil {
+						src = s.AsMap()
+					}
+					streamID := resolveStreamID(stream.Id, src, u.ID, i)
+					receiverByInputID[streamID] = rs
+				}
+			}
+		}
+	} else {
+		// Default: each receiver is named compID/streamID.
+		receiverPrefix := OtelNamePrefix + comp.ID + "/"
+		for receiverOtelID, rs := range receiverStatuses {
+			if inputID, found := strings.CutPrefix(receiverOtelID.Name(), receiverPrefix); found {
+				receiverByInputID[inputID] = rs
+			}
 		}
 	}
 

--- a/internal/pkg/otel/translate/status.go
+++ b/internal/pkg/otel/translate/status.go
@@ -300,10 +300,7 @@ func getComponentState(pipelineStatus *status.AggregateStatus, comp component.Co
 					continue
 				}
 				for i, stream := range u.Config.Streams {
-					var src map[string]any
-					if s := stream.GetSource(); s != nil {
-						src = s.AsMap()
-					}
+					src := stream.GetSource().AsMap()
 					streamID := resolveStreamID(stream.Id, src, u.ID, i)
 					receiverByInputID[streamID] = rs
 				}

--- a/internal/pkg/otel/translate/status_test.go
+++ b/internal/pkg/otel/translate/status_test.go
@@ -571,6 +571,18 @@ func TestGetComponentStateSingleReceiver(t *testing.T) {
 	outputKey := runtime.ComponentUnitKey{UnitID: "output-osquery-default", UnitType: client.UnitTypeOutput}
 	assert.Contains(t, result.State.Units, inputKey, "input unit must be present in component state")
 	assert.Contains(t, result.State.Units, outputKey, "output unit must be present in component state")
+
+	// Both streams must be individually reported in the input unit payload, even
+	// though they share a single receiver. This confirms getComponentState correctly
+	// maps each stream to the single receiver under single_receiver: true.
+	inputUnitState := result.State.Units[inputKey]
+	assert.Equal(t, client.UnitStateHealthy, inputUnitState.State)
+	require.NotNil(t, inputUnitState.Payload, "input unit payload must not be nil")
+	streams, ok := inputUnitState.Payload["streams"].(map[string]map[string]string)
+	require.True(t, ok, "payload streams must be map[string]map[string]string")
+	healthyStream := map[string]string{"error": "", "status": client.UnitStateHealthy.String()}
+	assert.Equal(t, healthyStream, streams["action-responses"], "action-responses stream must be healthy")
+	assert.Equal(t, healthyStream, streams["results"], "results stream must be healthy")
 }
 
 func TestGetComponentUnitStateWithPerStreamReceivers(t *testing.T) {

--- a/internal/pkg/otel/translate/status_test.go
+++ b/internal/pkg/otel/translate/status_test.go
@@ -519,6 +519,60 @@ func TestGetComponentStatus(t *testing.T) {
 	}
 }
 
+func TestGetComponentStateSingleReceiver(t *testing.T) {
+	// A component with single_receiver: true has exactly one receiver whose name is
+	// OtelNamePrefix+comp.ID (no stream suffix). getComponentState must map all input
+	// streams to that receiver so the input unit is included in the component state.
+	comp := component.Component{
+		ID:             "osquery-default",
+		RuntimeManager: component.OtelRuntimeManager,
+		InputSpec: &component.InputRuntimeSpec{
+			Spec: component.InputSpec{
+				SingleReceiver: true,
+			},
+		},
+		Units: []component.Unit{
+			{
+				ID:   "input-osquery-default",
+				Type: client.UnitTypeInput,
+				Config: &proto.UnitExpectedConfig{
+					Streams: []*proto.Stream{
+						{Id: "action-responses"},
+						{Id: "results"},
+					},
+				},
+			},
+			{
+				ID:   "output-osquery-default",
+				Type: client.UnitTypeOutput,
+			},
+		},
+	}
+
+	// Receiver name is exactly OtelNamePrefix+comp.ID with no stream suffix.
+	receiverKey := fmt.Sprintf("receiver:osquerybeatreceiver/%sosquery-default", OtelNamePrefix)
+	exporterKey := fmt.Sprintf("exporter:elasticsearch/%soutput-osquery-default", OtelNamePrefix)
+
+	pipelineStatus := &status.AggregateStatus{
+		Event: componentstatus.NewEvent(componentstatus.StatusOK),
+		ComponentStatusMap: map[string]*status.AggregateStatus{
+			receiverKey: {Event: componentstatus.NewEvent(componentstatus.StatusOK)},
+			exporterKey: {Event: componentstatus.NewEvent(componentstatus.StatusOK)},
+		},
+	}
+
+	result, err := getComponentState(pipelineStatus, comp)
+	require.NoError(t, err)
+	assert.Equal(t, client.UnitStateHealthy, result.State.State)
+
+	// Both the input unit and the output unit must appear in component state.
+	require.Len(t, result.State.Units, 2)
+	inputKey := runtime.ComponentUnitKey{UnitID: "input-osquery-default", UnitType: client.UnitTypeInput}
+	outputKey := runtime.ComponentUnitKey{UnitID: "output-osquery-default", UnitType: client.UnitTypeOutput}
+	assert.Contains(t, result.State.Units, inputKey, "input unit must be present in component state")
+	assert.Contains(t, result.State.Units, outputKey, "output unit must be present in component state")
+}
+
 func TestGetComponentUnitStateWithPerStreamReceivers(t *testing.T) {
 	t.Run("single stream with attributes", func(t *testing.T) {
 		unit := component.Unit{

--- a/pkg/component/input_spec.go
+++ b/pkg/component/input_spec.go
@@ -23,6 +23,11 @@ type InputSpec struct {
 	Command      *CommandSpec `config:"command,omitempty" yaml:"command,omitempty"`
 	Service      *ServiceSpec `config:"service,omitempty" yaml:"service,omitempty"`
 	IsolateUnits bool         `config:"isolate_units,omitempty" yaml:"isolate_units,omitempty"`
+	// SingleReceiver causes all streams for this input to be merged into a single OTel receiver
+	// instance rather than one receiver per stream. Required for inputs whose underlying process
+	// (e.g. osqueryd) cannot tolerate multiple independently-launched receiver instances sharing
+	// the same working directory.
+	SingleReceiver bool `config:"single_receiver,omitempty" yaml:"single_receiver,omitempty"`
 }
 
 // Validate ensures correctness of input specification.

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -129,7 +129,7 @@ func (runner *OsqueryManagerRunner) validateOsqueryEvents(t *testing.T, ctx cont
 		require.NoError(collect, err)
 		require.NotEmpty(collect, res.Hits.Hits)
 		doc = res.Hits.Hits[0].Source
-	}, time.Minute*15, time.Second*10, "could not fetch events for osquery_manager")
+	}, time.Minute*5, time.Second*10, "could not fetch events for osquery_manager")
 	return doc
 }
 

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -179,7 +179,6 @@ func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 			assert.True(collect, foundReceiver, "expected an osquery component to be running as beats receiver")
 		}, 2*time.Minute, 5*time.Second, "beat component should be running as beats receiver")
 
-		t.Skip("osqreceiver does not yet produce events, skipping OTel data validation")
 		otelDoc = runner.validateOsqueryEvents(t, ctx, agentStatus.Info.ID, otelSince)
 	})
 


### PR DESCRIPTION
Taking a look at osquerybeat as a receiver again, and it seems it has been broken by the each receiver as a stream approach, this is because the osquery integration creates two streams but is written to assume they both run in the same process that shares an osqueryd instance. With each receiver as a stream, we start osquerybeat twice on the same machine which doesn't work

Allows osquery to run as a beat receiver and pass it's document comparison tests. This required fixing two problems:
1. The configuration translation was not complete, and was missing the logic to handle the `osquery` configuration section that is provided separate from the streams configuration that must be injected into the results stream as [osquerybeatCfgFromStreams](https://github.com/elastic/beats/blob/7764586737b76758db262a06fb3c594c52185c48/x-pack/osquerybeat/cmd/root.go#L92-L132) did.
2. The change to run each stream in its own receiver does not work for osquery, as each stream would attempt to independently start the osqueryd daemon and fail because the two instances would attempt to bind to the same unix socket resulting in the error below:

```
            input-osquery-default-osquery-osquery_manager-d2ec3957-daeb-4f3c-afa3-66aa753556b0:
                message: 'Permanent: signal: killed'
                payload:
                    streams:
                        osquery-osquery_manager.action.responses-23c0815f-6842-4d8d-879e-8406950a23e9:
                            error: ""
                            status: HEALTHY
                        osquery-osquery_manager.result-23c0815f-6842-4d8d-879e-8406950a23e9:
                            error: 'Permanent: signal: killed'
                            status: FAILED
```

The fix for this is to add a spec file setting called `single_receiver` that does as it's name suggests, it allows individual inputs to opt into running as a single receiver instead of having each stream split into its own receiver. For osquery, this was the most sensible choice as running osqueryd twice on the same machine would have a resource cost, and figuring out how to share one instance of it with two processes would be even more complex. The way the osquery integration is written it declares two streams because osquerybeat writes to them both, but the beat only executes one of them as an input so this is the way it is meant to work regardless. 