### PR TITLE
Make the dynamic inputs runtime override configurable

### DIFF
--- a/changelog/fragments/1785503040-make-the-dynamic-inputs-runtime-override-configurable.yaml
+++ b/changelog/fragments/1785503040-make-the-dynamic-inputs-runtime-override-configurable.yaml
@@ -1,0 +1,37 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Make the dynamic inputs runtime override configurable per beat, input type and variable
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  `agent.internal.runtime.dynamic_inputs` now accepts a map in addition to the existing
+  runtime name, allowing the runtime used by components with dynamic inputs to be set per
+  beat and per input type. It also accepts a `static_variables` list of dynamic provider
+  variables that cannot change at runtime; an input resolving only such variables is no
+  longer treated as dynamic.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/docs/hybrid-agent-beats-receivers.md
+++ b/docs/hybrid-agent-beats-receivers.md
@@ -96,6 +96,58 @@ agent:
         kafka: process # Force all inputs using the kafka output to use the process runtime
 ```
 
+### Dynamic Inputs
+
+Inputs rendered from a [dynamic variable provider](https://www.elastic.co/docs/reference/fleet/dynamic-input-configuration)
+(`kubernetes`, `docker`, `local_dynamic`) can be added and removed while the Elastic Agent is running. Every such change
+requires a configuration reload, which is significantly more expensive for the OpenTelemetry collector than for a Beat
+sub-process. Components containing such inputs are therefore flagged as dynamic and can be moved to a different runtime
+with `agent.internal.runtime.dynamic_inputs`.
+
+The setting was introduced in https://github.com/elastic/elastic-agent/pull/12438 as a single runtime name, which is
+still supported:
+
+```yaml
+agent:
+  internal:
+    runtime:
+      dynamic_inputs: process # Run every component with dynamic inputs as a sub-process.
+```
+
+The full form allows setting the runtime per Beat and per input type, using the same precedence scheme as
+`agent.internal.runtime` itself: the per input type value wins over the per Beat `default`, which wins over the
+top-level `default`. An unset (or empty) value at the end of that chain means the feature is disabled and dynamic
+components are left in the runtime they were assigned by `agent.internal.runtime`.
+
+```yaml
+agent:
+  internal:
+    runtime:
+      dynamic_inputs:
+        default: process # Move every component with dynamic inputs to the process runtime, unless overridden below.
+        filebeat:
+          default: process # Move Filebeat components with dynamic inputs to the process runtime.
+          filestream: otel # Except filestream ones, which stay as beats receivers.
+        metricbeat:
+          default: otel # Keep Metricbeat components with dynamic inputs as beats receivers.
+        static_variables: # Variables that cannot change at runtime, listed here so they don't make an input dynamic.
+          - kubernetes.node # Matches kubernetes.node and everything below it, e.g. kubernetes.node.name.
+          - local_dynamic.group # Matches only local_dynamic.group.
+```
+
+`static_variables` lets you narrow down which inputs are considered dynamic. While rendering the policy, the Elastic
+Agent records the variables each input actually resolves. An input is only treated as dynamic if at least one of the
+variables it resolved from its dynamic provider is not covered by `static_variables`. This is useful for variables that
+come from a dynamic provider but never change while the Elastic Agent runs, such as `${kubernetes.node.name}`.
+
+Entries match a variable name exactly, or as a `.`-separated path prefix, so `kubernetes.node` covers
+`kubernetes.node.name` and `kubernetes.node.labels.*` but not `kubernetes.nodename`. Trailing `.` characters are
+ignored, so `kubernetes.node.` is equivalent to `kubernetes.node`. Only variables namespaced under the
+input's dynamic provider are taken into account; variables of context providers can never make an input dynamic.
+
+Running the Elastic Agent with `agent.logging.level: debug` logs the dynamic provider and the resolved provider
+variables for every rendered input, along with the inputs that were excluded by `static_variables`.
+
 ### Configuration Translation Overrides
 
 When an input is executed as a Beat receiver, it is injected into an OpenTelemetry collector pipeline that was

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -1928,17 +1928,67 @@ func (c *Coordinator) observeASTVars(ctx context.Context) error {
 	return nil
 }
 
-// getDynamicInputs returns the set of dynamic inputs based on a map from input id to the dynamic provider used.
-// Currently, this simply checks if the provider really is dynamic, but this may become more complex in the future.
+// getDynamicInputs returns the set of dynamic inputs based on the information recorded while
+// rendering the inputs.
+//
+// An input is dynamic when it was rendered from a dynamic variable provider and it resolved at
+// least one variable owned by that provider which isn't listed in staticVariables. If no provider
+// variables were recorded for an input we can't tell whether it is static, so it stays flagged
+// as dynamic.
 // Returns a map of input ID to bool.
-func getDynamicInputs(inputToDynamicProvider map[string]string) map[string]bool {
+func getDynamicInputs(
+	log *logger.Logger,
+	renderedInputs map[string]transpiler.RenderedInputInfo,
+	staticVariables []string,
+) map[string]bool {
 	dynamicInputs := make(map[string]bool)
-	for inputId, dynamicProvider := range inputToDynamicProvider {
-		if composable.IsDynamic(dynamicProvider) {
-			dynamicInputs[inputId] = true
+	for inputId, info := range renderedInputs {
+		if !composable.IsDynamic(info.DynamicProvider) {
+			continue
 		}
+		// keep inputs without recorded variables flagged as dynamic
+		isDynamic := len(info.ProviderVars) == 0
+		for _, name := range info.ProviderVars {
+			if !isStaticVariable(staticVariables, name) {
+				isDynamic = true
+				break
+			}
+		}
+		if !isDynamic {
+			log.Debugf(
+				"Input %s is not treated as dynamic, all %s provider variables it uses (%v) are configured as static",
+				inputId, info.DynamicProvider, info.ProviderVars,
+			)
+			continue
+		}
+		dynamicInputs[inputId] = true
 	}
 	return dynamicInputs
+}
+
+// isStaticVariable reports whether the variable name is covered by one of the configured static
+// variables, either by an exact match or as a '.'-separated path prefix. For example
+// `kubernetes.node` covers `kubernetes.node.name` but not `kubernetes.nodename`.
+func isStaticVariable(staticVariables []string, name string) bool {
+	for _, static := range staticVariables {
+		if name == static || strings.HasPrefix(name, static+".") {
+			return true
+		}
+	}
+	return false
+}
+
+// renderedInputsForLog turns the variable introspection results into a value suitable for
+// structured logging.
+func renderedInputsForLog(renderedInputs map[string]transpiler.RenderedInputInfo) map[string]any {
+	loggable := make(map[string]any, len(renderedInputs))
+	for inputId, info := range renderedInputs {
+		loggable[inputId] = map[string]any{
+			"dynamic_provider": info.DynamicProvider,
+			"provider_vars":    info.ProviderVars,
+		}
+	}
+	return loggable
 }
 
 // processVars updates the transpiler vars in the Coordinator.
@@ -2249,8 +2299,8 @@ func maybeOverrideRuntimeForComponent(logger *logger.Logger, runtimeCfg *compone
 
 		// check if the component is dynamic and use the right runtime
 		// dynamic components can cause problems for the otel collector because of its expensive configuration reloading
-		dynamicRuntimeManager := component.RuntimeManager(runtimeCfg.DynamicInputs)
-		if runtimeCfg.DynamicInputs != "" && comp.Dynamic && comp.RuntimeManager != dynamicRuntimeManager {
+		dynamicRuntimeManager := runtimeCfg.DynamicInputs.RuntimeManagerForDynamicInput(comp.BeatName(), comp.InputType)
+		if dynamicRuntimeManager != "" && comp.Dynamic && comp.RuntimeManager != dynamicRuntimeManager {
 			logger.Warnf("Component %s uses dynamic variable providers, switching to %s runtime", comp.ID, dynamicRuntimeManager)
 			comp.RuntimeManager = dynamicRuntimeManager
 		}
@@ -2297,10 +2347,10 @@ func (c *Coordinator) generateComponentModel() (err error) {
 
 	// perform variable substitution for inputs
 	inputs, ok := transpiler.Lookup(ast, "inputs")
-	var inputToDynamicProvider map[string]string
+	var renderedInputInfo map[string]transpiler.RenderedInputInfo
 	if ok {
 		var renderedInputs transpiler.Node
-		renderedInputs, inputToDynamicProvider, err = transpiler.RenderInputs(inputs, c.vars)
+		renderedInputs, renderedInputInfo, err = transpiler.RenderInputs(inputs, c.vars)
 		if err != nil {
 			return fmt.Errorf("rendering inputs failed: %w", err)
 		}
@@ -2344,8 +2394,15 @@ func (c *Coordinator) generateComponentModel() (err error) {
 		}
 		return comps, nil
 	}
-	dynamicInputs := getDynamicInputs(inputToDynamicProvider)
-	c.logger.With("dynamic_inputs", dynamicInputs).Debugf("Dynamic inputs found")
+	dynamicInputs := getDynamicInputs(
+		c.logger, renderedInputInfo, c.currentCfg.Settings.Internal.Runtime.DynamicInputs.StaticVariables)
+	if c.logger.IsDebug() {
+		// building the introspection details isn't free, only do it when it can be logged
+		c.logger.With(
+			"dynamic_inputs", dynamicInputs,
+			"rendered_dynamic_inputs", renderedInputsForLog(renderedInputInfo),
+		).Debugf("Dynamic inputs found")
+	}
 	comps, err := c.specs.ToComponents(
 		cfg,
 		c.currentCfg.Settings.Internal.Runtime,

--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -1250,6 +1250,72 @@ inputs:
 		assert.False(t, filestreamInOtel, "Dynamic filestream input should NOT be in otel manager")
 	})
 
+	t.Run("dynamic input using only static variables stays on the otel runtime", func(t *testing.T) {
+		// Reset state from previous test runs
+		updated = false
+		otelUpdated = false
+		components = nil
+		otelConfig = nil
+
+		// Track components sent to otel manager
+		var otelComponents []pkgcomponent.Component
+		otelManager.updateComponentCallback = func(comp []pkgcomponent.Component) error {
+			otelComponents = comp
+			return nil
+		}
+
+		// The input only references a variable declared as static, so even though it is rendered
+		// from a dynamic provider it can't cause configuration reloads and must stay on otel.
+		cfg := config.MustNewConfigFrom(`
+agent.internal.runtime.filebeat.filestream: otel
+agent.internal.runtime.dynamic_inputs:
+  default: process
+  static_variables:
+    - local_dynamic.group
+outputs:
+  default:
+    type: elasticsearch
+    hosts:
+      - localhost:9200
+inputs:
+  - id: static-filestream-input
+    type: filestream
+    path: "/var/log/${local_dynamic.group}.log"
+    use_output: default
+`)
+
+		vars, err := transpiler.NewVarsWithProcessors("local_dynamic-1", map[string]interface{}{
+			"local_dynamic": map[string]interface{}{
+				"group": "shared",
+				"path":  "/var/log/test.log",
+			},
+		}, "local_dynamic", nil, nil, "", "local_dynamic")
+		require.NoError(t, err)
+		coord.vars = []*transpiler.Vars{vars}
+		coord.varsMgr = &fakeVarsManager{}
+
+		cfgChange := &configChange{cfg: cfg}
+		configChan <- cfgChange
+		coord.runLoopIteration(ctx)
+		assert.True(t, cfgChange.acked, "Coordinator should ACK a successful policy change")
+		assert.NoError(t, cfgChange.err, "config processing shouldn't report an error")
+
+		var filestreamInOtel bool
+		for _, comp := range otelComponents {
+			if strings.Contains(comp.ID, "filestream") {
+				filestreamInOtel = true
+				assert.Equal(t, pkgcomponent.OtelRuntimeManager, comp.RuntimeManager,
+					"input using only static variables should stay on the otel runtime")
+				assert.False(t, comp.Dynamic, "component should not be marked as dynamic")
+			}
+		}
+		for _, comp := range components {
+			assert.NotContains(t, comp.ID, "filestream",
+				"input using only static variables should not be moved to the process runtime")
+		}
+		assert.True(t, filestreamInOtel, "filestream input should be handled by the otel manager")
+	})
+
 }
 
 func TestCoordinatorManagesComponentWorkDirs(t *testing.T) {
@@ -2707,7 +2773,7 @@ func TestMaybeOverrideRuntimeForComponent(t *testing.T) {
 	}
 
 	t.Run("no change when DynamicInputs is empty", func(t *testing.T) {
-		runtimeCfg := &pkgcomponent.RuntimeConfig{DynamicInputs: ""}
+		runtimeCfg := &pkgcomponent.RuntimeConfig{}
 		comp := otelSupportedComponent(true)
 		maybeOverrideRuntimeForComponent(logger, runtimeCfg, &comp)
 		assert.Equal(t, pkgcomponent.OtelRuntimeManager, comp.RuntimeManager)
@@ -2715,7 +2781,9 @@ func TestMaybeOverrideRuntimeForComponent(t *testing.T) {
 
 	t.Run("no change when component is not dynamic", func(t *testing.T) {
 		runtimeCfg := &pkgcomponent.RuntimeConfig{
-			DynamicInputs: string(pkgcomponent.ProcessRuntimeManager),
+			DynamicInputs: pkgcomponent.DynamicInputsConfig{
+				Default: string(pkgcomponent.ProcessRuntimeManager),
+			},
 		}
 		comp := otelSupportedComponent(false)
 		maybeOverrideRuntimeForComponent(logger, runtimeCfg, &comp)
@@ -2724,11 +2792,38 @@ func TestMaybeOverrideRuntimeForComponent(t *testing.T) {
 
 	t.Run("dynamic component switches to the configured runtime", func(t *testing.T) {
 		runtimeCfg := &pkgcomponent.RuntimeConfig{
-			DynamicInputs: string(pkgcomponent.ProcessRuntimeManager),
+			DynamicInputs: pkgcomponent.DynamicInputsConfig{
+				Default: string(pkgcomponent.ProcessRuntimeManager),
+			},
 		}
 		comp := otelSupportedComponent(true)
 		maybeOverrideRuntimeForComponent(logger, runtimeCfg, &comp)
-		assert.Equal(t, pkgcomponent.RuntimeManager(runtimeCfg.DynamicInputs), comp.RuntimeManager)
+		assert.Equal(t, pkgcomponent.ProcessRuntimeManager, comp.RuntimeManager)
+	})
+
+	t.Run("per beat and per input type overrides are honored", func(t *testing.T) {
+		runtimeCfg := &pkgcomponent.RuntimeConfig{
+			DynamicInputs: pkgcomponent.DynamicInputsConfig{
+				Default: string(pkgcomponent.ProcessRuntimeManager),
+				Filebeat: pkgcomponent.BeatRuntimeConfig{
+					// the input type override keeps this component on the otel runtime
+					InputType: map[string]string{"filestream": string(pkgcomponent.OtelRuntimeManager)},
+				},
+			},
+		}
+
+		filestream := otelSupportedComponent(true)
+		filestream.InputSpec = &pkgcomponent.InputRuntimeSpec{BinaryName: "filebeat"}
+		filestream.InputType = "filestream"
+		maybeOverrideRuntimeForComponent(logger, runtimeCfg, &filestream)
+		assert.Equal(t, pkgcomponent.OtelRuntimeManager, filestream.RuntimeManager)
+
+		// another filebeat input type falls back to the global default
+		logInput := otelSupportedComponent(true)
+		logInput.InputSpec = &pkgcomponent.InputRuntimeSpec{BinaryName: "filebeat"}
+		logInput.InputType = "log"
+		maybeOverrideRuntimeForComponent(logger, runtimeCfg, &logInput)
+		assert.Equal(t, pkgcomponent.ProcessRuntimeManager, logInput.RuntimeManager)
 	})
 
 	t.Run("default configuration leaves dynamic otel components on otel runtime", func(t *testing.T) {
@@ -2740,26 +2835,29 @@ func TestMaybeOverrideRuntimeForComponent(t *testing.T) {
 }
 
 func TestGetDynamicInputs(t *testing.T) {
+	log, _ := loggertest.New("get-dynamic-inputs")
 
-	t.Run("returns empty map when inputToDynamicProvider is nil", func(t *testing.T) {
-		result := getDynamicInputs(nil)
+	t.Run("returns empty map when renderedInputs is nil", func(t *testing.T) {
+		result := getDynamicInputs(log, nil, nil)
 		assert.NotNil(t, result)
 		assert.Empty(t, result)
 	})
 
-	t.Run("returns empty map when inputToDynamicProvider is empty", func(t *testing.T) {
-		result := getDynamicInputs(map[string]string{})
+	t.Run("returns empty map when renderedInputs is empty", func(t *testing.T) {
+		result := getDynamicInputs(log, map[string]transpiler.RenderedInputInfo{}, nil)
 		assert.NotNil(t, result)
 		assert.Empty(t, result)
 	})
 
 	t.Run("identifies inputs with dynamic provider variables", func(t *testing.T) {
 		// The `local_dynamic` provider is registered via import side effect above
-		inputToDynamicProvider := map[string]string{
-			"static-input":  "",              // no dynamic provider
-			"dynamic-input": "local_dynamic", // uses local_dynamic provider
+		renderedInputs := map[string]transpiler.RenderedInputInfo{
+			// no dynamic provider
+			"static-input": {DynamicProvider: ""},
+			// uses local_dynamic provider
+			"dynamic-input": {DynamicProvider: "local_dynamic", ProviderVars: []string{"local_dynamic.id"}},
 		}
-		result := getDynamicInputs(inputToDynamicProvider)
+		result := getDynamicInputs(log, renderedInputs, nil)
 		assert.NotNil(t, result)
 		// The static-input should NOT be marked as dynamic (empty provider)
 		assert.False(t, result["static-input"], "static-input should not be marked as dynamic")
@@ -2769,13 +2867,61 @@ func TestGetDynamicInputs(t *testing.T) {
 
 	t.Run("inputs with non-dynamic provider variables are not marked dynamic", func(t *testing.T) {
 		// The env provider is a context provider, not a dynamic provider
-		inputToDynamicProvider := map[string]string{
-			"env-input": "env",
+		renderedInputs := map[string]transpiler.RenderedInputInfo{
+			"env-input": {DynamicProvider: "env", ProviderVars: []string{"env.SOME_VAR"}},
 		}
-		result := getDynamicInputs(inputToDynamicProvider)
+		result := getDynamicInputs(log, renderedInputs, nil)
 		assert.NotNil(t, result)
 		// The env provider is a context provider, not a dynamic provider
 		// So this input should NOT be marked as dynamic
 		assert.False(t, result["env-input"], "env-input should not be marked as dynamic")
+	})
+
+	t.Run("static_variables", func(t *testing.T) {
+		tests := map[string]struct {
+			providerVars    []string
+			staticVariables []string
+			wantDynamic     bool
+		}{
+			"exact match excludes the input": {
+				providerVars:    []string{"local_dynamic.group"},
+				staticVariables: []string{"local_dynamic.group"},
+				wantDynamic:     false,
+			},
+			"path prefix match excludes the input": {
+				providerVars:    []string{"local_dynamic.node.name", "local_dynamic.node.labels.app"},
+				staticVariables: []string{"local_dynamic.node"},
+				wantDynamic:     false,
+			},
+			"prefix must end on a path separator": {
+				providerVars:    []string{"local_dynamic.nodename"},
+				staticVariables: []string{"local_dynamic.node"},
+				wantDynamic:     true,
+			},
+			"a single uncovered variable keeps the input dynamic": {
+				providerVars:    []string{"local_dynamic.group", "local_dynamic.id"},
+				staticVariables: []string{"local_dynamic.group"},
+				wantDynamic:     true,
+			},
+			"no recorded variables keeps the input dynamic": {
+				providerVars:    nil,
+				staticVariables: []string{"local_dynamic.group"},
+				wantDynamic:     true,
+			},
+			"empty static_variables keeps the current behavior": {
+				providerVars:    []string{"local_dynamic.group"},
+				staticVariables: nil,
+				wantDynamic:     true,
+			},
+		}
+
+		for name, tt := range tests {
+			t.Run(name, func(t *testing.T) {
+				result := getDynamicInputs(log, map[string]transpiler.RenderedInputInfo{
+					"input-1": {DynamicProvider: "local_dynamic", ProviderVars: tt.providerVars},
+				}, tt.staticVariables)
+				assert.Equal(t, tt.wantDynamic, result["input-1"])
+			})
+		}
 	})
 }

--- a/internal/pkg/agent/configuration/configuration_test.go
+++ b/internal/pkg/agent/configuration/configuration_test.go
@@ -51,6 +51,77 @@ func TestNewFromConfig_RuntimeConfigFromFile(t *testing.T) {
 	assert.Equal(t, string(component.OtelRuntimeManager), runtime.Metricbeat.InputType["system/metrics"])
 }
 
+// TestNewFromConfig_DynamicInputsConfig verifies that both the legacy scalar form and the
+// richer map form of agent.internal.runtime.dynamic_inputs are unpacked correctly through the
+// regular configuration loading path.
+func TestNewFromConfig_DynamicInputsConfig(t *testing.T) {
+	t.Run("legacy scalar form", func(t *testing.T) {
+		c, err := NewFromConfig(config.MustNewConfigFrom(`
+agent.internal.runtime.dynamic_inputs: process
+`))
+		require.NoError(t, err)
+
+		dynamicInputs := c.Settings.Internal.Runtime.DynamicInputs
+		assert.Equal(t, string(component.ProcessRuntimeManager), dynamicInputs.Default)
+		assert.Empty(t, dynamicInputs.StaticVariables)
+		assert.Equal(t, component.ProcessRuntimeManager,
+			dynamicInputs.RuntimeManagerForDynamicInput("filebeat", "filestream"))
+	})
+
+	t.Run("map form", func(t *testing.T) {
+		c, err := NewFromConfig(config.MustNewConfigFrom(`
+agent:
+  internal:
+    runtime:
+      dynamic_inputs:
+        default: process
+        filebeat:
+          default: process
+          filestream: otel
+        metricbeat:
+          default: otel
+        static_variables:
+          - local_dynamic.group
+          - kubernetes.node
+`))
+		require.NoError(t, err)
+
+		dynamicInputs := c.Settings.Internal.Runtime.DynamicInputs
+		assert.Equal(t, "process", dynamicInputs.Default)
+		assert.Equal(t, "process", dynamicInputs.Filebeat.Default)
+		assert.Equal(t, map[string]string{"filestream": "otel"}, dynamicInputs.Filebeat.InputType)
+		assert.Equal(t, "otel", dynamicInputs.Metricbeat.Default)
+		assert.Equal(t, []string{"local_dynamic.group", "kubernetes.node"}, dynamicInputs.StaticVariables)
+
+		// per input type wins over the beat default, which wins over the global default
+		assert.Equal(t, component.OtelRuntimeManager,
+			dynamicInputs.RuntimeManagerForDynamicInput("filebeat", "filestream"))
+		assert.Equal(t, component.ProcessRuntimeManager,
+			dynamicInputs.RuntimeManagerForDynamicInput("filebeat", "log"))
+		assert.Equal(t, component.OtelRuntimeManager,
+			dynamicInputs.RuntimeManagerForDynamicInput("metricbeat", "system/metrics"))
+		assert.Equal(t, component.ProcessRuntimeManager,
+			dynamicInputs.RuntimeManagerForDynamicInput("packetbeat", "packet"))
+	})
+
+	t.Run("unset leaves the feature disabled", func(t *testing.T) {
+		c, err := NewFromConfig(config.MustNewConfigFrom(`agent.internal.runtime.default: otel`))
+		require.NoError(t, err)
+
+		dynamicInputs := c.Settings.Internal.Runtime.DynamicInputs
+		assert.Equal(t, "", dynamicInputs.Default)
+		assert.Equal(t, component.RuntimeManager(""),
+			dynamicInputs.RuntimeManagerForDynamicInput("filebeat", "filestream"))
+	})
+
+	t.Run("invalid runtime manager is rejected", func(t *testing.T) {
+		_, err := NewFromConfig(config.MustNewConfigFrom(`
+agent.internal.runtime.dynamic_inputs.default: nonsense
+`))
+		require.Error(t, err)
+	})
+}
+
 func TestNewConfigReloader_StandaloneConfig(t *testing.T) {
 	setupConfigReloaderTest(t)
 

--- a/internal/pkg/agent/transpiler/inputs.go
+++ b/internal/pkg/agent/transpiler/inputs.go
@@ -7,6 +7,7 @@ package transpiler
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/cespare/xxhash/v2"
 )
@@ -19,9 +20,20 @@ const (
 	idKey      = "id"
 )
 
-// RenderInputs renders dynamic inputs section. It also returns a map of input id to the dynamic provider used when
-// rendering that input.
-func RenderInputs(inputs Node, varsArray []*Vars) (Node, map[string]string, error) {
+// RenderedInputInfo describes how a rendered input was produced from a set of variables.
+type RenderedInputInfo struct {
+	// DynamicProvider is the name of the dynamic provider whose mapping produced the variable
+	// set the input was rendered from.
+	DynamicProvider string
+	// ProviderVars are the variables owned by DynamicProvider (that is, namespaced under its
+	// name) which were actually resolved while rendering the input. It is sorted and
+	// deduplicated.
+	ProviderVars []string
+}
+
+// RenderInputs renders dynamic inputs section. It also returns a map of input id to information about the dynamic
+// provider used when rendering that input, including which of the provider's variables the input resolved.
+func RenderInputs(inputs Node, varsArray []*Vars) (Node, map[string]RenderedInputInfo, error) {
 	l, ok := inputs.Value().(*List)
 	if !ok {
 		return nil, nil, fmt.Errorf("inputs must be an array")
@@ -29,7 +41,7 @@ func RenderInputs(inputs Node, varsArray []*Vars) (Node, map[string]string, erro
 	var nodes []varIDMap
 	// the below allocation doesn't account for nodes filtered out by conditions, but it's still preferable to
 	// overallocate once compared to dynamically growing the map
-	inputIdToDynamicProvider := make(map[string]string, len(varsArray)-1)
+	inputIdToRenderInfo := make(map[string]RenderedInputInfo, len(varsArray)-1)
 	nodesMap := map[uint64]*Dict{}
 	hasher := xxhash.New()
 	for _, vars := range varsArray {
@@ -42,8 +54,18 @@ func RenderInputs(inputs Node, varsArray []*Vars) (Node, map[string]string, erro
 			if streams := getStreams(dict); streams != nil {
 				hadStreams = true
 			}
+			// Only variable sets coming from a dynamic provider need introspection, the
+			// variables of context providers can't make an input dynamic.
+			applyVars := vars
+			var observed map[string]struct{}
+			if vars.dynamicProvider != "" {
+				observed = make(map[string]struct{})
+				applyVars = vars.WithVarObserver(func(name string) {
+					observed[name] = struct{}{}
+				})
+			}
 			// Apply creates a new Node with a deep copy of all the values
-			n, err := dict.Apply(vars)
+			n, err := dict.Apply(applyVars)
 			if errors.Is(err, ErrNoMatch) {
 				// has a variable that didn't exist, so we ignore it
 				continue
@@ -70,7 +92,12 @@ func RenderInputs(inputs Node, varsArray []*Vars) (Node, map[string]string, erro
 			_, exists := nodesMap[hash]
 			if !exists {
 				nodesMap[hash] = dict
-				nodes = append(nodes, varIDMap{vars.ID(), vars.dynamicProvider, dict})
+				nodes = append(nodes, varIDMap{
+					id:              vars.ID(),
+					dynamicProvider: vars.dynamicProvider,
+					providerVars:    providerOwnedVars(vars.dynamicProvider, observed),
+					d:               dict,
+				})
 			}
 		}
 	}
@@ -101,24 +128,49 @@ func RenderInputs(inputs Node, varsArray []*Vars) (Node, map[string]string, erro
 					return nil, nil, fmt.Errorf("id field type invalid, expected string, int, uint, or float got: %T", idKey.value)
 				}
 				if node.dynamicProvider != "" {
-					inputIdToDynamicProvider[idKey.value.String()] = node.dynamicProvider
+					inputIdToRenderInfo[idKey.value.String()] = node.renderedInputInfo()
 				}
 			} else {
 				node.d.Insert(NewKey("id", NewStrVal(node.id)))
 				if node.dynamicProvider != "" {
-					inputIdToDynamicProvider[node.id] = node.dynamicProvider
+					inputIdToRenderInfo[node.id] = node.renderedInputInfo()
 				}
 			}
 		}
 		nInputs = append(nInputs, promoteProcessors(node.d))
 	}
-	return NewList(nInputs), inputIdToDynamicProvider, nil
+	return NewList(nInputs), inputIdToRenderInfo, nil
 }
 
 type varIDMap struct {
 	id              string
 	dynamicProvider string
+	providerVars    []string
 	d               *Dict
+}
+
+func (v varIDMap) renderedInputInfo() RenderedInputInfo {
+	return RenderedInputInfo{
+		DynamicProvider: v.dynamicProvider,
+		ProviderVars:    v.providerVars,
+	}
+}
+
+// providerOwnedVars returns the sorted subset of observed variable names that are namespaced
+// under the given provider, that is, whose first '.'-separated segment is the provider name.
+func providerOwnedVars(provider string, observed map[string]struct{}) []string {
+	if provider == "" || len(observed) == 0 {
+		return nil
+	}
+	var vars []string
+	for name := range observed {
+		if varPrefixMatched(name, provider) {
+			vars = append(vars, name)
+		}
+	}
+	// sort to keep the result stable, it ends up in logs and diagnostics
+	slices.Sort(vars)
+	return vars
 }
 
 func getStreams(dict *Dict) *List {

--- a/internal/pkg/agent/transpiler/inputs_test.go
+++ b/internal/pkg/agent/transpiler/inputs_test.go
@@ -805,9 +805,9 @@ func TestRenderInputs(t *testing.T) {
 
 func TestRenderInputs_DynamicProviderMap(t *testing.T) {
 	testcases := map[string]struct {
-		input                      Node
-		varsArray                  []*Vars
-		expectedDynamicProviderMap map[string]string
+		input                Node
+		varsArray            []*Vars
+		expectedRenderedInfo map[string]RenderedInputInfo
 	}{
 		"no dynamic provider returns empty map": {
 			input: NewKey("inputs", NewList([]Node{
@@ -820,7 +820,7 @@ func TestRenderInputs_DynamicProviderMap(t *testing.T) {
 				mustMakeVars(map[string]interface{}{}),
 			},
 			// Static inputs (no dynamic provider) are not added to the map
-			expectedDynamicProviderMap: map[string]string{},
+			expectedRenderedInfo: map[string]RenderedInputInfo{},
 		},
 		"with dynamic provider": {
 			input: NewKey("inputs", NewList([]Node{
@@ -837,8 +837,11 @@ func TestRenderInputs_DynamicProviderMap(t *testing.T) {
 					},
 				}, "kubernetes", nil),
 			},
-			expectedDynamicProviderMap: map[string]string{
-				"input-1-kubernetes-123": "kubernetes",
+			expectedRenderedInfo: map[string]RenderedInputInfo{
+				"input-1-kubernetes-123": {
+					DynamicProvider: "kubernetes",
+					ProviderVars:    []string{"kubernetes.path"},
+				},
 			},
 		},
 		"mixed static and dynamic inputs": {
@@ -862,17 +865,161 @@ func TestRenderInputs_DynamicProviderMap(t *testing.T) {
 				}, "local_dynamic", nil),
 			},
 			// Only dynamic inputs are added to the map
-			expectedDynamicProviderMap: map[string]string{
-				"dynamic-input-local_dynamic-abc": "local_dynamic",
+			expectedRenderedInfo: map[string]RenderedInputInfo{
+				"dynamic-input-local_dynamic-abc": {
+					DynamicProvider: "local_dynamic",
+					ProviderVars:    []string{"local_dynamic.path"},
+				},
+			},
+		},
+		"multiple provider variables are recorded sorted and deduplicated": {
+			input: NewKey("inputs", NewList([]Node{
+				NewDict([]Node{
+					NewKey("id", NewStrVal("input-1")),
+					NewKey("type", NewStrVal("filestream")),
+					NewKey("path", NewStrVal("${kubernetes.path}")),
+					NewKey("other_path", NewStrVal("${kubernetes.path}")),
+					NewKey("group", NewStrVal("${kubernetes.node.name}-${kubernetes.namespace}")),
+				}),
+			})),
+			varsArray: []*Vars{
+				mustMakeVarsP("kubernetes-123", map[string]interface{}{
+					"kubernetes": map[string]interface{}{
+						"path":      "/var/log/containers",
+						"namespace": "default",
+						"node": map[string]interface{}{
+							"name": "node-1",
+						},
+					},
+				}, "kubernetes", nil),
+			},
+			expectedRenderedInfo: map[string]RenderedInputInfo{
+				"input-1-kubernetes-123": {
+					DynamicProvider: "kubernetes",
+					ProviderVars: []string{
+						"kubernetes.namespace",
+						"kubernetes.node.name",
+						"kubernetes.path",
+					},
+				},
+			},
+		},
+		"variables of other providers are not recorded": {
+			input: NewKey("inputs", NewList([]Node{
+				NewDict([]Node{
+					NewKey("id", NewStrVal("input-1")),
+					NewKey("type", NewStrVal("filestream")),
+					NewKey("path", NewStrVal("${kubernetes.path}")),
+					NewKey("host", NewStrVal("${host.name}")),
+				}),
+			})),
+			varsArray: []*Vars{
+				mustMakeVarsP("kubernetes-123", map[string]interface{}{
+					"kubernetes": map[string]interface{}{
+						"path": "/var/log/containers",
+					},
+					"host": map[string]interface{}{
+						"name": "localhost",
+					},
+				}, "kubernetes", nil),
+			},
+			expectedRenderedInfo: map[string]RenderedInputInfo{
+				"input-1-kubernetes-123": {
+					DynamicProvider: "kubernetes",
+					ProviderVars:    []string{"kubernetes.path"},
+				},
+			},
+		},
+		"alternation records only the matching branch": {
+			input: NewKey("inputs", NewList([]Node{
+				NewDict([]Node{
+					NewKey("id", NewStrVal("input-1")),
+					NewKey("type", NewStrVal("filestream")),
+					// the first alternative is missing, so the provider variable matches
+					NewKey("path", NewStrVal("${kubernetes.missing|kubernetes.path}")),
+					// the first alternative matches, so the second one is never resolved
+					NewKey("host", NewStrVal("${host.name|kubernetes.namespace}")),
+				}),
+			})),
+			varsArray: []*Vars{
+				mustMakeVarsP("kubernetes-123", map[string]interface{}{
+					"kubernetes": map[string]interface{}{
+						"path":      "/var/log/containers",
+						"namespace": "default",
+					},
+					"host": map[string]interface{}{
+						"name": "localhost",
+					},
+				}, "kubernetes", nil),
+			},
+			expectedRenderedInfo: map[string]RenderedInputInfo{
+				"input-1-kubernetes-123": {
+					DynamicProvider: "kubernetes",
+					ProviderVars:    []string{"kubernetes.path"},
+				},
+			},
+		},
+		"deduplicated renders keep the info of the surviving instance": {
+			input: NewKey("inputs", NewList([]Node{
+				NewDict([]Node{
+					NewKey("id", NewStrVal("input-1")),
+					NewKey("type", NewStrVal("filestream")),
+					// identical for both vars sets, so the second render is deduplicated
+					NewKey("group", NewStrVal("${local_dynamic.group}")),
+				}),
+			})),
+			varsArray: []*Vars{
+				mustMakeVarsP("local_dynamic-1", map[string]interface{}{
+					"local_dynamic": map[string]interface{}{
+						"id":    "1",
+						"group": "shared",
+					},
+				}, "local_dynamic", nil),
+				mustMakeVarsP("local_dynamic-2", map[string]interface{}{
+					"local_dynamic": map[string]interface{}{
+						"id":    "2",
+						"group": "shared",
+					},
+				}, "local_dynamic", nil),
+			},
+			expectedRenderedInfo: map[string]RenderedInputInfo{
+				"input-1-local_dynamic-1": {
+					DynamicProvider: "local_dynamic",
+					ProviderVars:    []string{"local_dynamic.group"},
+				},
+			},
+		},
+		"conditions on provider variables are recorded": {
+			input: NewKey("inputs", NewList([]Node{
+				NewDict([]Node{
+					NewKey("id", NewStrVal("input-1")),
+					NewKey("type", NewStrVal("filestream")),
+					NewKey("condition", NewStrVal("${kubernetes.namespace} == 'default'")),
+					NewKey("path", NewStrVal("${kubernetes.path}")),
+				}),
+			})),
+			varsArray: []*Vars{
+				mustMakeVarsP("kubernetes-123", map[string]interface{}{
+					"kubernetes": map[string]interface{}{
+						"path":      "/var/log/containers",
+						"namespace": "default",
+					},
+				}, "kubernetes", nil),
+			},
+			expectedRenderedInfo: map[string]RenderedInputInfo{
+				"input-1-kubernetes-123": {
+					DynamicProvider: "kubernetes",
+					ProviderVars:    []string{"kubernetes.namespace", "kubernetes.path"},
+				},
 			},
 		},
 	}
 
 	for name, test := range testcases {
 		t.Run(name, func(t *testing.T) {
-			_, dynamicProviderMap, err := RenderInputs(test.input, test.varsArray)
+			_, renderedInfo, err := RenderInputs(test.input, test.varsArray)
 			require.NoError(t, err)
-			assert.Equal(t, test.expectedDynamicProviderMap, dynamicProviderMap)
+			assert.Equal(t, test.expectedRenderedInfo, renderedInfo)
 		})
 	}
 }

--- a/internal/pkg/agent/transpiler/vars.go
+++ b/internal/pkg/agent/transpiler/vars.go
@@ -31,6 +31,9 @@ type Vars struct {
 	fetchContextProviders mapstr.M
 	defaultProvider       string
 	dynamicProvider       string
+	// observer, when set, is called with the name of every variable that is successfully
+	// resolved from this vars set. See WithVarObserver.
+	observer func(name string)
 }
 
 // NewVars returns a new instance of vars.
@@ -96,13 +99,35 @@ func NewVarsWithProcessorsFromAst(
 	}
 }
 
+// WithVarObserver returns a shallow copy of the vars that reports the name of every variable
+// successfully resolved from it to the given observer. A copy is returned so that a shared
+// Vars instance can be reused across renders without the observers interfering.
+func (v *Vars) WithVarObserver(observer func(name string)) *Vars {
+	if v == nil {
+		return nil
+	}
+	observed := *v
+	observed.observer = observer
+	return &observed
+}
+
+// observe reports a successfully resolved variable to the observer, if one is set.
+func (v *Vars) observe(name string) {
+	if v.observer != nil {
+		v.observer(name)
+	}
+}
+
 // Replace returns a new value based on variable replacement.
 func (v *Vars) Replace(value string) (Node, error) {
 	return replaceVars(value, func(variable string) (Node, Processors, bool) {
 		var processors Processors
 		node, ok := v.lookupNode(variable)
-		if ok && v.processorsKey != "" && varPrefixMatched(variable, v.processorsKey) {
-			processors = v.processors
+		if ok {
+			if v.processorsKey != "" && varPrefixMatched(variable, v.processorsKey) {
+				processors = v.processors
+			}
+			v.observe(variable)
 		}
 		return node, processors, ok
 	}, true, v.defaultProvider)
@@ -116,7 +141,11 @@ func (v *Vars) ID() string {
 // Lookup returns the value from the vars.
 func (v *Vars) Lookup(name string) (interface{}, bool) {
 	// lookup in the AST tree
-	return v.tree.Lookup(name)
+	val, ok := v.tree.Lookup(name)
+	if ok {
+		v.observe(name)
+	}
+	return val, ok
 }
 
 // Map transforms the variables into a map[string]interface{} and will abort and return any errors related

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/eql"
 	"github.com/elastic/elastic-agent/pkg/features"
 	"github.com/elastic/elastic-agent/pkg/limits"
+	"github.com/elastic/go-ucfg"
 )
 
 // GenerateMonitoringCfgFn is a function that can inject information into the model generation process.
@@ -38,16 +39,16 @@ type HeadersProvider interface {
 type RuntimeManager string
 
 type RuntimeConfig struct {
-	Default                 string            `yaml:"default" config:"default" json:"default"`
-	Auditbeat               BeatRuntimeConfig `yaml:"auditbeat" config:"auditbeat" json:"auditbeat"`
-	Filebeat                BeatRuntimeConfig `yaml:"filebeat" config:"filebeat" json:"filebeat"`
-	Heartbeat               BeatRuntimeConfig `yaml:"heartbeat" config:"heartbeat" json:"heartbeat"`
-	Metricbeat              BeatRuntimeConfig `yaml:"metricbeat" config:"metricbeat" json:"metricbeat"`
-	Osquerybeat             BeatRuntimeConfig `yaml:"osquerybeat" config:"osquerybeat" json:"osquerybeat"`
-	Packetbeat              BeatRuntimeConfig `yaml:"packetbeat" config:"packetbeat" json:"packetbeat"`
-	DynamicInputs           string            `yaml:"dynamic_inputs" config:"dynamic_inputs" json:"dynamic_inputs"`
-	Output                  map[string]string `yaml:"output" config:"output" json:"output"`
-	OtelPartialConfigReload bool              `yaml:"otel_partial_config_reload" config:"otel_partial_config_reload" json:"otel_partial_config_reload"`
+	Default                 string              `yaml:"default" config:"default" json:"default"`
+	Auditbeat               BeatRuntimeConfig   `yaml:"auditbeat" config:"auditbeat" json:"auditbeat"`
+	Filebeat                BeatRuntimeConfig   `yaml:"filebeat" config:"filebeat" json:"filebeat"`
+	Heartbeat               BeatRuntimeConfig   `yaml:"heartbeat" config:"heartbeat" json:"heartbeat"`
+	Metricbeat              BeatRuntimeConfig   `yaml:"metricbeat" config:"metricbeat" json:"metricbeat"`
+	Osquerybeat             BeatRuntimeConfig   `yaml:"osquerybeat" config:"osquerybeat" json:"osquerybeat"`
+	Packetbeat              BeatRuntimeConfig   `yaml:"packetbeat" config:"packetbeat" json:"packetbeat"`
+	DynamicInputs           DynamicInputsConfig `yaml:"dynamic_inputs" config:"dynamic_inputs" json:"dynamic_inputs"`
+	Output                  map[string]string   `yaml:"output" config:"output" json:"output"`
+	OtelPartialConfigReload bool                `yaml:"otel_partial_config_reload" config:"otel_partial_config_reload" json:"otel_partial_config_reload"`
 }
 
 type BeatRuntimeConfig struct {
@@ -55,10 +56,156 @@ type BeatRuntimeConfig struct {
 	InputType map[string]string `yaml:",inline,omitempty" config:",inline,omitempty" json:",inline,omitempty"`
 }
 
+// DynamicInputsConfig controls the runtime used by components that contain dynamic inputs,
+// that is, inputs rendered from a dynamic variable provider. Such components can cause
+// frequent configuration reloads, which are expensive for the otel collector, so they can be
+// moved to a different runtime.
+//
+// The resolved value is the runtime a dynamic component running under the otel runtime should
+// be moved to. An empty value means the feature is disabled and components are left alone.
+//
+// For backwards compatibility the configuration also accepts the legacy scalar form
+// (`dynamic_inputs: process`), which is equivalent to setting only `default`.
+type DynamicInputsConfig struct {
+	Default     string            `yaml:"default" config:"default" json:"default"`
+	Auditbeat   BeatRuntimeConfig `yaml:"auditbeat" config:"auditbeat" json:"auditbeat"`
+	Filebeat    BeatRuntimeConfig `yaml:"filebeat" config:"filebeat" json:"filebeat"`
+	Heartbeat   BeatRuntimeConfig `yaml:"heartbeat" config:"heartbeat" json:"heartbeat"`
+	Metricbeat  BeatRuntimeConfig `yaml:"metricbeat" config:"metricbeat" json:"metricbeat"`
+	Osquerybeat BeatRuntimeConfig `yaml:"osquerybeat" config:"osquerybeat" json:"osquerybeat"`
+	Packetbeat  BeatRuntimeConfig `yaml:"packetbeat" config:"packetbeat" json:"packetbeat"`
+	// StaticVariables lists dynamic provider variables that cannot change at runtime, and
+	// therefore don't make an input dynamic. Entries match a variable name exactly or as a
+	// '.'-separated path prefix, so `kubernetes.node` covers `kubernetes.node.name` but not
+	// `kubernetes.nodename`. Trailing '.' characters are trimmed when the configuration is
+	// read, so `kubernetes.node.` is equivalent to `kubernetes.node`.
+	StaticVariables []string `yaml:"static_variables" config:"static_variables" json:"static_variables"`
+}
+
+// dynamicInputsConfigFields mirrors DynamicInputsConfig, but without the custom unpacking
+// methods, so it can be used as the unpack target without recursing forever.
+type dynamicInputsConfigFields DynamicInputsConfig
+
+// Unpack implements the go-ucfg Unpacker interface. It accepts both the legacy scalar form
+// (`dynamic_inputs: process`), which sets Default, and the full map form.
+func (d *DynamicInputsConfig) Unpack(value interface{}) error {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case string:
+		d.Default = v
+		return nil
+	case map[string]interface{}:
+		cfg, err := ucfg.NewFrom(v)
+		if err != nil {
+			return fmt.Errorf("failed to read dynamic_inputs configuration: %w", err)
+		}
+		// start from the current value so defaults set by DefaultRuntimeConfig are preserved
+		fields := dynamicInputsConfigFields(*d)
+		if err := cfg.Unpack(&fields); err != nil {
+			return fmt.Errorf("failed to unpack dynamic_inputs configuration: %w", err)
+		}
+		*d = DynamicInputsConfig(fields)
+		d.normalize()
+		return nil
+	default:
+		return fmt.Errorf("dynamic_inputs must be a string or an object, got %T", value)
+	}
+}
+
+// UnmarshalYAML mirrors Unpack for the yaml code path, so that both the legacy scalar form
+// and the map form are accepted when the runtime configuration is read from YAML directly.
+func (d *DynamicInputsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	if err := unmarshal(&str); err == nil {
+		d.Default = str
+		return nil
+	}
+	// start from the current value so defaults set by DefaultRuntimeConfig are preserved
+	fields := dynamicInputsConfigFields(*d)
+	if err := unmarshal(&fields); err != nil {
+		return err
+	}
+	*d = DynamicInputsConfig(fields)
+	d.normalize()
+	return nil
+}
+
+// normalize cleans up configuration values after unpacking. Trailing '.' characters are
+// trimmed from static variable entries, so `kubernetes.node.` matches the same variables
+// as `kubernetes.node`.
+func (d *DynamicInputsConfig) normalize() {
+	for i, static := range d.StaticVariables {
+		d.StaticVariables[i] = strings.TrimRight(static, ".")
+	}
+}
+
+// beatRuntimeConfig returns the per-beat configuration for beatName, or nil for an unknown beat.
+func (d *DynamicInputsConfig) beatRuntimeConfig(beatName string) *BeatRuntimeConfig {
+	switch beatName {
+	case "auditbeat":
+		return &d.Auditbeat
+	case "filebeat":
+		return &d.Filebeat
+	case "heartbeat":
+		return &d.Heartbeat
+	case "metricbeat":
+		return &d.Metricbeat
+	case "osquerybeat":
+		return &d.Osquerybeat
+	case "packetbeat":
+		return &d.Packetbeat
+	default:
+		return nil
+	}
+}
+
+// RuntimeManagerForDynamicInput returns the runtime manager that components with dynamic
+// inputs should be moved to, or "" if they should be left alone.
+//
+// The precedence is: the beat's per-input-type value, the beat's default, the top-level
+// default, disabled.
+func (d *DynamicInputsConfig) RuntimeManagerForDynamicInput(beatName string, inputType string) RuntimeManager {
+	if beatConfig := d.beatRuntimeConfig(beatName); beatConfig != nil {
+		if manager, ok := beatConfig.InputType[inputType]; ok && manager != "" {
+			return RuntimeManager(manager)
+		}
+		if beatConfig.Default != "" {
+			return RuntimeManager(beatConfig.Default)
+		}
+	}
+	return RuntimeManager(d.Default)
+}
+
+// validate checks that the configured runtime managers and static variables are valid.
+// It is intentionally unexported so that go-ucfg doesn't pick it up as a Validator; it is
+// called from RuntimeConfig.Validate instead.
+func (d *DynamicInputsConfig) validate() error {
+	if err := validateRuntimeManager(d.Default, true); err != nil {
+		return err
+	}
+	for _, beatConfig := range []BeatRuntimeConfig{d.Auditbeat, d.Filebeat, d.Heartbeat, d.Metricbeat, d.Osquerybeat, d.Packetbeat} {
+		if err := validateRuntimeManager(beatConfig.Default, true); err != nil {
+			return err
+		}
+		for _, val := range beatConfig.InputType {
+			if err := validateRuntimeManager(val, false); err != nil {
+				return err
+			}
+		}
+	}
+	for _, static := range d.StaticVariables {
+		if strings.TrimSpace(static) == "" {
+			return errors.New("static_variables entries must not be empty")
+		}
+	}
+	return nil
+}
+
 func DefaultRuntimeConfig() *RuntimeConfig {
 	return &RuntimeConfig{
 		Default:                 string(DefaultRuntimeManager),
-		DynamicInputs:           "",
+		DynamicInputs:           DefaultDynamicInputsConfig(),
 		OtelPartialConfigReload: true,
 		Auditbeat: BeatRuntimeConfig{
 			Default: string(OtelRuntimeManager),
@@ -93,31 +240,54 @@ func DefaultRuntimeConfig() *RuntimeConfig {
 	}
 }
 
-func (r *RuntimeConfig) Validate() error {
-	validateRuntime := func(val string, allowEmpty bool) error {
-		if allowEmpty && val == "" {
-			return nil
-		}
-		switch RuntimeManager(val) {
-		case "", OtelRuntimeManager, ProcessRuntimeManager:
-			return nil
-		default:
-			return fmt.Errorf("invalid runtime manager: %s, must be either %s or %s",
-				val, OtelRuntimeManager, ProcessRuntimeManager)
-		}
+// DefaultDynamicInputsConfig returns the default dynamic inputs configuration, which leaves
+// the feature disabled.
+func DefaultDynamicInputsConfig() DynamicInputsConfig {
+	return DynamicInputsConfig{
+		Default: "",
+		// go-ucfg sets the inline maps while unpacking, having them in the default makes
+		// testing easier
+		Auditbeat:   BeatRuntimeConfig{InputType: make(map[string]string)},
+		Filebeat:    BeatRuntimeConfig{InputType: make(map[string]string)},
+		Heartbeat:   BeatRuntimeConfig{InputType: make(map[string]string)},
+		Metricbeat:  BeatRuntimeConfig{InputType: make(map[string]string)},
+		Osquerybeat: BeatRuntimeConfig{InputType: make(map[string]string)},
+		Packetbeat:  BeatRuntimeConfig{InputType: make(map[string]string)},
 	}
-	if err := validateRuntime(r.Default, false); err != nil {
+}
+
+// validateRuntimeManager checks that val names a supported runtime manager. When allowEmpty
+// is true an empty value means "not set at this level" and is accepted.
+func validateRuntimeManager(val string, allowEmpty bool) error {
+	if allowEmpty && val == "" {
+		return nil
+	}
+	switch RuntimeManager(val) {
+	case "", OtelRuntimeManager, ProcessRuntimeManager:
+		return nil
+	default:
+		return fmt.Errorf("invalid runtime manager: %s, must be either %s or %s",
+			val, OtelRuntimeManager, ProcessRuntimeManager)
+	}
+}
+
+func (r *RuntimeConfig) Validate() error {
+	if err := validateRuntimeManager(r.Default, false); err != nil {
 		return err
 	}
 	for _, beatConfig := range []BeatRuntimeConfig{r.Auditbeat, r.Filebeat, r.Heartbeat, r.Metricbeat, r.Osquerybeat, r.Packetbeat} {
-		if err := validateRuntime(beatConfig.Default, true); err != nil {
+		if err := validateRuntimeManager(beatConfig.Default, true); err != nil {
 			return err
 		}
 		for _, val := range beatConfig.InputType {
-			if err := validateRuntime(val, false); err != nil {
+			if err := validateRuntimeManager(val, false); err != nil {
 				return err
 			}
 		}
+	}
+
+	if err := r.DynamicInputs.validate(); err != nil {
+		return fmt.Errorf("invalid dynamic_inputs configuration: %w", err)
 	}
 
 	allowedOutput := []string{"elasticsearch", "logstash", "kafka"}
@@ -125,7 +295,7 @@ func (r *RuntimeConfig) Validate() error {
 		if !slices.Contains(allowedOutput, name) {
 			return fmt.Errorf("%s output is not supported", name)
 		}
-		if err := validateRuntime(runtime, false); err != nil {
+		if err := validateRuntimeManager(runtime, false); err != nil {
 			return err
 		}
 	}

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -3357,7 +3357,7 @@ func gatherDurationFieldPaths(s interface{}, pathSoFar string) []string {
 		}
 		return gatheredPaths
 
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if rv.IsNil() {
 			// Nil pointer, nothing more to do
 			return gatheredPaths
@@ -4278,7 +4278,9 @@ func TestDefaultRuntimeConfig(t *testing.T) {
 	config := DefaultRuntimeConfig()
 	require.NotNil(t, config)
 	assert.Equal(t, string(DefaultRuntimeManager), config.Default)
-	assert.Equal(t, "", config.DynamicInputs)
+	assert.Equal(t, DefaultDynamicInputsConfig(), config.DynamicInputs)
+	assert.Equal(t, "", config.DynamicInputs.Default)
+	assert.Empty(t, config.DynamicInputs.StaticVariables)
 	assert.Equal(t, "otel", config.Auditbeat.Default)
 	assert.Empty(t, config.Auditbeat.InputType)
 	assert.Equal(t, "otel", config.Filebeat.Default)
@@ -4708,12 +4710,47 @@ func TestRuntimeConfig_UCFGUnpack(t *testing.T) {
 				c.Metricbeat.Default = "process"
 			},
 		},
-		"set_dynamic_inputs": {
+		"set_dynamic_inputs_legacy_scalar": {
 			input: map[string]interface{}{
 				"dynamic_inputs": "otel",
 			},
 			mutate: func(c *RuntimeConfig) {
-				c.DynamicInputs = "otel"
+				c.DynamicInputs.Default = "otel"
+			},
+		},
+		"set_dynamic_inputs_default": {
+			input: map[string]interface{}{
+				"dynamic_inputs": map[string]interface{}{
+					"default": "process",
+				},
+			},
+			mutate: func(c *RuntimeConfig) {
+				c.DynamicInputs.Default = "process"
+			},
+		},
+		"set_dynamic_inputs_per_beat_and_input_type": {
+			input: map[string]interface{}{
+				"dynamic_inputs": map[string]interface{}{
+					"default": "process",
+					"filebeat": map[string]interface{}{
+						"default":    "process",
+						"filestream": "otel",
+					},
+					"metricbeat": map[string]interface{}{
+						"default": "otel",
+					},
+					"static_variables": []interface{}{
+						"local_dynamic.group",
+						"kubernetes.node",
+					},
+				},
+			},
+			mutate: func(c *RuntimeConfig) {
+				c.DynamicInputs.Default = "process"
+				c.DynamicInputs.Filebeat.Default = "process"
+				c.DynamicInputs.Filebeat.InputType["filestream"] = "otel"
+				c.DynamicInputs.Metricbeat.Default = "otel"
+				c.DynamicInputs.StaticVariables = []string{"local_dynamic.group", "kubernetes.node"}
 			},
 		},
 	}
@@ -4730,6 +4767,235 @@ func TestRuntimeConfig_UCFGUnpack(t *testing.T) {
 			tt.mutate(expected)
 
 			assert.Equal(t, expected, cfg)
+		})
+	}
+}
+
+func TestDynamicInputsConfig_Unpack(t *testing.T) {
+	t.Run("legacy scalar form sets the default", func(t *testing.T) {
+		cfg := DefaultDynamicInputsConfig()
+		require.NoError(t, cfg.Unpack("process"))
+
+		expected := DefaultDynamicInputsConfig()
+		expected.Default = "process"
+		assert.Equal(t, expected, cfg)
+	})
+
+	t.Run("empty scalar keeps the feature disabled", func(t *testing.T) {
+		cfg := DefaultDynamicInputsConfig()
+		require.NoError(t, cfg.Unpack(""))
+		assert.Equal(t, DefaultDynamicInputsConfig(), cfg)
+	})
+
+	t.Run("nil value leaves the configuration untouched", func(t *testing.T) {
+		cfg := DefaultDynamicInputsConfig()
+		cfg.Default = "process"
+		require.NoError(t, cfg.Unpack(nil))
+		assert.Equal(t, "process", cfg.Default)
+	})
+
+	t.Run("map form unpacks all fields", func(t *testing.T) {
+		cfg := DefaultDynamicInputsConfig()
+		require.NoError(t, cfg.Unpack(map[string]interface{}{
+			"default": "process",
+			"filebeat": map[string]interface{}{
+				"default":    "process",
+				"filestream": "otel",
+			},
+			"static_variables": []interface{}{"local_dynamic.group"},
+		}))
+
+		expected := DefaultDynamicInputsConfig()
+		expected.Default = "process"
+		expected.Filebeat.Default = "process"
+		expected.Filebeat.InputType["filestream"] = "otel"
+		expected.StaticVariables = []string{"local_dynamic.group"}
+		assert.Equal(t, expected, cfg)
+	})
+
+	t.Run("trailing dots are trimmed from static variables", func(t *testing.T) {
+		cfg := DefaultDynamicInputsConfig()
+		require.NoError(t, cfg.Unpack(map[string]interface{}{
+			"static_variables": []interface{}{"kubernetes.node.", "local_dynamic.group"},
+		}))
+		assert.Equal(t, []string{"kubernetes.node", "local_dynamic.group"}, cfg.StaticVariables)
+	})
+
+	t.Run("unsupported type is rejected", func(t *testing.T) {
+		cfg := DefaultDynamicInputsConfig()
+		assert.Error(t, cfg.Unpack(true))
+	})
+}
+
+func TestDynamicInputsConfig_UnmarshalYAML(t *testing.T) {
+	t.Run("legacy scalar form", func(t *testing.T) {
+		var cfg struct {
+			DynamicInputs DynamicInputsConfig `yaml:"dynamic_inputs"`
+		}
+		cfg.DynamicInputs = DefaultDynamicInputsConfig()
+		require.NoError(t, yaml.Unmarshal([]byte("dynamic_inputs: process\n"), &cfg))
+		assert.Equal(t, "process", cfg.DynamicInputs.Default)
+	})
+
+	t.Run("map form", func(t *testing.T) {
+		var cfg struct {
+			DynamicInputs DynamicInputsConfig `yaml:"dynamic_inputs"`
+		}
+		cfg.DynamicInputs = DefaultDynamicInputsConfig()
+		require.NoError(t, yaml.Unmarshal([]byte(`dynamic_inputs:
+  default: process
+  metricbeat:
+    default: otel
+  static_variables:
+    - kubernetes.node.
+`), &cfg))
+		assert.Equal(t, "process", cfg.DynamicInputs.Default)
+		assert.Equal(t, "otel", cfg.DynamicInputs.Metricbeat.Default)
+		// trailing dots are trimmed from static variables
+		assert.Equal(t, []string{"kubernetes.node"}, cfg.DynamicInputs.StaticVariables)
+	})
+}
+
+func TestDynamicInputsConfig_RuntimeManagerForDynamicInput(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    DynamicInputsConfig
+		beatName  string
+		inputType string
+		want      RuntimeManager
+	}{
+		{
+			name:      "disabled by default",
+			config:    DefaultDynamicInputsConfig(),
+			beatName:  "filebeat",
+			inputType: "filestream",
+			want:      "",
+		},
+		{
+			name:      "global default applies to every beat",
+			config:    DynamicInputsConfig{Default: string(ProcessRuntimeManager)},
+			beatName:  "metricbeat",
+			inputType: "system/metrics",
+			want:      ProcessRuntimeManager,
+		},
+		{
+			name: "per beat default overrides the global default",
+			config: DynamicInputsConfig{
+				Default:    string(ProcessRuntimeManager),
+				Metricbeat: BeatRuntimeConfig{Default: string(OtelRuntimeManager)},
+			},
+			beatName:  "metricbeat",
+			inputType: "system/metrics",
+			want:      OtelRuntimeManager,
+		},
+		{
+			name: "per beat default doesn't affect other beats",
+			config: DynamicInputsConfig{
+				Default:    string(ProcessRuntimeManager),
+				Metricbeat: BeatRuntimeConfig{Default: string(OtelRuntimeManager)},
+			},
+			beatName:  "filebeat",
+			inputType: "filestream",
+			want:      ProcessRuntimeManager,
+		},
+		{
+			name: "per input type overrides the per beat default",
+			config: DynamicInputsConfig{
+				Default: string(OtelRuntimeManager),
+				Filebeat: BeatRuntimeConfig{
+					Default:   string(OtelRuntimeManager),
+					InputType: map[string]string{"filestream": string(ProcessRuntimeManager)},
+				},
+			},
+			beatName:  "filebeat",
+			inputType: "filestream",
+			want:      ProcessRuntimeManager,
+		},
+		{
+			name: "per input type doesn't affect other input types of the same beat",
+			config: DynamicInputsConfig{
+				Filebeat: BeatRuntimeConfig{
+					InputType: map[string]string{"filestream": string(ProcessRuntimeManager)},
+				},
+			},
+			beatName:  "filebeat",
+			inputType: "log",
+			want:      "",
+		},
+		{
+			name: "per input type only needs the beat section",
+			config: DynamicInputsConfig{
+				Filebeat: BeatRuntimeConfig{
+					InputType: map[string]string{"filestream": string(ProcessRuntimeManager)},
+				},
+			},
+			beatName:  "filebeat",
+			inputType: "filestream",
+			want:      ProcessRuntimeManager,
+		},
+		{
+			name: "unknown beat falls back to the global default",
+			config: DynamicInputsConfig{
+				Default:  string(ProcessRuntimeManager),
+				Filebeat: BeatRuntimeConfig{Default: string(OtelRuntimeManager)},
+			},
+			beatName:  "",
+			inputType: "endpoint",
+			want:      ProcessRuntimeManager,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.config.RuntimeManagerForDynamicInput(tt.beatName, tt.inputType))
+		})
+	}
+}
+
+func TestRuntimeConfig_ValidateDynamicInputs(t *testing.T) {
+	tests := map[string]struct {
+		dynamicInputs func(*DynamicInputsConfig)
+		wantErr       bool
+	}{
+		"valid default": {
+			dynamicInputs: func(c *DynamicInputsConfig) { c.Default = string(ProcessRuntimeManager) },
+		},
+		"empty default is allowed": {
+			dynamicInputs: func(c *DynamicInputsConfig) { c.Default = "" },
+		},
+		"invalid default": {
+			dynamicInputs: func(c *DynamicInputsConfig) { c.Default = "nonsense" },
+			wantErr:       true,
+		},
+		"invalid per beat default": {
+			dynamicInputs: func(c *DynamicInputsConfig) { c.Filebeat.Default = "nonsense" },
+			wantErr:       true,
+		},
+		"invalid per input type": {
+			dynamicInputs: func(c *DynamicInputsConfig) { c.Metricbeat.InputType["system/metrics"] = "nonsense" },
+			wantErr:       true,
+		},
+		"valid static variables": {
+			dynamicInputs: func(c *DynamicInputsConfig) {
+				c.StaticVariables = []string{"kubernetes.node", "local_dynamic.group"}
+			},
+		},
+		"empty static variable": {
+			dynamicInputs: func(c *DynamicInputsConfig) { c.StaticVariables = []string{"kubernetes.node", "  "} },
+			wantErr:       true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := DefaultRuntimeConfig()
+			tt.dynamicInputs(&cfg.DynamicInputs)
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/testing/integration/ess/beat_receivers_test.go
+++ b/testing/integration/ess/beat_receivers_test.go
@@ -1014,8 +1014,12 @@ const (
 	otelDynamicVariableLogLineTemplate = "Component %s uses dynamic variable providers, switching to process runtime"
 )
 
-// TestBeatsReceiverDynamicInputProcessRuntimeFallback verifies that we fall back to the process runtime if the input
-// uses variables from a dynamic provider.
+// TestBeatsReceiverDynamicInputProcessRuntimeFallback verifies that we fall back to the process
+// runtime if the input uses variables from a dynamic provider, and the configurable parts of this
+// behavior:
+//   - the override runtime can be set per beat, and only affects components of that beat
+//   - variables listed in agent.internal.runtime.dynamic_inputs.static_variables don't make an input
+//     dynamic, so an input using only those keeps running as a beats receiver
 func TestBeatsReceiverDynamicInputProcessRuntimeFallback(t *testing.T) {
 	_ = define.Require(t, define.Requirements{
 		Group: integration.Default,
@@ -1031,13 +1035,33 @@ func TestBeatsReceiverDynamicInputProcessRuntimeFallback(t *testing.T) {
 
 	esURL := integration.StartMockES(t, 0, 0, 0, 0)
 
+	// The local_dynamic provider emits two items which share the same `group` variable but have a
+	// different `id`. `group` is declared static, so the filestream input referencing only `${local_dynamic.group}`
+	// isn't considered dynamic and stays on the otel runtime, while the system/metrics input referencing
+	// `${local_dynamic.id}` is moved to the process runtime by the metricbeat override.
 	config := fmt.Sprintf(`agent.logging.to_stderr: true
 agent.logging.to_files: false
 agent.monitoring.enabled: false
