### PR TITLE
Fix Windows FIPS upgrade failure caused by mismatched directory name

### DIFF
--- a/changelog/fragments/1786061388-strip-fips-from-zip-filename-prefix.yaml
+++ b/changelog/fragments/1786061388-strip-fips-from-zip-filename-prefix.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix Windows FIPS upgrade failure caused by mismatched directory name
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/upgrade/step_unpack.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack.go
@@ -125,7 +125,7 @@ func unzip(log *logger.Logger, archivePath, dataDir string, flavor string, copy 
 	}
 	defer r.Close()
 
-	fileNamePrefix := strings.TrimSuffix(filepath.Base(archivePath), ".zip") + "/" // omitting `elastic-agent-{version}-{os}-{arch}/` in filename
+	fileNamePrefix := getFileNamePrefix(archivePath)
 
 	pm := pathMapper{}
 	var versionedHome string
@@ -266,7 +266,7 @@ func getPackageMetadataFromZip(archivePath string) (packageMetadata, error) {
 		return packageMetadata{}, fmt.Errorf("opening zip archive %q: %w", archivePath, err)
 	}
 	defer r.Close()
-	fileNamePrefix := strings.TrimSuffix(filepath.Base(archivePath), ".zip") + "/" // omitting `elastic-agent-{version}-{os}-{arch}/` in filename
+	fileNamePrefix := getFileNamePrefix(archivePath)
 	return getPackageMetadataFromZipReader(r, fileNamePrefix)
 }
 
@@ -660,10 +660,11 @@ func readCommitHash(reader io.Reader) (string, error) {
 }
 
 func getFileNamePrefix(archivePath string) string {
-	prefix := strings.TrimSuffix(filepath.Base(archivePath), ".tar.gz") + "/" // omitting `elastic-agent-{version}-{os}-{arch}/` in filename
-	prefix = strings.Replace(prefix, fipsPrefix, "", 1)
-
-	return prefix
+	base := filepath.Base(archivePath)
+	base = strings.TrimSuffix(base, ".tar.gz")
+	base = strings.TrimSuffix(base, ".zip")
+	base = strings.Replace(base, fipsPrefix, "", 1)
+	return base + "/"
 }
 
 func validFileName(p string) bool {

--- a/internal/pkg/agent/application/upgrade/step_unpack_test.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack_test.go
@@ -762,11 +762,11 @@ func TestGetFileNamePrefix(t *testing.T) {
 		archivePath    string
 		expectedPrefix string
 	}{
-		"fips": {
+		"fips_tar_gz": {
 			archivePath:    "/foo/bar/elastic-agent-fips-9.1.0-SNAPSHOT-linux-arm64.tar.gz",
 			expectedPrefix: "elastic-agent-9.1.0-SNAPSHOT-linux-arm64/",
 		},
-		"no_fips": {
+		"no_fips_tar_gz": {
 			archivePath:    "/foo/bar/elastic-agent-9.1.0-SNAPSHOT-linux-arm64.tar.gz",
 			expectedPrefix: "elastic-agent-9.1.0-SNAPSHOT-linux-arm64/",
 		},

--- a/internal/pkg/agent/application/upgrade/step_unpack_test.go
+++ b/internal/pkg/agent/application/upgrade/step_unpack_test.go
@@ -770,6 +770,14 @@ func TestGetFileNamePrefix(t *testing.T) {
 			archivePath:    "/foo/bar/elastic-agent-9.1.0-SNAPSHOT-linux-arm64.tar.gz",
 			expectedPrefix: "elastic-agent-9.1.0-SNAPSHOT-linux-arm64/",
 		},
+		"fips_zip": {
+			archivePath:    "/foo/bar/elastic-agent-fips-9.1.0-SNAPSHOT-windows-x86_64.zip",
+			expectedPrefix: "elastic-agent-9.1.0-SNAPSHOT-windows-x86_64/",
+		},
+		"no_fips_zip": {
+			archivePath:    "/foo/bar/elastic-agent-9.1.0-SNAPSHOT-windows-x86_64.zip",
+			expectedPrefix: "elastic-agent-9.1.0-SNAPSHOT-windows-x86_64/",
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION

## What does this PR do?

Strip 'fips' from filename prefix for .zip in the upgrade unpack step, matching the naming for .tar.gz archives.

## Why is it important?

Windows FIPS upgrades failed due to a mismatch between the directory name computed from the zip filename and the actual directory name inside the archive.

## Checklist

- [X] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [X] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~ Upgrade integration tests for Windows FIPS should be enabled in separate PR for tracking.

## Disruptive User Impact

N/A

## How to test this PR locally

`go test ./internal/pkg/agent/application/upgrade/... -run TestGetFileNamePrefix -v`

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/16050
