### PR TITLE
Use otel runtime for heartbeat by default

### DIFF
--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -759,7 +759,7 @@ steps:
     key: integration-tests-linux-tier-3
     # NOTE: as long as we use the scheduler pipeline we need to use BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG.
     #       We use that pipeline to run the tier 3 tests on a schedule for the active branches.
-    if: build.source == "schedule" || build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "elastic-agent-pipeline-scheduler"
+    # if: build.source == "schedule" || build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "elastic-agent-pipeline-scheduler"
     notify:
       - github_commit_status:
           context: "buildkite/elastic-agent-extended-testing - Linux - tier 3"

--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -759,7 +759,7 @@ steps:
     key: integration-tests-linux-tier-3
     # NOTE: as long as we use the scheduler pipeline we need to use BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG.
     #       We use that pipeline to run the tier 3 tests on a schedule for the active branches.
-    # if: build.source == "schedule" || build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "elastic-agent-pipeline-scheduler"
+    if: build.source == "schedule" || build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") == "elastic-agent-pipeline-scheduler"
     notify:
       - github_commit_status:
           context: "buildkite/elastic-agent-extended-testing - Linux - tier 3"

--- a/changelog/fragments/1783070726-Set-OTel-as-the-default-runtime-for-Heartbeat.yaml
+++ b/changelog/fragments/1783070726-Set-OTel-as-the-default-runtime-for-Heartbeat.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Set OTel as the default runtime for Heartbeat
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -69,6 +69,7 @@ func DefaultRuntimeConfig() *RuntimeConfig {
 			InputType: make(map[string]string),
 		},
 		Heartbeat: BeatRuntimeConfig{
+			Default: string(OtelRuntimeManager),
 			// go-ucfg sets this while unpacking, having it in the default makes testing easier
 			InputType: make(map[string]string),
 		},

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -4283,7 +4283,7 @@ func TestDefaultRuntimeConfig(t *testing.T) {
 	assert.Empty(t, config.Auditbeat.InputType)
 	assert.Equal(t, "otel", config.Filebeat.Default)
 	assert.Empty(t, config.Filebeat.InputType)
-	assert.Equal(t, "", config.Heartbeat.Default)
+	assert.Equal(t, "otel", config.Heartbeat.Default)
 	assert.Empty(t, config.Heartbeat.InputType)
 	assert.Equal(t, string(OtelRuntimeManager), config.Metricbeat.Default)
 	assert.Equal(t, map[string]string{}, config.Metricbeat.InputType)

--- a/testing/integration/ess/heartbeat_monitoring_test.go
+++ b/testing/integration/ess/heartbeat_monitoring_test.go
@@ -82,6 +82,10 @@ func (runner *HeartbeatRunner) SetupSuite() {
 			kibana.MonitoringEnabledLogs,
 			kibana.MonitoringEnabledMetrics,
 		},
+		// Heartbeat defaults to the OTel runtime; start with an override forcing
+		// process mode so process mode can be validated first, then remove the
+		// override to fall back to the (OTel) default.
+		Overrides: heartbeatProcessRuntimeOverride(),
 	}
 
 	installOpts := atesting.InstallOpts{
@@ -172,7 +176,8 @@ func (runner *HeartbeatRunner) TestBeatsMetrics() {
 
 	testStart := time.Now()
 
-	// Validate process mode
+	// The policy was created with an override forcing heartbeat to process mode,
+	// so validate that first.
 	var processDoc mapstr.M
 	t.Run("process", func(t *testing.T) {
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -194,11 +199,12 @@ func (runner *HeartbeatRunner) TestBeatsMetrics() {
 		processDoc = runner.validateHeartbeatEvents(t, ctx, agentStatus.Info.ID, testStart)
 	})
 
-	// Switch to OTel runtime and validate the same data
+	// Remove the process-mode override, falling back to the (OTel) default, and
+	// validate the same data.
 	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
 		otelSince := time.Now()
-		policyRevision := switchPolicyToOtelRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
+		policyRevision := removeHeartbeatRuntimeOverride(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
 
 		// Wait for the agent to apply the new policy revision
 		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
@@ -233,4 +239,33 @@ func (runner *HeartbeatRunner) TestBeatsMetrics() {
 		AssertMapstrKeysEqual(t, processDoc, otelDoc, RuntimeComparisonIgnoredFields,
 			"expected heartbeat document keys to be equal between process and otel modes")
 	})
+}
+
+// heartbeatProcessRuntimeOverride returns a policy override that forces
+// heartbeat to run in process mode, overriding its OTel default.
+func heartbeatProcessRuntimeOverride() map[string]interface{} {
+	return map[string]interface{}{
+		"agent": map[string]interface{}{
+			"internal": map[string]interface{}{
+				"runtime": map[string]interface{}{
+					"heartbeat": map[string]interface{}{
+						"default": "process",
+					},
+				},
+			},
+		},
+	}
+}
+
+// removeHeartbeatRuntimeOverride clears the policy's runtime overrides, so
+// heartbeat falls back to its (OTel) default, and returns the new policy revision.
+func removeHeartbeatRuntimeOverride(ctx context.Context, t testing.TB, kibanaClient *kibana.Client, policyID, policyName, namespace string) int {
+	t.Helper()
+	updateReq := kibana.AgentPolicyUpdateRequest{
+		Name:      policyName,
+		Namespace: namespace,
+	}
+	policyResp, err := kibanaClient.UpdatePolicy(ctx, policyID, updateReq)
+	require.NoError(t, err)
+	return policyResp.Revision
 }

--- a/testing/integration/ess/heartbeat_monitoring_test.go
+++ b/testing/integration/ess/heartbeat_monitoring_test.go
@@ -199,12 +199,11 @@ func (runner *HeartbeatRunner) TestBeatsMetrics() {
 		processDoc = runner.validateHeartbeatEvents(t, ctx, agentStatus.Info.ID, testStart)
 	})
 
-	// Remove the process-mode override, falling back to the (OTel) default, and
-	// validate the same data.
+	// Switch to an explicit OTel override and validate the same data.
 	var otelDoc mapstr.M
 	t.Run("otel", func(t *testing.T) {
 		otelSince := time.Now()
-		policyRevision := removeHeartbeatRuntimeOverride(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
+		policyRevision := switchHeartbeatToOtelRuntime(ctx, t, runner.info.KibanaClient, runner.policyID, runner.policyName, runner.info.Namespace)
 
 		// Wait for the agent to apply the new policy revision
 		require.Eventually(t, tools.IsPolicyRevision(ctx, t, runner.info.KibanaClient, runner.agentID, policyRevision),
@@ -257,13 +256,30 @@ func heartbeatProcessRuntimeOverride() map[string]interface{} {
 	}
 }
 
-// removeHeartbeatRuntimeOverride clears the policy's runtime overrides, so
-// heartbeat falls back to its (OTel) default, and returns the new policy revision.
-func removeHeartbeatRuntimeOverride(ctx context.Context, t testing.TB, kibanaClient *kibana.Client, policyID, policyName, namespace string) int {
+// switchHeartbeatToOtelRuntime updates the given policy to override the
+// heartbeat runtime to otel and returns the new policy revision.
+//
+// This uses an explicit override rather than clearing the process-mode
+// override set in SetupSuite: kibana.AgentPolicyUpdateRequest.Overrides has an
+// `omitempty` JSON tag, so an empty/nil map is dropped from the request body
+// entirely, and Fleet's update API treats a missing "overrides" field as
+// "leave unchanged" rather than "clear it".
+func switchHeartbeatToOtelRuntime(ctx context.Context, t testing.TB, kibanaClient *kibana.Client, policyID, policyName, namespace string) int {
 	t.Helper()
 	updateReq := kibana.AgentPolicyUpdateRequest{
 		Name:      policyName,
 		Namespace: namespace,
+		Overrides: map[string]interface{}{
+			"agent": map[string]interface{}{
+				"internal": map[string]interface{}{
+					"runtime": map[string]interface{}{
+						"heartbeat": map[string]interface{}{
+							"default": "otel",
+						},
+					},
+				},
+			},
+		},
 	}
 	policyResp, err := kibanaClient.UpdatePolicy(ctx, policyID, updateReq)
 	require.NoError(t, err)


### PR DESCRIPTION
## What does this PR do?

Makes heartbeat run as an otel receiver by default.

The integration test now starts with a policy override forcing process mode so process mode is still exercised, then removes the override to validate the new (OTel) default.

## Why is it important?

We want all beats to eventually run as otel receivers by default.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## How to test this PR locally

Build agent and run it with a synthetics/http input. You should see it run as an otel receiver via the status.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/14552


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
