### PR TITLE
docs: fix packaging example to match linux/amd64 build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,15 @@ To install the agent extract the package and run the install command:
 
 ```sh
 cd build/distributions
-tar xvfz elastic-agent-8.8.0-SNAPSHOT-darwin-aarch64.tar.gz
-cd elastic-agent-8.8.0-SNAPSHOT-darwin-aarch64
+tar xvfz elastic-agent-<version>-SNAPSHOT-linux-x86_64.tar.gz
+cd elastic-agent-<version>-SNAPSHOT-linux-x86_64
 sudo ./elastic-agent install
+```
+
+Replace `<version>` with the current version from [version/version.go](version/version.go). You can also discover the generated filename with:
+
+```sh
+ls elastic-agent-*-linux-x86_64.tar.gz
 ```
 
 For basic use the agent binary can be run directly, with the `./elastic-agent run` command.


### PR DESCRIPTION
## What does this PR do?

Fixes the packaging install snippet in the `Developing > Packaging` section of README.md. The snippet previously extracted a hardcoded macOS 8.8.0 artifact (`elastic-agent-8.8.0-SNAPSHOT-darwin-aarch64.tar.gz`) while the preceding build command targeted `linux/amd64`.

Changes:
- Replace the stale `darwin-aarch64` platform with `linux-x86_64` to match the `PLATFORMS=linux/amd64` build command
- Replace the hardcoded `8.8.0` version literal with a `<version>` placeholder
- Add a `ls elastic-agent-*-linux-x86_64.tar.gz` discovery command so contributors can find the generated filename without guessing

## Why is it important?

New external contributors following the README's packaging/install steps would hit a file-not-found error before they could run the agent, because the archive name the docs told them to extract did not match the artifact produced by the build command they just ran.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the changelog tool~~
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None — documentation-only change.

## How to test this PR locally

Read the updated `README.md` packaging section and verify the extract command platform and placeholder match the preceding `PLATFORMS=linux/amd64` build command.

## Related issues

- Closes #15239