### PR TITLE
fix(test): remove redundant embedded field selectors in k8s standalone tests

### DIFF
--- a/testing/integration/k8s/kubernetes_agent_standalone_test.go
+++ b/testing/integration/k8s/kubernetes_agent_standalone_test.go
@@ -1125,7 +1125,7 @@ func k8sStepDeployKustomize(containerName string, overrides k8sKustomizeOverride
 					// to match the test namespace
 					if volume.Name == "elastic-agent-state" {
 						hostPathType := corev1.HostPathDirectoryOrCreate
-						pod.Volumes[volumeIdx].VolumeSource.HostPath = &corev1.HostPathVolumeSource{
+						pod.Volumes[volumeIdx].HostPath = &corev1.HostPathVolumeSource{
 							Type: &hostPathType,
 							Path: fmt.Sprintf("/var/lib/elastic-agent-standalone/%s/state", namespace),
 						}
@@ -1547,7 +1547,7 @@ func k8sStepHintsRedisCheckAgentStatus(agentPodLabelSelector string, hintDeploye
 			require.NotEmpty(t, redisPodList.Items, "no redis pods found with selector ", redisPodSelector)
 			// check that redis pods have the correct annotations
 			for _, redisPod := range redisPodList.Items {
-				hintPackage, ok := redisPod.ObjectMeta.Annotations["co.elastic.hints/package"]
+				hintPackage, ok := redisPod.Annotations["co.elastic.hints/package"]
 				require.True(t, ok, "missing hints annotation")
 				require.Equal(t, "redis", hintPackage, "hints annotation package wrong value")
 			}


### PR DESCRIPTION
## What does this PR do?

Removes redundant embedded field references flagged by staticcheck QF1008 in `testing/integration/k8s/kubernetes_agent_standalone_test.go`:

- Line 1129: `pod.Volumes[volumeIdx].VolumeSource.HostPath` → `pod.Volumes[volumeIdx].HostPath` (`VolumeSource` is an embedded field of `corev1.Volume`)
- Line 1557: `redisPod.ObjectMeta.Annotations` → `redisPod.Annotations` (`ObjectMeta` is an embedded field of `corev1.Pod`)

## Why is it important?

These warnings cause the `lint (*/define)` CI checks to fail, blocking PRs that touch the same file (e.g. #16032).

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~ (test-only, no user-facing impact)
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None.

## How to test this PR locally

```
golangci-lint run --build-tags integration ./testing/integration/k8s/...
```

## Related issues

- Relates #16032