### PR TITLE
[CODEOWNERS] `ingest-tech-leads` rule missing final character

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,7 +21,7 @@ changelog/fragments/
 /.ci/scripts/update-integration-testdata.sh @elastic/elastic-agent-control-plane
 /.ci/scripts/update-otel.sh @elastic/elastic-agent-control-plane
 /.github @elastic/elastic-agent-control-plane @elastic/observablt-ci
-/.github/CODEOWNERS @elastic/ingest-tech-lead
+/.github/CODEOWNERS @elastic/ingest-tech-leads
 /.github/workflows/release-notes.yml @elastic/ingest-docs @elastic/elastic-agent-control-plane 
 /deploy/helm @elastic/elastic-agent-control-plane
 /deploy/helm/edot-collector @elastic/ingest-otel-data


### PR DESCRIPTION
Realized when https://github.com/elastic/elastic-agent/pull/15247 was missing the required codeowner approval.