### PR TITLE
test: fix unit tests

### DIFF
--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -2289,7 +2289,7 @@ func TestGetOtelConfig(t *testing.T) {
 				"extensions": map[string]any{
 					"beatsauth/_agent-component/default": expectedExtensionConfig(),
 				},
-				"processors": defaultExpectedProcessors("filestream-default"),
+				"processors": defaultExpectedProcessors("filebeat", "filestream-default"),
 				"receivers": map[string]any{
 					"filebeatreceiver/_agent-component/filestream-default/test-1": expectedFilestreamConfig("filestream-default", "test-1", "generic-1"),
 				},


### PR DESCRIPTION
Unit tests needed updating after recent changes around OTel processors.

 https://github.com/elastic/elastic-agent/pull/15749/ used `defaultExpectedProcessors` and https://github.com/elastic/elastic-agent/pull/15758/ changed the signature of this function.