### PR TITLE
Correct affected versions for checkin actions known issue

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -25,7 +25,7 @@ Known issues are significant defects or limitations that may impact your impleme
 
 :::{dropdown} {{agent}} logs a "failed to unmarshal checkin actions" error on almost every {{fleet}} check-in
 
-**Applies to: {{agent}} 9.4.0, 9.4.1, 9.4.2, 9.4.3**
+**Applies to: {{agent}} 8.19.17, 8.19.18, 9.3.6, 9.3.7, 9.4.3**
 
 On July 7, 2026, a known issue was discovered where {{fleet}}-managed {{agents}} log an error on nearly every check-in when there is nothing new for {{fleet}} to tell them to do:
 


### PR DESCRIPTION
Follow up to https://github.com/elastic/elastic-agent/pull/15398

update list of affected versions in known issues with exact list of versions after more detailed investigation. The  issue has been introduced by https://github.com/elastic/elastic-agent/pull/14706 backported to all versions