### PR TITLE
Fix getting current user failing on Windows when no profile directory is present

### DIFF
--- a/changelog/fragments/1784257071-fix-windows-no-profile-directory.yaml
+++ b/changelog/fragments/1784257071-fix-windows-no-profile-directory.yaml
@@ -9,7 +9,7 @@
 # - security: impacts on the security of a product or a user’s deployment.
 # - upgrade: important information for someone upgrading from a prior version
 # - other: does not fit into any of the other categories
-kind: bug
+kind: bug-fix
 
 # REQUIRED for all kinds
 # Change summary; a 80ish characters long description of the change.

--- a/changelog/fragments/1784257071-fix-windows-no-profile-directory.yaml
+++ b/changelog/fragments/1784257071-fix-windows-no-profile-directory.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix getting current user failing on Windows when no profile directory is present
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/actions/handlers/handler_action_privilege_level_change_windows.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_privilege_level_change_windows.go
@@ -8,18 +8,17 @@ package handlers
 
 import (
 	"fmt"
-	"os/user"
+
+	"github.com/elastic/elastic-agent/pkg/utils"
 )
 
 // currentEffectiveIDs returns the SID of the current user and primary group,
 // matching the SID strings that install.FindUID and install.FindGID return on
-// Windows. The os/user.Current() pitfall described in the Unix variant does
-// not apply on Windows — the process token is the source of truth and
-// user.Current() reads it correctly.
+// Windows.
 func currentEffectiveIDs() (string, string, error) {
-	u, err := user.Current()
+	u, err := utils.CurrentFileOwner()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get current user: %w", err)
 	}
-	return u.Uid, u.Gid, nil
+	return u.UID, u.GID, nil
 }

