### PR TITLE
fix(synthetics): bake Playwright browsers into complete image

### DIFF
--- a/changelog/fragments/1785872496-fix-complete-image-synthetics-browser-install.yaml
+++ b/changelog/fragments/1785872496-fix-complete-image-synthetics-browser-install.yaml
@@ -1,0 +1,29 @@
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Bake Synthetics browser binaries into the elastic-agent-complete image
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  npm 12 no longer runs a dependency's `install` lifecycle script during `npm i` by
+  default, so the transitive playwright-chromium `install` hook that used to download
+  the Playwright browsers into the elastic-agent-complete image during build stopped
+  running. As a result the 9.5.0 complete image shipped with no browsers and all
+  Synthetics browser monitors on Fleet-managed Private Locations failed with
+  "browserType.launch: Executable doesn't exist at .../chromium_headless_shell-<rev>/...".
+  The image build now installs the browsers explicitly with the bundled Playwright CLI
+  after `npm i`, independent of npm's install-script policy.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/15993

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -255,6 +255,11 @@ USER {{ .user }}
 # If this fails dump the NPM logs
 RUN (npm i -g --loglevel verbose --production --engine-strict @elastic/synthetics@stack_release || sh -c 'tail -n +1 /root/.npm/_logs/* && exit 1') && \
     chmod ugo+rwX -R $NODE_PATH
+# npm >= 12 blocks dependency install scripts by default, so playwright-chromium's
+# install hook no longer downloads browsers during `npm i`. Install them explicitly
+# with the bundled Playwright CLI (same revision synthetics expects).
+RUN HOME={{ $beatHome }} node "$(npm root -g)/@elastic/synthetics/node_modules/playwright-core/cli.js" install chromium && \
+    test -d {{ $beatHome }}/.cache/ms-playwright
 USER root
 
 # Install the deps as needed by the exact version of playwright elastic synthetics uses
@@ -311,6 +316,11 @@ RUN echo \
 USER {{ .user }}
 
 RUN (npm i -g --loglevel verbose --production --engine-strict  @elastic/synthetics@stack_release || sh -c 'tail -n +1 ${NPM_CONFIG_PREFIX}/_logs/* && exit 1')
+# npm >= 12 blocks dependency install scripts by default, so playwright-chromium's
+# install hook no longer downloads browsers during `npm i`. Install them explicitly
+# with the bundled Playwright CLI (same revision synthetics expects).
+RUN HOME={{ $beatHome }} node "$(npm root -g)/@elastic/synthetics/node_modules/playwright-core/cli.js" install chromium && \
+    test -d {{ $beatHome }}/.cache/ms-playwright
 {{- end }}
 
 USER {{ .user }}


### PR DESCRIPTION
## 📝 Summary

The `elastic-agent-complete` **9.5.0** image ships **with no Playwright browser binaries**, so all Synthetics **browser** monitors on Fleet-managed Private Locations fail:

```
browserType.launch: Executable doesn't exist at
/usr/share/elastic-agent/.cache/ms-playwright/chromium_headless_shell-1228/chrome-linux/headless_shell
```

Fixes #15993.

## 🎯 Root cause

Browsers were provisioned as a side effect of `npm i -g @elastic/synthetics`, via the `install` lifecycle script of transitive `playwright-chromium`.

[#15716](https://github.com/elastic/elastic-agent/pull/15716) (backport [#15743](https://github.com/elastic/elastic-agent/pull/15743)) bumped **npm to 12.0.1**. npm 12 **blocks dependency install scripts by default**, so that hook stopped firing and no browsers were baked.

> [!NOTE]
> Distinct from #15968 / INC-3446 (OTel schedule bug). Here the component starts and `elastic-synthetics` runs — it just can't find the browser binary.

## 🔧 Changes

After `npm i -g @elastic/synthetics@stack_release`, explicitly install browsers with the **bundled** Playwright CLI (same revision synthetics expects), in **both** complete variants. Assert the cache directory exists so a silent miss fails the build.

```dockerfile
RUN HOME={{ $beatHome }} node "$(npm root -g)/@elastic/synthetics/node_modules/playwright-core/cli.js" install chromium && \
    test -d {{ $beatHome }}/.cache/ms-playwright
```

This matches Playwright's recommended path (`npx playwright install` / explicit CLI) and is independent of npm's install-script allowlist ([microsoft/playwright#41083](https://github.com/microsoft/playwright/issues/41083)).

## ✅ Testing

Built a real image layer on GA `elastic-agent-complete:9.5.0` applying the exact RUN above:

- baked: `chromium-1228`, `chromium_headless_shell-1228`, `ffmpeg-1011`
- real inline journey: `✓ Step: 'open blank' succeeded` — `1 passed`

## 🔗 Related

- Standalone heartbeat image: elastic/beats#52439 / elastic/beats#52440

## Backport

Backport to **9.5** (and any branch that shipped the npm-12 bump) so `9.5.1` restores browser monitors.