### PR TITLE
[mage] Fix FindFilesRecursive walking into git submodules and worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Directories
+/.claude/worktrees
 /.agent-testing
 /.integration-cache
 /.ogc-cache

--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -659,7 +659,8 @@ func FindFiles(globs ...string) ([]string, error) {
 
 // FindFilesRecursive recursively traverses from the CWD and invokes the given
 // match function on each regular file to determine if the given path should be
-// returned as a match. It ignores files in .git directories.
+// returned as a match. It ignores files in .git directories and the roots of
+// nested git repositories (submodules and worktrees).
 func FindFilesRecursive(match func(path string, d fs.FileInfo) bool) ([]string, error) {
 	var matches []string
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
@@ -672,9 +673,12 @@ func FindFilesRecursive(match func(path string, d fs.FileInfo) bool) ([]string, 
 			return filepath.SkipDir
 		}
 
-		// Don't look for files in beats submodule
-		if d.IsDir() && filepath.Base(path) == "beats" {
-			return filepath.SkipDir
+		// Skip directories that are the root of a separate git repository
+		// (submodules and worktrees have a .git file at their root).
+		if d.IsDir() && path != "." {
+			if _, err := os.Lstat(filepath.Join(path, ".git")); err == nil {
+				return filepath.SkipDir
+			}
 		}
 
 		if !d.Type().IsRegular() {

--- a/dev-tools/mage/common_test.go
+++ b/dev-tools/mage/common_test.go
@@ -5,10 +5,70 @@
 package mage
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestFindFilesRecursive(t *testing.T) {
+	dir := t.TempDir()
+
+	mkfile := func(rel string) {
+		t.Helper()
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, nil, 0o644))
+	}
+
+	// Regular files the match function should find.
+	mkfile("a.go")
+	mkfile("sub/b.go")
+	mkfile("sub/c.txt")
+
+	// The repo's own .git directory — files inside must not be returned.
+	mkfile(".git/HEAD")
+	mkfile(".git/config")
+
+	// A git submodule: .git is a file, the directory should be skipped entirely.
+	mkfile("submodule/.git") // file, not dir
+	mkfile("submodule/d.go")
+
+	// A git worktree: same shape as a submodule from the walker's perspective.
+	mkfile("worktrees/feat/.git") // file, not dir
+	mkfile("worktrees/feat/e.go")
+
+	t.Chdir(dir)
+
+	t.Run("returns only files matched by the predicate", func(t *testing.T) {
+		files, err := FindFilesRecursive(func(path string, _ os.FileInfo) bool {
+			return filepath.Ext(path) == ".go"
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"a.go", filepath.FromSlash("sub/b.go")}, files)
+	})
+
+	t.Run("does not descend into the .git directory", func(t *testing.T) {
+		files, err := FindFilesRecursive(func(path string, _ os.FileInfo) bool {
+			return strings.HasPrefix(path, ".git/")
+		})
+		require.NoError(t, err)
+		assert.Empty(t, files)
+	})
+
+	t.Run("does not descend into directories that contain a .git entry", func(t *testing.T) {
+		files, err := FindFilesRecursive(func(_ string, _ os.FileInfo) bool { return true })
+		require.NoError(t, err)
+		for _, f := range files {
+			slashF := filepath.ToSlash(f)
+			assert.False(t, strings.HasPrefix(slashF, "submodule/"), "walked into submodule: %s", f)
+			assert.False(t, strings.HasPrefix(slashF, "worktrees/feat/"), "walked into worktree: %s", f)
+		}
+	})
+}
 
 func TestParseVersion(t *testing.T) {
 	var tests = []struct {


### PR DESCRIPTION
## What does this PR do?

Previously FindFilesRecursive would recurse into any directory with its own .git root (submodules, worktrees), causing mage tidy and mage notice to run go mod tidy on those trees as an unintended side effect. In particular, this was annoying on claude-created worktrees, which live in `.claude/worktrees`.

Now any non-root directory that contains a .git entry is skipped, which covers the beats submodule, git worktrees, and any future nested repos without needing to name them explicitly.

Also adds /.claude/worktrees to .gitignore and unit tests for the new behaviour.

## Why is it important?

This function should only return results from its current working tree.


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
