### PR TITLE
docs: update generated docs owner

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -96,7 +96,7 @@ jobs:
             - **Source components.yaml**: https://github.com/elastic/elastic-agent/blob/${{ steps.get_version.outputs.version }}/internal/edot/components.yaml
             - **Release tag**: https://github.com/elastic/elastic-agent/tree/${{ steps.get_version.outputs.version }}
             
-            cc @elastic/ingest-docs
+            cc @elastic/ski-docs
             
             This is an automated PR created by the documentation update workflow.
           branch: update-docs-${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
## What does this PR do?

Updates the generated documentation PR body to mention `@elastic/ski-docs` instead of the retired `@elastic/ingest-docs` team.

The workflow CODEOWNERS entry already includes `@elastic/ski-docs` and `@elastic/docs-engineering`.

## Why is it important?

Generated documentation PRs should notify the current documentation owners. This PR is intended to be backported with the release-trigger workflow so releases from active branches use the correct team.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

None.

## How to test this PR locally

Run `actionlint .github/workflows/update-docs.yml`.

## Related issues

- Follow-up to #15057