### PR TITLE
ci: support versioned dispatches for docs updates

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -7,7 +7,12 @@ on:
     # Run weekly on Monday at 8:00 AM UTC
     - cron: '0 8 * * 1'
   workflow_dispatch:
-    # Allow manual triggering
+    # Allow manual triggering and release automation dispatches.
+    inputs:
+      version:
+        description: "Released version tag to generate documentation for (for example, v9.4.3)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -37,6 +42,8 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "release" ]]; then
             LATEST_VERSION="${{ github.event.release.tag_name }}"
+          elif [[ -n "${{ inputs.version }}" ]]; then
+            LATEST_VERSION="${{ inputs.version }}"
           else
             # Get the latest semantic version tag (excluding pre-release versions)
             LATEST_VERSION=$(git tag --list | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -1)


### PR DESCRIPTION
## What does this PR do?

Adds an optional `version` input to the generated-documentation workflow. A release publisher can dispatch the workflow with its exact release tag, rather than relying on a `release.published` event or resolving the latest tag at run time.

## Why is it important?

The v9.4.3 release did not create a `release`-event run. Explicit `workflow_dispatch` is reliable even when the publisher uses `GITHUB_TOKEN`, and passing the version prevents races with subsequent releases.

`@elastic/docs-engineering` is already a CODEOWNER for `.github/workflows/update-docs.yml` on the current upstream `main`; no CODEOWNERS edit is required.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

None.

## How to test this PR locally

Run `actionlint .github/workflows/update-docs.yml`.

After the release publisher dispatches the workflow with `version: vX.Y.Z`, verify the generated documentation PR references that same tag.