### PR TITLE
Retry transient failures in integration test infrastructure

### DIFF
--- a/pkg/testing/define/define_notdefine.go
+++ b/pkg/testing/define/define_notdefine.go
@@ -189,6 +189,17 @@ func getESClient() (*elasticsearch.Client, error) {
 		Addresses: []string{esHost},
 		Username:  esUser,
 		Password:  esPass,
+		// Retry transient failures with a backoff, mirroring the Kibana client
+		// below. The transport defaults (3 immediate retries on 502/503/504
+		// only) leave 429 - common on ESS and serverless - and 500 unhandled.
+		MaxRetries:    5,
+		RetryOnStatus: []int{429, 500, 502, 503, 504},
+		RetryBackoff: func(attempt int) time.Duration {
+			base := time.Second
+			maxWait := 10 * time.Second
+			wait := (1 << (attempt - 1)) * base
+			return min(wait, maxWait)
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create elasticsearch client: %w", err)

--- a/testing/integration/k8s/otel_helm_test.go
+++ b/testing/integration/k8s/otel_helm_test.go
@@ -210,9 +210,6 @@ func k8sStepHelmTemplateApplyWithValueOptions(chartPath string, releaseName stri
 }
 
 func mergeValues(t *testing.T, namespace string, values values.Options) map[string]any {
-	// Initialize a map to hold the parsed data
-	helmValues := make(map[string]any)
-
 	settings := cli.New()
 	settings.SetNamespace(namespace)
 	providers := getter.All(settings)

--- a/testing/integration/k8s/otel_helm_test.go
+++ b/testing/integration/k8s/otel_helm_test.go
@@ -285,11 +285,14 @@ func k8sStepDeployApp(manifest string) func(t *testing.T, ctx context.Context, k
 // are created and documents being written
 func k8sStepCheckDatastreamsHits(info *define.Info, dsType, dataset, datastreamNamespace string) k8sTestStep {
 	return func(t *testing.T, ctx context.Context, kCtx k8sContext, namespace string) {
-		require.Eventually(t, func() bool {
+		dsName := fmt.Sprintf("%s-%s-%s", dsType, dataset, datastreamNamespace)
+		// Check errors against the CollectT so a transient query failure is
+		// retried on the next tick instead of aborting the test.
+		require.EventuallyWithT(t, func(collectT *assert.CollectT) {
 			query := queryK8sNamespaceDataStream(dsType, dataset, datastreamNamespace, namespace)
 			docs, err := estools.PerformQueryForRawQuery(ctx, query, fmt.Sprintf(".ds-%s*", dsType), info.ESClient)
-			require.NoError(t, err, "failed to get %s datastream documents", fmt.Sprintf("%s-%s-%s", dsType, dataset, datastreamNamespace))
-			return docs.Hits.Total.Value > 0
-		}, 5*time.Minute, 10*time.Second, fmt.Sprintf("at least one document should be available for %s datastream", fmt.Sprintf("%s-%s-%s", dsType, dataset, datastreamNamespace)))
+			require.NoError(collectT, err, "failed to get %s datastream documents", dsName)
+			require.Greater(collectT, docs.Hits.Total.Value, 0)
+		}, 5*time.Minute, 10*time.Second, fmt.Sprintf("at least one document should be available for %s datastream", dsName))
 	}
 }

--- a/testing/integration/leak/long_running_test.go
+++ b/testing/integration/leak/long_running_test.go
@@ -87,11 +87,24 @@ func TestLongRunningAgentForLeaks(t *testing.T) {
 func (runner *ExtendedRunner) SetupSuite() {
 	ctx, cancel := context.WithTimeout(runner.T().Context(), 5*time.Minute)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "go", "install", "-v", "github.com/mingrammer/flog@latest")
-	out, err := cmd.CombinedOutput()
+	// Retry the install: a transient module proxy or network failure here
+	// would otherwise abort the whole suite.
+	var out []byte
+	var err error
+	for attempt := 1; attempt <= 3; attempt++ {
+		if attempt > 1 {
+			runner.T().Logf("go install flog failed (attempt %d/3), retrying: %s", attempt-1, err)
+			time.Sleep(10 * time.Second)
+		}
+		cmd := exec.CommandContext(ctx, "go", "install", "-v", "github.com/mingrammer/flog@v0.4.4")
+		out, err = cmd.CombinedOutput()
+		if err == nil {
+			break
+		}
+	}
 	require.NoError(runner.T(), err, "got out: %s", string(out))
 
-	cmd = exec.CommandContext(ctx, "flog", "-t", "log", "-f", "apache_error", "-o", "/var/log/httpd/error_log", "-b", "50485760", "-p", "1048576")
+	cmd := exec.CommandContext(ctx, "flog", "-t", "log", "-f", "apache_error", "-o", "/var/log/httpd/error_log", "-b", "50485760", "-p", "1048576")
 	out, err = cmd.CombinedOutput()
 	require.NoError(runner.T(), err, "got out: %s", string(out))
 

--- a/testing/integration/leak/long_running_test.go
+++ b/testing/integration/leak/long_running_test.go
@@ -334,7 +334,7 @@ func (gm *goroutinesMonitor) Init(ctx context.Context, t *testing.T, fixture *at
 					DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 						if runtime.GOOS != "windows" {
 							path := strings.ReplaceAll(socketPath, "unix://", "")
-							return net.Dial("unix", path)
+							return (&net.Dialer{}).DialContext(ctx, "unix", path)
 						} else {
 							if strings.HasPrefix(socketPath, "npipe:///") {
 								path := strings.TrimPrefix(socketPath, "npipe:///")
@@ -357,7 +357,9 @@ func (gm *goroutinesMonitor) Init(ctx context.Context, t *testing.T, fixture *at
 func (gm *goroutinesMonitor) Update(t *testing.T, fixture *atesting.Fixture) {
 	// reach out to the unix sockets to get the raw stats that includes a count of gorutines
 	for _, comp := range gm.handles {
-		resp, err := comp.httpClient.Get("http://unix/stats")
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://unix/stats", nil)
+		require.NoError(t, err)
+		resp, err := comp.httpClient.Do(req)
 		require.NoError(t, err)
 		respRaw, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)


### PR DESCRIPTION
## What does this PR do?

Retries various transient network errors that can come up in integration tests:

- Configure retries on the shared ES client (5 attempts on 429/500/502/503/504 with backoff), mirroring the Kibana client next to it. The transport defaults only retried 502/503/504, immediately and without backoff, so one-shot estools calls in test setup failed on ES rate limiting (429), which is common on ESS and serverless.
- Fix k8sStepCheckDatastreamsHits checking the ES query error against the outer t inside require.Eventually, which aborted the test on the first transient error instead of retrying; use EventuallyWithT. This was the only such instance in testing/integration.
- Pin flog to v0.4.4 and retry its installation in the leak suite setup; a transient module proxy failure aborted the whole suite.

## Why is it important?

Integration tests should be robust and shouldn't fail due to random network blips.

- Closes https://github.com/elastic/elastic-agent/issues/15448

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
