### PR TITLE
fix: OTel heartbeat runtime breaks Synthetics browser monitors on Private Locations

### DIFF
--- a/changelog/fragments/1785779400-fix-otel-heartbeat-browser-monitors.yaml
+++ b/changelog/fragments/1785779400-fix-otel-heartbeat-browser-monitors.yaml
@@ -1,0 +1,39 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix OTel heartbeat runtime breaking Synthetics browser monitors on Private Locations
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  When heartbeat runs via the OTel heartbeatreceiver, a Synthetics browser monitor
+  compiles into a single synthetics/browser input with three streams: the scheduled
+  "browser" monitor stream plus schedule-less "browser.network" and "browser.screenshot"
+  auxiliary streams used only for data-stream routing. The beat-receiver translation
+  emitted one monitor per stream, so the schedule-less auxiliary streams were rejected
+  ("missing required field accessing 'heartbeat.monitors.0.schedule'") and the whole
+  browser component failed to start. The auxiliary streams are now dropped during
+  translation, matching classic process-runtime heartbeat behavior.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/15968

--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -846,11 +846,45 @@ func getInputsForUnit(unit component.Unit, info info.Agent, defaultDataStreamTyp
 		result[i] = receiverInput{streamID: streamID, config: input}
 	}
 
+	// A Synthetics browser monitor compiles into a single synthetics/browser input
+	// with three streams: the "browser" monitor stream, which carries the schedule,
+	// plus schedule-less "browser.network" and "browser.screenshot" auxiliary streams
+	// used only for data-stream routing. Classic (process) heartbeat collapses these
+	// into a single monitor via stdfields.UnnestStream, keeping only the base stream
+	// and dropping the auxiliary ones. The beat-receiver path emits one monitor per
+	// stream instead, so the schedule-less streams have to be filtered out here — the
+	// heartbeatreceiver otherwise rejects them ("missing required field accessing
+	// 'heartbeat.monitors.0.schedule'") and the whole component fails to start.
+	// See https://github.com/elastic/elastic-agent/issues/15968.
+	if comp.InputType == "synthetics/browser" {
+		result = keepScheduledMonitors(result)
+	}
+
 	if comp.InputSpec != nil && comp.InputSpec.Spec.SingleReceiver && comp.InputType == "osquery" {
 		result = injectOsqueryConfig(result, unit)
 	}
 
 	return result, nil
+}
+
+// keepScheduledMonitors filters beat-receiver inputs down to those that represent an
+// actual heartbeat monitor, i.e. streams that define a schedule. Auxiliary Synthetics
+// browser sub-streams (browser.network, browser.screenshot) carry no schedule and exist
+// only for data-stream routing, mirroring what stdfields.UnnestStream drops in classic
+// heartbeat. If no stream defines a schedule the config is malformed, so the inputs are
+// returned unchanged to let the heartbeatreceiver surface the real validation error
+// rather than silently producing a monitor-less component.
+func keepScheduledMonitors(inputs []receiverInput) []receiverInput {
+	scheduled := make([]receiverInput, 0, len(inputs))
+	for _, ri := range inputs {
+		if sched, ok := ri.config["schedule"]; ok && sched != nil && sched != "" {
+			scheduled = append(scheduled, ri)
+		}
+	}
+	if len(scheduled) == 0 {
+		return inputs
+	}
+	return scheduled
 }
 
 // stripDefaultProcessors removes per-input processor entries that exactly match

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -2867,6 +2867,108 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 	}
 }
 
