### PR TITLE
Add flaky test report GHA workflow

### DIFF
--- a/.github/workflows/report-buildkite-flaky-tests.yml
+++ b/.github/workflows/report-buildkite-flaky-tests.yml
@@ -1,0 +1,29 @@
+name: Buildkite Test Flaky
+on:
+  schedule:
+  - cron: "0 11 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+    - uses: elastic/oblt-actions/github/create-token@v1
+      id: fetch-token
+
+    - uses: elastic/oblt-actions/buildkite/flaky-report@v1
+      with:
+        days: '1'
+        github-issue-title-prefix: "[Flaky Test]"
+        github-label: "flaky-test"
+        github-repo: ${{ github.repository }}
+        github-token: ${{ steps.fetch-token.outputs.token }}
+        max-issues: '10'
+        org: 'elastic'
+        test-suite-id: 'elastic-agent-ci'
+        token: ${{ secrets.BUILDKITE_TEST_ENGINE_TOKEN }}


### PR DESCRIPTION
Add a workflow to create issues for flaky tests based on what is reported in Buildkite's Test Suite. This is identical to what happens in [beats](https://github.com/elastic/beats/blob/main/.github/workflows/buildkite-test-flaky.yml) right now. It creates issue of the following format: https://github.com/elastic/beats/issues/52228.

This should free us from the toil of manually creating these issues, and should facilitate automated troubleshooting and fixes in the near future.