### PR TITLE
Adopt fleet-server union ack event types

### DIFF
--- a/internal/pkg/agent/application/dispatcher/dispatcher_test.go
+++ b/internal/pkg/agent/application/dispatcher/dispatcher_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	api "github.com/elastic/fleet-server/pkg/api"
+
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/actions/handlers"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/acker"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/acker/noop"
@@ -61,9 +63,9 @@ func (m *mockAction) String() string {
 	args := m.Called()
 	return args.String(0)
 }
-func (m *mockAction) AckEvent() fleetapi.AckEvent {
-	args := m.Called()
-	return args.Get(0).(fleetapi.AckEvent)
+func (m *mockAction) AckEvent(agentID string, ts time.Time) api.AckRequest_Events_Item {
+	args := m.Called(agentID, ts)
+	return args.Get(0).(api.AckRequest_Events_Item)
 }
 func (m *mockScheduledAction) StartTime() (time.Time, error) {
 	args := m.Called()

--- a/internal/pkg/agent/storage/store/state_store_test.go
+++ b/internal/pkg/agent/storage/store/state_store_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	api "github.com/elastic/fleet-server/pkg/api"
+
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/secret"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/storage"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/vault"
@@ -24,10 +26,12 @@ import (
 
 type wrongAction struct{}
 
-func (wrongAction) ID() string                  { return "" }
-func (wrongAction) Type() string                { return "" }
-func (wrongAction) String() string              { return "" }
-func (wrongAction) AckEvent() fleetapi.AckEvent { return fleetapi.AckEvent{} }
+func (wrongAction) ID() string     { return "" }
+func (wrongAction) Type() string   { return "" }
+func (wrongAction) String() string { return "" }
+func (wrongAction) AckEvent(string, time.Time) api.AckRequest_Events_Item {
+	return api.AckRequest_Events_Item{}
+}
 
 func TestStateStore(t *testing.T) {
 	t.Run("ack token", func(t *testing.T) {

--- a/internal/pkg/fleetapi/ack_cmd.go
+++ b/internal/pkg/fleetapi/ack_cmd.go
@@ -20,9 +20,6 @@ import (
 
 const ackPath = "/api/fleet/agents/%s/acks"
 
-// AckEvent is re-exported from pkg/fleetapi for backward compatibility.
-type AckEvent = pkgfleetapi.AckEvent
-
 // AckRequest is re-exported from pkg/fleetapi for backward compatibility.
 type AckRequest = pkgfleetapi.AckRequest
 
@@ -53,10 +50,6 @@ func (e *AckCmd) Execute(ctx context.Context, r *AckRequest) (_ *AckResponse, er
 		apm.CaptureError(ctx, err).Send()
 		span.End()
 	}()
-	if err := r.Validate(); err != nil {
-		return nil, err
-	}
-
 	b, err := json.Marshal(r)
 	if err != nil {
 		return nil, errors.New(err,

--- a/internal/pkg/fleetapi/ack_cmd_test.go
+++ b/internal/pkg/fleetapi/ack_cmd_test.go
@@ -10,8 +10,11 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+
+	api "github.com/elastic/fleet-server/pkg/api"
 
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
 	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
@@ -29,9 +32,7 @@ func TestAck(t *testing.T) {
 			mux.HandleFunc(path, authHandler(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 
-				responses := struct {
-					Events []AckEvent `json:"events"`
-				}{}
+				var responses AckRequest
 
 				decoder := json.NewDecoder(r.Body)
 				defer r.Body.Close()
@@ -41,8 +42,9 @@ func TestAck(t *testing.T) {
 
 				require.Equal(t, 1, len(responses.Events))
 
-				id := responses.Events[0].ActionID
-				require.Equal(t, "my-id", id)
+				event, err := responses.Events[0].AsGenericEvent()
+				require.NoError(t, err)
+				require.Equal(t, "my-id", event.ActionId)
 
 				fmt.Fprint(w, raw)
 			}, withAPIKey))
@@ -60,12 +62,8 @@ func TestAck(t *testing.T) {
 			cmd := NewAckCmd(&agentinfo{}, client)
 
 			request := AckRequest{
-				Events: []AckEvent{
-					{
-						EventType: "ACTION_RESULT",
-						SubType:   "ACKNOWLEDGED",
-						ActionID:  action.ID(),
-					},
+				Events: []api.AckRequest_Events_Item{
+					action.AckEvent(agentInfo.AgentID(), time.Now()),
 				},
 			}
 

--- a/internal/pkg/fleetapi/acker/fleet/fleet_acker.go
+++ b/internal/pkg/fleetapi/acker/fleet/fleet_acker.go
@@ -12,14 +12,14 @@ import (
 
 	"go.elastic.co/apm/v2"
 
+	api "github.com/elastic/fleet-server/pkg/api"
+
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 )
-
-const fleetTimeFormat = "2006-01-02T15:04:05.99999-07:00"
 
 type agentInfo interface {
 	AgentID() string
@@ -60,11 +60,9 @@ func (f *Acker) Ack(ctx context.Context, action pkgfleetapi.Action) (err error) 
 	// checkin
 	agentID := f.agentInfo.AgentID()
 	cmd := fleetapi.NewAckCmd(f.agentInfo, f.client)
-	event := action.AckEvent()
-	event.AgentID = agentID
-	event.Timestamp = time.Now().Format(fleetTimeFormat)
+	event := action.AckEvent(agentID, time.Now())
 	req := &fleetapi.AckRequest{
-		Events: []fleetapi.AckEvent{event},
+		Events: []api.AckRequest_Events_Item{event},
 	}
 
 	_, err = cmd.Execute(ctx, req)
@@ -87,13 +85,11 @@ func (f *Acker) AckBatch(ctx context.Context, actions []pkgfleetapi.Action) (res
 	}()
 	// checkin
 	agentID := f.agentInfo.AgentID()
-	events := make([]fleetapi.AckEvent, 0, len(actions))
+	events := make([]api.AckRequest_Events_Item, 0, len(actions))
 	ids := make([]string, 0, len(actions))
+	now := time.Now()
 	for _, action := range actions {
-		event := action.AckEvent()
-		event.AgentID = agentID
-		event.Timestamp = time.Now().Format(fleetTimeFormat)
-		events = append(events, event)
+		events = append(events, action.AckEvent(agentID, now))
 		ids = append(ids, action.ID())
 	}
 

--- a/internal/pkg/fleetapi/acker/fleet/fleet_acker_test.go
+++ b/internal/pkg/fleetapi/acker/fleet/fleet_acker_test.go
@@ -13,9 +13,12 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	api "github.com/elastic/fleet-server/pkg/api"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
@@ -23,7 +26,7 @@ import (
 )
 
 type ackRequest struct {
-	Events []fleetapi.AckEvent `json:"events"`
+	Events []api.AckRequest_Events_Item `json:"events"`
 }
 
 type testAgentInfo struct{}
@@ -152,44 +155,64 @@ func TestAcker_Ack(t *testing.T) {
 		}
 		assert.EqualValues(t, len(actions), len(req.Events))
 		for i, ac := range actions {
-			assert.EqualValues(t, "ACTION_RESULT", req.Events[i].EventType)
-			assert.EqualValues(t, "ACKNOWLEDGED", req.Events[i].SubType)
-			assert.EqualValues(t, ac.ID(), req.Events[i].ActionID)
-			assert.EqualValues(t, agentInfo.AgentID(), req.Events[i].AgentID)
-			assert.EqualValues(t, fmt.Sprintf("Action %q of type %q acknowledged.", ac.ID(), ac.Type()), req.Events[i].Message)
-			// Check if the fleet acker handles RetryableActions correctly using the UpgradeAction
-			if a, ok := ac.(*fleetapi.ActionUpgrade); ok {
+			switch a := ac.(type) {
+			case *fleetapi.ActionUpgrade:
+				event, err := req.Events[i].AsUpgradeEvent()
+				require.NoError(t, err)
+				assert.Equal(t, api.ACTIONRESULT, event.Type)
+				assert.Equal(t, api.EventSubtypeACKNOWLEDGED, event.Subtype)
+				assert.Equal(t, a.ID(), event.ActionId)
+				assert.Equal(t, agentInfo.AgentID(), event.AgentId)
+				assert.Equal(t, fmt.Sprintf("Action %q of type %q acknowledged.", a.ID(), a.Type()), event.Message)
 				if a.Err != nil {
-					assert.EqualValues(t, a.Err.Error(), req.Events[i].Error)
+					require.NotNil(t, event.Error)
+					assert.Equal(t, a.Err.Error(), *event.Error)
 					// Check payload
-					require.NotEmpty(t, req.Events[i].Payload)
-					var pl struct {
-						Retry   bool `json:"retry"`
-						Attempt int  `json:"retry_attempt,omitempty"`
-					}
-					err := json.Unmarshal(req.Events[i].Payload, &pl)
-					require.NoError(t, err)
-					assert.Equal(t, a.Data.Retry, pl.Attempt,
+					require.NotNil(t, event.Payload)
+					assert.Equal(t, a.Data.Retry, event.Payload.RetryAttempt,
 						"action ID %s failed", a.ActionID)
 					// Check retry flag
-					if pl.Attempt > 0 {
-						assert.True(t, pl.Retry)
+					if event.Payload.RetryAttempt > 0 {
+						assert.True(t, event.Payload.Retry)
 					} else {
-						assert.False(t, pl.Retry)
+						assert.False(t, event.Payload.Retry)
 					}
 				} else {
-					assert.Empty(t, req.Events[i].Error)
+					assert.Nil(t, event.Error)
 				}
+			case *fleetapi.ActionApp:
+				event, err := req.Events[i].AsInputEvent()
+				require.NoError(t, err)
+				assert.Equal(t, api.ACTIONRESULT, event.Type)
+				assert.Equal(t, api.EventSubtypeACKNOWLEDGED, event.Subtype)
+				assert.Equal(t, a.ID(), event.ActionId)
+				assert.Equal(t, agentInfo.AgentID(), event.AgentId)
+				assert.Equal(t, a.InputType, event.ActionInputType)
+				assert.EqualValues(t, a.Data, event.ActionData)
+				wantResponse, err := json.Marshal(a.Response)
+				require.NoError(t, err)
+				assert.JSONEq(t, string(wantResponse), string(event.ActionResponse))
+				wantStarted, err := time.Parse(time.RFC3339Nano, a.StartedAt)
+				require.NoError(t, err)
+				assert.True(t, wantStarted.Equal(event.StartedAt))
+				wantCompleted, err := time.Parse(time.RFC3339Nano, a.CompletedAt)
+				require.NoError(t, err)
+				assert.True(t, wantCompleted.Equal(event.CompletedAt))
+				if a.Error != "" {
+					require.NotNil(t, event.Error)
+					assert.Equal(t, a.Error, *event.Error)
+				} else {
+					assert.Nil(t, event.Error)
+				}
+			default:
+				event, err := req.Events[i].AsGenericEvent()
+				require.NoError(t, err)
+				assert.Equal(t, api.ACTIONRESULT, event.Type)
+				assert.Equal(t, api.EventSubtypeACKNOWLEDGED, event.Subtype)
+				assert.Equal(t, ac.ID(), event.ActionId)
+				assert.Equal(t, agentInfo.AgentID(), event.AgentId)
+				assert.Equal(t, fmt.Sprintf("Action %q of type %q acknowledged.", ac.ID(), ac.Type()), event.Message)
 			}
-			if a, ok := ac.(*fleetapi.ActionApp); ok {
-				assert.EqualValues(t, a.InputType, req.Events[i].ActionInputType)
-				assert.EqualValues(t, a.Data, req.Events[i].ActionData)
-				assert.EqualValues(t, a.Response, req.Events[i].ActionResponse)
-				assert.EqualValues(t, a.StartedAt, req.Events[i].StartedAt)
-				assert.EqualValues(t, a.CompletedAt, req.Events[i].CompletedAt)
-				assert.EqualValues(t, a.Error, req.Events[i].Error)
-			}
-
 		}
 	}
 

--- a/internal/pkg/queue/actionqueue_test.go
+++ b/internal/pkg/queue/actionqueue_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	api "github.com/elastic/fleet-server/pkg/api"
+
 	"github.com/elastic/elastic-agent/pkg/fleetapi"
 )
 
@@ -36,9 +38,9 @@ func (m *mockAction) ID() string {
 	return args.String(0)
 }
 
-func (m *mockAction) AckEvent() fleetapi.AckEvent {
-	args := m.Called()
-	return args.Get(0).(fleetapi.AckEvent)
+func (m *mockAction) AckEvent(agentID string, ts time.Time) api.AckRequest_Events_Item {
+	args := m.Called(agentID, ts)
+	return args.Get(0).(api.AckRequest_Events_Item)
 }
 
 func (m *mockAction) StartTime() (time.Time, error) {

--- a/pkg/fleetapi/ack.go
+++ b/pkg/fleetapi/ack.go
@@ -4,66 +4,16 @@
 
 package fleetapi
 
-import "encoding/json"
+import api "github.com/elastic/fleet-server/pkg/api"
 
-// AckEvent is an event sent in an ACK request.
-type AckEvent struct {
-	EventType string          `json:"type"`              //  'STATE' | 'ERROR' | 'ACTION_RESULT' | 'ACTION'
-	SubType   string          `json:"subtype"`           // 'RUNNING','STARTING','IN_PROGRESS','CONFIG','FAILED','STOPPING','STOPPED','DATA_DUMP','ACKNOWLEDGED','UNKNOWN';
-	Timestamp string          `json:"timestamp"`         // : '2019-01-05T14:32:03.36764-05:00'
-	ActionID  string          `json:"action_id"`         // : '48cebde1-c906-4893-b89f-595d943b72a2',
-	AgentID   string          `json:"agent_id"`          // : 'agent1',
-	Message   string          `json:"message,omitempty"` // : 'hello2',
-	Payload   json.RawMessage `json:"payload,omitempty"` // : 'payload2',
-	Data      json.RawMessage `json:"data,omitempty"`    // : 'data',
+// AckRequest is re-exported from fleet-server's pkg/api for callers that don't want
+// to import fleet-server directly.
+type AckRequest = api.AckRequest
 
-	ActionInputType string                 `json:"action_input_type,omitempty"` // copy of original action input_type
-	ActionData      json.RawMessage        `json:"action_data,omitempty"`       // copy of original action data
-	ActionResponse  map[string]interface{} `json:"action_response,omitempty"`   // custom (per beat) response payload
-	StartedAt       string                 `json:"started_at,omitempty"`        // time action started
-	CompletedAt     string                 `json:"completed_at,omitempty"`      // time action completed
-	Error           string                 `json:"error,omitempty"`             // optional action error
-}
+// AckResponseItem is re-exported from fleet-server's pkg/api for callers that don't want
+// to import fleet-server directly.
+type AckResponseItem = api.AckResponseItem
 
-// AckRequest consists of multiple actions acked to fleet ui.
-// POST /agents/{agentId}/acks
-// Authorization: ApiKey {AgentAccessApiKey}
-//
-//	{
-//	  "action_ids": ["id1"]
-//	}
-type AckRequest struct {
-	Events []AckEvent `json:"events"`
-}
-
-// Validate validates the ack request before sending it to the API.
-func (e *AckRequest) Validate() error {
-	return nil
-}
-
-// AckResponseItem the status items for individual acks
-type AckResponseItem struct {
-	Status  int    `json:"status"`
-	Message string `json:"message,omitempty"`
-}
-
-// AckResponse is the response send back from the server.
-// 200
-//
-//	{
-//		 "action": "acks"
-//	  "items": [
-//		    {"status": 200},
-//		    {"status": 404},
-//	  ]
-//	}
-type AckResponse struct {
-	Action string            `json:"action"`
-	Errors bool              `json:"errors,omitempty"` // indicates that some of the events in the ack request failed
-	Items  []AckResponseItem `json:"items,omitempty"`
-}
-
-// Validate validates the response send from the server.
-func (e *AckResponse) Validate() error {
-	return nil
-}
+// AckResponse is re-exported from fleet-server's pkg/api for callers that don't want
+// to import fleet-server directly.
+type AckResponse = api.AckResponse

--- a/pkg/fleetapi/action.go
+++ b/pkg/fleetapi/action.go
@@ -683,6 +683,10 @@ func (a *ActionApp) AckEvent(agentID string, ts time.Time) api.AckRequest_Events
 		Message:         fmt.Sprintf("Action %q of type %q acknowledged.", a.ActionID, a.ActionType),
 		ActionInputType: a.InputType,
 		ActionData:      a.Data,
+		// StartedAt/CompletedAt fall back to ts if a.StartedAt/a.CompletedAt are
+		// empty or fail to parse, so the event never carries a zero time.Time.
+		StartedAt:   ts,
+		CompletedAt: ts,
 	}
 	if a.Response != nil {
 		if b, err := json.Marshal(a.Response); err == nil {

--- a/pkg/fleetapi/action.go
+++ b/pkg/fleetapi/action.go
@@ -42,7 +42,10 @@ type Action interface {
 	fmt.Stringer
 	Type() string
 	ID() string
-	AckEvent() AckEvent
+	// AckEvent builds the ack event for this action, to be sent to fleet-server as part of an
+	// AckRequest. agentID and ts are injected here (rather than set on the returned value) because
+	// api.AckRequest_Events_Item is an opaque union type with no settable fields after construction.
+	AckEvent(agentID string, ts time.Time) api.AckRequest_Events_Item
 }
 
 // Actions is a slice of Actions to executes and allow to unmarshal
@@ -121,13 +124,28 @@ func NewAction(actionType string) Action {
 	return action
 }
 
-func newAckEvent(id, aType string) AckEvent {
-	return AckEvent{
-		EventType: "ACTION_RESULT",
-		SubType:   "ACKNOWLEDGED",
-		ActionID:  id,
+// newGenericEvent builds the common fields shared by every ack event.
+func newGenericEvent(id, aType, agentID string, ts time.Time) api.GenericEvent {
+	return api.GenericEvent{
+		Type:      api.ACTIONRESULT,
+		Subtype:   api.EventSubtypeACKNOWLEDGED,
+		ActionId:  id,
+		AgentId:   agentID,
+		Timestamp: ts,
 		Message:   fmt.Sprintf("Action %q of type %q acknowledged.", id, aType),
 	}
+}
+
+// toGenericAckEvent wraps a GenericEvent in the AckRequest_Events_Item union.
+func toGenericAckEvent(ev api.GenericEvent) api.AckRequest_Events_Item {
+	var item api.AckRequest_Events_Item
+	_ = item.FromGenericEvent(ev)
+	return item
+}
+
+// newAckEvent builds the default (no-error) ack event for actions with no additional fields to report.
+func newAckEvent(id, aType, agentID string, ts time.Time) api.AckRequest_Events_Item {
+	return toGenericAckEvent(newGenericEvent(id, aType, agentID, ts))
 }
 
 // ActionUnknown is an action that is not know by the current version of the Agent and we don't want
@@ -164,14 +182,11 @@ func (a *ActionUnknown) String() string {
 	return s.String()
 }
 
-func (a *ActionUnknown) AckEvent() AckEvent {
-	return AckEvent{
-		EventType: "ACTION_RESULT", // TODO Discuss EventType/SubType needed - by default only ACTION_RESULT was used - what is (or was) the intended purpose of these attributes? Are they documented? Can we change them to better support acking an error or a retry?
-		SubType:   "ACKNOWLEDGED",
-		ActionID:  a.ActionID,
-		Message:   fmt.Sprintf("Action %q of type %q acknowledged.", a.ActionID, a.ActionType),
-		Error:     fmt.Sprintf("Action %q of type %q is unknown to the elastic-agent", a.ActionID, a.OriginalType),
-	}
+func (a *ActionUnknown) AckEvent(agentID string, ts time.Time) api.AckRequest_Events_Item {
+	event := newGenericEvent(a.ActionID, a.ActionType, agentID, ts)
+	errStr := fmt.Sprintf("Action %q of type %q is unknown to the elastic-agent", a.ActionID, a.OriginalType)
+	event.Error = &errStr
+	return toGenericAckEvent(event)
 }
 
 // ActionPolicyReassign is a request to apply a new policy
@@ -204,8 +219,8 @@ func (a *ActionPolicyReassign) ID() string {
 	return a.ActionID
 }
 
-func (a *ActionPolicyReassign) AckEvent() AckEvent {
-	return newAckEvent(a.ActionID, a.ActionType)
+func (a *ActionPolicyReassign) AckEvent(agentID string, ts time.Time) api.AckRequest_Events_Item {
+	return newAckEvent(a.ActionID, a.ActionType, agentID, ts)
 }
 
 // ActionPolicyChange is a request to apply a new
@@ -238,8 +253,8 @@ func (a *ActionPolicyChange) ID() string {
 	return a.ActionID
 }
 
-func (a *ActionPolicyChange) AckEvent() AckEvent {
-	return newAckEvent(a.ActionID, a.ActionType)
+func (a *ActionPolicyChange) AckEvent(agentID string, ts time.Time) api.AckRequest_Events_Item {
+	return newAckEvent(a.ActionID, a.ActionType, agentID, ts)
 }
 
 // PolicyID returns the policy ID from the action's policy data, or "" if
@@ -300,24 +315,31 @@ func (a *ActionUpgrade) String() string {
 	return s.String()
 }
 
-func (a *ActionUpgrade) AckEvent() AckEvent {
-	event := newAckEvent(a.ActionID, a.ActionType)
+func (a *ActionUpgrade) AckEvent(agentID string, ts time.Time) api.AckRequest_Events_Item {
+	event := api.UpgradeEvent{
+		Type:      api.ACTIONRESULT,
+		Subtype:   api.EventSubtypeACKNOWLEDGED,
+		ActionId:  a.ActionID,
+		AgentId:   agentID,
+		Timestamp: ts,
+		Message:   fmt.Sprintf("Action %q of type %q acknowledged.", a.ActionID, a.ActionType),
+	}
 	if a.Err != nil {
 		// FIXME Do we want to change EventType/SubType here?
-		event.Error = a.Err.Error()
-		var payload struct {
-			Retry   bool `json:"retry"`
-			Attempt int  `json:"retry_attempt,omitempty"`
+		errStr := a.Err.Error()
+		event.Error = &errStr
+		// retry is set to -1 if it will not re attempt
+		event.Payload = &struct {
+			Retry        bool `json:"retry"`
+			RetryAttempt int  `json:"retry_attempt"`
+		}{
+			Retry:        a.Data.Retry >= 1,
+			RetryAttempt: a.Data.Retry,
 		}
-		payload.Retry = true
-		payload.Attempt = a.Data.Retry
-		if a.Data.Retry < 1 { // retry is set to -1 if it will not re attempt
-			payload.Retry = false
-		}
-		p, _ := json.Marshal(payload)
-		event.Payload = p
 	}
-	return event
+	var item api.AckRequest_Events_Item
+	_ = item.FromUpgradeEvent(event)
+	return item
 }
 
 // Type returns the type of the Action.
@@ -413,8 +435,8 @@ func (a *ActionUnenroll) ID() string {
 	return a.ActionID
 }
 
-func (a *ActionUnenroll) AckEvent() AckEvent {
-	return newAckEvent(a.ActionID, a.ActionType)
+func (a *ActionUnenroll) AckEvent(agentID string, ts time.Time) api.AckRequest_Events_Item {
+	return newAckEvent(a.ActionID, a.ActionType, agentID, ts)
 }
 
 // MarshalMap marshals ActionUnenroll into a corresponding map
@@ -499,12 +521,13 @@ func (a *ActionMigrate) MarshalMap() (map[string]interface{}, error) {
 	return res, err
 }
 
-func (a *ActionMigrate) AckEvent() AckEvent {
-	event := newAckEvent(a.ActionID, a.ActionType)
+func (a *ActionMigrate) AckEvent(agentID string, ts time.Time) api.AckRequest_Events_Item {
+	event := newGenericEvent(a.ActionID, a.ActionType, agentID, ts)
 	if a.Err != nil {
-		event.Error = a.Err.Error()
+		errStr := a.Err.Error()
+		event.Error = &errStr
 	}
-	return event
+	return toGenericAckEvent(event)
 }
 
 type ActionMigrateData struct {
@@ -518,8 +541,8 @@ type ActionMigrateData struct {
 	Settings json.RawMessage `json:"settings" yaml:"settings,omitempty"`
 }
 
-func (a *ActionSettings) AckEvent() AckEvent {
-	return newAckEvent(a.ActionID, a.ActionType)
+func (a *ActionSettings) AckEvent(agentID string, ts time.Time) api.AckRequest_Events_Item {
+	return newAckEvent(a.ActionID, a.ActionType, agentID, ts)
 }
 
 // ActionCancel is a request to cancel an action.
@@ -554,8 +577,8 @@ func (a *ActionCancel) String() string {
 	return s.String()
 }
 
-func (a *ActionCancel) AckEvent() AckEvent {
-	return newAckEvent(a.ActionID, a.ActionType)
+func (a *ActionCancel) AckEvent(agentID string, ts time.Time) api.AckRequest_Events_Item {
+	return newAckEvent(a.ActionID, a.ActionType, agentID, ts)
 }
 
 // ActionDiagnostics is a request to gather and upload a diagnostics bundle.
@@ -591,21 +614,28 @@ func (a *ActionDiagnostics) String() string {
 	return s.String()
 }
 
-func (a *ActionDiagnostics) AckEvent() AckEvent {
-	event := newAckEvent(a.ActionID, a.ActionType)
+func (a *ActionDiagnostics) AckEvent(agentID string, ts time.Time) api.AckRequest_Events_Item {
+	event := api.DiagnosticsEvent{
+		Type:      api.ACTIONRESULT,
+		Subtype:   api.EventSubtypeACKNOWLEDGED,
+		ActionId:  a.ActionID,
+		AgentId:   agentID,
+		Timestamp: ts,
+		Message:   fmt.Sprintf("Action %q of type %q acknowledged.", a.ActionID, a.ActionType),
+	}
 	if a.Err != nil {
-		event.Error = a.Err.Error()
+		errStr := a.Err.Error()
+		event.Error = &errStr
 	}
 	if a.UploadID != "" {
-		var data struct {
-			UploadID string `json:"upload_id"`
-		}
-		data.UploadID = a.UploadID
-		p, _ := json.Marshal(data)
-		event.Data = p
+		event.Data = &struct {
+			UploadId string `json:"upload_id"`
+		}{UploadId: a.UploadID}
 	}
 
-	return event
+	var item api.AckRequest_Events_Item
+	_ = item.FromDiagnosticsEvent(event)
+	return item
 }
 
 // ActionApp is the application action request.
@@ -643,19 +673,36 @@ func (a *ActionApp) Type() string {
 	return a.ActionType
 }
 
-func (a *ActionApp) AckEvent() AckEvent {
-	return AckEvent{
-		EventType:       "ACTION_RESULT",
-		SubType:         "ACKNOWLEDGED",
-		ActionID:        a.ActionID,
+func (a *ActionApp) AckEvent(agentID string, ts time.Time) api.AckRequest_Events_Item {
+	event := api.InputEvent{
+		Type:            api.ACTIONRESULT,
+		Subtype:         api.EventSubtypeACKNOWLEDGED,
+		ActionId:        a.ActionID,
+		AgentId:         agentID,
+		Timestamp:       ts,
 		Message:         fmt.Sprintf("Action %q of type %q acknowledged.", a.ActionID, a.ActionType),
 		ActionInputType: a.InputType,
 		ActionData:      a.Data,
-		ActionResponse:  a.Response,
-		StartedAt:       a.StartedAt,
-		CompletedAt:     a.CompletedAt,
-		Error:           a.Error,
 	}
+	if a.Response != nil {
+		if b, err := json.Marshal(a.Response); err == nil {
+			event.ActionResponse = b
+		}
+	}
+	if t, err := time.Parse(time.RFC3339Nano, a.StartedAt); err == nil {
+		event.StartedAt = t
+	}
+	if t, err := time.Parse(time.RFC3339Nano, a.CompletedAt); err == nil {
+		event.CompletedAt = t
+	}
+	if a.Error != "" {
+		errStr := a.Error
+		event.Error = &errStr
+	}
+
+	var item api.AckRequest_Events_Item
+	_ = item.FromInputEvent(event)
+	return item
 }
 
 func (a *ActionApp) Signed() *Signed {
@@ -696,12 +743,13 @@ func (a *ActionPrivilegeLevelChange) String() string {
 	return s.String()
 }
 
-func (a *ActionPrivilegeLevelChange) AckEvent() AckEvent {
-	event := newAckEvent(a.ActionID, a.ActionType)
+func (a *ActionPrivilegeLevelChange) AckEvent(agentID string, ts time.Time) api.AckRequest_Events_Item {
+	event := newGenericEvent(a.ActionID, a.ActionType, agentID, ts)
 	if a.Err != nil {
-		event.Error = a.Err.Error()
+		errStr := a.Err.Error()
+		event.Error = &errStr
 	}
-	return event
+	return toGenericAckEvent(event)
 }
 
 type ActionPrivilegeLevelChangeData struct {

--- a/testing/fleetservertest/fleetserver_test.go
+++ b/testing/fleetservertest/fleetserver_test.go
@@ -106,7 +106,7 @@ func TestRunFleetServer(t *testing.T) {
 
 		switch actionsIdx {
 		case 0:
-			return CheckinAction{
+			return CheckinAction{ //nolint:gosec // it's a test
 					AckToken: "tmpl.AckToken", Actions: []string{action.data}},
 				nil
 		}

--- a/testing/fleetservertest/fleetserver_test.go
+++ b/testing/fleetservertest/fleetserver_test.go
@@ -16,11 +16,35 @@ import (
 	"testing"
 	"time"
 
+	api "github.com/elastic/fleet-server/pkg/api"
+
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/pkg/ecsmeta"
 	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 )
+
+// newGenericAckEvent builds a generic ack event for tests that ack sample actions
+// not tied to a concrete pkgfleetapi.Action (the timestamp layout matches the
+// literal fixture strings used throughout this file).
+func newGenericAckEvent(actionID, agentID, timestamp, message string) api.AckRequest_Events_Item {
+	ts, err := time.Parse("2006-01-02T15:04:05.99999-07:00", timestamp)
+	if err != nil {
+		panic(fmt.Sprintf("could not parse timestamp %q: %v", timestamp, err))
+	}
+	var item api.AckRequest_Events_Item
+	if err := item.FromGenericEvent(api.GenericEvent{
+		Type:      api.ACTIONRESULT,
+		Subtype:   api.EventSubtypeACKNOWLEDGED,
+		ActionId:  actionID,
+		AgentId:   agentID,
+		Timestamp: ts,
+		Message:   message,
+	}); err != nil {
+		panic(fmt.Sprintf("could not build generic ack event: %v", err))
+	}
+	return item
+}
 
 // TestRunFleetServer shows how to configure and run a fleet-server capable of
 // enrolling and send actions to a single agent.
@@ -347,32 +371,23 @@ func ExampleNewServer_ack() {
 		agentInfo(agentID), sender{url: ts.URL, path: NewPathAgentAcks(agentID)})
 
 	respAck, err := cmdAck.Execute(context.Background(),
-		&fleetapi.AckRequest{Events: []fleetapi.AckEvent{
-			{
-				EventType: "ACTION_RESULT",
-				SubType:   "ACKNOWLEDGED",
-				Timestamp: "2022-12-01T01:02:03.00004-07:00",
-				ActionID:  actionID,
-				AgentID:   agentID,
-				Message: fmt.Sprintf("Action '%s' of type 'ACTION_TYPE' acknowledged.",
-					actionID),
-			},
-			{
-				EventType: "ACTION_RESULT",
-				SubType:   "ACKNOWLEDGED",
-				Timestamp: "2022-12-01T01:02:03.00004-07:00",
-				ActionID:  "not-received-on-checkin",
-				AgentID:   agentID,
-				Message: fmt.Sprintf("Action '%s' of type 'unknwon_action' acknowledged.",
-					"not-received-on-checkin"),
-			}}})
+		&fleetapi.AckRequest{Events: []api.AckRequest_Events_Item{
+			newGenericAckEvent(actionID, agentID, "2022-12-01T01:02:03.00004-07:00",
+				fmt.Sprintf("Action '%s' of type 'ACTION_TYPE' acknowledged.", actionID)),
+			newGenericAckEvent("not-received-on-checkin", agentID, "2022-12-01T01:02:03.00004-07:00",
+				fmt.Sprintf("Action '%s' of type 'unknwon_action' acknowledged.", "not-received-on-checkin")),
+		}})
 	if err != nil {
 		panic(fmt.Sprintf("failed executing checkin: %v", err))
 	}
-	fmt.Printf("%#v\n", respAck)
+	bs, err := json.Marshal(respAck)
+	if err != nil {
+		panic(fmt.Sprintf("could not marshal ack response: %v", err))
+	}
+	fmt.Println(string(bs))
 
 	// Output:
-	// &fleetapi.AckResponse{Action:"acks", Errors:false, Items:[]fleetapi.AckResponseItem{fleetapi.AckResponseItem{Status:200, Message:"OK"}, fleetapi.AckResponseItem{Status:200, Message:"OK"}}}
+	// {"action":"acks","items":[{"message":"OK","status":200},{"message":"OK","status":200}]}
 }
 
 func ExampleNewServer_enroll() {
@@ -625,32 +640,23 @@ func ExampleNewServer_ackWithAcker() {
 		agentInfo(agentID), sender{url: ts.URL, path: NewPathAgentAcks(agentID)})
 
 	respAck, err := cmdAck.Execute(context.Background(),
-		&fleetapi.AckRequest{Events: []fleetapi.AckEvent{
-			{
-				EventType: "ACTION_RESULT",
-				SubType:   "ACKNOWLEDGED",
-				Timestamp: "2022-12-01T01:02:03.00004-07:00",
-				ActionID:  actionID,
-				AgentID:   agentID,
-				Message: fmt.Sprintf("Action '%s' of type 'ACTION_TYPE' acknowledged.",
-					actionID),
-			},
-			{
-				EventType: "ACTION_RESULT",
-				SubType:   "ACKNOWLEDGED",
-				Timestamp: "2022-12-01T01:02:03.00004-07:00",
-				ActionID:  "not-received-on-checkin",
-				AgentID:   "invalid-action-id",
-				Message: fmt.Sprintf("Action '%s' of type 'unknwon_action' acknowledged.",
-					"not-received-on-checkin"),
-			}}})
+		&fleetapi.AckRequest{Events: []api.AckRequest_Events_Item{
+			newGenericAckEvent(actionID, agentID, "2022-12-01T01:02:03.00004-07:00",
+				fmt.Sprintf("Action '%s' of type 'ACTION_TYPE' acknowledged.", actionID)),
+			newGenericAckEvent("not-received-on-checkin", "invalid-action-id", "2022-12-01T01:02:03.00004-07:00",
+				fmt.Sprintf("Action '%s' of type 'unknwon_action' acknowledged.", "not-received-on-checkin")),
+		}})
 	if err != nil {
 		panic(fmt.Sprintf("failed executing checkin: %v", err))
 	}
-	fmt.Printf("%#v\n", respAck)
+	bs, err := json.Marshal(respAck)
+	if err != nil {
+		panic(fmt.Sprintf("could not marshal ack response: %v", err))
+	}
+	fmt.Println(string(bs))
 
 	// Output:
-	// &fleetapi.AckResponse{Action:"acks", Errors:true, Items:[]fleetapi.AckResponseItem{fleetapi.AckResponseItem{Status:200, Message:"OK"}, fleetapi.AckResponseItem{Status:404, Message:"action not-received-on-checkin not found"}}}
+	// {"action":"acks","errors":true,"items":[{"message":"OK","status":200},{"message":"action not-received-on-checkin not found","status":404}]}
 }
 
 // ExampleNewServer_checkin_and_ackWithAcker demonstrates how to assemble a
@@ -753,23 +759,24 @@ func ExampleNewServer_checkin_and_ackWithAcker() {
 	// 5th - Simulate the checkin -> ack flow by calling the checkin and ack
 	// commands in order
 
-	ackEventPolicyChange := fleetapi.AckEvent{
-		EventType: "ACTION_RESULT",
-		SubType:   "ACKNOWLEDGED",
-		Timestamp: "2022-12-01T01:02:03.00004-07:00",
-		ActionID:  actionID,
-		AgentID:   agentID,
-		Message: fmt.Sprintf("Action '%s' of type 'ACTION_TYPE' acknowledged.",
-			actionID),
+	ackEventPolicyChange := newGenericAckEvent(actionID, agentID, "2022-12-01T01:02:03.00004-07:00",
+		fmt.Sprintf("Action '%s' of type 'ACTION_TYPE' acknowledged.", actionID))
+
+	printAckResponse := func(prefix string, resp *fleetapi.AckResponse) {
+		bs, err := json.Marshal(resp)
+		if err != nil {
+			panic(fmt.Sprintf("could not marshal ack response: %v", err))
+		}
+		fmt.Printf("%s %s\n", prefix, string(bs))
 	}
 
 	// 1st ack: acking an action that haven't been sent
 	respAck, err := cmdAck.Execute(context.Background(),
-		&fleetapi.AckRequest{Events: []fleetapi.AckEvent{ackEventPolicyChange}})
+		&fleetapi.AckRequest{Events: []api.AckRequest_Events_Item{ackEventPolicyChange}})
 	if err != nil {
 		panic(fmt.Sprintf("failed executing checkin: %v", err))
 	}
-	fmt.Printf("[1st ack] %#v\n", respAck)
+	printAckResponse("[1st ack]", respAck)
 
 	// 1st checkin: it will return a POLICY_CHANGE.
 	// TODO: make the acker only ack if the checkin was called
@@ -781,11 +788,11 @@ func ExampleNewServer_checkin_and_ackWithAcker() {
 
 	// 2dn ack: acking the POLICY_CHANGE
 	respAck, err = cmdAck.Execute(context.Background(),
-		&fleetapi.AckRequest{Events: []fleetapi.AckEvent{ackEventPolicyChange}})
+		&fleetapi.AckRequest{Events: []api.AckRequest_Events_Item{ackEventPolicyChange}})
 	if err != nil {
 		panic(fmt.Sprintf("failed executing checkin: %v", err))
 	}
-	fmt.Printf("[2nd ack] %#v\n", respAck)
+	printAckResponse("[2nd ack]", respAck)
 
 	// 2nd checkin: it will fail.
 	_, _, err = cmdCheckin.Execute(context.Background(), &pkgfleetapi.CheckinRequest{})
@@ -796,27 +803,21 @@ func ExampleNewServer_checkin_and_ackWithAcker() {
 
 	// 3rd ack: acking an action not received during checkin
 	respAck, err = cmdAck.Execute(context.Background(),
-		&fleetapi.AckRequest{Events: []fleetapi.AckEvent{
-			{
-				EventType: "ACTION_RESULT",
-				SubType:   "ACKNOWLEDGED",
-				Timestamp: "2022-12-01T01:02:03.00004-07:00",
-				ActionID:  "not-received-on-checkin",
-				AgentID:   agentID,
-				Message: fmt.Sprintf("Action '%s' of type 'unknwon_action' acknowledged.",
-					"not-received-on-checkin"),
-			}}})
+		&fleetapi.AckRequest{Events: []api.AckRequest_Events_Item{
+			newGenericAckEvent("not-received-on-checkin", agentID, "2022-12-01T01:02:03.00004-07:00",
+				fmt.Sprintf("Action '%s' of type 'unknwon_action' acknowledged.", "not-received-on-checkin")),
+		}})
 	if err != nil {
 		panic(fmt.Sprintf("failed executing checkin: %v", err))
 	}
-	fmt.Printf("[3rd ack] %#v\n", respAck)
+	printAckResponse("[3rd ack]", respAck)
 
 	// Output:
-	// [1st ack] &fleetapi.AckResponse{Action:"acks", Errors:true, Items:[]fleetapi.AckResponseItem{fleetapi.AckResponseItem{Status:404, Message:"action anActionID not found"}}}
+	// [1st ack] {"action":"acks","errors":true,"items":[{"message":"action anActionID not found","status":404}]}
 	// [1st checkin] [id: anActionID, type: POLICY_CHANGE]
-	// [2nd ack] &fleetapi.AckResponse{Action:"acks", Errors:false, Items:[]fleetapi.AckResponseItem{fleetapi.AckResponseItem{Status:200, Message:"OK"}}}
+	// [2nd ack] {"action":"acks","items":[{"message":"OK","status":200}]}
 	// [2nd checkin] Error: status code: 418, fleet-server returned an error: I'm a teapot
-	// [3rd ack] &fleetapi.AckResponse{Action:"acks", Errors:true, Items:[]fleetapi.AckResponseItem{fleetapi.AckResponseItem{Status:404, Message:"action not-received-on-checkin not found"}}}
+	// [3rd ack] {"action":"acks","errors":true,"items":[{"message":"action not-received-on-checkin not found","status":404}]}
 }
 
 type agentInfo string


### PR DESCRIPTION
<!-- Type of change: Cleanup -->

## What does this PR do?

Replaces the local flat `AckEvent` struct in `pkg/fleetapi` with fleet-server's published union types (`GenericEvent`, `UpgradeEvent`, `DiagnosticsEvent`, `InputEvent` via `AckRequest_Events_Item`). `Action.AckEvent()` now takes `(agentID string, ts time.Time)` and returns `api.AckRequest_Events_Item` directly — the union wrapper has no settable fields after construction, so these can no longer be set by the caller after the fact as they were previously. All 11 concrete action types, `AckCmd`, the fleet acker, retrier, and lazy acker are updated accordingly. `pkg/fleetapi/ack.go` now just re-exports `AckRequest`/`AckResponse`/`AckResponseItem` as aliases of fleet-server's `api` types.

The emitted JSON is unchanged for all fields the flat struct previously had (`omitempty` behavior preserved) — the one new-vs-old difference is that `InputEvent`'s generated fields (`action_data`, `action_response`, `started_at`, `completed_at`) don't have `omitempty` in fleet-server's spec, so they're always present for `ActionApp` acks, matching the actual contract rather than our previous ad hoc omission.

## Why is it important?

Agent and Horde both ack fleet actions with the same flat, hand-maintained `AckEvent` struct rather than fleet-server's published contract. This is the last item of elastic/ingest-dev#7601 ("share Fleet Server interaction code between Elastic Agent and Horde") — full alignment with fleet-server's `pkg/api` means both consumers get any future ack-shape changes for free instead of drifting.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~ (internal-only refactor, no user-facing/wire behavior change)
- [ ] ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None. Pure internal refactor — wire format is unchanged (see note above re: `InputEvent`'s always-present fields, which is a spec-alignment fix, not a behavior change agents will notice).

## How to test this PR locally

```
go build ./...
go vet ./...
go test ./pkg/fleetapi/... ./internal/pkg/fleetapi/...
grep -n "AckEvent{" pkg/ internal/  # should return empty
```

## Related issues

- Relates elastic/ingest-dev#7601 (item 7)