### PR TITLE
bump github.com/kardianos/service v1.2.4 -> v1.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ pkg/core/process/testsignal/testsignal
 internal/pkg/agent/install/testblocking/testblocking
 internal/edot/testing/testing
 pkg/core/process/testsignal/testsignal
+.claude/settings.local.json

--- a/NOTICE-fips.txt
+++ b/NOTICE-fips.txt
@@ -2279,11 +2279,11 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/kardianos/service
-Version: v1.2.4
+Version: v1.3.0
 Licence type (autodetected): Zlib
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/kardianos/service@v1.2.4/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/kardianos/service@v1.3.0/LICENSE:
 
 Copyright (c) 2015 Daniel Theophanes
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2279,11 +2279,11 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/kardianos/service
-Version: v1.2.4
+Version: v1.3.0
 Licence type (autodetected): Zlib
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/kardianos/service@v1.2.4/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/kardianos/service@v1.3.0/LICENSE:
 
 Copyright (c) 2015 Daniel Theophanes
 

--- a/changelog/fragments/1785938601-bump-github.com-kardianos-service-to-v1.3.0.yaml
+++ b/changelog/fragments/1785938601-bump-github.com-kardianos-service-to-v1.3.0.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Bump github.com/kardianos/service to v1.3.0 and update Linux systemd template for new mini template engine
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/jaypipes/ghw v0.25.0
 	github.com/jedib0t/go-pretty/v6 v6.8.3
 	github.com/josephspurrier/goversioninfo v1.7.0
-	github.com/kardianos/service v1.2.4
+	github.com/kardianos/service v1.3.0
 	github.com/knadh/koanf/maps v0.1.2
 	github.com/magefile/mage v1.17.2
 	github.com/moby/moby/client v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -416,6 +416,8 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/kardianos/service v1.2.4 h1:XNlGtZOYNx2u91urOdg/Kfmc+gfmuIo1Dd3rEi2OgBk=
 github.com/kardianos/service v1.2.4/go.mod h1:E4V9ufUuY82F7Ztlu1eN9VXWIQxg8NoLQlmFe0MtrXc=
+github.com/kardianos/service v1.3.0 h1:/LGy+xPP2TM+GLTiCZ2di7cy0Jd/qrawlTUfqKYFdTI=
+github.com/kardianos/service v1.3.0/go.mod h1:E4V9ufUuY82F7Ztlu1eN9VXWIQxg8NoLQlmFe0MtrXc=
 github.com/klauspost/compress v1.19.0 h1:sXLILfc9jV2QYWkzFOPWStmcUVH2RHEB1JCdY2oVvCQ=
 github.com/klauspost/compress v1.19.0/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=

--- a/go.sum
+++ b/go.sum
@@ -414,8 +414,6 @@ github.com/josephspurrier/goversioninfo v1.7.0/go.mod h1:z9y0r2G6g5jwSJaFE0cxW9t
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
-github.com/kardianos/service v1.2.4 h1:XNlGtZOYNx2u91urOdg/Kfmc+gfmuIo1Dd3rEi2OgBk=
-github.com/kardianos/service v1.2.4/go.mod h1:E4V9ufUuY82F7Ztlu1eN9VXWIQxg8NoLQlmFe0MtrXc=
 github.com/kardianos/service v1.3.0 h1:/LGy+xPP2TM+GLTiCZ2di7cy0Jd/qrawlTUfqKYFdTI=
 github.com/kardianos/service v1.3.0/go.mod h1:E4V9ufUuY82F7Ztlu1eN9VXWIQxg8NoLQlmFe0MtrXc=
 github.com/klauspost/compress v1.19.0 h1:sXLILfc9jV2QYWkzFOPWStmcUVH2RHEB1JCdY2oVvCQ=

--- a/internal/pkg/agent/install/svc.go
+++ b/internal/pkg/agent/install/svc.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/kardianos/service"
 	"gopkg.in/ini.v1"
