### PR TITLE
Remove duplicate global processors

### DIFF
--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -781,7 +781,9 @@ func getInputsForUnit(unit component.Unit, info info.Agent, defaultDataStreamTyp
 
 		// Strip per-input copies of default processors already run by the beatprocessor.
 		if features.DefaultProcessors() {
-			input["processors"] = stripDefaultProcessors(comp.BeatName(), input["processors"])
+			if _, ok := input["processors"]; ok {
+				input["processors"] = stripDefaultProcessors(comp.BeatName(), input["processors"])
+			}
 		}
 
 		var protoStreamID string
@@ -825,12 +827,8 @@ func stripDefaultProcessors(beatName string, raw any) []any {
 			filtered = append(filtered, item)
 			continue
 		}
-		var key string
-		var val any
-		for k, v := range p {
-			key, val = k, v
-		}
-		if defaultVal, isDefault := defaultsByName[key]; isDefault && reflect.DeepEqual(val, defaultVal) {
+		key := maps.Keys(p)[0]
+		if defaultVal, isDefault := defaultsByName[key]; isDefault && reflect.DeepEqual(p[key], defaultVal) {
 			continue
 		}
 		filtered = append(filtered, item)

--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -778,6 +779,11 @@ func getInputsForUnit(unit component.Unit, info info.Agent, defaultDataStreamTyp
 			}
 		}
 
+		// Strip per-input copies of default processors already run by the beatprocessor.
+		if features.DefaultProcessors() {
+			input["processors"] = stripDefaultProcessors(comp.BeatName(), input["processors"])
+		}
+
 		var protoStreamID string
 		if i < len(streams) {
 			protoStreamID = streams[i].GetId()
@@ -791,6 +797,45 @@ func getInputsForUnit(unit component.Unit, info info.Agent, defaultDataStreamTyp
 	}
 
 	return result, nil
+}
+
+// stripDefaultProcessors removes per-input processor entries that exactly match
+// (same name and config) a default processor handled by the beatprocessor, so
+// they don't run twice. Entries with a matching name but different config are
+// kept so user customisations are not silently discarded.
+func stripDefaultProcessors(beatName string, raw any) []any {
+	list, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	defaults := GetDefaultProcessors(beatName)
+	if len(defaults) == 0 {
+		return list
+	}
+	defaultsByName := make(map[string]any, len(defaults))
+	for _, p := range defaults {
+		for k, v := range p {
+			defaultsByName[k] = v
+		}
+	}
+	filtered := make([]any, 0, len(list))
+	for _, item := range list {
+		p, ok := item.(map[string]any)
+		if !ok || len(p) != 1 {
+			filtered = append(filtered, item)
+			continue
+		}
+		var key string
+		var val any
+		for k, v := range p {
+			key, val = k, v
+		}
+		if defaultVal, isDefault := defaultsByName[key]; isDefault && reflect.DeepEqual(val, defaultVal) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
 }
 
 // injectOsqueryConfig replicates what osquerybeatCfgFromStreams does in process

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -2243,6 +2243,78 @@ func TestGetOtelConfig(t *testing.T) {
 				},
 			}),
 		},
