### PR TITLE
Switch osquerybeat to run as a receiver by default.

### DIFF
--- a/changelog/fragments/1783021378-run-osquery-inputs-as-collector-receivers-by-default.yaml
+++ b/changelog/fragments/1783021378-run-osquery-inputs-as-collector-receivers-by-default.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Run osquery inputs as collector receivers by default, reducing steady state memory usage.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "elastic-agent"
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -77,6 +77,7 @@ func DefaultRuntimeConfig() *RuntimeConfig {
 			InputType: map[string]string{},
 		},
 		Osquerybeat: BeatRuntimeConfig{
+			Default: string(OtelRuntimeManager),
 			// go-ucfg sets this while unpacking, having it in the default makes testing easier
 			InputType: make(map[string]string),
 		},

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -4287,7 +4287,7 @@ func TestDefaultRuntimeConfig(t *testing.T) {
 	assert.Empty(t, config.Heartbeat.InputType)
 	assert.Equal(t, string(OtelRuntimeManager), config.Metricbeat.Default)
 	assert.Equal(t, map[string]string{}, config.Metricbeat.InputType)
-	assert.Equal(t, "", config.Osquerybeat.Default)
+	assert.Equal(t, "otel", config.Osquerybeat.Default)
 	assert.Empty(t, config.Osquerybeat.InputType)
 	assert.Equal(t, string(OtelRuntimeManager), config.Packetbeat.Default)
 	assert.Empty(t, config.Packetbeat.InputType)

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -144,25 +144,12 @@ func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 
 	testStart := time.Now()
 
-	// Validate process mode
-	var processDoc mapstr.M
-	t.Run("process", func(t *testing.T) {
-		processDoc = runner.validateOsqueryEvents(t, ctx, agentStatus.Info.ID, testStart)
-	})
-
-	// Switch to OTel runtime and validate the same data
+	// Validate OTel mode (the default for osquerybeat).
 	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
-		otelSince := time.Now()
-		policyRevision := switchPolicyToOtelRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
-
-		// Wait for the agent to apply the new policy revision
-		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
-			5*time.Minute, time.Second)
-
 		// Verify that an osquery component is running as a beats receiver.
-		// The component may not appear immediately after the policy switch, so we
-		// look for it inside the loop rather than capturing its ID up front.
+		// The component may not appear immediately after startup, so we look
+		// for it inside the loop rather than capturing its ID up front.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			status, statusErr := runner.agentFixture.ExecStatus(ctx)
 			require.NoError(collect, statusErr)
@@ -179,14 +166,68 @@ func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 			assert.True(collect, foundReceiver, "expected an osquery component to be running as beats receiver")
 		}, 2*time.Minute, 5*time.Second, "beat component should be running as beats receiver")
 
-		otelDoc = runner.validateOsqueryEvents(t, ctx, agentStatus.Info.ID, otelSince)
+		otelDoc = runner.validateOsqueryEvents(t, ctx, agentStatus.Info.ID, testStart)
 	})
 
-	// Compare documents from process and otel modes have the same keys
+	// Switch to process runtime and validate the same data.
+	var processDoc mapstr.M
+	t.Run("process", func(t *testing.T) {
+		processSince := time.Now()
+		policyRevision := switchOsquerybeatToProcessRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
+
+		// Wait for the agent to apply the new policy revision.
+		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
+			5*time.Minute, time.Second)
+
+		// Verify that the osquery component has switched to process mode.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			status, statusErr := runner.agentFixture.ExecStatus(ctx)
+			require.NoError(collect, statusErr)
+			var foundProcess bool
+			for _, comp := range status.Components {
+				if strings.HasPrefix(comp.ID, "osquery") &&
+					comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.ProcessRuntimeManager) {
+					assert.Equal(collect, int(cproto.State_HEALTHY), comp.State,
+						"expected osquery component to be healthy, got %s", cproto.State(comp.State))
+					foundProcess = true
+					break
+				}
+			}
+			assert.True(collect, foundProcess, "expected an osquery component to be running as a process")
+		}, 2*time.Minute, 5*time.Second, "beat component should be running as a process")
+
+		processDoc = runner.validateOsqueryEvents(t, ctx, agentStatus.Info.ID, processSince)
+	})
+
+	// Compare documents from otel and process modes have the same keys.
 	t.Run("compare", func(t *testing.T) {
-		if processDoc == nil || otelDoc == nil {
+		if otelDoc == nil || processDoc == nil {
 			t.Skip("skipping comparison because a previous subtest failed")
 		}
-		AssertMapstrKeysEqual(t, processDoc, otelDoc, RuntimeComparisonIgnoredFields, "expected osquery document keys to be equal between process and otel modes")
+		AssertMapstrKeysEqual(t, otelDoc, processDoc, RuntimeComparisonIgnoredFields, "expected osquery document keys to be equal between otel and process modes")
 	})
+}
+
+// switchOsquerybeatToProcessRuntime updates the given policy to override the
+// osquerybeat runtime to process and returns the new policy revision.
+func switchOsquerybeatToProcessRuntime(ctx context.Context, t testing.TB, kibanaClient *kibana.Client, policyID, policyName, namespace string) int {
+	t.Helper()
+	updateReq := kibana.AgentPolicyUpdateRequest{
+		Name:      policyName,
+		Namespace: namespace,
+		Overrides: map[string]interface{}{
+			"agent": map[string]interface{}{
+				"internal": map[string]interface{}{
+					"runtime": map[string]interface{}{
+						"osquerybeat": map[string]interface{}{
+							"default": "process",
+						},
+					},
+				},
+			},
+		},
+	}
+	policyResp, err := kibanaClient.UpdatePolicy(ctx, policyID, updateReq)
+	require.NoError(t, err)
+	return policyResp.Revision
 }


