### PR TITLE
fix(test): retry agent ID lookup in k8sStepForEachAgentID after pod restart

### DIFF
--- a/testing/integration/k8s/kubernetes_agent_standalone_test.go
+++ b/testing/integration/k8s/kubernetes_agent_standalone_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/cli/values"
 
@@ -1185,9 +1186,15 @@ func k8sStepForEachAgentID(agentPodLabelSelector string, expectedPodNumber int, 
 		require.Equal(t, expectedPodNumber, len(perNodePodList.Items), "unexpected number of pods found with selector ", perNodePodList)
 		var stdout, stderr bytes.Buffer
 		for _, pod := range perNodePodList.Items {
-			id, err := k8sGetAgentID(ctx, kCtx.client, &stdout, &stderr, namespace, pod.Name, containerName)
-			require.NoError(t, err, "failed to unenroll agent %s", pod.Name)
-			require.NotEmpty(t, id, "agent id should not be empty")
+			// The agent may be healthy but not yet have a populated ID immediately after
+			// startup or pod restart, so retry until the ID is non-empty.
+			var id string
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				var err error
+				id, err = k8sGetAgentID(ctx, kCtx.client, &stdout, &stderr, namespace, pod.Name, containerName)
+				assert.NoErrorf(c, err, "failed to get agent ID for pod %s (stderr: %s)", pod.Name, stderr.String())
+				assert.NotEmptyf(c, id, "agent id for pod %s should not be empty", pod.Name)
+			}, 2*time.Minute, 5*time.Second)
 			require.NoError(t, cb(ctx, id), "callback for each agent id failed")
 		}
 	}


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition in `k8sStepForEachAgentID` where the agent ID comes back empty immediately after pod startup or restart.

`k8sGetAgentID` runs `elastic-agent status --output=json` inside the pod and returns `status.Info.ID`. After a pod restart the agent can pass the health check in `k8sStepCheckAgentStatus` while still returning an empty ID — it hasn't finished initializing. The previous code called `k8sGetAgentID` exactly once per pod and immediately asserted the ID was non-empty, causing `TestKubernetesFleetServerStatePersistence` (added in #15987) to fail on every CI run.

The fix replaces the single call + `require.NotEmpty` with `require.EventuallyWithT` that retries every 5 s for up to 2 min, consistent with the patience used by other k8s test step helpers (e.g. `k8sStepCheckAgentStatus`).

## Why is it important?

`TestKubernetesFleetServerStatePersistence` was failing on every CI run (`:kubernetes:tier2:*:amd64:basic` jobs), blocking unrelated PRs from getting a clean CI pass.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~ (test-only change, no user-facing impact)
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None.

## How to test this PR locally

Run the `:kubernetes:tier2:*:amd64:basic` CI job and confirm `TestKubernetesFleetServerStatePersistence` passes.

## Related issues

- Relates #15987