### PR TITLE
test: use t.Context() as parent context in integration tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,10 @@ linters:
     forbidigo:
       forbid:
         - pattern: fmt.Print.*
+        - pattern: context\.Background\(\)
+          msg: "use t.Context() in tests so the context is cancelled when the test ends"
+          files:
+            - ".*_test\\.go$"
       exclude-godoc-examples: true
     gomoddirectives:
       replace-allow-list:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,8 +47,6 @@ linters:
         - pattern: fmt.Print.*
         - pattern: context\.Background\(\)
           msg: "use t.Context() in tests so the context is cancelled when the test ends"
-          files:
-            - ".*_test\\.go$"
       exclude-godoc-examples: true
     gomoddirectives:
       replace-allow-list:
@@ -106,6 +104,10 @@ linters:
       - linters:
           - forbidigo
         path: (.*magefile.go|.*dev-tools/mage/.*)
+      - linters:
+          - forbidigo
+        path-except: ".*_test\\.go$"
+        text: "use t\\.Context\\(\\) in tests"
     paths:
       - third_party$
       - builtin$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,7 +45,7 @@ linters:
     forbidigo:
       forbid:
         - pattern: fmt.Print.*
-        - pattern: context\.Background\(\)
+        - pattern: ^context\.Background$
           msg: "use t.Context() in tests so the context is cancelled when the test ends"
       exclude-godoc-examples: true
     gomoddirectives:
@@ -106,7 +106,7 @@ linters:
         path: (.*magefile.go|.*dev-tools/mage/.*)
       - linters:
           - forbidigo
-        path-except: ".*_test\\.go$"
+        path-except: "testing/integration/.*_test\\.go$"
         text: "use t\\.Context\\(\\) in tests"
     paths:
       - third_party$

--- a/testing/integration/beats/serverless/beats_serverless_test.go
+++ b/testing/integration/beats/serverless/beats_serverless_test.go
@@ -89,7 +89,7 @@ func (runner *BeatRunner) SetupSuite() {
 	runner.pass = os.Getenv("ELASTICSEARCH_PASSWORD")
 	runner.kibHost = os.Getenv("KIBANA_HOST")
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute)
 	defer cancel()
 
 	beatOutConfig := `
@@ -188,7 +188,7 @@ auditbeat.modules:
 
 // run the beat with default metricsets, ensure no errors in logs + data is ingested
 func (runner *BeatRunner) TestRunAndCheckData() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*4)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute*4)
 	defer cancel()
 
 	// in case there's already a running template, delete it, forcing the beat to re-install
@@ -208,7 +208,7 @@ func (runner *BeatRunner) TestRunAndCheckData() {
 
 // tests the [beat] setup --dashboards command
 func (runner *BeatRunner) TestSetupDashboards() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*3) //dashboards seem to take a while
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute*3) //dashboards seem to take a while
 	defer cancel()
 
 	resp, err := runner.agentFixture.Exec(ctx, []string{"--path.home", runner.agentFixture.WorkDir(), "setup", "--dashboards"})
@@ -245,7 +245,7 @@ func (runner *BeatRunner) TestSetupDashboards() {
 
 // tests the [beat] export dashboard command
 func (runner *BeatRunner) SubtestExportDashboards() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*2)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute*2)
 	defer cancel()
 	outDir := runner.T().TempDir()
 
@@ -278,7 +278,7 @@ func (runner *BeatRunner) TestSetupPipelines() {
 	if runner.testbeatName != "filebeat" {
 		runner.T().Skip("pipelines only available on filebeat")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute)
 	defer cancel()
 
 	defer func() {
@@ -307,7 +307,7 @@ func (runner *BeatRunner) TestSetupPipelines() {
 
 // test beat setup --index-management with ILM disabled
 func (runner *BeatRunner) TestIndexManagementNoILM() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute)
 	defer cancel()
 	defer func() {
 		runner.CleanupTemplates(ctx)
@@ -337,7 +337,7 @@ func (runner *BeatRunner) TestIndexManagementNoILM() {
 
 // tests setup with all default settings
 func (runner *BeatRunner) TestWithAllDefaults() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute)
 	defer cancel()
 	defer func() {
 		runner.CleanupTemplates(ctx)
@@ -362,7 +362,7 @@ func (runner *BeatRunner) TestWithAllDefaults() {
 
 // test the setup process with mismatching template and DSL names
 func (runner *BeatRunner) TestCustomBadNames() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute)
 	defer cancel()
 
 	defer func() {
@@ -386,7 +386,7 @@ func (runner *BeatRunner) TestOverwriteWithCustomName() {
 	updatedPolicy := mapstr.M{
 		"data_retention": "1d",
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute)
 	defer cancel()
 	defer func() {
 		runner.CleanupTemplates(ctx)
@@ -433,7 +433,7 @@ func (runner *BeatRunner) TestWithCustomLifecyclePolicy() {
 		"data_retention": "1d",
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute)
 	defer cancel()
 	defer func() {
 		runner.CleanupTemplates(ctx)
@@ -465,7 +465,7 @@ func (runner *BeatRunner) TestWithCustomLifecyclePolicy() {
 // tests beat setup --index-management with ILM explicitly set
 // On serverless, this should fail.
 func (runner *BeatRunner) TestIndexManagementILMEnabledFailure() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute)
 	defer cancel()
 	info, err := estools.GetPing(ctx, runner.requirementsInfo.ESClient)
 	require.NoError(runner.T(), err)
@@ -486,7 +486,7 @@ func (runner *BeatRunner) TestIndexManagementILMEnabledFailure() {
 
 // tests setup with both ILM and DSL enabled, should fail
 func (runner *BeatRunner) TestBothLifecyclesEnabled() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute)
 	defer cancel()
 
 	resp, err := runner.agentFixture.Exec(ctx, []string{"--path.home",
@@ -500,7 +500,7 @@ func (runner *BeatRunner) TestBothLifecyclesEnabled() {
 
 // disable all lifecycle management, ensure it's actually disabled
 func (runner *BeatRunner) TestAllLifecyclesDisabled() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute)
 	defer cancel()
 	defer func() {
 		runner.CleanupTemplates(ctx)
@@ -534,7 +534,7 @@ func (runner *BeatRunner) TestAllLifecyclesDisabled() {
 // the export command doesn't actually make a network connection,
 // so this won't fail
 func (runner *BeatRunner) TestExport() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute)
 	defer cancel()
 	info, err := estools.GetPing(ctx, runner.requirementsInfo.ESClient)
 	require.NoError(runner.T(), err)
@@ -558,7 +558,7 @@ func (runner *BeatRunner) TestExport() {
 
 // tests beat export with DSL
 func (runner *BeatRunner) TestExportDSL() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute)
 	defer cancel()
 	resp, err := runner.agentFixture.Exec(ctx, []string{"--path.home",
 		runner.agentFixture.WorkDir(),
@@ -574,7 +574,7 @@ func (runner *BeatRunner) TestExportDSL() {
 }
 
 func (runner *BeatRunner) SubtestExportTemplates() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*2)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute*2)
 	defer cancel()
 	outDir := runner.T().TempDir()
 
@@ -591,7 +591,7 @@ func (runner *BeatRunner) SubtestExportTemplates() {
 }
 
 func (runner *BeatRunner) SubtestExportIndexPatterns() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*2)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute*2)
 	defer cancel()
 
 	rawPattern, err := runner.agentFixture.Exec(ctx, []string{"--path.home",

--- a/testing/integration/ess/apm_propagation_test.go
+++ b/testing/integration/ess/apm_propagation_test.go
@@ -62,7 +62,7 @@ func TestAPMConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	deadline := time.Now().Add(10 * time.Minute)
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), deadline)
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), deadline)
 	defer cancel()
 
 	err = f.Prepare(ctx, fakeComponent)

--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -80,7 +80,7 @@ func (runner *AuditDRunner) SetupSuite() {
 		Privileged:     true,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), 3*time.Minute)
 	defer cancel()
 
 	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, fleettools.DefaultFleetOutputID, fleettools.OutputPresetLatency))

--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -146,7 +146,7 @@ func (runner *AuditDRunner) validateAuditdEvents(t *testing.T, ctx context.Conte
 func (runner *AuditDRunner) TestBeatsMetrics() {
 	t := runner.T()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*20)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute*20)
 	defer cancel()
 
 	agentStatus, err := runner.agentFixture.ExecStatus(ctx)

--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -1876,7 +1876,7 @@ func TestMonitoringNoDuplicates(t *testing.T) {
 	})
 
 	ctx, cancel := testcontext.WithDeadline(t,
-		context.Background(),
+		t.Context(),
 		time.Now().Add(5*time.Minute))
 	t.Cleanup(cancel)
 

--- a/testing/integration/ess/container_cmd_test.go
+++ b/testing/integration/ess/container_cmd_test.go
@@ -138,7 +138,7 @@ func TestContainerCMD(t *testing.T) {
 		Group: "container",
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
 	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
@@ -205,7 +205,7 @@ func TestContainerCMDWithAVeryLongStatePath(t *testing.T) {
 		Group: "container",
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Minute)
 	defer cancel()
 
 	fleetURL, err := fleettools.DefaultURL(ctx, info.KibanaClient)
@@ -325,7 +325,7 @@ func TestContainerCMDEventToStderr(t *testing.T) {
 		Group: "container",
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
 	defer cancel()
 
 	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
@@ -934,7 +934,7 @@ func TestContainerCMDDiagnosticsSocket(t *testing.T) {
 		Group: "container",
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
 	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
@@ -1004,7 +1004,7 @@ func TestContainerCMDTLSCertOverride(t *testing.T) {
 		Group: "container",
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
 	defer cancel()
 
 	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())

--- a/testing/integration/ess/delay_enroll_test.go
+++ b/testing/integration/ess/delay_enroll_test.go
@@ -33,7 +33,7 @@ func TestDelayEnroll(t *testing.T) {
 		Sudo:  true,
 	})
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
@@ -93,7 +93,7 @@ func TestDelayEnrollUnprivileged(t *testing.T) {
 		Sudo:  true,
 	})
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())

--- a/testing/integration/ess/delay_enroll_test.go
+++ b/testing/integration/ess/delay_enroll_test.go
@@ -7,7 +7,6 @@
 package ess
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"

--- a/testing/integration/ess/diagnostics_test.go
+++ b/testing/integration/ess/diagnostics_test.go
@@ -126,7 +126,7 @@ func TestDiagnosticsOptionalValues(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 	err = fixture.Prepare(ctx, fakeComponent)
 	require.NoError(t, err)
@@ -152,7 +152,7 @@ func TestIsolatedUnitsDiagnosticsOptionalValues(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 	err = fixture.Prepare(ctx, fakeComponent)
 	require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestDiagnosticsCommand(t *testing.T) {
 	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 	err = f.Prepare(ctx, fakeComponent)
 	require.NoError(t, err)
@@ -201,7 +201,7 @@ func TestIsolatedUnitsDiagnosticsCommand(t *testing.T) {
 	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 	err = f.Prepare(ctx, fakeComponent)
 	require.NoError(t, err)
@@ -222,7 +222,7 @@ func TestRedactFleetSecretPathsDiagnostics(t *testing.T) {
 		Sudo:  true,
 	})
 
-	ctx, cancel := testcontext.WithTimeout(t, context.Background(), time.Minute*10)
+	ctx, cancel := testcontext.WithTimeout(t, t.Context(), time.Minute*10)
 	defer cancel()
 
 	t.Log("Setup fake fleet-server")
@@ -459,7 +459,7 @@ agent.internal.runtime.filebeat.httpjson: process
 		},
 	}
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 	expectedAgentState := integrationtest.NewClientState(client.Healthy)
 
@@ -614,7 +614,7 @@ agent.monitoring.enabled: false
 agent.internal.runtime.filebeat.filestream: otel
 `
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Create the fixture

