### PR TITLE
chore: use mage notice directly in post-dependency-update workflow

### DIFF
--- a/.github/workflows/post-dependency-update.yml
+++ b/.github/workflows/post-dependency-update.yml
@@ -76,7 +76,7 @@ jobs:
           git commit -m "Update archive-proxy go.mod"
 
       - name: update NOTICE.txt and NOTICE-fips.txt
-        run: make notice
+        run: mage notice
 
       - name: check for modified NOTICE.txt or NOTICE-fips.txt
         id: notice-check


### PR DESCRIPTION
## Summary

`make notice` is a thin one-line wrapper that just calls `mage notice`. Since `mage` is already installed earlier in the `post-dependency-update` workflow via `magefile/mage-action`, calling `mage notice` directly is cleaner and avoids the unnecessary `make` indirection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)