### PR TITLE
Use a separate beatsprocessor per pipeline

### DIFF
--- a/internal/pkg/otel/manager/manager.go
+++ b/internal/pkg/otel/manager/manager.go
@@ -661,7 +661,7 @@ func injectMonitoringReceiver(
 	connectorType := otelcomponent.MustNewType(elasticMonitoringConnectorName)
 	receiverName := "internal-telemetry-monitoring"
 	receiverID := translate.GetReceiverID(receiverType, receiverName).String()
-	processorID := translate.GetProcessorID().String()
+	processorID := translate.GetProcessorID(receiverName).String()
 
 	diagName := translate.OtelNamePrefix + receiverName
 	connectorID := otelcomponent.NewIDWithName(connectorType, diagName).String()
@@ -720,12 +720,12 @@ func injectMonitoringReceiver(
 			"exporters": []string{exporterID},
 		}
 		if features.DefaultProcessors() {
-			// If default processors are enabled, reference the shared beat processor.
-			// The processor definition is the same as the one added in GetOtelConfig,
-			// so upon merge one replaces the other with identical content.
+			// This pipeline forwards Agent's own internal telemetry in beats format,
+			// not a specific beat's data, so it always gets the standard default
+			// processors.
 			collectorCfg["processors"] = map[string]any{
 				processorID: map[string]any{
-					"processors": translate.GetDefaultProcessors(),
+					"processors": translate.GetDefaultProcessors(""),
 				},
 			}
 			logsPipelineCfg["processors"] = []string{processorID}

--- a/internal/pkg/otel/manager/manager_test.go
+++ b/internal/pkg/otel/manager/manager_test.go
@@ -2521,7 +2521,7 @@ func TestAddCollectorMetricsPort(t *testing.T) {
 
 func TestMonitoringReceiverProcessors(t *testing.T) {
 	exporterName := "elasticsearch/" + translate.OtelNamePrefix + "monitoring"
-	procName := translate.GetProcessorID().String()
+	procName := translate.GetProcessorID("internal-telemetry-monitoring").String()
 	// Processors are injected on the logs pipeline (connector → ES), which is only
 	// created when an OTel-based monitoring exporter is present.
 	logsPipelineName := "logs/" + translate.OtelNamePrefix + "internal-telemetry-monitoring"
@@ -2538,7 +2538,7 @@ func TestMonitoringReceiverProcessors(t *testing.T) {
 	require.NoError(t, err, "injectMonitoringReceiver should succeed")
 	result := mapstr.M(cfg.ToStringMap()).Flatten()
 
-	expectedBeatsProcessors := translate.GetDefaultProcessors()
+	expectedBeatsProcessors := translate.GetDefaultProcessors("")
 	actualBeatsProcessors := result["processors."+procName+".processors"]
 	assert.NotNil(t, actualBeatsProcessors, "monitoring receiver processors should not be nil")
 	if actualBeatsProcessors != nil {

--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -113,21 +113,6 @@ func GetOtelConfig(
 		}
 	}
 
-	// If the default_processors feature flag is enabled, add a single shared
-	// beat processor definition that all pipelines reference.
-	if features.DefaultProcessors() {
-		processorConf := confmap.NewFromStringMap(map[string]any{
-			"processors": map[string]any{
-				GetProcessorID().String(): map[string]any{
-					"processors": GetDefaultProcessors(),
-				},
-			},
-		})
-		if mergeErr := otelConfig.Merge(processorConf); mergeErr != nil {
-			return nil, fmt.Errorf("error merging beat processor config: %w", mergeErr)
-		}
-	}
-
 	return otelConfig, nil
 }
 
@@ -239,9 +224,13 @@ func GetExporterID(exporterType otelcomponent.Type, outputName string) otelcompo
 	return otelcomponent.NewIDWithName(exporterType, exporterName)
 }
 
-// GetProcessorID returns the shared beat processor id used across all pipelines.
-func GetProcessorID() otelcomponent.ID {
-	return otelcomponent.NewIDWithName(otelcomponent.MustNewType("beat"), strings.TrimSuffix(OtelNamePrefix, "/"))
+// GetProcessorID returns the beat processor id for the given name. Each pipeline
+// gets its own processor, since default processors can differ by beat; the
+// beatsprocessor implementation shares state internally between instances that
+// end up with identical configuration.
+func GetProcessorID(name string) otelcomponent.ID {
+	processorName := fmt.Sprintf("%s%s", OtelNamePrefix, name)
+	return otelcomponent.NewIDWithName(otelcomponent.MustNewType("beat"), processorName)
 }
 
 // getBeatsAuthExtensionID returns the id for beatsauth extension
@@ -291,11 +280,17 @@ func getCollectorConfigForComponent(
 		"receivers": receiverKeys,
 	}
 
-	// Build the pipeline processors list: the shared beat processor first (if enabled),
-	// then per-output processors from config. then any other processors from processorConfig (e.g. Kafka transform),
+	// Build the pipeline processors list: this component's own default beat processor
+	// first (if enabled and its beat has any default processors), then per-output
+	// processors from config, then any other processors from processorConfig (e.g. Kafka transform).
+	// Each pipeline gets its own default-processor definition (scoped by comp.ID) rather
+	// than sharing one across all pipelines, since different beats can have different
+	// default processors.
+	beatDefaultProcessors := GetDefaultProcessors(comp.BeatName())
+	beatProcessorID := GetProcessorID(comp.ID).String()
 	var pipelineProcessors []string
-	if features.DefaultProcessors() {
-		pipelineProcessors = append(pipelineProcessors, GetProcessorID().String())
+	if features.DefaultProcessors() && len(beatDefaultProcessors) > 0 {
+		pipelineProcessors = append(pipelineProcessors, beatProcessorID)
 	}
 
 	// per output processor if any
@@ -349,8 +344,17 @@ func getCollectorConfigForComponent(
 		}
 	}
 
-	if len(processorConfig) > 0 {
-		fullConfig["processors"] = processorConfig
+	allProcessorsConfig := map[string]any{}
+	for k, v := range processorConfig {
+		allProcessorsConfig[k] = v
+	}
+	if features.DefaultProcessors() && len(beatDefaultProcessors) > 0 {
+		allProcessorsConfig[beatProcessorID] = map[string]any{
+			"processors": beatDefaultProcessors,
+		}
+	}
+	if len(allProcessorsConfig) > 0 {
+		fullConfig["processors"] = allProcessorsConfig
 	}
 
 	return confmap.NewFromStringMap(fullConfig), nil
@@ -476,39 +480,22 @@ func beatInputsKey(beatName string) string {
 	}
 }
 
-// GetDefaultProcessors returns the default beat processors used across all pipelines.
+// GetDefaultProcessors returns the default processors for the given beat.
 // These mirror the fleetDefaultProcessors that each beat sets for process mode.
-// Synthetics (heartbeat) events skip all four metadata processors: process-mode
-// heartbeat sets fleetDefaultProcessors=nil, so adding any of them in OTel mode
-// would produce fields with no equivalent in process mode.
-func GetDefaultProcessors() []map[string]any {
-	notSynthetics := map[string]any{
-		"not": map[string]any{
-			"equals": map[string]any{
-				"data_stream.type": "synthetics",
-			},
-		},
+// Heartbeat sets fleetDefaultProcessors=nil, so it gets no default processors.
+func GetDefaultProcessors(beatName string) []map[string]any {
+	if beatName == "heartbeat" {
+		return nil
 	}
 	return []map[string]any{
 		{
 			"add_host_metadata": map[string]any{
-				"when": map[string]any{
-					"and": []any{
-						map[string]any{
-							"not": map[string]any{
-								"contains": map[string]any{
-									"tags": "forwarded",
-								},
-							},
-						},
-						notSynthetics,
-					},
-				},
+				"when.not.contains.tags": "forwarded",
 			},
 		},
-		{"add_cloud_metadata": map[string]any{"when": notSynthetics}},
-		{"add_docker_metadata": map[string]any{"when": notSynthetics}},
-		{"add_kubernetes_metadata": map[string]any{"when": notSynthetics}},
+		{"add_cloud_metadata": nil},
+		{"add_docker_metadata": nil},
+		{"add_kubernetes_metadata": nil},
 	}
 }
 

--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -477,10 +477,18 @@ func beatInputsKey(beatName string) string {
 }
 
 // GetDefaultProcessors returns the default beat processors used across all pipelines.
-// Synthetics (heartbeat) events skip add_host_metadata: heartbeat's internal preProcessors
-// already enriches events with observer.* fields, and adding host.* would diverge from
-// what process-mode heartbeat produces.
+// These mirror the fleetDefaultProcessors that each beat sets for process mode.
+// Synthetics (heartbeat) events skip all four metadata processors: process-mode
+// heartbeat sets fleetDefaultProcessors=nil, so adding any of them in OTel mode
+// would produce fields with no equivalent in process mode.
 func GetDefaultProcessors() []map[string]any {
+	notSynthetics := map[string]any{
+		"not": map[string]any{
+			"equals": map[string]any{
+				"data_stream.type": "synthetics",
+			},
+		},
+	}
 	return []map[string]any{
 		{
 			"add_host_metadata": map[string]any{
@@ -493,20 +501,14 @@ func GetDefaultProcessors() []map[string]any {
 								},
 							},
 						},
-						map[string]any{
-							"not": map[string]any{
-								"equals": map[string]any{
-									"data_stream.type": "synthetics",
-								},
-							},
-						},
+						notSynthetics,
 					},
 				},
 			},
 		},
-		{"add_cloud_metadata": nil},
-		{"add_docker_metadata": nil},
-		{"add_kubernetes_metadata": nil},
+		{"add_cloud_metadata": map[string]any{"when": notSynthetics}},
+		{"add_docker_metadata": map[string]any{"when": notSynthetics}},
+		{"add_kubernetes_metadata": map[string]any{"when": notSynthetics}},
 	}
 }
 

--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -477,11 +477,44 @@ func beatInputsKey(beatName string) string {
 }
 
 // GetDefaultProcessors returns the default beat processors used across all pipelines.
+// Synthetics (heartbeat) data is identified by data_stream.type == "synthetics":
+// it skips add_host_metadata (which would add irrelevant host fields) and instead
+// runs add_observer_metadata to match the observer.* fields emitted in process mode.
 func GetDefaultProcessors() []map[string]any {
+	notSynthetics := map[string]any{
+		"not": map[string]any{
+			"equals": map[string]any{
+				"data_stream.type": "synthetics",
+			},
+		},
+	}
+	isSynthetics := map[string]any{
+		"equals": map[string]any{
+			"data_stream.type": "synthetics",
+		},
+	}
 	return []map[string]any{
 		{
 			"add_host_metadata": map[string]any{
-				"when.not.contains.tags": "forwarded",
+				"when": map[string]any{
+					"and": []any{
+						map[string]any{
+							"not": map[string]any{
+								"contains": map[string]any{
+									"tags": "forwarded",
+								},
+							},
+						},
+						notSynthetics,
+					},
+				},
+			},
+		},
+		{
+			// Heartbeat/synthetics monitors use add_observer_metadata (the observer is the
+			// monitoring agent, not the monitored host), matching process-mode behaviour.
+			"add_observer_metadata": map[string]any{
+				"when": isSynthetics,
 			},
 		},
 		{"add_cloud_metadata": nil},

--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -477,22 +477,10 @@ func beatInputsKey(beatName string) string {
 }
 
 // GetDefaultProcessors returns the default beat processors used across all pipelines.
-// Synthetics (heartbeat) data is identified by data_stream.type == "synthetics":
-// it skips add_host_metadata (which would add irrelevant host fields) and instead
-// runs add_observer_metadata to match the observer.* fields emitted in process mode.
+// Synthetics (heartbeat) events skip add_host_metadata: heartbeat's internal preProcessors
+// already enriches events with observer.* fields, and adding host.* would diverge from
+// what process-mode heartbeat produces.
 func GetDefaultProcessors() []map[string]any {
-	notSynthetics := map[string]any{
-		"not": map[string]any{
-			"equals": map[string]any{
-				"data_stream.type": "synthetics",
-			},
-		},
-	}
-	isSynthetics := map[string]any{
-		"equals": map[string]any{
-			"data_stream.type": "synthetics",
-		},
-	}
 	return []map[string]any{
 		{
 			"add_host_metadata": map[string]any{
@@ -505,16 +493,15 @@ func GetDefaultProcessors() []map[string]any {
 								},
 							},
 						},
-						notSynthetics,
+						map[string]any{
+							"not": map[string]any{
+								"equals": map[string]any{
+									"data_stream.type": "synthetics",
+								},
+							},
+						},
 					},
 				},
-			},
-		},
-		{
-			// Heartbeat/synthetics monitors use add_observer_metadata (the observer is the
-			// monitoring agent, not the monitored host), matching process-mode behaviour.
-			"add_observer_metadata": map[string]any{
-				"when": isSynthetics,
 			},
 		},
 		{"add_cloud_metadata": nil},

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -493,13 +493,6 @@ func TestGetOtelConfig(t *testing.T) {
 				},
 			},
 		},
