### PR TITLE
Fix Renovate beats submodule and branch pattern issues

### DIFF
--- a/.github/workflows/post-dependency-update.yml
+++ b/.github/workflows/post-dependency-update.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - "dependabot/go_modules/**"
-      - "renovate/golang/**"
+      - "renovate/*golang/**"
 
 permissions:
   contents: read

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "cloneSubmodules": true,
   "dependencyDashboard": true,
   "enabledManagers": ["gomod", "github-actions", "pip_requirements", "pre-commit"],
   "baseBranchPatterns": ["main", "9.5", "9.4", "9.3", "8.19"],


### PR DESCRIPTION
## What does this PR do?

Fixes the renovate update failures visible in https://github.com/elastic/elastic-agent/pull/15911.

- Add cloneSubmodules: true to renovate.json so Renovate initialises the beats git submodule before running go artifact commands (go get -t ./...). Without it, go fails to resolve the replace directive pointing at ./beats.
- Update post-dependency-update.yml branch trigger from renovate/golang/** to renovate/*golang/** to match the actual branch names Renovate creates: renovate/{baseBranch}-{prefix}/group (e.g. renovate/main-golang/packaging).

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
