### PR TITLE
Stop mergify from closing renovate/dependabot PRs on conflicts

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -80,6 +80,8 @@ pull_request_rules:
       - -closed
       - conflict
       - label=automation
+      - "author!=elastic-renovate-prod[bot]"
+      - "author!=dependabot[bot]"
     actions:
       close:
         message: |


### PR DESCRIPTION
Renovate and dependabot can handle conflicts on their own.