### PR TITLE
fix: upgrade marker not deleted on Windows after successful upgrade

### DIFF
--- a/changelog/fragments/1752580000-fix-upgrade-marker-not-deleted-windows.yaml
+++ b/changelog/fragments/1752580000-fix-upgrade-marker-not-deleted-windows.yaml
@@ -1,0 +1,14 @@
+kind: bug-fix
+
+summary: Remove upgrade marker after successful upgrade on all platforms including Windows
+
+description: |
+  The upgrade watcher previously skipped deleting the upgrade marker on Windows,
+  leaving a stale marker that interfered with subsequent upgrades. This change
+  introduces a new watcher-owned .watcher-marker file that records the terminal
+  upgrade outcome (completed, rolled back, or failed) before the upgrade marker
+  is deleted. The upgrade marker is now removed unconditionally on all platforms.
+
+component: elastic-agent
+
+issue: https://github.com/elastic/elastic-agent/issues/3027

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -2,10 +2,8 @@
 
 ### Communications amongst components
 The following sequence diagram illustrates the process of upgrading a
-Fleet-managed Agent. The diagram focusses on the communications that occur
+Fleet-managed Agent. The diagram focuses on the communications that occur
 amongst the various components involved in the upgrade process.
-
-This diagram is accurate as of version `8.9.0` of every component shown.
 
 ```mermaid
 sequenceDiagram
@@ -15,7 +13,8 @@ sequenceDiagram
     participant FS as Fleet Server
     participant A as Agent
     participant UW as Upgrade Watcher
-    participant UM as Upgrader Marker
+    participant UM as .update-marker
+    participant WM as .watcher-marker
 
     U->>UI: Initiate upgrade
     UI->>ES: Update Agent doc in `.fleet-agents`<br />set `upgrade_started_at`
@@ -30,37 +29,101 @@ sequenceDiagram
        FS->>ES: Update Agent doc in `.fleet-agents`<br />set `upgrade_status` = "failed"
        UI->>UI: Agent status remains as "updating" (bug)
     else
-       opt If previous upgrades found
-          A->>FS: Ack previous upgrades
-          A->>A: Remove previous upgrades from queue
-       end
        A->>A: Download new Agent artifact
+       A->>UM: Create (version, hash, versionedHome — protects new dir from cleanup)
        A->>A: Extract new Agent artifact
        A->>A: Change symlink from current Agent binary to new one
-       A->>UM: Create
+       A->>A: Register rollback candidate in TTL registry
+       A->>UM: Update (action ID, TTL rollbacks, timestamp)
        A->>A: Update active commit file
-       A->>UW: Start
-       A->>A: Rexec to start new Agent artifact
-       A->>FS: Ack successful upgrade
+       A->>UW: Start (`elastic-agent watch`)
+       UW->>UM: Update (state=watching)
+       A->>UM: Poll until state=watching (up to 30s)
+       A->>A: Rexec to start new Agent binary
+       A->>FS: Ack upgrade action
        FS->>ES: Write successful ack in `.fleet-actions-results`
-       FS->>ES: Update Agent doc in `.fleet-agents`<br />set `upgrade_status` = null<br />`upgraded_at` = <now><br />`upgrade_started_at` = null
+       FS->>ES: Update Agent doc in `.fleet-agents`<br />set `upgrade_status` = null<br />`upgraded_at` = now, `upgrade_started_at` = null
        UI->>UI: Show Agent status as "healthy"
-       UW->>UW: Start watching new Agent
-       alt New Agent is OK
-         UW->>UM: Remove
+       UW->>UW: Monitor new Agent (grace period or error)
+       alt New Agent is healthy
+         UW->>WM: Write (outcome=completed, versions, action ID)
+         UW->>UM: Remove (all platforms)
          UW->>UW: Cleanup old Agent files
-       else Rollback
-         UW->>UW: Change symlink from current Agent binary to new one
+       else Rollback (watch failed)
+         UW->>WM: Write (outcome=rollback, reason)
+         UW->>UW: Change symlink back to old Agent binary
          UW->>UW: Update active commit file
-         UW->>A: Rexec to start old Agent artifact
-         A->>FS: Ack failed upgrade
-         FS->>ES: Update Agent doc in `.fleet-agents`<br />set `upgrade_status` = null<br />`upgraded_at = <now>
+         UW->>A: Restart old Agent binary
+         A->>FS: Ack upgrade action
+         FS->>ES: Write successful ack in `.fleet-actions-results`
+         FS->>ES: Update Agent doc in `.fleet-agents`<br />set `upgrade_status` = null<br />`upgraded_at` = now, `upgrade_started_at` = null
          UI->>UI: Show Agent status as "healthy"
