### PR TITLE
Fix live OSQuery results being misrouted when in a policy with no scheduled queries

### DIFF
--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -803,7 +803,7 @@ func injectOsqueryConfig(result []receiverInput, unit component.Unit) []receiver
 	//
 	// The osquery object may be nil when the integration has no scheduled queries (live-query-only policy).
 	// In that case we still need to reorder streams so that osquery_manager.result is at
-	// inputs[0] — osquerybeat wires it's client to inputs[0] and live-query result rows must
+	// inputs[0] — osquerybeat wires its client to inputs[0] and live-query result rows must
 	// land in the result stream, not action.responses.
 	osqMap, _ := unit.Config.GetSource().AsMap()["osquery"].(map[string]any)
 	for i, ri := range result {

--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -800,10 +800,12 @@ func getInputsForUnit(unit component.Unit, info info.Agent, defaultDataStreamTyp
 // beat startup.
 func injectOsqueryConfig(result []receiverInput, unit component.Unit) []receiverInput {
 	// Mirror the implementation from https://github.com/elastic/beats/blob/7764586737b76758db262a06fb3c594c52185c48/x-pack/osquerybeat/cmd/root.go#L92
-	osqMap, ok := unit.Config.GetSource().AsMap()["osquery"].(map[string]any)
-	if !ok {
-		return result
-	}
+	//
+	// The osquery object may be nil when the integration has no scheduled queries (live-query-only policy).
+	// In that case we still need to reorder streams so that osquery_manager.result is at
+	// inputs[0] — osquerybeat wires it's client to inputs[0] and live-query result rows must
+	// land in the result stream, not action.responses.
+	osqMap, _ := unit.Config.GetSource().AsMap()["osquery"].(map[string]any)
 	for i, ri := range result {
 		// "osquery_manager.result" is the dataset of the stream that carries osquery
 		// scheduled query results and must receive the input-level osquery configuration.
@@ -815,12 +817,14 @@ func injectOsqueryConfig(result []receiverInput, unit component.Unit) []receiver
 		if dataset != "osquery_manager.result" {
 			continue
 		}
-		if _, exists := result[i].config["osquery"]; !exists {
-			// Clone before mutating so we don't modify the map returned by CreateInputsFromStreamsForReceiver.
-			result[i].config = maps.Clone(result[i].config)
-			result[i].config["osquery"] = osqMap
+		if osqMap != nil {
+			if _, exists := result[i].config["osquery"]; !exists {
+				// Clone before mutating so we don't modify the map returned by CreateInputsFromStreamsForReceiver.
+				result[i].config = maps.Clone(result[i].config)
+				result[i].config["osquery"] = osqMap
+			}
 		}
-		// Place the result stream first so inputs[0].Osquery is set.
+		// Place the result stream first as osquerybeat requires the result data stream to be first.
 		result[0], result[i] = result[i], result[0]
 		break
 	}

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -636,20 +636,12 @@ func TestGetOtelConfig(t *testing.T) {
 
 	// expectedOsquerybeatSingleReceiverConfig is the expected config for an osquery component
 	// with single_receiver: true and two streams merged into one receiver.
+	// The osquery_manager.result stream must be first (index 0) so that
+	// osquerybeat assigns it's client to it.
 	expectedOsquerybeatSingleReceiverConfig := func(id string) map[string]any {
 		cfg := beatReceiverBaseConfig(id, "osquerybeat", "osquery")
 		cfg["osquerybeat"] = map[string]any{
 			"inputs": []map[string]any{
-				{
-					"id": "action-responses",
-					"data_stream": map[string]any{
-						"dataset": "osquery_manager.action.responses",
-					},
-					"query":      nil,
-					"index":      "logs-osquery_manager.action.responses-default",
-					"processors": defaultInputProcessors("action-responses", "osquery_manager.action.responses", "logs"),
-					"type":       "osquery",
-				},
 				{
 					"id": "results",
 					"data_stream": map[string]any{
@@ -659,6 +651,16 @@ func TestGetOtelConfig(t *testing.T) {
 					"interval":   "3600",
 					"index":      "logs-osquery_manager.result-default",
 					"processors": defaultInputProcessors("results", "osquery_manager.result", "logs"),
+					"type":       "osquery",
+				},
+				{
+					"id": "action-responses",
+					"data_stream": map[string]any{
+						"dataset": "osquery_manager.action.responses",
+					},
+					"query":      nil,
+					"index":      "logs-osquery_manager.action.responses-default",
+					"processors": defaultInputProcessors("action-responses", "osquery_manager.action.responses", "logs"),
 					"type":       "osquery",
 				},
 			},
@@ -2511,6 +2513,53 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 		},
 	}
 
+	// osquerybeat with single_receiver but without an "osquery" key (no scheduled queries
+	// or packs configured — live-query-only policy). The result stream must still be
+	// placed first so publisher.Configure routes live-query result rows correctly.
+	// Regression test for https://github.com/elastic/elastic-agent/issues/15601.
+	osquerybeatSingleReceiverNoOsqueryKeyComponent := &component.Component{
+		ID:        "osquerybeat-test-id",
+		InputType: "osquery",
+		InputSpec: &component.InputRuntimeSpec{
+			BinaryName: "elastic-otel-collector",
+			Spec: component.InputSpec{
+				Name: "osquery",
+				Command: &component.CommandSpec{
+					Args: []string{"osquerybeat"},
+				},
+				SingleReceiver: true,
+			},
+		},
+		Units: []component.Unit{
+			{
+				ID:   "osquerybeat-test-id-unit",
+				Type: client.UnitTypeInput,
+				Config: component.MustExpectedConfig(map[string]any{
+					"id":         "test",
+					"use_output": "default",
+					"type":       "osquery",
+					"streams": []any{
+						map[string]any{
+							"id": "action-responses",
+							"data_stream": map[string]any{
+								"dataset": "osquery_manager.action.responses",
+							},
+							"query": nil,
+						},
+						map[string]any{
+							"id": "results",
+							"data_stream": map[string]any{
+								"dataset": "osquery_manager.result",
+							},
+						},
+					},
+					// Intentionally no "osquery" key — simulates a live-query-only policy
+					// with no scheduled queries or packs.
+				}),
+			},
+		},
+	}
+
 	packetbeatComponent := &component.Component{
 		ID:        "packetbeat-test-id",
 		InputType: "packet",
@@ -2632,6 +2681,25 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 				actionInput := inputs[1]
 				_, hasOsquery := actionInput["osquery"]
 				assert.False(t, hasOsquery, "action-responses stream must not have osquery injected")
+			},
+		},
+		{
+			name:               "osquerybeat single_receiver without osquery key still puts result stream first",
+			component:          osquerybeatSingleReceiverNoOsqueryKeyComponent,
+			outputQueueConfig:  nil,
+			expectedReceiverID: "osquerybeatreceiver/_agent-component/osquerybeat-test-id",
+			expectedBeatName:   "osquerybeat",
+			verifyBeatConfig: func(t *testing.T, beatConfig map[string]any) {
+				inputs, ok := beatConfig["inputs"].([]map[string]any)
+				require.True(t, ok, "osquerybeat inputs should be a slice of maps")
+				require.Len(t, inputs, 2, "both streams must be merged into the single receiver")
+
+				// Even without an "osquery" key, the result stream must be at position 0.
+				// If action.responses were first, live-query result rows would be routed to the wrong data stream.
+				assert.Equal(t, "results", inputs[0]["id"], "osquery_manager.result stream must be first even without osquery key")
+
+				_, hasOsquery := inputs[0]["osquery"]
+				assert.False(t, hasOsquery, "no osquery section should be injected when key is absent from unit config")
 			},
 		},
 		{

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -637,7 +637,7 @@ func TestGetOtelConfig(t *testing.T) {
 	// expectedOsquerybeatSingleReceiverConfig is the expected config for an osquery component
 	// with single_receiver: true and two streams merged into one receiver.
 	// The osquery_manager.result stream must be first (index 0) so that
-	// osquerybeat assigns it's client to it.
+	// osquerybeat assigns its client to it.
 	expectedOsquerybeatSingleReceiverConfig := func(id string) map[string]any {
 		cfg := beatReceiverBaseConfig(id, "osquerybeat", "osquery")
 		cfg["osquerybeat"] = map[string]any{

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -50,10 +50,11 @@ func TestOsqueryManager(t *testing.T) {
 	info := define.Require(t, define.Requirements{
 		Group: integration.Fleet,
 		Stack: &define.Stack{},
-		Local: false, // requires Agent installation
-		Sudo:  true,  // requires Agent installation
+		Local: true, // requires Agent installation
+		Sudo:  true, // requires Agent installation
 		OS: []define.OS{
 			{Type: define.Linux},
+			{Type: define.Darwin},
 		},
 	})
 
@@ -80,6 +81,7 @@ func (runner *OsqueryManagerRunner) SetupSuite() {
 		NonInteractive: true,
 		Force:          true,
 		Privileged:     true,
+		Develop:        true,
 	}
 
 	ctx, cancel := context.WithTimeout(runner.T().Context(), 3*time.Minute)
@@ -92,79 +94,108 @@ func (runner *OsqueryManagerRunner) SetupSuite() {
 	runner.agentID = agentID
 	runner.policyID = policyResp.ID
 	runner.policyName = policyResp.Name
-
-	packageFile := filepath.Join("testdata", "osquery_package.json")
-	_, err = tools.InstallPackageFromDefaultFile(ctx, runner.info.KibanaClient, "osquery_manager",
-		integration.PreinstalledPackages["osquery_manager"], packageFile, uuid.Must(uuid.NewV4()).String(), policyResp.ID)
-	require.NoError(runner.T(), err)
-
 }
 
-func (runner *OsqueryManagerRunner) validateOsqueryEvents(t *testing.T, ctx context.Context, agentID string, since time.Time) mapstr.M {
-	now := time.Now()
-	var query map[string]any
-	var doc mapstr.M
-	defer func() {
-		if t.Failed() {
-			bs, err := json.Marshal(query)
-			if err != nil {
-				t.Errorf("executed at %s: %v",
-					now.Format(time.RFC3339Nano), query)
-				return
-			}
-			t.Errorf("executed at %s: query: %s",
-				now.Format(time.RFC3339Nano), string(bs))
-		}
-	}()
+// TestLiveQueryRoutingNoSchedule is a regression test for
+// https://github.com/elastic/elastic-agent/issues/15601.
+//
+// When an osquery integration has no scheduled queries the Fleet policy
+// contains no "config.osquery" section. This bypassed the configuration
+// translation logic to reorder the streams causing live-query result rows
+// to be written to logs-osquery_manager.action.responses instead of
+// logs-osquery_manager.result.
+func (runner *OsqueryManagerRunner) TestLiveQueryRoutingNoSchedule() {
+	t := runner.T()
 
-	t.Logf("starting to query ES for osquery events at %s", now.Format(time.RFC3339Nano))
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Minute)
+	defer cancel()
+
+	// Create a package with no schedule actions so only live queries can be processed.
+	noScheduleFile := filepath.Join("testdata", "osquery_package_no_schedule.json")
+	pkgResp, err := tools.InstallPackageFromDefaultFile(ctx, runner.info.KibanaClient, "osquery_manager",
+		integration.PreinstalledPackages["osquery_manager"], noScheduleFile, uuid.Must(uuid.NewV4()).String(), runner.policyID)
+	require.NoError(t, err, "failed to install no-schedule osquery package policy")
+	packagePolicyID := pkgResp.Item.ID
+
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		if _, err := runner.info.KibanaClient.DeleteFleetPackage(cleanupCtx, packagePolicyID); err != nil {
+			t.Logf("failed to delete no-schedule osquery package policy %s: %v", packagePolicyID, err)
+		}
+	})
+
+	agentStatus, err := runner.agentFixture.ExecStatus(ctx)
+	require.NoError(t, err, "could not get agent status")
+
+	// Wait for the osquery component to become healthy in OTel mode.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		query = genESQuery(agentID,
-			[][]string{
-				{"exists", "field", "osquery.physical_memory"},
-			})
-		query["query"].(map[string]interface{})["bool"].(map[string]interface{})["filter"] = map[string]any{
-			"range": map[string]any{
-				"@timestamp": map[string]any{"gte": since.UTC().Format("2006-01-02T15:04:05.000Z")},
-			},
+		status, statusErr := runner.agentFixture.ExecStatus(ctx)
+		require.NoError(collect, statusErr)
+		var foundHealthy bool
+		for _, comp := range status.Components {
+			if strings.HasPrefix(comp.ID, "osquery") &&
+				comp.VersionInfo.Name == componentVersionInfoNameForRuntime(component.OtelRuntimeManager) &&
+				comp.State == int(cproto.State_HEALTHY) {
+				foundHealthy = true
+				break
+			}
 		}
-		now = time.Now()
-		res, err := estools.PerformQueryForRawQuery(ctx, query, "logs-osquery_manager.result*", runner.info.ESClient)
-		require.NoError(collect, err)
-		require.NotEmpty(collect, res.Hits.Hits)
-		doc = res.Hits.Hits[0].Source
-	}, time.Minute*5, time.Second*10, "could not fetch events for osquery_manager")
-	return doc
-}
+		assert.True(collect, foundHealthy, "expected a healthy OTel osquery component")
+	}, 3*time.Minute, 5*time.Second, "osquery OTel component did not become healthy")
 
-// validateOsqueryLiveQuery submits an osquery live query for agentID via
-// Kibana's osquery plugin, waits for it to complete, and confirms the result
-// document landed in Elasticsearch tagged with this query's action ID.
-func (runner *OsqueryManagerRunner) validateOsqueryLiveQuery(t *testing.T, ctx context.Context, agentID string) {
-	liveQuery, err := submitOsqueryLiveQuery(ctx, runner.info.KibanaClient, agentID, "SELECT * FROM os_version;")
-	require.NoError(t, err, "failed to submit osquery live query")
+	// Dispatch a live query.
+	liveQuery, err := submitOsqueryLiveQuery(ctx, runner.info.KibanaClient, agentStatus.Info.ID, "SELECT * FROM os_version;")
+	require.NoError(t, err, "failed to submit live query")
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		status, statusErr := getOsqueryLiveQueryStatus(ctx, runner.info.KibanaClient, liveQuery.ActionID)
 		require.NoError(collect, statusErr)
 		assert.Equal(collect, "completed", status)
-	}, 2*time.Minute, 5*time.Second, "osquery live query did not complete")
+	}, 2*time.Minute, 5*time.Second, "live query did not complete")
 
+	// Positive: result rows must appear in logs-osquery_manager.result*.
+	// We require the "osquery" field so the assertion only matches actual result
+	// rows, not the action-response summary (which also carries action_id but
+	// has no osquery data).
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		query := genESQuery(agentID, [][]string{
+		query := genESQuery(agentStatus.Info.ID, [][]string{
 			{"term", "action_id", liveQuery.QueryActionID},
+			{"exists", "field", "osquery"},
 		})
 		res, err := estools.PerformQueryForRawQuery(ctx, query, "logs-osquery_manager.result*", runner.info.ESClient)
 		require.NoError(collect, err)
-		require.NotEmpty(collect, res.Hits.Hits, "expected a result document for the live query")
-	}, time.Minute*5, time.Second*10, "could not fetch osquery live query result from ES")
+		require.NotEmpty(collect, res.Hits.Hits, "live-query result rows must appear in logs-osquery_manager.result*")
+	}, 5*time.Minute, 10*time.Second, "live-query result rows not found in logs-osquery_manager.result*")
+
+	// Negative: every document in action.responses for this action must be an
+	// action-response summary (has action_response field). Before the fix, result
+	// rows from the no-schedule component were misrouted here.
+	misroutedQuery := genESQuery(agentStatus.Info.ID, [][]string{
+		{"term", "action_id", liveQuery.QueryActionID},
+	})
+	misroutedRes, err := estools.PerformQueryForRawQuery(ctx, misroutedQuery, "logs-osquery_manager.action.responses*", runner.info.ESClient)
+	require.NoError(t, err)
+	for _, hit := range misroutedRes.Hits.Hits {
+		_, hasActionResponse := hit.Source["action_response"]
+		assert.True(t, hasActionResponse,
+			"logs-osquery_manager.action.responses* must contain an action-response; found a misrouted result row: %v",
+			liveQuery.QueryActionID, hit.Source)
+	}
+
 }
 
