### PR TITLE
[9.4] (backport #15484) docs: update generated docs owner

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -93,8 +93,8 @@ jobs:
             - **Source components.yaml**: https://github.com/elastic/elastic-agent/blob/${{ steps.get_version.outputs.version }}/internal/edot/components.yaml
             - **Release tag**: https://github.com/elastic/elastic-agent/tree/${{ steps.get_version.outputs.version }}
             
-            cc @elastic/ingest-docs
-            
+            cc @elastic/ski-docs
+
             This is an automated PR created by the documentation update workflow.
           branch: update-docs-${{ steps.get_version.outputs.version }}
           base: main


### PR DESCRIPTION
Replaces #15494 — resolves the merge conflict in the Mergify-generated backport.

**Conflict:** `cc @elastic/ingest-docs` (on `9.4`) vs `cc @elastic/ski-docs` (from the backport). Resolved in favor of the backport (new owner).

/backport of #15484

🤖 Generated with [Claude Code](https://claude.com/claude-code)