--- a/internal/pkg/agent/application/actions/handlers/handler_action_privilege_level_change_windows.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_privilege_level_change_windows.go
@@ -14,7 +14,9 @@ import (
 
 // currentEffectiveIDs returns the SID of the current user and primary group,
 // matching the SID strings that install.FindUID and install.FindGID return on
-// Windows.
+// Windows. The pitfall described in the Unix variant does not apply on Windows
+// - the process token is the source of truth and utils.CurrentFileOwner reads
+// it correctly.
 func currentEffectiveIDs() (string, string, error) {
 	u, err := utils.CurrentFileOwner()
 	if err != nil {

--- a/pkg/ipc/listener_windows.go
+++ b/pkg/ipc/listener_windows.go
@@ -9,7 +9,6 @@ package ipc
 import (
 	"fmt"
 	"net"
-	"os/user"
 	"strings"
 
 	"golang.org/x/sys/windows"
@@ -47,12 +46,12 @@ func CleanupListener(log *logger.Logger, address string) {
 }
 
 func securityDescriptor(log *logger.Logger) (string, error) {
-	u, err := user.Current()
+	u, err := utils.CurrentFileOwner()
 	if err != nil {
 		return "", fmt.Errorf("failed to get current user: %w", err)
 	}
 
-	descriptor := "D:P(A;;GA;;;" + u.Uid + ")"
+	descriptor := "D:P(A;;GA;;;" + u.UID + ")"
 
 	isAdmin, err := utils.HasRoot()
 	if err != nil {

--- a/testing/integration/ess/install_test.go
+++ b/testing/integration/ess/install_test.go
@@ -14,6 +14,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -22,6 +23,7 @@ import (
 	"time"
 
 	"github.com/schollz/progressbar/v3"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
@@ -881,4 +883,145 @@ func randStr(length int) string {
 	}
 
 	return string(runes)
+}
+
+// Regression test for elastic-agent/issues/15626
+func TestInstalledServiceWithoutUserProfile(t *testing.T) {
+	define.Require(t, define.Requirements{
+		Group: integration.Default,
+		Local: false,
+		Sudo:  true,
+		OS: []define.OS{
+			{Type: define.Windows},
+		},
+	})
+
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(15*time.Minute))
+	defer cancel()
+
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
+	require.NoError(t, err)
+	require.NoError(t, fixture.Prepare(ctx))
+
+	config := `
+outputs:
+  default:
+    type: elasticsearch
+    hosts: [127.0.0.1:9200]
+inputs: []
+agent.monitoring.enabled: false
+`
+	require.NoError(t, fixture.Configure(ctx, []byte(config)))
+
+	profileListKey := `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\S-1-5-18`
+
+	backup := filepath.Join(t.TempDir(), "profilelist-s-1-5-18.reg")
+	out, err := exec.CommandContext(ctx, "reg", "export", profileListKey, backup, "/y").CombinedOutput()
+	require.NoError(t, err, "failed to export ProfileList key: %s", out)
+	defer func() {
+		out, err := exec.CommandContext(t.Context(), "reg", "import", backup).CombinedOutput()
+		if err != nil {
+			t.Errorf("failed to restore ProfileList key: %v: %s", err, out)
+		}
+	}()
+
+	// Remove profile path value so LocalSystem has no resolvable profile.
+	out, err = exec.CommandContext(ctx, "reg", "delete", profileListKey, "/v", "ProfileImagePath", "/f").CombinedOutput()
+	require.NoError(t, err, "failed to delete ProfileImagePath: %s", out)
+	out, err = exec.CommandContext(ctx, "reg", "query", profileListKey, "/v", "ProfileImagePath").CombinedOutput()
+	require.Error(t, err, "ProfileImagePath must be absent for this test to be valid: %s", out)
+
+	opts := atesting.InstallOpts{
+		Privileged:     true,
+		Force:          true,
+		NonInteractive: true,
+	}
+	out, err = fixture.Install(ctx, &opts)
+	if err != nil {
+		t.Logf("install output: %s", out)
+		require.NoError(t, err)
+	}
+
+	checks := &installtest.CheckOpts{
+		Privileged:    opts.Privileged,
+		TargetVersion: fixture.Version(),
+		TopPath:       installtest.DefaultTopPath(),
+	}
+	require.NoError(t, installtest.CheckSuccess(ctx, fixture, opts.BasePath, checks))
+	fixture.PostUninstallHook(func(t *testing.T) {
+		require.NoError(t, installtest.CheckUninstallSuccess(checks))
+	})
+
+	serviceName := paths.ServiceName()
+
+	defer func() {
+		if t.Failed() {
+			out, err := exec.CommandContext(t.Context(), "sc", "query", serviceName).CombinedOutput()
+			t.Logf("service state (err=%v):\n%s", err, out)
+		}
+	}()
+
+	queryService := func() string {
+		out, err := exec.CommandContext(t.Context(), "sc", "query", serviceName).CombinedOutput()
+		if err != nil {
+			return fmt.Sprintf("sc query failed: %v: %s", err, out)
+		}
+		return string(out)
+	}
+
+	logPattern := filepath.Join(fixture.WorkDir(), "data", "elastic-agent-*", "logs", "elastic-agent-*.ndjson")
+	waitForHealthy := func(timeout time.Duration, failureMessage string) {
+		t.Helper()
+
+		var lastErr error
+		if assert.Eventually(t, func() bool {
+			lastErr = fixture.IsHealthy(ctx)
+			return lastErr == nil
+		}, timeout, 5*time.Second, failureMessage) {
+			return
+		}
+
+		t.Fatalf("%s\nlast status error: %v\nservice state:\n%s\nagent error logs:\n%s",
+			failureMessage, lastErr, queryService(), readAgentErrorLogs(logPattern, 20))
+	}
+
+	waitForHealthy(3*time.Minute, "agent did not become healthy with the profile unresolvable")
+
+	_, err = fixture.ExecDiagnostics(ctx)
+	require.NoError(t, err, "diagnostics collection failed")
+
+	require.NoError(t, fixture.ExecRestart(ctx), "daemon restart failed")
+	waitForHealthy(2*time.Minute, "agent did not become healthy again after restart")
+}
+
+func readAgentErrorLogs(pattern string, limit int) string {
+	matches, _ := filepath.Glob(pattern)
+	var lines []string
+	for _, match := range matches {
+		b, err := os.ReadFile(match)
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(b), "\n") {
+			if line == "" {
+				continue
+			}
+			var entry struct {
+				Timestamp string `json:"@timestamp"`
+				LogLevel  string `json:"log.level"`
+				Message   string `json:"message"`
+			}
+			if err := json.Unmarshal([]byte(line), &entry); err != nil || entry.LogLevel != "error" {
+				continue
+			}
+			lines = append(lines, fmt.Sprintf("%s %s", entry.Timestamp, entry.Message))
+			if len(lines) > limit {
+				lines = lines[len(lines)-limit:]
+			}
+		}
+	}
+	if len(lines) == 0 {
+		return "(no agent error logs found)"
+	}
+	return strings.Join(lines, "\n")
 }

--- a/testing/integration/ess/install_test.go
+++ b/testing/integration/ess/install_test.go
@@ -952,46 +952,33 @@ agent.monitoring.enabled: false
 		require.NoError(t, installtest.CheckUninstallSuccess(checks))
 	})
 
-	serviceName := paths.ServiceName()
-
-	defer func() {
+	t.Cleanup(func() {
 		if t.Failed() {
-			out, err := exec.CommandContext(t.Context(), "sc", "query", serviceName).CombinedOutput()
-			t.Logf("service state (err=%v):\n%s", err, out)
+			serviceOutput, err := exec.CommandContext(t.Context(), "sc", "query", paths.ServiceName()).CombinedOutput()
+			if err != nil {
+				t.Logf("sc query failed: %v: %s", err, serviceOutput)
+				return
+			}
+
+			t.Logf("Service state:\n%s\n", serviceOutput)
+			logPattern := filepath.Join(fixture.WorkDir(), "data", "elastic-agent-*", "logs", "elastic-agent-*.ndjson")
+			if err != nil {
+				t.Logf("failed to fetch final logs inside cleanup: %v", err)
+				return
+			}
+			t.Logf("Logs:\n%s\n", readAgentErrorLogs(logPattern, 20))
 		}
-	}()
+	})
 
-	queryService := func() string {
-		out, err := exec.CommandContext(t.Context(), "sc", "query", serviceName).CombinedOutput()
-		if err != nil {
-			return fmt.Sprintf("sc query failed: %v: %s", err, out)
-		}
-		return string(out)
-	}
-
-	logPattern := filepath.Join(fixture.WorkDir(), "data", "elastic-agent-*", "logs", "elastic-agent-*.ndjson")
-	waitForHealthy := func(timeout time.Duration, failureMessage string) {
-		t.Helper()
-
-		var lastErr error
-		if assert.Eventually(t, func() bool {
-			lastErr = fixture.IsHealthy(ctx)
-			return lastErr == nil
-		}, timeout, 5*time.Second, failureMessage) {
-			return
-		}
-
-		t.Fatalf("%s\nlast status error: %v\nservice state:\n%s\nagent error logs:\n%s",
-			failureMessage, lastErr, queryService(), readAgentErrorLogs(logPattern, 20))
-	}
-
-	waitForHealthy(3*time.Minute, "agent did not become healthy with the profile unresolvable")
-
-	_, err = fixture.ExecDiagnostics(ctx)
-	require.NoError(t, err, "diagnostics collection failed")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NoError(c, fixture.IsHealthy(ctx))
+	}, 3*time.Minute, 5*time.Second, "agent did not become healthy on first startup")
 
 	require.NoError(t, fixture.ExecRestart(ctx), "daemon restart failed")