-		{
-			"add_observer_metadata": map[string]any{
-				"when": map[string]any{
-					"equals": map[string]any{"data_stream.type": "synthetics"},
-				},
-			},
-		},
 		{"add_cloud_metadata": nil},
 		{"add_docker_metadata": nil},
 		{"add_kubernetes_metadata": nil},

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -482,20 +482,21 @@ func TestGetOtelConfig(t *testing.T) {
 		}
 	}
 
+	notSynthetics := map[string]any{"not": map[string]any{"equals": map[string]any{"data_stream.type": "synthetics"}}}
 	defaultGlobalProcessors := []map[string]any{
 		{
 			"add_host_metadata": map[string]any{
 				"when": map[string]any{
 					"and": []any{
 						map[string]any{"not": map[string]any{"contains": map[string]any{"tags": "forwarded"}}},
-						map[string]any{"not": map[string]any{"equals": map[string]any{"data_stream.type": "synthetics"}}},
+						notSynthetics,
 					},
 				},
 			},
 		},
-		{"add_cloud_metadata": nil},
-		{"add_docker_metadata": nil},
-		{"add_kubernetes_metadata": nil},
+		{"add_cloud_metadata": map[string]any{"when": notSynthetics}},
+		{"add_docker_metadata": map[string]any{"when": notSynthetics}},
+		{"add_kubernetes_metadata": map[string]any{"when": notSynthetics}},
 	}
 	defaultExpectedProcessors := map[string]any{
 		"beat/_agent-component": map[string]any{

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -482,26 +482,32 @@ func TestGetOtelConfig(t *testing.T) {
 		}
 	}
 
-	notSynthetics := map[string]any{"not": map[string]any{"equals": map[string]any{"data_stream.type": "synthetics"}}}
 	defaultGlobalProcessors := []map[string]any{
 		{
 			"add_host_metadata": map[string]any{
-				"when": map[string]any{
-					"and": []any{
-						map[string]any{"not": map[string]any{"contains": map[string]any{"tags": "forwarded"}}},
-						notSynthetics,
-					},
-				},
+				"when.not.contains.tags": "forwarded",
 			},
 		},
-		{"add_cloud_metadata": map[string]any{"when": notSynthetics}},
-		{"add_docker_metadata": map[string]any{"when": notSynthetics}},
-		{"add_kubernetes_metadata": map[string]any{"when": notSynthetics}},
+		{"add_cloud_metadata": nil},
+		{"add_docker_metadata": nil},
+		{"add_kubernetes_metadata": nil},
 	}
-	defaultExpectedProcessors := map[string]any{
-		"beat/_agent-component": map[string]any{
-			"processors": defaultGlobalProcessors,
-		},
+	// beatProcessorID returns the id of the default beat processor for the
+	// component with the given id, matching translate.GetProcessorID.
+	beatProcessorID := func(id string) string {
+		return "beat/_agent-component/" + id
+	}
+	// defaultExpectedProcessors builds the expected top-level "processors" map
+	// for the components with the given ids, each getting its own default
+	// beat processor definition.
+	defaultExpectedProcessors := func(ids ...string) map[string]any {
+		m := map[string]any{}
+		for _, id := range ids {
+			m[beatProcessorID(id)] = map[string]any{
+				"processors": defaultGlobalProcessors,
+			}
+		}
+		return m
 	}
 
 	// expected receiver config shared shape for ES-output beats with a single stream.
@@ -783,7 +789,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": defaultExpectedProcessors,
+				"processors": defaultExpectedProcessors("filestream-default"),
 				"receivers": map[string]any{
 					"filebeatreceiver/_agent-component/filestream-default/test-1": expectedFilestreamConfig("filestream-default", "test-1", "generic-1"),
 					"filebeatreceiver/_agent-component/filestream-default/test-2": expectedFilestreamConfig("filestream-default", "test-2", "generic-2"),
@@ -793,7 +799,7 @@ func TestGetOtelConfig(t *testing.T) {
 					"pipelines": map[string]any{
 						"logs/_agent-component/filestream-default": map[string][]string{
 							"exporters":  {"elasticsearch/_agent-component/default"},
-							"processors": {"beat/_agent-component"},
+							"processors": {beatProcessorID("filestream-default")},
 							"receivers":  {"filebeatreceiver/_agent-component/filestream-default/test-1", "filebeatreceiver/_agent-component/filestream-default/test-2"},
 						},
 					},
@@ -897,7 +903,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": defaultExpectedProcessors,
+				"processors": defaultExpectedProcessors("filestream-default"),
 				"receivers": map[string]any{
 					"filebeatreceiver/_agent-component/filestream-default/test-1": expectedFilestreamConfig("filestream-default", "test-1", "generic-1"),
 					"filebeatreceiver/_agent-component/filestream-default/test-2": expectedFilestreamConfig("filestream-default", "test-2", "generic-2"),
@@ -907,7 +913,7 @@ func TestGetOtelConfig(t *testing.T) {
 					"pipelines": map[string]any{
 						"logs/_agent-component/filestream-default": map[string][]string{
 							"exporters":  {"elasticsearch/_agent-component/default"},
-							"processors": {"beat/_agent-component", "filter/remove-something", "beat", "batch"},
+							"processors": {beatProcessorID("filestream-default"), "filter/remove-something", "beat", "batch"},
 							"receivers":  {"filebeatreceiver/_agent-component/filestream-default/test-1", "filebeatreceiver/_agent-component/filestream-default/test-2"},
 						},
 					},
@@ -976,7 +982,7 @@ func TestGetOtelConfig(t *testing.T) {
 						"workers":                  int64(0),
 					},
 				},
-				"processors": defaultExpectedProcessors,
+				"processors": defaultExpectedProcessors("beat-metrics-monitoring"),
 				"receivers": map[string]any{
 					"metricbeatreceiver/_agent-component/beat-metrics-monitoring/test-1": map[string]any{
 						"include_metadata": true,
@@ -1030,7 +1036,7 @@ func TestGetOtelConfig(t *testing.T) {
 					"pipelines": map[string]any{
 						"logs/_agent-component/beat-metrics-monitoring": map[string][]string{
 							"exporters":  {"logstash/_agent-component/default"},
-							"processors": {"beat/_agent-component"},
+							"processors": {beatProcessorID("beat-metrics-monitoring")},
 							"receivers":  {"metricbeatreceiver/_agent-component/beat-metrics-monitoring/test-1"},
 						},
 					},
@@ -1117,7 +1123,7 @@ func TestGetOtelConfig(t *testing.T) {
 					},
 				},
 				"processors": map[string]any{
-					"beat/_agent-component": map[string]any{
+					beatProcessorID("beat-metrics-monitoring"): map[string]any{
 						"processors": defaultGlobalProcessors,
 					},
 					"transform/_agent-component/default": map[string]any{
@@ -1140,7 +1146,7 @@ func TestGetOtelConfig(t *testing.T) {
 					"pipelines": map[string]any{
 						"logs/_agent-component/beat-metrics-monitoring": map[string][]string{
 							"exporters":  {"kafka/_agent-component/default"},
-							"processors": {"beat/_agent-component", "transform/_agent-component/default"},
+							"processors": {beatProcessorID("beat-metrics-monitoring"), "transform/_agent-component/default"},
 							"receivers":  {"metricbeatreceiver/_agent-component/beat-metrics-monitoring/test-1"},
 						},
 					},
@@ -1240,7 +1246,7 @@ func TestGetOtelConfig(t *testing.T) {
 						},
 					},
 				},
-				"processors": defaultExpectedProcessors,
+				"processors": defaultExpectedProcessors("beat-metrics-monitoring"),
 				"receivers": map[string]any{
 					"metricbeatreceiver/_agent-component/beat-metrics-monitoring/test-1": expectedBeatMetricConfig,
 				},
@@ -1249,7 +1255,7 @@ func TestGetOtelConfig(t *testing.T) {
 					"pipelines": map[string]any{
 						"logs/_agent-component/beat-metrics-monitoring": map[string][]string{
 							"exporters":  {"kafka/_agent-component/default"},
-							"processors": {"beat/_agent-component"},
+							"processors": {beatProcessorID("beat-metrics-monitoring")},
 							"receivers":  {"metricbeatreceiver/_agent-component/beat-metrics-monitoring/test-1"},
 						},
 					},
@@ -1347,7 +1353,7 @@ func TestGetOtelConfig(t *testing.T) {
 						},
 					},
 				},
-				"processors": defaultExpectedProcessors,
+				"processors": defaultExpectedProcessors("beat-metrics-monitoring"),
 				"receivers": map[string]any{
 					"metricbeatreceiver/_agent-component/beat-metrics-monitoring/test-1": expectedBeatMetricConfig,
 				},
@@ -1356,7 +1362,7 @@ func TestGetOtelConfig(t *testing.T) {
 					"pipelines": map[string]any{
 						"logs/_agent-component/beat-metrics-monitoring": map[string][]string{
 							"exporters":  {"kafka/_agent-component/default"},
-							"processors": {"beat/_agent-component"},
+							"processors": {beatProcessorID("beat-metrics-monitoring")},
 							"receivers":  {"metricbeatreceiver/_agent-component/beat-metrics-monitoring/test-1"},
 						},
 					},
@@ -1536,7 +1542,7 @@ func TestGetOtelConfig(t *testing.T) {
 						},
 					},
 				},
-				"processors": defaultExpectedProcessors,
+				"processors": defaultExpectedProcessors("beat-metrics-monitoring", "beat-metrics-monitoring2"),
 				"receivers": map[string]any{
 					"metricbeatreceiver/_agent-component/beat-metrics-monitoring/test-1": expectedBeatMetricConfig,
 					"metricbeatreceiver/_agent-component/beat-metrics-monitoring2/test-1": map[string]any{
@@ -1592,12 +1598,12 @@ func TestGetOtelConfig(t *testing.T) {
 					"pipelines": map[string]any{
 						"logs/_agent-component/beat-metrics-monitoring": map[string][]string{
 							"exporters":  {"kafka/_agent-component/default"},
-							"processors": {"beat/_agent-component"},
+							"processors": {beatProcessorID("beat-metrics-monitoring")},
 							"receivers":  {"metricbeatreceiver/_agent-component/beat-metrics-monitoring/test-1"},
 						},
 						"logs/_agent-component/beat-metrics-monitoring2": map[string][]string{
 							"exporters":  {"kafka/_agent-component/monitoring"},
-							"processors": {"beat/_agent-component"},
+							"processors": {beatProcessorID("beat-metrics-monitoring2")},
 							"receivers":  {"metricbeatreceiver/_agent-component/beat-metrics-monitoring2/test-1"},
 						},
 					},
@@ -1669,7 +1675,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": defaultExpectedProcessors,
+				"processors": defaultExpectedProcessors("filestream1-default", "filestream2-default"),
 				"receivers": map[string]any{
 					"filebeatreceiver/_agent-component/filestream1-default/test-1": expectedFilestreamConfig("filestream1-default", "test-1", "generic-1"),
 					"filebeatreceiver/_agent-component/filestream1-default/test-2": expectedFilestreamConfig("filestream1-default", "test-2", "generic-2"),
@@ -1681,12 +1687,12 @@ func TestGetOtelConfig(t *testing.T) {
 					"pipelines": map[string]any{
 						"logs/_agent-component/filestream1-default": map[string][]string{
 							"exporters":  {"elasticsearch/_agent-component/default"},
-							"processors": {"beat/_agent-component"},
+							"processors": {beatProcessorID("filestream1-default")},
 							"receivers":  {"filebeatreceiver/_agent-component/filestream1-default/test-1", "filebeatreceiver/_agent-component/filestream1-default/test-2"},
 						},
 						"logs/_agent-component/filestream2-default": map[string][]string{
 							"exporters":  {"elasticsearch/_agent-component/default"},
-							"processors": {"beat/_agent-component"},
+							"processors": {beatProcessorID("filestream2-default")},
 							"receivers":  {"filebeatreceiver/_agent-component/filestream2-default/test-1", "filebeatreceiver/_agent-component/filestream2-default/test-2"},
 						},
 					},
@@ -1732,7 +1738,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": defaultExpectedProcessors,
+				"processors": defaultExpectedProcessors("beat-metrics-monitoring"),
 				"receivers": map[string]any{
 					"metricbeatreceiver/_agent-component/beat-metrics-monitoring/test-1": map[string]any{
 						"metricbeat": map[string]any{
@@ -1786,7 +1792,7 @@ func TestGetOtelConfig(t *testing.T) {
 					"pipelines": map[string]any{
 						"logs/_agent-component/beat-metrics-monitoring": map[string][]string{
 							"exporters":  {"elasticsearch/_agent-component/default"},
-							"processors": {"beat/_agent-component"},
+							"processors": {beatProcessorID("beat-metrics-monitoring")},
 							"receivers":  {"metricbeatreceiver/_agent-component/beat-metrics-monitoring/test-1"},
 						},
 					},
@@ -1832,7 +1838,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": defaultExpectedProcessors,
+				"processors": defaultExpectedProcessors("system-metrics"),
 				"receivers": map[string]any{
 					"metricbeatreceiver/_agent-component/system-metrics/test-1": map[string]any{
 						"metricbeat": map[string]any{
@@ -1897,7 +1903,7 @@ func TestGetOtelConfig(t *testing.T) {
 					"pipelines": map[string]any{
 						"logs/_agent-component/system-metrics": map[string][]string{
 							"exporters":  {"elasticsearch/_agent-component/default"},
-							"processors": {"beat/_agent-component"},
+							"processors": {beatProcessorID("system-metrics")},
 							"receivers":  {"metricbeatreceiver/_agent-component/system-metrics/test-1"},
 						},
 					},
@@ -1943,7 +1949,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": defaultExpectedProcessors,
+				"processors": defaultExpectedProcessors("auditbeat-default"),
 				"receivers": map[string]any{
 					"auditbeatreceiver/_agent-component/auditbeat-default/test-1": expectedAuditbeatReceiverConfig("auditbeat-default"),
 				},
@@ -1952,7 +1958,7 @@ func TestGetOtelConfig(t *testing.T) {
 					"pipelines": map[string]any{
 						"logs/_agent-component/auditbeat-default": map[string][]string{
 							"exporters":  {"elasticsearch/_agent-component/default"},
-							"processors": {"beat/_agent-component"},
+							"processors": {beatProcessorID("auditbeat-default")},
 							"receivers":  {"auditbeatreceiver/_agent-component/auditbeat-default/test-1"},
 						},
 					},
@@ -1998,7 +2004,6 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": defaultExpectedProcessors,
 				"receivers": map[string]any{
 					"heartbeatreceiver/_agent-component/heartbeat-default/test-1": expectedHeartbeatReceiverConfig("heartbeat-default"),
 				},
@@ -2006,9 +2011,8 @@ func TestGetOtelConfig(t *testing.T) {
 					"extensions": []any{"beatsauth/_agent-component/default"},
 					"pipelines": map[string]any{
 						"logs/_agent-component/heartbeat-default": map[string][]string{
-							"exporters":  {"elasticsearch/_agent-component/default"},
-							"processors": {"beat/_agent-component"},
-							"receivers":  {"heartbeatreceiver/_agent-component/heartbeat-default/test-1"},
+							"exporters": {"elasticsearch/_agent-component/default"},
+							"receivers": {"heartbeatreceiver/_agent-component/heartbeat-default/test-1"},
 						},
 					},
 				},
@@ -2053,7 +2057,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": defaultExpectedProcessors,
+				"processors": defaultExpectedProcessors("osquerybeat-default"),
 				"receivers": map[string]any{
 					"osquerybeatreceiver/_agent-component/osquerybeat-default/test-1": expectedOsquerybeatReceiverConfig("osquerybeat-default"),
 				},
@@ -2062,7 +2066,7 @@ func TestGetOtelConfig(t *testing.T) {
 					"pipelines": map[string]any{
 						"logs/_agent-component/osquerybeat-default": map[string][]string{
 							"exporters":  {"elasticsearch/_agent-component/default"},
-							"processors": {"beat/_agent-component"},
+							"processors": {beatProcessorID("osquerybeat-default")},
 							"receivers":  {"osquerybeatreceiver/_agent-component/osquerybeat-default/test-1"},
 						},
 					},
@@ -2108,7 +2112,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": defaultExpectedProcessors,
+				"processors": defaultExpectedProcessors("packetbeat-default"),
 				"receivers": map[string]any{
 					"packetbeatreceiver/_agent-component/packetbeat-default/test-1": expectedPacketbeatReceiverConfig("packetbeat-default"),
 				},
@@ -2117,7 +2121,7 @@ func TestGetOtelConfig(t *testing.T) {
 					"pipelines": map[string]any{
 						"logs/_agent-component/packetbeat-default": map[string][]string{
 							"exporters":  {"elasticsearch/_agent-component/default"},
-							"processors": {"beat/_agent-component"},
+							"processors": {beatProcessorID("packetbeat-default")},
 							"receivers":  {"packetbeatreceiver/_agent-component/packetbeat-default/test-1"},
 						},
 					},

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -485,12 +485,29 @@ func TestGetOtelConfig(t *testing.T) {
 	defaultGlobalProcessors := []map[string]any{
 		{
 			"add_host_metadata": map[string]any{
-				"when.not.contains.tags": "forwarded",
+				"when": map[string]any{
+					"and": []any{
+						map[string]any{"not": map[string]any{"contains": map[string]any{"tags": "forwarded"}}},
+						map[string]any{"not": map[string]any{"equals": map[string]any{"data_stream.type": "synthetics"}}},
+					},
+				},
+			},
+		},
+		{
+			"add_observer_metadata": map[string]any{
+				"when": map[string]any{
+					"equals": map[string]any{"data_stream.type": "synthetics"},
+				},
 			},
 		},
 		{"add_cloud_metadata": nil},
 		{"add_docker_metadata": nil},
 		{"add_kubernetes_metadata": nil},
+	}
+	defaultExpectedProcessors := map[string]any{
+		"beat/_agent-component": map[string]any{
+			"processors": defaultGlobalProcessors,
+		},
 	}
 
 	// expected receiver config shared shape for ES-output beats with a single stream.
@@ -772,11 +789,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": map[string]any{
-					"beat/_agent-component": map[string]any{
-						"processors": defaultGlobalProcessors,
-					},
-				},
+				"processors": defaultExpectedProcessors,
 				"receivers": map[string]any{
 					"filebeatreceiver/_agent-component/filestream-default/test-1": expectedFilestreamConfig("filestream-default", "test-1", "generic-1"),
 					"filebeatreceiver/_agent-component/filestream-default/test-2": expectedFilestreamConfig("filestream-default", "test-2", "generic-2"),
@@ -890,11 +903,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": map[string]any{
-					"beat/_agent-component": map[string]any{
-						"processors": defaultGlobalProcessors,
-					},
-				},
+				"processors": defaultExpectedProcessors,
 				"receivers": map[string]any{
 					"filebeatreceiver/_agent-component/filestream-default/test-1": expectedFilestreamConfig("filestream-default", "test-1", "generic-1"),
 					"filebeatreceiver/_agent-component/filestream-default/test-2": expectedFilestreamConfig("filestream-default", "test-2", "generic-2"),
@@ -973,11 +982,7 @@ func TestGetOtelConfig(t *testing.T) {
 						"workers":                  int64(0),
 					},
 				},
-				"processors": map[string]any{
-					"beat/_agent-component": map[string]any{
-						"processors": defaultGlobalProcessors,
-					},
-				},
+				"processors": defaultExpectedProcessors,
 				"receivers": map[string]any{
 					"metricbeatreceiver/_agent-component/beat-metrics-monitoring/test-1": map[string]any{
 						"include_metadata": true,
@@ -1241,11 +1246,7 @@ func TestGetOtelConfig(t *testing.T) {
 						},
 					},
 				},
-				"processors": map[string]any{
-					"beat/_agent-component": map[string]any{
-						"processors": defaultGlobalProcessors,
-					},
-				},
+				"processors": defaultExpectedProcessors,
 				"receivers": map[string]any{
 					"metricbeatreceiver/_agent-component/beat-metrics-monitoring/test-1": expectedBeatMetricConfig,
 				},
@@ -1352,11 +1353,7 @@ func TestGetOtelConfig(t *testing.T) {
 						},
 					},
 				},
-				"processors": map[string]any{
-					"beat/_agent-component": map[string]any{
-						"processors": defaultGlobalProcessors,
-					},
-				},
+				"processors": defaultExpectedProcessors,
 				"receivers": map[string]any{
 					"metricbeatreceiver/_agent-component/beat-metrics-monitoring/test-1": expectedBeatMetricConfig,
 				},
@@ -1545,11 +1542,7 @@ func TestGetOtelConfig(t *testing.T) {
 						},
 					},
 				},
-				"processors": map[string]any{
-					"beat/_agent-component": map[string]any{
-						"processors": defaultGlobalProcessors,
-					},
-				},
+				"processors": defaultExpectedProcessors,
 				"receivers": map[string]any{
 					"metricbeatreceiver/_agent-component/beat-metrics-monitoring/test-1": expectedBeatMetricConfig,
 					"metricbeatreceiver/_agent-component/beat-metrics-monitoring2/test-1": map[string]any{
@@ -1682,11 +1675,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": map[string]any{
-					"beat/_agent-component": map[string]any{
-						"processors": defaultGlobalProcessors,
-					},
-				},
+				"processors": defaultExpectedProcessors,
 				"receivers": map[string]any{
 					"filebeatreceiver/_agent-component/filestream1-default/test-1": expectedFilestreamConfig("filestream1-default", "test-1", "generic-1"),
 					"filebeatreceiver/_agent-component/filestream1-default/test-2": expectedFilestreamConfig("filestream1-default", "test-2", "generic-2"),
@@ -1749,11 +1738,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": map[string]any{
-					"beat/_agent-component": map[string]any{
-						"processors": defaultGlobalProcessors,
-					},
-				},
+				"processors": defaultExpectedProcessors,
 				"receivers": map[string]any{
 					"metricbeatreceiver/_agent-component/beat-metrics-monitoring/test-1": map[string]any{
 						"metricbeat": map[string]any{
@@ -1853,11 +1838,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": map[string]any{
-					"beat/_agent-component": map[string]any{
-						"processors": defaultGlobalProcessors,
-					},
-				},
+				"processors": defaultExpectedProcessors,
 				"receivers": map[string]any{
 					"metricbeatreceiver/_agent-component/system-metrics/test-1": map[string]any{
 						"metricbeat": map[string]any{
@@ -1968,11 +1949,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": map[string]any{
-					"beat/_agent-component": map[string]any{
-						"processors": defaultGlobalProcessors,
-					},
-				},
+				"processors": defaultExpectedProcessors,
 				"receivers": map[string]any{
 					"auditbeatreceiver/_agent-component/auditbeat-default/test-1": expectedAuditbeatReceiverConfig("auditbeat-default"),
 				},
@@ -2027,11 +2004,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": map[string]any{
-					"beat/_agent-component": map[string]any{
-						"processors": defaultGlobalProcessors,
-					},
-				},
+				"processors": defaultExpectedProcessors,
 				"receivers": map[string]any{
 					"heartbeatreceiver/_agent-component/heartbeat-default/test-1": expectedHeartbeatReceiverConfig("heartbeat-default"),
 				},
@@ -2086,11 +2059,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": map[string]any{
-					"beat/_agent-component": map[string]any{
-						"processors": defaultGlobalProcessors,
-					},
-				},
+				"processors": defaultExpectedProcessors,
 				"receivers": map[string]any{
 					"osquerybeatreceiver/_agent-component/osquerybeat-default/test-1": expectedOsquerybeatReceiverConfig("osquerybeat-default"),
 				},
@@ -2145,11 +2114,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": map[string]any{
-					"beat/_agent-component": map[string]any{
-						"processors": defaultGlobalProcessors,
-					},
-				},
+				"processors": defaultExpectedProcessors,
 				"receivers": map[string]any{
 					"packetbeatreceiver/_agent-component/packetbeat-default/test-1": expectedPacketbeatReceiverConfig("packetbeat-default"),
 				},

--- a/testing/integration/ess/heartbeat_monitoring_test.go
+++ b/testing/integration/ess/heartbeat_monitoring_test.go
@@ -210,12 +210,15 @@ func (runner *HeartbeatRunner) TestBeatsMetrics() {
 		otelDoc = runner.validateHeartbeatEvents(t, ctx, agentStatus.Info.ID, otelSince)
 	})
 
-	// Compare that documents produced by process and OTel modes have the same keys
+	// Compare that documents produced by process and OTel modes have the same keys.
+	// host.* fields are excluded: the OTel collector's resource detection processor
+	// adds host metadata that heartbeat doesn't emit in process mode.
+	heartbeatIgnoredFields := append(RuntimeComparisonIgnoredFields, "host")
 	t.Run("compare", func(t *testing.T) {
 		if processDoc == nil || otelDoc == nil {
 			t.Skip("skipping comparison because a previous subtest failed")
 		}
-		AssertMapstrKeysEqual(t, processDoc, otelDoc, RuntimeComparisonIgnoredFields,
+		AssertMapstrKeysEqual(t, processDoc, otelDoc, heartbeatIgnoredFields,
 			"expected heartbeat document keys to be equal between process and otel modes")
 	})
 }

--- a/testing/integration/ess/heartbeat_monitoring_test.go
+++ b/testing/integration/ess/heartbeat_monitoring_test.go
@@ -90,7 +90,7 @@ func (runner *HeartbeatRunner) SetupSuite() {
 		Privileged:     true,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
 	defer cancel()
 
 	require.NoError(t, fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, fleettools.DefaultFleetOutputID, fleettools.OutputPresetLatency))
@@ -164,7 +164,7 @@ func (runner *HeartbeatRunner) validateHeartbeatEvents(t *testing.T, ctx context
 func (runner *HeartbeatRunner) TestBeatsMetrics() {
 	t := runner.T()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Minute)
 	defer cancel()
 
 	agentStatus, err := runner.agentFixture.ExecStatus(ctx)
@@ -175,6 +175,22 @@ func (runner *HeartbeatRunner) TestBeatsMetrics() {
 	// Validate process mode
 	var processDoc mapstr.M
 	t.Run("process", func(t *testing.T) {
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			status, statusErr := runner.agentFixture.ExecStatus(ctx)
+			require.NoError(collect, statusErr)
+			var foundProcess bool
+			for _, comp := range status.Components {
+				if strings.HasPrefix(comp.ID, "synthetics/http") &&
+					comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.ProcessRuntimeManager) {
+					assert.Equal(collect, int(cproto.State_HEALTHY), comp.State,
+						"expected synthetics/http component to be healthy, got %s", cproto.State(comp.State))
+					foundProcess = true
+					break
+				}
+			}
+			assert.True(collect, foundProcess, "expected a synthetics/http component to be running as a process")
+		}, 2*time.Minute, 5*time.Second, "heartbeat component should be running as a process")
+
 		processDoc = runner.validateHeartbeatEvents(t, ctx, agentStatus.Info.ID, testStart)
 	})
 
@@ -211,8 +227,9 @@ func (runner *HeartbeatRunner) TestBeatsMetrics() {
 	})
 
 	// Compare that documents produced by process and OTel modes have the same keys.
-	// host.* fields are excluded: the OTel collector's resource detection processor
-	// adds host metadata that heartbeat doesn't emit in process mode.
+	// host.* fields are excluded: hbreceiver uses WithHost in its MakeDefaultSupport
+	// call, which adds host.name to events; the heartbeat command does not include
+	// WithHost, so process mode never emits host.* fields.
 	heartbeatIgnoredFields := append(RuntimeComparisonIgnoredFields, "host")
 	t.Run("compare", func(t *testing.T) {
 		if processDoc == nil || otelDoc == nil {

--- a/testing/integration/ess/heartbeat_monitoring_test.go
+++ b/testing/integration/ess/heartbeat_monitoring_test.go
@@ -226,16 +226,11 @@ func (runner *HeartbeatRunner) TestBeatsMetrics() {
 		otelDoc = runner.validateHeartbeatEvents(t, ctx, agentStatus.Info.ID, otelSince)
 	})
 
-	// Compare that documents produced by process and OTel modes have the same keys.
-	// host.* fields are excluded: hbreceiver uses WithHost in its MakeDefaultSupport
-	// call, which adds host.name to events; the heartbeat command does not include
-	// WithHost, so process mode never emits host.* fields.
-	heartbeatIgnoredFields := append(RuntimeComparisonIgnoredFields, "host")
 	t.Run("compare", func(t *testing.T) {
 		if processDoc == nil || otelDoc == nil {
 			t.Skip("skipping comparison because a previous subtest failed")
 		}
-		AssertMapstrKeysEqual(t, processDoc, otelDoc, heartbeatIgnoredFields,
+		AssertMapstrKeysEqual(t, processDoc, otelDoc, RuntimeComparisonIgnoredFields,
 			"expected heartbeat document keys to be equal between process and otel modes")
 	})
 }

--- a/testing/integration/ess/heartbeat_monitoring_test.go
+++ b/testing/integration/ess/heartbeat_monitoring_test.go
@@ -153,7 +153,7 @@ func (runner *HeartbeatRunner) validateHeartbeatEvents(t *testing.T, ctx context
 			},
 		}
 		now = time.Now()
-		res, err := estools.PerformQueryForRawQuery(ctx, query, "synthetics-http.summary*", runner.info.ESClient)
+		res, err := estools.PerformQueryForRawQuery(ctx, query, "synthetics-http*", runner.info.ESClient)
 		require.NoError(collect, err)
 		require.NotEmpty(collect, res.Hits.Hits)
 		doc = res.Hits.Hits[0].Source

--- a/testing/integration/ess/heartbeat_monitoring_test.go
+++ b/testing/integration/ess/heartbeat_monitoring_test.go
@@ -1,0 +1,221 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build integration
+
+package ess
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/elastic/elastic-agent-libs/kibana"
+	"github.com/elastic/elastic-agent-libs/mapstr"
+	"github.com/elastic/elastic-agent-libs/testing/estools"
+	"github.com/elastic/elastic-agent/pkg/component"
+	"github.com/elastic/elastic-agent/pkg/control/v2/cproto"
+	atesting "github.com/elastic/elastic-agent/pkg/testing"
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+	"github.com/elastic/elastic-agent/pkg/testing/tools"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/fleettools"
+	"github.com/elastic/elastic-agent/testing/integration"
+)
+
+type HeartbeatRunner struct {
+	suite.Suite
+	info         *define.Info
+	agentFixture *atesting.Fixture
+	httpServer   *httptest.Server
+
+	agentID    string
+	policyID   string
+	policyName string
+}
+
+func TestHeartbeatHTTPMonitor(t *testing.T) {
+	info := define.Require(t, define.Requirements{
+		Group: integration.Fleet,
+		Stack: &define.Stack{},
+		Local: false, // requires Agent installation
+		Sudo:  true,  // requires Agent installation
+		OS: []define.OS{
+			{Type: define.Linux},
+			{Type: define.Darwin},
+		},
+	})
+
+	suite.Run(t, &HeartbeatRunner{info: info})
+}
+
+func (runner *HeartbeatRunner) SetupSuite() {
+	t := runner.T()
+
+	// Start a local HTTP server that always returns 200. Heartbeat will poll this.
+	runner.httpServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "OK")
+	}))
+	t.Cleanup(runner.httpServer.Close)
+
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
+	require.NoError(t, err)
+	runner.agentFixture = fixture
+
+	policyUUID := uuid.Must(uuid.NewV4()).String()
+	basePolicy := kibana.AgentPolicy{
+		Name:        "test-policy-" + policyUUID,
+		Namespace:   runner.info.Namespace,
+		Description: "Test policy " + policyUUID,
+		MonitoringEnabled: []kibana.MonitoringEnabledOption{
+			kibana.MonitoringEnabledLogs,
+			kibana.MonitoringEnabledMetrics,
+		},
+	}
+
+	installOpts := atesting.InstallOpts{
+		NonInteractive: true,
+		Force:          true,
+		Privileged:     true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	require.NoError(t, fleettools.UpdateESOutputPreset(ctx, runner.info.KibanaClient, fleettools.DefaultFleetOutputID, fleettools.OutputPresetLatency))
+	policyResp, agentID, err := tools.InstallAgentWithPolicy(ctx, t, installOpts, runner.agentFixture, runner.info.KibanaClient, basePolicy)
+	require.NoError(t, err)
+
+	runner.agentID = agentID
+	runner.policyID = policyResp.ID
+	runner.policyName = policyResp.Name
+
+	// Create a Synthetics private location backed by the Fleet policy so that
+	// Kibana can push a heartbeat monitor to the agent via Fleet.
+	locationLabel := fmt.Sprintf("test-location-%s", policyUUID)
+	_, err = createSyntheticsPrivateLocation(ctx, runner.info.KibanaClient, locationLabel, policyResp.ID)
+	require.NoError(t, err)
+
+	// Push one HTTP monitor targeting the local test server.
+	monitors := []syntheticsMonitorSchema{
+		{
+			ID:               "heartbeat-http-monitor-" + policyUUID,
+			Type:             "http",
+			Name:             "Test HTTP Monitor",
+			Enabled:          true,
+			Schedule:         1, // 1-minute polling interval
+			PrivateLocations: []string{locationLabel},
+			URLs:             runner.httpServer.URL,
+		},
+	}
+	projectName := fmt.Sprintf("heartbeat-test-%s", policyUUID)
+	require.NoError(t, bulkPushSyntheticsMonitors(ctx, t, runner.info.KibanaClient, projectName, monitors))
+}
+
+// validateHeartbeatEvents polls Elasticsearch until at least one heartbeat HTTP
+// summary document appears for the given agent, filtered to events after `since`.
+// It returns the first matching document.
+func (runner *HeartbeatRunner) validateHeartbeatEvents(t *testing.T, ctx context.Context, agentID string, since time.Time) mapstr.M {
+	now := time.Now()
+	var query map[string]any
+	var doc mapstr.M
+
+	defer func() {
+		if t.Failed() {
+			bs, err := json.Marshal(query)
+			if err != nil {
+				t.Errorf("executed at %s: %v", now.Format(time.RFC3339Nano), query)
+				return
+			}
+			t.Errorf("executed at %s: query: %s", now.Format(time.RFC3339Nano), string(bs))
+		}
+	}()
+
+	t.Logf("querying ES for heartbeat events at %s", now.Format(time.RFC3339Nano))
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		query = genESQuery(agentID, [][]string{
+			{"exists", "field", "monitor.status"},
+		})
+		query["query"].(map[string]interface{})["bool"].(map[string]interface{})["filter"] = map[string]any{
+			"range": map[string]any{
+				"@timestamp": map[string]any{"gte": since.UTC().Format("2006-01-02T15:04:05.000Z")},
+			},
+		}
+		now = time.Now()
+		res, err := estools.PerformQueryForRawQuery(ctx, query, "synthetics-http.summary*", runner.info.ESClient)
+		require.NoError(collect, err)
+		require.NotEmpty(collect, res.Hits.Hits)
+		doc = res.Hits.Hits[0].Source
+	}, 10*time.Minute, 10*time.Second, "could not fetch heartbeat HTTP events")
+	return doc
+}
+
+func (runner *HeartbeatRunner) TestBeatsMetrics() {
+	t := runner.T()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	agentStatus, err := runner.agentFixture.ExecStatus(ctx)
+	require.NoError(t, err, "could not get agent status")
+
+	testStart := time.Now()
+
+	// Validate process mode
+	var processDoc mapstr.M
+	t.Run("process", func(t *testing.T) {
+		processDoc = runner.validateHeartbeatEvents(t, ctx, agentStatus.Info.ID, testStart)
+	})
+
+	// Switch to OTel runtime and validate the same data
+	var otelDoc mapstr.M
+	t.Run("otel", func(t *testing.T) {
+		otelSince := time.Now()
+		policyRevision := switchPolicyToOtelRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
+
+		// Wait for the agent to apply the new policy revision
+		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
+			5*time.Minute, time.Second)
+
+		// Verify that a synthetics/http component is running as a beats receiver.
+		// The component may not appear immediately after the policy switch, so we
+		// look for it inside the loop rather than capturing its ID up front.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			status, statusErr := runner.agentFixture.ExecStatus(ctx)
+			require.NoError(collect, statusErr)
+			var foundReceiver bool
+			for _, comp := range status.Components {
+				if strings.HasPrefix(comp.ID, "synthetics/http") &&
+					comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) {
+					assert.Equal(collect, int(cproto.State_HEALTHY), comp.State,
+						"expected synthetics/http component to be healthy, got %s", cproto.State(comp.State))
+					foundReceiver = true
+					break
+				}
+			}
+			assert.True(collect, foundReceiver, "expected a synthetics/http component to be running as beats receiver")
+		}, 2*time.Minute, 5*time.Second, "heartbeat component should be running as beats receiver")
+
+		otelDoc = runner.validateHeartbeatEvents(t, ctx, agentStatus.Info.ID, otelSince)
+	})
+
+	// Compare that documents produced by process and OTel modes have the same keys
+	t.Run("compare", func(t *testing.T) {
+		if processDoc == nil || otelDoc == nil {
+			t.Skip("skipping comparison because a previous subtest failed")
+		}
+		AssertMapstrKeysEqual(t, processDoc, otelDoc, RuntimeComparisonIgnoredFields,
+			"expected heartbeat document keys to be equal between process and otel modes")
+	})
+}


### PR DESCRIPTION
## What does this PR do?

Use a separate beatsprocessor per pipeline. Heartbeat doesn't use any default processors, so this is necessary avoid running unnecessary processors in otel mode. The processors are still shared for other receivers, because beatsprocessor internally shares them if the configuration is the same.

We also add an integration test for synthetics/http that checks a test server and compares documents between process and otel mode.

## Why is it important?

Heartbeat should produce the same data in process and otel modes.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [x] I have added an integration test or an E2E test

## How to test this PR locally

Run the equivalent of the added test locally and inspect the data in Kibana.

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/14552


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
