### PR TITLE
Permit context cancelled error message in TestMonitoringLogsAreShipped

### DIFF
--- a/testing/integration/common_logs_ingestion.go
+++ b/testing/integration/common_logs_ingestion.go
@@ -249,6 +249,7 @@ func TestMonitoringLogsAreShipped(
 			"elastic-agent-client error: rpc error: code = Canceled desc = context canceled",               // can happen on restart
 			"failed to invoke rollback watcher: starting watcher process: failed to start Upgrade Watcher", // on debian/rpm package installs the binary symlink at Top() doesn't exist
 			"falling back to IMDSv1: operation error ec2imds: getToken",                                    // okay for the cloud metadata to not work
+			"context cancelled",                 // can happen on restar
 			"bulk indexer flush error",          // can happen on restart (caused by context canceled)
 			"Exporting failed. Dropping data.",  // can happen on restart (caused by context canceled)
 			"Exporting failed. Rejecting data.", // can happen on restart (caused by context canceled)


### PR DESCRIPTION
We can get this error message when the elasticmonitoring connector has its consume call cancelled. See https://buildkite.com/elastic/elastic-agent/builds/42312/canvas?jid=019f205f-8110-4e69-88a6-269ea88834c1&tab=output.