-agent.internal.runtime.dynamic_inputs: process
+agent.internal.runtime:
+  filebeat:
+    filestream: otel
+  metricbeat:
+    system/metrics: otel
+  dynamic_inputs:
+    filebeat:
+      default: process
+    metricbeat:
+      default: process
+    static_variables:
+      - local_dynamic.group
 inputs:
+  - type: filestream
+    id: filestream-static-vars
+    data_stream.dataset: generic
+    paths:
+      - /var/log/${local_dynamic.group}/*.log
   - type: system/metrics
-    id: "${local_dynamic.id}"
+    id: "system-metrics-${local_dynamic.id}"
     streams:
       - metricsets:
         - cpu
@@ -1051,7 +1075,11 @@ providers:
   local_dynamic:
     items:
     - vars:
-        id: system-metrics-1
+        id: one
+        group: shared
+    - vars:
+        id: two
+        group: shared
 `, esURL.Host)
 
 	// this is the context for the whole test, with a global timeout defined
@@ -1070,30 +1098,50 @@ providers:
 	installOutput, err := fixture.Install(ctx, &atesting.InstallOpts{Privileged: true, Force: true})
 	require.NoError(t, err, "install failed, output: %s", string(installOutput))
 
-	var compId string
+	var filestreamCompId, metricsCompId string
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		var statusErr error
 		status, statusErr := fixture.ExecStatus(ctx)
 		assert.NoError(collect, statusErr)
-		// we should be running a single component in a beat process
 		assert.Equal(collect, int(cproto.State_HEALTHY), status.State)
-		require.Equal(collect, 1, len(status.Components))
-		comp := status.Components[0]
+		// one component per input type, each in a different runtime
+		require.Equal(collect, 2, len(status.Components))
 
-		assert.Equal(collect, int(cproto.State_HEALTHY), comp.State)
-		expectedComponentVersionInfoName := componentVersionInfoNameForRuntime(component.ProcessRuntimeManager)
-		assert.Equal(collect, expectedComponentVersionInfoName, comp.VersionInfo.Name)
-		for _, unit := range comp.Units {
-			assert.Equal(collect, int(cproto.State_HEALTHY), unit.State)
+		for _, comp := range status.Components {
+			assert.Equal(collect, int(cproto.State_HEALTHY), comp.State)
+			for _, unit := range comp.Units {
+				assert.Equal(collect, int(cproto.State_HEALTHY), unit.State)
+			}
+			switch {
+			case strings.HasPrefix(comp.ID, "filestream"):
+				filestreamCompId = comp.ID
+				// only uses a static variable, so it isn't dynamic and stays a beats receiver
+				assert.Equal(collect, componentVersionInfoNameForRuntime(component.OtelRuntimeManager),
+					comp.VersionInfo.Name)
+			case strings.HasPrefix(comp.ID, "system/metrics"):
+				metricsCompId = comp.ID
+				// uses a variable that changes per provider item, so it's moved to the process runtime
+				assert.Equal(collect, componentVersionInfoNameForRuntime(component.ProcessRuntimeManager),
+					comp.VersionInfo.Name)
+			default:
+				assert.Fail(collect, "unexpected component", "component %s", comp.ID)
+			}
 		}
-		compId = comp.ID
 	}, 1*time.Minute, 1*time.Second)
 	logsBytes, err := fixture.Exec(ctx, []string{"logs", "-n", "1000", "--exclude-events"})
 	require.NoError(t, err)
 
-	// verify we've logged a warning about using the process runtime
-	foundLogMessage := false
-	expectedMessage := fmt.Sprintf(otelDynamicVariableLogLineTemplate, compId)
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Log("Elastic-Agent logs seen by the test:")
+			t.Log(string(logsBytes))
+		}
+	})
+
+	// only the system/metrics component should have been switched to the process runtime
+	metricsMessage := fmt.Sprintf(otelDynamicVariableLogLineTemplate, metricsCompId)
+	filestreamMessage := fmt.Sprintf(otelDynamicVariableLogLineTemplate, filestreamCompId)
+	foundMetricsLogMessage := false
+	foundFilestreamLogMessage := false
 	for _, line := range strings.Split(string(logsBytes), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -1106,17 +1154,14 @@ providers:
 			continue
 		}
 
-		foundLogMessage = foundLogMessage || logRecord.Message == expectedMessage
+		foundMetricsLogMessage = foundMetricsLogMessage || logRecord.Message == metricsMessage
+		foundFilestreamLogMessage = foundFilestreamLogMessage || logRecord.Message == filestreamMessage
 	}
 
-	t.Cleanup(func() {
-		if t.Failed() {
-			t.Log("Elastic-Agent logs seen by the test:")
-			t.Log(string(logsBytes))
-		}
-	})
-
-	assert.True(t, foundLogMessage, "there should be a log line with a warning about falling back to process runtime")
+	assert.True(t, foundMetricsLogMessage,
+		"there should be a log line with a warning about falling back to process runtime for the system/metrics component")
+	assert.False(t, foundFilestreamLogMessage,
+		"the filestream component only uses static variables, it should not fall back to the process runtime")
 }
 
 // TestBeatsReceiverSubcomponentStatus verifies that we correctly reflect the status of beats inputs in the elastic


### PR DESCRIPTION
## What does this PR do?

The dynamic inputs runtime override (agent.internal.runtime.dynamic_inputs) previously accepted a single runtime name and moved every component with inputs rendered from a dynamic variable provider off the otel runtime. To allow finer control for testing and benchmarking:

- The override runtime can now be set per beat and per input type, with the same precedence scheme as the general runtime configuration. The legacy scalar form keeps working and maps to the top-level default.
- A new static_variables list excludes provider variables that cannot change at runtime (e.g. kubernetes.node.name): an input is only treated as dynamic if it resolved at least one provider variable not covered by the list. The variables each input resolves are recorded during rendering and logged at debug level for introspection.

The only interesting implementation bit is the an observer added to walking the config AST.

## Why is it important?

Having more control over these will make it easier to progressively test them in production environments.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/ingest-dev/issues/8901


<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