-func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
+func (runner *OsqueryManagerRunner) TestOtelAndProcessMode() {
 	t := runner.T()
 
 	ctx, cancel := context.WithTimeout(t.Context(), time.Minute*20)
 	defer cancel()
+
+	// Install a package with a scheduled query.
+	packageFile := filepath.Join("testdata", "osquery_package.json")
+	_, err := tools.InstallPackageFromDefaultFile(ctx, runner.info.KibanaClient, "osquery_manager",
+		integration.PreinstalledPackages["osquery_manager"], packageFile, uuid.Must(uuid.NewV4()).String(), runner.policyID)
+	require.NoError(t, err, "failed to install scheduled osquery package policy")
 
 	agentStatus, err := runner.agentFixture.ExecStatus(ctx)
 	require.NoError(t, err, "could not get agent status")
@@ -194,14 +225,6 @@ func (runner *OsqueryManagerRunner) TestBeatsMetrics() {
 		}, 2*time.Minute, 5*time.Second, "beat component should be running as beats receiver")
 
 		otelDoc = runner.validateOsqueryEvents(t, ctx, agentStatus.Info.ID, testStart)
-
-		// Regression test for https://github.com/elastic/elastic-agent/issues/15410:
-		// osquery live queries dispatched by Fleet must reach osquerybeat even
-		// though it is running as a beats receiver inside the collector rather than as a
-		// standalone process with a gRPC control connection to elastic-agent.
-		t.Run("live query", func(t *testing.T) {
-			runner.validateOsqueryLiveQuery(t, ctx, agentStatus.Info.ID)
-		})
 	})
 
 	// Switch to process runtime and validate the same data.
