### PR TITLE
Report host total memory in agent metadata

### DIFF
--- a/changelog/fragments/1784624899-report-host-total-memory-in-agent-metadata.yaml
+++ b/changelog/fragments/1784624899-report-host-total-memory-in-agent-metadata.yaml
@@ -1,0 +1,11 @@
+kind: enhancement
+
+summary: Report host total physical memory as `host.memory` in agent metadata
+
+description: |
+  The Elastic Agent now includes the host's total physical memory (in bytes) as
+  `host.memory` in the local metadata sent to Fleet on enrollment and check-in.
+  This lets Fleet distinguish the agent's own process memory usage from the total
+  RAM available on the host.
+
+component: elastic-agent

--- a/internal/pkg/agent/application/info/agent_metadata.go
+++ b/internal/pkg/agent/application/info/agent_metadata.go
@@ -86,6 +86,15 @@ func (i *AgentInfo) ECSMetadata(l *logger.Logger) (*ecsmeta.ECSMeta, error) {
 	info := sysInfo.Info()
 	hostname := util.GetHostName(features.FQDN(), info, sysInfo, l)
 
+	// Total physical memory is best-effort: some platforms/providers don't
+	// report it, in which case we leave it at 0 (omitted in the payload).
+	var totalMemory uint64
+	if memInfo, memErr := sysInfo.Memory(); memErr != nil {
+		l.Warnf("failed to gather host memory info: %v", memErr)
+	} else if memInfo != nil {
+		totalMemory = memInfo.Total
+	}
+
 	return &ecsmeta.ECSMeta{
 		Elastic: &ecsmeta.ElasticECSMeta{
 			Agent: &ecsmeta.AgentECSMeta{
@@ -109,6 +118,7 @@ func (i *AgentInfo) ECSMetadata(l *logger.Logger) (*ecsmeta.ECSMeta, error) {
 			ID:       info.UniqueID,
 			IP:       info.IPs,
 			MAC:      info.MACs,
+			Memory:   totalMemory,
 		},
 
 		// Operating system

--- a/internal/pkg/agent/application/info/agent_metadata_test.go
+++ b/internal/pkg/agent/application/info/agent_metadata_test.go
@@ -57,6 +57,12 @@ func TestECSMetadata(t *testing.T) {
 	assert.Equal(t, info.IPs, metadata.Host.IP)
 	assert.Equal(t, info.MACs, metadata.Host.MAC)
 
+	var expectedMemory uint64
+	if memInfo, memErr := sysInfo.Memory(); memErr == nil && memInfo != nil {
+		expectedMemory = memInfo.Total
+	}
+	assert.Equal(t, expectedMemory, metadata.Host.Memory)
+
 	assert.Equal(t, info.OS.Family, metadata.OS.Family)
 	assert.Equal(t, info.KernelVersion, metadata.OS.Kernel)
 	assert.Equal(t, info.OS.Platform, metadata.OS.Platform)

--- a/pkg/ecsmeta/ecsmeta.go
+++ b/pkg/ecsmeta/ecsmeta.go
@@ -47,4 +47,7 @@ type HostECSMeta struct {
 	ID       string   `json:"id"`
 	IP       []string `json:"ip"`
 	MAC      []string `json:"mac"`
+	// Memory is the total physical memory of the host in bytes.
+	// Omitted when the platform does not report it (value 0).
+	Memory uint64 `json:"memory,omitempty"`
 }

--- a/pkg/ecsmeta/ecsmeta.go
+++ b/pkg/ecsmeta/ecsmeta.go
@@ -49,5 +49,5 @@ type HostECSMeta struct {
 	MAC      []string `json:"mac"`
 	// Memory is the total physical memory of the host in bytes.
 	// Omitted when the platform does not report it (value 0).
-	Memory uint64 `json:"memory,omitempty"`
+	Memory uint64 `json:"memory,omitempty" yaml:",omitempty"`
 }


### PR DESCRIPTION
## 🧠 What

Reports the host's **total physical memory** (bytes) as `host.memory` in the agent's `local_metadata`, sent to Fleet on enrollment and every check-in.

- ➕ New `Memory uint64` field (`json:"memory,omitempty"`) on `HostECSMeta`
- 🔌 Populated from `go-sysinfo` `Host.Memory().Total`
- 🛟 Best-effort: if the platform doesn't report it, we log a warning and leave `0` (omitted from payload)

## 🎯 Why

Fleet's per-agent `memory_size_byte_avg` only reflects the **agent process's own** usage (`system.process.memory.size`), not the host's total RAM. Emitting `host.memory` gives Fleet a host-total signal for **every** enrolled agent — no System integration required.

> 📝 Kibana/Fleet consumer side is intentionally **out of scope** here.

## ✅ How to test

1. Enroll an agent against Fleet Server.
2. Check `local_metadata.host.memory` on the agent doc — it should equal the host's total RAM in bytes.
3. `go test ./internal/pkg/agent/application/info/ -run TestECSMetadata` ✅

## 🔗 Related

Relates to Fleet per-agent memory reporting (agent process memory vs. host total RAM).
