### PR TITLE
Emit a single batch from elasticmonitoring connector

### DIFF
--- a/internal/edot/connectors/elasticmonitoring/connector.go
+++ b/internal/edot/connectors/elasticmonitoring/connector.go
@@ -49,8 +49,7 @@ func (c *monitoringConnector) Capabilities() consumer.Capabilities {
 }
 
 // ConsumeMetrics converts all monitoring metrics to Beats-format log records and
-// forwards them as a single ConsumeLogs call. Batching all records into one call
-// avoids per-document blocking in the downstream pipeline (e.g. ES exporter retries).
+// forwards them as a single ConsumeLogs call.
 func (c *monitoringConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 	pLogs := plog.NewLogs()
 	resourceLogs := pLogs.ResourceLogs().AppendEmpty()
@@ -59,42 +58,12 @@ func (c *monitoringConnector) ConsumeMetrics(ctx context.Context, md pmetric.Met
 
 	now := time.Now()
 
-	exporterMetricsMap := convertScopeMetrics(md)
-	for exporter, metrics := range exporterMetricsMap {
-		componentID, ok := c.config.ExporterNames[exporter]
-		if !ok {
-			c.logger.Warn("Reporting metrics for exporter with no specified component name", zap.String("exporter_id", exporter))
-			componentID = exporter
-		}
-		beatEvent := mapstr.M(c.config.EventTemplate.Fields).Clone()
-		addMetricsToEventFields(c.logger, metrics, &beatEvent)
-		_, _ = beatEvent.Put("component.id", componentID)
-		c.appendLogRecord(scopeLogs, beatEvent, now)
-	}
+	var beatEvents []mapstr.M
+	beatEvents = append(beatEvents, buildExporterEvents(c.logger, c.config, md)...)
+	beatEvents = append(beatEvents, buildInputEvents(c.config, md)...)
+	beatEvents = append(beatEvents, buildReceiverPipelineEvents(c.config, md)...)
 
-	componentMetrics := collectComponentInputMetrics(md)
-	for compID, compData := range componentMetrics {
-		if compData.beatType != "filebeat" {
-			continue
-		}
-		for _, inputMetrics := range compData.inputs {
-			beatEvent := mapstr.M(c.config.InputEventTemplate.Fields).Clone()
-			_, _ = beatEvent.Put("component.id", compID)
-			namespace := compData.beatType + "_input"
-			for k, v := range inputMetrics {
-				_, _ = beatEvent.Put(namespace+"."+k, v)
-			}
-			c.appendLogRecord(scopeLogs, beatEvent, now)
-		}
-	}
-
-	receiverPipelineMetrics := collectReceiverMetrics(md)
-	for compID, fields := range receiverPipelineMetrics {
-		beatEvent := mapstr.M(c.config.EventTemplate.Fields).Clone()
-		_, _ = beatEvent.Put("component.id", compID)
-		for k, v := range fields {
-			_, _ = beatEvent.Put(k, v)
-		}
+	for _, beatEvent := range beatEvents {
 		c.appendLogRecord(scopeLogs, beatEvent, now)
 	}
 
@@ -106,6 +75,64 @@ func (c *monitoringConnector) ConsumeMetrics(ctx context.Context, md pmetric.Met
 		c.logger.Error("error sending internal telemetry log records", zap.Error(err))
 	}
 	return nil
+}
+
+// buildExporterEvents builds one Beats-format monitoring event per exporter
+// reporting metrics in md, using cfg.EventTemplate for static fields and
+// cfg.ExporterNames to resolve the agent component name.
+func buildExporterEvents(logger *zap.Logger, cfg *Config, md pmetric.Metrics) []mapstr.M {
+	exporterMetricsMap := convertScopeMetrics(md)
+	events := make([]mapstr.M, 0, len(exporterMetricsMap))
+	for exporter, metrics := range exporterMetricsMap {
+		componentID, ok := cfg.ExporterNames[exporter]
+		if !ok {
+			logger.Warn("Reporting metrics for exporter with no specified component name", zap.String("exporter_id", exporter))
+			componentID = exporter
+		}
+		beatEvent := mapstr.M(cfg.EventTemplate.Fields).Clone()
+		addMetricsToEventFields(logger, metrics, &beatEvent)
+		_, _ = beatEvent.Put("component.id", componentID)
+		events = append(events, beatEvent)
+	}
+	return events
+}
+
+// buildInputEvents builds one Beats-format monitoring event per filebeat input
+// reporting metrics in md, using cfg.InputEventTemplate for static fields.
+func buildInputEvents(cfg *Config, md pmetric.Metrics) []mapstr.M {
+	var events []mapstr.M
+	for compID, compData := range collectComponentInputMetrics(md) {
+		if compData.beatType != "filebeat" {
+			continue
+		}
+		for _, inputMetrics := range compData.inputs {
+			beatEvent := mapstr.M(cfg.InputEventTemplate.Fields).Clone()
+			_, _ = beatEvent.Put("component.id", compID)
+			namespace := compData.beatType + "_input"
+			for k, v := range inputMetrics {
+				_, _ = beatEvent.Put(namespace+"."+k, v)
+			}
+			events = append(events, beatEvent)
+		}
+	}
+	return events
+}
+
+// buildReceiverPipelineEvents builds one Beats-format monitoring event per
+// component reporting RegistryBridge pipeline metrics in md, using
+// cfg.EventTemplate for static fields.
+func buildReceiverPipelineEvents(cfg *Config, md pmetric.Metrics) []mapstr.M {
+	receiverPipelineMetrics := collectReceiverMetrics(md)
+	events := make([]mapstr.M, 0, len(receiverPipelineMetrics))
+	for compID, fields := range receiverPipelineMetrics {
+		beatEvent := mapstr.M(cfg.EventTemplate.Fields).Clone()
+		_, _ = beatEvent.Put("component.id", compID)
+		for k, v := range fields {
+			_, _ = beatEvent.Put(k, v)
+		}
+		events = append(events, beatEvent)
+	}
+	return events
 }
 
 func (c *monitoringConnector) appendLogRecord(scopeLogs plog.ScopeLogs, beatEvent mapstr.M, now time.Time) {

--- a/internal/edot/connectors/elasticmonitoring/connector.go
+++ b/internal/edot/connectors/elasticmonitoring/connector.go
@@ -48,7 +48,17 @@ func (c *monitoringConnector) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
+// ConsumeMetrics converts all monitoring metrics to Beats-format log records and
+// forwards them as a single ConsumeLogs call. Batching all records into one call
+// avoids per-document blocking in the downstream pipeline (e.g. ES exporter retries).
 func (c *monitoringConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	pLogs := plog.NewLogs()
+	resourceLogs := pLogs.ResourceLogs().AppendEmpty()
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	scopeLogs.Scope().Attributes().PutStr("elastic.mapping.mode", "bodymap")
+
+	now := time.Now()
+
 	exporterMetricsMap := convertScopeMetrics(md)
 	for exporter, metrics := range exporterMetricsMap {
 		componentID, ok := c.config.ExporterNames[exporter]
@@ -56,7 +66,10 @@ func (c *monitoringConnector) ConsumeMetrics(ctx context.Context, md pmetric.Met
 			c.logger.Warn("Reporting metrics for exporter with no specified component name", zap.String("exporter_id", exporter))
 			componentID = exporter
 		}
-		c.sendExporterMetricsEvent(ctx, componentID, metrics)
+		beatEvent := mapstr.M(c.config.EventTemplate.Fields).Clone()
+		addMetricsToEventFields(c.logger, metrics, &beatEvent)
+		_, _ = beatEvent.Put("component.id", componentID)
+		c.appendLogRecord(scopeLogs, beatEvent, now)
 	}
 
 	componentMetrics := collectComponentInputMetrics(md)
@@ -65,54 +78,39 @@ func (c *monitoringConnector) ConsumeMetrics(ctx context.Context, md pmetric.Met
 			continue
 		}
 		for _, inputMetrics := range compData.inputs {
-			c.sendInputMetricsEvent(ctx, compID, compData.beatType, inputMetrics)
+			beatEvent := mapstr.M(c.config.InputEventTemplate.Fields).Clone()
+			_, _ = beatEvent.Put("component.id", compID)
+			namespace := compData.beatType + "_input"
+			for k, v := range inputMetrics {
+				_, _ = beatEvent.Put(namespace+"."+k, v)
+			}
+			c.appendLogRecord(scopeLogs, beatEvent, now)
 		}
 	}
 
 	receiverPipelineMetrics := collectReceiverMetrics(md)
 	for compID, fields := range receiverPipelineMetrics {
-		c.sendReceiverPipelineMetricsEvent(ctx, compID, fields)
+		beatEvent := mapstr.M(c.config.EventTemplate.Fields).Clone()
+		_, _ = beatEvent.Put("component.id", compID)
+		for k, v := range fields {
+			_, _ = beatEvent.Put(k, v)
+		}
+		c.appendLogRecord(scopeLogs, beatEvent, now)
 	}
 
+	if pLogs.LogRecordCount() == 0 {
+		return nil
+	}
+
+	if err := c.consumer.ConsumeLogs(ctx, pLogs); err != nil {
+		c.logger.Error("error sending internal telemetry log records", zap.Error(err))
+	}
 	return nil
 }
 
-func (c *monitoringConnector) sendExporterMetricsEvent(ctx context.Context, componentID string, metrics exporterMetrics) {
-	beatEvent := mapstr.M(c.config.EventTemplate.Fields).Clone()
-	addMetricsToEventFields(c.logger, metrics, &beatEvent)
-	_, _ = beatEvent.Put("component.id", componentID)
-	c.sendLogRecord(ctx, beatEvent, componentID)
-}
+func (c *monitoringConnector) appendLogRecord(scopeLogs plog.ScopeLogs, beatEvent mapstr.M, now time.Time) {
+	logRecord := scopeLogs.LogRecords().AppendEmpty()
 
-func (c *monitoringConnector) sendReceiverPipelineMetricsEvent(ctx context.Context, componentID string, fields map[string]any) {
-	beatEvent := mapstr.M(c.config.EventTemplate.Fields).Clone()
-	_, _ = beatEvent.Put("component.id", componentID)
-	for k, v := range fields {
-		_, _ = beatEvent.Put(k, v)
-	}
-	c.sendLogRecord(ctx, beatEvent, componentID)
-}
-
-func (c *monitoringConnector) sendInputMetricsEvent(ctx context.Context, componentID string, beatType string, inputMetrics map[string]any) {
-	beatEvent := mapstr.M(c.config.InputEventTemplate.Fields).Clone()
-	_, _ = beatEvent.Put("component.id", componentID)
-	namespace := beatType + "_input"
-	for k, v := range inputMetrics {
-		_, _ = beatEvent.Put(namespace+"."+k, v)
-	}
-	c.sendLogRecord(ctx, beatEvent, componentID)
-}
-
-func (c *monitoringConnector) sendLogRecord(ctx context.Context, beatEvent mapstr.M, componentID string) {
-	pLogs := plog.NewLogs()
-	resourceLogs := pLogs.ResourceLogs().AppendEmpty()
-	sourceLogs := resourceLogs.ScopeLogs().AppendEmpty()
-	logRecords := sourceLogs.LogRecords()
-	logRecord := logRecords.AppendEmpty()
-
-	sourceLogs.Scope().Attributes().PutStr("elastic.mapping.mode", "bodymap")
-
-	now := time.Now()
 	beatEvent["@timestamp"] = now
 	timestamp := pcommon.NewTimestampFromTime(now)
 	logRecord.SetTimestamp(timestamp)
@@ -129,9 +127,5 @@ func (c *monitoringConnector) sendLogRecord(ctx context.Context, beatEvent mapst
 
 	if err := otelmap.FromMapstr(logRecord.Body().SetEmptyMap(), beatEvent); err != nil {
 		c.logger.Error("couldn't convert map to plog.Log, some fields might be missing", zap.Error(err))
-	}
-
-	if err := c.consumer.ConsumeLogs(ctx, pLogs); err != nil {
-		c.logger.Error("error sending internal telemetry log record", zap.String("component.id", componentID), zap.Error(err))
 	}
 }

--- a/internal/edot/connectors/elasticmonitoring/connector.go
+++ b/internal/edot/connectors/elasticmonitoring/connector.go
@@ -58,12 +58,18 @@ func (c *monitoringConnector) ConsumeMetrics(ctx context.Context, md pmetric.Met
 
 	now := time.Now()
 
-	var beatEvents []mapstr.M
-	beatEvents = append(beatEvents, buildExporterEvents(c.logger, c.config, md)...)
-	beatEvents = append(beatEvents, buildInputEvents(c.config, md)...)
-	beatEvents = append(beatEvents, buildReceiverPipelineEvents(c.config, md)...)
+	// exporter events
+	for _, beatEvent := range buildInputEvents(c.config, md) {
+		c.appendLogRecord(scopeLogs, beatEvent, now)
+	}
 
-	for _, beatEvent := range beatEvents {
+	// input events
+	for _, beatEvent := range buildExporterEvents(c.logger, c.config, md) {
+		c.appendLogRecord(scopeLogs, beatEvent, now)
+	}
+
+	// receiver pipeline events
+	for _, beatEvent := range buildReceiverPipelineEvents(c.config, md) {
 		c.appendLogRecord(scopeLogs, beatEvent, now)
 	}
 

--- a/internal/edot/connectors/elasticmonitoring/connector_test.go
+++ b/internal/edot/connectors/elasticmonitoring/connector_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.uber.org/zap"
+
+	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
 func newTestConnector(sink *consumertest.LogsSink) *monitoringConnector {
@@ -25,8 +27,7 @@ func newTestConnector(sink *consumertest.LogsSink) *monitoringConnector {
 // TestConsumeMetrics_SingleBatchedConsumeLogsCall verifies that all monitoring
 // events derived from one ConsumeMetrics call (exporter, input, and receiver
 // pipeline metrics) are forwarded in a single ConsumeLogs call rather than one
-// call per event. The downstream ES exporter is slow (network round-trip per
-// call), so batching avoids blocking once per component on every cycle.
+// call per event.
 func TestConsumeMetrics_SingleBatchedConsumeLogsCall(t *testing.T) {
 	const exporterID = "elasticsearch/_agent-component/monitoring"
 	md, sm := newMetricsWithExporterScope(exporterID)
@@ -46,7 +47,7 @@ func TestConsumeMetrics_SingleBatchedConsumeLogsCall(t *testing.T) {
 	c := newTestConnector(sink)
 	c.config.ExporterNames = map[string]string{exporterID: "monitoring"}
 
-	require.NoError(t, c.ConsumeMetrics(context.Background(), md))
+	require.NoError(t, c.ConsumeMetrics(t.Context(), md))
 
 	assert.Len(t, sink.AllLogs(), 1, "expected exactly one ConsumeLogs call, all events should be batched together")
 	assert.Equal(t, 3, sink.LogRecordCount(), "expected one log record per generated monitoring event")
@@ -64,4 +65,78 @@ func TestConsumeMetrics_NoData(t *testing.T) {
 	require.NoError(t, c.ConsumeMetrics(context.Background(), md))
 
 	assert.Empty(t, sink.AllLogs())
+}
+
+// eventValue looks up a dotted field path in a Beats-format event, the same
+// way mapstr.M.Put interprets the paths used to build these events.
+func eventValue(t *testing.T, event mapstr.M, key string) any {
+	t.Helper()
+	val, err := event.GetValue(key)
+	require.NoError(t, err, "key %q not found in event", key)
+	return val
+}
+
+func TestBuildExporterEvents(t *testing.T) {
+	const exporterID = "elasticsearch/_agent-component/monitoring"
+	md, sm := newMetricsWithExporterScope(exporterID)
+	appendGaugeInt(sm, otelQueueCapacityKey, 100)
+
+	cfg := &Config{ExporterNames: map[string]string{exporterID: "monitoring"}}
+
+	events := buildExporterEvents(zap.NewNop(), cfg, md)
+
+	require.Len(t, events, 1)
+	assert.Equal(t, "monitoring", eventValue(t, events[0], "component.id"))
+	assert.Equal(t, int64(100), eventValue(t, events[0], "beat.stats.libbeat.pipeline.queue.max_events"))
+}
+
+func TestBuildExporterEvents_UnknownExporterFallsBackToExporterID(t *testing.T) {
+	const exporterID = "elasticsearch/_agent-component/monitoring"
+	md, sm := newMetricsWithExporterScope(exporterID)
+	appendGaugeInt(sm, otelQueueCapacityKey, 1)
+
+	events := buildExporterEvents(zap.NewNop(), &Config{}, md)
+
+	require.Len(t, events, 1)
+	assert.Equal(t, exporterID, eventValue(t, events[0], "component.id"))
+}
+
+func TestBuildInputEvents(t *testing.T) {
+	md, sm := newMetricsWithReceiverScope(fbreceiverScopeName, "filebeatreceiver/_agent-component/filebeat-default")
+	appendGaugeIntWithAttrs(sm, "beat.input.events.published", 42, otelInputIDKey, "logs.my-input")
+
+	events := buildInputEvents(&Config{}, md)
+
+	require.Len(t, events, 1)
+	assert.Equal(t, "filebeat-default", eventValue(t, events[0], "component.id"))
+	assert.Equal(t, int64(42), eventValue(t, events[0], "filebeat_input.beat.input.events.published"))
+}
+
+func TestBuildInputEvents_IgnoresNonFilebeatComponents(t *testing.T) {
+	md, sm := newMetricsWithReceiverScope(mbreceiverScopeName, "metricbeatreceiver/_agent-component/metricbeat-default")
+	appendGaugeIntWithAttrs(sm, "beat.input.events.published", 1, otelInputIDKey, "some-input")
+
+	events := buildInputEvents(&Config{}, md)
+
+	assert.Empty(t, events)
+}
+
+func TestBuildReceiverPipelineEvents(t *testing.T) {
+	const receiverID = "filebeatreceiver/_agent-component/filestream-default"
+	md, sm := newMetricsWithRegistryBridgeScope()
+	appendSumIntWithAttrs(sm, "libbeat.output.events.acked", 7, registryBridgeReceiverKey, receiverID)
+
+	events := buildReceiverPipelineEvents(&Config{}, md)
+
+	require.Len(t, events, 1)
+	assert.Equal(t, "filestream-default", eventValue(t, events[0], "component.id"))
+	assert.Equal(t, int64(7), eventValue(t, events[0], "beat.stats.filebeat.libbeat.output.events.acked"))
+}
+
+func TestBuildReceiverPipelineEvents_NoData(t *testing.T) {
+	md, _ := newMetricsWithScope("some.unrelated.scope")
+
+	events := buildReceiverPipelineEvents(&Config{}, md)
+
+	assert.Empty(t, events)
 }

--- a/internal/edot/connectors/elasticmonitoring/connector_test.go
+++ b/internal/edot/connectors/elasticmonitoring/connector_test.go
@@ -1,0 +1,67 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package elasticmonitoring
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.uber.org/zap"
+)
+
+func newTestConnector(sink *consumertest.LogsSink) *monitoringConnector {
+	return &monitoringConnector{
+		logger:   zap.NewNop(),
+		config:   &Config{},
+		consumer: sink,
+	}
+}
+
+// TestConsumeMetrics_SingleBatchedConsumeLogsCall verifies that all monitoring
+// events derived from one ConsumeMetrics call (exporter, input, and receiver
+// pipeline metrics) are forwarded in a single ConsumeLogs call rather than one
+// call per event. The downstream ES exporter is slow (network round-trip per
+// call), so batching avoids blocking once per component on every cycle.
+func TestConsumeMetrics_SingleBatchedConsumeLogsCall(t *testing.T) {
+	const exporterID = "elasticsearch/_agent-component/monitoring"
+	md, sm := newMetricsWithExporterScope(exporterID)
+	appendGaugeInt(sm, otelQueueCapacityKey, 100)
+
+	appendScopeToMetrics(md, fbreceiverScopeName,
+		otelComponentKindKey, "receiver",
+		otelComponentIDKey, "filebeatreceiver/_agent-component/filebeat-default",
+	)
+	inputSM := md.ResourceMetrics().At(0).ScopeMetrics().At(1)
+	appendGaugeIntWithAttrs(inputSM, "beat.input.events.published", 42, otelInputIDKey, "logs.my-input")
+
+	registrySM := appendScopeToMetrics(md, registryBridgeScopeName)
+	appendSumIntWithAttrs(registrySM, "libbeat.output.events.acked", 7, registryBridgeReceiverKey, "filebeatreceiver/_agent-component/filestream-default")
+
+	sink := &consumertest.LogsSink{}
+	c := newTestConnector(sink)
+	c.config.ExporterNames = map[string]string{exporterID: "monitoring"}
+
+	require.NoError(t, c.ConsumeMetrics(context.Background(), md))
+
+	assert.Len(t, sink.AllLogs(), 1, "expected exactly one ConsumeLogs call, all events should be batched together")
+	assert.Equal(t, 3, sink.LogRecordCount(), "expected one log record per generated monitoring event")
+}
+
+// TestConsumeMetrics_NoData verifies that ConsumeMetrics doesn't call
+// ConsumeLogs at all when there's nothing to report, rather than sending an
+// empty batch.
+func TestConsumeMetrics_NoData(t *testing.T) {
+	md, _ := newMetricsWithScope("some.unrelated.scope")
+
+	sink := &consumertest.LogsSink{}
+	c := newTestConnector(sink)
+
+	require.NoError(t, c.ConsumeMetrics(context.Background(), md))
+
+	assert.Empty(t, sink.AllLogs())
+}


### PR DESCRIPTION
## What does this PR do?

In the elasticmonitoring connector, instead of emitting every event in a separate consumeMetrics call, batches all of them together. 

Refactors the consume call to be more modular and adds some basic tests.

## Why is it important?

This is more efficient and plays better with exporter batching. After the switch to receiver-per-stream in https://github.com/elastic/elastic-agent/pull/13000, we have a lot more metric samples, so sending them one by one becomes more of a performance problem.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
