### PR TITLE
[beatreceiver] Add support for kerberos on kafka output

### DIFF
--- a/changelog/fragments/1786359572-kafka-kerberos.yaml
+++ b/changelog/fragments/1786359572-kafka-kerberos.yaml
@@ -28,7 +28,7 @@ summary: Adds support for Kerberos in Kafka outputs using OTel runtime.
 
 # REQUIRED for all kinds
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
-component:
+component: elastic-agent
 
 # AUTOMATED
 # OPTIONAL to manually add other PR URLs

--- a/changelog/fragments/1786359572-kafka-kerberos.yaml
+++ b/changelog/fragments/1786359572-kafka-kerberos.yaml
@@ -13,7 +13,7 @@ kind: enhancement
 
 # REQUIRED for all kinds
 # Change summary; a 80ish characters long description of the change.
-summary: Adds support for Kerberos in Kafka outputs using OTel runtime. 
+summary: Add Kerberos authentication support for Kafka outputs in the OTel runtime
 
 # REQUIRED for breaking-change, deprecation, known-issue
 # Long description; in case the summary is not enough to describe the change

--- a/changelog/fragments/1786359572-kafka-kerberos.yaml
+++ b/changelog/fragments/1786359572-kafka-kerberos.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Adds support for Kerberos in Kafka outputs using OTel runtime. 
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component:
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/otel/translate/output_kafka.go
+++ b/internal/pkg/otel/translate/output_kafka.go
@@ -104,6 +104,7 @@ func KafkaToOTelConfig(config *config.C, outputName string, logger *logp.Logger)
 
 	setIfNotNil(kafkaExporter, "tls", tlsCfg)
 	setIfNotNil(kafkaExporter, "record_headers", headers)
+	setIfNotNil(kafkaExporter, "kerberos", getKerberosConfig(kConfig))
 
 	// compiles topic and validates against any malformed strings
 	fmtstr, err := fmtstr.CompileEvent(kConfig.Topic)
@@ -122,6 +123,25 @@ func KafkaToOTelConfig(config *config.C, outputName string, logger *logp.Logger)
 		return kafkaExporter, processor, nil
 	}
 	return kafkaExporter, nil, nil
+}
+
+func getKerberosConfig(kConfig *kafka.KafkaConfig) map[string]any {
+	if !kConfig.Kerberos.IsEnabled() {
+		return nil
+	}
+
+	useKeyTab := kConfig.Kerberos.AuthType.String() == "keytab"
+
+	return map[string]any{
+		"service_name":             kConfig.Kerberos.ServiceName,
+		"realm":                    kConfig.Kerberos.Realm,
+		"username":                 kConfig.Kerberos.Username,
+		"password":                 kConfig.Kerberos.Password,
+		"config_file":              kConfig.Kerberos.ConfigPath,
+		"disable_fast_negotiation": !kConfig.Kerberos.EnableFAST,
+		"keytab_file":              kConfig.Kerberos.KeyTabPath,
+		"use_keytab":               useKeyTab,
+	}
 }
 
 // dynamicTopicSetterProcessor parses topic field with dynamic values such as %{[data_stream.type]}

--- a/internal/pkg/otel/translate/output_kafka.go
+++ b/internal/pkg/otel/translate/output_kafka.go
@@ -84,6 +84,7 @@ func KafkaToOTelConfig(config *config.C, outputName string, logger *logp.Logger)
 		},
 	}
 
+	// Enables SASL authentication
 	if kConfig.Username != "" {
 		if kConfig.Sasl.SaslMechanism == "" {
 			kConfig.Sasl.SaslMechanism = "PLAIN"
@@ -97,6 +98,13 @@ func KafkaToOTelConfig(config *config.C, outputName string, logger *logp.Logger)
 		}
 	}
 
+	// Enables Kerberos authentication
+	if kConfig.Kerberos.IsEnabled() {
+		kafkaExporter["auth"] = map[string]any{
+			"kerberos": getKerberosConfig(kConfig),
+		}
+	}
+
 	tlsCfg, err := TLSToOTel(kConfig.TLS, logger)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error translating tls config :%w", err)
@@ -104,7 +112,6 @@ func KafkaToOTelConfig(config *config.C, outputName string, logger *logp.Logger)
 
 	setIfNotNil(kafkaExporter, "tls", tlsCfg)
 	setIfNotNil(kafkaExporter, "record_headers", headers)
-	setIfNotNil(kafkaExporter, "kerberos", getKerberosConfig(kConfig))
 
 	// compiles topic and validates against any malformed strings
 	fmtstr, err := fmtstr.CompileEvent(kConfig.Topic)

--- a/internal/pkg/otel/translate/output_kafka_nofips_test.go
+++ b/internal/pkg/otel/translate/output_kafka_nofips_test.go
@@ -101,14 +101,14 @@ kerberos:
 			gotMap, _, err := KafkaToOTelConfig(cfg, "", logp.NewNopLogger())
 			require.NoError(t, err, "error translating kafka to kafka exporter")
 
