### PR TITLE
Add stack provisioning to mage integration:local

### DIFF
--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -917,6 +917,13 @@ func (s *Settings) WithStackProvisioner(provisioner string) *Settings {
 	return clone
 }
 
+// WithInstanceProvisioner returns a copy of the settings with the specified instance provisioner.
+func (s *Settings) WithInstanceProvisioner(provisioner string) *Settings {
+	clone := s.Clone()
+	clone.IntegrationTest.InstanceProvisioner = provisioner
+	return clone
+}
+
 // WithTestGroups returns a copy of the settings with the specified test groups.
 func (s *Settings) WithTestGroups(groups string) *Settings {
 	clone := s.Clone()

--- a/magefile.go
+++ b/magefile.go
@@ -59,6 +59,7 @@ import (
 	"github.com/elastic/elastic-agent/pkg/testing/gcloud"
 	"github.com/elastic/elastic-agent/pkg/testing/kubernetes"
 	"github.com/elastic/elastic-agent/pkg/testing/kubernetes/kind"
+	"github.com/elastic/elastic-agent/pkg/testing/local"
 	"github.com/elastic/elastic-agent/pkg/testing/multipass"
 	"github.com/elastic/elastic-agent/pkg/testing/runner"
 	"github.com/elastic/elastic-agent/pkg/testing/tools/git"
@@ -2101,7 +2102,7 @@ func (Integration) Local(ctx context.Context, testName string) error {
 	cfg := devtools.SettingsFromContext(ctx)
 	if shouldBuildAgent(cfg) {
 		// need only local package for current platform
-		cfg = cfg.WithPlatformFilter(fmt.Sprintf("+all %s/%s", runtime.GOOS, runtime.GOARCH))
+		cfg = cfg.WithPlatformFilter(fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH))
 		ctx = devtools.ContextWithSettings(ctx, cfg)
 		mg.CtxDeps(ctx, Package)
 	}
@@ -2110,25 +2111,21 @@ func (Integration) Local(ctx context.Context, testName string) error {
 	// clean the .agent-testing/local so this run will use the latest build
 	_ = os.RemoveAll(".agent-testing/local")
 
-	// run the integration tests but only run test that can run locally
-	params := devtools.DefaultGoTestIntegrationArgs(cfg)
-	params.Tags = append(params.Tags, "local")
-	params.Packages = []string{
-		"github.com/elastic/elastic-agent/testing/integration/...",
-	}
+	cfg = cfg.WithInstanceProvisioner(local.Name)
+	ctx = devtools.ContextWithSettings(ctx, cfg)
 
-	var goTestFlags []string
-	if cfg.IntegrationTest.GoTestFlags != "" {
-		goTestFlags = strings.Split(cfg.IntegrationTest.GoTestFlags, " ")
+	singleTest := testName
+	if singleTest == "all" {
+		singleTest = ""
 	}
-	params.ExtraFlags = goTestFlags
-
-	if testName == "all" {
-		params.RunExpr = ""
-	} else {
-		params.RunExpr = testName
+	failedCount, err := integRunnerOnce(ctx, false, "./testing/integration/...", singleTest)
+	if err != nil {
+		return err
 	}
-	return devtools.GoTest(ctx, params)
+	if failedCount > 0 {
+		os.Exit(1)
+	}
+	return nil
 }
 
 // Auth authenticates users who run it to various IaaS CSPs and ESS
@@ -3083,6 +3080,8 @@ func createTestRunner(cfg *devtools.Settings, matrix bool, singleTest string, go
 		instanceProvisioner = multipass.NewProvisioner()
 	case kind.Name:
 		instanceProvisioner = kind.NewProvisioner()
+	case local.Name:
+		instanceProvisioner = local.NewProvisioner()
 	default:
 		return nil, fmt.Errorf("INSTANCE_PROVISIONER environment variable must be one of 'gcloud' or 'multipass', not %s", instanceProvisionerMode)
 	}

--- a/pkg/testing/common/instance.go
+++ b/pkg/testing/common/instance.go
@@ -15,6 +15,7 @@ type ProvisionerType uint32
 const (
 	ProvisionerTypeVM ProvisionerType = iota
 	ProvisionerTypeK8SCluster
+	ProvisionerTypeLocal
 )
 
 // Instance represents a provisioned instance.

--- a/pkg/testing/local/local.go
+++ b/pkg/testing/local/local.go
@@ -1,0 +1,64 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+// Package local provides a common.InstanceProvisioner and common.OSRunner
+// that run tests directly on the host running mage, instead of provisioning
+// a VM or Kubernetes cluster.
+package local
+
+import (
+	"context"
+	"runtime"
+
+	"github.com/elastic/elastic-agent/pkg/testing/common"
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+)
+
+// Name is the name of the local instance provisioner.
+const Name = "local"
+
+// NewProvisioner creates a new local instance provisioner.
+func NewProvisioner() common.InstanceProvisioner {
+	return &provisioner{}
+}
+
+type provisioner struct {
+	logger common.Logger
+}
+
+func (p *provisioner) Name() string {
+	return Name
+}
+
+func (p *provisioner) Type() common.ProvisionerType {
+	return common.ProvisionerTypeLocal
+}
+
+func (p *provisioner) SetLogger(l common.Logger) {
+	p.logger = l
+}
+
+// Supported only allows batches matching the current host's OS and architecture.
+func (p *provisioner) Supported(os define.OS) bool {
+	return os.Type == runtime.GOOS && os.Arch == runtime.GOARCH
+}
+
+// Provision returns one instance per batch, representing the current host; no
+// actual instance is created.
+func (p *provisioner) Provision(_ context.Context, _ common.Config, batches []common.OSBatch) ([]common.Instance, error) {
+	instances := make([]common.Instance, 0, len(batches))
+	for _, batch := range batches {
+		instances = append(instances, common.Instance{
+			ID:          batch.ID,
+			Name:        "local",
+			Provisioner: Name,
+		})
+	}
+	return instances, nil
+}
+
+// Clean does nothing, there is nothing to clean up for the local host.
+func (p *provisioner) Clean(_ context.Context, _ common.Config, _ []common.Instance) error {
+	return nil
+}

--- a/pkg/testing/local/runner.go
+++ b/pkg/testing/local/runner.go
@@ -1,0 +1,110 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package local
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/elastic/elastic-agent/pkg/testing/ssh"
+
+	devtools "github.com/elastic/elastic-agent/dev-tools/mage"
+	"github.com/elastic/elastic-agent/pkg/testing/common"
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+)
+
+// Runner runs tests directly on the host running mage, mirroring
+// kubernetes.Runner's use of devtools.GoTest instead of an SSH transport.
+type Runner struct{}
+
+// Prepare does nothing, the host running mage already has everything it needs.
+func (Runner) Prepare(ctx context.Context, sshClient ssh.SSHClient, logger common.Logger, arch string, goVersion string) error {
+	return nil
+}
+
+// Copy does nothing, tests run directly out of the local repo.
+func (Runner) Copy(ctx context.Context, sshClient ssh.SSHClient, logger common.Logger, repoArchive string, builds []common.Build) error {
+	return nil
+}
+
+// Run the test
+func (Runner) Run(ctx context.Context, verbose bool, sshClient ssh.SSHClient, logger common.Logger, agentVersion string, prefix string, batch define.Batch, env map[string]string) (common.OSRunnerResult, error) {
+	var goTestFlags []string
+	rawTestFlags := os.Getenv("GOTEST_FLAGS")
+	if rawTestFlags != "" {
+		goTestFlags = strings.Split(rawTestFlags, " ")
+	}
+
+	maxDuration := 2 * time.Hour
+	var result []common.OSRunnerPackageResult
+	for _, pkg := range batch.Tests {
+		packageTestsStrBuilder := strings.Builder{}
+		packageTestsStrBuilder.WriteString("^(")
+		for idx, test := range pkg.Tests {
+			if idx > 0 {
+				packageTestsStrBuilder.WriteString("|")
+			}
+			packageTestsStrBuilder.WriteString(test.Name)
+		}
+		packageTestsStrBuilder.WriteString(")$")
+
+		testPrefix := fmt.Sprintf("%s.%s", prefix, filepath.Base(pkg.Name))
+		testName := fmt.Sprintf("local-%s", testPrefix)
+		fileName := fmt.Sprintf("build/TEST-go-%s", testName)
+		extraFlags := make([]string, 0, len(goTestFlags)+6)
+		if len(goTestFlags) > 0 {
+			extraFlags = append(extraFlags, goTestFlags...)
+		}
+		extraFlags = append(extraFlags, "-test.shuffle", "on",
+			"-test.timeout", maxDuration.String(), "-test.run", packageTestsStrBuilder.String())
+
+		env["AGENT_VERSION"] = agentVersion
+		env["TEST_DEFINE_PREFIX"] = testPrefix
+
+		params := devtools.GoTestArgs{
+			LogName:         testName,
+			OutputFile:      fileName + ".out",
+			JUnitReportFile: fileName + ".xml",
+			Packages:        []string{pkg.Name},
+			Tags:            []string{"integration", "local"},
+			ExtraFlags:      extraFlags,
+			Env:             env,
+		}
+		err := devtools.GoTest(ctx, params)
+		if err != nil {
+			return common.OSRunnerResult{}, err
+		}
+
+		var resultPkg common.OSRunnerPackageResult
+		resultPkg.Name = pkg.Name
+		outputPath := fileName
+		resultPkg.Output, err = os.ReadFile(outputPath + ".out")
+		if err != nil {
+			return common.OSRunnerResult{}, fmt.Errorf("failed to fetched test output at %s.out", outputPath)
+		}
+		resultPkg.JSONOutput, err = os.ReadFile(outputPath + ".out.json")
+		if err != nil {
+			return common.OSRunnerResult{}, fmt.Errorf("failed to fetched test output at %s.out.json", outputPath)
+		}
+		resultPkg.XMLOutput, err = os.ReadFile(outputPath + ".xml")
+		if err != nil {
+			return common.OSRunnerResult{}, fmt.Errorf("failed to fetched test output at %s.xml", outputPath)
+		}
+		result = append(result, resultPkg)
+	}
+
+	return common.OSRunnerResult{
+		Packages: result,
+	}, nil
+}
+
+// Diagnostics does nothing, diagnostics are already on the local host.
+func (Runner) Diagnostics(ctx context.Context, sshClient ssh.SSHClient, logger common.Logger, destination string) error {
+	return nil
+}

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/common"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
+	"github.com/elastic/elastic-agent/pkg/testing/local"
 	tssh "github.com/elastic/elastic-agent/pkg/testing/ssh"
 	"github.com/elastic/elastic-agent/pkg/testing/supported"
 )
@@ -93,6 +94,12 @@ func NewRunner(cfg common.Config, ip common.InstanceProvisioner, sp common.Stack
 	}
 	osBatches = filterSupportedOS(osBatches, ip)
 
+	if ip.Type() == common.ProvisionerTypeLocal {
+		for i := range osBatches {
+			osBatches[i].OS.Runner = local.Runner{}
+		}
+	}
+
 	logger := &runnerLogger{
 		writer:    os.Stdout,
 		timestamp: cfg.Timestamp,
@@ -126,14 +133,6 @@ func (r *Runner) Logger() common.Logger {
 func (r *Runner) Run(ctx context.Context) (Result, error) {
 	// validate tests can even be performed
 	err := r.validate()
-	if err != nil {
-		return Result{}, err
-	}
-
-	// prepare
-	prepareCtx, prepareCancel := context.WithTimeout(ctx, 10*time.Minute)
-	defer prepareCancel()
-	sshAuth, repoArchive, err := r.prepare(prepareCtx)
 	if err != nil {
 		return Result{}, err
 	}
@@ -173,6 +172,14 @@ func (r *Runner) Run(ctx context.Context) (Result, error) {
 	var results map[string]common.OSRunnerResult
 	switch r.ip.Type() {
 	case common.ProvisionerTypeVM:
+		// prepare an SSH key and repo archive to reach the instances
+		prepareCtx, prepareCancel := context.WithTimeout(ctx, 10*time.Minute)
+		sshAuth, repoArchive, prepareErr := r.prepare(prepareCtx)
+		prepareCancel()
+		if prepareErr != nil {
+			return Result{}, prepareErr
+		}
+
 		// use SSH to perform all the required work on the instances
 		results, err = r.runInstances(ctx, sshAuth, repoArchive, instances)
 		if err != nil {
@@ -180,6 +187,11 @@ func (r *Runner) Run(ctx context.Context) (Result, error) {
 		}
 	case common.ProvisionerTypeK8SCluster:
 		results, err = r.runK8sInstances(ctx, instances)
+		if err != nil {
+			return Result{}, err
+		}
+	case common.ProvisionerTypeLocal:
+		results, err = r.runLocalInstances(ctx, instances)
 		if err != nil {
 			return Result{}, err
 		}
@@ -235,6 +247,29 @@ func (r *Runner) Clean() error {
 	return g.Wait()
 }
 
+func (r *Runner) stackEnv(batch common.OSBatch, logger common.Logger) (map[string]string, error) {
+	env := map[string]string{}
+	for k, v := range r.cfg.ExtraEnv {
+		env[k] = v
+	}
+	if batch.Batch.Stack != nil {
+		logger.Logf("Waiting for stack to be ready...")
+		stack, err := r.getStackForBatchID(batch.ID)
+		if err != nil {
+			return nil, err
+		}
+		env["ELASTICSEARCH_HOST"] = stack.Elasticsearch
+		env["ELASTICSEARCH_USERNAME"] = stack.Username
+		env["ELASTICSEARCH_PASSWORD"] = stack.Password
+		env["KIBANA_HOST"] = stack.Kibana
+		env["KIBANA_USERNAME"] = stack.Username
+		env["KIBANA_PASSWORD"] = stack.Password
+		env["ELASTIC_APM_SERVER_URL"] = stack.IntegrationsServer
+		logger.Logf("Using Stack with Kibana host %s, credentials available under .integration-cache", stack.Kibana)
+	}
+	return env, nil
+}
+
 func (r *Runner) runK8sInstances(ctx context.Context, instances []StateInstance) (map[string]common.OSRunnerResult, error) {
 	results := make(map[string]common.OSRunnerResult)
 	var resultsMx sync.Mutex
@@ -247,29 +282,10 @@ func (r *Runner) runK8sInstances(ctx context.Context, instances []StateInstance)
 		}
 
 		logger := &batchLogger{wrapped: r.logger, prefix: instance.ID}
-		// start with the ExtraEnv first preventing the other environment flags below
-		// from being overwritten
-		env := map[string]string{}
-		for k, v := range r.cfg.ExtraEnv {
-			env[k] = v
-		}
-		// ensure that we have all the requirements for the stack if required
-		if batch.Batch.Stack != nil {
-			// wait for the stack to be ready before continuing
-			logger.Logf("Waiting for stack to be ready...")
-			stack, stackErr := r.getStackForBatchID(batch.ID)
-			if stackErr != nil {
-				err = stackErr
-				continue
-			}
-			env["ELASTICSEARCH_HOST"] = stack.Elasticsearch
-			env["ELASTICSEARCH_USERNAME"] = stack.Username
-			env["ELASTICSEARCH_PASSWORD"] = stack.Password
-			env["KIBANA_HOST"] = stack.Kibana
-			env["KIBANA_USERNAME"] = stack.Username
-			env["KIBANA_PASSWORD"] = stack.Password
-			env["ELASTIC_APM_SERVER_URL"] = stack.IntegrationsServer
-			logger.Logf("Using Stack with Kibana host %s, credentials available under .integration-cache", stack.Kibana)
+		env, stackErr := r.stackEnv(batch, logger)
+		if stackErr != nil {
+			err = stackErr
+			continue
 		}
 
 		// set the go test flags
@@ -295,6 +311,32 @@ func (r *Runner) runK8sInstances(ctx context.Context, instances []StateInstance)
 	}
 	if err != nil {
 		return nil, err
+	}
+	return results, nil
+}
+
+func (r *Runner) runLocalInstances(ctx context.Context, instances []StateInstance) (map[string]common.OSRunnerResult, error) {
+	results := make(map[string]common.OSRunnerResult)
+	for _, instance := range instances {
+		batch, ok := findBatchByID(instance.ID, r.batches)
+		if !ok {
+			return nil, fmt.Errorf("unable to find batch with ID: %s", instance.ID)
+		}
+
+		logger := &batchLogger{wrapped: r.logger, prefix: instance.ID}
+		env, err := r.stackEnv(batch, logger)
+		if err != nil {
+			return nil, err
+		}
+		env["GOTEST_FLAGS"] = r.cfg.TestFlags
+		env["TEST_BINARY_NAME"] = r.cfg.BinaryName
+
+		result, err := batch.OS.Runner.Run(ctx, r.cfg.VerboseMode, nil, logger, r.cfg.AgentVersion, batch.ID, batch.Batch, env)
+		if err != nil {
+			logger.Logf("Failed to execute tests: %s", err)
+			return nil, fmt.Errorf("failed to execute tests for batch %s: %w", batch.ID, err)
+		}
+		results[batch.ID] = result
 	}
 	return results, nil
 }
@@ -373,29 +415,9 @@ func (r *Runner) runInstance(ctx context.Context, sshAuth ssh.AuthMethod, logger
 		logger.Logf("Failed to copy files instance: %s", err)
 		return common.OSRunnerResult{}, fmt.Errorf("failed to copy files to instance %s: %w", instance.Name, err)
 	}
-	// start with the ExtraEnv first preventing the other environment flags below
-	// from being overwritten
-	env := map[string]string{}
-	for k, v := range r.cfg.ExtraEnv {
-		env[k] = v
-	}
-
-	// ensure that we have all the requirements for the stack if required
-	if batch.Batch.Stack != nil {
-		// wait for the stack to be ready before continuing
-		logger.Logf("Waiting for stack to be ready...")
-		stack, err := r.getStackForBatchID(batch.ID)
-		if err != nil {
-			return common.OSRunnerResult{}, err
-		}
-		env["ELASTICSEARCH_HOST"] = stack.Elasticsearch
-		env["ELASTICSEARCH_USERNAME"] = stack.Username
-		env["ELASTICSEARCH_PASSWORD"] = stack.Password
-		env["KIBANA_HOST"] = stack.Kibana
-		env["KIBANA_USERNAME"] = stack.Username
-		env["KIBANA_PASSWORD"] = stack.Password
-		env["ELASTIC_APM_SERVER_URL"] = stack.IntegrationsServer
-		logger.Logf("Using Stack with Kibana host %s, credentials available under .integration-cache", stack.Kibana)
+	env, err := r.stackEnv(batch, logger)
+	if err != nil {
+		return common.OSRunnerResult{}, err
 	}
 
 	// set the go test flags

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -137,6 +137,12 @@ func (r *Runner) Run(ctx context.Context) (Result, error) {
 		return Result{}, err
 	}
 
+	// ensure the cache dir exists before any state gets written to it
+	cacheDir, err := r.ensureCacheDir()
+	if err != nil {
+		return Result{}, err
+	}
+
 	// start the needed stacks
 	err = r.startStacks(ctx)
 	if err != nil {
@@ -174,7 +180,7 @@ func (r *Runner) Run(ctx context.Context) (Result, error) {
 	case common.ProvisionerTypeVM:
 		// prepare an SSH key and repo archive to reach the instances
 		prepareCtx, prepareCancel := context.WithTimeout(ctx, 10*time.Minute)
-		sshAuth, repoArchive, prepareErr := r.prepare(prepareCtx)
+		sshAuth, repoArchive, prepareErr := r.prepare(prepareCtx, cacheDir)
 		prepareCancel()
 		if prepareErr != nil {
 			return Result{}, prepareErr
@@ -532,23 +538,7 @@ func (r *Runner) getBuilds(b common.OSBatch) []common.Build {
 // prepare prepares for the runner to run.
 //
 // Creates the SSH keys to use and creates the archive of the repo.
-func (r *Runner) prepare(ctx context.Context) (ssh.AuthMethod, string, error) {
-	wd, err := WorkDir()
-	if err != nil {
-		return nil, "", err
-	}
-	cacheDir := filepath.Join(wd, r.cfg.StateDir)
-	_, err = os.Stat(cacheDir)
-	if errors.Is(err, os.ErrNotExist) {
-		err = os.Mkdir(cacheDir, 0755)
-		if err != nil {
-			return nil, "", fmt.Errorf("failed to create %q: %w", cacheDir, err)
-		}
-	} else if err != nil {
-		// unknown error
-		return nil, "", err
-	}
-
+func (r *Runner) prepare(ctx context.Context, cacheDir string) (ssh.AuthMethod, string, error) {
 	var auth ssh.AuthMethod
 	var repoArchive string
 	g, gCtx := errgroup.WithContext(ctx)
@@ -568,7 +558,7 @@ func (r *Runner) prepare(ctx context.Context) (ssh.AuthMethod, string, error) {
 		repoArchive = repo
 		return nil
 	})
-	err = g.Wait()
+	err := g.Wait()
 	if err != nil {
 		return nil, "", err
 	}
@@ -849,6 +839,25 @@ func (r *Runner) writeState() error {
 		return fmt.Errorf("failed to write state file %s: %w", r.getStatePath(), err)
 	}
 	return nil
+}
+
+func (r *Runner) ensureCacheDir() (string, error) {
+	wd, err := WorkDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(wd, r.cfg.StateDir)
+	_, err = os.Stat(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		err = os.Mkdir(dir, 0755)
+		if err != nil {
+			return "", fmt.Errorf("failed to create %q: %w", dir, err)
+		}
+	} else if err != nil {
+		// unknown error
+		return "", err
+	}
+	return dir, nil
 }
 
 func (r *Runner) getStatePath() string {


### PR DESCRIPTION
## What does this PR do?

The `mage integration:local` target can now run tests that need a real Elastic Stack. It provisions or reuses it automatically, the same way `mage integration:single` does but runs the test directly on your machine instead of provisioning a VM.

## Why is it important?

Allow running integration tests on your own machine.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

None.

## How to test this PR locally

Make sure your test has `Stack: &define.Stack{}` and `Local: true`:
```golang
define.Require(t, define.Requirements{
    Group: integration.Default,
    Stack: &define.Stack{},
    Local: true,
...
})
```

Then run:
```
TEST_PACKAGES=tar.gz mage -v integration:local <your-test-name>
```

You should see it provision (or reuse) a stack and then run the test directly on your machine, with no VM created:
```
>>> (linux-amd64-ubuntu-2404-default) Waiting for stack to be ready...
>>> Creating cloud stack 9.5.0-SNAPSHOT [stack_id: 950-SNAPSHOT]
>>> Created cloud stack 9.5.0-SNAPSHOT [stack_id: 950-SNAPSHOT, deployment_id: 1234...]
>>> Waiting for cloud stack 9.5.0-SNAPSHOT to be ready [stack_id: 950-SNAPSHOT, deployment_id: 1234...]
>>> (linux-amd64-ubuntu-2404-default) Using Stack with Kibana host https://<redacted>.us-west2.gcp.elastic-cloud.com, credentials available under .integration-cache
...
--- PASS: <your-test-name> (22.66s)
PASS
ok  	github.com/elastic/elastic-agent/testing/integration/ess	22.763s
```
