### PR TITLE
Fix FIPS-only binaries incorrectly passing fips140=on check

### DIFF
--- a/dev-tools/packaging/testing/package_test.go
+++ b/dev-tools/packaging/testing/package_test.go
@@ -881,8 +881,11 @@ func checkFIPS(t *testing.T, agentPackageRootDir string) {
 					require.True(t, strings.HasPrefix(setting.Value, "v1.0.0"), "GOFIPS140 must reference the certified module version v1.0.0, got: %s", setting.Value)
 					continue
 				case "DefaultGODEBUG":
-					if strings.Contains(setting.Value, "fips140=on") {
-						foundFIPSDefault = true
+					for _, entry := range strings.Split(setting.Value, ",") {
+						if key, val, ok := strings.Cut(entry, "="); ok && key == "fips140" && val == "on" {
+							foundFIPSDefault = true
+							break
+						}
 					}
 					continue
 				}


### PR DESCRIPTION
ensure that we do not matches `fips140=only` isntead of `fips140=on`

based on fleet-server review: https://github.com/elastic/fleet-server/pull/7332#discussion_r3545691286