-			gotKerberos, ok := gotMap["kerberos"]
+			gotKerberos, ok := gotMap["auth"]
 			if !tc.expectKerberos {
 				require.False(t, ok, "kerberos should be omitted from exporter config")
 				return
 			}
 
 			require.True(t, ok, "kerberos should be present in exporter config")
-			require.Equal(t, tc.expectedKerberos, gotKerberos)
+			require.Equal(t, tc.expectedKerberos, gotKerberos.(map[string]any)["kerberos"])
 		})
 	}
 }

--- a/internal/pkg/otel/translate/output_kafka_nofips_test.go
+++ b/internal/pkg/otel/translate/output_kafka_nofips_test.go
@@ -1,0 +1,114 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build !requirefips
+
+package translate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+func TestKafkaKerberosTranslation(t *testing.T) {
+	testCases := []struct {
+		name             string
+		input            string
+		expectedKerberos map[string]any
+		expectKerberos   bool
+	}{
+		{
+			name: "kerberos with password auth",
+			input: `
+hosts: ["kafka1:9092"]
+topic: static-topic
+kerberos:
+  enabled: true
+  auth_type: password
+  username: elastic
+  password: changeme
+  config_path: /etc/krb5.conf
+  service_name: kafka
+  realm: ELASTIC
+  enable_krb5_fast: true
+`,
+			expectKerberos: true,
+			expectedKerberos: map[string]any{
+				"service_name":             "kafka",
+				"realm":                    "ELASTIC",
+				"username":                 "elastic",
+				"password":                 "changeme",
+				"config_file":              "/etc/krb5.conf",
+				"disable_fast_negotiation": false,
+				"keytab_file":              "",
+				"use_keytab":               false,
+			},
+		},
+		{
+			name: "kerberos with keytab auth",
+			input: `
+hosts: ["kafka1:9092"]
+topic: static-topic
+kerberos:
+  enabled: true
+  auth_type: keytab
+  username: elastic
+  keytab: /etc/security/kafka.keytab
+  config_path: /etc/krb5.conf
+  service_name: kafka
+  realm: ELASTIC
+`,
+			expectKerberos: true,
+			expectedKerberos: map[string]any{
+				"service_name":             "kafka",
+				"realm":                    "ELASTIC",
+				"username":                 "elastic",
+				"password":                 "",
+				"config_file":              "/etc/krb5.conf",
+				"disable_fast_negotiation": true,
+				"keytab_file":              "/etc/security/kafka.keytab",
+				"use_keytab":               true,
+			},
+		},
+		{
+			name: "kerberos disabled is omitted",
+			input: `
+hosts: ["kafka1:9092"]
+topic: static-topic
+kerberos:
+  enabled: false
+  auth_type: password
+  username: elastic
+  password: changeme
+  config_path: /etc/krb5.conf
+  service_name: kafka
+  realm: ELASTIC
+`,
+			expectKerberos: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := config.NewConfigFrom(tc.input)
+			require.NoError(t, err, "error creating kafka config")
+
+			gotMap, _, err := KafkaToOTelConfig(cfg, "", logp.NewNopLogger())
+			require.NoError(t, err, "error translating kafka to kafka exporter")
+
+			gotKerberos, ok := gotMap["kerberos"]
+			if !tc.expectKerberos {
+				require.False(t, ok, "kerberos should be omitted from exporter config")
+				return
+			}
+
+			require.True(t, ok, "kerberos should be present in exporter config")
+			require.Equal(t, tc.expectedKerberos, gotKerberos)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This PR adds translation logic for kerberos support for kafka output. This was missed in the original kafka translation task.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
This is important for users to switch from process to otel runtime when using kafka output

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact
None

## Testing

1. See [steps mentioned](https://github.com/elastic/beats/issues/39761#issuecomment-5213620665) here to setup kerberos + kafka environment first. 

2. Checkout this branch and run below elastic-agent.yml configuration

<details>

<summary> elastic-agent.yml </summary>

```yml
outputs:
  default:
    type: kafka
    hosts:
      - localhost:9095
    topic: elastic-agent
    required_acks: 1
    compression: gzip
    max_message_bytes: 1000000
    kerberos:
      enabled: true
      auth_type: password
      username: beats
      password: Testing1!
      config_path: /etc/krb5.conf   # must point at a krb5.conf 
      service_name: kafka
      realm: INGEST.EXAMPLE.COM
      enable_krb5_fast: false

inputs:
  - type: system/metrics
    id: system-metrics-kafka-kerberos
    use_output: default
    data_stream.namespace: default
    streams:
      - metricsets:
          - cpu
        data_stream.dataset: system.cpu

agent.monitoring:
  enabled: false
agent.grpc.port: 6799
```

</details>