### PR TITLE
fix(otel): fix queue flush timeout translation for unitless values

### DIFF
--- a/changelog/fragments/1783071900-fix-otel-flush-timeout-missing-unit.yaml
+++ b/changelog/fragments/1783071900-fix-otel-flush-timeout-missing-unit.yaml
@@ -1,0 +1,51 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix translation of `queue.mem.flush.timeout` to OTel `flush_timeout` for unitless values
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  When translating an output's Beats configuration to an OpenTelemetry Collector
+  configuration, a unitless queue.mem.flush.timeout value (e.g. `5`, which Beats
+  interprets as 5 seconds) was passed through verbatim as a string to the exporterhelper
+  sending_queue.batch.flush_timeout option. Because that option is a time.Duration,
+  the collector failed to start with "'flush_timeout' time: missing unit in duration".
+  Unitless values are now suffixed with the seconds unit.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/otel/translate/common.go
+++ b/internal/pkg/otel/translate/common.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -136,6 +137,11 @@ func getFlushTimeout(logger *logp.Logger, output *config.C) string {
 	if err != nil {
 		logger.Debugf("Failed to get flush timeout: %v", err)
 		return "10s" // return default queue.mem.flush.timeout for sending_queue in case of an errr
+	}
+	// Append seconds unit if Agent config does not specify a unit
+	// to prevent the OTel exporterhelper from failing to start.
+	if _, parseErr := strconv.ParseFloat(timeout, 64); parseErr == nil {
+		return timeout + "s"
 	}
 	return timeout
 }

--- a/internal/pkg/otel/translate/common_test.go
+++ b/internal/pkg/otel/translate/common_test.go
@@ -6,12 +6,85 @@ package translate
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 )
+
+func TestGetFlushTimeout(t *testing.T) {
+	logger := logptest.NewTestingLogger(t, "")
+
+	testCases := []struct {
+		name     string
+		input    map[string]any
+		expected string
+	}{
+		{
+			name:     "unitless integer is interpreted as seconds",
+			input:    map[string]any{"queue.mem.flush.timeout": 5},
+			expected: "5s",
+		},
+		{
+			name:     "unitless zero is interpreted as seconds",
+			input:    map[string]any{"queue.mem.flush.timeout": 0},
+			expected: "0s",
+		},
+		{
+			name:     "unitless fractional value preserves original text",
+			input:    map[string]any{"queue.mem.flush.timeout": 0.1},
+			expected: "0.1s",
+		},
+		{
+			name:     "unitless value with leading dot preserves original text",
+			input:    map[string]any{"queue.mem.flush.timeout": ".9"},
+			expected: ".9s",
+		},
+		{
+			name:     "unitless value with trailing dot preserves original text",
+			input:    map[string]any{"queue.mem.flush.timeout": "2."},
+			expected: "2.s",
+		},
+		{
+			name:     "value with seconds unit is passed through",
+			input:    map[string]any{"queue.mem.flush.timeout": "5s"},
+			expected: "5s",
+		},
+		{
+			name:     "value with minutes unit is passed through",
+			input:    map[string]any{"queue.mem.flush.timeout": "2m"},
+			expected: "2m",
+		},
+		{
+			name:     "value with milliseconds unit is passed through",
+			input:    map[string]any{"queue.mem.flush.timeout": "100ms"},
+			expected: "100ms",
+		},
+		{
+			name:     "missing value falls back to default",
+			input:    map[string]any{},
+			expected: "10s",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			cfg, err := config.NewConfigFrom(test.input)
+			require.NoError(t, err)
+
+			got := getFlushTimeout(logger, cfg)
+			require.Equal(t, test.expected, got)
+
+			// The OTel exporterhelper flush_timeout is a time.Duration, so the
+			// returned value must always parse with a unit.
+			_, err = time.ParseDuration(got)
+			require.NoError(t, err, "flush_timeout %q must be a valid duration", got)
+		})
+	}
+}
 
 func TestTLSCommonToOTel(t *testing.T) {
 


### PR DESCRIPTION
## What does this PR do?

Fixes OTel config translation for unitless `queue.mem.flush.timeout` values, see https://github.com/elastic/elastic-agent/issues/15400.

## Why is it important?

Without it, any input that runs in OTel mode and has the output flush timeout configured as a number will fail to start. This can result in Agent monitoring being unavailable, as it runs in OTel mode in v9.4.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

Bug fix, can fix monitoring for users of Agent 9.4.

## How to test this PR locally

```console
EXTERNAL=true mage package
```

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/15400