--- a/testing/integration/ess/endpoint_security_test.go
+++ b/testing/integration/ess/endpoint_security_test.go
@@ -564,7 +564,7 @@ func buildPolicyWithTamperProtection(policy kibana.AgentPolicy, protected bool) 
 
 func testInstallAndCLIUninstallWithEndpointSecurity(t *testing.T, info *define.Info, protected bool) {
 	deadline := time.Now().Add(10 * time.Minute)
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), deadline)
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), deadline)
 	defer cancel()
 
 	fixture, policy, agentID := installSecurityAgent(ctx, t, info, protected)
@@ -599,7 +599,7 @@ func testInstallAndCLIUninstallWithEndpointSecurity(t *testing.T, info *define.I
 }
 
 func testInstallAndUnenrollWithEndpointSecurity(t *testing.T, info *define.Info, protected bool) {
-	ctx, cn := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cn := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cn()
 
 	fixture, policy, agentID := installSecurityAgent(ctx, t, info, protected)
@@ -609,7 +609,7 @@ func testInstallAndUnenrollWithEndpointSecurity(t *testing.T, info *define.Info,
 	require.NoError(t, err)
 
 	t.Log("Polling for endpoint-security to become Healthy")
-	ctx, cancel := context.WithTimeout(context.Background(), endpointHealthPollingTimeout)
+	ctx, cancel := context.WithTimeout(ctx, endpointHealthPollingTimeout)
 	defer cancel()
 
 	agentClient := fixture.Client()
@@ -675,7 +675,7 @@ func testInstallAndUnenrollWithEndpointSecurity(t *testing.T, info *define.Info,
 }
 
 func testInstallWithEndpointSecurityAndRemoveEndpointIntegration(t *testing.T, info *define.Info, protected bool) {
-	ctx, cn := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cn := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cn()
 
 	fixture, policy, _ := installSecurityAgent(ctx, t, info, protected)
@@ -685,7 +685,7 @@ func testInstallWithEndpointSecurityAndRemoveEndpointIntegration(t *testing.T, i
 	require.NoErrorf(t, err, "Policy Response was: %#v", pkgPolicyResp)
 
 	t.Log("Polling for endpoint-security to become Healthy")
-	ctx, cancel := context.WithTimeout(context.Background(), endpointHealthPollingTimeout)
+	ctx, cancel := context.WithTimeout(ctx, endpointHealthPollingTimeout)
 	defer cancel()
 
 	agentClient := fixture.Client()
@@ -773,7 +773,7 @@ func TestEndpointSecurityNonDefaultBasePath(t *testing.T) {
 		Sudo:  true,  // requires Agent installation
 	})
 
-	ctx, cn := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cn := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cn()
 
 	// Get path to agent executable.
@@ -804,7 +804,7 @@ func TestEndpointSecurityNonDefaultBasePath(t *testing.T) {
 	pkgPolicyResp, err := installElasticDefendPackage(t, info, policyResp.ID)
 	require.NoErrorf(t, err, "Policy Response was: %v", pkgPolicyResp)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	c := fixture.Client()
@@ -851,7 +851,7 @@ func TestEndpointSecurityUnprivileged(t *testing.T) {
 		},
 	})
 
-	ctx, cn := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cn := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cn()
 
 	// Get path to agent executable.
@@ -881,7 +881,7 @@ func TestEndpointSecurityUnprivileged(t *testing.T) {
 	pkgPolicyResp, err := installElasticDefendPackage(t, info, policyResp.ID)
 	require.NoErrorf(t, err, "Policy Response was: %v", pkgPolicyResp)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	c := fixture.Client()
@@ -931,7 +931,7 @@ func TestEndpointSecurityCannotSwitchToUnprivileged(t *testing.T) {
 		},
 	})
 
-	ctx, cn := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cn := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cn()
 
 	// Get path to agent executable.
@@ -997,7 +997,7 @@ func TestEndpointLogsAreCollectedInDiagnostics(t *testing.T) {
 		},
 	})
 
-	ctx, cn := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cn := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cn()
 
 	// Get path to agent executable.
@@ -1215,7 +1215,7 @@ func TestForceInstallOverProtectedPolicy(t *testing.T) {
 	})
 
 	deadline := time.Now().Add(10 * time.Minute)
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), deadline)
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), deadline)
 	defer cancel()
 
 	fixture, policy, agentID := installSecurityAgent(ctx, t, info, true)
@@ -1279,7 +1279,7 @@ func TestInstallDefendWithMTLSandEncCertKey(t *testing.T) {
 		OS: []define.OS{{Type: define.Linux}},
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	testUUID := uuid.Must(uuid.NewV4()).String()
 	policyID := "mTLS-defend-" + testUUID
 
@@ -1818,7 +1818,7 @@ func TestPolicyReassignWithTamperProtectedEndpoint(t *testing.T) {
 		},
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Minute)
 	defer cancel()
 
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())

--- a/testing/integration/ess/enroll_replace_token_test.go
+++ b/testing/integration/ess/enroll_replace_token_test.go
@@ -7,7 +7,6 @@
 package ess
 
 import (
-	"context"
 	"testing"
 	"time"
 

--- a/testing/integration/ess/enroll_replace_token_test.go
+++ b/testing/integration/ess/enroll_replace_token_test.go
@@ -30,7 +30,7 @@ func TestEnrollReplaceToken(t *testing.T) {
 		Sudo:  true,
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 

--- a/testing/integration/ess/escaping_secrets_in_policy_test.go
+++ b/testing/integration/ess/escaping_secrets_in_policy_test.go
@@ -32,7 +32,7 @@ func TestEscapingSecretsInPolicy(t *testing.T) {
 		Sudo:  true,
 	})
 	t.Skip("flaky test: https://github.com/elastic/elastic-agent/issues/6107")
-	ctx := context.Background()
+	ctx := t.Context()
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 	installOpts := atesting.InstallOpts{

--- a/testing/integration/ess/event_logging_test.go
+++ b/testing/integration/ess/event_logging_test.go
@@ -79,7 +79,7 @@ func TestEventLogFile(t *testing.T) {
 	})
 	ctx, cancel := testcontext.WithDeadline(
 		t,
-		context.Background(),
+		t.Context(),
 		time.Now().Add(10*time.Minute))
 	defer cancel()
 
@@ -165,7 +165,7 @@ func TestEventLogOutputConfiguredViaFleet(t *testing.T) {
 		},
 		Group: "container",
 	})
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
 	defer cancel()
 
 	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version())

