### PR TITLE
Add k8s-ecosystem group to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,10 +21,20 @@ updates:
       - dependency-name: "go.opentelemetry.io/*"
       - dependency-name: "github.com/open-telemetry/*"
       - dependency-name: "github.com/elastic/opentelemetry-collector-components/*"
-      # k8s dependencies are bumped transitively by Otel dependency updates; do not update independently
-      - dependency-name: "k8s.io/*"
-      - dependency-name: "sigs.k8s.io/*"
     groups:
+      # k8s-ecosystem must come before the elastic group: Dependabot assigns a dependency to
+      # the first matching group, and elastic/cloud-on-k8s and elastic/elastic-agent-autodiscover
+      # would otherwise match the elastic group's wildcard pattern first.
+      k8s-ecosystem:
+        patterns:
+          # k8s core libraries
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+          # Direct dependencies whose own go.mod requires k8s.io/* and must be bumped
+          # in lockstep when k8s has a breaking API change
+          - "helm.sh/helm/*"
+          - "github.com/elastic/cloud-on-k8s/*"
+          - "github.com/elastic/elastic-agent-autodiscover"
       elastic:
         patterns:
           # github.com/elastic/* and go.elastic.co/* cover all Elastic and APM Go packages
@@ -38,8 +48,6 @@ updates:
           # Test frameworks and helpers
           - "github.com/stretchr/*"
           - "github.com/testcontainers/*"
-          # Helm: only used in k8s integration tests
-          - "helm.sh/helm/*"
           # Only used in *_test.go files
           - "github.com/google/pprof"
           - "github.com/google/go-containerregistry"


### PR DESCRIPTION
## What does this PR do?

Groups k8s core libraries with the direct dependencies whose own go.mod requires k8s.io/*, so that breaking k8s API changes can be bumped in a single coordinated PR.

Packages in the group:
- k8s.io/* and sigs.k8s.io/* (previously ignored; now grouped instead)
- helm.sh/helm/v3 (moved from tooling-test)
- github.com/elastic/cloud-on-k8s/v3 (overrides elastic group for this package)
- github.com/elastic/elastic-agent-autodiscover (overrides elastic group)

The k8s-ecosystem group is defined before elastic in the YAML so that Dependabot's first-match rule assigns cloud-on-k8s and autodiscover here rather than to the elastic catch-all.

## Why is it important?

Right now, bumping these fails the groups they're in whenever there's breakage. The way this should work is that they should all wait until otel does the bump, and then their updates can follow. All other dependencies should be unaffected by this.


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