-	waitForHealthy(2*time.Minute, "agent did not become healthy again after restart")
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NoError(c, fixture.IsHealthy(ctx))
+	}, 3*time.Minute, 5*time.Second, "agent did not become healthy after restart")
 }
 
 func readAgentErrorLogs(pattern string, limit int) string {

--- a/testing/integration/ess/install_test.go
+++ b/testing/integration/ess/install_test.go
@@ -920,9 +920,7 @@ agent.monitoring.enabled: false
 	require.NoError(t, err, "failed to export ProfileList key: %s", out)
 	defer func() {
 		out, err := exec.CommandContext(t.Context(), "reg", "import", backup).CombinedOutput()
-		if err != nil {
-			t.Errorf("failed to restore ProfileList key: %v: %s", err, out)
-		}
+		require.NoError(t, err, "failed to restore ProfileList, key : %s", out)
 	}()
 
 	// Remove profile path value so LocalSystem has no resolvable profile.

--- a/testing/integration/ess/install_test.go
+++ b/testing/integration/ess/install_test.go
@@ -954,16 +954,19 @@ agent.monitoring.enabled: false
 
 	t.Cleanup(func() {
 		if t.Failed() {
-			serviceOutput, err := exec.CommandContext(t.Context(), "sc", "query", paths.ServiceName()).CombinedOutput()
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), time.Minute) //nolint:forbidigo // t.Context() is cancelled by cleanup time
+			defer cleanupCancel()
+
+			serviceOutput, err := exec.CommandContext(cleanupCtx, "sc", "query", paths.ServiceName()).CombinedOutput() //nolint:gosec // G204: service name is not user input
 			if err != nil {
 				t.Logf("sc query failed: %v: %s", err, serviceOutput)
-				return
+			} else {
+				t.Logf("Service state:\n%s\n", serviceOutput)
 			}
 
-			t.Logf("Service state:\n%s\n", serviceOutput)
-			logs, err := fixture.Exec(context.Background(), []string{"logs", "-n", "20", "--exclude-events"})
+			logs, err := fixture.Exec(cleanupCtx, []string{"logs", "-n", "20", "--exclude-events"})
 			if err != nil {
-				t.Logf("failed to fetch final logs inside cleanup: %v", err)
+				t.Logf("failed to fetch final logs inside cleanup: %v: %s", err, logs)
 				return
 			}
 			t.Logf("Logs:\n%s\n", string(logs))

--- a/testing/integration/ess/install_test.go
+++ b/testing/integration/ess/install_test.go
@@ -961,12 +961,12 @@ agent.monitoring.enabled: false
 			}
 
 			t.Logf("Service state:\n%s\n", serviceOutput)
-			logPattern := filepath.Join(fixture.WorkDir(), "data", "elastic-agent-*", "logs", "elastic-agent-*.ndjson")
+			logs, err := fixture.Exec(context.Background(), []string{"logs", "-n", "20", "--exclude-events"})
 			if err != nil {
 				t.Logf("failed to fetch final logs inside cleanup: %v", err)
 				return
 			}
-			t.Logf("Logs:\n%s\n", readAgentErrorLogs(logPattern, 20))
+			t.Logf("Logs:\n%s\n", string(logs))
 		}
 	})
 