+// TestGetReceiversConfigForComponentBrowserMonitor verifies that a Synthetics browser
+// monitor, which compiles into a single synthetics/browser input with a scheduled
+// "browser" stream plus schedule-less "browser.network" and "browser.screenshot"
+// auxiliary streams, produces exactly one heartbeat monitor. The auxiliary streams
+// must be dropped so the heartbeatreceiver does not reject them for missing a schedule.
+// Regression test for https://github.com/elastic/elastic-agent/issues/15968.
+func TestGetReceiversConfigForComponentBrowserMonitor(t *testing.T) {
+	testAgentInfo := &info.AgentInfo{}
+
+	browserComponent := &component.Component{
+		ID:        "heartbeat-browser-test-id",
+		InputType: "synthetics/browser",
+		InputSpec: &component.InputRuntimeSpec{
+			BinaryName: "elastic-otel-collector",
+			Spec: component.InputSpec{
+				Name: "synthetics/browser",
+				Command: &component.CommandSpec{
+					Args: []string{"heartbeat"},
+				},
+			},
+		},
+		Units: []component.Unit{
+			{
+				ID:   "heartbeat-browser-test-id-unit",
+				Type: client.UnitTypeInput,
+				Config: component.MustExpectedConfig(map[string]any{
+					"id":         "test",
+					"use_output": "default",
+					"type":       "synthetics/browser",
+					"streams": []any{
+						map[string]any{
+							"id":   "browser-1",
+							"type": "browser",
+							"data_stream": map[string]any{
+								"dataset": "browser",
+								"type":    "synthetics",
+							},
+							"schedule": "@every 3m",
+						},
+						map[string]any{
+							"id": "browser-network-1",
+							"data_stream": map[string]any{
+								"dataset": "browser.network",
+								"type":    "synthetics",
+							},
+						},
+						map[string]any{
+							"id": "browser-screenshot-1",
+							"data_stream": map[string]any{
+								"dataset": "browser.screenshot",
+								"type":    "synthetics",
+							},
+						},
+					},
+				}),
+			},
+		},
+	}
+
+	result, err := getReceiversConfigForComponent(browserComponent, testAgentInfo, nil)
+	require.NoError(t, err)
+
+	// Only the scheduled "browser" stream must become a receiver/monitor; the
+	// schedule-less auxiliary streams must be dropped.
+	require.Len(t, result, 1, "only the scheduled browser stream should produce a receiver")
+
+	scheduledReceiverID := "heartbeatreceiver/_agent-component/heartbeat-browser-test-id/browser-1"
+	require.Contains(t, result, scheduledReceiverID)
+	assert.NotContains(t, result, "heartbeatreceiver/_agent-component/heartbeat-browser-test-id/browser-network-1")
+	assert.NotContains(t, result, "heartbeatreceiver/_agent-component/heartbeat-browser-test-id/browser-screenshot-1")
+
+	receiverConfig, ok := result[scheduledReceiverID].(map[string]any)
+	require.True(t, ok, "receiver config should be a map")
+	heartbeatConfig, ok := receiverConfig["heartbeat"].(map[string]any)
+	require.True(t, ok, "heartbeat config should be a map")
+	monitors, ok := heartbeatConfig["monitors"].([]map[string]any)
+	require.True(t, ok, "heartbeat monitors should be a slice of maps")
+	require.Len(t, monitors, 1, "exactly one monitor should be emitted")
+	assert.Equal(t, "@every 3m", monitors[0]["schedule"], "the emitted monitor must carry the schedule")
+	assert.Equal(t, "browser", monitors[0]["type"], "the emitted monitor must be the browser stream")
+}
+
+// TestKeepScheduledMonitors verifies the schedule-based filtering used to drop
+// auxiliary Synthetics browser sub-streams, including the malformed-config fallback.
+func TestKeepScheduledMonitors(t *testing.T) {
+	scheduled := receiverInput{streamID: "browser-1", config: map[string]any{"schedule": "@every 3m"}}
+	network := receiverInput{streamID: "browser-network-1", config: map[string]any{}}
+	screenshot := receiverInput{streamID: "browser-screenshot-1", config: map[string]any{"schedule": nil}}
+
+	t.Run("drops schedule-less streams", func(t *testing.T) {
+		got := keepScheduledMonitors([]receiverInput{scheduled, network, screenshot})
+		require.Len(t, got, 1)
+		assert.Equal(t, "browser-1", got[0].streamID)
+	})
+
+	t.Run("returns inputs unchanged when none are scheduled", func(t *testing.T) {
+		in := []receiverInput{network, screenshot}
+		got := keepScheduledMonitors(in)
+		assert.Equal(t, in, got)
+	})
+}
+
 // TestGetReceiversConfigForComponentFeatures verifies that all agent feature flags
 // are propagated into the generated Beat receiver config.
 func TestGetReceiversConfigForComponentFeatures(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Since #15325 heartbeat defaults to the OTel `heartbeatreceiver`. A Synthetics **browser** monitor compiles into a single `synthetics/browser` input with **three streams**:

| stream | `schedule`? | role |
|---|---|---|
| `browser` | ✅ | the actual monitor |
| `browser.network` | ❌ | data-routing only |
| `browser.screenshot` | ❌ | data-routing only |

The beat-receiver translation in [`otelconfig.go`](https://github.com/elastic/elastic-agent/blob/main/internal/pkg/otel/translate/otelconfig.go) emits **one receiver/monitor per stream**, so the schedule-less `browser.network` / `browser.screenshot` streams each became a "monitor" with no `schedule`. The `heartbeatreceiver` rejects them and the whole browser component fails to start:

```
synthetics/browser-default (FAILED): Permanent: could not create monitor:
could not parse cfg for datastream error unpacking monitor plugin config:
missing required field accessing 'heartbeat.monitors.0.schedule'
```

This PR filters the `synthetics/browser` input's streams down to those that define a `schedule` during translation, dropping the auxiliary sub-streams. This mirrors classic **process-runtime** heartbeat, which collapses the streams into a single monitor via `stdfields.UnnestStream` (in beats) and drops the auxiliary ones — the browser monitor routes network/screenshot events to their datasets internally. If no stream defines a schedule the inputs are left unchanged so the `heartbeatreceiver` still surfaces the real validation error.

## Why is it important?

Browser monitors on Fleet-managed Private Locations are fully non-functional on 9.5 (and `main`/9.6) under the default OTel heartbeat runtime. Lightweight monitors (HTTP/TCP/ICMP) are unaffected (single stream, has `schedule`).

## Checklist

- [x] I have added tests that prove my fix is effective (`TestGetReceiversConfigForComponentBrowserMonitor`, `TestKeepScheduledMonitors`)
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## How to test this PR locally

Enroll `elastic-agent-complete` to a Synthetics private-location agent policy with one browser monitor. Before this change the `synthetics/browser` component reports `FAILED`; after it, the monitor runs `up`.

## Related issues

Fixes #15968

## Notes

- The `heartbeat.default: process` agent-policy override remains a valid short-term mitigation until this fix is merged and backported to 9.5/9.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)