### PR TITLE
[9.5] Fix production Helm Chart package

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -4223,12 +4223,13 @@ func (h Helm) Package(ctx context.Context) error {
 	mg.SerialDeps(h.BuildDependencies)
 
 	cfg := devtools.SettingsFromContext(ctx)
-	productionPackage := !cfg.Build.Snapshot
 
 	cfg, err := cfg.WithManifestInfo(ctx)
 	if err != nil {
 		return fmt.Errorf("failed downloading manifest: %w", err)
 	}
+
+	productionPackage := !cfg.Build.Snapshot
 	agentPackageVersion := cfg.AgentPackageVersion()
 	agentImageTag := agentPackageVersion
 	agentChartVersion := agentPackageVersion


### PR DESCRIPTION
Due to a combination of incorrect config modification order and SNAPSHOT=true becoming the default, the production Helm Chart package was built as a snapshot build. The build would check if it was a snapshot build before loading the manifest. Fix the ordering.

Tested manually against the current staging manifest.

I'll port the fix to other branches later, right now it's blocking the 9.5 build candidate.
