### PR TITLE
Fix serverless beats workflow on non-main branches

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -472,6 +472,8 @@ steps:
     build:
       commit: "${BUILDKITE_COMMIT}"
       branch: "${BUILDKITE_BRANCH}"
+      env:
+        BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
     if_changed:
       include:
         - .buildkite/serverless.beats.tests.yml

--- a/.buildkite/scripts/steps/beats_tests.sh
+++ b/.buildkite/scripts/steps/beats_tests.sh
@@ -11,6 +11,9 @@ set -euo pipefail
 source .buildkite/scripts/common.sh
 STACK_PROVISIONER="${1:-"serverless"}"
 
+# We don't want any metadata from .package-version in these tests
+export USE_PACKAGE_VERSION=false
+
 run_test_for_beat(){
     export GOFLAGS='-buildvcs=false'
     local beat_name=$1
@@ -44,7 +47,8 @@ mage -l
 mkdir -p /tmp/beats-build
 pushd /tmp/beats-build
 
-git clone --depth=1 git@github.com:elastic/beats.git
+BEATS_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-${BUILDKITE_BRANCH}}"
+git clone --depth=1 --branch "${BEATS_BRANCH}" git@github.com:elastic/beats.git
 popd
 
 # export WORKSPACE=beats/x-pack/metricbeat


### PR DESCRIPTION
The script was always cloning beats main, so the beats build version would diverge from what the integration runner expects on maintenance branches where beats main has moved ahead.

Use the Buildkite-provided branch name directly: the PR base branch when running in PR context, otherwise the current branch. Branch names are kept in sync between elastic-agent and beats.

Also disable reading from .package-version in these tests to prevent local metadata from leaking into the Beats build.

No backports, as this change is included in the backports of https://github.com/elastic/elastic-agent/pull/15924.
