### PR TITLE
Disable intermediate build cancellation for elastic-agent-package

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -264,10 +264,8 @@ spec:
         # required by "build_pull_requests: true" when used with buildkite-pr-bot
         filter_condition: >-
           build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
-      cancel_intermediate_builds: true
-      cancel_intermediate_builds_branch_filter: "!main !7.* !8.* !9.*"
-      skip_intermediate_builds: true
-      skip_intermediate_builds_branch_filter: "!main !7.* !8.* !9.*"
+      cancel_intermediate_builds: false
+      skip_intermediate_builds: false
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
## What does this PR do?

Disables skipping of intermediate builds for the packaging workflow.

PR checks trigger two concurrent builds of elastic-agent-package from the same revision (snapshot without manifest, snapshot with manifest). With cancel_intermediate_builds and skip_intermediate_builds both true, each new triggered build would cancel/skip its predecessor on the same branch, leaving only the last one running.

## Why is it important?

These triggered builds should be able to run in parallel, they're logically different and have different arguments. I'd also like to add another one which verifies Independent Agent Releases on branches where it's feasible.