### PR TITLE
docs: update 9.5.0 Synthetics browser known issue (missing browsers + discourage upgrade)

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -23,33 +23,19 @@ Known issues are significant defects or limitations that may impact your impleme
 % Workaround description.
 % :::
 
-::::{dropdown} {{agent}} Synthetics browser monitors fail to start on private locations when Heartbeat uses the OTel runtime
+::::{dropdown} {{agent}} Synthetics browser monitors fail on private locations on 9.5.0
 
 **Applies to: {{agent}} 9.5.0**
 
-On August 3, 2026, a known issue was discovered where browser (journey) monitors assigned to a {{fleet}}-managed private location never start. {{agent}} reports the Synthetics browser component as permanently failed with `missing required field accessing 'heartbeat.monitors.0.schedule'`. Lightweight monitors (HTTP, TCP, and ICMP) are not affected. This happens because Heartbeat runs under the OTel runtime by default in this version, which rejects the schedule-less data-routing sub-streams (`browser.network` and `browser.screenshot`) that a browser monitor emits.
+**Do not upgrade private location {{agents}} that run Synthetics browser (journey) monitors to 9.5.0.** Keep those agents on **9.4.x** (for example 9.4.4) and wait for **9.5.1**. It is supported to run an older {{agent}} version (such as 9.4.4) against a 9.5.0 {{stack}}. Lightweight monitors (HTTP, TCP, and ICMP) and Elastic-managed locations are not affected.
 
-**Workaround**
+On 9.5.0, browser monitors on {{fleet}}-managed private locations fail for two independent reasons:
 
-Pin Heartbeat back to the process runtime on the {{fleet}} agent policy that backs the affected private location:
+1. **Missing Playwright browser binaries** in the `elastic-agent-complete` image. Journeys fail at launch with `browserType.launch: Executable doesn't exist at .../chromium_headless_shell-<rev>/...`. For more information, check [Issue #15993](https://github.com/elastic/elastic-agent/issues/15993).
 
-1. In {{kib}}, go to **Fleet > Agent policies** and open the agent policy for the private location.
+2. **OTel Heartbeat runtime** rejects browser monitor config and reports the component as permanently failed with `missing required field accessing 'heartbeat.monitors.0.schedule'`. For more information, check [Issue #15968](https://github.com/elastic/elastic-agent/issues/15968).
 
-2. On the **Settings** tab, expand **Advanced settings** and locate **Advanced internal YAML settings**.
-
-3. Enter the following, then select **Save changes**:
-
-    ```yaml
-    runtime:
-      heartbeat:
-        default: process
-    ```
-
-This is equivalent to the agent policy override `{ "agent": { "internal": { "runtime": { "heartbeat": { "default": "process" } } } } }` ({{fleet}} stores the field as `advanced_settings.agent_internal`). The change takes effect on the next policy revision and is fully reversible: remove the setting to return Heartbeat to its default runtime.
-
-To avoid downtime when upgrading from 9.3.x or 9.4.x, apply this override **before** you upgrade. It has no effect on those versions (Heartbeat already runs in the process runtime there), and because the setting lives on the agent policy it is already in effect the moment the agent upgrades to 9.5.0 — so browser monitors keep running through the upgrade.
-
-For more information, check [Issue #15968](https://github.com/elastic/elastic-agent/issues/15968).
+Both issues are addressed in 9.5.1. There is no supported workaround on 9.5.0 that restores browser monitors without changing the agent version.
 ::::
 
 ::::{dropdown} {{agent}} restarts repeatedly in containers after a {{fleet}} policy update


### PR DESCRIPTION
## 📝 Summary

Simplifies the 9.5.0 Synthetics browser-monitor known issue:

- **Do not upgrade** private location agents used for browser monitors to 9.5.0
- Keep them on **9.4.x** (e.g. 9.4.4) and wait for **9.5.1**
- Documents both defects (#15993 missing browsers, #15968 OTel schedule)
- Removes interim workarounds (process-runtime override / derived image)

## ✅ Testing

Docs-only.