### PR TITLE
Fix update-renovate-branches workflow

### DIFF
--- a/.github/workflows/update-renovate-branches.yml
+++ b/.github/workflows/update-renovate-branches.yml
@@ -31,7 +31,7 @@ jobs:
           MATRIX: ${{ steps.generator.outputs.matrix }}
         run: |
           branches=$(printf '%s' "$MATRIX" | jq -c '[.include[].branch]')
-          jq --argjson branches "$branches" '.baseBranches = ["main"] + $branches' \
+          jq --argjson branches "$branches" '.baseBranches = $branches' \
             renovate.json > renovate.json.new
           mv renovate.json.new renovate.json
 


### PR DESCRIPTION
We don't need main as an exception in this workslow, the active-branches action includes it. See https://github.com/elastic/elastic-agent/pull/15835.


