### PR TITLE
Fix workflow updating active branches in renovate.json

### DIFF
--- a/.github/workflows/update-renovate-branches.yml
+++ b/.github/workflows/update-renovate-branches.yml
@@ -31,7 +31,7 @@ jobs:
           MATRIX: ${{ steps.generator.outputs.matrix }}
         run: |
           branches=$(printf '%s' "$MATRIX" | jq -c '[.include[].branch]')
-          jq --argjson branches "$branches" '.baseBranches = $branches' \
+          jq --argjson branches "$branches" '.baseBranchPatterns = $branches' \
             renovate.json > renovate.json.new
           mv renovate.json.new renovate.json
 


### PR DESCRIPTION
The field is now called `baseBranchPatterns`.

