### PR TITLE
fix(diagnostics): redact sensitive values in JSON diagnostic files

### DIFF
--- a/changelog/fragments/1785317648-redact-json-diagnostics.yaml
+++ b/changelog/fragments/1785317648-redact-json-diagnostics.yaml
@@ -1,0 +1,49 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user's deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: security
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Sensitive values in JSON diagnostic files are now redacted
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  When collecting diagnostics, files with a JSON content type were not having
+  sensitive values (such as passwords and private keys) redacted before being
+  included in the diagnostic bundle. Only YAML files were redacted. JSON files
+  are now redacted in the same way as YAML files.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -373,14 +373,6 @@ func writeRedacted(errOut, resultWriter io.Writer, fullFilePath string, fileResu
 	switch fileResult.ContentType {
 	case "application/yaml":
 		err = yaml.Unmarshal(fileResult.Content, &unmarshalled)
-		if err == nil {
-			switch unmarshalled.(type) {
-			case map[string]any, []any:
-			default:
-				_, err = resultWriter.Write(*out)
-				return err
-			}
-		}
 		marshal = yaml.Marshal
 	case "application/json":
 		decoder := json.NewDecoder(bytes.NewReader(fileResult.Content))
@@ -398,6 +390,14 @@ func writeRedacted(errOut, resultWriter io.Writer, fullFilePath string, fileResu
 		// Best effort, output a warning but still include the file
 		fmt.Fprintf(errOut, "[WARNING] Could not redact %s due to unmarshalling error: %s\n", fullFilePath, err)
 	} else {
+		// Only redact structured diagnostic content, leaving plain text unchanged.
+		switch unmarshalled.(type) {
+		case map[string]any, []any:
+		default:
+			_, err = resultWriter.Write(*out)
+			return err
+		}
+
 		// Redact accepts a map, so wrap the value to support top-level arrays.
 		wrapped := map[string]any{"content": unmarshalled}
 		redact.Redact(wrapped, RedactOpts(errOut)...)

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -8,6 +8,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -80,7 +81,7 @@ func GlobalHooks() Hooks {
 				v := release.Info()
 				o, err := yaml.Marshal(v)
 				if err != nil {
-					return []byte(fmt.Sprintf("error: %q", err))
+					return fmt.Appendf(nil, "error: %q", err)
 				}
 				return o
 			},
@@ -93,11 +94,11 @@ func GlobalHooks() Hooks {
 			Hook: func(_ context.Context) []byte {
 				pkgVersionPath, err := version.GetAgentPackageVersionFilePath()
 				if err != nil {
-					return []byte(fmt.Sprintf("error: %q", err))
+					return fmt.Appendf(nil, "error: %q", err)
 				}
 				fileBytes, err := os.ReadFile(pkgVersionPath)
 				if err != nil {
-					return []byte(fmt.Sprintf("error: %q", err))
+					return fmt.Appendf(nil, "error: %q", err)
 				}
 				return fileBytes
 			},
@@ -114,7 +115,7 @@ func GlobalHooks() Hooks {
 				}
 				out, err := yaml.Marshal(redacted)
 				if err != nil {
-					return []byte(fmt.Sprintf("Unable to marshall env vars into yaml: %v", err))
+					return fmt.Appendf(nil, "Unable to marshall env vars into yaml: %v", err)
 				}
 				return out
 			},
@@ -170,7 +171,7 @@ func pprofDiag(name string, debug int) func(context.Context) []byte {
 		err := pprof.Lookup(name).WriteTo(&w, debug)
 		if err != nil {
 			// error is returned as the content
-			return []byte(fmt.Sprintf("failed to write pprof to bytes buffer: %s", err))
+			return fmt.Appendf(nil, "failed to write pprof to bytes buffer: %s", err)
 		}
 		return w.Bytes()
 	}
@@ -363,30 +364,53 @@ func RedactOpts(w io.Writer) []redact.RedactOption {
 func writeRedacted(errOut, resultWriter io.Writer, fullFilePath string, fileResult client.DiagnosticFileResult) error {
 	out := &fileResult.Content
 
-	// Should we support json too?
-	if fileResult.ContentType == "application/yaml" {
-		var unmarshalled any
-		err := yaml.Unmarshal(fileResult.Content, &unmarshalled)
+	var (
+		unmarshalled any
+		marshal      func(any) ([]byte, error)
+		err          error
+	)
+
+	switch fileResult.ContentType {
+	case "application/yaml":
+		err = yaml.Unmarshal(fileResult.Content, &unmarshalled)
+		if err == nil {
+			switch unmarshalled.(type) {
+			case map[string]any, []any:
+			default:
+				_, err = resultWriter.Write(*out)
+				return err
+			}
+		}
+		marshal = yaml.Marshal
+	case "application/json":
+		decoder := json.NewDecoder(bytes.NewReader(fileResult.Content))
+		decoder.UseNumber()
+		err = decoder.Decode(&unmarshalled)
+		marshal = func(value any) ([]byte, error) {
+			return json.MarshalIndent(value, "", "  ")
+		}
+	default:
+		_, err = resultWriter.Write(*out)
+		return err
+	}
+
+	if err != nil {
+		// Best effort, output a warning but still include the file
+		fmt.Fprintf(errOut, "[WARNING] Could not redact %s due to unmarshalling error: %s\n", fullFilePath, err)
+	} else {
+		// Redact accepts a map, so wrap the value to support top-level arrays.
+		wrapped := map[string]any{"content": unmarshalled}
+		redact.Redact(wrapped, RedactOpts(errOut)...)
+		redacted, err := marshal(wrapped["content"])
 		if err != nil {
 			// Best effort, output a warning but still include the file
-			fmt.Fprintf(errOut, "[WARNING] Could not redact %s due to unmarshalling error: %s\n", fullFilePath, err)
+			fmt.Fprintf(errOut, "[WARNING] Could not redact %s due to marshalling error: %s\n", fullFilePath, err)
 		} else {
-			switch t := unmarshalled.(type) { // could be a plain string, we only redact if this is a proper map
-			case map[string]any:
-				redact.Redact(t, RedactOpts(errOut)...)
-				redacted, err := yaml.Marshal(t)
-				if err != nil {
-					// Best effort, output a warning but still include the file
-					fmt.Fprintf(errOut, "[WARNING] Could not redact %s due to marshalling error: %s\n", fullFilePath, err)
-				} else {
-					out = &redacted
-				}
-			default:
-			}
+			out = &redacted
 		}
 	}
 
-	_, err := resultWriter.Write(*out)
+	_, err = resultWriter.Write(*out)
 	return err
 }
 

--- a/internal/pkg/diagnostics/diagnostics_test.go
+++ b/internal/pkg/diagnostics/diagnostics_test.go
@@ -10,6 +10,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -118,18 +119,39 @@ i4EFZLWrFRsAAAARYWxleGtAZ3JlbWluLm5lc3QBAg==
 		},
 	}
 
-	formatted, err := yaml.Marshal(exampleConfig)
-	require.NoError(t, err)
-	errOut := strings.Builder{}
-	outWriter := strings.Builder{}
-	res := client.DiagnosticFileResult{Content: formatted, ContentType: "application/yaml"}
+	tests := []struct {
+		name        string
+		contentType string
+		marshal     func(any) ([]byte, error)
+	}{
+		{
+			name:        "YAML top-level array",
+			contentType: "application/yaml",
+			marshal:     yaml.Marshal,
+		},
+		{
+			name:        "JSON top-level array",
+			contentType: "application/json",
+			marshal:     json.Marshal,
+		},
+	}
 
-	err = writeRedacted(&errOut, &outWriter, "test/path", res)
-	require.NoError(t, err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			formatted, err := tc.marshal([]any{exampleConfig})
+			require.NoError(t, err)
+			errOut := strings.Builder{}
+			outWriter := strings.Builder{}
+			res := client.DiagnosticFileResult{Content: formatted, ContentType: tc.contentType}
 
-	require.Empty(t, errOut.String())
-	require.NotContains(t, outWriter.String(), "unredacted")
-	require.NotContains(t, outWriter.String(), privKey)
+			err = writeRedacted(&errOut, &outWriter, "test/path", res)
+			require.NoError(t, err)
+
+			require.Empty(t, errOut.String())
+			require.NotContains(t, outWriter.String(), "unredacted")
+			require.NotContains(t, outWriter.String(), privKey)
+		})
+	}
 }
 
 func TestRedactPlainString(t *testing.T) {

--- a/internal/pkg/diagnostics/diagnostics_test.go
+++ b/internal/pkg/diagnostics/diagnostics_test.go
@@ -155,16 +155,36 @@ i4EFZLWrFRsAAAARYWxleGtAZ3JlbWluLm5lc3QBAg==
 }
 
 func TestRedactPlainString(t *testing.T) {
-	errOut := strings.Builder{}
-	outWriter := strings.Builder{}
-	inputString := "Just a string"
-	res := client.DiagnosticFileResult{Content: []byte(inputString), ContentType: "application/yaml"}
+	tests := []struct {
+		name        string
+		input       string
+		contentType string
+	}{
+		{
+			name:        "YAML scalar is unchanged",
+			input:       "Just a string",
+			contentType: "application/yaml",
+		},
+		{
+			name:        "JSON scalar is unchanged",
+			input:       `"Just a string"`,
+			contentType: "application/json",
+		},
+	}
 
-	err := writeRedacted(&errOut, &outWriter, "test/path", res)
-	require.NoError(t, err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errOut := strings.Builder{}
+			outWriter := strings.Builder{}
+			res := client.DiagnosticFileResult{Content: []byte(tc.input), ContentType: tc.contentType}
 
-	require.Empty(t, errOut.String())
-	require.Equal(t, outWriter.String(), inputString)
+			err := writeRedacted(&errOut, &outWriter, "test/path", res)
+			require.NoError(t, err)
+
+			require.Empty(t, errOut.String())
+			require.Equal(t, tc.input, outWriter.String())
+		})
+	}
 }
 
 func TestRedactComplexKeys(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Sensitive values (passwords, private keys, etc) were not being redacted from JSON diagnostic files. Only YAML files were redacted, JSON files are now redacted too.

For example, the SQL input exposes its connection string in `input_metrics.json`:

```json
[
  {
    "host": "postgres://sqluser:SuperSecretPass123@postgres:5432/testdb?sslmode=disable",
    "input": "sql/query"
  }
]
```

After this fix, the credential is redacted:

```json
[
  {
    "host": "postgres://REDACTED:REDACTED@postgres:5432/testdb?sslmode=disable",
    "input": "sql/query"
  }
]
```

## Why is it important?

Diagnostic bundles are often shared with support or uploaded publicly. Any component returning JSON diagnostics could have leaked secrets in plain text.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None.

## How to test this PR locally

```
go test -run TestWriteRedacted ./internal/pkg/diagnostics/... -v
```

## Related issues

- Closes #15896