--- a/testing/integration/ess/fake_test.go
+++ b/testing/integration/ess/fake_test.go
@@ -7,7 +7,6 @@
 package ess
 
 import (
-	"context"
 	"testing"
 	"time"
 

--- a/testing/integration/ess/fake_test.go
+++ b/testing/integration/ess/fake_test.go
@@ -77,7 +77,7 @@ func TestFakeComponent(t *testing.T) {
 	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 	err = f.Prepare(ctx, fakeComponent)
 	require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestFakeIsolatedUnitsComponent(t *testing.T) {
 	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 	err = f.Prepare(ctx, fakeComponent)
 	require.NoError(t, err)

--- a/testing/integration/ess/fips_test.go
+++ b/testing/integration/ess/fips_test.go
@@ -177,7 +177,7 @@ func enrollLocalFIPSAgentInFleetServer(t *testing.T, info *define.Info) (*atesti
 		Privileged:     true,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
 	defer cancel()
 
 	require.NoError(t, fleettools.UpdateESOutputPreset(ctx, info.KibanaClient, fleettools.DefaultFleetOutputID, fleettools.OutputPresetLatency))
@@ -191,7 +191,7 @@ func addIntegrationAndCheckData(t *testing.T, info *define.Info, fixture *atesti
 	t.Helper()
 
 	// Install system integration
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
 	defer cancel()
 	_, err := tools.InstallPackageFromDefaultFile(ctx, info.KibanaClient, "system", integration.PreinstalledPackages["system"], "testdata/system_integration_setup.json", uuid.Must(uuid.NewV4()).String(), policyID)
 	require.NoError(t, err)

--- a/testing/integration/ess/fleetserver_test.go
+++ b/testing/integration/ess/fleetserver_test.go
@@ -48,7 +48,7 @@ func TestInstallFleetServerBootstrap(t *testing.T) {
 		Local: false,
 	})
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	t.Log("Ensure base path is clean")

--- a/testing/integration/ess/fleetserver_test.go
+++ b/testing/integration/ess/fleetserver_test.go
@@ -7,7 +7,6 @@
 package ess
 
 import (
-	"context"
 	"crypto/tls"
 	"net/http"
 	"net/url"

--- a/testing/integration/ess/fqdn_test.go
+++ b/testing/integration/ess/fqdn_test.go
@@ -54,7 +54,7 @@ func TestFQDN(t *testing.T) {
 	origEtcHosts, err := getEtcHosts()
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Save original hostname so we can restore it at the end of each test

--- a/testing/integration/ess/inspect_test.go
+++ b/testing/integration/ess/inspect_test.go
@@ -7,7 +7,6 @@
 package ess
 
 import (
-	"context"
 	"testing"
 	"time"
 

--- a/testing/integration/ess/inspect_test.go
+++ b/testing/integration/ess/inspect_test.go
@@ -32,7 +32,7 @@ func TestInspect(t *testing.T) {
 		Sudo:  true,
 	})
 
-	ctx, cancel := testcontext.WithTimeout(t, context.Background(), time.Minute*10)
+	ctx, cancel := testcontext.WithTimeout(t, t.Context(), time.Minute*10)
 	defer cancel()
 
 	apiKey, policy := createBasicFleetPolicyData(t, "http://fleet-server:8220")

--- a/testing/integration/ess/install_test.go
+++ b/testing/integration/ess/install_test.go
@@ -58,7 +58,7 @@ func TestInstallWithoutBasePath(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Prepare the Elastic Agent so the binary is extracted and ready to use.
@@ -85,7 +85,7 @@ func TestInstallWithoutBasePathWithCustomUser(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Prepare the Elastic Agent so the binary is extracted and ready to use.
@@ -112,7 +112,7 @@ func TestInstallWithBasePath(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Prepare the Elastic Agent so the binary is extracted and ready to use.
@@ -219,7 +219,7 @@ func TestInstallServersWithBasePath(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Prepare the Elastic Agent so the binary is extracted and ready to use.
@@ -319,7 +319,7 @@ func TestInstallPrivilegedWithoutBasePath(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Prepare the Elastic Agent so the binary is extracted and ready to use.
@@ -369,7 +369,7 @@ func TestInstallPrivilegedWithBasePath(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Prepare the Elastic Agent so the binary is extracted and ready to use.
@@ -428,7 +428,7 @@ func TestInstallFailureCleanup(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Prepare the Elastic Agent so the binary is extracted and ready to use.
@@ -480,7 +480,7 @@ func TestInstallSecondAgentInDevelopmentNamespace(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Prepare the Elastic Agent so the binary is extracted and ready to use.
@@ -679,7 +679,7 @@ func TestInstallUninstallAudit(t *testing.T) {
 		},
 	})
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	policyResp, enrollmentTokenResp := createPolicyAndEnrollmentToken(ctx, t, info.KibanaClient, createBasicPolicy())
@@ -800,7 +800,7 @@ func TestRepeatedInstallUninstallFleet(t *testing.T) {
 		Local: false,
 	})
 
-	prepareCtx, prepareCancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
+	prepareCtx, prepareCancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(5*time.Minute))
 	defer prepareCancel()
 
 	policyResp, enrollmentTokenResp := createPolicyAndEnrollmentToken(prepareCtx, t, info.KibanaClient, createBasicPolicy())
@@ -821,7 +821,7 @@ func TestRepeatedInstallUninstallFleet(t *testing.T) {
 	maxRunTime := 2 * time.Minute
 	for i := 0; i < iterations(); i++ {
 		successful := t.Run(fmt.Sprintf("%s-%d", t.Name(), i), func(t *testing.T) {
-			ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(maxRunTime))
+			ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(maxRunTime))
 			defer cancel()
 
 			// Run `elastic-agent install`.  We use `--force` to prevent interactive

--- a/testing/integration/ess/linux_deb_test.go
+++ b/testing/integration/ess/linux_deb_test.go
@@ -48,7 +48,7 @@ func TestDebLogIngestFleetManaged(t *testing.T) {
 		Sudo:  true,
 	})
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), atesting.WithPackageFormat("deb"))
@@ -96,7 +96,7 @@ func TestDebInstallsServers(t *testing.T) {
 		Sudo:  true,
 	})
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), atesting.WithPackageFormat("deb"))
@@ -219,7 +219,7 @@ func TestDebFleetUpgrade(t *testing.T) {
 }
 
 func testDebUpgrade(t *testing.T, upgradeFromVersion *version.ParsedSemVer, info *define.Info, installingServers bool, expectingServers bool) {
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// start from previous minor

--- a/testing/integration/ess/linux_rpm_test.go
+++ b/testing/integration/ess/linux_rpm_test.go
@@ -45,7 +45,7 @@ func TestRpmLogIngestFleetManaged(t *testing.T) {
 		Sudo:  true,
 	})
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), atesting.WithPackageFormat("rpm"))
@@ -89,7 +89,7 @@ func TestRpmInstallsServers(t *testing.T) {
 		Sudo:  true,
 	})
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), atesting.WithPackageFormat("rpm"))
@@ -207,7 +207,7 @@ func TestRpmFleetUpgrade(t *testing.T) {
 }
 
 func testRpmUpgrade(t *testing.T, upgradeFromVersion *version.ParsedSemVer, info *define.Info, installingServers bool, expectingServers bool, prefix string) {
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// start from snapshot of the rpm
@@ -393,7 +393,7 @@ func TestRpmWithPrefix(t *testing.T) {
 		Sudo:  true,
 	})
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), atesting.WithPackageFormat("rpm"))

--- a/testing/integration/ess/log_level_test.go
+++ b/testing/integration/ess/log_level_test.go
@@ -47,7 +47,7 @@ func TestSetLogLevelFleetManaged(t *testing.T) {
 	})
 
 	deadline := time.Now().Add(30 * time.Minute)
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), deadline)
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), deadline)
 	defer cancel()
 
 	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
@@ -94,7 +94,7 @@ func TestSetLogLevelFleetManagedSurvivesRestart(t *testing.T) {
 	})
 
 	deadline := time.Now().Add(30 * time.Minute)
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), deadline)
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), deadline)
 	defer cancel()
 
 	f, err := define.NewFixtureFromLocalBuild(t, define.Version())

--- a/testing/integration/ess/logging_file_test.go
+++ b/testing/integration/ess/logging_file_test.go
@@ -40,7 +40,7 @@ func TestLoggingFilePathChangedViaFleet(t *testing.T) {
 	})
 
 	deadline := time.Now().Add(15 * time.Minute)
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), deadline)
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), deadline)
 	defer cancel()
 
 	f, err := define.NewFixtureFromLocalBuild(t, define.Version())

--- a/testing/integration/ess/logging_file_test.go
+++ b/testing/integration/ess/logging_file_test.go
@@ -7,7 +7,6 @@
 package ess
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"

--- a/testing/integration/ess/metrics_monitoring_test.go
+++ b/testing/integration/ess/metrics_monitoring_test.go
@@ -86,7 +86,7 @@ func (runner *MetricsRunner) SetupSuite() {
 		Privileged:     true,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), 3*time.Minute)
 	defer cancel()
 
 	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, fleettools.DefaultFleetOutputID, fleettools.OutputPresetLatency))
@@ -146,7 +146,7 @@ func (runner *MetricsRunner) addMonitoringToOtelRuntimeOverwrite() {
 func (runner *MetricsRunner) TestBeatsMetrics() {
 	t := runner.T()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*20)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute*20)
 	defer cancel()
 
 	agentStatus, err := runner.agentFixture.ExecStatus(ctx)

--- a/testing/integration/ess/monitoring_endpoint_test.go
+++ b/testing/integration/ess/monitoring_endpoint_test.go
@@ -60,7 +60,7 @@ func TestEndpointAgentServiceMonitoring(t *testing.T) {
 
 func (runner *EndpointMetricsMonRunner) SetupSuite() {
 	deadline := time.Now().Add(10 * time.Minute)
-	ctx, cancel := testcontext.WithDeadline(runner.T(), context.Background(), deadline)
+	ctx, cancel := testcontext.WithDeadline(runner.T(), runner.T().Context(), deadline)
 	defer cancel()
 
 	runner.T().Log("Enrolling the agent in Fleet")
@@ -109,7 +109,7 @@ func (runner *EndpointMetricsMonRunner) SetupSuite() {
 }
 
 func (runner *EndpointMetricsMonRunner) TestEndpointMetrics() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*15)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute*15)
 	defer cancel()
 
 	agentStatus, err := runner.fixture.ExecStatus(ctx)
@@ -127,7 +127,7 @@ func (runner *EndpointMetricsMonRunner) TestEndpointMetrics() {
 }
 
 func (runner *EndpointMetricsMonRunner) TestEndpointMetricsAfterRestart() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*15)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute*15)
 	defer cancel()
 	// once we've gotten the first round of metrics,forcably restart endpoint, see if we still get metrics
 	// This makes sure that the backend coordinator can deal with properly updating the metrics handlers if there's unexpected state changes

--- a/testing/integration/ess/monitoring_probe_preserve_text_cfg_test.go
+++ b/testing/integration/ess/monitoring_probe_preserve_text_cfg_test.go
@@ -116,7 +116,7 @@ func (runner *MonitoringTextRunner) SetupSuite() {
 		Privileged:     true,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), 3*time.Minute)
 	defer cancel()
 
 	// write a default config file that enables monitoring
@@ -136,7 +136,7 @@ func (runner *MonitoringTextRunner) SetupSuite() {
 }
 
 func (runner *MonitoringTextRunner) TestMonitoringLiveness() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute*10)
 	defer cancel()
 
 	runner.AllComponentsHealthy(ctx)

