### PR TITLE
Skip previous-minor upgrade integration tests on unsupported platforms

### DIFF
--- a/testing/integration/ess/upgrade_rollback_test.go
+++ b/testing/integration/ess/upgrade_rollback_test.go
@@ -83,6 +83,9 @@ func TestStandaloneUpgradeRollback(t *testing.T) {
 	// be ran. Otherwise the test will run the old watcher from the old build.
 	upgradeFromVersion, err := upgradetest.PreviousMinor()
 	require.NoError(t, err)
+	if !upgradetest.SupportsUpgradeSourceOnPlatform(upgradeFromVersion, runtime.GOOS, runtime.GOARCH) {
+		t.Skipf("upgrade from %s is not supported on %s/%s", upgradeFromVersion, runtime.GOOS, runtime.GOARCH)
+	}
 	startFixture, err := atesting.NewFixture(
 		t,
 		upgradeFromVersion.String(),
@@ -214,6 +217,9 @@ func TestStandaloneUpgradeRollbackOnRestarts(t *testing.T) {
 				// be ran. Otherwise the test will run the old watcher from the old build.
 				upgradeFromVersion, err := upgradetest.PreviousMinor()
 				require.NoError(t, err)
+				if !upgradetest.SupportsUpgradeSourceOnPlatform(upgradeFromVersion, runtime.GOOS, runtime.GOARCH) {
+					t.Skipf("upgrade from %s is not supported on %s/%s", upgradeFromVersion, runtime.GOOS, runtime.GOARCH)
+				}
 				startFixture, err := atesting.NewFixture(
 					t,
 					upgradeFromVersion.String(),

--- a/testing/integration/ess/upgrade_standalone_inprogress_test.go
+++ b/testing/integration/ess/upgrade_standalone_inprogress_test.go
@@ -9,6 +9,7 @@ package ess
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 
@@ -42,6 +43,9 @@ func TestStandaloneUpgradeFailsWhenUpgradeIsInProgress(t *testing.T) {
 	// this second upgrade.
 	upgradeFromVersion, err := upgradetest.PreviousMinor()
 	require.NoError(t, err)
+	if !upgradetest.SupportsUpgradeSourceOnPlatform(upgradeFromVersion, runtime.GOOS, runtime.GOARCH) {
+		t.Skipf("upgrade from %s is not supported on %s/%s", upgradeFromVersion, runtime.GOOS, runtime.GOARCH)
+	}
 	startFixture, err := atesting.NewFixture(
 		t,
 		upgradeFromVersion.String(),

--- a/testing/integration/ess/upgrade_uninstall_test.go
+++ b/testing/integration/ess/upgrade_uninstall_test.go
@@ -9,6 +9,7 @@ package ess
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 
@@ -50,6 +51,9 @@ func TestStandaloneUpgradeUninstallKillWatcher(t *testing.T) {
 	// We need a version with a non-matching commit hash to perform the upgrade
 	startVersion, err := upgradetest.PreviousMinor()
 	require.NoError(t, err)
+	if !upgradetest.SupportsUpgradeSourceOnPlatform(startVersion, runtime.GOOS, runtime.GOARCH) {
+		t.Skipf("upgrade from %s is not supported on %s/%s", startVersion, runtime.GOOS, runtime.GOARCH)
+	}
 	startFixture, err := atesting.NewFixture(
 		t,
 		startVersion.String(),

--- a/testing/upgradetest/versions.go
+++ b/testing/upgradetest/versions.go
@@ -51,6 +51,9 @@ var (
 	// Version_9_2_0_SNAPSHOT is the minimum version for manual rollback and rollback reason
 	Version_9_2_0_SNAPSHOT = version.NewParsedSemVer(9, 2, 0, "SNAPSHOT", "")
 
+	// Version_9_3_0 is the first release that supports upgrading on Windows/arm64 (#11673).
+	Version_9_3_0 = version.NewParsedSemVer(9, 3, 0, "", "")
+
 	// ErrNoSnapshot is returned when a requested snapshot is not on the version list.
 	ErrNoSnapshot = errors.New("failed to find a snapshot on the version list")
 	// ErrNoPreviousMinor is returned when a requested previous minor is not on the version list.
@@ -260,6 +263,16 @@ func PreviousMinor() (*version.ParsedSemVer, error) {
 	}
 
 	return previousMinor(currentVersion, upgradeableVersions)
+}
+
+// SupportsUpgradeSourceOnPlatform reports whether an agent of version v can be
+// upgraded when installed on the given platform. Windows/arm64 upgrades require
+// 9.3.0 or newer (#11673).
+func SupportsUpgradeSourceOnPlatform(v *version.ParsedSemVer, goos, goarch string) bool {
+	if goos == "windows" && goarch == "arm64" {
+		return !v.Less(*Version_9_3_0)
+	}
+	return true
 }
 
 // previousMinor returns the previous minor version available for upgrade from the given list of upgradeable versions.

--- a/testing/upgradetest/versions_test.go
+++ b/testing/upgradetest/versions_test.go
@@ -757,3 +757,27 @@ func (f fetcherMock) FetchAgentVersions(ctx context.Context) (version.SortablePa
 func (f fetcherMock) FindLatestSnapshots(ctx context.Context, branches []string) (version.SortableParsedVersions, error) {
 	return f.list, nil
 }
+
+func TestSupportsUpgradeSourceOnPlatform(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		goos    string
+		goarch  string
+		want    bool
+	}{
+		{"windows/arm64 before 9.3.0 not supported", "9.2.8", "windows", "arm64", false},
+		{"windows/arm64 9.3.0 supported", "9.3.0", "windows", "arm64", true},
+		{"windows/arm64 after 9.3.0 supported", "9.4.1", "windows", "arm64", true},
+		{"windows/amd64 before 9.3.0 supported", "9.2.8", "windows", "amd64", true},
+		{"linux/arm64 before 9.3.0 supported", "9.2.8", "linux", "arm64", true},
+		{"darwin/arm64 before 9.3.0 supported", "9.2.8", "darwin", "arm64", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := version.ParseVersion(tc.version)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, SupportsUpgradeSourceOnPlatform(v, tc.goos, tc.goarch))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Type of change: Bug -->

## What does this PR do?

Skips the "upgrade from previous minor" integration tests on Windows/arm64 when the previous minor can't run there. Windows/arm64 upgrades need 9.3.0 or newer, so upgrading from 9.2.x on that platform was never possible.

## Why is it important?

Fixes the `windows:arm64:tier3:sudo:upgrade` failures on the 9.3 release integration tests. The skip does nothing on newer branches (where the previous minor already supports Windows/arm64), so it cleans itself up over time.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~ (test-only change; `skip-changelog`)
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

None. Test-only change; no product code or user-facing behavior is affected.

## How to test this PR locally

```
go test ./testing/upgradetest/ -run TestSupportsUpgradeSourceOnPlatform -v
go vet -tags integration ./testing/integration/ess/
```

On a 9.3 checkout the previously-failing Windows/arm64 upgrade cases now skip instead of failing.

## Related issues

-

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
