### PR TITLE
Fix spurious unmarshal error on idle Fleet check-ins

### DIFF
--- a/changelog/fragments/1783412071-fix-spurious-failed-to-unmarshal-checkin-actions-error-on-idle-fleet-check-ins.yaml
+++ b/changelog/fragments/1783412071-fix-spurious-failed-to-unmarshal-checkin-actions-error-on-idle-fleet-check-ins.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix spurious "failed to unmarshal checkin actions" error on idle Fleet check-ins
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/15397

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -23,6 +23,21 @@ Known issues are significant defects or limitations that may impact your impleme
 % Workaround description.
 % :::
 
+:::{dropdown} {{agent}} logs a "failed to unmarshal checkin actions" error on almost every {{fleet}} check-in
+
+**Applies to: {{agent}} 9.4.0, 9.4.1, 9.4.2, 9.4.3**
+
+On July 7, 2026, a known issue was discovered where {{fleet}}-managed {{agents}} log an error on nearly every check-in when there is nothing new for {{fleet}} to tell them to do:
+
+```
+failed to unmarshal checkin actions: unexpected end of JSON input
+```
+
+This is a cosmetic logging issue only. Actions are still delivered and processed normally whenever {{fleet}} does send any; nothing about how the agent actually operates is affected. No action is required — the error can be safely ignored.
+
+For more information, check [Issue #15397](https://github.com/elastic/elastic-agent/issues/15397).
+:::
+
 :::{dropdown} [Windows] {{agent}} fails to upgrade when the host has 100 or more installed programs
 
 **Applies to: {{agent}} 9.4.0, 9.4.1, 9.4.2 (Windows only)**

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -33,7 +33,7 @@ On July 7, 2026, a known issue was discovered where {{fleet}}-managed {{agents}}
 failed to unmarshal checkin actions: unexpected end of JSON input
 ```
 
-This is a cosmetic logging issue only. Actions are still delivered and processed normally whenever {{fleet}} does send any; nothing about how the agent actually operates is affected. No action is required — the error can be safely ignored.
+This is a cosmetic logging issue only. Actions are still delivered and processed normally whenever {{fleet}} does send any. Nothing about how the agent actually operates is affected, and no action is required — the error can be safely ignored.
 
 For more information, check [Issue #15397](https://github.com/elastic/elastic-agent/issues/15397).
 :::

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -190,10 +190,15 @@ func (f *FleetGateway) Run(ctx context.Context) error {
 				continue
 			}
 
+			// Fleet Server omits the "actions" field entirely when there is nothing
+			// new to report, leaving resp.Actions nil; only unmarshal when it
+			// actually sent a payload.
 			var actions fleetapi.Actions
-			if err := json.Unmarshal(resp.Actions, &actions); err != nil {
-				f.log.Errorf("failed to unmarshal checkin actions: %v", err)
-				continue
+			if len(resp.Actions) > 0 {
+				if err := json.Unmarshal(resp.Actions, &actions); err != nil {
+					f.log.Errorf("failed to unmarshal checkin actions: %v", err)
+					continue
+				}
 			}
 			if len(actions) > 0 {
 				f.actionCh <- actions

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -497,6 +497,63 @@ func TestFleetGateway(t *testing.T) {
 	})
 }
 
+// TestFleetGatewayCheckinResponseMissingActionsField reproduces
+// https://github.com/elastic/elastic-agent/issues/15397: fleet-server omits
+// the "actions" field from its checkin response when it has nothing new to
+// report, and the agent was logging an error every time that happened.
+func TestFleetGatewayCheckinResponseMissingActionsField(t *testing.T) {
+	agentInfo := &testAgentInfo{}
+	settings := &fleetGatewaySettings{
+		Duration: 5 * time.Second,
+		Backoff:  &backoffSettings{Init: 1 * time.Second, Max: 5 * time.Second},
+	}
+
+	scheduler := scheduler.NewStepper()
+	client := newTestingClient()
+
+	log, obs := loggertest.New("fleet_gateway")
+
+	stateStore := newStateStore(t, log)
+
+	mockRollbacksSrc := ttl.NewMockReadOnlySource(t)
+	mockRollbacksSrc.EXPECT().GetAll().Return(nil, nil, nil)
+
+	gateway, err := newFleetGatewayWithScheduler(log, settings, agentInfo, client, scheduler, noop.New(), stateStore, NewCheckinStateFetcher(emptyStateFetcher), mockRollbacksSrc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	waitFn := ackSeq(
+		client.Answer(func(_ context.Context, _ http.Header, _ io.Reader) (*http.Response, error) {
+			// Real-world fleet-server response when there is nothing new to
+			// report: no "actions" key at all, not even an empty array.
+			resp := wrapStrToResp(http.StatusOK, `{ "ack_token": "token1" }`)
+			return resp, nil
+		}),
+	)
+
+	errCh := runFleetGateway(ctx, gateway)
+
+	scheduler.Next()
+	waitFn()
+
+	cancel()
+	err = <-errCh
+	require.NoError(t, err)
+
+	select {
+	case actions := <-gateway.Actions():
+		t.Errorf("Expected no actions, got %v", actions)
+	default:
+	}
+
+	unmarshalErrors := obs.FilterMessageSnippet("failed to unmarshal checkin actions").All()
+	require.Empty(t, unmarshalErrors,
+		"a checkin response without an \"actions\" field should not produce an unmarshal "+
+			"error (see https://github.com/elastic/elastic-agent/issues/15397): %+v", unmarshalErrors)
+}
+
 func TestRetriesOnFailures(t *testing.T) {
 	agentInfo := &testAgentInfo{}
 	settings := &fleetGatewaySettings{

--- a/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/internal/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
 	"github.com/elastic/elastic-agent/pkg/fleetapi"
-	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/pkg/scheduler"
 	"github.com/elastic/elastic-agent/pkg/upgrade/details"
 )
@@ -337,7 +336,7 @@ func TestFleetGateway(t *testing.T) {
 				data, err := io.ReadAll(body)
 				require.NoError(t, err)
 
-				var checkinRequest pkgfleetapi.CheckinRequest
+				var checkinRequest fleetapi.CheckinRequest
 				err = json.Unmarshal(data, &checkinRequest)
 				require.NoError(t, err)
 
@@ -399,7 +398,7 @@ func TestFleetGateway(t *testing.T) {
 				data, err := io.ReadAll(body)
 				require.NoError(t, err)
 
-				var checkinRequest pkgfleetapi.CheckinRequest
+				var checkinRequest fleetapi.CheckinRequest
 				err = json.Unmarshal(data, &checkinRequest)
 				require.NoError(t, err)
 
@@ -782,7 +781,7 @@ func TestFleetGatewaySchedulerSwitch(t *testing.T) {
 		defer cancel()
 
 		unauth := func(_ context.Context, _ http.Header, _ io.Reader) (*http.Response, error) {
-			return nil, pkgfleetapi.ErrInvalidAPIKey
+			return nil, fleetapi.ErrInvalidAPIKey
 		}
 
 		clientWaitFn := c.Answer(unauth)
@@ -912,7 +911,7 @@ func TestConvertToCheckingComponents(t *testing.T) {
 		name       string
 		components []runtime.ComponentComponentState
 		collector  *status.AggregateStatus
-		expected   []pkgfleetapi.CheckinComponent
+		expected   []fleetapi.CheckinComponent
 	}{
 		{
 			name:       "Nil inputs",
@@ -924,7 +923,7 @@ func TestConvertToCheckingComponents(t *testing.T) {
 			name:       "Empty inputs",
 			components: []runtime.ComponentComponentState{},
 			collector:  &status.AggregateStatus{},
-			expected:   []pkgfleetapi.CheckinComponent{},
+			expected:   []fleetapi.CheckinComponent{},
 		},
 		{
 			name: "Only agent components",
@@ -952,7 +951,7 @@ func TestConvertToCheckingComponents(t *testing.T) {
 				},
 			},
 			collector: nil,
-			expected: []pkgfleetapi.CheckinComponent{
+			expected: []fleetapi.CheckinComponent{
 				{
 					ID:      "comp-1",
 					Type:    "log",
@@ -964,7 +963,7 @@ func TestConvertToCheckingComponents(t *testing.T) {
 					Type:    "log",
 					Status:  "DEGRADED",
 					Message: "Component is degraded",
-					Units: []pkgfleetapi.CheckinUnit{
+					Units: []fleetapi.CheckinUnit{
 						{
 							ID:      "unit-1",
 							Type:    "input",
@@ -1005,13 +1004,13 @@ func TestConvertToCheckingComponents(t *testing.T) {
 					},
 				},
 			},
-			expected: []pkgfleetapi.CheckinComponent{
+			expected: []fleetapi.CheckinComponent{
 				{
 					ID:      "extensions",
 					Type:    "otel",
 					Status:  "HEALTHY",
 					Message: "Healthy",
-					Units: []pkgfleetapi.CheckinUnit{
+					Units: []fleetapi.CheckinUnit{
 						{
 							ID:      "extensions:healthcheck",
 							Type:    "",
@@ -1025,7 +1024,7 @@ func TestConvertToCheckingComponents(t *testing.T) {
 					Type:    "otel",
 					Status:  "DEGRADED",
 					Message: "Recoverable: pipeline error",
-					Units: []pkgfleetapi.CheckinUnit{
+					Units: []fleetapi.CheckinUnit{
 						{
 							ID:      "exporter:elasticsearch",
 							Type:    "output",
@@ -1066,7 +1065,7 @@ func TestConvertToCheckingComponents(t *testing.T) {
 					},
 				},
 			},
-			expected: []pkgfleetapi.CheckinComponent{
+			expected: []fleetapi.CheckinComponent{
 				{
 					ID:      "comp-1",
 					Type:    "log",
@@ -1099,13 +1098,13 @@ func TestConvertToCheckingComponents(t *testing.T) {
 				},
 			},
 			collector: nil,
-			expected: []pkgfleetapi.CheckinComponent{
+			expected: []fleetapi.CheckinComponent{
 				{
 					ID:      "comp-1",
 					Type:    "log",
 					Status:  "",
 					Message: "Unknown state",
-					Units: []pkgfleetapi.CheckinUnit{
+					Units: []fleetapi.CheckinUnit{
 						{
 							ID:      "unit-1",
 							Type:    "",
@@ -1131,13 +1130,13 @@ func TestConvertToCheckingComponents(t *testing.T) {
 					},
 				},
 			},
-			expected: []pkgfleetapi.CheckinComponent{
+			expected: []fleetapi.CheckinComponent{
 				{
 					ID:      "invalid-id",
 					Type:    "otel",
 					Status:  "HEALTHY",
 					Message: "Healthy",
-					Units: []pkgfleetapi.CheckinUnit{
+					Units: []fleetapi.CheckinUnit{
 						{
 							ID:      "invalid-unit-id",
 							Type:    "",
@@ -1154,11 +1153,11 @@ func TestConvertToCheckingComponents(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := convertToCheckinComponents(logp.NewNopLogger(), tt.components, tt.collector)
 			// Testify diffs are nicer if we sort and compare directly vs using ElementsMathc
-			slices.SortFunc(result, func(a, b pkgfleetapi.CheckinComponent) int {
+			slices.SortFunc(result, func(a, b fleetapi.CheckinComponent) int {
 				return strings.Compare(a.ID, b.ID)
 			})
 			for _, c := range result {
-				slices.SortFunc(c.Units, func(a, b pkgfleetapi.CheckinUnit) int {
+				slices.SortFunc(c.Units, func(a, b fleetapi.CheckinUnit) int {
 					return strings.Compare(a.ID, b.ID)
 				})
 			}
@@ -1172,7 +1171,7 @@ func TestAvailableRollbacks(t *testing.T) {
 		name                  string
 		setup                 func(t *testing.T, rbSource *ttl.MockReadOnlySource, client *testingClient)
 		wantErr               assert.ErrorAssertionFunc
-		assertCheckinResponse func(t *testing.T, resp *pkgfleetapi.CheckinResponse)
+		assertCheckinResponse func(t *testing.T, resp *fleetapi.CheckinResponse)
 	}{
 		{
 			name: "no available rollbacks - normal checkin",
@@ -1214,11 +1213,11 @@ func TestAvailableRollbacks(t *testing.T) {
 					assert.NoError(t, err, "error decoding checkin body")
 					if assert.Contains(t, unmarshaled, "upgrade") {
 						// verify that we got the correct data
-						var actualUpgrade pkgfleetapi.CheckinUpgrade
+						var actualUpgrade fleetapi.CheckinUpgrade
 						err = json.Unmarshal(unmarshaled["upgrade"], &actualUpgrade)
 						require.NoError(t, err, "error decoding upgrade info from checkin body")
 
-						expected := []pkgfleetapi.CheckinRollback{{
+						expected := []fleetapi.CheckinRollback{{
 							Version:    "1.2.3",
 							ValidUntil: validUntil,
 						}}


### PR DESCRIPTION
## What does this PR do?

Stops the agent from logging an error every time it checks in with Fleet and there's nothing new for it to do.

## Why is it important?

Since 9.4.0, agents have been logging `failed to unmarshal checkin actions: unexpected end of JSON input` on almost every check-in. Actions still work fine when Fleet actually sends any, so this doesn't affect functionality, but it shows up constantly in logs and diagnostics and has already led to two support cases (https://github.com/elastic/sdh-beats/issues/7337).

The cause: Fleet Server leaves the "actions" field out of its response when it has nothing to report, and the agent wasn't handling that case — it tried to read the missing value anyway. This fixes that so the check is only done when there's actually something to read.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~ (small, self-explanatory change)
- ~~I have made corresponding changes to the documentation~~ (internal bug fix, nothing user-facing to document)
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the changelog tool
- ~~I have added an integration test or an E2E test~~ (covered by a unit test, plus manually verified against a real local Fleet setup)

## Disruptive User Impact

None — this only removes an error message from the logs. Nothing about how the agent actually behaves changes.

## How to test this PR locally

`go test ./internal/pkg/agent/application/gateway/fleet/... -v`

Or build the agent, enroll it against a Fleet Server, and watch the logs while it's idle — the error should no longer appear.

## Related issues

- Relates https://github.com/elastic/sdh-beats/issues/7337