@@ -265,6 +288,43 @@ func switchOsquerybeatToProcessRuntime(ctx context.Context, t testing.TB, kibana
 	policyResp, err := kibanaClient.UpdatePolicy(ctx, policyID, updateReq)
 	require.NoError(t, err)
 	return policyResp.Revision
+}
+
+func (runner *OsqueryManagerRunner) validateOsqueryEvents(t *testing.T, ctx context.Context, agentID string, since time.Time) mapstr.M {
+	now := time.Now()
+	var query map[string]any
+	var doc mapstr.M
+	defer func() {
+		if t.Failed() {
+			bs, err := json.Marshal(query)
+			if err != nil {
+				t.Errorf("executed at %s: %v",
+					now.Format(time.RFC3339Nano), query)
+				return
+			}
+			t.Errorf("executed at %s: query: %s",
+				now.Format(time.RFC3339Nano), string(bs))
+		}
+	}()
+
+	t.Logf("starting to query ES for osquery events at %s", now.Format(time.RFC3339Nano))
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		query = genESQuery(agentID,
+			[][]string{
+				{"exists", "field", "osquery.physical_memory"},
+			})
+		query["query"].(map[string]interface{})["bool"].(map[string]interface{})["filter"] = map[string]any{
+			"range": map[string]any{
+				"@timestamp": map[string]any{"gte": since.UTC().Format("2006-01-02T15:04:05.000Z")},
+			},
+		}
+		now = time.Now()
+		res, err := estools.PerformQueryForRawQuery(ctx, query, "logs-osquery_manager.result*", runner.info.ESClient)
+		require.NoError(collect, err)
+		require.NotEmpty(collect, res.Hits.Hits)
+		doc = res.Hits.Hits[0].Source
+	}, time.Minute*5, time.Second*10, "could not fetch events for osquery_manager")
+	return doc
 }
 
 // osqueryLiveQuery identifies a submitted live query: ActionID is the parent

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -176,8 +176,7 @@ func (runner *OsqueryManagerRunner) TestLiveQueryRoutingNoSchedule() {
 	for _, hit := range misroutedRes.Hits.Hits {
 		_, hasActionResponse := hit.Source["action_response"]
 		assert.True(t, hasActionResponse,
-			"logs-osquery_manager.action.responses* must contain an action-response; found a misrouted result row: %v",
-			liveQuery.QueryActionID, hit.Source)
+			"logs-osquery_manager.action.responses* must contain an action-response; found a misrouted result row: %v", hit.Source)
 	}
 
 }

