### PR TITLE
[mage] Retry network failures in packaging downloads

### DIFF
--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -33,6 +33,7 @@ import (
 	"time"
 	"unicode"
 
+	backoff "github.com/cenkalti/backoff/v4"
 	"github.com/magefile/mage/sh"
 )
 
@@ -239,27 +240,21 @@ func MustFindReplace(file string, re *regexp.Regexp, repl string) {
 	}
 }
 
-// retryBackoffSchedule is the wait time before each retry of a failed network
-// operation; the number of entries bounds the number of retries.
-var retryBackoffSchedule = []time.Duration{
-	1 * time.Second,
-	3 * time.Second,
-	10 * time.Second,
-}
+// retryMaxRetries bounds the number of retries of a failed network operation,
+// in addition to the initial attempt.
+const retryMaxRetries = 3
 
-// Retry runs f up to len(retryBackoffSchedule)+1 times, backing off between
+// Retry runs f up to retryMaxRetries+1 times with exponential backoff between
 // attempts, to protect network operations against transient failures.
 func Retry(f func() error) error {
-	err := f()
-	for _, backoff := range retryBackoffSchedule {
-		if err == nil {
-			return nil
-		}
-		log.Printf("Attempt failed: %v, retrying in %v", err, backoff)
-		time.Sleep(backoff)
-		err = f()
-	}
-	return err
+	exp := backoff.NewExponentialBackOff()
+	exp.InitialInterval = 1 * time.Second
+	exp.Multiplier = 3
+	exp.MaxInterval = 10 * time.Second
+	return backoff.RetryNotify(f, backoff.WithMaxRetries(exp, retryMaxRetries),
+		func(err error, wait time.Duration) {
+			log.Printf("Attempt failed: %v, retrying in %v", err, wait)
+		})
 }
 
 // DownloadFile downloads the given URL and writes the file to destinationDir,

--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -239,11 +239,47 @@ func MustFindReplace(file string, re *regexp.Regexp, repl string) {
 	}
 }
 
