### PR TITLE
fix: preserve locally-configured monitoring.http/pprof settings on Fleet policy check-in

### DIFF
--- a/changelog/fragments/1782932182-preserve-locally-configured-monitoring.http.host-across-fleet-policy-check-ins.yaml
+++ b/changelog/fragments/1782932182-preserve-locally-configured-monitoring.http.host-across-fleet-policy-check-ins.yaml
@@ -1,0 +1,37 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Preserve locally-configured monitoring.http.host across Fleet policy check-ins
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  A regression introduced in 9.4.2 caused the agent's monitoring HTTP listener to rebind to the
+  default host (localhost) on every Fleet policy check-in, discarding any host configured locally
+  via agent.monitoring.http.host (e.g. 0.0.0.0). The policy-change handler now only applies
+  monitoring.http/pprof settings from the policy when they are explicitly present, leaving the
+  locally-configured values untouched otherwise.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -305,8 +305,7 @@ func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.
 	if loggingConfig != nil {
 		h.config.Settings.LoggingConfig.Level = loggingConfig.Level
 	}
-	h.config.Settings.MonitoringConfig.HTTP = cfg.Settings.MonitoringConfig.HTTP
-	h.config.Settings.MonitoringConfig.Pprof = cfg.Settings.MonitoringConfig.Pprof
+	h.applyMonitoringConfigChange(partialCfg)
 
 	if err := saveConfig(h.agentInfo, h.config, h.store, h.log); err != nil {
 		return fmt.Errorf("failed to persist policy config: %w", err)
@@ -341,6 +340,26 @@ func (h *PolicyChangeHandler) applyEventLoggingOutputChange(new *configuration.C
 	current.ToFiles = incoming.ToFiles
 	current.ToStderr = incoming.ToStderr
 	return true
+}
+
+// applyMonitoringConfigChange updates h.config.Settings.MonitoringConfig.HTTP/Pprof only when the
+// incoming policy explicitly sets them (partialCfg is unpacked without defaults, so a nil HTTP/Pprof
+// means the policy didn't carry that section at all). Fleet policies don't have a way to set
+// monitoring.http today, so this preserves whatever was configured locally (e.g.
+// agent.monitoring.http.host in elastic-agent.yml) instead of clobbering it with library defaults
+// on every policy check-in. Mirrors the EnabledIsSet safeguard in monitoring/reload/reload.go,
+// see https://github.com/elastic/elastic-agent/issues/4582.
+func (h *PolicyChangeHandler) applyMonitoringConfigChange(partialCfg *configuration.Configuration) {
+	if partialCfg == nil || partialCfg.Settings == nil || partialCfg.Settings.MonitoringConfig == nil {
+		return
+	}
+
+	if partialCfg.Settings.MonitoringConfig.HTTP != nil {
+		h.config.Settings.MonitoringConfig.HTTP = partialCfg.Settings.MonitoringConfig.HTTP
+	}
+	if partialCfg.Settings.MonitoringConfig.Pprof != nil {
+		h.config.Settings.MonitoringConfig.Pprof = partialCfg.Settings.MonitoringConfig.Pprof
+	}
 }
 
 func (h *PolicyChangeHandler) applyLoggingConfigChange(new *configuration.Configuration, loggingConfig *logger.Config) bool {

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
@@ -1204,6 +1204,96 @@ func TestPolicyChangeHandler_handlePolicyChange_LogLevelPersistedToConfig(t *tes
 	}
 }
 
+func TestPolicyChangeHandler_handlePolicyChange_MonitoringHTTPHostPreserved(t *testing.T) {
+	// Regression test for https://github.com/elastic/elastic-agent/issues/4582-style breakage:
+	// a locally-configured agent.monitoring.http.host (e.g. 0.0.0.0 for Kubernetes probes) must
+	// survive a Fleet policy check-in, since Fleet policies never carry a monitoring.http section.
+	t.Run("policy without a monitoring.http section leaves the local host binding untouched", func(t *testing.T) {
+		log, _ := loggertest.New(t.Name())
+
+		cfg := configuration.DefaultConfiguration()
+		cfg.Settings.MonitoringConfig.HTTP.Host = "0.0.0.0"
+		cfg.Settings.MonitoringConfig.HTTP.Port = 6791
+
+		h := &PolicyChangeHandler{
+			log:                   log,
+			agentInfo:             &info.AgentInfo{},
+			config:                cfg,
+			store:                 &storage.NullStore{},
+			runtimeLogLevelSetter: defaultLogLevelSet(t),
+		}
+
+		// A typical Fleet policy: no "agent.monitoring.http" key at all.
+		policy := config.MustNewConfigFrom(map[string]interface{}{
+			"agent.monitoring.enabled": true,
+			"agent.monitoring.logs":    true,
+			"agent.monitoring.metrics": true,
+		})
+
+		err := h.handlePolicyChange(context.Background(), policy, nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, "0.0.0.0", h.config.Settings.MonitoringConfig.HTTP.Host,
+			"local monitoring.http.host must not be reset to the library default on policy check-in")
+		assert.Equal(t, 6791, h.config.Settings.MonitoringConfig.HTTP.Port)
+	})
+
+	t.Run("policy that explicitly sets monitoring.http.host overrides the local value", func(t *testing.T) {
+		log, _ := loggertest.New(t.Name())
+
+		cfg := configuration.DefaultConfiguration()
+		cfg.Settings.MonitoringConfig.HTTP.Host = "0.0.0.0"
+
+		h := &PolicyChangeHandler{
+			log:                   log,
+			agentInfo:             &info.AgentInfo{},
+			config:                cfg,
+			store:                 &storage.NullStore{},
+			runtimeLogLevelSetter: defaultLogLevelSet(t),
+		}
+
+		policy := config.MustNewConfigFrom(map[string]interface{}{
+			"agent.monitoring.http.host": "192.168.1.1",
+		})
+
+		err := h.handlePolicyChange(context.Background(), policy, nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, "192.168.1.1", h.config.Settings.MonitoringConfig.HTTP.Host,
+			"an explicit policy value should still take precedence over the local config")
+	})
+
+	t.Run("host set via elastic-agent.yml survives repeated policy check-ins", func(t *testing.T) {
+		log, _ := loggertest.New(t.Name())
+
+		cfg := configuration.DefaultConfiguration()
+		cfg.Settings.MonitoringConfig.HTTP.Host = "0.0.0.0"
+
+		defaultLogLevel := logger.DefaultLogLevel
+		logLevelSetter := newMockLogLevelSetter(t)
+		logLevelSetter.EXPECT().SetLogLevel(mock.Anything, &defaultLogLevel).Return(nil)
+
+		h := &PolicyChangeHandler{
+			log:                   log,
+			agentInfo:             &info.AgentInfo{},
+			config:                cfg,
+			store:                 &storage.NullStore{},
+			runtimeLogLevelSetter: logLevelSetter,
+		}
+
+		policy := config.MustNewConfigFrom(map[string]interface{}{
+			"agent.monitoring.enabled": true,
+		})
+
+		for i := 0; i < 3; i++ {
+			err := h.handlePolicyChange(context.Background(), policy, nil)
+			require.NoError(t, err)
+			require.Equal(t, "0.0.0.0", h.config.Settings.MonitoringConfig.HTTP.Host,
+				"host binding must survive every subsequent policy check-in, not just the first")
+		}
+	})
+}
+
 // captureStore is a storage.Store that records the bytes passed to Save so a
 // test can assert on the yaml that fleetToReader produced.
 type captureStore struct {


### PR DESCRIPTION
## What does this PR do?

`handlePolicyChange` unconditionally overwrote `h.config.Settings.MonitoringConfig.HTTP` and `.Pprof` with the policy-parsed configuration on every `POLICY_CHANGE` action:

```go
h.config.Settings.MonitoringConfig.HTTP = cfg.Settings.MonitoringConfig.HTTP
h.config.Settings.MonitoringConfig.Pprof = cfg.Settings.MonitoringConfig.Pprof
```

`cfg` is parsed strictly from the incoming Fleet policy payload. Fleet policies never carry a `monitoring.http` section, so this always resolved to the library default (`host: localhost`), discarding any host configured locally (e.g. `agent.monitoring.http.host: 0.0.0.0` for Kubernetes liveness/startup probes) — and persisting the loss to `fleet.enc`, so it didn't survive a restart either.

This PR replaces the unconditional overwrite with `applyMonitoringConfigChange`, which only applies the policy's `monitoring.http`/`monitoring.pprof` settings when the policy explicitly sets them (detected via the existing no-defaults `partialCfg`, the same idiom already used by `validateLoggingConfig` in this file). When the policy doesn't carry that section — which is the case today — the locally-configured value is left untouched.

## Why is it important?

This is a regression introduced by #14078 ("fix: apply policy log-level changes after agent restart"), first shipped in 9.4.2 (absent from 9.4.1). That PR's intent was only to fix policy-driven log-level persistence across restarts; the monitoring HTTP/Pprof overwrite was an unrelated side effect of refactoring the same function.

The codebase already has a safeguard for exactly this scenario in `monitoring/reload/reload.go` (added for #4582 — "fleet does not expect the monitoring to be reloadable"), but it never gets a chance to run because the policy-change handler now persists the overwritten value to `h.config`/`fleet.enc` first.

Impact: any Fleet-managed agent with a custom `agent.monitoring.http.host` in its local `elastic-agent.yml` (e.g. `0.0.0.0` so Kubernetes probes can reach it from outside the pod's loopback namespace) has that binding silently reset to `127.0.0.1` on its first policy check-in after enrollment, breaking `httpGet` liveness/startup probes and causing a restart loop.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

None expected. This restores the pre-9.4.2 behavior where locally-configured `monitoring.http`/`monitoring.pprof` settings are not overwritten by policy check-ins. Agents that were relying on the buggy behavior to have Fleet reset monitoring HTTP settings are not a known use case — Fleet has no UI/policy field for `monitoring.http.host` today.

## Related issues

- Relates https://github.com/elastic/security-integrations/issues/816
- Relates https://github.com/elastic/elastic-agent/issues/4582