@@ -979,36 +979,4 @@ agent.monitoring.enabled: false
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.NoError(c, fixture.IsHealthy(ctx))
 	}, 3*time.Minute, 5*time.Second, "agent did not become healthy after restart")
-}
-
-func readAgentErrorLogs(pattern string, limit int) string {
-	matches, _ := filepath.Glob(pattern)
-	var lines []string
-	for _, match := range matches {
-		b, err := os.ReadFile(match)
-		if err != nil {
-			continue
-		}
-		for _, line := range strings.Split(string(b), "\n") {
-			if line == "" {
-				continue
-			}
-			var entry struct {
-				Timestamp string `json:"@timestamp"`
-				LogLevel  string `json:"log.level"`
-				Message   string `json:"message"`
-			}
-			if err := json.Unmarshal([]byte(line), &entry); err != nil || entry.LogLevel != "error" {
-				continue
-			}
-			lines = append(lines, fmt.Sprintf("%s %s", entry.Timestamp, entry.Message))
-			if len(lines) > limit {
-				lines = lines[len(lines)-limit:]
-			}
-		}
-	}
-	if len(lines) == 0 {
-		return "(no agent error logs found)"
-	}
-	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
## What does this PR do?

Uses `utils.CurrentFileOwner` instead of `os/user.Current` when retrieving user ID on Windows. This has fewer failure modes and does not require a profile directory to exist.

## Why is it important?

Without this, the two uses (startup gRPC npipe creation, privilege change) fail on Windows servers that have only ever been accessed non-interactively and have never had a profile directory set up. 

## Checklist

- [X] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [X] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files~
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [X] I have added an integration test or an E2E test

## Disruptive User Impact

N/A

## Related issues

- Closes #15626
