### PR TITLE
Fix submodule access error in post-checkout merge for sparse checkouts

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -20,7 +20,7 @@ checkout_merge() {
     # function when beats is not an initialized repository.
     local -a git=( git )
     if [[ ! -e beats/.git ]]; then
-        git=( git -c submodule.recurse=false )
+        git+=( -c submodule.recurse=false )
     fi
 
     "${git[@]}" fetch -v origin "${target_branch}"

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -20,7 +20,7 @@ checkout_merge() {
     # function when beats is not an initialized repository.
     local -a git=( git )
     if [[ ! -e beats/.git ]]; then
-        git+=( -c submodule.recurse=false )
+        git=( git -c submodule.recurse=false )
     fi
 
     "${git[@]}" fetch -v origin "${target_branch}"

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -12,7 +12,18 @@ checkout_merge() {
         exit 1
     fi
 
-    git fetch -v origin "${target_branch}"
+    # The sparse-checkout plugin creates a blobless partial clone that leaves
+    # an empty beats/ stub in the working tree but no beats/.git inside it.
+    # With the Buildkite agent's global submodule.recurse=true, every git
+    # command below would attempt submodule operations on that stub and fail
+    # with "Could not access submodule 'beats'".  Override it for the entire
+    # function when beats is not an initialized repository.
+    local -a git=( git )
+    if [[ ! -e beats/.git ]]; then
+        git=( git -c submodule.recurse=false )
+    fi
+
+    "${git[@]}" fetch -v origin "${target_branch}"
     local fetched_sha
     fetched_sha=$(git rev-parse FETCH_HEAD)
 
@@ -34,20 +45,20 @@ checkout_merge() {
     # depth-1 fetch are not re-transferred.  Full checkouts skip this block.
     if [[ "$(git rev-parse --is-shallow-repository 2>/dev/null)" == "true" ]]; then
         echo "Shallow repository detected; unshallowing to enable merge"
-        git fetch --unshallow origin
+        "${git[@]}" fetch --unshallow origin
     fi
 
     # Create the merge branch directly from the pinned base SHA.  This works
     # whether HEAD is currently on a symbolic ref (normal checkout) or detached
     # (sparse-checkout steps that do git checkout <sha>).
-    git checkout -b "${merge_branch}" "${pinned_sha}"
+    "${git[@]}" checkout -b "${merge_branch}" "${pinned_sha}"
     echo "New branch created: $(git rev-parse --abbrev-ref HEAD)"
 
     # set author identity so it can be run git merge
     git config user.name "github-merged-pr-post-checkout"
     git config user.email "auto-merge@buildkite"
 
-    git merge --no-edit "${pr_commit}" || {
+    "${git[@]}" merge --no-edit "${pr_commit}" || {
         local merge_result=$?
         echo "Merge failed: ${merge_result}"
         git merge --abort


### PR DESCRIPTION
## What does this PR do?

Fixes the `.buildkite/hooks/post-checkout` hook so it overrides `submodule.recurse=false` for the `beats` submodule whenever `beats/.git` is absent, i.e. in the sparse-checkout "pipeline-upload" steps that intentionally never initialize it.

## Why is it important?

Buildkite agents have `submodule.recurse=true` set globally. The sparse-checkout pipeline-upload steps only check out `.buildkite`, `.go-version`, `.package-version`, and `version/version.go`, so `beats` is never initialized there. Whenever `checkout_merge()` has to reconcile a changed `beats` gitlink (e.g. an automated beats-bump PR), git tries to recurse into the uninitialized submodule and fails with:

```
Could not access submodule 'beats'
```

This fix already exists on the `9.4`, `9.3`, and `8.19` backport branches (added directly there when #14556 was backported), but was never applied to `main`, so branches cut from `main` after that point (like `9.5`) inherited the bug. It first surfaced on #15428, an automated beats-bump PR targeting `9.5`.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~ (CI infra fix, not user-facing)
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None. This only affects CI infrastructure (the Buildkite post-checkout hook), not the released product.

## How to test this PR locally

Not directly testable locally; verified by reproducing the failure in a sandbox sparse-checkout clone with a submodule gitlink change, and by comparing against the already-working `9.4`/`9.3`/`8.19` versions of this hook.

## Related issues

- Relates #15428