### PR TITLE
fix(windows): local privilege escalation via binary tampering on unprivileged installs

### DIFF
--- a/changelog/fragments/1786027979-fix-local-privilege-escalation-via-binary-tampering-on-windows-unprivileged-installs.yaml
+++ b/changelog/fragments/1786027979-fix-local-privilege-escalation-via-binary-tampering-on-windows-unprivileged-installs.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: security
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix local privilege escalation via binary tampering on Windows unprivileged installs
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/perms/opts.go
+++ b/internal/pkg/agent/perms/opts.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultMask = 0770
+	defaultMask = 0750
 )
 
 type opts struct {

--- a/internal/pkg/agent/perms/unix_test.go
+++ b/internal/pkg/agent/perms/unix_test.go
@@ -41,7 +41,7 @@ func TestFixPermissions_MasksWorldPermissions(t *testing.T) {
 	fileInfo, err := os.Stat(filePath)
 	require.NoError(t, err)
 
-	// Default mask is 0770; ensure "other" bits are removed.
+	// Default mask is 0750; ensure "other" bits are removed.
 	require.Equal(t, os.FileMode(0), dirInfo.Mode().Perm()&0007)
 	require.Equal(t, os.FileMode(0), fileInfo.Mode().Perm()&0007)
 }

--- a/pkg/utils/perm_windows.go
+++ b/pkg/utils/perm_windows.go
@@ -15,7 +15,7 @@ const (
 	// AdministratorSID is the SID for the Administrator user.
 	AdministratorSID = "S-1-5-32-544"
 	// SystemSID is the SID for the SYSTEM user.
-	SystemSID = "S-1-5-32-544"
+	SystemSID = "S-1-5-18"
 	// EveryoneSID is the SID for Everyone.
 	EveryoneSID = "S-1-1-0"
 	// InteractiveSID is the SID for Interactive users.

--- a/pkg/utils/perm_windows.go
+++ b/pkg/utils/perm_windows.go
@@ -128,8 +128,7 @@ func HasStrictExecPerms(path string) error {
 		}
 
 		if ace.Mask&writeMask != 0 {
-			sidStr, _ := sid.String()
-			return fmt.Errorf("non-privileged SID %s has write access to %s", sidStr, path)
+			return fmt.Errorf("non-privileged SID %s has write access to %s", sid.String(), path)
 		}
 	}
 

--- a/pkg/utils/perm_windows.go
+++ b/pkg/utils/perm_windows.go
@@ -8,6 +8,7 @@ package utils
 
 import (
 	"fmt"
+	"runtime"
 	"syscall"
 	"unsafe"
 
@@ -132,6 +133,10 @@ func HasStrictExecPerms(path string) error {
 		}
 	}
 
+	// Keep sd alive through the loop so that dacl/ace/sid interior pointers
+	// remain valid even if a future x/sys version backs the SD with Windows-heap
+	// memory subject to a GC finalizer.
+	runtime.KeepAlive(sd)
 	return nil
 }
 

--- a/pkg/utils/perm_windows.go
+++ b/pkg/utils/perm_windows.go
@@ -9,6 +9,9 @@ package utils
 import (
 	"fmt"
 	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -63,15 +66,80 @@ func CurrentFileOwner() (FileOwner, error) {
 	}, nil
 }
 
