### PR TITLE
fix: retry DRA artifact downloads on checksum mismatch; download checksum before the artifact

### DIFF
--- a/dev-tools/mage/manifest/checksum_retry.go
+++ b/dev-tools/mage/manifest/checksum_retry.go
@@ -21,11 +21,9 @@ import (
 type fetchFunc func(ctx context.Context, url, target string) error
 
 // DownloadArtifactWithChecksum downloads a DRA artifact together with its
-// sha512 checksum file and verifies they match, retrying on a mismatch.
-//
-// The checksum file is fetched first, before the much larger artifact, to
-// minimize the chance that the artifact is republished mid-download and no
-// longer matches the checksum already on hand.
+// sha512 checksum file, verifying that they match. On a checksum mismatch,
+// both files are re-downloaded and re-verified, up to len(backoffSchedule)
+// attempts.
 func DownloadArtifactWithChecksum(ctx context.Context, artifactURL, artifactPath, shaURL, shaPath string) error {
 	return downloadArtifactWithChecksum(ctx, DownloadPackage, artifactURL, artifactPath, shaURL, shaPath)
 }

--- a/dev-tools/mage/manifest/checksum_retry.go
+++ b/dev-tools/mage/manifest/checksum_retry.go
@@ -1,0 +1,70 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package manifest
+
+import (
+	"context"
+	"crypto/sha512"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/magefile/mage/mg"
+
+	artifactdownload "github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact/download"
+)
+
+type fetchFunc func(ctx context.Context, url, target string) error
+
+// DownloadArtifactWithChecksum downloads a DRA artifact together with its
+// sha512 checksum file and verifies they match, retrying on a mismatch.
+//
+// The checksum file is fetched first, before the much larger artifact, to
+// minimize the chance that the artifact is republished mid-download and no
+// longer matches the checksum already on hand.
+func DownloadArtifactWithChecksum(ctx context.Context, artifactURL, artifactPath, shaURL, shaPath string) error {
+	return downloadArtifactWithChecksum(ctx, DownloadPackage, artifactURL, artifactPath, shaURL, shaPath)
+}
+
+func downloadArtifactWithChecksum(ctx context.Context, fetch fetchFunc, artifactURL, artifactPath, shaURL, shaPath string) error {
+	var lastErr error
+	for attempt, backoff := range backoffSchedule {
+		if err := fetch(ctx, shaURL, shaPath); err != nil {
+			return fmt.Errorf("downloading sha512 file: %w", err)
+		}
+		if err := fetch(ctx, artifactURL, artifactPath); err != nil {
+			return fmt.Errorf("downloading artifact: %w", err)
+		}
+
+		err := artifactdownload.VerifyChecksum(sha512.New(), artifactPath, shaPath)
+		if err == nil {
+			return nil
+		}
+
+		var mismatchErr *artifactdownload.ChecksumMismatchError
+		if !errors.As(err, &mismatchErr) {
+			return err
+		}
+
+		lastErr = err
+
+		// Remove the mismatched files so the retry re-fetches both from scratch.
+		_ = os.Remove(artifactPath)
+		_ = os.Remove(shaPath)
+
+		if mg.Verbose() {
+			log.Printf("checksum mismatch downloading %q (attempt %d/%d), retrying in %v: %v", artifactPath, attempt+1, len(backoffSchedule), backoff, err)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+	}
+
+	return fmt.Errorf("checksum mismatch persisted after %d attempts: %w", len(backoffSchedule), lastErr)
+}

--- a/dev-tools/mage/manifest/checksum_retry_test.go
+++ b/dev-tools/mage/manifest/checksum_retry_test.go
@@ -69,15 +69,13 @@ func TestDownloadArtifactWithChecksum_RetriesOnMismatchThenSucceeds(t *testing.T
 	artifactPath := filepath.Join(dir, "artifact.tar.gz")
 	shaPath := artifactPath + ".sha512"
 
-	staleContent := []byte("stale-bytes-from-before-republish")
-	freshContent := []byte("fresh-bytes-after-republish")
+	staleContent := []byte("mismatched-bytes")
+	freshContent := []byte("matching-bytes")
 	checksumLine := checksumLineFor(freshContent, filepath.Base(artifactPath))
 
 	var artifactFetches int
 	fetch := func(_ context.Context, url, target string) error {
 		if strings.HasSuffix(url, ".sha512") {
-			// the manifest always advertises the checksum for the latest
-			// (fresh) artifact generation
 			return os.WriteFile(target, []byte(checksumLine), 0o644)
 		}
 		artifactFetches++
@@ -136,8 +134,8 @@ func TestDownloadArtifactWithChecksum_FailsAfterExhaustingRetries(t *testing.T) 
 	artifactPath := filepath.Join(dir, "artifact.tar.gz")
 	shaPath := artifactPath + ".sha512"
 
-	staleContent := []byte("stale-bytes-from-before-republish")
-	freshContent := []byte("fresh-bytes-after-republish")
+	staleContent := []byte("mismatched-bytes")
+	freshContent := []byte("matching-bytes")
 	checksumLine := checksumLineFor(freshContent, filepath.Base(artifactPath))
 
 	var artifactFetches int

--- a/dev-tools/mage/manifest/checksum_retry_test.go
+++ b/dev-tools/mage/manifest/checksum_retry_test.go
@@ -1,0 +1,185 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package manifest
+
+import (
+	"context"
+	"crypto/sha512"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	artifactdownload "github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact/download"
+)
+
+func checksumLineFor(content []byte, name string) string {
+	hash := sha512.Sum512(content)
+	return fmt.Sprintf("%s  %s\n", hex.EncodeToString(hash[:]), name)
+}
+
+func useFastBackoffSchedule(t *testing.T) {
+	t.Helper()
+	original := backoffSchedule
+	backoffSchedule = []time.Duration{time.Millisecond, time.Millisecond, time.Millisecond}
+	t.Cleanup(func() { backoffSchedule = original })
+}
+
+func TestDownloadArtifactWithChecksum_Success(t *testing.T) {
+	dir := t.TempDir()
+	artifactPath := filepath.Join(dir, "artifact.tar.gz")
+	shaPath := artifactPath + ".sha512"
+	content := []byte("the-real-artifact-bytes")
+	checksumLine := checksumLineFor(content, filepath.Base(artifactPath))
+
+	var shaFetches, artifactFetches int
+	fetch := func(_ context.Context, url, target string) error {
+		if strings.HasSuffix(url, ".sha512") {
+			shaFetches++
+			return os.WriteFile(target, []byte(checksumLine), 0o644)
+		}
+		artifactFetches++
+		return os.WriteFile(target, content, 0o644)
+	}
+
+	err := downloadArtifactWithChecksum(context.Background(), fetch, "https://example.com/artifact.tar.gz", artifactPath, "https://example.com/artifact.tar.gz.sha512", shaPath)
+	require.NoError(t, err)
+	assert.Equal(t, 1, shaFetches)
+	assert.Equal(t, 1, artifactFetches)
+
+	// the sha512 file must be fetched before the artifact
+	got, err := os.ReadFile(artifactPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}
+
+func TestDownloadArtifactWithChecksum_RetriesOnMismatchThenSucceeds(t *testing.T) {
+	useFastBackoffSchedule(t)
+
+	dir := t.TempDir()
+	artifactPath := filepath.Join(dir, "artifact.tar.gz")
+	shaPath := artifactPath + ".sha512"
+
+	staleContent := []byte("stale-bytes-from-before-republish")
+	freshContent := []byte("fresh-bytes-after-republish")
+	checksumLine := checksumLineFor(freshContent, filepath.Base(artifactPath))
+
+	var artifactFetches int
+	fetch := func(_ context.Context, url, target string) error {
+		if strings.HasSuffix(url, ".sha512") {
+			// the manifest always advertises the checksum for the latest
+			// (fresh) artifact generation
+			return os.WriteFile(target, []byte(checksumLine), 0o644)
+		}
+		artifactFetches++
+		if artifactFetches == 1 {
+			return os.WriteFile(target, staleContent, 0o644)
+		}
+		return os.WriteFile(target, freshContent, 0o644)
+	}
+
+	err := downloadArtifactWithChecksum(context.Background(), fetch, "https://example.com/artifact.tar.gz", artifactPath, "https://example.com/artifact.tar.gz.sha512", shaPath)
+	require.NoError(t, err)
+	assert.Equal(t, 2, artifactFetches)
+
+	got, err := os.ReadFile(artifactPath)
+	require.NoError(t, err)
+	assert.Equal(t, freshContent, got)
+}
+
+func TestDownloadArtifactWithChecksum_CancelledDuringBackoff(t *testing.T) {
+	original := backoffSchedule
+	backoffSchedule = []time.Duration{2 * time.Second}
+	t.Cleanup(func() { backoffSchedule = original })
+
+	dir := t.TempDir()
+	artifactPath := filepath.Join(dir, "artifact.tar.gz")
+	shaPath := artifactPath + ".sha512"
+
+	// the sha512 file will never match the artifact, forcing a retry that
+	// waits out the (long) backoff above
+	checksumLine := checksumLineFor([]byte("does-not-match-what-is-downloaded"), filepath.Base(artifactPath))
+	fetch := func(_ context.Context, url, target string) error {
+		if strings.HasSuffix(url, ".sha512") {
+			return os.WriteFile(target, []byte(checksumLine), 0o644)
+		}
+		return os.WriteFile(target, []byte("stale-bytes"), 0o644)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := downloadArtifactWithChecksum(ctx, fetch, "https://example.com/artifact.tar.gz", artifactPath, "https://example.com/artifact.tar.gz.sha512", shaPath)
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, elapsed, 2*time.Second, "should return as soon as the context is cancelled, not wait out the full backoff")
+}
+
+func TestDownloadArtifactWithChecksum_FailsAfterExhaustingRetries(t *testing.T) {
+	useFastBackoffSchedule(t)
+
+	dir := t.TempDir()
+	artifactPath := filepath.Join(dir, "artifact.tar.gz")
+	shaPath := artifactPath + ".sha512"
+
+	staleContent := []byte("stale-bytes-from-before-republish")
+	freshContent := []byte("fresh-bytes-after-republish")
+	checksumLine := checksumLineFor(freshContent, filepath.Base(artifactPath))
+
+	var artifactFetches int
+	fetch := func(_ context.Context, url, target string) error {
+		if strings.HasSuffix(url, ".sha512") {
+			return os.WriteFile(target, []byte(checksumLine), 0o644)
+		}
+		artifactFetches++
+		// always serve stale bytes: checksum never matches
+		return os.WriteFile(target, staleContent, 0o644)
+	}
+
+	err := downloadArtifactWithChecksum(context.Background(), fetch, "https://example.com/artifact.tar.gz", artifactPath, "https://example.com/artifact.tar.gz.sha512", shaPath)
+	require.Error(t, err)
+	var mismatchErr *artifactdownload.ChecksumMismatchError
+	assert.True(t, errors.As(err, &mismatchErr), "expected error to wrap a ChecksumMismatchError, got: %v", err)
+	assert.Equal(t, len(backoffSchedule), artifactFetches)
+
+	// local copies of the last (mismatched) attempt must not be left behind
+	_, err = os.Stat(artifactPath)
+	assert.True(t, os.IsNotExist(err))
+	_, err = os.Stat(shaPath)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestDownloadArtifactWithChecksum_NonChecksumErrorFailsFast(t *testing.T) {
+	dir := t.TempDir()
+	artifactPath := filepath.Join(dir, "artifact.tar.gz")
+	shaPath := artifactPath + ".sha512"
+
+	boom := errors.New("boom")
+	var artifactFetches int
+	fetch := func(_ context.Context, url, target string) error {
+		if strings.HasSuffix(url, ".sha512") {
+			return os.WriteFile(target, []byte("deadbeef  artifact.tar.gz\n"), 0o644)
+		}
+		artifactFetches++
+		return boom
+	}
+
+	err := downloadArtifactWithChecksum(context.Background(), fetch, "https://example.com/artifact.tar.gz", artifactPath, "https://example.com/artifact.tar.gz.sha512", shaPath)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, boom))
+	assert.Equal(t, 1, artifactFetches, "should not retry on a plain download error")
+}

--- a/magefile.go
+++ b/magefile.go
@@ -12,7 +12,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/sha512"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -51,7 +50,6 @@ import (
 	"github.com/elastic/elastic-agent/dev-tools/mage/manifest"
 	"github.com/elastic/elastic-agent/dev-tools/mage/pkgcommon"
 	"github.com/elastic/elastic-agent/dev-tools/packaging"
-	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact/download"
 	"github.com/elastic/elastic-agent/pkg/testing/buildkite"
 	tcommon "github.com/elastic/elastic-agent/pkg/testing/common"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
@@ -1602,21 +1600,11 @@ func downloadDRAArtifacts(ctx context.Context, build *manifest.Build, version st
 				downloadFunc := func(pkgName string, pkgDesc manifest.Package) func() error {
 					return func() error {
 						artifactDownloadPath := filepath.Join(draDownloadDir, pkgName)
-						err := manifest.DownloadPackage(errCtx, pkgDesc.URL, artifactDownloadPath)
+						artifactSHADownloadPath := filepath.Join(draDownloadDir, pkgName+sha512FileExt)
+
+						err := manifest.DownloadArtifactWithChecksum(errCtx, pkgDesc.URL, artifactDownloadPath, pkgDesc.ShaURL, artifactSHADownloadPath)
 						if err != nil {
 							return fmt.Errorf("downloading %q: %w", pkgName, err)
-						}
-
-						// download the SHA to check integrity
-						artifactSHADownloadPath := filepath.Join(draDownloadDir, pkgName+sha512FileExt)
-						err = manifest.DownloadPackage(errCtx, pkgDesc.ShaURL, artifactSHADownloadPath)
-						if err != nil {
-							return fmt.Errorf("downloading SHA for %q: %w", pkgName, err)
-						}
-
-						err = download.VerifyChecksum(sha512.New(), artifactDownloadPath, artifactSHADownloadPath)
-						if err != nil {
-							return fmt.Errorf("validating checksum for %q: %w", pkgName, err)
 						}
 
 						// we should probably validate the signature, it can be done later as we return the package metadata


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Changes the way we download DRA (release) artifacts: we now fetch the checksum file before the (much larger) artifact, and retry the whole download+verify sequence if the checksum doesn't match, instead of failing the build outright.

## Why is it important?

A packaging build ([Buildkite build 14200](https://buildkite.com/elastic/elastic-agent-package/builds/14200)) failed with a checksum mismatch on `elastic-agent-core-9.3.8-SNAPSHOT-windows-x86_64.zip`, even though the artifact itself wasn't actually broken. The artifact and its checksum are fetched as two independent HTTP requests, so any transient inconsistency between them — whatever the exact cause — turns into a hard failure that needs a human to notice and manually rerun the job.

Fetching the checksum first shrinks the window between the two requests, and retrying on a mismatch means an occasional bad pairing no longer fails the whole job — it just retries and moves on.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~ (internal build/release tooling, no user-facing docs)
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~I have added an entry in `./changelog/fragments`~~ (CI/release tooling only, doesn't affect shipped behavior — `skip-changelog`)
- ~~I have added an integration test or an E2E test~~ (covered by unit tests against an injected download function; no network/CI-only behavior to exercise end-to-end)

## Disruptive User Impact

None. This only affects the mage packaging/DRA build tooling used to produce release artifacts; it doesn't touch the runtime Elastic Agent upgrade/download/verify path (`internal/pkg/agent/application/upgrade/artifact/download`), which is unchanged.

## How to test this PR locally

```bash
go test ./dev-tools/mage/manifest/...
go build -tags mage .
mage check:lint
```

The new tests in `dev-tools/mage/manifest/checksum_retry_test.go` exercise the retry logic directly (success, retry-then-succeed on mismatch, exhausting retries with cleanup of stale files, fail-fast on non-checksum errors, and cancellation during backoff) against a fake fetch function, without hitting the network.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
