### PR TITLE
Skip fragment-in-pr for mergify[bot]-authored PRs

### DIFF
--- a/.github/workflows/fragment-in-pr.yml
+++ b/.github/workflows/fragment-in-pr.yml
@@ -12,7 +12,7 @@ jobs:
     if: >-
       !contains(github.event.pull_request.labels.*.name, 'skip-changelog') &&
       !contains(github.event.pull_request.labels.*.name, 'backport') &&
-      github.event.pull_request.user.login != 'mergify[bot]'
+      !startsWith(github.head_ref, 'mergify/merge-queue/')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/fragment-in-pr.yml
+++ b/.github/workflows/fragment-in-pr.yml
@@ -9,7 +9,10 @@ permissions:
 
 jobs:
   fragments:
-    if: "!contains(github.event.pull_request.labels.*.name, 'skip-changelog') && !contains(github.event.pull_request.labels.*.name, 'backport')"
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'skip-changelog') &&
+      !contains(github.event.pull_request.labels.*.name, 'backport') &&
+      github.event.pull_request.user.login != 'mergify[bot]'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7


### PR DESCRIPTION
## What does this PR do?

Skip the `fragment-in-pr` check when the head branch starts with `mergify/merge-queue/` so the merge queue doesn't fail.

## Why is it important?

Merge queue speculative merge PRs trigger `fragment-in-pr` and fail because they have no `skip-changelog` or `backport` label.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None.

## Related issues

-