-// HasStrictExecPerms ensures that the path is executable by the owner.
+// writeMask covers all access-mask bits that allow a file's content or
+// metadata to be modified, or the file to be deleted/replaced.
+const writeMask = windows.ACCESS_MASK(
+	windows.GENERIC_WRITE | windows.GENERIC_ALL |
+		windows.FILE_WRITE_DATA | windows.FILE_APPEND_DATA |
+		windows.FILE_WRITE_EA | windows.FILE_WRITE_ATTRIBUTES |
+		windows.DELETE | windows.WRITE_DAC | windows.WRITE_OWNER,
+)
+
+// HasStrictExecPerms ensures that no non-privileged SID has write access to
+// the file at path. Privileged SIDs (SYSTEM, Administrators, and the file
+// owner) may have any access; all other SIDs must not hold write-capable bits.
 func HasStrictExecPerms(path string) error {
-	// TODO: Need to add check on Windows to ensure that the ACL are correct for the binary before execution.
+	sd, err := windows.GetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.OWNER_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to get security descriptor for %s: %w", path, err)
+	}
+
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		return fmt.Errorf("failed to get DACL for %s: %w", path, err)
+	}
+	if dacl == nil {
+		return fmt.Errorf("file %s has a null DACL (fully permissive)", path)
+	}
+
+	systemSID, err := windows.StringToSid(SystemSID)
+	if err != nil {
+		return fmt.Errorf("failed to parse SYSTEM SID: %w", err)
+	}
+	adminsSID, err := windows.StringToSid(AdministratorSID)
+	if err != nil {
+		return fmt.Errorf("failed to parse Administrators SID: %w", err)
+	}
+	ownerSID, _, err := sd.Owner()
+	if err != nil {
+		return fmt.Errorf("failed to get owner SID for %s: %w", path, err)
+	}
+
+	for i := uint32(0); i < uint32(dacl.AceCount); i++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(dacl, i, &ace); err != nil {
+			return fmt.Errorf("failed to read ACE %d for %s: %w", i, path, err)
+		}
+
+		// ACCESS_DENIED_ACEs restrict access and are safe to skip.
+		if ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE {
+			continue
+		}
+
+		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+
+		// SYSTEM, Administrators, and the file owner may hold any access.
+		if sid.Equals(systemSID) || sid.Equals(adminsSID) || (ownerSID != nil && sid.Equals(ownerSID)) {
+			continue
+		}
+
+		if ace.Mask&writeMask != 0 {
+			sidStr, _ := sid.String()
+			return fmt.Errorf("non-privileged SID %s has write access to %s", sidStr, path)
+		}
+	}
+
 	return nil
 }
 
-// HasStrictExecPermsAndOwnership ensures that the path is executable by the owner and that the owner of the file
-// is the same as the UID or root.
-func HasStrictExecPermsAndOwnership(path string, uid int) error {
-	// TODO: Need to add check on Windows to ensure that the ACL are correct for the binary before execution.
-	return nil
+// HasStrictExecPermsAndOwnership ensures that the path is executable by the
+// owner and that the ACLs do not grant write access to non-privileged accounts.
+// The uid parameter is unused on Windows; ownership is determined from the
+// file's security descriptor.
+func HasStrictExecPermsAndOwnership(path string, _ int) error {
+	return HasStrictExecPerms(path)
 }

--- a/pkg/utils/perm_windows_test.go
+++ b/pkg/utils/perm_windows_test.go
@@ -1,0 +1,63 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build windows
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+
+	"github.com/elastic/elastic-agent/internal/pkg/acl"
+)
+
+func TestHasStrictExecPerms_OwnerWriteAllowed(t *testing.T) {
+	// A file owned by the current user (no non-privileged group write) should pass.
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "exec.exe")
+	require.NoError(t, os.WriteFile(path, []byte("dummy"), 0600))
+
+	err := HasStrictExecPerms(path)
+	assert.NoError(t, err)
+}
+
+func TestHasStrictExecPerms_NonExistentFile(t *testing.T) {
+	err := HasStrictExecPerms(`C:\does\not\exist\binary.exe`)
+	assert.Error(t, err)
+}
+
+func TestHasStrictExecPerms_GroupWriteRejected(t *testing.T) {
+	// Grant Everyone write access explicitly; HasStrictExecPerms must reject it.
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "tampered.exe")
+	require.NoError(t, os.WriteFile(path, []byte("dummy"), 0600))
+
+	everyoneSID, err := windows.StringToSid(EveryoneSID)
+	require.NoError(t, err)
+
+	// Grant Everyone FILE_WRITE_DATA on the file.
+	err = acl.Apply(path, false, false,
+		acl.GrantSid(windows.FILE_WRITE_DATA, everyoneSID),
+	)
+	require.NoError(t, err)
+
+	err = HasStrictExecPerms(path)
+	assert.Error(t, err, "expected error: Everyone has write access")
+}
+
+func TestHasStrictExecPermsAndOwnership_DelegatesToHasStrictExecPerms(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "exec.exe")
+	require.NoError(t, os.WriteFile(path, []byte("dummy"), 0600))
+
+	// uid is ignored on Windows; result must match HasStrictExecPerms.
+	assert.Equal(t, HasStrictExecPerms(path), HasStrictExecPermsAndOwnership(path, 0))
+	assert.Equal(t, HasStrictExecPerms(path), HasStrictExecPermsAndOwnership(path, 1000))
+}

