### PR TITLE
Allow using the otel runtime by default for dynamic inputs

### DIFF
--- a/changelog/fragments/1784105960-dynamic-inputs-otel.yaml
+++ b/changelog/fragments/1784105960-dynamic-inputs-otel.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Allow using the otel runtime for dynamic inputs
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -2724,11 +2724,11 @@ func TestMaybeOverrideRuntimeForComponent(t *testing.T) {
 		assert.Equal(t, pkgcomponent.RuntimeManager(runtimeCfg.DynamicInputs), comp.RuntimeManager)
 	})
 
-	t.Run("default configuration switches dynamic otel components to process runtime", func(t *testing.T) {
+	t.Run("default configuration leaves dynamic otel components on otel runtime", func(t *testing.T) {
 		runtimeCfg := pkgcomponent.DefaultRuntimeConfig()
 		comp := otelSupportedComponent(true)
 		maybeOverrideRuntimeForComponent(logger, runtimeCfg, &comp)
-		assert.Equal(t, pkgcomponent.ProcessRuntimeManager, comp.RuntimeManager)
+		assert.Equal(t, pkgcomponent.OtelRuntimeManager, comp.RuntimeManager)
 	})
 }
 

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -58,7 +58,7 @@ type BeatRuntimeConfig struct {
 func DefaultRuntimeConfig() *RuntimeConfig {
 	return &RuntimeConfig{
 		Default:                 string(DefaultRuntimeManager),
-		DynamicInputs:           string(ProcessRuntimeManager),
+		DynamicInputs:           "",
 		OtelPartialConfigReload: true,
 		Auditbeat: BeatRuntimeConfig{
 			Default: string(OtelRuntimeManager),

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -4278,7 +4278,7 @@ func TestDefaultRuntimeConfig(t *testing.T) {
 	config := DefaultRuntimeConfig()
 	require.NotNil(t, config)
 	assert.Equal(t, string(DefaultRuntimeManager), config.Default)
-	assert.Equal(t, string(ProcessRuntimeManager), config.DynamicInputs)
+	assert.Equal(t, "", config.DynamicInputs)
 	assert.Equal(t, "otel", config.Auditbeat.Default)
 	assert.Empty(t, config.Auditbeat.InputType)
 	assert.Equal(t, "otel", config.Filebeat.Default)


### PR DESCRIPTION
## What does this PR do?

Allows dynamic inputs to run in the otel runtime. Until now, these were forced to run in the process runtime by default. Now, each dynamic input runs in the runtime it has configured, without any override. This can still be changed via the respective config variable.

## Why is it important?

We'd like dynamic inputs to be able to run in the otel runtime by default, and https://github.com/elastic/elastic-agent/pull/15381 makes this technically feasible.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

This may cause a performance regression in very dynamic environments like large Nodes in Kubernetes clusters, depending on configuration. We'll evaluate and potentially revert this change before the 9.5.0 release if downstream benchmarks and dogfooding surfaces any problems.

## How to test this PR locally

Run an input using the local_dynamic provider and verify that it uses the otel runtime.

## Related issues

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
