### PR TITLE
[mage] Fix incorrect snapshot metadata in the core package

### DIFF
--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -323,6 +323,7 @@ func (b GolangCrossBuilder) Build() error {
 		"--env", fmt.Sprintf("SNAPSHOT=%v", cfg.Build.Snapshot),
 		"--env", fmt.Sprintf("DEV=%v", cfg.Build.DevBuild),
 		"--env", fmt.Sprintf("FIPS=%v", cfg.Build.FIPSBuild),
+		"--env", fmt.Sprintf("USE_PACKAGE_VERSION=%v", cfg.Packaging.UsePackageVersion),
 		"-v", repoInfo.RootDir+":"+mountPoint,
 	)
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fixes a bug that caused the agent binary we create for the core package to always have `snapshot: true` metadata stamped into it. This caused major and confusing breakage in a release package built with such a binary.

The reason this happens is fairly subtle. As part of a slow process of making the packaging process more maintainable, we've introduced monolithic configuration which is loaded once from environment variables and passed around either directly or by attaching it to a context. This works in principle, with one wrinkle - we also compile and run our magefile inside a golang-crossbuild docker container. There, we can only pass configuration via environment variables.

A recent change set `SNAPSHOT=true` by default, which was correct and worked everywhere, we unset it where it needed to be unset. Then https://github.com/elastic/elastic-agent/pull/14871 set `USE_PACKAGE_VERSION=true` by default. This causes us to read package metadata from a `.package-version` file, which includes whether the package is a snapshot - and in practice, it always is. This also overrides `SNAPSHOT`. 

The bug is that we don't pass `USE_PACKAGE_VERSION` to the crossbuild container. So it's always true, and therefore the build is always a snapshot build, even if we set `USE_PACKAGE_VERSION=false` for the package target.

Why exactly this presents in the way that it does in https://github.com/elastic/elastic-agent/issues/15578 is a small mystery, but this change definitely fixes it. I'd like to do a more fundamental fix to this problem in a follow up, this is just to unblock staging builds.

## Why is it important?

Our staging builds are currently broken due to this issue.

## How to test this PR locally

```bash
export MANIFEST_URL="https://staging.elastic.co/9.5.0-643286de/agent-package/agent-artifacts-9.5.0.json" AGENT_CORE_SOURCE=local AGENT_DROP_PATH=build/elastic-agent-drop USE_PACKAGE_VERSION=false
mage package
```

Then install from the resulting package. The install should be valid. If you do this without this fix, your install will be broken, with agent detecting the wrong path, and will require explicitly setting `path.home` and `

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/15578

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
