### PR TITLE
Fix progress bars for EnsureUserAndGroup causing false integration test failures

### DIFF
--- a/testing/integration/ess/install_test.go
+++ b/testing/integration/ess/install_test.go
@@ -537,6 +537,8 @@ func testInstallWithoutBasePathWithCustomUser(ctx context.Context, t *testing.T,
 	if customUsername != "" {
 		pt := progressbar.NewOptions(-1)
 		_, err := install.EnsureUserAndGroup(customUsername, customGroup, pt, true)
+		_ = pt.Finish()
+		_ = pt.Exit()
 		require.NoError(t, err)
 	}
 

--- a/testing/integration/ess/install_test.go
+++ b/testing/integration/ess/install_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
-	aTesting "github.com/elastic/elastic-agent/pkg/testing"
 	atesting "github.com/elastic/elastic-agent/pkg/testing"
 	"github.com/elastic/elastic-agent/pkg/testing/define"
 	"github.com/elastic/elastic-agent/pkg/testing/tools/check"
@@ -583,7 +582,7 @@ func testInstallWithoutBasePathWithCustomUser(ctx context.Context, t *testing.T,
 
 func testComponentsPresence(ctx context.Context, fixture *atesting.Fixture, requiredComponents []componentPresenceDefinition, unwantedComponents []componentPresenceDefinition) func(*testing.T) {
 	return func(t *testing.T) {
-		componentsDir, err := aTesting.FindComponentsDir(fixture.AgentDataDir(), fixture.Version())
+		componentsDir, err := atesting.FindComponentsDir(fixture.AgentDataDir(), fixture.Version())
 		require.NoError(t, err)
 
 		componentsPaths := func(component string) []string {

--- a/testing/integration/ess/switch_unprivileged_test.go
+++ b/testing/integration/ess/switch_unprivileged_test.go
@@ -111,6 +111,8 @@ func testSwitchUnprivilegedWithoutBasePathCustomUser(ctx context.Context, t *tes
 	if customUsername != "" {
 		pt := progressbar.NewOptions(-1)
 		_, err = install.EnsureUserAndGroup(customUsername, customGroup, pt, true)
+		_ = pt.Finish()
+		_ = pt.Exit()
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
## What does this PR do?

Stop the progress bars for EnsureUserAndGroup in integration tests once no longer needed.

## Why is it important?

The unfinished progress bars were outputting to stdout for the rest of the test run, corrupting PASS lines which caused passing tests to report as failed.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- [ ] ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

N/A
