### PR TITLE
chore: run go mod tidy after gomod updates in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,11 +19,12 @@
   },
   "packageRules": [
     {
-      "description": "Go modules: schedule, labels, PR limit, and branch prefix",
+      "description": "Go modules: schedule, labels, PR limit, branch prefix, and post-update tidy",
       "matchManagers": ["gomod"],
       "additionalBranchPrefix": "golang/",
       "schedule": ["on monday"],
-      "prConcurrentLimit": 10
+      "prConcurrentLimit": 10,
+      "postUpdateOptions": ["gomodTidy"]
     },
     {
       "description": "misc: catch-all group for Go modules not claimed by a more specific group",


### PR DESCRIPTION
## Summary

- Adds `postUpdateOptions: ["gomodTidy"]` to the Go modules `packageRule` in `renovate.json`
- Renovate will now run `go mod tidy` as part of every gomod PR it creates, keeping all `go.mod`/`go.sum` files consistent with the version changes it makes
- Prevents maintainers from needing to run tidy manually on Renovate branches, which can accidentally pull in unrelated dependency upgrades (e.g. an OTel minor-version cascade when only `golang.org/x` packages were intended to change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)