-// DownloadFile downloads the given URL and writes the file to destinationDir.
-// The path to the file is returned.
+// retryBackoffSchedule is the wait time before each retry of a failed network
+// operation; the number of entries bounds the number of retries.
+var retryBackoffSchedule = []time.Duration{
+	1 * time.Second,
+	3 * time.Second,
+	10 * time.Second,
+}
+
+// Retry runs f up to len(retryBackoffSchedule)+1 times, backing off between
+// attempts, to protect network operations against transient failures.
+func Retry(f func() error) error {
+	err := f()
+	for _, backoff := range retryBackoffSchedule {
+		if err == nil {
+			return nil
+		}
+		log.Printf("Attempt failed: %v, retrying in %v", err, backoff)
+		time.Sleep(backoff)
+		err = f()
+	}
+	return err
+}
+
+// DownloadFile downloads the given URL and writes the file to destinationDir,
+// retrying transient failures. The path to the file is returned.
 func DownloadFile(url, destinationDir string) (string, error) {
 	log.Println("Downloading", url)
 
+	var name string
+	err := Retry(func() error {
+		var err error
+		name, err = downloadFileAttempt(url, destinationDir)
+		return err
+	})
+	if err != nil {
+		return "", err
+	}
+	return name, nil
+}
+
+func downloadFileAttempt(url, destinationDir string) (string, error) {
 	//nolint:gosec,noctx // url is not user input
 	resp, err := http.Get(url)
 	if err != nil {
@@ -252,7 +288,7 @@ func DownloadFile(url, destinationDir string) (string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("download failed with http status: %v : %w", resp.StatusCode, err)
+		return "", fmt.Errorf("download failed with http status: %v", resp.StatusCode)
 	}
 
 	name := filepath.Join(destinationDir, filepath.Base(url))

--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -216,30 +216,6 @@ func HaveKubectl() error {
 	return nil
 }
 
-// FindReplace reads a file, performs a find/replace operation, then writes the
-// output to the same file path.
-func FindReplace(file string, re *regexp.Regexp, repl string) error {
-	info, err := os.Stat(file)
-	if err != nil {
-		return err
-	}
-
-	contents, err := os.ReadFile(file)
-	if err != nil {
-		return err
-	}
-
-	out := re.ReplaceAllString(string(contents), repl)
-	return os.WriteFile(file, []byte(out), info.Mode().Perm())
-}
-
-// MustFindReplace invokes FindReplace and panics if an error occurs.
-func MustFindReplace(file string, re *regexp.Regexp, repl string) {
-	if err := FindReplace(file, re, repl); err != nil {
-		panic(fmt.Errorf("failed to find and replace: %w", err))
-	}
-}
-
 // retryMaxRetries bounds the number of retries of a failed network operation,
 // in addition to the initial attempt.
 const retryMaxRetries = 3
@@ -383,6 +359,14 @@ func Tar(src string, targetFile string) error {
 	zr := gzip.NewWriter(f)
 	tw := tar.NewWriter(zr)
 
+	// open files via a root scoped to src so a path component replaced with a
+	// symlink mid-walk cannot redirect reads outside the tree (TOCTOU)
+	root, err := os.OpenRoot(src)
+	if err != nil {
+		return fmt.Errorf("error opening source directory: %w", err)
+	}
+	defer root.Close()
+
 	// walk through every file in the folder
 	err = filepath.WalkDir(src, func(file string, d fs.DirEntry, errFn error) error {
 		if errFn != nil {
@@ -417,7 +401,11 @@ func Tar(src string, targetFile string) error {
 
 		// if not a dir, write file content
 		if !fi.IsDir() {
-			data, err := os.Open(file)
+			rel, err := filepath.Rel(src, file)
+			if err != nil {
+				return fmt.Errorf("error resolving path relative to %q: %w", src, err)
+			}
+			data, err := root.Open(rel)
 			if err != nil {
 				return fmt.Errorf("error opening file: %w", err)
 			}

--- a/dev-tools/mage/downloads/utils.go
+++ b/dev-tools/mage/downloads/utils.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	devtools "github.com/elastic/elastic-agent/dev-tools/mage"
 
@@ -27,13 +28,19 @@ type downloadRequest struct {
 	TargetPath string
 }
 
+// downloadFileBackoff returns the retry policy for downloadFile; a variable so
+// tests can substitute a fast policy.
+var downloadFileBackoff = func() backoff.BackOff {
+	return getExponentialBackoff(time.Minute)
+}
+
 // downloadFile will download a url and store it in a temporary path.
 // It writes to the destination file as it downloads it, without
 // loading the entire file into memory.
 func downloadFile(downloadRequest *downloadRequest) error {
 	stat, _ := os.Stat(downloadRequest.TargetPath)
 
-	exp := getExponentialBackoff(3)
+	exp := downloadFileBackoff()
 
 	retryCount := 1
 	download := func() error {
@@ -57,6 +64,15 @@ func downloadFile(downloadRequest *downloadRequest) error {
 
 		if resp.StatusCode == http.StatusNotModified {
 			return nil
+		}
+
+		// Return an error on a bad HTTP status so transient failures (429, 5xx)
+		// are retried instead of the error body being saved as the downloaded
+		// file. Drain the body so the connection can be reused.
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			retryCount++
+			return fmt.Errorf("downloading file %s: bad HTTP status: %d - %q", downloadRequest.URL, resp.StatusCode, resp.Status)
 		}
 
 		targetFile, err := os.Create(downloadRequest.TargetPath)

--- a/dev-tools/mage/downloads/utils.go
+++ b/dev-tools/mage/downloads/utils.go
@@ -42,7 +42,6 @@ func downloadFile(downloadRequest *downloadRequest) error {
 
 	exp := downloadFileBackoff()
 
-	retryCount := 1
 	download := func() error {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, downloadRequest.URL, nil)
 		if err != nil {
@@ -55,7 +54,6 @@ func downloadFile(downloadRequest *downloadRequest) error {
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
-			retryCount++
 			return fmt.Errorf("downloading file %s: %w", downloadRequest.URL, err)
 		}
 		defer func() {
@@ -71,7 +69,6 @@ func downloadFile(downloadRequest *downloadRequest) error {
 		// file. Drain the body so the connection can be reused.
 		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 			_, _ = io.Copy(io.Discard, resp.Body)
-			retryCount++
 			return fmt.Errorf("downloading file %s: bad HTTP status: %d - %q", downloadRequest.URL, resp.StatusCode, resp.Status)
 		}
 

--- a/dev-tools/mage/downloads/utils_test.go
+++ b/dev-tools/mage/downloads/utils_test.go
@@ -13,7 +13,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	backoff "github.com/cenkalti/backoff/v4"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
@@ -32,6 +34,62 @@ func TestDownloadFile(t *testing.T) {
 	err := downloadFile(&dRequest)
 	assert.Nil(t, err)
 	assert.FileExistsf(t, dRequest.TargetPath, "file should exist")
+}
+
+// useFastDownloadFileBackoff replaces the download retry policy with one that
+// does not wait between attempts and gives up after maxRetries retries.
+func useFastDownloadFileBackoff(t *testing.T, maxRetries uint64) {
+	orig := downloadFileBackoff
+	downloadFileBackoff = func() backoff.BackOff {
+		return backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Millisecond), maxRetries)
+	}
+	t.Cleanup(func() { downloadFileBackoff = orig })
+}
+
+func TestDownloadFileRetriesOnServerError(t *testing.T) {
+	useFastDownloadFileBackoff(t, 5)
+
+	const content = "some content"
+	attempts := 0
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts <= 2 {
+			http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(content))
+	}))
+	t.Cleanup(s.Close)
+
+	var dRequest = downloadRequest{
+		URL:        s.URL,
+		TargetPath: filepath.Join(t.TempDir(), "some-file.txt"),
+	}
+
+	err := downloadFile(&dRequest)
+	require.NoError(t, err)
+	assert.Equal(t, 3, attempts, "expected two failed attempts and one successful one")
+	got, err := os.ReadFile(dRequest.TargetPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(got), "the error response body must not be saved as the file")
+}
+
+func TestDownloadFileFailsOnPersistentServerError(t *testing.T) {
+	useFastDownloadFileBackoff(t, 2)
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(s.Close)
+
+	var dRequest = downloadRequest{
+		URL:        s.URL,
+		TargetPath: filepath.Join(t.TempDir(), "some-file.txt"),
+	}
+
+	err := downloadFile(&dRequest)
+	require.Error(t, err)
+	assert.NoFileExists(t, dRequest.TargetPath, "the error response body must not be saved as the file")
 }
 
 func TestVerifyChecksum(t *testing.T) {

--- a/dev-tools/mage/lint.go
+++ b/dev-tools/mage/lint.go
@@ -43,7 +43,7 @@ func InstallGolangciLint() error {
 	}
 	fmt.Printf(">> install golangci-lint %s\n", wantVer)
 	return sh.RunV("bash", "-c",
-		fmt.Sprintf("curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s %s", wantVer))
+		fmt.Sprintf("curl -sSfL --retry 5 --retry-delay 5 --retry-all-errors https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s %s", wantVer))
 }
 
 // golangciLintInstalledVersion returns the version of the locally installed

--- a/dev-tools/mage/manifest/manifestspecs.go
+++ b/dev-tools/mage/manifest/manifestspecs.go
@@ -54,7 +54,7 @@ func downloadFile(ctx context.Context, url string, filepath string) (string, err
 
 	resp, reqErr := http.DefaultClient.Do(req)
 	if reqErr != nil {
-		return filepath, fmt.Errorf("failed to download manifest [%s]\n %w", url, err)
+		return filepath, fmt.Errorf("failed to download manifest [%s]\n %w", url, reqErr)
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -62,9 +62,16 @@ func downloadFile(ctx context.Context, url string, filepath string) (string, err
 		}
 	}()
 
+	// Return an error on a bad HTTP status so transient failures (429, 5xx)
+	// are retried by the caller instead of the error body being saved as the
+	// downloaded file.
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("bad HTTP status for GET %q: %d - %q", url, resp.StatusCode, resp.Status)
+	}
+
 	_, errCopy := io.Copy(outFile, resp.Body)
 	if errCopy != nil {
-		return "", fmt.Errorf("failed to decode manifest response [%s]\n %w", url, err)
+		return "", fmt.Errorf("failed to write downloaded file [%s]\n %w", url, errCopy)
 	}
 	if mg.Verbose() {
 		log.Printf("<<<<<<<<< Downloaded: %s to %s", url, filepath)
@@ -89,6 +96,10 @@ func downloadManifestData(ctx context.Context, url string) (Build, error) {
 			panic(err)
 		}
 	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return response, fmt.Errorf("bad HTTP status for GET %q: %d - %q", url, resp.StatusCode, resp.Status)
+	}
 
 	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {

--- a/dev-tools/mage/manifest/manifestspecs_test.go
+++ b/dev-tools/mage/manifest/manifestspecs_test.go
@@ -1,0 +1,58 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package manifest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadFile(t *testing.T) {
+	const content = "some content"
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(content))
+	}))
+	t.Cleanup(s.Close)
+
+	target := filepath.Join(t.TempDir(), "some-file.txt")
+	name, err := downloadFile(t.Context(), s.URL, target)
+	require.NoError(t, err)
+	assert.Equal(t, target, name)
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(got))
+}
+
+func TestDownloadFileBadStatus(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(s.Close)
+
+	target := filepath.Join(t.TempDir(), "some-file.txt")
+	_, err := downloadFile(t.Context(), s.URL, target)
+	require.Error(t, err, "a bad HTTP status must be an error so the caller retries")
+
+	got, readErr := os.ReadFile(target)
+	if readErr == nil {
+		assert.Empty(t, string(got), "the error response body must not be saved as the file")
+	}
+}
+
+func TestDownloadManifestDataBadStatus(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(s.Close)
+
+	_, err := downloadManifestData(t.Context(), s.URL)
+	require.Error(t, err, "a bad HTTP status must be an error so the caller retries")
+}

--- a/magefile.go
+++ b/magefile.go
@@ -1081,7 +1081,9 @@ func (Cloud) Push(ctx context.Context) error {
 	fmt.Println(">> Docker image tag updated successfully")
 
 	fmt.Println(">> Pushing a docker image to remote registry")
-	err = sh.RunV("docker", "image", "push", targetCloudImageName)
+	err = devtools.Retry(func() error {
+		return sh.RunV("docker", "image", "push", targetCloudImageName)
+	})
 	if err != nil {
 		return fmt.Errorf("failed pushing docker image: %w", err)
 	}
@@ -1543,6 +1545,24 @@ func FetchLatestAgentCoreStagingDRA(ctx context.Context, branch string) error {
 func findLatestBuildForBranch(ctx context.Context, baseURL string, branch string) (*branchInfo, error) {
 	// latest build info for a branch is at "<base url>/latest/<branch>.json"
 	branchLatestBuildUrl := strings.TrimSuffix(baseURL, "/") + fmt.Sprintf("/latest/%s.json", branch)
+	var bi *branchInfo
+	err := devtools.Retry(func() error {
+		var fetchErr error
+		bi, fetchErr = fetchBranchInfo(ctx, branchLatestBuildUrl)
+		return fetchErr
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if mg.Verbose() {
+		log.Printf("Received branch information for %q: %+v", branch, bi)
+	}
+
+	return bi, nil
+}
+
+func fetchBranchInfo(ctx context.Context, branchLatestBuildUrl string) (*branchInfo, error) {
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, branchLatestBuildUrl, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error composing request for finding latest build using %q: %w", branchLatestBuildUrl, err)
@@ -1566,10 +1586,6 @@ func findLatestBuildForBranch(ctx context.Context, baseURL string, branch string
 	err = json.NewDecoder(resp.Body).Decode(bi)
 	if err != nil {
 		return nil, fmt.Errorf("decoding json branch information: %w", err)
-	}
-
-	if mg.Verbose() {
-		log.Printf("Received branch information for %q: %+v", branch, bi)
 	}
 
 	return bi, nil
@@ -4115,7 +4131,10 @@ func (Helm) ensureRepository(repoName, repoURL string, settings *cli.EnvSettings
 		return fmt.Errorf("could not create repo %s: %w", repoURL, err)
 	}
 
-	_, err = chartRepo.DownloadIndexFile()
+	err = devtools.Retry(func() error {
+		_, err := chartRepo.DownloadIndexFile()
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("could not download index file for repo %s: %w", repoURL, err)
 	}
@@ -4198,12 +4217,12 @@ func (h Helm) handleDependencies(update bool) error {
 	}
 
 	if update {
-		if err = man.Update(); err != nil {
-			return fmt.Errorf("failed to build helm dependencies: %w", err)
+		if err = devtools.Retry(man.Update); err != nil {
+			return fmt.Errorf("failed to update helm dependencies: %w", err)
 		}
 	} else {
-		if err = man.Build(); err != nil {
-			return fmt.Errorf("failed to update helm dependencies: %w", err)
+		if err = devtools.Retry(man.Build); err != nil {
+			return fmt.Errorf("failed to build helm dependencies: %w", err)
 		}
 	}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Retries all retryable network failures in packaging related mage targets.

The package download helpers never checked the HTTP status code, so a transient 429/5xx from the artifact host wrote the error body to disk as the downloaded file and reported success - the surrounding retry logic never fired. Return an error on bad statuses in both helpers (`dev-tools/mage/manifest` and `dev-tools/mage/downloads`) so their existing retry wrappers take effect, and fix error wrapping that referenced the wrong (nil) error variable.

Also fix `downloads.downloadFile` passing a bare 3 (nanoseconds) as the `backoff MaxElapsedTime`, which made `backoff.Retry` give up after the first attempt; it now uses `time.Minute` like every other call site in the package.

Add a `devtools.Retry` helper and use it for the remaining one-shot network operations in the magefile: the DRA latest-build lookup, helm repository index and chart dependency downloads, the kube-stack chart download (`devtools.DownloadFile`), and the cloud image docker push.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/15448

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