### PR DESCRIPTION
- Closes https://github.com/elastic/elastic-agent/issues/14555
- Closes https://github.com/elastic/ingest-dev/issues/7384
- Relates https://github.com/elastic/beats/pull/51160

Have osquerybeat run as a receiver by default. Memory usage when running as a receiver with the system integration drops to ~167M similar to the results we got with auditbeat running as a receiver.

Memory Usage Before:

```
ubuntu@ubuntu:~/elastic-agent-9.5.0-SNAPSHOT-linux-arm64$ sudo systemctl status elastic-agent
● elastic-agent.service - Elastic Agent is a unified agent to observe, monitor and protect your system.
     Loaded: loaded (/etc/systemd/system/elastic-agent.service; enabled; preset: enabled)
     Active: active (running) since Fri 2026-07-03 15:25:05 EDT; 2min 12s ago
   Main PID: 246036 (elastic-agent)
      Tasks: 48 (limit: 1056)
     Memory: 306.8M (peak: 309.3M)
        CPU: 4.299s
     CGroup: /system.slice/elastic-agent.service
             ├─246036 /opt/Elastic/Agent/elastic-agent
             ├─246051 /opt/Elastic/Agent/data/elastic-agent-9.5.0-SNAPSHOT-c5bdc4/components/elastic-ot>
             ├─246052 /opt/Elastic/Agent/data/elastic-agent-9.5.0-SNAPSHOT-c5bdc4/components/elastic-ot>
             ├─246071 /opt/Elastic/Agent/data/elastic-agent-9.5.0-SNAPSHOT-c5bdc4/components/osqueryd ->
             └─246073 /opt/Elastic/Agent/data/elastic-agent-9.5.0-SNAPSHOT-c5bdc4/components/osquery-ex>

Jul 03 15:25:05 ubuntu systemd[1]: Started elastic-agent.service - Elastic Agent is a unified agent to >
Jul 03 15:25:07 ubuntu osqueryd[246071]: osqueryd started [version=5.23.0]
```

Memory usage after:
```
● elastic-agent.service - Elastic Agent is a unified agent to observe, monitor and protect your system.
     Loaded: loaded (/etc/systemd/system/elastic-agent.service; enabled; preset: enabled)
     Active: active (running) since Fri 2026-07-03 15:20:59 EDT; 1min 57s ago
   Main PID: 245401 (elastic-agent)
      Tasks: 34 (limit: 1056)
     Memory: 167.0M (peak: 176.6M)
        CPU: 5.439s
     CGroup: /system.slice/elastic-agent.service
             ├─245401 /opt/Elastic/Agent/elastic-agent
             ├─245414 /opt/Elastic/Agent/data/elastic-agent-9.5.0-SNAPSHOT-c5bdc4/components/elastic-ot>
             └─245594 /opt/Elastic/Agent/data/elastic-agent-9.5.0-SNAPSHOT-c5bdc4/components/osqueryd ->

Jul 03 15:20:59 ubuntu systemd[1]: Started elastic-agent.service - Elastic Agent is a unified agent to >
Jul 03 15:20:59 ubuntu osqueryd[245424]: osqueryd started [version=5.23.0]
Jul 03 15:21:31 ubuntu osqueryd[245594]: osqueryd started [version=5.23.0]
```

The built in dashboards are somewhat tricky to populate as I've customized the queries, but I was able to get the it-compliance pack to run on a 10s schedule successfully.

<img width="2442" height="830" alt="Screenshot 2026-07-03 at 4 28 15 PM" src="https://github.com/user-attachments/assets/42e08e14-b47f-4749-b8ae-2fd3e248a7d6" />

Here's the visualized results of the deb packages query:

<img width="2017" height="1058" alt="Screenshot 2026-07-03 at 4 26 20 PM" src="https://github.com/user-attachments/assets/1e469c46-ebd6-407f-826e-b4c17349a4c7" />
