### PR TITLE
feat(pkg): add IsPermanentDownloadError to pkg/artifact/download

### DIFF
--- a/internal/pkg/agent/application/upgrade/artifact/download/http/downloader.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/http/downloader.go
@@ -16,12 +16,14 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact/download"
 	downloadErrors "github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/artifact/download/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
+	pkgdownload "github.com/elastic/elastic-agent/pkg/artifact/download"
 	"github.com/elastic/elastic-agent/pkg/upgrade/details"
 )
 
@@ -160,7 +162,11 @@ func (e *Downloader) downloadFile(ctx context.Context, sourceURI, targetPath str
 
 	if resp.StatusCode != 200 {
 		// return path, file already exists and needs to be cleaned up
-		return targetPath, errors.New(fmt.Sprintf("call to '%s' returned unsuccessful status code: %d", sourceURI, resp.StatusCode), errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
+		httpErr := errors.New(fmt.Sprintf("call to '%s' returned unsuccessful status code: %d", sourceURI, resp.StatusCode), errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
+		if pkgdownload.IsPermanentDownloadError(resp.StatusCode) {
+			return targetPath, backoff.Permanent(httpErr)
+		}
+		return targetPath, httpErr
 	}
 
 	fileSize := -1

--- a/pkg/artifact/download/errors.go
+++ b/pkg/artifact/download/errors.go
@@ -1,0 +1,25 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+// Package download provides shared artifact download policy used by Elastic
+// Agent and Horde.
+package download
+
+// IsPermanentDownloadError reports whether an HTTP status code received when
+// downloading a release artifact indicates a permanent failure that should not
+// be retried.
+//
+// No HTTP status code alone is treated as unrecoverable: transient server or
+// infrastructure errors may resolve on retry. The only permanent failure
+// recognised at this layer is disk-space exhaustion, which is detected
+// separately via errors.IsDiskSpaceError (which takes an error value, not a
+// status code).
+//
+// This function is the authoritative policy for both Elastic Agent and Horde.
+// Consumers that previously maintained their own status-code abort lists should
+// replace them with this function so that any future policy change propagates
+// automatically.
+func IsPermanentDownloadError(code int) bool {
+	return false
+}


### PR DESCRIPTION
## Summary

- Adds a new public `pkg/artifact/download` package exporting `IsPermanentDownloadError(code int) bool`
- The function returns `false` for all HTTP status codes, reflecting Elastic Agent's existing behavior: all HTTP errors are retried during release artifact downloads; no status code alone is treated as a permanent failure
- This is the authoritative policy for both Elastic Agent and Horde — Horde will import it in a follow-up PR, replacing its local `checkCodeAbort()` which was incorrectly treating 404 as non-retryable

## Background

During a 30k serverless all-steps scale test, 29,784/30,000 Horde drones failed Step10 (agent upgrade) with a non-retryable HTTP error. The upgrade target version (v9.3.8) was listed in the artifacts API as published, but CDN edge nodes had not yet fully propagated the files. Drones that happened to hit un-propagated edge nodes received a `404`, which Horde's `checkCodeAbort()` treated as a permanent abort — matching neither Elastic Agent's behavior (which retries all HTTP errors until timeout) nor the reality of CDN propagation (which is eventually consistent).

Extracting the policy into `pkg/artifact/download` follows the code-sharing pattern established in elastic/ingest-dev#7601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)