### PR TITLE
Add environment variables to collector diagnostics

### DIFF
--- a/changelog/fragments/1783991840-add-collector-env-diagnostics.yaml
+++ b/changelog/fragments/1783991840-add-collector-env-diagnostics.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Add environment variables to collector diagnostics
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -108,7 +108,7 @@ func GlobalHooks() Hooks {
 			Description: "Environment variables",
 			ContentType: "application/yaml",
 			Hook: func(_ context.Context) []byte {
-				redacted, err := redactEnv()
+				redacted, err := RedactEnv()
 				if err != nil {
 					return []byte(err.Error())
 				}
@@ -661,7 +661,7 @@ func addSecretMarkers(cfg *config.Config, secretPaths []string) error {
 	return aggregateError
 }
 
-func redactEnv() (map[string]any, error) {
+func RedactEnv() (map[string]any, error) {
 	envMap := map[string]any{}
 	for _, e := range os.Environ() {
 		pair := strings.SplitN(e, "=", 2)

--- a/internal/pkg/diagnostics/diagnostics_test.go
+++ b/internal/pkg/diagnostics/diagnostics_test.go
@@ -1354,7 +1354,7 @@ func TestRedactEnv(t *testing.T) {
 			for k, v := range tt.env {
 				t.Setenv(k, v)
 			}
-			redacted, err := redactEnv()
+			redacted, err := RedactEnv()
 			require.NoError(t, err)
 
 			// redacted includes full env vars, we want to check if the expected k:v's are present

--- a/internal/pkg/otel/extension/elasticdiagnostics/extension.go
+++ b/internal/pkg/otel/extension/elasticdiagnostics/extension.go
@@ -126,6 +126,23 @@ func (d *diagnosticsExtension) registerGlobalDiagnostics() {
 		},
 	}
 
+	d.globalHooks["environment"] = &diagHook{
+		description: "environment variables of the collector process",
+		filename:    "edot/environment.yaml",
+		contentType: "application/yaml",
+		hook: func() []byte {
+			redacted, err := diagnostics.RedactEnv()
+			if err != nil {
+				return fmt.Appendf(nil, "error: %v", err)
+			}
+			b, err := yaml.Marshal(redacted)
+			if err != nil {
+				return fmt.Appendf(nil, "error: failed to convert to yaml: %v", err)
+			}
+			return b
+		},
+	}
+
 	// register basic profiles.
 	for _, profile := range []string{"goroutine", "heap", "allocs", "mutex", "threadcreate", "block"} {
 		d.globalHooks[profile] = &diagHook{

--- a/internal/pkg/otel/extension/elasticdiagnostics/extension_test.go
+++ b/internal/pkg/otel/extension/elasticdiagnostics/extension_test.go
@@ -89,16 +89,23 @@ func TestExtension(t *testing.T) {
 		require.NotEmpty(collect, res.GlobalDiagnostics)
 		require.NotEmpty(collect, res.ComponentDiagnostics)
 		foundCPU := false
+		foundEnv := false
 		for _, global := range res.GlobalDiagnostics {
-			if global.Name == "cpu" {
+			switch global.Name {
+			case "cpu":
 				foundCPU = true
-				break
-			}
-			if strings.HasSuffix(global.Filename, "profile.gz") {
-				verifyPprof(t, global.Content)
+			case "environment":
+				foundEnv = true
+				require.Equal(collect, "edot/environment.yaml", global.Filename)
+				require.Equal(collect, "application/yaml", global.ContentType)
+			default:
+				if strings.HasSuffix(global.Filename, "profile.gz") {
+					verifyPprof(t, global.Content)
+				}
 			}
 		}
 		require.True(collect, foundCPU, "cpu.pprof not found in global diagnostics")
+		require.True(collect, foundEnv, "environment not found in global diagnostics")
 
 		for _, comp := range res.ComponentDiagnostics {
 			switch comp.Name {

--- a/internal/pkg/otel/extension/elasticdiagnostics/extension_test.go
+++ b/internal/pkg/otel/extension/elasticdiagnostics/extension_test.go
@@ -74,9 +74,9 @@ func TestExtension(t *testing.T) {
 	client := &http.Client{Transport: tr}
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		req, err := http.NewRequest(http.MethodGet, "http://localhost/diagnostics?cpu=true&cpuduration=5s", nil)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://localhost/diagnostics?cpu=true&cpuduration=5s", nil)
 		require.NoError(collect, err)
-		resp, err := client.Do(req.WithContext(context.Background()))
+		resp, err := client.Do(req)
 		require.NoError(collect, err)
 		require.Equal(collect, http.StatusOK, resp.StatusCode)
 

--- a/testing/integration/ess/diagnostics_test.go
+++ b/testing/integration/ess/diagnostics_test.go
@@ -39,8 +39,6 @@ import (
 	"github.com/elastic/elastic-agent/testing/integration"
 )
 
-const diagnosticsArchiveGlobPattern = "elastic-agent-diagnostics-*.zip"
-
 var diagnosticsFiles = []string{
 	"package.version",
 	"agent-info.yaml",
@@ -715,6 +713,7 @@ func testDiagnosticsFactory(t *testing.T, compSetup map[string]integrationtest.C
 		}
 
 		diagZip, err := fix.ExecDiagnostics(ctx, cmd...)
+		require.NoError(t, err)
 
 		// get the version of the running agent
 		avi, err := getRunningAgentVersion(ctx, fix)
@@ -814,7 +813,7 @@ func extractZipArchive(t *testing.T, zipFile string, dst string) {
 
 	t.Logf("extracting diagnostic archive in dir %q", dst)
 	for _, zf := range zReader.File {
-		filePath := filepath.Join(dst, zf.Name)
+		filePath := filepath.Join(dst, zf.Name) //nolint:gosec // G305: test file
 		t.Logf("unzipping file %q", filePath)
 		require.Truef(t, strings.HasPrefix(filePath, filepath.Clean(dst)+string(os.PathSeparator)), "file %q points outside of extraction dir %q", filePath, dst)
 
@@ -844,7 +843,7 @@ func extractSingleFileFromArchive(t *testing.T, src *zip.File, dst string) {
 
 	defer srcFile.Close()
 
-	_, err = io.Copy(dstFile, srcFile)
+	_, err = io.Copy(dstFile, srcFile) //nolint:gosec // G110: test file
 	require.NoErrorf(t, err, "error copying content from zipped file %q to extracted file %q", src.Name, dst)
 }
 

--- a/testing/integration/ess/diagnostics_test.go
+++ b/testing/integration/ess/diagnostics_test.go
@@ -569,7 +569,8 @@ agent.internal.runtime.filebeat.httpjson: process
 					"edot/block.profile.gz",
 					"edot/mutex.profile.gz",
 					"edot/threadcreate.profile.gz",
-					"edot/otel-merged-actual.yaml")
+					"edot/otel-merged-actual.yaml",
+					"edot/environment.yaml")
 			}
 			if tc.monitoringEnabled {
 				// When OTel-based elasticsearch monitoring is active, the manager
@@ -669,6 +670,7 @@ agent.internal.runtime.filebeat.filestream: otel
 	// at the component level and land under the component directory, same as for process-runtime beats.
 	expectedFiles := []string{
 		"edot/otel-merged-actual.yaml",
+		"edot/environment.yaml",
 		"edot/allocs.profile.gz",
 		"edot/block.profile.gz",
 		"edot/goroutine.profile.gz",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Adds the collector process's current environment variables to the diagnostics bundle as edot/environment.yaml.

## Why is it important?

Previously, there was no way to retrieve the collector's current runtime environmental variables without a core dump or debugger.

## Checklist

- [X] I have read and understood the pull request guidelines of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in ./changelog/fragments using the changelog tool
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

N/A