@@ -90,9 +91,6 @@ func newService(topPath string, opt ...serviceOpt) (service.Service, error) {
 	}
 
 	option := map[string]interface{}{
-		// GroupName
-		"GroupName": opts.Group,
-
 		// Linux (systemd) always restart on failure
 		"Restart": "always",
 
@@ -116,17 +114,17 @@ func newService(topPath string, opt ...serviceOpt) (service.Service, error) {
 	}
 
 	if runtime.GOOS == "linux" {
-		// The github.com/kardianos/service library doesn't support KillMode in their prebuilt template.
-		// This option allows to pass our own template for the systemd unit configuration, which is a copy
-		// of the prebuilt template with added KillMode option
-		cfg.Option["SystemdScript"] = linuxSystemdScript
-
-		// By setting KillMode=process in Elastic Agent's systemd unit configuration file, we ensure
-		// that in a scenario where the upgraded Agent's process is repeatedly crashing, systemd keeps
-		// the Upgrade Watcher process running so it can monitor the Agent process for long enough to
-		// initiate a rollback.
-		// See also https://github.com/elastic/elastic-agent/pull/3220#issuecomment-1673935694.
-		cfg.Option["KillMode"] = "process"
+		// kardianos/service v1.3.0 switched to a mini template engine that does not expose
+		// Config.Option in the template data map, so KillMode and GroupName must be injected
+		// as literals before the template is handed to the library.
+		// KillMode=process ensures the Upgrade Watcher process survives an Agent crash loop
+		// long enough to initiate a rollback.
+		// See https://github.com/elastic/elastic-agent/pull/3220#issuecomment-1673935694.
+		groupLine := ""
+		if opts.Group != "" {
+			groupLine = "Group=" + opts.Group + "\n"
+		}
+		cfg.Option["SystemdScript"] = strings.ReplaceAll(linuxSystemdScript, "@GROUP_LINE@", groupLine)
 	}
 
 	if runtime.GOOS == "darwin" {
@@ -284,36 +282,33 @@ const darwinLaunchdConfig = `<?xml version='1.0' encoding='UTF-8'?>
 </plist>
 `
 
-// A copy of the systemd config template from github.com/kardianos/service
-// with added .Config.Option.KillMode option
+// A copy of the systemd config template from github.com/kardianos/service using the
+// v1.3.0 mini template engine syntax, with hardcoded KillMode=process and an @GROUP_LINE@
+// placeholder that newService() replaces with a literal "Group=<name>\n" or "".
+// kardianos/service v1.3.0 no longer exposes Config.Option in the template data map,
+// so KillMode and GroupName cannot be referenced as template variables.
 const linuxSystemdScript = `[Unit]
-Description={{.Description}}
-ConditionFileIsExecutable={{.Path|cmdEscape}}
-{{range $i, $dep := .Dependencies}}
-{{$dep}} {{end}}
-
+Description={{Description}}
+ConditionFileIsExecutable={{Path | cmdEscape}}
+{{range Dependencies}}{{.}}
+{{end}}
 [Service]
 StartLimitInterval=5
 StartLimitBurst=10
-ExecStart={{.Path|cmdEscape}}{{range .Arguments}} {{.|cmd}}{{end}}
-{{if .ChRoot}}RootDirectory={{.ChRoot|cmd}}{{end}}
-{{if .WorkingDirectory}}WorkingDirectory={{.WorkingDirectory|cmdEscape}}{{end}}
-{{if .UserName}}User={{.UserName}}{{end}}
-{{if .Config.Option.GroupName -}}
-Group={{.Config.Option.GroupName}}
-{{- end}}
-{{if .ReloadSignal}}ExecReload=/bin/kill -{{.ReloadSignal}} "$MAINPID"{{end}}
-{{if .PIDFile}}PIDFile={{.PIDFile|cmd}}{{end}}
-{{if and .LogOutput .HasOutputFileSupport -}}
-StandardOutput=file:/var/log/{{.Name}}.out
-StandardError=file:/var/log/{{.Name}}.err
-{{- end}}
-{{if gt .LimitNOFILE -1 }}LimitNOFILE={{.LimitNOFILE}}{{end}}
-{{if .Restart}}Restart={{.Restart}}{{end}}
-{{if .SuccessExitStatus}}SuccessExitStatus={{.SuccessExitStatus}}{{end}}
-{{if .Config.Option.KillMode}}KillMode={{.Config.Option.KillMode}}{{end}}
+ExecStart={{Path | cmdEscape}}{{range Arguments}} {{. | cmd}}{{end}}
+{{if ChRoot}}RootDirectory={{ChRoot | cmd}}
+{{end}}{{if WorkingDirectory}}WorkingDirectory={{WorkingDirectory | cmdEscape}}
+{{end}}{{if UserName}}User={{UserName}}
+{{end}}@GROUP_LINE@{{if ReloadSignal}}ExecReload=/bin/kill -{{ReloadSignal}} "$MAINPID"
+{{end}}{{if PIDFile}}PIDFile={{PIDFile | cmd}}
+{{end}}{{if OutputFileSupport}}StandardOutput=file:{{LogDirectory}}/{{Name}}.out
+StandardError=file:{{LogDirectory}}/{{Name}}.err
+{{end}}{{if LimitNOFILE}}LimitNOFILE={{LimitNOFILE}}
+{{end}}{{if Restart}}Restart={{Restart}}
+{{end}}{{if SuccessExitStatus}}SuccessExitStatus={{SuccessExitStatus}}
+{{end}}KillMode=process
 RestartSec=120
-EnvironmentFile=-/etc/sysconfig/{{.Name}}
+EnvironmentFile=-/etc/sysconfig/{{Name}}
 
 [Install]
 WantedBy=multi-user.target

--- a/internal/pkg/agent/install/svc.go
+++ b/internal/pkg/agent/install/svc.go
@@ -128,16 +128,24 @@ func newService(topPath string, opt ...serviceOpt) (service.Service, error) {
 	}
 
 	if runtime.GOOS == "darwin" {
-		// The github.com/kardianos/service library doesn't support ExitTimeOut in their prebuilt template.
-		// This option allows to pass our own template for the launch daemon plist, which is a copy
-		// of the prebuilt template with added ExitTimeOut option
-		cfg.Option["LaunchdConfig"] = darwinLaunchdConfig
-		cfg.Option["ExitTimeOut"] = darwinServiceExitTimeout
+		// kardianos/service v1.3.0 switched to a mini template engine that does not expose
+		// Config.Option in the template data map, so ExitTimeOut and GroupName must be injected
+		// as literals before the template is handed to the library.
+		// ExitTimeOut prevents launchd from force-killing the agent before it can shut down.
+		exitTimeoutEntry := fmt.Sprintf("<key>ExitTimeOut</key>\n    <integer>%d</integer>", darwinServiceExitTimeout)
+		groupNameEntry := ""
+		if opts.Group != "" {
+			groupNameEntry = "<key>GroupName</key>\n    <string>" + opts.Group + "</string>"
+		}
+		launchdCfg := strings.ReplaceAll(darwinLaunchdConfig, "@EXIT_TIMEOUT_ENTRY@", exitTimeoutEntry)
+		launchdCfg = strings.ReplaceAll(launchdCfg, "@GROUP_NAME_ENTRY@", groupNameEntry)
+		cfg.Option["LaunchdConfig"] = launchdCfg
 
-		// Set the stdout and stderr logs to be inside the installation directory, ensures that the
-		// executing user for the service can write to the directory for the logs.
-		cfg.Option["StandardOutPath"] = filepath.Join(topPath, fmt.Sprintf("%s.out.log", paths.ServiceName()))
-		cfg.Option["StandardErrorPath"] = filepath.Join(topPath, fmt.Sprintf("%s.err.log", paths.ServiceName()))
+		// LogDirectory is used by v1.3.0 to compute StandardOutPath/StandardErrorPath from
+		// <LogDirectory>/<Name>.out.log and <LogDirectory>/<Name>.err.log. Setting it to
+		// topPath ensures log files land inside the installation directory where the service
+		// user has write access.
+		cfg.Option["LogDirectory"] = topPath
 	}
 
 	return service.New(nil, cfg)
@@ -236,47 +244,46 @@ func changeLaunchdServiceFile(serviceName string, plistPath string, username str
 	return nil
 }
 
-// A copy of the launchd plist template from github.com/kardianos/service
-// with added .Config.Option.ExitTimeOut option
+// A copy of the launchd plist template from github.com/kardianos/service using the
+// v1.3.0 mini template engine syntax, with @EXIT_TIMEOUT_ENTRY@ and @GROUP_NAME_ENTRY@
+// placeholders that newService() replaces with literal plist entries (or empty strings).
+// kardianos/service v1.3.0 no longer exposes Config.Option in the template data map,
+// so ExitTimeOut and GroupName cannot be referenced as template variables.
 const darwinLaunchdConfig = `<?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
 "http://www.apple.com/DTDs/PropertyList-1.0.dtd" >
 <plist version='1.0'>
   <dict>
     <key>Label</key>
-    <string>{{html .Name}}</string>
+    <string>{{Name | html}}</string>
     <key>ProgramArguments</key>
     <array>
-      <string>{{html .Path}}</string>
-    {{range .Config.Arguments}}
-      <string>{{html .}}</string>
+      <string>{{Path | html}}</string>
+    {{range Arguments}}
+      <string>{{. | html}}</string>
     {{end}}
     </array>
-    {{if .UserName}}<key>UserName</key>
-    <string>{{html .UserName}}</string>{{end}}
-	{{if .Config.Option.GroupName -}}
-	<key>GroupName</key>
-    <string>{{html .Config.Option.GroupName}}</string>
-	{{- end}}
-    {{if .ChRoot}}<key>RootDirectory</key>
-    <string>{{html .ChRoot}}</string>{{end}}
-    {{if .Config.Option.ExitTimeOut}}<key>ExitTimeOut</key>
-    <integer>{{html .Config.Option.ExitTimeOut}}</integer>{{end}}
-    {{if .WorkingDirectory}}<key>WorkingDirectory</key>
-    <string>{{html .WorkingDirectory}}</string>{{end}}
+    {{if UserName}}<key>UserName</key>
+    <string>{{UserName | html}}</string>{{end}}
+    @GROUP_NAME_ENTRY@
+    {{if ChRoot}}<key>RootDirectory</key>
+    <string>{{ChRoot | html}}</string>{{end}}
+    @EXIT_TIMEOUT_ENTRY@
+    {{if WorkingDirectory}}<key>WorkingDirectory</key>
+    <string>{{WorkingDirectory | html}}</string>{{end}}
     <key>SessionCreate</key>
-    <{{bool .SessionCreate}}/>
+    <{{SessionCreate}}/>
     <key>KeepAlive</key>
-    <{{bool .KeepAlive}}/>
+    <{{KeepAlive}}/>
     <key>RunAtLoad</key>
-    <{{bool .RunAtLoad}}/>
+    <{{RunAtLoad}}/>
     <key>Disabled</key>
     <false/>
 
     <key>StandardOutPath</key>
-    <string>{{html .Config.Option.StandardOutPath}}</string>
+    <string>{{StandardOutPath | html}}</string>
     <key>StandardErrorPath</key>
-    <string>{{html .Config.Option.StandardErrorPath}}</string>
+    <string>{{StandardErrorPath | html}}</string>
 
   </dict>
 </plist>


### PR DESCRIPTION
## What does this PR do?

Bumps `github.com/kardianos/service` from v1.2.4 to v1.3.0 and updates the custom Linux systemd unit template to be compatible with the new version.

### Why is a template change needed?

v1.3.0 replaced Go's `text/template` with a purpose-built mini template engine to avoid inflating binary size via `reflect`. The new engine uses a different syntax and — critically — **does not expose `Config.Option` in the template data map**. The old template used `{{.Description}}`, `{{.Path|cmdEscape}}`, `{{.Config.Option.KillMode}}`, etc., which are all invalid in the new engine. Without this fix, Linux agent install fails immediately with `service: unknown template key ".Description"`.

### Changes

- `go.mod`/`go.sum`: version bump
- `internal/pkg/agent/install/svc.go`:
  - Updated all template variables from Go text/template syntax (`{{.Key}}`) to mini engine syntax (`{{Key}}`, `{{Key | fn}}`)
  - **KillMode**: hardcoded `KillMode=process` as a literal in the template (it was always `"process"`; the option key is no longer accessible)
  - **GroupName**: injected as a pre-rendered literal string via an `@GROUP_LINE@` placeholder that `newService()` replaces before passing the template to the library

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `changelog/fragments` as necessary