--- a/testing/integration/ess/monitoring_probe_reload_test.go
+++ b/testing/integration/ess/monitoring_probe_reload_test.go
@@ -78,7 +78,7 @@ func (runner *MonitoringRunner) SetupSuite() {
 		Privileged:     true,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), 3*time.Minute)
 	defer cancel()
 
 	policyResp, agentID, err := tools.InstallAgentWithPolicy(ctx, runner.T(), installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
@@ -94,7 +94,7 @@ func (runner *MonitoringRunner) SetupSuite() {
 }
 
 func (runner *MonitoringRunner) TestMonitoringLiveness() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Minute*10)
 	defer cancel()
 
 	runner.AllComponentsHealthy(ctx)

--- a/testing/integration/ess/network_traffic_monitoring_test.go
+++ b/testing/integration/ess/network_traffic_monitoring_test.go
@@ -89,7 +89,7 @@ func (runner *NetworkTrafficRunner) SetupSuite() {
 
 	// 5 minutes: agent install can take 2+ minutes on slow machines, leaving
 	// insufficient time for the subsequent package install with a 3-minute budget.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), 5*time.Minute)
 	defer cancel()
 
 	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, fleettools.DefaultFleetOutputID, fleettools.OutputPresetLatency))
@@ -179,7 +179,7 @@ func dialTLS(t *testing.T, host string) {
 func (runner *NetworkTrafficRunner) TestBeatsMetrics() {
 	t := runner.T()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*20)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute*20)
 	defer cancel()
 
 	agentStatus, err := runner.agentFixture.ExecStatus(ctx)

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -78,7 +78,7 @@ func (runner *OsqueryManagerRunner) SetupSuite() {
 		Privileged:     true,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), 3*time.Minute)
 	defer cancel()
 
 	require.NoError(runner.T(), fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, fleettools.DefaultFleetOutputID, fleettools.OutputPresetLatency))
@@ -136,7 +136,7 @@ func (runner *OsqueryManagerRunner) validateOsqueryEvents(t *testing.T, ctx cont
 func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 	t := runner.T()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*20)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute*20)
 	defer cancel()
 
 	agentStatus, err := runner.agentFixture.ExecStatus(ctx)

--- a/testing/integration/ess/otel_log_as_filestream_test.go
+++ b/testing/integration/ess/otel_log_as_filestream_test.go
@@ -120,7 +120,7 @@ func TestFilebeatReceiverLogAsFilestream(t *testing.T) {
 	t.Cleanup(wg.Wait)
 	go func() {
 		defer wg.Done()
-		ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(3*time.Minute))
+		ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(3*time.Minute))
 		defer cancel()
 		require.NoError(t, fixture.RunOtelWithClient(ctx))
 	}()
@@ -160,7 +160,7 @@ func TestFilebeatReceiverLogAsFilestream(t *testing.T) {
 	t.Cleanup(wg.Wait)
 	go func() {
 		defer wg.Done()
-		ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
+		ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(5*time.Minute))
 		defer cancel()
 		require.NoError(t, fixture.RunOtelWithClient(ctx))
 	}()
@@ -206,7 +206,7 @@ func TestFilebeatReceiverLogAsFilestream(t *testing.T) {
 	t.Cleanup(wg.Wait)
 	go func() {
 		defer wg.Done()
-		ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(3*
+		ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(3*
 			time.Minute))
 		defer cancel()
 		require.NoError(t, fixture.RunOtelWithClient(ctx))

--- a/testing/integration/ess/otel_log_as_filestream_test.go
+++ b/testing/integration/ess/otel_log_as_filestream_test.go
@@ -9,6 +9,7 @@ package ess
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -122,7 +123,10 @@ func TestFilebeatReceiverLogAsFilestream(t *testing.T) {
 		defer wg.Done()
 		ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(3*time.Minute))
 		defer cancel()
-		require.NoError(t, fixture.RunOtelWithClient(ctx))
+		err := fixture.RunOtelWithClient(ctx)
+		assert.Conditionf(t, func() bool {
+			return err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+		}, "unexpected error running OtelWithClient: %v", err)
 	}()
 
 	agentLogFile := fs.LogFile{}
@@ -162,7 +166,10 @@ func TestFilebeatReceiverLogAsFilestream(t *testing.T) {
 		defer wg.Done()
 		ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(5*time.Minute))
 		defer cancel()
-		require.NoError(t, fixture.RunOtelWithClient(ctx))
+		err := fixture.RunOtelWithClient(ctx)
+		assert.Conditionf(t, func() bool {
+			return err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+		}, "unexpected error running OtelWithClient: %v", err)
 	}()
 
 	// Ensure the Filestream input starts
@@ -209,7 +216,10 @@ func TestFilebeatReceiverLogAsFilestream(t *testing.T) {
 		ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(3*
 			time.Minute))
 		defer cancel()
-		require.NoError(t, fixture.RunOtelWithClient(ctx))
+		err := fixture.RunOtelWithClient(ctx)
+		assert.Conditionf(t, func() bool {
+			return err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+		}, "unexpected error running OtelWithClient: %v", err)
 	}()
 
 	// Start Elastic Agent again to ensure it is correctly tracking the state

--- a/testing/integration/ess/otel_test.go
+++ b/testing/integration/ess/otel_test.go
@@ -1705,17 +1705,17 @@ service:
 
 	require.EventuallyWithT(
 		t,
-		func(t *assert.CollectT) {
-			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
+		func(ct *assert.CollectT) {
+			findCtx, findCancel := context.WithTimeout(ctx, 10*time.Second)
 			defer findCancel()
 
 			docs, err := estools.GetLogsForIndexWithContext(findCtx, info.ESClient, ".ds-"+index+"*", map[string]any{
 				"log.file.path": inputFilePath,
 			})
-			require.NoError(t, err)
+			require.NoError(ct, err)
 			got := int(docs.Hits.Total.Value)
 
-			require.GreaterOrEqual(t, got, 10, "")
+			require.GreaterOrEqual(ct, got, 10, "")
 		},
 		time.Minute,
 		time.Second,
@@ -1742,28 +1742,28 @@ service:
 
 	require.EventuallyWithT(
 		t,
-		func(t *assert.CollectT) {
-			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
+		func(ct *assert.CollectT) {
+			findCtx, findCancel := context.WithTimeout(ctx, 10*time.Second)
 			defer findCancel()
 
 			docs, err := estools.GetLogsForIndexWithContext(findCtx, info.ESClient, ".ds-"+index+"*", map[string]any{
 				"log.file.path": inputFilePath,
 			})
-			require.NoError(t, err)
+			require.NoError(ct, err)
 
 			uniqueIngestedLogs := make(map[string]struct{})
 			for _, hit := range docs.Hits.Hits {
 				message, found := hit.Source["message"]
-				require.True(t, found, "expected message field in document %q", hit.Source)
+				require.True(ct, found, "expected message field in document %q", hit.Source)
 				msg, ok := message.(string)
-				require.True(t, ok, "expected message field to be a string, got %T", message)
-				require.NotContainsf(t, uniqueIngestedLogs, msg, "found duplicated log message %q", msg)
+				require.True(ct, ok, "expected message field to be a string, got %T", message)
+				require.NotContainsf(ct, uniqueIngestedLogs, msg, "found duplicated log message %q", msg)
 				uniqueIngestedLogs[msg] = struct{}{}
 			}
 
 			want := inputLinesCounter.Load()
 			got := docs.Hits.Total.Value
-			require.EqualValues(t, want, got, "expecting %d hits got %d hits", want, got)
+			require.EqualValues(ct, want, got, "expecting %d hits got %d hits", want, got)
 		},
 		20*time.Second,
 		time.Second,
@@ -3432,7 +3432,7 @@ agent.monitoring:
 				t.Log("Elastic-Agent output:")
 				t.Log(output.String())
 
-				logCtx, logCancel := context.WithTimeout(t.Context(), 30*time.Second)
+				logCtx, logCancel := context.WithTimeout(context.Background(), 30*time.Second)
 				defer logCancel()
 
 				lsContainer, err := stack.ServiceContainer(logCtx, "logstash")

--- a/testing/integration/ess/otel_test.go
+++ b/testing/integration/ess/otel_test.go
@@ -264,7 +264,7 @@ service:
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), aTesting.WithAdditionalArgs([]string{"--config", otelConfigPath}))
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 	err = fixture.Prepare(ctx, fakeComponent)
 	require.NoError(t, err)
@@ -380,7 +380,7 @@ service:
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 	err = fixture.Prepare(ctx, fakeComponent)
 	require.NoError(t, err)
@@ -593,7 +593,7 @@ func TestOtelLogsIngestion(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), aTesting.WithAdditionalArgs([]string{"--config", cfgFilePath}))
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 	err = fixture.Prepare(ctx, fakeComponent)
 	require.NoError(t, err)
@@ -681,7 +681,7 @@ func TestOtelAPMIngestion(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), aTesting.WithAdditionalArgs([]string{"--config", cfgFilePath}))
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 	err = fixture.Prepare(ctx, fakeComponent)
 	require.NoError(t, err)
@@ -953,7 +953,7 @@ agent.internal.runtime.filebeat.filestream: otel
 				ESApiKey:   decodedApiKey,
 			}))
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(5*time.Minute))
 	defer cancel()
 	err = fixture.Prepare(ctx)
 	require.NoError(t, err)
