### PR TITLE
Clean up renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "enabledManagers": ["gomod", "github-actions", "pip_requirements", "pre-commit"],
   "baseBranchPatterns": ["main", "9.5", "9.4", "9.3", "8.19"],
   "labels": [
     "automation",
@@ -10,6 +11,9 @@
   ],
   "pip_requirements": {
     "managerFilePatterns": ["/^docs/scripts/update-docs//"]
+  },
+  "pre-commit": {
+    "enabled": true
   },
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "baseBranches": ["main", "9.5", "9.4", "9.3", "8.19"],
+  "baseBranchPatterns": ["main", "9.5", "9.4", "9.3", "8.19"],
   "labels": [
     "automation",
     "skip-changelog",
@@ -9,7 +9,7 @@
     "Team:Elastic-Agent-Control-Plane"
   ],
   "pip_requirements": {
-    "fileMatch": ["^docs/scripts/update-docs/"]
+    "managerFilePatterns": ["/^docs/scripts/update-docs//"]
   },
   "packageRules": [
     {
@@ -27,66 +27,66 @@
     {
       "description": "elastic: all Elastic org and APM packages",
       "matchManagers": ["gomod"],
-      "matchPackagePatterns": [
-        "^github\\.com/elastic/",
-        "^go\\.elastic\\.co/"
+      "matchPackageNames": [
+        "/^github\\.com/elastic//",
+        "/^go\\.elastic\\.co//"
       ],
       "groupName": "elastic"
     },
     {
       "description": "golang-x: extended standard library",
       "matchManagers": ["gomod"],
-      "matchPackagePatterns": ["^golang\\.org/x/"],
+      "matchPackageNames": ["/^golang\\.org/x//"],
       "groupName": "golang-x"
     },
     {
       "description": "tooling-test: dependencies used only in tests or test infrastructure",
       "matchManagers": ["gomod"],
-      "matchPackagePatterns": [
-        "^github\\.com/stretchr/",
-        "^github\\.com/testcontainers/",
-        "^github\\.com/google/pprof$",
-        "^github\\.com/google/go-containerregistry$",
-        "^github\\.com/cavaliergopher/",
-        "^github\\.com/blakesmith/",
-        "^github\\.com/sajari/",
-        "^github\\.com/moby/"
+      "matchPackageNames": [
+        "/^github\\.com/stretchr//",
+        "/^github\\.com/testcontainers//",
+        "/^github\\.com/google/pprof$/",
+        "/^github\\.com/google/go-containerregistry$/",
+        "/^github\\.com/cavaliergopher//",
+        "/^github\\.com/blakesmith//",
+        "/^github\\.com/sajari//",
+        "/^github\\.com/moby//"
       ],
       "groupName": "tooling-test"
     },
     {
       "description": "packaging: dependencies used only in magefile.go, dev-tools/, or tools/tools.go",
       "matchManagers": ["gomod"],
-      "matchPackagePatterns": [
-        "^github\\.com/magefile/",
-        "^github\\.com/Jeffail/gabs",
-        "^github\\.com/josephspurrier/goversioninfo$",
-        "^github\\.com/rednafi/link-patrol$",
-        "^gotest\\.tools/",
-        "^github\\.com/vektra/mockery/"
+      "matchPackageNames": [
+        "/^github\\.com/magefile//",
+        "/^github\\.com/Jeffail/gabs/",
+        "/^github\\.com/josephspurrier/goversioninfo$/",
+        "/^github\\.com/rednafi/link-patrol$/",
+        "/^gotest\\.tools//",
+        "/^github\\.com/vektra/mockery//"
       ],
       "groupName": "packaging"
     },
     {
       "description": "k8s-ecosystem: k8s core libraries and all direct deps whose go.mod requires k8s.io/*, so breaking API changes are bumped in lockstep. Placed after elastic (last-match-wins) to pull cloud-on-k8s and elastic-agent-autodiscover into this group.",
       "matchManagers": ["gomod"],
-      "matchPackagePatterns": [
-        "^k8s\\.io/",
-        "^sigs\\.k8s\\.io/",
-        "^helm\\.sh/helm/",
-        "^github\\.com/elastic/cloud-on-k8s/"
+      "matchPackageNames": [
+        "/^k8s\\.io//",
+        "/^sigs\\.k8s\\.io//",
+        "/^helm\\.sh/helm//",
+        "/^github\\.com/elastic/cloud-on-k8s//"
       ],
       "groupName": "k8s-ecosystem"
     },
     {
       "description": "Disabled: beats (git submodule), sarama (manual path handling), OTel packages (own release cycle)",
       "matchManagers": ["gomod"],
-      "matchPackagePatterns": [
-        "^github\\.com/elastic/beats/",
-        "^github\\.com/elastic/sarama$",
-        "^go\\.opentelemetry\\.io/",
-        "^github\\.com/open-telemetry/",
-        "^github\\.com/elastic/opentelemetry-collector-components/"
+      "matchPackageNames": [
+        "/^github\\.com/elastic/beats//",
+        "/^github\\.com/elastic/sarama$/",
+        "/^go\\.opentelemetry\\.io//",
+        "/^github\\.com/open-telemetry//",
+        "/^github\\.com/elastic/opentelemetry-collector-components//"
       ],
       "enabled": false
     },

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
     "Team:Elastic-Agent-Control-Plane"
   ],
   "pip_requirements": {
-    "managerFilePatterns": ["/^docs/scripts/update-docs//"]
+    "managerFilePatterns": ["/^docs/scripts/update-docs/requirements\\.txt$/"]
   },
   "pre-commit": {
     "enabled": true

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "dependencyDashboard": true,
   "enabledManagers": ["gomod", "github-actions", "pip_requirements", "pre-commit"],
   "baseBranchPatterns": ["main", "9.5", "9.4", "9.3", "8.19"],
   "labels": [

--- a/renovate.json
+++ b/renovate.json
@@ -102,6 +102,13 @@
       "prConcurrentLimit": 10
     },
     {
+      "description": "GitHub Actions: keep macOS runner updates manual",
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["github-runner"],
+      "matchPackageNames": ["macos"],
+      "enabled": false
+    },
+    {
       "description": "pip (docs/scripts/update-docs): weekly Monday updates",
       "matchManagers": ["pip_requirements"],
       "schedule": ["on monday"],


### PR DESCRIPTION
## What does this PR do?

Cleans up the renovate config:

- Migrate deprecated configuration: https://github.com/elastic/elastic-agent/commit/e3a981c47aac5ed8bafd3103b6a5f204f018ff26
- Limit renovate to explicitly configured managers: https://github.com/elastic/elastic-agent/commit/22db401963f13c8f4c1bcd583e52218490552efc
- Narrow the scope of the pip updates: https://github.com/elastic/elastic-agent/commit/1481b4422c1aa1e81841d472de50419d2a579f7e
- Disable Github Actions macos runner updates: https://github.com/elastic/elastic-agent/commit/343a1fde0c21a0127b06c9c430bb4c65c6365ca0
- Enable dependency dashboard: https://github.com/elastic/elastic-agent/commit/fb020a05083aad082f37c76e22651e7aa0ab34a7

## Why is it important?

The current config produces some extraneous updates. We may want to enable these in the future, but for now we want parity with dependabot.

The dependency dashboard is enabled because it's the main way to interact with the service in the absence of a hosted UI.

## How to test this PR locally

Something like:

```
LOG_LEVEL=debug \                                                                                                                                             
  npx --yes --package renovate@43.285.6 -- \
    renovate --platform=local --dry-run=lookup
```

will show you what renovate wants to update.

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
