### PR TITLE
chore(docker): upgrade OS packages in Ubuntu-based agent image build

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -91,6 +91,7 @@ RUN for iter in {1..10}; do microdnf update -y && microdnf install -y tar gzip f
 RUN touch /var/mail/ubuntu && chown ubuntu /var/mail/ubuntu && userdel -r ubuntu
 RUN for iter in {1..10}; do \
         apt-get update -y && \
+        DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes ca-certificates curl gawk xz-utils systemd && \
         apt-get clean all && \
         exit_code=0 && break || exit_code=$? && echo "apt-get error: retry $iter in 10s" && sleep 10; \


### PR DESCRIPTION
## What does this PR do?

Adds a package upgrade step to the Ubuntu-based Elastic Agent Docker image build, so the OS packages that come with the base image get patched at build time, not just the ones we install ourselves.

## Why is it important?

Vulnerability scans sometimes flag outdated OS packages baked into the base image. This keeps them reasonably up to date each time we build. It only helps when the base image actually has a vulnerable package and a fixed version is already available upstream — if no fix exists upstream yet, this won't change anything.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~ (one line, self-explanatory)
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~ (verified by building the image)
- ~~I have added an entry in `./changelog/fragments` using the changelog tool~~ (skip-changelog — internal only, no user-facing change)
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None. Only affects what's inside the built Docker image, not how the agent behaves.

## How to test this PR locally

Build the Ubuntu-based Docker image and check the build logs — the new upgrade step should run cleanly.