+		{
+			name: "fleet policy global add_cloud_metadata stripped from input processors, kept in beatprocessor",
+			model: &component.Model{
+				Components: []component.Component{
+					{
+						ID:         "filestream-default",
+						InputType:  "filestream",
+						OutputType: "elasticsearch",
+						OutputName: "default",
+						InputSpec: &component.InputRuntimeSpec{
+							BinaryName: "elastic-otel-collector",
+							Spec: component.InputSpec{
+								Command: &component.CommandSpec{
+									Args: []string{"filebeat"},
+								},
+							},
+						},
+						Units: []component.Unit{
+							{
+								ID:   "filestream-unit",
+								Type: client.UnitTypeInput,
+								Config: component.MustExpectedConfig(map[string]any{
+									"id":         "test",
+									"use_output": "default",
+									// Fleet integration packages include add_cloud_metadata at
+									// the input root; it must be stripped in OTel mode.
+									"processors": []any{
+										map[string]any{"add_cloud_metadata": nil},
+									},
+									"streams": []any{
+										map[string]any{
+											"id": "test-1",
+											"data_stream": map[string]any{
+												"dataset": "generic-1",
+											},
+											"paths": []any{"/var/log/*.log"},
+										},
+									},
+								}),
+							},
+							{
+								ID:     "filestream-default",
+								Type:   client.UnitTypeOutput,
+								Config: component.MustExpectedConfig(esOutputConfig()),
+							},
+						},
+					},
+				},
+			},
+			expectedConfig: confmap.NewFromStringMap(map[string]any{
+				"exporters": map[string]any{
+					"elasticsearch/_agent-component/default": expectedESConfig("default"),
+				},
+				"extensions": map[string]any{
+					"beatsauth/_agent-component/default": expectedExtensionConfig(),
+				},
+				"processors": defaultExpectedProcessors("filestream-default"),
+				"receivers": map[string]any{
+					"filebeatreceiver/_agent-component/filestream-default/test-1": expectedFilestreamConfig("filestream-default", "test-1", "generic-1"),
+				},
+				"service": map[string]any{
+					"extensions": []any{"beatsauth/_agent-component/default"},
+					"pipelines": map[string]any{
+						"logs/_agent-component/filestream-default": map[string][]string{
+							"exporters":  {"elasticsearch/_agent-component/default"},
+							"processors": {beatProcessorID("filestream-default")},
+							"receivers":  {"filebeatreceiver/_agent-component/filestream-default/test-1"},
+						},
+					},
+				},
+			}),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -3705,6 +3777,106 @@ func TestResolveStreamID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := resolveStreamID(tt.streamID, tt.streamSource, tt.unitID, tt.index)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestStripDefaultProcessors(t *testing.T) {
+	tests := []struct {
+		name     string
+		beatName string
+		raw      any
+		want     []any
+	}{
+		{
+			name:     "nil input returns nil",
+			beatName: "filebeat",
+			raw:      nil,
+			want:     nil,
+		},
+		{
+			name:     "non-list input returns nil",
+			beatName: "filebeat",
+			raw:      "not a list",
+			want:     nil,
+		},
+		{
+			name:     "heartbeat gets no defaults, list is unchanged",
+			beatName: "heartbeat",
+			raw: []any{
+				map[string]any{"add_cloud_metadata": nil},
+			},
+			want: []any{
+				map[string]any{"add_cloud_metadata": nil},
+			},
+		},
+		{
+			name:     "add_cloud_metadata null matches default and is stripped",
+			beatName: "filebeat",
+			raw: []any{
+				map[string]any{"add_agent_metadata": map[string]any{"stream_id": "s1"}},
+				map[string]any{"add_cloud_metadata": nil},
+				map[string]any{"timestamp": map[string]any{"field": "datetime"}},
+			},
+			want: []any{
+				map[string]any{"add_agent_metadata": map[string]any{"stream_id": "s1"}},
+				map[string]any{"timestamp": map[string]any{"field": "datetime"}},
+			},
+		},
+		{
+			name:     "add_cloud_metadata with custom config is preserved",
+			beatName: "filebeat",
+			raw: []any{
+				map[string]any{"add_cloud_metadata": map[string]any{"overwrite": true}},
+			},
+			want: []any{
+				map[string]any{"add_cloud_metadata": map[string]any{"overwrite": true}},
+			},
+		},
+		{
+			name:     "add_host_metadata null does not match default (default has when.not.contains.tags) and is preserved",
+			beatName: "filebeat",
+			raw: []any{
+				map[string]any{"add_host_metadata": nil},
+			},
+			want: []any{
+				map[string]any{"add_host_metadata": nil},
+			},
+		},
+		{
+			name:     "add_host_metadata exact-match default config is stripped",
+			beatName: "filebeat",
+			raw: []any{
+				map[string]any{"add_host_metadata": map[string]any{"when.not.contains.tags": "forwarded"}},
+			},
+			want: []any{},
+		},
+		{
+			name:     "multi-key processor entry is not a valid single-name proc and is preserved",
+			beatName: "filebeat",
+			raw: []any{
+				map[string]any{"add_cloud_metadata": nil, "extra_key": "value"},
+			},
+			want: []any{
+				map[string]any{"add_cloud_metadata": nil, "extra_key": "value"},
+			},
+		},
+		{
+			name:     "all default processors with null config are stripped",
+			beatName: "filebeat",
+			raw: []any{
+				map[string]any{"add_cloud_metadata": nil},
+				map[string]any{"add_docker_metadata": nil},
+				map[string]any{"add_kubernetes_metadata": nil},
+			},
+			want: []any{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripDefaultProcessors(tt.beatName, tt.raw)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This removes duplicate global processors at each beat receiver level as long as the processor name and configuration is the same that the Elastic Agent already adds by default.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Some integration adds global processors that are already added by the elastic-agent when running in OTEL mode as global processors. To get the latest improvements to the global processors its best to run them at the `beatprocessor` level versus running them inside each beat receiver.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

None