### PR TITLE
Enable agent develop mode for local integration tests

### DIFF
--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -1264,6 +1264,10 @@ type IntegrationTestSettings struct {
 	// TestEnvironmentEnabled indicates if the test environment is enabled (from TEST_ENVIRONMENT env var).
 	// Defaults to true if not set.
 	TestEnvironmentEnabled bool
+
+	// AgentDevelop enables development mode for the agent fixture (from TEST_AGENT_DEVELOP env var).
+	// When true, --develop is passed to elastic-agent. Only applies to local runs by default.
+	AgentDevelop string
 }
 
 // DockerSettings contains Docker-related settings.
@@ -1694,6 +1698,9 @@ func (s *Settings) loadIntegrationTestSettingsFromEnv() error {
 	}
 	if v := os.Getenv("GOTEST_FLAGS"); v != "" {
 		s.IntegrationTest.GoTestFlags = v
+	}
+	if v := os.Getenv("TEST_AGENT_DEVELOP"); v != "" {
+		s.IntegrationTest.AgentDevelop = v
 	}
 
 	var err error

--- a/magefile.go
+++ b/magefile.go
@@ -3178,6 +3178,9 @@ func createTestRunner(cfg *devtools.Settings, matrix bool, singleTest string, go
 	timestamp := cfg.IntegrationTest.TimestampEnabled
 
 	extraEnv := map[string]string{}
+	if cfg.IntegrationTest.AgentDevelop != "" {
+		extraEnv["TEST_AGENT_DEVELOP"] = cfg.IntegrationTest.AgentDevelop
+	}
 	if cfg.IntegrationTest.CollectDiag != "" {
 		extraEnv["AGENT_COLLECT_DIAG"] = cfg.IntegrationTest.CollectDiag
 	}

--- a/pkg/testing/define/define.go
+++ b/pkg/testing/define/define.go
@@ -5,30 +5,18 @@
 package define
 
 import (
-	"crypto/sha256"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
-	"slices"
 	"strings"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/elastic-agent/pkg/utils"
-
-	"github.com/gofrs/uuid/v5"
-
 	"github.com/elastic/elastic-agent-libs/kibana"
 	"github.com/elastic/go-elasticsearch/v8"
-	"github.com/elastic/go-sysinfo"
-	"github.com/elastic/go-sysinfo/types"
 
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	semver "github.com/elastic/elastic-agent/pkg/version"
@@ -37,24 +25,12 @@ import (
 	"sigs.k8s.io/e2e-framework/klient"
 )
 
-var osInfo *types.OSInfo
-var osInfoErr error
-var osInfoOnce sync.Once
-var noSpecialCharsRegexp = regexp.MustCompile("[^a-zA-Z0-9]+")
-var kubernetesSupported = false
-
 // Require defines what this test requires for it to be run by the test runner.
 //
 // This must be defined as the first line of a test, or `ValidateDir` will fail
 // and the test runner will not be able to determine the requirements for a test.
 func Require(t *testing.T, req Requirements) *Info {
 	return defineAction(t, req)
-}
-
-// SetKubernetesSupported sets the kubernetesSupported flag to true
-// to allow kubernetes tests to be run.
-func SetKubernetesSupported() {
-	kubernetesSupported = true
 }
 
 type Info struct {
@@ -121,7 +97,11 @@ func NewFixtureWithBinary(t *testing.T, version string, binary string, buildsDir
 	binFetcher := atesting.LocalFetcher(buildsDir, localFetcherOpts...)
 
 	opts = append(opts, atesting.WithFetcher(binFetcher), atesting.WithLogOutput())
-	if binary != "elastic-agent" {
+	if binary == "elastic-agent" {
+		if os.Getenv("TEST_AGENT_DEVELOP") == "true" {
+			opts = append(opts, atesting.WithAppendAdditionalArgs([]string{"--develop"}))
+		}
+	} else {
 		opts = append(opts, atesting.WithBinaryName(binary))
 	}
 	return atesting.NewFixture(t, version, opts...)
@@ -146,189 +126,6 @@ func findProjectRoot() (string, error) {
 			return "", fmt.Errorf("unable to find golang root directory from caller path %s", caller)
 		}
 	}
-}
-
-func runOrSkip(t *testing.T, req Requirements, local bool) *Info {
-	// always validate requirement is valid
-	if err := req.Validate(); err != nil {
-		panic(fmt.Sprintf("test %s has invalid requirements: %s", t.Name(), err))
-	}
-
-	filteredGroups := GroupsFilter.values
-	if len(filteredGroups) > 0 && !slices.Contains(filteredGroups, req.Group) {
-		t.Skipf("group %s not found in groups filter %s. Skipping", req.Group, filteredGroups)
-		return nil
-	}
-
-	if SudoFilter.value != nil && req.Sudo != *SudoFilter.value {
-		t.Skipf("sudo requirement %t not matching sudo filter %t. Skipping", req.Sudo, *SudoFilter.value)
-	}
-
-	if FipsFilter.value != nil && req.FIPS != *FipsFilter.value {
-		t.Skipf("FIPS requirement %t not matching FIPS filter %t. Skipping.", req.FIPS, *FipsFilter.value)
-	}
-
-	// record autodiscover after filtering by group and sudo and before validating against the actual environment
-	if AutoDiscover {
-		discoverTest(t, req)
-	}
-
-	if !req.Local && local {
-		t.Skip("running local only tests and this test doesn't support local")
-		return nil
-	}
-	for _, o := range req.OS {
-		if o.Type == Kubernetes && !kubernetesSupported {
-			t.Skip("test requires kubernetes")
-			return nil
-		}
-	}
-	if req.Sudo {
-		// we can run sudo tests if we are being executed as root
-		root, err := utils.HasRoot()
-		if err != nil {
-			panic(fmt.Sprintf("test %s failed to determine if running as root: %s", t.Name(), err))
-		}
-		if !root {
-			t.Skip("not running as root and test requires root")
-			return nil
-		}
-	}
-	// need OS info to determine if the test can run
-	osInfo, err := getOSInfo()
-	if err != nil {
-		panic("failed to get OS information")
-	}
-	dockerVariant := os.Getenv("DOCKER_VARIANT")
-	if !req.runtimeAllowed(runtime.GOOS, runtime.GOARCH, osInfo.Version, osInfo.Platform, dockerVariant) {
-		t.Skipf("platform: %s, architecture: %s, version: %s, and distro: %s combination is not supported by test.  required: %v", runtime.GOOS, runtime.GOARCH, osInfo.Version, osInfo.Platform, req.OS)
-		return nil
-	}
-	if skipped, ok := req.runtimeSkipped(runtime.GOOS, runtime.GOARCH, osInfo.Version, osInfo.Platform, dockerVariant); ok {
-		t.Skipf("platform: %s, architecture: %s, version: %s, and distro: %s matches skip_os entry %+v. Skipping", runtime.GOOS, runtime.GOARCH, osInfo.Version, osInfo.Platform, skipped)
-		return nil
-	}
-
-	if DryRun {
-		return dryRun(t, req)
-	}
-
-	t.Cleanup(func() {
-		if runtime.GOOS != "windows" {
-			_ = os.RemoveAll("/tmp/elastic-agent") // clean up any leftover data from tests
-		}
-	})
-
-	namespace, err := getNamespace(t, local)
-	if err != nil {
-		panic(err)
-	}
-	info := &Info{
-		Namespace: namespace,
-	}
-	if req.Stack != nil {
-		info.ESClient, err = getESClient()
-		if err != nil {
-			if local {
-				t.Skipf("test requires a stack but failed to create a valid client to elasticsearch: %s", err)
-				return nil
-			}
-			// non-local test and stack was required
-			panic(err)
-		}
-		info.KibanaClient, err = getKibanaClient()
-		if err != nil {
-			if local {
-				t.Skipf("test requires a stack but failed to create a valid client to kibana: %s", err)
-				return nil
-			}
-			// non-local test and stack was required
-			panic(err)
-		}
-	}
-	return info
-}
-
-func getOSInfo() (*types.OSInfo, error) {
-	osInfoOnce.Do(func() {
-		sysInfo, err := sysinfo.Host()
-		if err != nil {
-			osInfoErr = err
-		} else {
-			osInfo = sysInfo.Info().OS
-		}
-	})
-	return osInfo, osInfoErr
-}
-
-// getNamespace is a general namespace that the test can use that will ensure that it
-// is unique and won't collide with other tests (even the same test from a different batch).
-//
-// This function uses a sha256 of an UUIDv4 to ensure that the
-// length of the namespace is not over the 100 byte limit from Fleet
-// see: https://www.elastic.co/guide/en/fleet/current/data-streams.html#data-streams-naming-scheme
-func getNamespace(t *testing.T, local bool) (string, error) {
-	nsUUID, err := uuid.NewV4()
-	if err != nil {
-		return "", fmt.Errorf("cannot generate UUID V4: %w", err)
-	}
-	hasher := sha256.New()
-	hasher.Write([]byte(nsUUID.String()))
-
-	// Fleet API requires the namespace to be lowercased and not contain
-	// special characters.
-	namespace := strings.ToLower(base64.URLEncoding.EncodeToString(hasher.Sum(nil)))
-	namespace = noSpecialCharsRegexp.ReplaceAllString(namespace, "")
-	return namespace, nil
-}
-
-// getESClient creates the elasticsearch client from the information passed from the test runner.
-func getESClient() (*elasticsearch.Client, error) {
-	esHost := os.Getenv("ELASTICSEARCH_HOST")
-	esUser := os.Getenv("ELASTICSEARCH_USERNAME")
-	esPass := os.Getenv("ELASTICSEARCH_PASSWORD")
-	if esHost == "" || esUser == "" || esPass == "" {
-		return nil, errors.New("ELASTICSEARCH_* must be defined by the test runner")
-	}
-	c, err := elasticsearch.NewClient(elasticsearch.Config{
-		Addresses: []string{esHost},
-		Username:  esUser,
-		Password:  esPass,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create elasticsearch client: %w", err)
-	}
-	return c, nil
-}
-
-// getKibanaClient creates the kibana client from the information passed from the test runner.
-func getKibanaClient() (*kibana.Client, error) {
-	kibanaHost := os.Getenv("KIBANA_HOST")
-	kibanaUser := os.Getenv("KIBANA_USERNAME")
-	kibanaPass := os.Getenv("KIBANA_PASSWORD")
-	if kibanaHost == "" || kibanaUser == "" || kibanaPass == "" {
-		return nil, errors.New("KIBANA_* must be defined by the test runner")
-	}
-	c, err := kibana.NewClientWithConfigDefault(&kibana.ClientConfig{
-		Host:          kibanaHost,
-		Username:      kibanaUser,
-		Password:      kibanaPass,
-		IgnoreVersion: false,
-		Retry: kibana.RetryConfig{
-			MaxRetries:    5,
-			RetryOnStatus: []int{429, 500, 502, 503, 504},
-			RetryBackoff: func(attempt int) time.Duration {
-				base := time.Second
-				maxWait := 10 * time.Second
-				wait := (1 << (attempt - 1)) * base
-				return min(wait, maxWait)
-			},
-		},
-	}, 0, "Elastic-Agent-Test-Define", version.GetDefaultVersion(), version.Commit(), version.BuildTime().String())
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kibana client: %w", err)
-	}
-	return c, nil
 }
 
 func buildsDir(t *testing.T) string {

--- a/pkg/testing/define/define_define.go
+++ b/pkg/testing/define/define_define.go
@@ -12,6 +12,9 @@ import (
 	"testing"
 )
 
+// SetKubernetesSupported is a no-op in define mode.
+func SetKubernetesSupported() {}
+
 func defineAction(t *testing.T, req Requirements) *Info {
 	// always validate requirement is valid
 	if err := req.Validate(); err != nil {
@@ -23,6 +26,6 @@ func defineAction(t *testing.T, req Requirements) *Info {
 	if err != nil {
 		panic(fmt.Sprintf("test %s failed to marshal requirements: %s", t.Name(), err))
 	}
-	t.Skip(fmt.Sprintf("define skip; requirements: %s", data))
+	t.Skipf("define skip; requirements: %s", data)
 	return nil
 }

--- a/pkg/testing/define/define_notdefine.go
+++ b/pkg/testing/define/define_notdefine.go
@@ -20,11 +20,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid/v5"
+
 	"github.com/elastic/elastic-agent-libs/kibana"
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-sysinfo"
 	"github.com/elastic/go-sysinfo/types"
-	"github.com/gofrs/uuid/v5"
 
 	"github.com/elastic/elastic-agent/pkg/utils"
 	"github.com/elastic/elastic-agent/version"

--- a/pkg/testing/define/define_notdefine.go
+++ b/pkg/testing/define/define_notdefine.go
@@ -1,0 +1,226 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build !define
+
+package define
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"runtime"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/kibana"
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/elastic/go-sysinfo"
+	"github.com/elastic/go-sysinfo/types"
+	"github.com/gofrs/uuid/v5"
+
+	"github.com/elastic/elastic-agent/pkg/utils"
+	"github.com/elastic/elastic-agent/version"
+)
+
+var osInfo *types.OSInfo
+var osInfoErr error
+var osInfoOnce sync.Once
+var noSpecialCharsRegexp = regexp.MustCompile("[^a-zA-Z0-9]+")
+var kubernetesSupported = false
+
+// SetKubernetesSupported sets the kubernetesSupported flag to true
+// to allow kubernetes tests to be run.
+func SetKubernetesSupported() {
+	kubernetesSupported = true
+}
+
+func runOrSkip(t *testing.T, req Requirements, local bool) *Info {
+	// always validate requirement is valid
+	if err := req.Validate(); err != nil {
+		panic(fmt.Sprintf("test %s has invalid requirements: %s", t.Name(), err))
+	}
+
+	filteredGroups := GroupsFilter.values
+	if len(filteredGroups) > 0 && !slices.Contains(filteredGroups, req.Group) {
+		t.Skipf("group %s not found in groups filter %s. Skipping", req.Group, filteredGroups)
+		return nil
+	}
+
+	if SudoFilter.value != nil && req.Sudo != *SudoFilter.value {
+		t.Skipf("sudo requirement %t not matching sudo filter %t. Skipping", req.Sudo, *SudoFilter.value)
+	}
+
+	if FipsFilter.value != nil && req.FIPS != *FipsFilter.value {
+		t.Skipf("FIPS requirement %t not matching FIPS filter %t. Skipping.", req.FIPS, *FipsFilter.value)
+	}
+
+	// record autodiscover after filtering by group and sudo and before validating against the actual environment
+	if AutoDiscover {
+		discoverTest(t, req)
+	}
+
+	if !req.Local && local {
+		t.Skip("running local only tests and this test doesn't support local")
+		return nil
+	}
+	for _, o := range req.OS {
+		if o.Type == Kubernetes && !kubernetesSupported {
+			t.Skip("test requires kubernetes")
+			return nil
+		}
+	}
+	if req.Sudo {
+		// we can run sudo tests if we are being executed as root
+		root, err := utils.HasRoot()
+		if err != nil {
+			panic(fmt.Sprintf("test %s failed to determine if running as root: %s", t.Name(), err))
+		}
+		if !root {
+			t.Skip("not running as root and test requires root")
+			return nil
+		}
+	}
+	// need OS info to determine if the test can run
+	osInfo, err := getOSInfo()
+	if err != nil {
+		panic("failed to get OS information")
+	}
+	dockerVariant := os.Getenv("DOCKER_VARIANT")
+	if !req.runtimeAllowed(runtime.GOOS, runtime.GOARCH, osInfo.Version, osInfo.Platform, dockerVariant) {
+		t.Skipf("platform: %s, architecture: %s, version: %s, and distro: %s combination is not supported by test.  required: %v", runtime.GOOS, runtime.GOARCH, osInfo.Version, osInfo.Platform, req.OS)
+		return nil
+	}
+	if skipped, ok := req.runtimeSkipped(runtime.GOOS, runtime.GOARCH, osInfo.Version, osInfo.Platform, dockerVariant); ok {
+		t.Skipf("platform: %s, architecture: %s, version: %s, and distro: %s matches skip_os entry %+v. Skipping", runtime.GOOS, runtime.GOARCH, osInfo.Version, osInfo.Platform, skipped)
+		return nil
+	}
+
+	if DryRun {
+		return dryRun(t, req)
+	}
+
+	t.Cleanup(func() {
+		if runtime.GOOS != "windows" {
+			_ = os.RemoveAll("/tmp/elastic-agent") // clean up any leftover data from tests
+		}
+	})
+
+	namespace, err := getNamespace(t, local)
+	if err != nil {
+		panic(err)
+	}
+	info := &Info{
+		Namespace: namespace,
+	}
+	if req.Stack != nil {
+		info.ESClient, err = getESClient()
+		if err != nil {
+			if local {
+				t.Skipf("test requires a stack but failed to create a valid client to elasticsearch: %s", err)
+				return nil
+			}
+			// non-local test and stack was required
+			panic(err)
+		}
+		info.KibanaClient, err = getKibanaClient()
+		if err != nil {
+			if local {
+				t.Skipf("test requires a stack but failed to create a valid client to kibana: %s", err)
+				return nil
+			}
+			// non-local test and stack was required
+			panic(err)
+		}
+	}
+	return info
+}
+
+func getOSInfo() (*types.OSInfo, error) {
+	osInfoOnce.Do(func() {
+		sysInfo, err := sysinfo.Host()
+		if err != nil {
+			osInfoErr = err
+		} else {
+			osInfo = sysInfo.Info().OS
+		}
+	})
+	return osInfo, osInfoErr
+}
+
+// getNamespace is a general namespace that the test can use that will ensure that it
+// is unique and won't collide with other tests (even the same test from a different batch).
+//
+// This function uses a sha256 of an UUIDv4 to ensure that the
+// length of the namespace is not over the 100 byte limit from Fleet
+// see: https://www.elastic.co/guide/en/fleet/current/data-streams.html#data-streams-naming-scheme
+func getNamespace(t *testing.T, local bool) (string, error) {
+	nsUUID, err := uuid.NewV4()
+	if err != nil {
+		return "", fmt.Errorf("cannot generate UUID V4: %w", err)
+	}
+	hasher := sha256.New()
+	hasher.Write([]byte(nsUUID.String()))
+
+	// Fleet API requires the namespace to be lowercased and not contain
+	// special characters.
+	namespace := strings.ToLower(base64.URLEncoding.EncodeToString(hasher.Sum(nil)))
+	namespace = noSpecialCharsRegexp.ReplaceAllString(namespace, "")
+	return namespace, nil
+}
+
+// getESClient creates the elasticsearch client from the information passed from the test runner.
+func getESClient() (*elasticsearch.Client, error) {
+	esHost := os.Getenv("ELASTICSEARCH_HOST")
+	esUser := os.Getenv("ELASTICSEARCH_USERNAME")
+	esPass := os.Getenv("ELASTICSEARCH_PASSWORD")
+	if esHost == "" || esUser == "" || esPass == "" {
+		return nil, errors.New("ELASTICSEARCH_* must be defined by the test runner")
+	}
+	c, err := elasticsearch.NewClient(elasticsearch.Config{
+		Addresses: []string{esHost},
+		Username:  esUser,
+		Password:  esPass,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create elasticsearch client: %w", err)
+	}
+	return c, nil
+}
+
+// getKibanaClient creates the kibana client from the information passed from the test runner.
+func getKibanaClient() (*kibana.Client, error) {
+	kibanaHost := os.Getenv("KIBANA_HOST")
+	kibanaUser := os.Getenv("KIBANA_USERNAME")
+	kibanaPass := os.Getenv("KIBANA_PASSWORD")
+	if kibanaHost == "" || kibanaUser == "" || kibanaPass == "" {
+		return nil, errors.New("KIBANA_* must be defined by the test runner")
+	}
+	c, err := kibana.NewClientWithConfigDefault(&kibana.ClientConfig{
+		Host:          kibanaHost,
+		Username:      kibanaUser,
+		Password:      kibanaPass,
+		IgnoreVersion: false,
+		Retry: kibana.RetryConfig{
+			MaxRetries:    5,
+			RetryOnStatus: []int{429, 500, 502, 503, 504},
+			RetryBackoff: func(attempt int) time.Duration {
+				base := time.Second
+				maxWait := 10 * time.Second
+				wait := (1 << (attempt - 1)) * base
+				return min(wait, maxWait)
+			},
+		},
+	}, 0, "Elastic-Agent-Test-Define", version.GetDefaultVersion(), version.Commit(), version.BuildTime().String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kibana client: %w", err)
+	}
+	return c, nil
+}

--- a/pkg/testing/fixture.go
+++ b/pkg/testing/fixture.go
@@ -175,6 +175,13 @@ func WithAdditionalArgs(args []string) FixtureOpt {
 	}
 }
 
+// WithAppendAdditionalArgs appends to any additional args already set on the fixture.
+func WithAppendAdditionalArgs(args []string) FixtureOpt {
+	return func(f *Fixture) {
+		f.additionalArgs = append(f.additionalArgs, args...)
+	}
+}
+
 func WithFIPSArtifact() FixtureOpt {
 	return func(f *Fixture) {
 		f.fipsArtifact = true

--- a/pkg/testing/local/runner.go
+++ b/pkg/testing/local/runner.go
@@ -66,6 +66,9 @@ func (Runner) Run(ctx context.Context, verbose bool, sshClient ssh.SSHClient, lo
 
 		env["AGENT_VERSION"] = agentVersion
 		env["TEST_DEFINE_PREFIX"] = testPrefix
+		if _, ok := env["TEST_AGENT_DEVELOP"]; !ok {
+			env["TEST_AGENT_DEVELOP"] = "true"
+		}
 
 		params := devtools.GoTestArgs{
 			LogName:         testName,


### PR DESCRIPTION
## What does this PR do?

When running integration tests locally via `mage integration:local` the agent fixture now starts with `--develop` mode enabled by default. This can be overridden by setting `TEST_AGENT_DEVELOP=false` in the environment.

## Why is it important?

Without this, developers had to manually pass `--develop` to the agent fixture builder when running integration tests locally. Now it is on by default.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None

## How to test this PR locally

Run any integration test locally and verify the agent process is started with `--develop`:

```
mage -v integration:local TestEDOTDiagnostics
```

This behavior can be disabled with:

```
TEST_AGENT_DEVELOP=false mage -v integration:local TestEDOTDiagnostics
```