--- a/testing/integration/ess/osquery_monitoring_test.go
+++ b/testing/integration/ess/osquery_monitoring_test.go
@@ -116,14 +116,11 @@ func (runner *OsqueryManagerRunner) TestLiveQueryRoutingNoSchedule() {
 		integration.PreinstalledPackages["osquery_manager"], noScheduleFile, uuid.Must(uuid.NewV4()).String(), runner.policyID)
 	require.NoError(t, err, "failed to install no-schedule osquery package policy")
 	packagePolicyID := pkgResp.Item.ID
-
-	t.Cleanup(func() {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cleanupCancel()
-		if _, err := runner.info.KibanaClient.DeleteFleetPackage(cleanupCtx, packagePolicyID); err != nil {
+	defer func() {
+		if _, err := runner.info.KibanaClient.DeleteFleetPackage(t.Context(), packagePolicyID); err != nil {
 			t.Logf("failed to delete no-schedule osquery package policy %s: %v", packagePolicyID, err)
 		}
-	})
+	}()
 
 	agentStatus, err := runner.agentFixture.ExecStatus(ctx)
 	require.NoError(t, err, "could not get agent status")

--- a/testing/integration/ess/testdata/osquery_package_no_schedule.json
+++ b/testing/integration/ess/testdata/osquery_package_no_schedule.json
@@ -1,0 +1,51 @@
+{
+    "id": "placeholder",
+    "name": "placeholder",
+    "namespace": "default",
+    "package": {
+        "name": "osquery_manager",
+        "version": "1.16.0"
+    },
+    "enabled": true,
+    "inputs": [
+        {
+            "type": "osquery",
+            "policy_template": "osquery_manager",
+            "enabled": true,
+            "streams": [
+                {
+                    "enabled": true,
+                    "data_stream": {
+                        "type": "logs",
+                        "dataset": "osquery_manager.action.responses"
+                    },
+                    "vars": {
+                        "query": {
+                            "type": "text"
+                        }
+                    },
+                    "id": "osquery-osquery_manager.action.responses-no-schedule",
+                    "compiled_stream": {
+                        "query": null
+                    }
+                },
+                {
+                    "enabled": true,
+                    "data_stream": {
+                        "type": "logs",
+                        "dataset": "osquery_manager.result"
+                    },
+                    "vars": {
+                        "query": {
+                            "type": "text"
+                        }
+                    },
+                    "id": "osquery-osquery_manager.result-no-schedule",
+                    "compiled_stream": {
+                        "query": null
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
- Closes https://github.com/elastic/elastic-agent/issues/15601

The OSQuery receiver translation logic had a guard in it that skipped re-ordering the data streams the way osquerybeat expects if there was no "osquery" configuration section present. This "osquery" section is only necessary when configuring scheduled queries, you can omit it if you only need osquerybeat to handle live queries.

Fix the guard and ensure that `logs-osquery_manager.result` is always the first stream passed to osquerybeat regardless of what order we receive them in. Adds an integration test for this case configuring a package policy with no schedule to test live queries, then using a separate package policy to test scheduled queries and do the document comparison between the otel and process modes.

Omitting the changelog because this bug was never released.