--- a/testing/installtest/checks_windows.go
+++ b/testing/installtest/checks_windows.go
@@ -100,10 +100,10 @@ func checkPlatform(ctx context.Context, f *atesting.Fixture, topPath string, opt
 		if !hasWellKnownSID(sids, windows.WinBuiltinAdministratorsSid) {
 			return fmt.Errorf("path %s should have ACE for Administrators", topPath)
 		}
-		if !hasWellKnownSID(sids, windows.WinLocalSystemSid) {
-			return fmt.Errorf("path %s should have ACE for SYSTEM", topPath)
-		}
-		// that is 5 unique SID's: elastic-agent-user, elastic-agent group, Administrators, SYSTEM, Interactive
+		// SYSTEM gets a distinct ACE with the fixed SystemSID; older agents
+		// (pre-fix) collapsed SYSTEM and Administrators into one ACE, so we
+		// allow but do not require SYSTEM here for upgrade compatibility.
+		// that is up to 5 unique SID's: elastic-agent-user, elastic-agent group, Administrators, SYSTEM, Interactive
 		if len(sids) > 5 {
 			return fmt.Errorf("DACL has more than allowed ACE for %s (unprivileged): %v", topPath, sids)
 		}
@@ -111,10 +111,10 @@ func checkPlatform(ctx context.Context, f *atesting.Fixture, topPath string, opt
 		if !owner.IsWellKnown(windows.WinBuiltinAdministratorsSid) {
 			return fmt.Errorf("%s not owned by Administrators", topPath)
 		}
-		if !hasWellKnownSID(sids, windows.WinLocalSystemSid) {
-			return fmt.Errorf("path %s should have ACE for SYSTEM", topPath)
-		}
-		// that is 3 unique SIDs: Administrators, SYSTEM, Interactive
+		// SYSTEM gets a distinct ACE with the fixed SystemSID; older agents
+		// (pre-fix) collapsed SYSTEM and Administrators into one ACE, so we
+		// allow but do not require SYSTEM here for upgrade compatibility.
+		// that is up to 3 unique SIDs: Administrators, SYSTEM, Interactive
 		if len(sids) > 3 {
 			return fmt.Errorf("DACL has more than allowed ACE for %s (privileged): %v", topPath, sids)
 		}

--- a/testing/installtest/checks_windows.go
+++ b/testing/installtest/checks_windows.go
@@ -111,9 +111,11 @@ func checkPlatform(ctx context.Context, f *atesting.Fixture, topPath string, opt
 		if !owner.IsWellKnown(windows.WinBuiltinAdministratorsSid) {
 			return fmt.Errorf("%s not owned by Administrators", topPath)
 		}
-		// that is 2 unique SID, it should not have anymore
-		// Administrators and INTERACTIVE
-		if len(sids) > 2 {
+		if !hasWellKnownSID(sids, windows.WinLocalSystemSid) {
+			return fmt.Errorf("path %s should have ACE for SYSTEM", topPath)
+		}
+		// that is 3 unique SIDs: Administrators, SYSTEM, Interactive
+		if len(sids) > 3 {
 			return fmt.Errorf("DACL has more than allowed ACE for %s (privileged): %v", topPath, sids)
 		}
 	}

--- a/testing/installtest/checks_windows.go
+++ b/testing/installtest/checks_windows.go
@@ -96,12 +96,15 @@ func checkPlatform(ctx context.Context, f *atesting.Fixture, topPath string, opt
 		if !hasSID(sids, gidSID) {
 			return fmt.Errorf("path %s should have ACE for %s group", topPath, group)
 		}
-		// administrators should have access as well
+		// administrators and SYSTEM should have access as well
 		if !hasWellKnownSID(sids, windows.WinBuiltinAdministratorsSid) {
 			return fmt.Errorf("path %s should have ACE for Administrators", topPath)
 		}
-		// that is 4 unique SID's, it should not have anymore
-		if len(sids) > 4 {
+		if !hasWellKnownSID(sids, windows.WinLocalSystemSid) {
+			return fmt.Errorf("path %s should have ACE for SYSTEM", topPath)
+		}
+		// that is 5 unique SID's: elastic-agent-user, elastic-agent group, Administrators, SYSTEM, Interactive
+		if len(sids) > 5 {
 			return fmt.Errorf("DACL has more than allowed ACE for %s (unprivileged): %v", topPath, sids)
 		}
 	} else {


### PR DESCRIPTION
## What does this PR do?

Fixes a local privilege escalation (LPE) vulnerability on Windows when Elastic Agent is installed with `--unprivileged`. Two changes:

1. **Removes group write from the default install permission mask** (`0770` → `0750`). The group `r-x` (read+execute) is sufficient — group members do not need to write to the install directory.

2. **Implements `HasStrictExecPerms` on Windows**, which was a no-op stub (`return nil`). The implementation reads each file's DACL via `GetNamedSecurityInfo` and rejects execution if any non-privileged SID (not SYSTEM, not Administrators, not the file owner) holds write-capable access bits (`GENERIC_WRITE`, `GENERIC_ALL`, `FILE_WRITE_DATA`, `FILE_APPEND_DATA`, `FILE_WRITE_EA`, `FILE_WRITE_ATTRIBUTES`, `DELETE`, `WRITE_DAC`, `WRITE_OWNER`).

Also fixes an incidental bug where `SystemSID` was set to `S-1-5-32-544` (the Administrators group SID) rather than `S-1-5-18` (the SYSTEM account SID).

## Why is it important?

On Windows unprivileged installs, the `elastic-agent` group was granted Modify (write) access to component binaries (e.g. `agentbeat.exe`) because the default mask `0770` translates the group-write bit to Windows Modify permissions. Any local user in the `elastic-agent` group could replace a component binary. After a restart, the agent service would execute the tampered binary as `elastic-agent-user`, which holds `SeImpersonatePrivilege`, enabling escalation to `NT AUTHORITY\SYSTEM` via standard potato-class exploits.


## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

The permission mask change (`0770` → `0750`) removes write access for members of the `elastic-agent` group to files in the install directory. Group members were only ever intended to interact with the agent via its socket — not to write files. There is no expected disruption to legitimate use cases.

## How to test this PR locally

Requires a Windows (amd64) machine.

**1. Build for Windows (amd64)**

```bash
PLATFORMS=windows/amd64 mage package
# Produces: build/distributions/elastic-agent-<version>-windows-x86_64.zip
```

**2. Install in unprivileged mode on the Windows machine**

Open PowerShell as Administrator, then:

```powershell
# Extract the zip
Expand-Archive -Path "elastic-agent-<version>-windows-x86_64.zip" -DestinationPath C:\Temp\ea
Set-Location "C:\Temp\ea\elastic-agent-<version>-windows-x86_64"

# Install in unprivileged mode (creates elastic-agent-user account and elastic-agent group)
.\elastic-agent.exe install --unprivileged --non-interactive
```

**3. Verify the permission fix (Commit 1)**

```powershell
# Group should show (RX) — read+execute only — not (M) for Modify
icacls "C:\Program Files\Elastic\Agent\data\elastic-agent-*\components\agentbeat.exe"
```

**4. Verify `HasStrictExecPerms` (Commit 3)**

Add a non-privileged user to the `elastic-agent` group (to simulate the attack surface), grant Everyone write on a component binary, then confirm the agent refuses to start that component:

```powershell
# Grant Everyone write access to agentbeat.exe
$target = (Get-Item "C:\Program Files\Elastic\Agent\data\elastic-agent-*\components\agentbeat.exe").FullName
icacls $target /grant "Everyone:(W)"

# Restart the agent service and check logs for the rejection
Restart-Service elastic-agent
# In C:\Program Files\Elastic\Agent\data\elastic-agent-*\logs\elastic-agent-*.ndjson,
# look for: "non-privileged SID ... has write access"
```

## Related issues