### PR TITLE
Allow running local sudo tests on MacOS.

### DIFF
--- a/pkg/testing/local/runner.go
+++ b/pkg/testing/local/runner.go
@@ -43,7 +43,10 @@ func (Runner) Run(ctx context.Context, verbose bool, sshClient ssh.SSHClient, lo
 
 	maxDuration := 2 * time.Hour
 	var result []common.OSRunnerPackageResult
-	for _, pkg := range batch.Tests {
+	// Combine Tests and SudoTests: integration:local is already invoked with sudo,
+	// so both sets run the same way on the local host.
+	allTests := append(batch.Tests, batch.SudoTests...)
+	for _, pkg := range allTests {
 		packageTestsStrBuilder := strings.Builder{}
 		packageTestsStrBuilder.WriteString("^(")
 		for idx, test := range pkg.Tests {

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -97,6 +97,12 @@ func NewRunner(cfg common.Config, ip common.InstanceProvisioner, sp common.Stack
 	if ip.Type() == common.ProvisionerTypeLocal {
 		for i := range osBatches {
 			osBatches[i].OS.Runner = local.Runner{}
+			// The Skip flag is set when an OS isn't in the known VM infrastructure.
+			// For local mode the provisioner runs directly on the host, so if it
+			// reports the OS as supported we can clear the flag and run the tests.
+			if osBatches[i].Skip && ip.Supported(osBatches[i].OS.OS) {
+				osBatches[i].Skip = false
+			}
 		}
 	}
 


### PR DESCRIPTION
- Relates https://github.com/elastic/elastic-agent/pull/15422

This is a follow up from https://github.com/elastic/elastic-agent/pull/15422 that allows running local tests with sudo directly on local MacOS machines for cases where the test can install an agent in develop mode.

To test apply the following diff:

```diff
diff --git a/testing/integration/ess/osquery_monitoring_test.go b/testing/integration/ess/osquery_monitoring_test.go
index 888fbfc253..f78b7b3b07 100644
--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -46,10 +46,11 @@ func TestOsqueryManager(t *testing.T) {
        info := define.Require(t, define.Requirements{
                Group: integration.Fleet,
                Stack: &define.Stack{},
-               Local: false, // requires Agent installation
-               Sudo:  true,  // requires Agent installation
+               Local: true, // requires Agent installation
+               Sudo:  true, // requires Agent installation
                OS: []define.OS{
                        {Type: define.Linux},
+                       {Type: define.Darwin},
                },
        })

@@ -76,6 +77,7 @@ func (runner *OsqueryManagerRunner) SetupSuite() {
                NonInteractive: true,
                Force:          true,
                Privileged:     true,
+               Develop:        true,
        }

        ctx, cancel := context.WithTimeout(runner.T().Context(), 3*time.Minute)
```

Then run `sudo mage -v integration:local TestOsquery` after packaging agent for MacOS locally.