@@ -986,7 +986,7 @@ agent.internal.runtime.filebeat.filestream: otel
 	actualHits := &struct{ Hits int }{}
 	assert.EventuallyWithT(t,
 		func(ct *assert.CollectT) {
-			findCtx, findCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer findCancel()
 
 			docs, err := estools.GetLogsForIndexWithContext(findCtx, info.ESClient, index, map[string]interface{}{
@@ -1007,7 +1007,7 @@ agent.internal.runtime.filebeat.filestream: otel
 	// Check metrics from self-monitoring
 	assert.EventuallyWithT(t,
 		func(ct *assert.CollectT) {
-			findCtx, findCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer findCancel()
 
 			docs, err := estools.GetLogsForIndexWithContext(findCtx, info.ESClient, metricsIndex, map[string]interface{}{
@@ -1090,7 +1090,7 @@ agent.monitoring:
 			ESApiKey:   decodedApiKey,
 		})
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(5*time.Minute))
 	defer cancel()
 	err = fixture.Prepare(ctx)
 	require.NoError(t, err)
@@ -1127,7 +1127,7 @@ agent.monitoring:
 	actualHits := &struct{ Hits int }{}
 	assert.Eventually(t,
 		func() bool {
-			findCtx, findCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer findCancel()
 
 			query := map[string]interface{}{
@@ -1306,7 +1306,7 @@ service:
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(5*time.Minute))
 	defer cancel()
 
 	err = fixture.Prepare(ctx)
@@ -1347,7 +1347,7 @@ service:
 	}{}
 	require.EventuallyWithT(t,
 		func(collect *assert.CollectT) {
-			findCtx, findCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer findCancel()
 
 			docs, err = estools.GetLogsForIndexWithContext(findCtx, info.ESClient, ".ds-"+fbIndex+"*", map[string]interface{}{
@@ -1484,7 +1484,7 @@ processors:
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(5*time.Minute))
 	defer cancel()
 
 	err = fixture.Prepare(ctx)
@@ -1525,7 +1525,7 @@ processors:
 	}{}
 	require.EventuallyWithT(t,
 		func(collect *assert.CollectT) {
-			findCtx, findCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer findCancel()
 
 			docs, err = estools.GetLogsForIndexWithContext(findCtx, info.ESClient, ".ds-"+fbIndex+"*", map[string]interface{}{
@@ -1666,7 +1666,7 @@ service:
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), aTesting.WithAdditionalArgs([]string{"--config", otelConfigPath}))
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(5*time.Minute))
 	defer cancel()
 	err = fixture.Prepare(ctx)
 	require.NoError(t, err)
@@ -1706,7 +1706,7 @@ service:
 	require.EventuallyWithT(
 		t,
 		func(t *assert.CollectT) {
-			findCtx, findCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer findCancel()
 
 			docs, err := estools.GetLogsForIndexWithContext(findCtx, info.ESClient, ".ds-"+index+"*", map[string]any{
@@ -1743,7 +1743,7 @@ service:
 	require.EventuallyWithT(
 		t,
 		func(t *assert.CollectT) {
-			findCtx, findCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer findCancel()
 
 			docs, err := estools.GetLogsForIndexWithContext(findCtx, info.ESClient, ".ds-"+index+"*", map[string]any{
@@ -2113,7 +2113,7 @@ outputs:
 		otelConfigOptions{
 			StatusReportingEnabled: true,
 		})
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(5*time.Minute))
 	defer cancel()
 
 	installOpts := aTesting.InstallOpts{
@@ -2909,7 +2909,7 @@ agent.monitoring:
 				CaCert:              filepath.Join(kafkaPath, "certs", "ca-cert"),
 			})
 
-		ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
+		ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(5*time.Minute))
 		defer cancel()
 		err = fixture.Prepare(ctx)
 		require.NoError(t, err)
@@ -3191,7 +3191,7 @@ agent.monitoring:
 			fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 			require.NoError(t, err)
 
-			ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
+			ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(5*time.Minute))
 			defer cancel()
 
 			err = fixture.Prepare(ctx)
@@ -3409,7 +3409,7 @@ agent.monitoring:
 				Host:                tt.host,
 			})
 
-		ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(5*time.Minute))
+		ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(5*time.Minute))
 		defer cancel()
 		err = fixture.Prepare(ctx)
 		require.NoError(t, err)
@@ -3432,7 +3432,7 @@ agent.monitoring:
 				t.Log("Elastic-Agent output:")
 				t.Log(output.String())
 
-				logCtx, logCancel := context.WithTimeout(context.Background(), 30*time.Second)
+				logCtx, logCancel := context.WithTimeout(t.Context(), 30*time.Second)
 				defer logCancel()
 
 				lsContainer, err := stack.ServiceContainer(logCtx, "logstash")

--- a/testing/integration/ess/otel_test.go
+++ b/testing/integration/ess/otel_test.go
@@ -995,7 +995,7 @@ agent.internal.runtime.filebeat.filestream: otel
 			require.NoError(ct, err)
 
 			actualHits.Hits = docs.Hits.Total.Value
-			output, execErr := fixture.ExecStatus(context.Background())
+			output, execErr := fixture.ExecStatus(ctx)
 			require.NoError(ct, execErr)
 			t.Logf("status output: %v", output)
 			assert.Equal(ct, numEvents, actualHits.Hits)
@@ -1016,7 +1016,7 @@ agent.internal.runtime.filebeat.filestream: otel
 			require.NoError(ct, err)
 
 			actualHits.Hits = docs.Hits.Total.Value
-			output, execErr := fixture.ExecStatus(context.Background())
+			output, execErr := fixture.ExecStatus(ctx)
 			require.NoError(ct, execErr)
 			t.Logf("status output: %v", output)
 			assert.Greater(ct, actualHits.Hits, 0)

--- a/testing/integration/ess/package_version_test.go
+++ b/testing/integration/ess/package_version_test.go
@@ -42,7 +42,7 @@ func TestPackageVersion(t *testing.T) {
 	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 	err = f.Prepare(ctx, fakeComponent)
 	require.NoError(t, err)

--- a/testing/integration/ess/package_version_test.go
+++ b/testing/integration/ess/package_version_test.go
@@ -68,7 +68,7 @@ func TestComponentBuildHashInDiagnostics(t *testing.T) {
 		Local: false, // requires Agent installation
 		Sudo:  true,  // requires Agent installation
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	f, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err, "could not create new fixture")

--- a/testing/integration/ess/proxy_url_test.go
+++ b/testing/integration/ess/proxy_url_test.go
@@ -679,7 +679,7 @@ func TestProxyURL(t *testing.T) {
 	for _, tt := range testcases {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+			ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 			defer cancel()
 
 			// create API Key and basic Fleet Policy

--- a/testing/integration/ess/restrict_upgrade_deb_test.go
+++ b/testing/integration/ess/restrict_upgrade_deb_test.go
@@ -37,7 +37,7 @@ func TestRestrictUpgradeDeb(t *testing.T) {
 		},
 	})
 	t.Run("when agent is deployed via deb, a user should not be able to upgrade the agent using the cli", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 
 		fixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), atesting.WithPackageFormat("deb"))
 		require.NoError(t, err)

--- a/testing/integration/ess/restrict_upgrade_deb_test.go
+++ b/testing/integration/ess/restrict_upgrade_deb_test.go
@@ -7,7 +7,6 @@
 package ess
 
 import (
-	"context"
 	"testing"
 	"time"
 

--- a/testing/integration/ess/restrict_upgrade_rpm_test.go
+++ b/testing/integration/ess/restrict_upgrade_rpm_test.go
@@ -7,7 +7,6 @@
 package ess
 
 import (
-	"context"
 	"testing"
 	"time"
 

--- a/testing/integration/ess/restrict_upgrade_rpm_test.go
+++ b/testing/integration/ess/restrict_upgrade_rpm_test.go
@@ -32,7 +32,7 @@ func TestRestrictUpgradeRPM(t *testing.T) {
 		},
 	})
 	t.Run("when agent is deployed via rpm, a user should not be able to upgrade the agent using the cli", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 
 		fixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), atesting.WithPackageFormat("rpm"))
 		require.NoError(t, err)

--- a/testing/integration/ess/switch_privileged_test.go
+++ b/testing/integration/ess/switch_privileged_test.go
@@ -39,7 +39,7 @@ func TestSwitchPrivilegedWithoutBasePath(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Prepare the Elastic Agent so the binary is extracted and ready to use.
@@ -85,7 +85,7 @@ func TestSwitchPrivilegedWithBasePath(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Prepare the Elastic Agent so the binary is extracted and ready to use.

--- a/testing/integration/ess/switch_privileged_test.go
+++ b/testing/integration/ess/switch_privileged_test.go
@@ -7,7 +7,6 @@
 package ess
 
 import (
-	"context"
 	"path/filepath"
 	"runtime"
 	"strings"

--- a/testing/integration/ess/switch_unprivileged_test.go
+++ b/testing/integration/ess/switch_unprivileged_test.go
@@ -56,7 +56,7 @@ func TestSwitchUnprivilegedWithoutBasePath(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Prepare the Elastic Agent so the binary is extracted and ready to use.
@@ -88,7 +88,7 @@ func TestSwitchUnprivilegedWithoutBasePathCustomUser(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Prepare the Elastic Agent so the binary is extracted and ready to use.
@@ -158,7 +158,7 @@ func TestSwitchUnprivilegedWithBasePath(t *testing.T) {
 	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Prepare the Elastic Agent so the binary is extracted and ready to use.

--- a/testing/integration/ess/upgrade_broken_package_test.go
+++ b/testing/integration/ess/upgrade_broken_package_test.go
@@ -34,7 +34,7 @@ func TestUpgradeBrokenPackageVersion(t *testing.T) {
 	})
 	t.Skip("Skip this test because it is not compatible with .package-version pinning")
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Start at the build version as we want to test the retry

--- a/testing/integration/ess/upgrade_broken_package_test.go
+++ b/testing/integration/ess/upgrade_broken_package_test.go
@@ -7,7 +7,6 @@
 package ess
 
 import (
-	"context"
 	"fmt"
 	"io/fs"
 	"os"

--- a/testing/integration/ess/upgrade_fleet_test.go
+++ b/testing/integration/ess/upgrade_fleet_test.go
@@ -283,8 +283,9 @@ func TestFleetUpgradeToPRBuild(t *testing.T) {
 }
 
 func testFleetAirGappedUpgrade(t *testing.T, stack *define.Info, unprivileged bool) {
-	ctx, _ := testcontext.WithDeadline(
-		t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(
+		t, t.Context(), time.Now().Add(10*time.Minute))
+	defer cancel()
 
 	latest := define.Version()
 

--- a/testing/integration/ess/upgrade_fleet_test.go
+++ b/testing/integration/ess/upgrade_fleet_test.go
@@ -155,7 +155,7 @@ func TestFleetUpgradeToPRBuild(t *testing.T) {
 		Local: false,
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// ========================= prepare from fixture ==========================
 	versions, err := upgradetest.GetUpgradableVersions()

--- a/testing/integration/ess/upgrade_gpg_test.go
+++ b/testing/integration/ess/upgrade_gpg_test.go
@@ -7,7 +7,6 @@
 package ess
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"

--- a/testing/integration/ess/upgrade_gpg_test.go
+++ b/testing/integration/ess/upgrade_gpg_test.go
@@ -38,7 +38,7 @@ func TestStandaloneUpgradeWithGPGFallback(t *testing.T) {
 		t.Skipf("Version %s is lower than min version %s", define.Version(), minVersion)
 	}
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Start at the build version as we want to test the retry
@@ -107,7 +107,7 @@ func TestStandaloneUpgradeWithGPGFallbackOneRemoteFailing(t *testing.T) {
 		t.Skipf("Version %s is lower than min version %s", define.Version(), minVersion)
 	}
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Start at the build version as we want to test the retry

--- a/testing/integration/ess/upgrade_integrations_server_test.go
+++ b/testing/integration/ess/upgrade_integrations_server_test.go
@@ -68,7 +68,7 @@ func TestUpgradeIntegrationsServer(t *testing.T) {
 		t.Run(fmt.Sprintf("%s_to_%s", startVersion.String(), endVersion), func(t *testing.T) {
 			// Create ECH deployment with start version
 			t.Logf("Creating ECH deployment with version [%s] in region [%s]", startVersion.String(), echRegion)
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 			deployment, err := statefulProv.Create(ctx, common.StackRequest{
 				ID:      "it-upgrade-integrations-server",

--- a/testing/integration/ess/upgrade_integrations_server_test.go
+++ b/testing/integration/ess/upgrade_integrations_server_test.go
@@ -95,18 +95,18 @@ func TestUpgradeIntegrationsServer(t *testing.T) {
 
 			// Check that deployment is ready and healthy after creation
 			t.Logf("Waiting for ECH deployment [%s] in region [%s] to be ready and healthy after creation", deployment.ID, echRegion)
-			deployment, err = prov.WaitForReady(context.Background(), deployment)
+			deployment, err = prov.WaitForReady(t.Context(), deployment)
 			require.NoError(t, err)
 
 			// Upgrade deployment to end version
 			t.Logf("Upgrading ECH deployment [%s] in region [%s] from version [%s] to [%s]", deployment.ID, echRegion, startVersion.String(), endVersion)
-			err = prov.Upgrade(context.Background(), deployment, endVersion)
+			err = prov.Upgrade(t.Context(), deployment, endVersion)
 			require.NoError(t, err)
 			deployment.Version = endVersion
 
 			// Check that deployment is ready and healthy after upgrade
 			t.Logf("Waiting for ECH deployment [%s] in region [%s] to be ready and healthy after upgrade", deployment.ID, echRegion)
-			deployment, err = prov.WaitForReady(context.Background(), deployment)
+			deployment, err = prov.WaitForReady(t.Context(), deployment)
 			require.NoError(t, err)
 		})
 	}

--- a/testing/integration/ess/upgrade_rollback_test.go
+++ b/testing/integration/ess/upgrade_rollback_test.go
@@ -76,7 +76,7 @@ func TestStandaloneUpgradeRollback(t *testing.T) {
 	})
 	esUrl := integration.StartMockES(t, 0, 0, 0, 0)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Upgrade from an old build because the new watcher from the new build will

--- a/testing/integration/ess/upgrade_standalone_flavors_test.go
+++ b/testing/integration/ess/upgrade_standalone_flavors_test.go
@@ -54,7 +54,7 @@ func TestStandaloneUpgrade_Flavor_Basic(t *testing.T) {
 	require.NoError(t, err)
 
 	checkFn := func(t *testing.T, fixture *atesting.Fixture) {
-		testComponentsPresence(context.Background(), fixture,
+		testComponentsPresence(t.Context(), fixture,
 			[]componentPresenceDefinition{
 				{"elastic-otel-collector", []string{"windows", "linux", "darwin"}},
 				{"endpoint-security", []string{"windows", "linux", "darwin"}},
@@ -127,7 +127,7 @@ func TestStandaloneUpgrade_Flavor_Servers(t *testing.T) {
 	require.NoError(t, err)
 
 	checkFn := func(t *testing.T, fixture *atesting.Fixture) {
-		testComponentsPresence(context.Background(), fixture,
+		testComponentsPresence(t.Context(), fixture,
 			[]componentPresenceDefinition{
 				{"elastic-otel-collector", []string{"windows", "linux", "darwin"}},
 				{"endpoint-security", []string{"windows", "linux", "darwin"}},
@@ -198,7 +198,7 @@ func TestStandaloneUpgrade_Flavor_UpgradeFromUnflavored(t *testing.T) {
 	require.NoError(t, err)
 
 	checkFn := func(t *testing.T, fixture *atesting.Fixture) {
-		testComponentsPresence(context.Background(), fixture,
+		testComponentsPresence(t.Context(), fixture,
 			[]componentPresenceDefinition{
 				{"elastic-otel-collector", []string{"windows", "linux", "darwin"}},
 				{"endpoint-security", []string{"windows", "linux", "darwin"}},

--- a/testing/integration/ess/upgrade_standalone_flavors_test.go
+++ b/testing/integration/ess/upgrade_standalone_flavors_test.go
@@ -240,7 +240,7 @@ func TestStandaloneUpgrade_Flavor_UpgradeFromUnflavored(t *testing.T) {
 }
 
 func testStandaloneUpgradeFlavorCheck(t *testing.T, startVersion *version.ParsedSemVer, endVersion string, unprivileged bool, hasServers bool, flavorCheck func(t *testing.T, f *atesting.Fixture)) {
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	startFixture, err := atesting.NewFixture(

--- a/testing/integration/ess/upgrade_standalone_flavors_test.go
+++ b/testing/integration/ess/upgrade_standalone_flavors_test.go
@@ -7,7 +7,6 @@
 package ess
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"testing"

--- a/testing/integration/ess/upgrade_standalone_inprogress_test.go
+++ b/testing/integration/ess/upgrade_standalone_inprogress_test.go
@@ -33,7 +33,7 @@ func TestStandaloneUpgradeFailsWhenUpgradeIsInProgress(t *testing.T) {
 		Sudo:  true,  // requires Agent installation
 	})
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// For this test we start with a version of Agent that's two minors older

--- a/testing/integration/ess/upgrade_standalone_inprogress_test.go
+++ b/testing/integration/ess/upgrade_standalone_inprogress_test.go
@@ -7,7 +7,6 @@
 package ess
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"

--- a/testing/integration/ess/upgrade_standalone_retry_test.go
+++ b/testing/integration/ess/upgrade_standalone_retry_test.go
@@ -34,7 +34,7 @@ func TestStandaloneUpgradeRetryDownload(t *testing.T) {
 		Sudo:  true,  // requires Agent installation
 	})
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Start at the build version as we want to test the retry

--- a/testing/integration/ess/upgrade_standalone_retry_test.go
+++ b/testing/integration/ess/upgrade_standalone_retry_test.go
@@ -7,7 +7,6 @@
 package ess
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"net/http"

--- a/testing/integration/ess/upgrade_standalone_same_commit_test.go
+++ b/testing/integration/ess/upgrade_standalone_same_commit_test.go
@@ -50,7 +50,7 @@ func TestStandaloneUpgradeSameCommit(t *testing.T) {
 	}
 
 	t.Run(fmt.Sprintf("Upgrade on the same version %s to %s (%s)", currentVersion, currentVersion, unPrivilegedString), func(t *testing.T) {
-		ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+		ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 		defer cancel()
 
 		// ensure we use the same package version

--- a/testing/integration/ess/upgrade_standalone_test.go
+++ b/testing/integration/ess/upgrade_standalone_test.go
@@ -58,7 +58,7 @@ func TestStandaloneUpgrade(t *testing.T) {
 }
 
 func testStandaloneUpgrade(t *testing.T, startVersion *version.ParsedSemVer, endVersion string, fetcher atesting.Fetcher, upgradeOpts ...upgradetest.UpgradeOpt) {
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	startFixture, err := atesting.NewFixture(

--- a/testing/integration/ess/upgrade_standalone_test.go
+++ b/testing/integration/ess/upgrade_standalone_test.go
@@ -7,7 +7,6 @@
 package ess
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"

--- a/testing/integration/ess/upgrade_uninstall_test.go
+++ b/testing/integration/ess/upgrade_uninstall_test.go
@@ -36,7 +36,7 @@ func TestStandaloneUpgradeUninstallKillWatcher(t *testing.T) {
 		t.Skipf("Version %s is lower than min version %s; test cannot be performed", define.Version(), upgradetest.Version_8_11_0_SNAPSHOT)
 	}
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 
 	// Upgrades to build under test.
@@ -93,7 +93,7 @@ func TestStandaloneUpgradeUninstallKillWatcher(t *testing.T) {
 
 	// call uninstall now, do not wait for the watcher to finish running
 	// 8.11+ should always kill the running watcher (if it doesn't uninstall will fail)
-	uninstallCtx, uninstallCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	uninstallCtx, uninstallCancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer uninstallCancel()
 	output, err := startFixture.Uninstall(uninstallCtx, &atesting.UninstallOpts{Force: true})
 	assert.NoError(t, err, "uninstall failed with output:\n%s", string(output))

--- a/testing/integration/ess/zombie_process_test.go
+++ b/testing/integration/ess/zombie_process_test.go
@@ -57,7 +57,7 @@ func TestNoZombieOnAgentShutdown(t *testing.T) {
 	f, err := define.NewFixtureFromLocalBuild(t, define.Version(), atesting.WithAllowErrors())
 	require.NoError(t, err)
 
-	ctx, cancel := testcontext.WithDeadline(t, context.Background(), time.Now().Add(10*time.Minute))
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
 	defer cancel()
 	err = f.Prepare(ctx, fakeSIGTERMComponent)
 	require.NoError(t, err)

--- a/testing/integration/k8s/agent_helm_test.go
+++ b/testing/integration/k8s/agent_helm_test.go
@@ -118,7 +118,7 @@ func TestKubernetesAgentHelmRotatedLogs(t *testing.T) {
 		),
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	testNamespace := kCtx.getNamespace(t)
 
 	for _, step := range steps {

--- a/testing/integration/k8s/agent_helm_test.go
+++ b/testing/integration/k8s/agent_helm_test.go
@@ -118,7 +118,7 @@ func TestKubernetesAgentHelmRotatedLogs(t *testing.T) {
 		),
 	}
 
-	ctx := context.Background()
+	ctx := context.Background() //nolint:forbidigo // ctx is captured by t.Cleanup in step functions; must outlive the test
 	testNamespace := kCtx.getNamespace(t)
 
 	for _, step := range steps {

--- a/testing/integration/k8s/agent_helm_test.go
+++ b/testing/integration/k8s/agent_helm_test.go
@@ -118,7 +118,7 @@ func TestKubernetesAgentHelmRotatedLogs(t *testing.T) {
 		),
 	}
 
-	ctx := t.Context()
+	ctx := context.Background()
 	testNamespace := kCtx.getNamespace(t)
 
 	for _, step := range steps {

--- a/testing/integration/k8s/journald_test.go
+++ b/testing/integration/k8s/journald_test.go
@@ -38,7 +38,7 @@ func TestKubernetesJournaldInput(t *testing.T) {
 	agentConfigYAML, err := os.ReadFile(filepath.Join("testdata", "journald-input.yml"))
 	require.NoError(t, err, "failed to read journald input template")
 
-	ctx := context.Background()
+	ctx := context.Background() //nolint:forbidigo // ctx is captured by t.Cleanup in step functions; must outlive the test
 	kCtx := k8sGetContext(t, info)
 
 	schedulableNodeCount, err := k8sSchedulableNodeCount(ctx, kCtx)
@@ -199,7 +199,7 @@ func journaldTest(
 	index, field, value string) {
 	t.Helper()
 
-	ctx := context.Background()
+	ctx := context.Background() //nolint:forbidigo // ctx is captured by t.Cleanup in step functions; must outlive the test
 	testNamespace := kCtx.getNamespace(t)
 
 	for _, step := range steps {

--- a/testing/integration/k8s/journald_test.go
+++ b/testing/integration/k8s/journald_test.go
@@ -7,7 +7,6 @@
 package k8s
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"

--- a/testing/integration/k8s/journald_test.go
+++ b/testing/integration/k8s/journald_test.go
@@ -38,7 +38,7 @@ func TestKubernetesJournaldInput(t *testing.T) {
 	agentConfigYAML, err := os.ReadFile(filepath.Join("testdata", "journald-input.yml"))
 	require.NoError(t, err, "failed to read journald input template")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	kCtx := k8sGetContext(t, info)
 
 	schedulableNodeCount, err := k8sSchedulableNodeCount(ctx, kCtx)
@@ -199,7 +199,7 @@ func journaldTest(
 	index, field, value string) {
 	t.Helper()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	testNamespace := kCtx.getNamespace(t)
 
 	for _, step := range steps {

--- a/testing/integration/k8s/journald_test.go
+++ b/testing/integration/k8s/journald_test.go
@@ -7,6 +7,7 @@
 package k8s
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -37,7 +38,7 @@ func TestKubernetesJournaldInput(t *testing.T) {
 	agentConfigYAML, err := os.ReadFile(filepath.Join("testdata", "journald-input.yml"))
 	require.NoError(t, err, "failed to read journald input template")
 
-	ctx := t.Context()
+	ctx := context.Background()
 	kCtx := k8sGetContext(t, info)
 
 	schedulableNodeCount, err := k8sSchedulableNodeCount(ctx, kCtx)
@@ -198,7 +199,7 @@ func journaldTest(
 	index, field, value string) {
 	t.Helper()
 
-	ctx := t.Context()
+	ctx := context.Background()
 	testNamespace := kCtx.getNamespace(t)
 
 	for _, step := range steps {

--- a/testing/integration/k8s/kubernetes_agent_cloud_defend_test.go
+++ b/testing/integration/k8s/kubernetes_agent_cloud_defend_test.go
@@ -29,7 +29,7 @@ func TestKubernetesAgentHelmCloudDefend(t *testing.T) {
 		Group: define.Kubernetes,
 	})
 
-	ctx := context.Background()
+	ctx := context.Background() //nolint:forbidigo // ctx is captured by t.Cleanup in step functions; must outlive the test
 	kCtx := k8sGetContext(t, info)
 
 	schedulableNodeCount, err := k8sSchedulableNodeCount(ctx, kCtx)
@@ -108,7 +108,7 @@ func TestKubernetesAgentHelmCloudDefend(t *testing.T) {
 				t.Skip(tc.skipReason)
 			}
 
-			ctx := context.Background()
+			ctx := context.Background() //nolint:forbidigo // ctx is captured by t.Cleanup in step functions; must outlive the test
 			testNamespace := kCtx.getNamespace(t)
 
 			for _, step := range tc.steps {

--- a/testing/integration/k8s/kubernetes_agent_cloud_defend_test.go
+++ b/testing/integration/k8s/kubernetes_agent_cloud_defend_test.go
@@ -29,7 +29,7 @@ func TestKubernetesAgentHelmCloudDefend(t *testing.T) {
 		Group: define.Kubernetes,
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	kCtx := k8sGetContext(t, info)
 
 	schedulableNodeCount, err := k8sSchedulableNodeCount(ctx, kCtx)
@@ -108,7 +108,7 @@ func TestKubernetesAgentHelmCloudDefend(t *testing.T) {
 				t.Skip(tc.skipReason)
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			testNamespace := kCtx.getNamespace(t)
 
 			for _, step := range tc.steps {

--- a/testing/integration/k8s/kubernetes_agent_cloud_defend_test.go
+++ b/testing/integration/k8s/kubernetes_agent_cloud_defend_test.go
@@ -29,7 +29,7 @@ func TestKubernetesAgentHelmCloudDefend(t *testing.T) {
 		Group: define.Kubernetes,
 	})
 
-	ctx := t.Context()
+	ctx := context.Background()
 	kCtx := k8sGetContext(t, info)
 
 	schedulableNodeCount, err := k8sSchedulableNodeCount(ctx, kCtx)
@@ -108,7 +108,7 @@ func TestKubernetesAgentHelmCloudDefend(t *testing.T) {
 				t.Skip(tc.skipReason)
 			}
 
-			ctx := t.Context()
+			ctx := context.Background()
 			testNamespace := kCtx.getNamespace(t)
 
 			for _, step := range tc.steps {

--- a/testing/integration/k8s/kubernetes_agent_service_test.go
+++ b/testing/integration/k8s/kubernetes_agent_service_test.go
@@ -40,7 +40,7 @@ func TestKubernetesAgentService(t *testing.T) {
 	serviceAgentYAML, err := os.ReadFile(filepath.Join("testdata", "connectors.agent.yml"))
 	require.NoError(t, err, "failed to read service agent config")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	kCtx := k8sGetContext(t, info)
 
 	schedulableNodeCount, err := k8sSchedulableNodeCount(ctx, kCtx)

--- a/testing/integration/k8s/kubernetes_agent_service_test.go
+++ b/testing/integration/k8s/kubernetes_agent_service_test.go
@@ -40,7 +40,7 @@ func TestKubernetesAgentService(t *testing.T) {
 	serviceAgentYAML, err := os.ReadFile(filepath.Join("testdata", "connectors.agent.yml"))
 	require.NoError(t, err, "failed to read service agent config")
 
-	ctx := t.Context()
+	ctx := context.Background()
 	kCtx := k8sGetContext(t, info)
 
 	schedulableNodeCount, err := k8sSchedulableNodeCount(ctx, kCtx)

--- a/testing/integration/k8s/kubernetes_agent_service_test.go
+++ b/testing/integration/k8s/kubernetes_agent_service_test.go
@@ -40,7 +40,7 @@ func TestKubernetesAgentService(t *testing.T) {
 	serviceAgentYAML, err := os.ReadFile(filepath.Join("testdata", "connectors.agent.yml"))
 	require.NoError(t, err, "failed to read service agent config")
 
-	ctx := context.Background()
+	ctx := context.Background() //nolint:forbidigo // ctx is captured by t.Cleanup in step functions; must outlive the test
 	kCtx := k8sGetContext(t, info)
 
 	schedulableNodeCount, err := k8sSchedulableNodeCount(ctx, kCtx)

--- a/testing/integration/k8s/kubernetes_agent_standalone_test.go
+++ b/testing/integration/k8s/kubernetes_agent_standalone_test.go
@@ -61,7 +61,7 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 		Group: define.Kubernetes,
 	})
 
-	ctx := context.Background()
+	ctx := context.Background() //nolint:forbidigo // ctx is captured by t.Cleanup in step functions; must outlive the test
 	kCtx := k8sGetContext(t, info)
 
 	schedulableNodeCount, err := k8sSchedulableNodeCount(ctx, kCtx)
@@ -165,7 +165,7 @@ func TestKubernetesAgentOtel(t *testing.T) {
 		Group: define.Kubernetes,
 	})
 
-	ctx := context.Background()
+	ctx := context.Background() //nolint:forbidigo // ctx is captured by t.Cleanup in step functions; must outlive the test
 	kCtx := k8sGetContext(t, info)
 
 	nodeList := corev1.NodeList{}
@@ -224,7 +224,7 @@ func TestKubernetesAgentHelm(t *testing.T) {
 		Group: define.Kubernetes,
 	})
 
-	ctx := context.Background()
+	ctx := context.Background() //nolint:forbidigo // ctx is captured by t.Cleanup in step functions; must outlive the test
 	kCtx := k8sGetContext(t, info)
 
 	nodeList := corev1.NodeList{}
@@ -850,7 +850,7 @@ func TestKubernetesAgentHelm(t *testing.T) {
 				t.Skip(tc.skipReason)
 			}
 
-			ctx := context.Background()
+			ctx := context.Background() //nolint:forbidigo // ctx is captured by t.Cleanup in step functions; must outlive the test
 			testNamespace := kCtx.getNamespace(t)
 
 			for _, step := range tc.steps {

--- a/testing/integration/k8s/kubernetes_agent_standalone_test.go
+++ b/testing/integration/k8s/kubernetes_agent_standalone_test.go
@@ -61,7 +61,7 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 		Group: define.Kubernetes,
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	kCtx := k8sGetContext(t, info)
 
 	schedulableNodeCount, err := k8sSchedulableNodeCount(ctx, kCtx)
@@ -165,7 +165,7 @@ func TestKubernetesAgentOtel(t *testing.T) {
 		Group: define.Kubernetes,
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	kCtx := k8sGetContext(t, info)
 
 	nodeList := corev1.NodeList{}
@@ -224,7 +224,7 @@ func TestKubernetesAgentHelm(t *testing.T) {
 		Group: define.Kubernetes,
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	kCtx := k8sGetContext(t, info)
 
 	nodeList := corev1.NodeList{}
@@ -850,7 +850,7 @@ func TestKubernetesAgentHelm(t *testing.T) {
 				t.Skip(tc.skipReason)
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			testNamespace := kCtx.getNamespace(t)
 
 			for _, step := range tc.steps {

--- a/testing/integration/k8s/kubernetes_agent_standalone_test.go
+++ b/testing/integration/k8s/kubernetes_agent_standalone_test.go
@@ -61,7 +61,7 @@ func TestKubernetesAgentStandaloneKustomize(t *testing.T) {
 		Group: define.Kubernetes,
 	})
 
-	ctx := t.Context()
+	ctx := context.Background()
 	kCtx := k8sGetContext(t, info)
 
 	schedulableNodeCount, err := k8sSchedulableNodeCount(ctx, kCtx)
@@ -165,7 +165,7 @@ func TestKubernetesAgentOtel(t *testing.T) {
 		Group: define.Kubernetes,
 	})
 
-	ctx := t.Context()
+	ctx := context.Background()
 	kCtx := k8sGetContext(t, info)
 
 	nodeList := corev1.NodeList{}
@@ -224,7 +224,7 @@ func TestKubernetesAgentHelm(t *testing.T) {
 		Group: define.Kubernetes,
 	})
 
-	ctx := t.Context()
+	ctx := context.Background()
 	kCtx := k8sGetContext(t, info)
 
 	nodeList := corev1.NodeList{}
@@ -850,7 +850,7 @@ func TestKubernetesAgentHelm(t *testing.T) {
 				t.Skip(tc.skipReason)
 			}
 
-			ctx := t.Context()
+			ctx := context.Background()
 			testNamespace := kCtx.getNamespace(t)
 
 			for _, step := range tc.steps {

--- a/testing/integration/k8s/otel_helm_test.go
+++ b/testing/integration/k8s/otel_helm_test.go
@@ -179,7 +179,7 @@ func TestOtelKubeStackHelm(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := t.Context()
+			ctx := context.Background()
 			testNamespace := kCtx.getNamespace(t)
 
 			for _, step := range tc.steps {

--- a/testing/integration/k8s/otel_helm_test.go
+++ b/testing/integration/k8s/otel_helm_test.go
@@ -179,7 +179,7 @@ func TestOtelKubeStackHelm(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := context.Background() //nolint:forbidigo // ctx is captured by t.Cleanup in step functions; must outlive the test
 			testNamespace := kCtx.getNamespace(t)
 
 			for _, step := range tc.steps {

--- a/testing/integration/k8s/otel_helm_test.go
+++ b/testing/integration/k8s/otel_helm_test.go
@@ -179,7 +179,7 @@ func TestOtelKubeStackHelm(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			testNamespace := kCtx.getNamespace(t)
 
 			for _, step := range tc.steps {

--- a/testing/integration/leak/long_running_test.go
+++ b/testing/integration/leak/long_running_test.go
@@ -85,7 +85,7 @@ func TestLongRunningAgentForLeaks(t *testing.T) {
 }
 
 func (runner *ExtendedRunner) SetupSuite() {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), 5*time.Minute)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "go", "install", "-v", "github.com/mingrammer/flog@latest")
 	out, err := cmd.CombinedOutput()
@@ -145,7 +145,7 @@ func (runner *ExtendedRunner) SetupSuite() {
 }
 
 func (runner *ExtendedRunner) TestHandleLeak() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	ctx, cancel := context.WithTimeout(runner.T().Context(), time.Hour)
 	defer cancel()
 
 	testRuntime := os.Getenv("LONG_TEST_RUNTIME")


### PR DESCRIPTION
# test: use t.Context() as parent context in integration tests

<!-- Type of change: Cleanup -->

## What does this PR do?

I am pretty annoyed to fix context in most of the flaky tests I have been touching, so decided to make those mostly mechanical changes

Replaces `context.Background()` with `t.Context()` as the parent context across ESS and leak integration tests in `testing/integration/`. **~48 files changed.**

`t.Context()` (Go 1.21+) returns a context that is automatically cancelled when the test ends — whether it passes, fails, or times out. Using `context.Background()` as the parent meant that operations started by a test would keep running even after the test had already finished or failed.

### Scope

**ESS tests** (`testing/integration/ess/`) and **leak tests** (`testing/integration/leak/`) are fully migrated.

**Kubernetes tests** (`testing/integration/k8s/`) remain on `context.Background()`. The k8s step infrastructure passes `ctx` into `t.Cleanup` closures (`k8sDeleteObjects`, `k8sDumpPods`, Helm uninstall). Since `t.Context()` is cancelled before `t.Cleanup` runs, migrating those tests caused cleanup to receive an already-cancelled context, leaving cluster-scoped objects behind and causing "already exists" failures in subsequent tests. Fixing k8s requires reworking the step infrastructure and is left for a follow-up.

### Change types in this PR

**1. Standard swap — `context.Background()` → `t.Context()` (~40 files)**

Most tests create a context at the top of the test function like:
```go
ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
```
All such calls in ESS/leak tests are now rooted at `t.Context()` instead of `context.Background()`.

**2. Leaked cancel function fix**
[`upgrade_fleet_test.go`](testing/integration/ess/upgrade_fleet_test.go)

The cancel return value from `testcontext.WithDeadline` was silently discarded (`_`), leaking the cancel. Fixed: capture and `defer cancel()`, and use `t.Context()` as the parent.

**3. testify suite — `runner.T().Context()`**
[`auditd_monitoring_test.go`](testing/integration/ess/auditd_monitoring_test.go)

Suite-based tests have no direct `t` in scope; the fix uses `runner.T().Context()`.

**4. `assert.CollectT` parameter rename**
[`otel_test.go`](testing/integration/ess/otel_test.go)

Two `EventuallyWithT` closures used `t` as the parameter name for `*assert.CollectT`, shadowing the outer `*testing.T`. Renamed to `ct` so the outer `t` and its context remain accessible inside the closure.

**5. `t.Cleanup` blocks — intentionally kept as `context.Background()`**
[`otel_test.go`](testing/integration/ess/otel_test.go), [`upgrade_integrations_server_test.go`](testing/integration/ess/upgrade_integrations_server_test.go), others

`t.Context()` is already cancelled by the time any `t.Cleanup` callback runs. Contexts inside cleanup blocks are deliberately left on `context.Background()` so cleanup actually has a live context to work with.

**6. Goroutines calling `require.NoError` — replaced with `assert.Conditionf`**
[`otel_log_as_filestream_test.go`](testing/integration/ess/otel_log_as_filestream_test.go)

Three goroutines called `require.NoError(t, fixture.RunOtelWithClient(ctx))`. `require` calls `t.FailNow()` which uses `runtime.Goexit()` — calling this from a non-test goroutine is undefined behavior per Go docs.

Replaced with `assert.Conditionf` that accepts `context.Canceled` and `context.DeadlineExceeded` as expected outcomes — matching the same pattern already used in `otel_test.go`.

**7. `forbidigo` rule to prevent regressions**
[`.golangci.yml`](.golangci.yml)

Adds a linter rule that flags any new `context.Background()` call in `*_test.go` files. The 11 k8s test sites that legitimately need `context.Background()` (because `ctx` is captured by `t.Cleanup` closures in the step infrastructure) carry a `//nolint:forbidigo` comment explaining why.

## Why is it important?

- **Prevents resource leaks on test failure.** When a test fails early, any goroutines or HTTP calls holding a `context.Background()`-rooted context will keep running until their own timeout fires. With `t.Context()`, they are cancelled immediately when the test ends.
- **More reliable CI.** Leaked operations from a failed test can interfere with the next test running in the same process, causing flaky results that are hard to reproduce.
- **Correctness.** The goroutine `require` issue (`otel_log_as_filestream_test.go`) was a pre-existing UB that this change surfaces more reliably, so it was fixed at the same time.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~ *(test-only changes, no new logic)*
- ~~I have made corresponding changes to the documentation~~ *(no user-facing behavior change)*
- ~~I have made corresponding change to the default configuration files~~ *(not applicable)*
- ~~I have added tests that prove my fix is effective or that my feature works~~ *(these ARE the tests)*
- ~~I have added an entry in `./changelog/fragments`~~ *(cleanup of test internals, no user-facing change)*
- ~~I have added an integration test or an E2E test~~ *(modifying existing integration tests)*

## Disruptive User Impact

None. All changes are in `testing/integration/` — test code only. No production behaviour changes.

## How to test this PR locally

The change is compile-verified:
```bash
go build -tags=integration ./testing/integration/ess/...
go build -tags=integration ./testing/integration/k8s/...
```

Integration tests run as normal — no change to how they are invoked. The test timeout (`-timeout`) is still respected via `t.Context()` cancellation.

## Related issues

-

## Questions to ask yourself

- How are we going to support this in production? — N/A, test-only.
- How are we going to measure its adoption? — N/A.
- How are we going to debug this? — N/A.
- What are the metrics I should take care of? — N/A.