### PR TITLE
[mage] Fix release Helm Chart version

### DIFF
--- a/deploy/helm/elastic-agent/values.yaml
+++ b/deploy/helm/elastic-agent/values.yaml
@@ -71,11 +71,11 @@ outputs:
     # -- contents to the client certificate for the output
     # @section -- 1.1 - Output Object
     # @key -- outputs.{name}.ssl.certificate.value
-    #  value: ""      
+    #  value: ""
     # -- path to the client private key for the output
     # @section -- 1.1 - Output Object
     # @key -- outputs.{name}.ssl.key
-    #  key: 
+    #  key:
     # -- path to the client private key for the output
     # @section -- 1.1 - Output Object
     # @key -- outputs.{name}.ssl.key.valueFromSecret

--- a/magefile.go
+++ b/magefile.go
@@ -4256,20 +4256,14 @@ func (h Helm) Package(ctx context.Context) error {
 	mg.SerialDeps(h.BuildDependencies)
 
 	cfg := devtools.SettingsFromContext(ctx)
-	productionPackage := !cfg.Build.Snapshot
 
 	cfg, err := cfg.WithManifestInfo(ctx)
 	if err != nil {
 		return fmt.Errorf("failed downloading manifest: %w", err)
 	}
 	agentPackageVersion := cfg.AgentPackageVersion()
-	agentImageTag := agentPackageVersion
-	agentChartVersion := agentPackageVersion
-	if !productionPackage {
-		// always use the SNAPSHOT version for image tag if not a production package
-		agentImageTag = agentImageTag + devtools.SnapshotSuffix
-		agentChartVersion = agentChartVersion + devtools.SnapshotSuffix
-	}
+	agentImageTag := agentPackageVersion + devtools.MaybeSnapshotSuffix(cfg)
+	agentChartVersion := agentPackageVersion + devtools.MaybeSnapshotSuffix(cfg)
 
 	for yamlFile, keyVals := range map[string][]struct {
 		key   string


### PR DESCRIPTION
## What does this PR do?

Due to a misordering of config modifiers and SNAPSHOT=true becoming the default, we would build the release package as if it was a snapshot build. Fix this and consolidate the logic.

## Why is it important?

It's a bug in the release build process.

## How to test this PR locally

Run `mage helm:package` plainly, and then with a staging manifest: `MANIFEST_URL="https://staging.elastic.co/9.5.0-0e81e6fd/agent-package/agent-artifacts-9.5.0.json" `. The former should produce a snapshot build, and the latter a release one.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