-         UW->>UM: Remove
+         UW->>UM: Remove (or keep for backward compat — see below)
          UW->>UW: Cleanup new Agent files
        end
     end
 ```
+
+### Marker file architecture
+
+The upgrade process uses two persistent files to track state. The split
+separates the upgrade marker (owned jointly by agent and watcher) from the
+watcher outcome record (watcher-only write, coordinator read-only).
+
+| File | Written by | Read by | Lifetime |
+|------|-----------|---------|---------|
+| `.update-marker` | Agent (create), Watcher (detail updates) | Coordinator, Watcher | Created at upgrade start; removed by Watcher on terminal outcome |
+| `.watcher-marker` | Watcher only | Coordinator (read-only) | Never deleted; overwritten at the start of each upgrade cycle |
+
+#### `.update-marker`
+
+Created by the agent when an upgrade begins. Contains the target and previous
+version/hash, the versioned home paths, the Fleet action ID, and the current
+upgrade details (state + metadata). The watcher updates the details field
+throughout the watch phase. Removed by the watcher on all platforms once a
+terminal outcome is reached.
+
+#### `.watcher-marker`
+
+Written by the watcher immediately before removing the upgrade marker. Records
+the terminal outcome (`completed`, `rollback`, or `failed`) along with version
+tuple, action ID, reason or error message, and a completion timestamp.
+
+The coordinator's file watcher fires on every upgrade marker change. While the
+upgrade marker exists, `marker.Details` is authoritative for Fleet reporting.
+When the marker is removed (nil details), the coordinator reads the watcher
+marker and re-reports any non-completed terminal state so Fleet receives the
+correct outcome even if the agent was offline between the watcher writing the
+file and the next check-in.
+
+A staleness guard prevents an old watcher marker from being mistaken for the
+current upgrade cycle by matching version tuple, completion timestamp, and action ID.
+
+#### Backward compatibility
+
+When rolling back to an older agent that reads the upgrade marker on startup to
+detect rollback, the upgrade marker is **kept on disk** after rollback. Those
+agents have no knowledge of the watcher marker.
+
+When rolling back to a recent agent, the upgrade marker is removed during
+rollback; the rolled-back agent relies on the watcher marker via the coordinator.
+
+### Manual rollback
+
+A manual rollback can be triggered by Fleet or the CLI after the upgrade grace
+period has elapsed.
+
+**When the upgrade marker is still present:** the upgrade marker is read to
+identify the agent installs involved and select the watcher executable. The
+existing watcher is gracefully stopped, rollback candidates are read from the
+TTL rollback files on disk, and a rollback watcher is started.
+
+**When the upgrade marker has already been removed** (the watcher finished its
+cleanup): the rollback path creates a temporary upgrade marker to drive the
+rollback watcher. Before starting the rollback watcher it checks whether a
+previous watcher is still in its cleanup phase by attempting to acquire
+`watcher.lock`. If the lock is held (lingering watcher), the rollback takes over
+the lingering watcher first, then starts the rollback watcher normally.
 
 ### Introducing package manifest
 

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -94,7 +94,9 @@ upgrade marker exists, `marker.Details` is authoritative for Fleet reporting.
 When the marker is removed (nil details), the coordinator reads the watcher
 marker and re-reports any non-completed terminal state so Fleet receives the
 correct outcome even if the agent was offline between the watcher writing the
-file and the next check-in.
+file and the next check-in. On agent restart with no upgrade marker on disk,
+the coordinator likewise reads the watcher marker on startup to re-report any
+pending terminal state from the previous upgrade cycle.
 
 A staleness guard prevents an old watcher marker from being mistaken for the
 current upgrade cycle by matching version tuple, completion timestamp, and action ID.

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -999,6 +999,56 @@ func (c *Coordinator) logUpgradeDetails(details *details.Details) {
 	c.logger.Infow("updated upgrade details", "upgrade_details", details)
 }
 
+// upgradeDetailsFromMarkerUpdate returns the upgrade details the coordinator
+// should report for a marker change. While the upgrade marker exists, its
+// details are used directly. Once removed, the watcher marker is consulted to
+// recover any non-completed terminal state for Fleet reporting. Reporting the
+// same state twice is idempotent on the Fleet side.
+func upgradeDetailsFromMarkerUpdate(log *logger.Logger, marker upgrade.UpdateMarker, dataDirPath string) *details.Details {
+	if marker.Details != nil {
+		return marker.Details
+	}
+
+	// Upgrade marker removed — check the watcher marker for a terminal outcome.
+	wm, err := upgrade.LoadWatcherMarker(dataDirPath)
+	if err != nil {
+		log.Warnw("failed to load watcher marker; upgrade details cleared", "error.message", err)
+		return nil
+	}
+	if wm == nil || !watcherMarkerMatchesUpgrade(wm, marker) {
+		return nil
+	}
+
+	if wm.Outcome == details.StateCompleted {
+		return nil
+	}
+
+	det := details.NewDetails(wm.TargetVersion, wm.Outcome, wm.ActionID)
+	switch wm.Outcome {
+	case details.StateRollback:
+		det.Metadata.Reason = wm.Reason
+	case details.StateFailed:
+		det.Metadata.ErrorMsg = wm.ErrorMsg
+	}
+	return det
+}
+
+// watcherMarkerMatchesUpgrade reports whether wm belongs to the same upgrade
+// as marker, not a stale result from a previous upgrade cycle.
+func watcherMarkerMatchesUpgrade(wm *upgrade.WatcherMarker, marker upgrade.UpdateMarker) bool {
+	if wm.TargetVersion != marker.Version || wm.PreviousVersion != marker.PrevVersion {
+		return false
+	}
+	// If both sides have an ActionID, they must match — retries to the same
+	// version get a different ActionID so the version tuple alone isn't enough.
+	if wm.ActionID != "" && marker.GetActionID() != "" && wm.ActionID != marker.GetActionID() {
+		return false
+	}
+	// False if the watcher marker was written before the upgrade marker was last updated (stale).
+	// Both timestamps come from the same machine, so wall-clock ordering is normally reliable here.
+	return !wm.CompletedAt.Before(marker.UpdatedOn)
+}
+
 // AckUpgrade is the method used on startup to ack a previously successful upgrade action.
 // Called from external goroutines.
 func (c *Coordinator) AckUpgrade(ctx context.Context, acker acker.Acker) error {
@@ -1703,7 +1753,7 @@ func (c *Coordinator) runLoopIteration(ctx context.Context) {
 
 	case upgradeMarker := <-c.managerChans.upgradeMarkerUpdate:
 		if ctx.Err() == nil {
-			c.setUpgradeDetails(upgradeMarker.Details)
+			c.setUpgradeDetails(upgradeDetailsFromMarkerUpdate(c.logger, upgradeMarker, paths.Data()))
 		}
 	}
 

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -1002,8 +1002,7 @@ func (c *Coordinator) logUpgradeDetails(details *details.Details) {
 // upgradeDetailsFromMarkerUpdate returns the upgrade details the coordinator
 // should report for a marker change. While the upgrade marker exists, its
 // details are used directly. Once removed, the watcher marker is consulted to
-// recover any non-completed terminal state for Fleet reporting. Reporting the
-// same state twice is idempotent on the Fleet side.
+// recover any non-completed terminal state for Fleet reporting.
 func upgradeDetailsFromMarkerUpdate(log *logger.Logger, marker upgrade.UpdateMarker, dataDirPath string) *details.Details {
 	if marker.Details != nil {
 		return marker.Details

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -1028,6 +1028,7 @@ func upgradeDetailsFromMarkerUpdate(log *logger.Logger, marker upgrade.UpdateMar
 		det.Metadata.Reason = wm.Reason
 	case details.StateFailed:
 		det.Metadata.ErrorMsg = wm.ErrorMsg
+		det.Metadata.FailedState = wm.FailedState
 	}
 	return det
 }

--- a/internal/pkg/agent/application/coordinator/coordinator_watcher_marker_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_watcher_marker_test.go
@@ -1,0 +1,228 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package coordinator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade"
+	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
+	"github.com/elastic/elastic-agent/pkg/upgrade/details"
+)
+
+func TestWatcherMarkerMatchesUpgrade(t *testing.T) {
+	updatedOn := time.Now().Add(-time.Minute)
+	completedAt := time.Now()
+
+	baseMarker := upgrade.UpdateMarker{
+		Version:     "8.5.0",
+		PrevVersion: "8.4.0",
+		UpdatedOn:   updatedOn,
+	}
+	baseWM := &upgrade.WatcherMarker{
+		TargetVersion:   "8.5.0",
+		PreviousVersion: "8.4.0",
+		CompletedAt:     completedAt,
+	}
+
+	t.Run("matches on version tuple and timestamp", func(t *testing.T) {
+		assert.True(t, watcherMarkerMatchesUpgrade(baseWM, baseMarker))
+	})
+
+	t.Run("rejects different target version", func(t *testing.T) {
+		wm := *baseWM
+		wm.TargetVersion = "8.6.0"
+		assert.False(t, watcherMarkerMatchesUpgrade(&wm, baseMarker))
+	})
+
+	t.Run("rejects different previous version", func(t *testing.T) {
+		wm := *baseWM
+		wm.PreviousVersion = "8.3.0"
+		assert.False(t, watcherMarkerMatchesUpgrade(&wm, baseMarker))
+	})
+
+	t.Run("rejects when CompletedAt is before UpdatedOn", func(t *testing.T) {
+		wm := *baseWM
+		wm.CompletedAt = updatedOn.Add(-time.Second)
+		assert.False(t, watcherMarkerMatchesUpgrade(&wm, baseMarker))
+	})
+
+	t.Run("matches when watcher marker has ActionID but marker has none", func(t *testing.T) {
+		wm := *baseWM
+		wm.ActionID = "action-A"
+		// marker.Action == nil → GetActionID() == "" → one side empty, no constraint
+		assert.True(t, watcherMarkerMatchesUpgrade(&wm, baseMarker))
+	})
+
+	t.Run("matches when both ActionIDs agree", func(t *testing.T) {
+		wm := *baseWM
+		wm.ActionID = "action-A"
+		marker := baseMarker
+		marker.Action = &fleetapi.ActionUpgrade{ActionID: "action-A"}
+		assert.True(t, watcherMarkerMatchesUpgrade(&wm, marker))
+	})
+
+	t.Run("rejects when both ActionIDs differ (retry of same version)", func(t *testing.T) {
+		wm := *baseWM
+		wm.ActionID = "action-A"
+		marker := baseMarker
+		marker.Action = &fleetapi.ActionUpgrade{ActionID: "action-B"}
+		assert.False(t, watcherMarkerMatchesUpgrade(&wm, marker))
+	})
+}
+
+func TestUpgradeDetailsFromMarkerUpdate(t *testing.T) {
+	log, _ := loggertest.New(t.Name())
+
+	updatedOn := time.Now().Add(-time.Minute)
+	completedAt := time.Now()
+
+	baseMarker := upgrade.UpdateMarker{
+		Version:     "8.5.0",
+		PrevVersion: "8.4.0",
+		UpdatedOn:   updatedOn,
+	}
+
+	// --- Upgrade marker still present (write events) ---
+
+	t.Run("returns marker details directly for active state (no watcher marker read)", func(t *testing.T) {
+		dataDir := t.TempDir()
+		det := details.NewDetails("8.5.0", details.StateWatching, "action-1")
+		marker := baseMarker
+		marker.Details = det
+		result := upgradeDetailsFromMarkerUpdate(log, marker, dataDir)
+		assert.Equal(t, det, result)
+	})
+
+	t.Run("returns marker details for StateCompleted write event (marker still present)", func(t *testing.T) {
+		// The watcher writes StateCompleted to the upgrade marker before deleting
+		// it. Fleet should observe UPG_COMPLETED from this write event.
+		dataDir := t.TempDir()
+		wm := &upgrade.WatcherMarker{
+			Outcome:         details.StateCompleted,
+			TargetVersion:   "8.5.0",
+			PreviousVersion: "8.4.0",
+			CompletedAt:     completedAt,
+		}
+		require.NoError(t, upgrade.WriteWatcherMarker(log, dataDir, wm))
+		det := details.NewDetails("8.5.0", details.StateCompleted, "action-1")
+		marker := baseMarker
+		marker.Details = det
+		result := upgradeDetailsFromMarkerUpdate(log, marker, dataDir)
+		// marker.Details is authoritative while the marker exists
+		assert.Equal(t, det, result)
+	})
+
+	// --- Upgrade marker gone (remove event: marker.Details == nil) ---
+
+	t.Run("returns nil when marker removed and no watcher marker", func(t *testing.T) {
+		dataDir := t.TempDir()
+		marker := baseMarker // Details == nil
+		result := upgradeDetailsFromMarkerUpdate(log, marker, dataDir)
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns nil for matched completed watcher marker on remove event", func(t *testing.T) {
+		dataDir := t.TempDir()
+		wm := &upgrade.WatcherMarker{
+			Outcome:         details.StateCompleted,
+			TargetVersion:   "8.5.0",
+			PreviousVersion: "8.4.0",
+			CompletedAt:     completedAt,
+		}
+		require.NoError(t, upgrade.WriteWatcherMarker(log, dataDir, wm))
+		marker := baseMarker // Details == nil (remove event)
+		result := upgradeDetailsFromMarkerUpdate(log, marker, dataDir)
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns rollback details from watcher marker on remove event", func(t *testing.T) {
+		dataDir := t.TempDir()
+		wm := &upgrade.WatcherMarker{
+			Outcome:         details.StateRollback,
+			TargetVersion:   "8.5.0",
+			PreviousVersion: "8.4.0",
+			Reason:          "watch failed",
+			CompletedAt:     completedAt,
+		}
+		require.NoError(t, upgrade.WriteWatcherMarker(log, dataDir, wm))
+		marker := baseMarker // Details == nil (remove event)
+		result := upgradeDetailsFromMarkerUpdate(log, marker, dataDir)
+		require.NotNil(t, result)
+		assert.Equal(t, details.StateRollback, result.State)
+		assert.Equal(t, "watch failed", result.Metadata.Reason)
+		assert.Equal(t, "8.5.0", result.TargetVersion)
+	})
+
+	t.Run("returns failed details with error message from watcher marker on remove event", func(t *testing.T) {
+		dataDir := t.TempDir()
+		wm := &upgrade.WatcherMarker{
+			Outcome:         details.StateFailed,
+			TargetVersion:   "8.5.0",
+			PreviousVersion: "8.4.0",
+			ErrorMsg:        "rollback mechanics failed",
+			CompletedAt:     completedAt,
+		}
+		require.NoError(t, upgrade.WriteWatcherMarker(log, dataDir, wm))
+		marker := baseMarker // Details == nil (remove event)
+		result := upgradeDetailsFromMarkerUpdate(log, marker, dataDir)
+		require.NotNil(t, result)
+		assert.Equal(t, details.StateFailed, result.State)
+		assert.Equal(t, "rollback mechanics failed", result.Metadata.ErrorMsg)
+	})
+
+	t.Run("returns nil when watcher marker is stale on remove event", func(t *testing.T) {
+		dataDir := t.TempDir()
+		// wm.CompletedAt before marker.UpdatedOn → stale, does not match
+		wm := &upgrade.WatcherMarker{
+			Outcome:         details.StateRollback,
+			TargetVersion:   "8.5.0",
+			PreviousVersion: "8.4.0",
+			Reason:          "old failure",
+			CompletedAt:     updatedOn.Add(-time.Second),
+		}
+		require.NoError(t, upgrade.WriteWatcherMarker(log, dataDir, wm))
+		marker := baseMarker // Details == nil (remove event)
+		result := upgradeDetailsFromMarkerUpdate(log, marker, dataDir)
+		// stale watcher marker → no match → nil (upgrade cleared)
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns nil when watcher marker ActionID mismatches on remove event", func(t *testing.T) {
+		dataDir := t.TempDir()
+		wm := &upgrade.WatcherMarker{
+			Outcome:         details.StateRollback,
+			TargetVersion:   "8.5.0",
+			PreviousVersion: "8.4.0",
+			ActionID:        "action-old",
+			Reason:          "old failure",
+			CompletedAt:     completedAt,
+		}
+		require.NoError(t, upgrade.WriteWatcherMarker(log, dataDir, wm))
+		marker := baseMarker
+		marker.Action = &fleetapi.ActionUpgrade{ActionID: "action-new"}
+		// Details == nil (remove event)
+		result := upgradeDetailsFromMarkerUpdate(log, marker, dataDir)
+		// ActionID mismatch: stale watcher marker from a previous retry
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns nil on watcher marker load error on remove event", func(t *testing.T) {
+		dataDir := t.TempDir()
+		wmPath := filepath.Join(dataDir, ".watcher-marker")
+		require.NoError(t, os.WriteFile(wmPath, []byte("not: valid: yaml: [[["), 0600))
+		marker := baseMarker // Details == nil (remove event)
+		result := upgradeDetailsFromMarkerUpdate(log, marker, dataDir)
+		assert.Nil(t, result)
+	})
+}

--- a/internal/pkg/agent/application/coordinator/coordinator_watcher_marker_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_watcher_marker_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	fleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
+	"github.com/elastic/elastic-agent/pkg/fleetapi"
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade"
 	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
@@ -141,7 +141,7 @@ func TestUpgradeDetailsFromMarkerUpdate(t *testing.T) {
 			CompletedAt:     completedAt,
 		}
 		require.NoError(t, upgrade.WriteWatcherMarker(log, dataDir, wm))
-		marker := baseMarker // Details == nil (remove event)
+		marker := baseMarker // Details == nil
 		result := upgradeDetailsFromMarkerUpdate(log, marker, dataDir)
 		assert.Nil(t, result)
 	})
@@ -156,7 +156,7 @@ func TestUpgradeDetailsFromMarkerUpdate(t *testing.T) {
 			CompletedAt:     completedAt,
 		}
 		require.NoError(t, upgrade.WriteWatcherMarker(log, dataDir, wm))
-		marker := baseMarker // Details == nil (remove event)
+		marker := baseMarker // Details == nil
 		result := upgradeDetailsFromMarkerUpdate(log, marker, dataDir)
 		require.NotNil(t, result)
 		assert.Equal(t, details.StateRollback, result.State)
@@ -171,14 +171,16 @@ func TestUpgradeDetailsFromMarkerUpdate(t *testing.T) {
 			TargetVersion:   "8.5.0",
 			PreviousVersion: "8.4.0",
 			ErrorMsg:        "rollback mechanics failed",
+			FailedState:     details.StateRollback,
 			CompletedAt:     completedAt,
 		}
 		require.NoError(t, upgrade.WriteWatcherMarker(log, dataDir, wm))
-		marker := baseMarker // Details == nil (remove event)
+		marker := baseMarker // Details == nil
 		result := upgradeDetailsFromMarkerUpdate(log, marker, dataDir)
 		require.NotNil(t, result)
 		assert.Equal(t, details.StateFailed, result.State)
 		assert.Equal(t, "rollback mechanics failed", result.Metadata.ErrorMsg)
+		assert.Equal(t, details.StateRollback, result.Metadata.FailedState)
 	})
 
 	t.Run("returns nil when watcher marker is stale on remove event", func(t *testing.T) {
@@ -192,7 +194,7 @@ func TestUpgradeDetailsFromMarkerUpdate(t *testing.T) {
 			CompletedAt:     updatedOn.Add(-time.Second),
 		}
 		require.NoError(t, upgrade.WriteWatcherMarker(log, dataDir, wm))
-		marker := baseMarker // Details == nil (remove event)
+		marker := baseMarker // Details == nil
 		result := upgradeDetailsFromMarkerUpdate(log, marker, dataDir)
 		// stale watcher marker → no match → nil (upgrade cleared)
 		assert.Nil(t, result)
@@ -221,8 +223,72 @@ func TestUpgradeDetailsFromMarkerUpdate(t *testing.T) {
 		dataDir := t.TempDir()
 		wmPath := filepath.Join(dataDir, ".watcher-marker")
 		require.NoError(t, os.WriteFile(wmPath, []byte("not: valid: yaml: [[["), 0600))
-		marker := baseMarker // Details == nil (remove event)
+		marker := baseMarker // Details == nil
 		result := upgradeDetailsFromMarkerUpdate(log, marker, dataDir)
 		assert.Nil(t, result)
+	})
+
+	// --- Startup path: agent restarted, no upgrade marker on disk ---
+
+	t.Run("startup: returns rollback details from watcher marker when UpdatedOn is zero", func(t *testing.T) {
+		dataDir := t.TempDir()
+		wm := &upgrade.WatcherMarker{
+			Outcome:         details.StateRollback,
+			TargetVersion:   "8.5.0",
+			PreviousVersion: "8.4.0",
+			Reason:          "watch failed",
+			CompletedAt:     time.Now().Add(-30 * time.Minute),
+		}
+		require.NoError(t, upgrade.WriteWatcherMarker(log, dataDir, wm))
+
+		syntheticMarker := upgrade.UpdateMarker{
+			Version:     "8.5.0",
+			PrevVersion: "8.4.0",
+		}
+		result := upgradeDetailsFromMarkerUpdate(log, syntheticMarker, dataDir)
+		require.NotNil(t, result)
+		assert.Equal(t, details.StateRollback, result.State)
+		assert.Equal(t, "watch failed", result.Metadata.Reason)
+	})
+
+	t.Run("startup: returns nil for completed watcher marker when UpdatedOn is zero", func(t *testing.T) {
+		dataDir := t.TempDir()
+		wm := &upgrade.WatcherMarker{
+			Outcome:         details.StateCompleted,
+			TargetVersion:   "8.5.0",
+			PreviousVersion: "8.4.0",
+			CompletedAt:     time.Now().Add(-30 * time.Minute),
+		}
+		require.NoError(t, upgrade.WriteWatcherMarker(log, dataDir, wm))
+
+		syntheticMarker := upgrade.UpdateMarker{
+			Version:     "8.5.0",
+			PrevVersion: "8.4.0",
+		}
+		result := upgradeDetailsFromMarkerUpdate(log, syntheticMarker, dataDir)
+		assert.Nil(t, result)
+	})
+
+	t.Run("startup: returns failed details from watcher marker when UpdatedOn is zero", func(t *testing.T) {
+		dataDir := t.TempDir()
+		wm := &upgrade.WatcherMarker{
+			Outcome:         details.StateFailed,
+			TargetVersion:   "8.5.0",
+			PreviousVersion: "8.4.0",
+			ErrorMsg:        "rollback itself failed",
+			FailedState:     details.StateRollback,
+			CompletedAt:     time.Now().Add(-30 * time.Minute),
+		}
+		require.NoError(t, upgrade.WriteWatcherMarker(log, dataDir, wm))
+
+		syntheticMarker := upgrade.UpdateMarker{
+			Version:     "8.5.0",
+			PrevVersion: "8.4.0",
+		}
+		result := upgradeDetailsFromMarkerUpdate(log, syntheticMarker, dataDir)
+		require.NotNil(t, result)
+		assert.Equal(t, details.StateFailed, result.State)
+		assert.Equal(t, "rollback itself failed", result.Metadata.ErrorMsg)
+		assert.Equal(t, details.StateRollback, result.Metadata.FailedState)
 	})
 }

--- a/internal/pkg/agent/application/upgrade/manual_rollback.go
+++ b/internal/pkg/agent/application/upgrade/manual_rollback.go
@@ -46,6 +46,30 @@ func (u *Upgrader) rollbackToPreviousVersion(ctx context.Context, topDir string,
 		// there is no upgrade marker (the rollback was requested after the watcher grace period had elapsed), we need
 		// to extract available rollbacks from agent installs
 		watcherExecutable, versionedHomeToRollbackTo, err = rollbackUsingAgentInstalls(u.log, u.watcherHelper, u.availableRollbacksSource, topDir, now, version, u.markUpgrade, action)
+		if err == nil {
+			// If a watcher is still in its cleanup phase, take it over before
+			// starting the rollback watcher, which would otherwise exit immediately.
+			quickLocker := filelock.NewAppLocker(topDir, watcherApplockerFileName)
+			lockErr := quickLocker.TryLock()
+			switch {
+			case lockErr == nil:
+				u.log.Debugw("no lingering upgrade watcher, proceeding with rollback")
+				_ = quickLocker.Unlock()
+			case errors.Is(lockErr, filelock.ErrAppAlreadyRunning):
+				u.log.Infow("lingering upgrade watcher detected; taking it over before starting rollback watcher")
+				if tErr := withTakeOverWatcher(ctx, u.log, topDir, u.watcherHelper, func() error { return nil }); tErr != nil {
+					if cleanErr := os.Remove(updateMarkerPath); cleanErr != nil {
+						u.log.Errorf("Error cleaning up fake upgrade marker: %v", cleanErr)
+					}
+					return nil, fmt.Errorf("taking over lingering upgrade watcher before rollback: %w", tErr)
+				}
+			default:
+				if cleanErr := os.Remove(updateMarkerPath); cleanErr != nil {
+					u.log.Errorf("Error cleaning up fake upgrade marker: %v", cleanErr)
+				}
+				return nil, fmt.Errorf("checking for lingering watcher: %w", lockErr)
+			}
+		}
 	} else {
 		// If upgrade marker is available, we need to gracefully stop any watcher process, read the available rollbacks from
 		// the TTL registry and then proceed with rollback

--- a/internal/pkg/agent/application/upgrade/manual_rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/manual_rollback_test.go
@@ -518,6 +518,114 @@ func TestManualRollback(t *testing.T) {
 			},
 		},
 		{
+			// When no upgrade marker is present the lock-wait code acquires and
+			// immediately releases watcher.lock (no lingering watcher). Verify
+			// that the lock is free after the rollback call returns.
+			name: "no update marker, no lingering watcher - lock acquired and released before rollback watcher starts",
+			setup: func(t *testing.T, topDir string, agent *info.MockAgent, watcherHelper *MockWatcherHelper, rollbacksSource *ttl.MockSource) {
+				rollbacksSource.EXPECT().GetAll().Return(map[string]ttl.TTLMarker{
+					filepath.Join("data", "elastic-agent-1.2.3-oldver"): {
+						Version:    "1.2.3",
+						Hash:       "oldver",
+						ValidUntil: aMomentTomorrow,
+					},
+				}, nil, nil)
+				newerWatcherExecutable := filepath.Join(topDir, "data", fmt.Sprintf("elastic-agent-%s-%s", release.VersionWithSnapshot(), release.ShortCommit()), "elastic-agent")
+				watcherHelper.EXPECT().SelectWatcherExecutable(topDir, agentInstall123, agentInstallCurrent).Return(newerWatcherExecutable)
+				watcherHelper.EXPECT().InvokeWatcher(mock.Anything, newerWatcherExecutable, "--rollback", filepath.Join("data", "elastic-agent-1.2.3-oldver")).
+					Return(&exec.Cmd{Path: newerWatcherExecutable, Args: []string{"watch", "for rollbacksies"}, Process: &os.Process{Pid: 123}}, nil)
+			},
+			artifactSettings: artifact.DefaultConfig(),
+			upgradeSettings: &configuration.UpgradeConfig{
+				Rollback: &configuration.UpgradeRollbackConfig{
+					Window: 24 * time.Hour,
+				},
+			},
+			now:     aMomentInTime,
+			version: "1.2.3",
+			wantErr: assert.NoError,
+			additionalAsserts: func(t *testing.T, topDir string) {
+				// The lock-wait code must have acquired and released watcher.lock;
+				// verify it is free after rollbackToPreviousVersion returns.
+				locker := filelock.NewAppLocker(topDir, watcherApplockerFileName)
+				require.NoError(t, locker.TryLock(), "watcher.lock should be free after rollback call — lock-wait code must have released it")
+				_ = locker.Unlock()
+			},
+		},
+		{
+			// Covers the TryLock-fails → withTakeOverWatcher-errors sub-path:
+			// the fake upgrade marker created by rollbackUsingAgentInstalls must
+			// be cleaned up and an error returned.
+			name: "no update marker, lingering watcher takeover fails - fake marker cleaned up and error returned",
+			setup: func(t *testing.T, topDir string, agent *info.MockAgent, watcherHelper *MockWatcherHelper, rollbacksSource *ttl.MockSource) {
+				rollbacksSource.EXPECT().GetAll().Return(map[string]ttl.TTLMarker{
+					filepath.Join("data", "elastic-agent-1.2.3-oldver"): {
+						Version:    "1.2.3",
+						Hash:       "oldver",
+						ValidUntil: aMomentTomorrow,
+					},
+				}, nil, nil)
+				newerWatcherExecutable := filepath.Join(topDir, "data", fmt.Sprintf("elastic-agent-%s-%s", release.VersionWithSnapshot(), release.ShortCommit()), "elastic-agent")
+				watcherHelper.EXPECT().SelectWatcherExecutable(topDir, agentInstall123, agentInstallCurrent).Return(newerWatcherExecutable)
+				// Hold watcher.lock to simulate a lingering watcher — TryLock in
+				// the production code will see the lock held and call TakeOverWatcher.
+				locker := filelock.NewAppLocker(topDir, watcherApplockerFileName)
+				err := locker.TryLock()
+				require.NoError(t, err, "test setup: error acquiring watcher.lock to simulate lingering watcher")
+				t.Cleanup(func() { _ = locker.Unlock() })
+				watcherHelper.EXPECT().TakeOverWatcher(t.Context(), mock.Anything, topDir).Return(nil, errors.New("takeover failed"))
+			},
+			artifactSettings: artifact.DefaultConfig(),
+			upgradeSettings: &configuration.UpgradeConfig{
+				Rollback: &configuration.UpgradeRollbackConfig{
+					Window: 24 * time.Hour,
+				},
+			},
+			now:     aMomentInTime,
+			version: "1.2.3",
+			wantErr: assert.Error,
+			additionalAsserts: func(t *testing.T, topDir string) {
+				actualMarkerFilePath := filepath.Join(topDir, "data", markerFilename)
+				require.NoFileExists(t, actualMarkerFilePath, "fake upgrade marker must be cleaned up after takeover failure")
+			},
+		},
+		{
+			// Covers the TryLock-fails → withTakeOverWatcher-succeeds sub-path:
+			// the rollback watcher must be started normally after takeover.
+			name: "no update marker, lingering watcher takeover succeeds - rollback watcher started",
+			setup: func(t *testing.T, topDir string, agent *info.MockAgent, watcherHelper *MockWatcherHelper, rollbacksSource *ttl.MockSource) {
+				rollbacksSource.EXPECT().GetAll().Return(map[string]ttl.TTLMarker{
+					filepath.Join("data", "elastic-agent-1.2.3-oldver"): {
+						Version:    "1.2.3",
+						Hash:       "oldver",
+						ValidUntil: aMomentTomorrow,
+					},
+				}, nil, nil)
+				newerWatcherExecutable := filepath.Join(topDir, "data", fmt.Sprintf("elastic-agent-%s-%s", release.VersionWithSnapshot(), release.ShortCommit()), "elastic-agent")
+				watcherHelper.EXPECT().SelectWatcherExecutable(topDir, agentInstall123, agentInstallCurrent).Return(newerWatcherExecutable)
+				// Hold watcher.lock to simulate a lingering watcher.
+				locker := filelock.NewAppLocker(topDir, watcherApplockerFileName)
+				err := locker.TryLock()
+				require.NoError(t, err, "test setup: error acquiring watcher.lock to simulate lingering watcher")
+				t.Cleanup(func() { _ = locker.Unlock() })
+				// Takeover succeeds — returns the locker it acquired.
+				takenOverLocker := filelock.NewAppLocker(topDir, watcherApplockerFileName)
+				watcherHelper.EXPECT().TakeOverWatcher(t.Context(), mock.Anything, topDir).Return(takenOverLocker, nil)
+				// After takeover the rollback watcher must be started.
+				watcherHelper.EXPECT().InvokeWatcher(mock.Anything, newerWatcherExecutable, "--rollback", filepath.Join("data", "elastic-agent-1.2.3-oldver")).
+					Return(&exec.Cmd{Path: newerWatcherExecutable, Process: &os.Process{Pid: 456}}, nil)
+			},
+			artifactSettings: artifact.DefaultConfig(),
+			upgradeSettings: &configuration.UpgradeConfig{
+				Rollback: &configuration.UpgradeRollbackConfig{
+					Window: 24 * time.Hour,
+				},
+			},
+			now:     aMomentInTime,
+			version: "1.2.3",
+			wantErr: assert.NoError,
+		},
+		{
 			name: "no update marker, available install for rollback with expired TTL - error",
 			setup: func(t *testing.T, topDir string, agent *info.MockAgent, watcherHelper *MockWatcherHelper, rollbacksSource *ttl.MockSource) {
 				rollbacksSource.EXPECT().GetAll().Return(

--- a/internal/pkg/agent/application/upgrade/marker_watcher.go
+++ b/internal/pkg/agent/application/upgrade/marker_watcher.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 
 	"github.com/elastic/elastic-agent/pkg/core/logger"
+	"github.com/elastic/elastic-agent/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/pkg/upgrade/details"
 	"github.com/elastic/elastic-agent/version"
 )
@@ -133,6 +134,34 @@ func (mfw *MarkerFileWatcher) Run(ctx context.Context) error {
 	return nil
 }
 
+// fallbackToWatcherMarker is called on startup when no upgrade marker is present.
+// It reads the watcher marker and emits an UpdateMarker derived from it so the
+// coordinator can re-report the terminal upgrade state to Fleet.
+func (mfw *MarkerFileWatcher) fallbackToWatcherMarker(ctx context.Context) {
+	dataDir := filepath.Dir(mfw.markerFilePath)
+	wm, err := LoadWatcherMarker(dataDir)
+	if err != nil {
+		mfw.logger.Debugf("could not load watcher marker on startup: %v", err)
+		return
+	}
+	if wm == nil {
+		return
+	}
+
+	synthetic := UpdateMarker{
+		Version:     wm.TargetVersion,
+		PrevVersion: wm.PreviousVersion,
+	}
+	if wm.ActionID != "" {
+		synthetic.Action = &fleetapi.ActionUpgrade{ActionID: wm.ActionID}
+	}
+	mfw.lastMarker = &synthetic
+	select {
+	case mfw.updateCh <- synthetic:
+	case <-ctx.Done():
+	}
+}
+
 func (mfw *MarkerFileWatcher) processMarker(ctx context.Context, currentVersion string, commit string) {
 	marker, err := loadMarker(mfw.markerFilePath)
 	if err != nil {
@@ -140,8 +169,11 @@ func (mfw *MarkerFileWatcher) processMarker(ctx context.Context, currentVersion 
 		return
 	}
 
-	// Nothing to do if marker is not (yet) present
+	// Nothing to do if marker is not (yet) present. Fall back to the watcher
+	// marker so the coordinator can re-report the terminal state to Fleet after
+	// a restart that follows successful watcher cleanup.
 	if marker == nil {
+		mfw.fallbackToWatcherMarker(ctx)
 		return
 	}
 

--- a/internal/pkg/agent/application/upgrade/marker_watcher_test.go
+++ b/internal/pkg/agent/application/upgrade/marker_watcher_test.go
@@ -14,6 +14,7 @@ import (
 
 	"go.uber.org/zap/zapcore"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"gopkg.in/yaml.v2"
@@ -315,5 +316,78 @@ details:
 			require.True(t, actualMarker.Details.Equals(test.expectedDetails))
 		})
 
+	}
+}
+
+// TestProcessMarker_FallbackToWatcherMarker verifies that when the agent restarts
+// with no upgrade marker on disk, processMarker emits an UpdateMarker derived
+// from the watcher marker so the coordinator can re-report the terminal upgrade
+// state to Fleet.
+func TestProcessMarker_FallbackToWatcherMarker(t *testing.T) {
+	cases := []struct {
+		name    string
+		outcome details.State
+	}{
+		{name: "completed", outcome: details.StateCompleted},
+		{name: "rollback", outcome: details.StateRollback},
+		{name: "failed", outcome: details.StateFailed},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			markerFilePath := filepath.Join(tmpDir, markerFilename)
+			// No upgrade marker — simulates agent restart after watcher cleanup.
+
+			log, _ := loggertest.New("marker_watcher")
+			updateCh := make(chan UpdateMarker)
+			mfw := MarkerFileWatcher{
+				markerFilePath: markerFilePath,
+				logger:         log,
+				updateCh:       updateCh,
+			}
+
+			wm := &WatcherMarker{
+				Outcome:         tc.outcome,
+				TargetVersion:   "9.1.0",
+				PreviousVersion: "9.0.0",
+				ActionID:        "action-abc",
+				CompletedAt:     time.Now(),
+			}
+			require.NoError(t, WriteWatcherMarker(log, tmpDir, wm))
+
+			done := make(chan struct{})
+			defer close(done)
+
+			var emitted bool
+			var received UpdateMarker
+			var mu sync.Mutex
+			go func() {
+				select {
+				case m := <-updateCh:
+					mu.Lock()
+					emitted = true
+					received = m
+					mu.Unlock()
+				case <-done:
+				}
+			}()
+
+			mfw.processMarker(t.Context(), "9.1.0", "somehash")
+
+			require.Eventually(t, func() bool {
+				mu.Lock()
+				defer mu.Unlock()
+				return emitted
+			}, 5*time.Second, 10*time.Millisecond,
+				"processMarker did not emit an UpdateMarker from the watcher marker")
+
+			mu.Lock()
+			defer mu.Unlock()
+			assert.Equal(t, "9.1.0", received.Version)
+			assert.Equal(t, "9.0.0", received.PrevVersion)
+			assert.Equal(t, "action-abc", received.GetActionID())
+			assert.Nil(t, received.Details)
+		})
 	}
 }

--- a/internal/pkg/agent/application/upgrade/watcher_marker.go
+++ b/internal/pkg/agent/application/upgrade/watcher_marker.go
@@ -1,0 +1,88 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package upgrade
+
+import (
+	goerrors "errors"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+	"github.com/elastic/elastic-agent/pkg/upgrade/details"
+	"github.com/elastic/elastic-agent/version"
+)
+
+const watcherMarkerFilename = ".watcher-marker"
+
+// WatcherMarker records the terminal outcome of an upgrade. Written exclusively
+// by the watcher; read-only for the agent and coordinator. Persists after the
+// upgrade marker is removed and is overwritten by the next upgrade cycle.
+type WatcherMarker struct {
+	// Outcome is the terminal state: completed, rolled back, or failed.
+	Outcome details.State `yaml:"outcome"`
+
+	// TargetVersion is the version this upgrade attempted to reach.
+	TargetVersion string `yaml:"target_version"`
+	// PreviousVersion is the version the agent upgraded from.
+	PreviousVersion string `yaml:"previous_version"`
+	// ActionID is the Fleet action that triggered this upgrade, or "" for
+	// locally-triggered upgrades. Used to distinguish retries to the same version.
+	ActionID string `yaml:"action_id"`
+
+	// Reason is set when Outcome is StateRollback.
+	Reason string `yaml:"reason,omitempty"`
+	// ErrorMsg is set when Outcome is StateFailed.
+	ErrorMsg string `yaml:"error_msg,omitempty"`
+
+	// CompletedAt is when the watcher reached this outcome.
+	CompletedAt time.Time `yaml:"completed_at"`
+	// WatcherVersion is the watcher binary version that wrote this record. Diagnostic only.
+	WatcherVersion string `yaml:"watcher_version,omitempty"`
+}
+
+// WriteWatcherMarker writes the marker to disk, overwriting any previous record.
+func WriteWatcherMarker(log *logger.Logger, dataDirPath string, wm *WatcherMarker) error {
+	if wm.WatcherVersion == "" {
+		wm.WatcherVersion = version.GetAgentPackageVersion()
+	}
+
+	wmBytes, err := yaml.Marshal(wm)
+	if err != nil {
+		return errors.New(err, errors.TypeConfig, "failed to marshal watcher marker")
+	}
+
+	wmPath := watcherMarkerFilePath(dataDirPath)
+	log.Infow("Writing watcher marker file", "file.path", wmPath, "outcome", wm.Outcome, "target_version", wm.TargetVersion)
+	if err := writeMarkerFile(wmPath, wmBytes, true); err != nil {
+		return goerrors.Join(err, errors.New(errors.TypeFilesystem, "failed to write watcher marker file", errors.M(errors.MetaKeyPath, wmPath)))
+	}
+
+	return nil
+}
+
+// LoadWatcherMarker loads the most recently recorded watcher marker, or returns nil if none exists.
+func LoadWatcherMarker(dataDirPath string) (*WatcherMarker, error) {
+	wmBytes, err := readMarkerFile(watcherMarkerFilePath(dataDirPath))
+	if err != nil {
+		return nil, err
+	}
+	if wmBytes == nil {
+		return nil, nil
+	}
+
+	wm := &WatcherMarker{}
+	if err := yaml.Unmarshal(wmBytes, wm); err != nil {
+		return nil, err
+	}
+
+	return wm, nil
+}
+
+func watcherMarkerFilePath(dataDirPath string) string {
+	return filepath.Join(dataDirPath, watcherMarkerFilename)
+}

--- a/internal/pkg/agent/application/upgrade/watcher_marker.go
+++ b/internal/pkg/agent/application/upgrade/watcher_marker.go
@@ -38,6 +38,9 @@ type WatcherMarker struct {
 	Reason string `yaml:"reason,omitempty"`
 	// ErrorMsg is set when Outcome is StateFailed.
 	ErrorMsg string `yaml:"error_msg,omitempty"`
+	// FailedState is set when Outcome is StateFailed and records which state the
+	// upgrade was in when it failed (e.g. StateRollback when rollback itself fails).
+	FailedState details.State `yaml:"failed_state,omitempty"`
 
 	// CompletedAt is when the watcher reached this outcome.
 	CompletedAt time.Time `yaml:"completed_at"`

--- a/internal/pkg/agent/application/upgrade/watcher_marker_test.go
+++ b/internal/pkg/agent/application/upgrade/watcher_marker_test.go
@@ -1,0 +1,95 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package upgrade
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
+	"github.com/elastic/elastic-agent/pkg/upgrade/details"
+)
+
+func TestLoadWatcherMarker_MissingFileIsNilNoError(t *testing.T) {
+	dataDir := t.TempDir()
+
+	wm, err := LoadWatcherMarker(dataDir)
+	require.NoError(t, err)
+	assert.Nil(t, wm)
+}
+
+func TestWriteAndLoadWatcherMarker_NoLoss(t *testing.T) {
+	dataDir := t.TempDir()
+	log, _ := loggertest.New(t.Name())
+
+	original := &WatcherMarker{
+		Outcome:         details.StateRollback,
+		TargetVersion:   "8.5.0",
+		PreviousVersion: "8.4.0",
+		ActionID:        "action-123",
+		Reason:          "watch failed",
+		CompletedAt:     time.Now().Truncate(time.Second),
+		WatcherVersion:  "8.5.0",
+	}
+
+	require.NoError(t, WriteWatcherMarker(log, dataDir, original))
+
+	loaded, err := LoadWatcherMarker(dataDir)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, original.Outcome, loaded.Outcome)
+	assert.Equal(t, original.TargetVersion, loaded.TargetVersion)
+	assert.Equal(t, original.PreviousVersion, loaded.PreviousVersion)
+	assert.Equal(t, original.ActionID, loaded.ActionID)
+	assert.Equal(t, original.Reason, loaded.Reason)
+	assert.Equal(t, original.ErrorMsg, loaded.ErrorMsg)
+	assert.True(t, original.CompletedAt.Equal(loaded.CompletedAt))
+	assert.Equal(t, original.WatcherVersion, loaded.WatcherVersion)
+}
+
+func TestWriteWatcherMarker_OverwritesPreviousRecord(t *testing.T) {
+	dataDir := t.TempDir()
+	log, _ := loggertest.New(t.Name())
+
+	first := &WatcherMarker{
+		Outcome:       details.StateRollback,
+		TargetVersion: "8.5.0",
+		CompletedAt:   time.Now().Truncate(time.Second),
+	}
+	require.NoError(t, WriteWatcherMarker(log, dataDir, first))
+
+	second := &WatcherMarker{
+		Outcome:       details.StateCompleted,
+		TargetVersion: "8.6.0",
+		CompletedAt:   first.CompletedAt.Add(time.Hour),
+	}
+	require.NoError(t, WriteWatcherMarker(log, dataDir, second))
+
+	loaded, err := LoadWatcherMarker(dataDir)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, details.StateCompleted, loaded.Outcome)
+	assert.Equal(t, "8.6.0", loaded.TargetVersion)
+}
+
+func TestWriteWatcherMarker_DefaultsWatcherVersion(t *testing.T) {
+	dataDir := t.TempDir()
+	log, _ := loggertest.New(t.Name())
+
+	wm := &WatcherMarker{
+		Outcome:       details.StateCompleted,
+		TargetVersion: "8.5.0",
+		CompletedAt:   time.Now(),
+	}
+	require.NoError(t, WriteWatcherMarker(log, dataDir, wm))
+
+	loaded, err := LoadWatcherMarker(dataDir)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.NotEmpty(t, loaded.WatcherVersion)
+}

--- a/internal/pkg/agent/application/upgrade/watcher_marker_test.go
+++ b/internal/pkg/agent/application/upgrade/watcher_marker_test.go
@@ -28,11 +28,12 @@ func TestWriteAndLoadWatcherMarker_NoLoss(t *testing.T) {
 	log, _ := loggertest.New(t.Name())
 
 	original := &WatcherMarker{
-		Outcome:         details.StateRollback,
+		Outcome:         details.StateFailed,
 		TargetVersion:   "8.5.0",
 		PreviousVersion: "8.4.0",
 		ActionID:        "action-123",
-		Reason:          "watch failed",
+		ErrorMsg:        "rollback failed: symlink error",
+		FailedState:     details.StateRollback,
 		CompletedAt:     time.Now().Truncate(time.Second),
 		WatcherVersion:  "8.5.0",
 	}
@@ -48,6 +49,7 @@ func TestWriteAndLoadWatcherMarker_NoLoss(t *testing.T) {
 	assert.Equal(t, original.ActionID, loaded.ActionID)
 	assert.Equal(t, original.Reason, loaded.Reason)
 	assert.Equal(t, original.ErrorMsg, loaded.ErrorMsg)
+	assert.Equal(t, original.FailedState, loaded.FailedState)
 	assert.True(t, original.CompletedAt.Equal(loaded.CompletedAt))
 	assert.Equal(t, original.WatcherVersion, loaded.WatcherVersion)
 }

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -196,22 +195,40 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 			stateString = string(marker.Details.State)
 		}
 		log.Infof("not within grace [updatedOn %v] %v or agent have been rolled back [state: %s]", marker.UpdatedOn.String(), time.Since(marker.UpdatedOn).String(), stateString)
-		// if it is started outside of upgrade loop
-		// if we're not within grace and marker is still there it might mean
-		// that cleanup was not performed ok, cleanup everything except current version
-		// hash is the same as hash of agent which initiated watcher.
+		// Grace period elapsed or upgrade already resolved. Clean up and exit.
+		// Preserve whatever terminal state is recorded (could be from a previous
+		// watcher pass or from the agent itself) in the watcher marker before
+		// removing the upgrade marker.
 		var versionedHomesToKeep []string
+		outcome := &upgrade.WatcherMarker{
+			TargetVersion:   marker.Version,
+			PreviousVersion: marker.PrevVersion,
+			ActionID:        marker.GetActionID(),
+			CompletedAt:     time.Now(),
+		}
 		if marker.Details != nil && marker.Details.State == details.StateRollback {
-			// we need to keep the previous versioned home (we have rolled back)
+			// Keep the previous version — we rolled back to it.
 			versionedHomesToKeep = []string{marker.PrevVersionedHome}
+			outcome.Outcome = details.StateRollback
+			outcome.Reason = marker.Details.Metadata.Reason
 		} else {
-			// we need to keep the upgraded version, since it has not been rolled back
+			// Keep the upgraded version — no rollback occurred.
 			absCurrentVersionedHome := paths.VersionedHome(topDir)
 			currentVersionedHome, err := filepath.Rel(topDir, absCurrentVersionedHome)
 			if err != nil {
 				return fmt.Errorf("extracting current home path %q relative to %q: %w", absCurrentVersionedHome, topDir, err)
 			}
 			versionedHomesToKeep = []string{currentVersionedHome}
+			if marker.Details != nil && marker.Details.State == details.StateFailed {
+				outcome.Outcome = details.StateFailed
+				outcome.ErrorMsg = marker.Details.Metadata.ErrorMsg
+			} else {
+				// No terminal state on record — treat the running version as good.
+				outcome.Outcome = details.StateCompleted
+			}
+		}
+		if err := upgrade.WriteWatcherMarker(log, dataDir, outcome); err != nil {
+			log.Errorw("failed to write watcher marker", "error.message", err)
 		}
 
 		log.Infof("About to clean up upgrade. Keeping versioned homes: %v", versionedHomesToKeep)
@@ -241,14 +258,25 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 
 		upgradeDetails.SetStateWithReason(details.StateRollback, details.ReasonWatchFailed)
 
-		// by default remove marker (backward compatible behaviour)
+		outcome := &upgrade.WatcherMarker{
+			Outcome:         details.StateRollback,
+			TargetVersion:   marker.Version,
+			PreviousVersion: marker.PrevVersion,
+			ActionID:        marker.GetActionID(),
+			Reason:          details.ReasonWatchFailed,
+			CompletedAt:     time.Now(),
+		}
+		if werr := upgrade.WriteWatcherMarker(log, dataDir, outcome); werr != nil {
+			log.Errorw("failed to write watcher marker", "error.message", werr)
+		}
+
 		removeMarker := true
 
 		previousVersion, versionParseErr := semver.ParseVersion(marker.PrevVersion)
 		if versionParseErr != nil {
 			log.Errorf("could not parse previous version %s: %s", marker.PrevVersion, versionParseErr)
-		} else if !previousVersion.Less(*semver.NewParsedSemVer(9, 2, 0, "SNAPSHOT", "")) {
-			// leave the marker in place when rolling back to agent >= 9.2.0-SNAPSHOT as it will be used to determine
+		} else if !previousVersion.Less(*upgrade.Version_9_3_0_SNAPSHOT) {
+			// leave the marker in place when rolling back to agent >= 9.3.0-SNAPSHOT as it will be used to determine
 			// that agent was rolled back and the reason
 			removeMarker = false
 		}
@@ -256,7 +284,7 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 		// remove the registry entry when rolling back to pre-9.4 agents that don't manage it,
 		// for >= 9.4 the old agent's handleUpgrade() will update it on restart
 		revertRegistryHook := func(ctx context.Context, log *logger.Logger, topDirPath string) error {
-			if versionParseErr == nil && previousVersion.Less(*semver.NewParsedSemVer(9, 4, 0, "SNAPSHOT", "")) {
+			if versionParseErr == nil && previousVersion.Less(*upgrade.Version_9_4_0_SNAPSHOT) {
 				if err := install.RemoveUninstallEntry(); err != nil {
 					log.Warnf("failed to remove uninstall registry entry during rollback: %v", err)
 				}
@@ -268,20 +296,29 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 		if err != nil {
 			log.Error("rollback failed", err)
 			upgradeDetails.Fail(err)
+			// Rollback itself failed — escalate the outcome so the record is accurate.
+			outcome.Outcome = details.StateFailed
+			outcome.ErrorMsg = err.Error()
+			if werr := upgrade.WriteWatcherMarker(log, dataDir, outcome); werr != nil {
+				log.Errorw("failed to update watcher marker after rollback failure", "error.message", werr)
+			}
 		}
 		return err
 	}
 
-	// watch succeeded - upgrade was successful!
 	upgradeDetails.SetState(details.StateCompleted)
 
-	// cleanup older versions,
-	// in windows it might leave self untouched, this will get cleaned up
-	// later at the start, because for windows we leave marker untouched.
-	//
-	// Why is this being skipped on Windows? The comment above is not clear.
-	// issue: https://github.com/elastic/elastic-agent/issues/3027
-	removeMarker := !isWindows()
+	if err := upgrade.WriteWatcherMarker(log, dataDir, &upgrade.WatcherMarker{
+		Outcome:         details.StateCompleted,
+		TargetVersion:   marker.Version,
+		PreviousVersion: marker.PrevVersion,
+		ActionID:        marker.GetActionID(),
+		CompletedAt:     time.Now(),
+	}); err != nil {
+		log.Errorw("failed to write watcher marker", "error.message", err)
+	}
+
+	// Remove the upgrade marker on all platforms. https://github.com/elastic/elastic-agent/issues/3027
 	newVersionedHome := marker.VersionedHome
 	if newVersionedHome == "" {
 		// the upgrade marker may have been created by an older version of agent where the versionedHome is always `data/elastic-agent-<shortHash>`
@@ -289,7 +326,7 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 	}
 	// Only newVersionedHome is explicitly kept here; rollback candidates are preserved by
 	// cleanupAgentDirectories reading the TTL registry and retaining unexpired entries.
-	err = installModifier.Cleanup(log, topDir, removeMarker, false /* keepLogs */, newVersionedHome)
+	err = installModifier.Cleanup(log, topDir, true /* removeMarker */, false /* keepLogs */, newVersionedHome)
 	if err != nil {
 		log.Error("cleanup after successful watch failed", err)
 	}
@@ -322,10 +359,22 @@ func rollback(log *logp.Logger, topDir string, client client.Client, installModi
 			marker.Details = details.NewDetails(marker.Version, details.StateRollback, actionID)
 		}
 		// use the previous version from the marker
-		marker.Details.SetStateWithReason(details.StateRollback, fmt.Sprintf(details.ReasonManualRollbackPattern, marker.PrevVersion))
+		reason := fmt.Sprintf(details.ReasonManualRollbackPattern, marker.PrevVersion)
+		marker.Details.SetStateWithReason(details.StateRollback, reason)
 		err = upgrade.SaveMarker(dataDir, marker, true)
 		if err != nil {
 			return fmt.Errorf("saving marker after rolling back: %w", err)
+		}
+
+		if werr := upgrade.WriteWatcherMarker(log, dataDir, &upgrade.WatcherMarker{
+			Outcome:         details.StateRollback,
+			TargetVersion:   marker.Version,
+			PreviousVersion: marker.PrevVersion,
+			ActionID:        marker.GetActionID(),
+			Reason:          reason,
+			CompletedAt:     time.Now(),
+		}); werr != nil {
+			log.Errorw("failed to write watcher marker", "error.message", werr)
 		}
 		return nil
 	}
@@ -347,10 +396,6 @@ func rollback(log *logp.Logger, topDir string, client client.Client, installModi
 	}
 
 	return nil
-}
-
-func isWindows() bool {
-	return runtime.GOOS == "windows"
 }
 
 // gracePeriod returns true if it is within grace period and time until grace period ends.

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -275,8 +275,8 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 		previousVersion, versionParseErr := semver.ParseVersion(marker.PrevVersion)
 		if versionParseErr != nil {
 			log.Errorf("could not parse previous version %s: %s", marker.PrevVersion, versionParseErr)
-		} else if !previousVersion.Less(*upgrade.Version_9_3_0_SNAPSHOT) {
-			// leave the marker in place when rolling back to agent >= 9.3.0-SNAPSHOT as it will be used to determine
+		} else if !previousVersion.Less(*semver.NewParsedSemVer(9, 2, 0, "SNAPSHOT", "")) {
+			// leave the marker in place when rolling back to agent >= 9.2.0-SNAPSHOT as it will be used to determine
 			// that agent was rolled back and the reason
 			removeMarker = false
 		}

--- a/internal/pkg/agent/cmd/watch.go
+++ b/internal/pkg/agent/cmd/watch.go
@@ -222,6 +222,7 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 			if marker.Details != nil && marker.Details.State == details.StateFailed {
 				outcome.Outcome = details.StateFailed
 				outcome.ErrorMsg = marker.Details.Metadata.ErrorMsg
+				outcome.FailedState = marker.Details.Metadata.FailedState
 			} else {
 				// No terminal state on record — treat the running version as good.
 				outcome.Outcome = details.StateCompleted
@@ -299,6 +300,7 @@ func watchCmd(log *logp.Logger, topDir string, cfg *configuration.UpgradeWatcher
 			// Rollback itself failed — escalate the outcome so the record is accurate.
 			outcome.Outcome = details.StateFailed
 			outcome.ErrorMsg = err.Error()
+			outcome.FailedState = upgradeDetails.Metadata.FailedState
 			if werr := upgrade.WriteWatcherMarker(log, dataDir, outcome); werr != nil {
 				log.Errorw("failed to update watcher marker after rollback failure", "error.message", werr)
 			}

--- a/internal/pkg/agent/cmd/watch_test.go
+++ b/internal/pkg/agent/cmd/watch_test.go
@@ -98,6 +98,7 @@ func Test_watchCmd(t *testing.T) {
 		setupUpgradeMarker func(t *testing.T, tmpDir string, watcher *mockAgentWatcher, installModifier *mockInstallationModifier)
 		args               args
 		wantErr            assert.ErrorAssertionFunc
+		additionalAsserts  func(t *testing.T, tmpDir string)
 	}{
 		{
 			name: "no upgrade marker, no party",
@@ -139,17 +140,22 @@ func Test_watchCmd(t *testing.T) {
 					Watch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
 
-				// on windows the marker is not removed immediately to allow for cleanup on restart
-				expectedRemoveMarkerFlag := runtime.GOOS != "windows"
-
 				installModifier.EXPECT().
-					Cleanup(mock.Anything, topDir, expectedRemoveMarkerFlag, false, filepath.Join("data", "elastic-agent-4.5.6-newver")).
+					Cleanup(mock.Anything, topDir, true, false, filepath.Join("data", "elastic-agent-4.5.6-newver")).
 					Return(nil)
 			},
 			args: args{
 				cfg: configuration.DefaultUpgradeConfig().Watcher,
 			},
 			wantErr: assert.NoError,
+			additionalAsserts: func(t *testing.T, tmpDir string) {
+				wm, err := upgrade.LoadWatcherMarker(paths.DataFrom(tmpDir))
+				require.NoError(t, err)
+				require.NotNil(t, wm, "watcher marker must be written on successful watch")
+				assert.Equal(t, details.StateCompleted, wm.Outcome)
+				assert.Equal(t, "4.5.6", wm.TargetVersion)
+				assert.Equal(t, "1.2.3", wm.PreviousVersion)
+			},
 		},
 		{
 			name: "unhappy path: error watching, rollback to previous install, leaving the upgrade marker",
@@ -157,15 +163,15 @@ func Test_watchCmd(t *testing.T) {
 				dataDirPath := paths.DataFrom(topDir)
 				err := os.MkdirAll(dataDirPath, 0755)
 				require.NoError(t, err)
-				previousVersionedHome := filepath.Join("data", "elastic-agent-9.2.0-prvver")
+				previousVersionedHome := filepath.Join("data", "elastic-agent-9.3.0-prvver")
 				err = upgrade.SaveMarker(
 					dataDirPath,
 					&upgrade.UpdateMarker{
-						Version:           "9.3.0",
+						Version:           "9.4.0",
 						Hash:              "newver",
-						VersionedHome:     filepath.Join("data", "elastic-agent-9.3.0-newver"),
+						VersionedHome:     filepath.Join("data", "elastic-agent-9.4.0-newver"),
 						UpdatedOn:         time.Now(),
-						PrevVersion:       "9.2.0",
+						PrevVersion:       "9.3.0",
 						PrevHash:          "prvver",
 						PrevVersionedHome: previousVersionedHome,
 						Acked:             false,
@@ -192,9 +198,17 @@ func Test_watchCmd(t *testing.T) {
 				cfg: configuration.DefaultUpgradeConfig().Watcher,
 			},
 			wantErr: assert.NoError,
+			additionalAsserts: func(t *testing.T, tmpDir string) {
+				wm, err := upgrade.LoadWatcherMarker(paths.DataFrom(tmpDir))
+				require.NoError(t, err)
+				require.NotNil(t, wm, "watcher marker must be written before rollback")
+				assert.Equal(t, details.StateRollback, wm.Outcome)
+				assert.Equal(t, "9.4.0", wm.TargetVersion)
+				assert.Equal(t, "9.3.0", wm.PreviousVersion)
+			},
 		},
 		{
-			name: "unhappy path: error watching, rollback to previous install, removing upgrade marker if version is < 9.2.0-SNAPSHOT",
+			name: "unhappy path: error watching, rollback to previous install, removing upgrade marker if version is < 9.3.0-SNAPSHOT",
 			setupUpgradeMarker: func(t *testing.T, topDir string, watcher *mockAgentWatcher, installModifier *mockInstallationModifier) {
 				dataDirPath := paths.DataFrom(topDir)
 				err := os.MkdirAll(dataDirPath, 0755)
@@ -322,6 +336,14 @@ func Test_watchCmd(t *testing.T) {
 				},
 			},
 			wantErr: assert.NoError,
+			additionalAsserts: func(t *testing.T, tmpDir string) {
+				// No terminal state recorded — defaults to StateCompleted.
+				wm, err := upgrade.LoadWatcherMarker(paths.DataFrom(tmpDir))
+				require.NoError(t, err)
+				require.NotNil(t, wm, "watcher marker must be written on grace-elapsed cleanup")
+				assert.Equal(t, details.StateCompleted, wm.Outcome)
+				assert.Equal(t, "4.5.6", wm.TargetVersion)
+			},
 		},
 		{
 			name: "Default config, no rollback and simple cleanup",
@@ -371,6 +393,9 @@ func Test_watchCmd(t *testing.T) {
 			mockInstallModifier := newMockInstallationModifier(t)
 			tt.setupUpgradeMarker(t, tmpDir, mockWatcher, mockInstallModifier)
 			tt.wantErr(t, watchCmd(log, tmpDir, tt.args.cfg, mockWatcher, mockInstallModifier), fmt.Sprintf("watchCmd(%v, ...)", tt.args.cfg))
+			if tt.additionalAsserts != nil {
+				tt.additionalAsserts(t, tmpDir)
+			}
 			t.Log("watchCmd logs:\n")
 			for _, osbLog := range obs.All() {
 				t.Logf("\t%s - %s - %v\n", osbLog.Level, osbLog.Message, osbLog.Context)
@@ -459,16 +484,10 @@ func Test_watchCmd_MarkerPointsToSelf(t *testing.T) {
 		paths.BinaryPath(filepath.Join(topDir, liveHome), binName),
 		"live agent binary must survive cleanup")
 
-	// Sanity: watchCmd sets removeMarker = !isWindows() for the success
-	// branch, so the marker should be gone on non-Windows and preserved
-	// on Windows.
+	// The upgrade marker must be removed on all platforms after a successful watch.
 	loaded, loadErr := upgrade.LoadMarker(dataDir)
 	require.NoError(t, loadErr)
-	if runtime.GOOS == "windows" {
-		assert.NotNil(t, loaded, "marker should be preserved after successful watch on windows")
-	} else {
-		assert.Nil(t, loaded, "marker should be cleaned up after successful watch on non-windows")
-	}
+	assert.Nil(t, loaded, "marker should be removed after successful watch on all platforms")
 }
 
 // writeFakeInstallForWatcherTest builds the on-disk shape that step_unpack

--- a/internal/pkg/agent/cmd/watch_test.go
+++ b/internal/pkg/agent/cmd/watch_test.go
@@ -163,15 +163,15 @@ func Test_watchCmd(t *testing.T) {
 				dataDirPath := paths.DataFrom(topDir)
 				err := os.MkdirAll(dataDirPath, 0755)
 				require.NoError(t, err)
-				previousVersionedHome := filepath.Join("data", "elastic-agent-9.3.0-prvver")
+				previousVersionedHome := filepath.Join("data", "elastic-agent-9.2.0-prvver")
 				err = upgrade.SaveMarker(
 					dataDirPath,
 					&upgrade.UpdateMarker{
-						Version:           "9.4.0",
+						Version:           "9.3.0",
 						Hash:              "newver",
-						VersionedHome:     filepath.Join("data", "elastic-agent-9.4.0-newver"),
+						VersionedHome:     filepath.Join("data", "elastic-agent-9.3.0-newver"),
 						UpdatedOn:         time.Now(),
-						PrevVersion:       "9.3.0",
+						PrevVersion:       "9.2.0",
 						PrevHash:          "prvver",
 						PrevVersionedHome: previousVersionedHome,
 						Acked:             false,
@@ -203,12 +203,12 @@ func Test_watchCmd(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, wm, "watcher marker must be written before rollback")
 				assert.Equal(t, details.StateRollback, wm.Outcome)
-				assert.Equal(t, "9.4.0", wm.TargetVersion)
-				assert.Equal(t, "9.3.0", wm.PreviousVersion)
+				assert.Equal(t, "9.3.0", wm.TargetVersion)
+				assert.Equal(t, "9.2.0", wm.PreviousVersion)
 			},
 		},
 		{
-			name: "unhappy path: error watching, rollback to previous install, removing upgrade marker if version is < 9.3.0-SNAPSHOT",
+			name: "unhappy path: error watching, rollback to previous install, removing upgrade marker if version is < 9.2.0-SNAPSHOT",
 			setupUpgradeMarker: func(t *testing.T, topDir string, watcher *mockAgentWatcher, installModifier *mockInstallationModifier) {
 				dataDirPath := paths.DataFrom(topDir)
 				err := os.MkdirAll(dataDirPath, 0755)


### PR DESCRIPTION
## What does this PR do?

### tl;dr;

Adds watcher marker file to keep the upgrade outcome. This allows us to remove the upgrade marker on windows without loosing any information about the upgrade status.  It is outcome of the following discussion: https://github.com/elastic/elastic-agent/pull/14937#discussion_r3460501019

### long description

On Windows the upgrade watcher never deleted the `.update-marker` file after a successful upgrade (guarded by `removeMarker := !isWindows()`). The stale marker was harmless in practice — the next upgrade overwrites it — but the behaviour was inconsistent with Linux and made it impossible to report the correct terminal state to Fleet after the marker disappeared.

This PR introduces a `.watcher-marker` file that the watcher writes before deleting the upgrade marker, recording the terminal outcome (completed, rolled back, or failed). With that record in place, the upgrade marker can be deleted unconditionally on all platforms. The coordinator reads the watcher marker when the upgrade marker is removed and re-reports any non-completed terminal state, so Fleet receives the correct outcome even if the agent was offline when the marker was written.

**Trade-off:** we now have two persistent files instead of one. The watcher marker is never deleted; it is overwritten by the next upgrade cycle. This is the same behaviour the upgrade marker had on Windows before this fix, applied to a smaller, purpose-built file.

### Why not move deletion to the coordinator?

[#14937](https://github.com/elastic/elastic-agent/pull/14937) proposed deleting the marker after a successful Fleet checkin. That avoids the two-file problem but keeps the marker alive for up to one full check-in interval (up to 5 minutes) after the upgrade has already completed on the agent side — and it conflates "upgrade done" with "Fleet acknowledged", which are separate concerns. In addition it was making the agent responsible for upgrade marker removal

### Ownership model

| File | Written by | Read by |
|---|---|---|
| `.update-marker` | agent (create), watcher (details during watch) | coordinator, watcher |
| `.watcher-marker` | watcher only | coordinator (read-only) |

The naming is intentional: it keeps the path open to a future full split where the agent owns the upgrade marker exclusively and the watcher owns its own file.

### Fleet reporting after marker deletion

The coordinator's file watcher fires on every upgrade marker change. While the marker exists, its `Details` field is authoritative. On the remove event, the coordinator reads the watcher marker and re-reports any non-completed terminal state (rollback or failed). A duplicate report is preferable to a missed one if the agent was offline between the marker write and deletion. Completed upgrades clear the reported state on removal.

A staleness guard prevents a watcher marker from a previous upgrade cycle from being mistaken for the current one: it checks the version tuple, the completion timestamp relative to the marker's last-updated timestamp, and the Fleet action ID when both sides carry one (retries to the same version produce different action IDs).

### Backward compatibility

The upgrade marker is still kept on disk after a rollback when rolling back to an agent >= 9.3.0. Those older agents read the marker on startup to know they were rolled back — they have no knowledge of the watcher marker.

### Manual rollback fix

When a manual rollback is requested after the grace period, the upgrade marker may already be gone but the previous watcher may still be in its cleanup phase holding `watcher.lock`. The rollback watcher would exit immediately if it cannot acquire that lock. This PR detects this and takes over the lingering watcher before starting the rollback watcher.

## Why is it important?

The Windows inconsistency was latent but real: after a rollback or failure on Windows, the upgrade marker was never removed, so the coordinator could not distinguish "marker present, upgrade in progress" from "marker present, upgrade already resolved". This made Fleet reporting of rollback and failure outcomes unreliable on Windows. The fix makes cross-platform behaviour consistent and Fleet reporting correct on all platforms.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

None. The `.watcher-marker` file is new and written alongside the existing files. Older agents that roll back to a version without this change will not read the watcher marker and are unaffected.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/3027
- Relates https://github.com/elastic/elastic-agent/pull/14937
