### PR TITLE
Increase status wait time in TestLoggingFilePathChangedViaFleet

### DIFF
--- a/testing/integration/ess/logging_file_test.go
+++ b/testing/integration/ess/logging_file_test.go
@@ -78,7 +78,7 @@ func TestLoggingFilePathChangedViaFleet(t *testing.T) {
 	// Wait for the agent to re-exec (due to Files config change) and recover.
 	require.Eventuallyf(t, func() bool {
 		return waitForAgentAndFleetHealthy(ctx, t, f)
-	}, 5*time.Minute, 5*time.Second, "agent never became healthy after logging path change")
+	}, 6*time.Minute, 5*time.Second, "agent never became healthy after logging path change")
 
 	// The agent must create at least one log file in the new directory.
 	require.Eventuallyf(t, func() bool {


### PR DESCRIPTION
## What does this PR do?

Agent long polls checkin for 5 minutes if there's no new policy. This is how long it can take for Fleet to report a healthy status.

## Why is it important?

The test is flaky.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/15149


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
