### PR TITLE
Add changelog for local upgrade snapshot artifact filename change

### DIFF
--- a/changelog/fragments/1784842766-change-local-snapshot-upgrade-path.yaml
+++ b/changelog/fragments/1784842766-change-local-snapshot-upgrade-path.yaml
@@ -1,0 +1,46 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: upgrade
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Local snapshot upgrades now expect an artifact filename with no build ID, matching remote snapshot artifact filename convention.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: When performing a local snapshot upgrade, the upgrade artifact is now expected to named without the build ID, e.g. elastic-agent-9.5.0-SNAPSHOT-linux-x86_64.tar.gz rather than elastic-agent-9.5.0-9.5.0-51bd4cc6-SNAPSHOT-linux-x86_64.tar.gz. This matches the naming convention of the snapshot registry and brings filename expectations in line with the remote upgrade path.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/elastic-agent/pull/15587
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234


### PR DESCRIPTION
## What does this PR do?

Adds a changelog fragment for the change made in #15587 to the expected artifact filename when performing a local snapshot upgrade.

This shouldn't affect any users, but documenting just in case.