### PR TITLE
ci: add ski-docs as reviewer on generated docs PRs

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -134,6 +134,8 @@ jobs:
           labels: |
             documentation
             automated-pr
+          team-reviewers: |
+            elastic/ski-docs
 
       - name: Skip PR creation (branch exists)
         if: steps.check_branch.outputs.branch_exists == 'true'


### PR DESCRIPTION
Adds `team-reviewers: elastic/ski-docs` to the `Create Pull Request` step in the update-docs workflow, so the ski-docs team receives a formal review request (not just a `cc` mention) when a new generated-docs PR is opened.

The `GITHUB_TOKEN` in this repo should have sufficient scope for `peter-evans/create-pull-request` to resolve org teams. If it silently fails, the existing `cc @elastic/ski-docs` in the PR body still notifies the team as a fallback.

cc @elastic/ski-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)