### PR TITLE
fix(policy): do not ACK POLICY_CHANGE when state store write fails

### DIFF
--- a/changelog/fragments/1786364798-agent-no-longer-acks-fleet-policy-change-when-state-store-write-fails.yaml
+++ b/changelog/fragments/1786364798-agent-no-longer-acks-fleet-policy-change-when-state-store-write-fails.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Agent no longer ACKs Fleet policy change when state store write fails
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/15126

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/storage"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
+	monitoringCfg "github.com/elastic/elastic-agent/internal/pkg/core/monitoring/config"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/acker"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
 	"github.com/elastic/elastic-agent/internal/pkg/remote"
@@ -293,12 +294,25 @@ func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.
 		return runtimeErr
 	}
 
-	// Step 5: Commit. Nothing below can fail so we update the caches, persist the
-	// config and the action and then re-exec.
+	// Step 5: Commit. Both disk writes must succeed before we return nil so
+	// that Fleet re-delivers the action if either write fails. Disk failures
+	// must not propagate as ACK failures — see
+	// https://github.com/elastic/elastic-agent/issues/13677.
 	//
-	// The caches are updated here, not earlier, because they are the baseline we
-	// compare the next policy against. If we updated them before a failure, the
-	// resent policy would look unchanged and we would skip re-applying it.
+	// Write order: saveConfig first, stateStore second.
+	//
+	// If saveConfig fails, stateStore is untouched. On restart the agent
+	// loads the old stateStore action and reports the old policy_revision_idx
+	// to Fleet, which re-delivers the policy — clean recovery.
+	//
+	// If stateStore fails after saveConfig succeeded, we restore the
+	// in-memory stateStore action so the fleet gateway continues to report
+	// the old policy_revision_idx via the checkin heartbeat (Fleet Server
+	// advances agent.policy_revision from that field without waiting for an
+	// explicit ACK). On restart the agent loads the old stateStore action
+	// from disk and Fleet re-delivers; saveConfig is idempotently
+	// overwritten on the second delivery.
+	snap := h.snapshotConfig()
 	hasEventLoggingChanged := h.applyEventLoggingOutputChange(cfg, partialCfg)
 	hasLoggingChanged := h.applyLoggingConfigChange(cfg, loggingConfig)
 
@@ -311,12 +325,21 @@ func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.
 	h.applyMonitoringConfigChange(partialCfg)
 
 	if err := saveConfig(h.agentInfo, h.config, h.store, h.log); err != nil {
+		h.restoreConfig(snap)
 		return fmt.Errorf("failed to persist policy config: %w", err)
 	}
 	if h.stateStore != nil && action != nil {
+		prevAction := h.stateStore.Action()
 		h.stateStore.SetAction(action)
 		if err := h.stateStore.Save(); err != nil {
-			h.log.Warnf("failed to persist policy action to state store: %v", err)
+			// Restore so the fleet gateway does not report the new revision to
+			// Fleet Server before it is on disk; Fleet Server advances
+			// agent.policy_revision from the checkin's policy_revision_idx
+			// without waiting for an explicit ACK. Restore unconditionally
+			// (even when prevAction is nil) so the in-memory action always
+			// mirrors what is on disk.
+			h.stateStore.SetAction(prevAction)
+			return fmt.Errorf("failed to persist policy action to state store: %w", err)
 		}
 	}
 
@@ -349,6 +372,36 @@ func (h *PolicyChangeHandler) parsePolicyConfiguration(c *config.Config) (*confi
 	cfg.UCfg = c
 
 	return cfg, nil
+}
+
+// handlerConfigSnapshot captures the h.config fields that handlePolicyChange
+// mutates before calling saveConfig, so they can be restored atomically if
+// saveConfig fails. Add a field here whenever a new mutation is introduced
+// before the saveConfig call.
+type handlerConfigSnapshot struct {
+	eventLogging    logger.Config
+	logging         logger.Config
+	fleetClient     remote.Config
+	monitoringHTTP  *monitoringCfg.MonitoringHTTPConfig
+	monitoringPprof *monitoringCfg.PprofConfig
+}
+
+func (h *PolicyChangeHandler) snapshotConfig() handlerConfigSnapshot {
+	return handlerConfigSnapshot{
+		eventLogging:    *h.config.Settings.EventLoggingConfig,
+		logging:         *h.config.Settings.LoggingConfig,
+		fleetClient:     h.config.Fleet.Client,
+		monitoringHTTP:  h.config.Settings.MonitoringConfig.HTTP,
+		monitoringPprof: h.config.Settings.MonitoringConfig.Pprof,
+	}
+}
+
+func (h *PolicyChangeHandler) restoreConfig(snap handlerConfigSnapshot) {
+	*h.config.Settings.EventLoggingConfig = snap.eventLogging
+	*h.config.Settings.LoggingConfig = snap.logging
+	h.config.Fleet.Client = snap.fleetClient
+	h.config.Settings.MonitoringConfig.HTTP = snap.monitoringHTTP
+	h.config.Settings.MonitoringConfig.Pprof = snap.monitoringPprof
 }
 
 func (h *PolicyChangeHandler) applyEventLoggingOutputChange(new, partial *configuration.Configuration) bool {
@@ -576,17 +629,13 @@ func (l *policyChange) Config() *config.Config {
 
 // Ack is the post-apply hook called by the coordinator's ack chain.
 //
-// The work happens in three steps so that the error returned by Ack reflects
-// only Fleet-side ack failures, not local persistence failures (see
+// Disk persistence happens in Handle() so that the error returned by Ack
+// reflects only Fleet-side ack failures, not local persistence failures (see
 // https://github.com/elastic/elastic-agent/issues/13677):
 //
-//  1. Persist the POLICY_CHANGE action to the state store and broadcast the
-//     policy id and revision to live consumers. Persistence failures are
-//     logged at warn level but do not propagate, so a transient disk hiccup
-//     does not masquerade as a Fleet ack failure.
-//  2. Send the network ack (unless explicitly disabled). A failure here
+//  1. Send the network ack (unless explicitly disabled). A failure here
 //     propagates so the coordinator can retry.
-//  3. Commit the ack batch. Failures propagate.
+//  2. Commit the ack batch. Failures propagate.
 func (l *policyChange) Ack() error {
 	if !l.disableAck && l.action != nil {
 		if err := l.acker.Ack(l.ctx, l.action); err != nil {

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -294,38 +294,16 @@ func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.
 		return runtimeErr
 	}
 
-	// Step 5: Commit. Both disk writes must succeed before we return nil so
-	// that Fleet re-delivers the action if either write fails. Disk failures
-	// must not propagate as ACK failures — see
-	// https://github.com/elastic/elastic-agent/issues/13677.
+	// Step 5: Commit. Both writes must succeed; Fleet re-delivers the action on
+	// the next checkin if either fails.
 	//
-	// Write order: saveConfig first, stateStore second.
-	//
-	// If saveConfig fails, stateStore is untouched. On restart the agent
-	// loads the old stateStore action and reports the old policy_revision_idx
-	// to Fleet, which re-delivers the policy — clean recovery.
-	//
-	// If stateStore fails after saveConfig succeeded, we restore the
-	// in-memory stateStore action so the fleet gateway continues to report
-	// the old policy_revision_idx via the checkin heartbeat (Fleet Server
-	// advances agent.policy_revision from that field without waiting for an
-	// explicit ACK). On restart the agent loads the old stateStore action
-	// from disk and Fleet re-delivers; saveConfig is idempotently
-	// overwritten on the second delivery.
-	snap := h.snapshotConfig()
-	hasEventLoggingChanged := h.applyEventLoggingOutputChange(cfg, partialCfg)
-	hasLoggingChanged := h.applyLoggingConfigChange(cfg, loggingConfig)
+	// If saveConfig succeeds but SaveAction fails, fleet.enc holds the new config
+	// while state.enc still records the old action. On restart Fleet re-delivers
+	// the policy and the agent re-applies it; this is safe because policies are
+	// idempotent.
+	patch, needsReExec := h.buildConfigPatch(cfg, partialCfg, validatedFleetConfig, loggingConfig)
 
-	if validatedFleetConfig != nil {
-		h.config.Fleet.Client = *validatedFleetConfig
-	}
-	if loggingConfig != nil {
-		h.config.Settings.LoggingConfig.Level = loggingConfig.Level
-	}
-	h.applyMonitoringConfigChange(partialCfg)
-
-	if err := saveConfig(h.agentInfo, h.config, h.store, h.log); err != nil {
-		h.restoreConfig(snap)
+	if err := saveConfig(h.agentInfo, h.configWithPatch(patch), h.store, h.log); err != nil {
 		return fmt.Errorf("failed to persist policy config: %w", err)
 	}
 	if h.stateStore != nil {
@@ -334,8 +312,8 @@ func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.
 		}
 	}
 
-	// Re-exec so the new event logging output is applied on restart.
-	if hasEventLoggingChanged || hasLoggingChanged {
+	h.commitConfig(patch)
+	if needsReExec {
 		h.runtimeLogLevelSetter.ReExec(nil)
 	}
 
@@ -365,11 +343,9 @@ func (h *PolicyChangeHandler) parsePolicyConfiguration(c *config.Config) (*confi
 	return cfg, nil
 }
 
-// handlerConfigSnapshot captures the h.config fields that handlePolicyChange
-// mutates before calling saveConfig, so they can be restored atomically if
-// saveConfig fails. Add a field here whenever a new mutation is introduced
-// before the saveConfig call.
-type handlerConfigSnapshot struct {
+// configPatch holds the pending new values for h.config fields that
+// handlePolicyChange may update.
+type configPatch struct {
 	eventLogging    logger.Config
 	logging         logger.Config
 	fleetClient     remote.Config
@@ -377,79 +353,112 @@ type handlerConfigSnapshot struct {
 	monitoringPprof *monitoringCfg.PprofConfig
 }
 
-func (h *PolicyChangeHandler) snapshotConfig() handlerConfigSnapshot {
-	return handlerConfigSnapshot{
+// buildConfigPatch computes the pending config values from the incoming policy.
+// Returns the patch and whether a re-exec is needed.
+func (h *PolicyChangeHandler) buildConfigPatch(
+	cfg *configuration.Configuration,
+	partialCfg *configuration.Configuration,
+	validatedFleetConfig *remote.Config,
+	loggingConfig *logger.Config,
+) (configPatch, bool) {
+	patch := configPatch{
 		eventLogging:    *h.config.Settings.EventLoggingConfig,
 		logging:         *h.config.Settings.LoggingConfig,
 		fleetClient:     h.config.Fleet.Client,
 		monitoringHTTP:  h.config.Settings.MonitoringConfig.HTTP,
 		monitoringPprof: h.config.Settings.MonitoringConfig.Pprof,
 	}
+	needsReExec := false
+
+	// Event logging output change.
+	if (h.fallbackConfig != nil || (partialCfg != nil &&
+		partialCfg.Settings != nil &&
+		partialCfg.Settings.EventLoggingConfig != nil)) &&
+		cfg != nil &&
+		cfg.Settings != nil &&
+		cfg.Settings.EventLoggingConfig != nil {
+		incoming := cfg.Settings.EventLoggingConfig
+		if patch.eventLogging.ToFiles != incoming.ToFiles || patch.eventLogging.ToStderr != incoming.ToStderr {
+			patch.eventLogging.ToFiles = incoming.ToFiles
+			patch.eventLogging.ToStderr = incoming.ToStderr
+			needsReExec = true
+		}
+	}
+
+	// Logging output change (ToFiles/ToStderr/Files.Path drive re-exec; Level is set separately).
+	if (h.fallbackConfig != nil || loggingConfig != nil) &&
+		cfg != nil &&
+		cfg.Settings != nil &&
+		cfg.Settings.LoggingConfig != nil {
+		incoming := cfg.Settings.LoggingConfig
+		if patch.logging.ToFiles != incoming.ToFiles ||
+			patch.logging.ToStderr != incoming.ToStderr ||
+			patch.logging.Files.Path != incoming.Files.Path {
+			patch.logging.ToFiles = incoming.ToFiles
+			patch.logging.ToStderr = incoming.ToStderr
+			patch.logging.Files.Path = incoming.Files.Path
+			needsReExec = true
+		}
+	}
+	if loggingConfig != nil {
+		patch.logging.Level = loggingConfig.Level
+	}
+
+	// Fleet client.
+	if validatedFleetConfig != nil {
+		patch.fleetClient = *validatedFleetConfig
+	}
+
+	// Monitoring config — only override when the policy explicitly carries the
+	// section (partialCfg is unpacked without defaults, so nil means absent).
+	// This preserves locally configured values (e.g. agent.monitoring.http.host)
+	// instead of clobbering them with library defaults on every policy check-in.
+	// See https://github.com/elastic/elastic-agent/issues/4582.
+	if partialCfg != nil && partialCfg.Settings != nil && partialCfg.Settings.MonitoringConfig != nil {
+		if partialCfg.Settings.MonitoringConfig.HTTP != nil {
+			patch.monitoringHTTP = partialCfg.Settings.MonitoringConfig.HTTP
+		}
+		if partialCfg.Settings.MonitoringConfig.Pprof != nil {
+			patch.monitoringPprof = partialCfg.Settings.MonitoringConfig.Pprof
+		}
+	}
+
+	return patch, needsReExec
 }
 
-func (h *PolicyChangeHandler) restoreConfig(snap handlerConfigSnapshot) {
-	*h.config.Settings.EventLoggingConfig = snap.eventLogging
-	*h.config.Settings.LoggingConfig = snap.logging
-	h.config.Fleet.Client = snap.fleetClient
-	h.config.Settings.MonitoringConfig.HTTP = snap.monitoringHTTP
-	h.config.Settings.MonitoringConfig.Pprof = snap.monitoringPprof
+// configWithPatch returns a copy of h.config with the patch fields applied.
+func (h *PolicyChangeHandler) configWithPatch(patch configPatch) *configuration.Configuration {
+	cfgCopy := *h.config
+	settingsCopy := *h.config.Settings
+	cfgCopy.Settings = &settingsCopy
+
+	eventLoggingCopy := patch.eventLogging
+	settingsCopy.EventLoggingConfig = &eventLoggingCopy
+
+	loggingCopy := patch.logging
+	settingsCopy.LoggingConfig = &loggingCopy
+
+	// Fleet is a shared pointer after the shallow copy; isolate before modifying Client.
+	fleetCopy := *h.config.Fleet
+	cfgCopy.Fleet = &fleetCopy
+	fleetCopy.Client = patch.fleetClient
+
+	// MonitoringConfig is likewise a shared pointer; isolate before replacing HTTP and Pprof.
+	monitoringCopy := *h.config.Settings.MonitoringConfig
+	settingsCopy.MonitoringConfig = &monitoringCopy
+	monitoringCopy.HTTP = patch.monitoringHTTP
+	monitoringCopy.Pprof = patch.monitoringPprof
+
+	return &cfgCopy
 }
 
-func (h *PolicyChangeHandler) applyEventLoggingOutputChange(new, partial *configuration.Configuration) bool {
-	if h.fallbackConfig == nil && (partial == nil || partial.Settings == nil || partial.Settings.EventLoggingConfig == nil) {
-		return false
-	}
-	if new == nil || new.Settings == nil || new.Settings.EventLoggingConfig == nil {
-		return false
-	}
-
-	current := h.config.Settings.EventLoggingConfig
-	incoming := new.Settings.EventLoggingConfig
-
-	if current.ToFiles == incoming.ToFiles && current.ToStderr == incoming.ToStderr {
-		return false
-	}
-
-	current.ToFiles = incoming.ToFiles
-	current.ToStderr = incoming.ToStderr
-	return true
-}
-
-// applyMonitoringConfigChange updates h.config.Settings.MonitoringConfig.HTTP/Pprof only when the
-// incoming policy explicitly sets them (partialCfg is unpacked without defaults, so a nil HTTP/Pprof
-// means the policy didn't carry that section at all). Fleet policies don't have a way to set
-// monitoring.http today, so this preserves whatever was configured locally (e.g.
-// agent.monitoring.http.host in elastic-agent.yml) instead of clobbering it with library defaults
-// on every policy check-in. Mirrors the EnabledIsSet safeguard in monitoring/reload/reload.go,
-// see https://github.com/elastic/elastic-agent/issues/4582.
-func (h *PolicyChangeHandler) applyMonitoringConfigChange(partialCfg *configuration.Configuration) {
-	if partialCfg == nil || partialCfg.Settings == nil || partialCfg.Settings.MonitoringConfig == nil {
-		return
-	}
-
-	if partialCfg.Settings.MonitoringConfig.HTTP != nil {
-		h.config.Settings.MonitoringConfig.HTTP = partialCfg.Settings.MonitoringConfig.HTTP
-	}
-	if partialCfg.Settings.MonitoringConfig.Pprof != nil {
-		h.config.Settings.MonitoringConfig.Pprof = partialCfg.Settings.MonitoringConfig.Pprof
-	}
-}
-
-func (h *PolicyChangeHandler) applyLoggingConfigChange(new *configuration.Configuration, loggingConfig *logger.Config) bool {
-	if h.fallbackConfig == nil && loggingConfig == nil {
-		return false
-	}
-	current := h.config.Settings.LoggingConfig
-	incoming := new.Settings.LoggingConfig
-	if current.ToFiles == incoming.ToFiles && current.ToStderr == incoming.ToStderr && current.Files.Path == incoming.Files.Path {
-		// if there is no change in the logging output settings, we consider that there is no change to the logging config
-		return false
-	}
-
-	current.ToFiles = incoming.ToFiles
-	current.ToStderr = incoming.ToStderr
-	current.Files.Path = incoming.Files.Path
-	return true
+// commitConfig applies the patch to h.config.
+func (h *PolicyChangeHandler) commitConfig(patch configPatch) {
+	*h.config.Settings.EventLoggingConfig = patch.eventLogging
+	*h.config.Settings.LoggingConfig = patch.logging
+	h.config.Fleet.Client = patch.fleetClient
+	h.config.Settings.MonitoringConfig.HTTP = patch.monitoringHTTP
+	h.config.Settings.MonitoringConfig.Pprof = patch.monitoringPprof
 }
 
 func validateLoggingConfig(cfg *configuration.Configuration) (*logger.Config, error) {

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change.go
@@ -328,17 +328,8 @@ func (h *PolicyChangeHandler) handlePolicyChange(ctx context.Context, c *config.
 		h.restoreConfig(snap)
 		return fmt.Errorf("failed to persist policy config: %w", err)
 	}
-	if h.stateStore != nil && action != nil {
-		prevAction := h.stateStore.Action()
-		h.stateStore.SetAction(action)
-		if err := h.stateStore.Save(); err != nil {
-			// Restore so the fleet gateway does not report the new revision to
-			// Fleet Server before it is on disk; Fleet Server advances
-			// agent.policy_revision from the checkin's policy_revision_idx
-			// without waiting for an explicit ACK. Restore unconditionally
-			// (even when prevAction is nil) so the in-memory action always
-			// mirrors what is on disk.
-			h.stateStore.SetAction(prevAction)
+	if h.stateStore != nil {
+		if err := h.stateStore.SaveAction(action); err != nil {
 			return fmt.Errorf("failed to persist policy action to state store: %w", err)
 		}
 	}

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"sync"
 	"testing"
@@ -35,6 +36,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/agent/configuration"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/storage"
 	"github.com/elastic/elastic-agent/internal/pkg/config"
+	monitoringCfg "github.com/elastic/elastic-agent/internal/pkg/core/monitoring/config"
 	noopacker "github.com/elastic/elastic-agent/internal/pkg/fleetapi/acker/noop"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
 	"github.com/elastic/elastic-agent/internal/pkg/remote"
@@ -1592,10 +1594,9 @@ func TestFleetToReaderPersistsLoggingOutputFlags(t *testing.T) {
 		}))
 		require.NoError(t, err)
 
-		assert.False(t, h.applyLoggingConfigChange(policyWithSameLogging, &logger.Config{
-			ToStderr: true,
-			ToFiles:  false,
-		}),
+		loggingConfig := &logger.Config{ToStderr: true, ToFiles: false}
+		_, needsReExec := h.buildConfigPatch(policyWithSameLogging, nil, nil, loggingConfig)
+		assert.False(t, needsReExec,
 			"after re-exec + reload the same policy must not be detected as a logging change, which would cause an infinite re-exec loop")
 	})
 }
@@ -1605,6 +1606,19 @@ func defaultLogLevelSet(t *testing.T) *mockLogLevelSetter {
 	logLevelSetter := newMockLogLevelSetter(t)
 	logLevelSetter.EXPECT().SetLogLevel(mock.Anything, &defaultLogLevel).Return(nil).Once()
 	return logLevelSetter
+}
+
+// configPatchFrom reads a configPatch-shaped snapshot from a full configuration.
+// It is the reverse of configWithPatch and commitConfig, used to verify that
+// those functions cover every field in configPatch.
+func configPatchFrom(cfg *configuration.Configuration) configPatch {
+	return configPatch{
+		eventLogging:    *cfg.Settings.EventLoggingConfig,
+		logging:         *cfg.Settings.LoggingConfig,
+		fleetClient:     cfg.Fleet.Client,
+		monitoringHTTP:  cfg.Settings.MonitoringConfig.HTTP,
+		monitoringPprof: cfg.Settings.MonitoringConfig.Pprof,
+	}
 }
 
 // mockStateStore implements the package-local stateStore interface to spy on
@@ -1660,17 +1674,25 @@ func TestPolicyChangeStateStoreSaveFail(t *testing.T) {
 	ch := make(chan coordinator.ConfigChange, 1)
 	tacker := &testAcker{}
 
+	// Policy sets a non-default log level so the non-mutation assertion below
+	// is meaningful: if commitConfig ran, h.config.Settings.LoggingConfig.Level
+	// would change from the default to debug.
 	action := &fleetapi.ActionPolicyChange{
 		ActionID:   "abc123",
 		ActionType: "POLICY_CHANGE",
-		Data:       fleetapi.ActionPolicyChangeData{Policy: map[string]interface{}{"hello": "world"}},
+		Data:       fleetapi.ActionPolicyChangeData{Policy: map[string]interface{}{"agent.logging.level": "debug"}},
 	}
 
 	failStore := &mockStateStore{}
 	failStore.On("SaveAction", action).Return(errors.New("injected disk error")).Once()
 
+	debugLevel := logp.DebugLevel
+	logLevelSetter := newMockLogLevelSetter(t)
+	logLevelSetter.EXPECT().SetLogLevel(mock.Anything, &debugLevel).Return(nil).Once()
+
 	cfg := configuration.DefaultConfiguration()
-	handler := NewPolicyChangeHandler(log, agentInfo, nil, cfg, &storage.NullStore{}, failStore, ch, defaultLogLevelSet(t))
+	handler := NewPolicyChangeHandler(log, agentInfo, nil, cfg, &storage.NullStore{}, failStore, ch, logLevelSetter)
+	original := configPatchFrom(handler.config)
 
 	err := handler.Handle(context.Background(), action, tacker)
 
@@ -1678,6 +1700,7 @@ func TestPolicyChangeStateStoreSaveFail(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to persist policy action to state store")
 	assert.Empty(t, ch, "policyChange must not be queued when state store write fails")
 	assert.Empty(t, tacker.Items(), "Fleet must not be ACKed when state store write fails")
+	assert.Equal(t, original, configPatchFrom(handler.config), "h.config must be unchanged when state store write fails")
 	failStore.AssertExpectations(t)
 }
 
@@ -1688,19 +1711,27 @@ func TestPolicyChangeSaveConfigFail(t *testing.T) {
 	ch := make(chan coordinator.ConfigChange, 1)
 	tacker := &testAcker{}
 
+	// Policy sets a non-default log level so the non-mutation assertion below
+	// is meaningful: if commitConfig ran, h.config.Settings.LoggingConfig.Level
+	// would change from the default to debug.
 	action := &fleetapi.ActionPolicyChange{
 		ActionID:   "def456",
 		ActionType: "POLICY_CHANGE",
-		Data:       fleetapi.ActionPolicyChangeData{Policy: map[string]interface{}{"hello": "world"}},
+		Data:       fleetapi.ActionPolicyChangeData{Policy: map[string]interface{}{"agent.logging.level": "debug"}},
 	}
 
 	// saveConfig is written before stateStore, so when saveConfig fails the
-	// stateStore is never touched — no Action/SetAction/Save calls expected.
+	// stateStore is never touched — no SaveAction calls expected.
 	untouchedStore := &mockStateStore{}
 	failFleetStore := &errorStore{err: errors.New("injected fleet.enc write error")}
 
+	debugLevel := logp.DebugLevel
+	logLevelSetter := newMockLogLevelSetter(t)
+	logLevelSetter.EXPECT().SetLogLevel(mock.Anything, &debugLevel).Return(nil).Once()
+
 	cfg := configuration.DefaultConfiguration()
-	handler := NewPolicyChangeHandler(log, agentInfo, nil, cfg, failFleetStore, untouchedStore, ch, defaultLogLevelSet(t))
+	handler := NewPolicyChangeHandler(log, agentInfo, nil, cfg, failFleetStore, untouchedStore, ch, logLevelSetter)
+	original := configPatchFrom(handler.config)
 
 	err := handler.Handle(context.Background(), action, tacker)
 
@@ -1708,7 +1739,70 @@ func TestPolicyChangeSaveConfigFail(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to persist policy config")
 	assert.Empty(t, ch, "policyChange must not be queued when fleet.enc write fails")
 	assert.Empty(t, tacker.Items(), "Fleet must not be ACKed when fleet.enc write fails")
+	assert.Equal(t, original, configPatchFrom(handler.config), "h.config must be unchanged when fleet.enc write fails")
 	untouchedStore.AssertExpectations(t)
+}
+
+func TestConfigPatchCompleteness(t *testing.T) {
+	// Field count guard: update this number when adding fields to configPatch,
+	// and update configPatchFrom, configWithPatch, and commitConfig to match.
+	assert.Equal(t, 5, reflect.TypeOf(configPatch{}).NumField(),
+		"configPatch has new fields — update configPatchFrom, configWithPatch, and commitConfig")
+
+	cfg := configuration.DefaultConfiguration()
+	h := &PolicyChangeHandler{config: cfg}
+
+	// Use values that differ from the defaults so the round-trip and non-mutation
+	// assertions below are meaningful (equal values would pass even with bugs).
+	altHTTP := &monitoringCfg.MonitoringHTTPConfig{Host: "1.2.3.4", Port: 1234}
+	altPprof := &monitoringCfg.PprofConfig{Enabled: true}
+	patch := configPatch{
+		eventLogging:    logger.Config{ToStderr: true, ToFiles: false},
+		logging:         logger.Config{ToStderr: false, ToFiles: true},
+		fleetClient:     remote.Config{Host: "https://fleet.example.com"},
+		monitoringHTTP:  altHTTP,
+		monitoringPprof: altPprof,
+	}
+	// configWithPatch: every patch field must appear in the returned config.
+	// Non-mutation of h.config is verified by TestConfigWithPatchDoesNotMutateConfig.
+	got := h.configWithPatch(patch)
+	assert.Equal(t, patch, configPatchFrom(got),
+		"configWithPatch must copy all configPatch fields into the returned configuration")
+
+	// commitConfig round-trip: every field in patch must be written to h.config.
+	h.commitConfig(patch)
+	assert.Equal(t, patch, configPatchFrom(h.config),
+		"commitConfig must write all configPatch fields into h.config")
+}
+
+func TestConfigWithPatchDoesNotMutateConfig(t *testing.T) {
+	// Serialize h.config before and after calling configWithPatch with a patch
+	// that differs in every field. Any shared-pointer aliasing that lets the
+	// patch write through to h.config will produce a different YAML output.
+	// This catches mutations at any nesting depth, not just the five fields
+	// tracked by configPatch.
+	cfg := configuration.DefaultConfiguration()
+	cfg.Fleet.Client.Host = "http://original.fleet.example.com"
+	cfg.Settings.MonitoringConfig.HTTP.Host = "0.0.0.0"
+
+	h := &PolicyChangeHandler{config: cfg}
+
+	before, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+
+	patch := configPatch{
+		eventLogging:    logger.Config{ToStderr: true},
+		logging:         logger.Config{ToFiles: true},
+		fleetClient:     remote.Config{Host: "http://new.fleet.example.com"},
+		monitoringHTTP:  &monitoringCfg.MonitoringHTTPConfig{Host: "1.2.3.4", Port: 1234},
+		monitoringPprof: &monitoringCfg.PprofConfig{Enabled: true},
+	}
+	h.configWithPatch(patch)
+
+	after, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after),
+		"configWithPatch must not mutate h.config — check for shallow-copy pointer aliasing")
 }
 
 func TestPolicyChangeNilStateStore(t *testing.T) {

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -1632,12 +1633,114 @@ func (m *mockStateStore) SetAckToken(s string) {
 
 func (m *mockStateStore) Action() fleetapi.Action {
 	args := m.Called()
-	return args.Get(0).(fleetapi.Action)
+	a, _ := args.Get(0).(fleetapi.Action)
+	return a
 }
 
 func newStateStoreMock() *mockStateStore {
 	s := &mockStateStore{}
+	s.On("Action").Return(nil).Once()
 	s.On("SetAction", mock.Anything).Return().Once()
 	s.On("Save").Return(nil).Once()
 	return s
+}
+
+// errorStore is a storage.Store that always returns an error from Save.
+type errorStore struct{ err error }
+
+func (e *errorStore) Save(_ io.Reader) error { return e.err }
+
+func TestPolicyChangeStateStoreSaveFail(t *testing.T) {
+	log, _ := logger.New("", false)
+	agentInfo := &info.AgentInfo{}
+
+	prevAction := &fleetapi.ActionPolicyChange{
+		ActionID:   "prev-action",
+		ActionType: "POLICY_CHANGE",
+		Data:       fleetapi.ActionPolicyChangeData{Policy: map[string]interface{}{"revision": int64(1)}},
+	}
+	action := &fleetapi.ActionPolicyChange{
+		ActionID:   "abc123",
+		ActionType: "POLICY_CHANGE",
+		Data:       fleetapi.ActionPolicyChangeData{Policy: map[string]interface{}{"hello": "world"}},
+	}
+
+	// Save() fails. The in-memory stateStore is restored unconditionally
+	// (even when prevAction is nil) so the in-memory action always mirrors
+	// disk and the fleet gateway does not report a stale policy_revision_idx.
+	for _, tc := range []struct {
+		name       string
+		prevAction fleetapi.Action
+	}{
+		{"with prior action", prevAction},
+		{"first delivery (nil prevAction)", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ch := make(chan coordinator.ConfigChange, 1)
+			tacker := &testAcker{}
+
+			failStore := &mockStateStore{}
+			failStore.On("Action").Return(tc.prevAction).Once()
+			failStore.On("SetAction", action).Return().Once()
+			failStore.On("Save").Return(errors.New("injected disk error")).Once()
+			failStore.On("SetAction", tc.prevAction).Return().Once()
+
+			cfg := configuration.DefaultConfiguration()
+			handler := NewPolicyChangeHandler(log, agentInfo, nil, cfg, &storage.NullStore{}, failStore, ch, defaultLogLevelSet(t))
+
+			err := handler.Handle(context.Background(), action, tacker)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to persist policy action to state store")
+			assert.Empty(t, ch, "policyChange must not be queued when state store write fails")
+			assert.Empty(t, tacker.Items(), "Fleet must not be ACKed when state store write fails")
+			failStore.AssertExpectations(t)
+		})
+	}
+}
+
+func TestPolicyChangeSaveConfigFail(t *testing.T) {
+	log, _ := logger.New("", false)
+	agentInfo := &info.AgentInfo{}
+
+	ch := make(chan coordinator.ConfigChange, 1)
+	tacker := &testAcker{}
+
+	action := &fleetapi.ActionPolicyChange{
+		ActionID:   "def456",
+		ActionType: "POLICY_CHANGE",
+		Data:       fleetapi.ActionPolicyChangeData{Policy: map[string]interface{}{"hello": "world"}},
+	}
+
+	// saveConfig is written before stateStore, so when saveConfig fails the
+	// stateStore is never touched — no Action/SetAction/Save calls expected.
+	untouchedStore := &mockStateStore{}
+	failFleetStore := &errorStore{err: errors.New("injected fleet.enc write error")}
+
+	cfg := configuration.DefaultConfiguration()
+	handler := NewPolicyChangeHandler(log, agentInfo, nil, cfg, failFleetStore, untouchedStore, ch, defaultLogLevelSet(t))
+
+	err := handler.Handle(context.Background(), action, tacker)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to persist policy config")
+	assert.Empty(t, ch, "policyChange must not be queued when fleet.enc write fails")
+	assert.Empty(t, tacker.Items(), "Fleet must not be ACKed when fleet.enc write fails")
+	untouchedStore.AssertExpectations(t)
+}
+
+func TestPolicyChangeNilStateStore(t *testing.T) {
+	log, _ := logger.New("", false)
+	agentInfo := &info.AgentInfo{}
+
+	ch := make(chan coordinator.ConfigChange, 1)
+	action := &fleetapi.ActionPolicyChange{
+		ActionID:   "nil-store",
+		ActionType: "POLICY_CHANGE",
+		Data:       fleetapi.ActionPolicyChangeData{Policy: map[string]interface{}{"k": "v"}},
+	}
+	cfg := configuration.DefaultConfiguration()
+	handler := NewPolicyChangeHandler(log, agentInfo, nil, cfg, &storage.NullStore{}, nil, ch, defaultLogLevelSet(t))
+	require.NoError(t, handler.Handle(context.Background(), action, noopacker.New()))
+	assert.Len(t, ch, 1, "policyChange must be queued when stateStore is nil")
 }

--- a/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_policy_change_test.go
@@ -1637,11 +1637,14 @@ func (m *mockStateStore) Action() fleetapi.Action {
 	return a
 }
 
+func (m *mockStateStore) SaveAction(a fleetapi.Action) error {
+	args := m.Called(a)
+	return args.Error(0)
+}
+
 func newStateStoreMock() *mockStateStore {
 	s := &mockStateStore{}
-	s.On("Action").Return(nil).Once()
-	s.On("SetAction", mock.Anything).Return().Once()
-	s.On("Save").Return(nil).Once()
+	s.On("SaveAction", mock.Anything).Return(nil).Once()
 	return s
 }
 
@@ -1654,49 +1657,28 @@ func TestPolicyChangeStateStoreSaveFail(t *testing.T) {
 	log, _ := logger.New("", false)
 	agentInfo := &info.AgentInfo{}
 
-	prevAction := &fleetapi.ActionPolicyChange{
-		ActionID:   "prev-action",
-		ActionType: "POLICY_CHANGE",
-		Data:       fleetapi.ActionPolicyChangeData{Policy: map[string]interface{}{"revision": int64(1)}},
-	}
+	ch := make(chan coordinator.ConfigChange, 1)
+	tacker := &testAcker{}
+
 	action := &fleetapi.ActionPolicyChange{
 		ActionID:   "abc123",
 		ActionType: "POLICY_CHANGE",
 		Data:       fleetapi.ActionPolicyChangeData{Policy: map[string]interface{}{"hello": "world"}},
 	}
 
-	// Save() fails. The in-memory stateStore is restored unconditionally
-	// (even when prevAction is nil) so the in-memory action always mirrors
-	// disk and the fleet gateway does not report a stale policy_revision_idx.
-	for _, tc := range []struct {
-		name       string
-		prevAction fleetapi.Action
-	}{
-		{"with prior action", prevAction},
-		{"first delivery (nil prevAction)", nil},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			ch := make(chan coordinator.ConfigChange, 1)
-			tacker := &testAcker{}
+	failStore := &mockStateStore{}
+	failStore.On("SaveAction", action).Return(errors.New("injected disk error")).Once()
 
-			failStore := &mockStateStore{}
-			failStore.On("Action").Return(tc.prevAction).Once()
-			failStore.On("SetAction", action).Return().Once()
-			failStore.On("Save").Return(errors.New("injected disk error")).Once()
-			failStore.On("SetAction", tc.prevAction).Return().Once()
+	cfg := configuration.DefaultConfiguration()
+	handler := NewPolicyChangeHandler(log, agentInfo, nil, cfg, &storage.NullStore{}, failStore, ch, defaultLogLevelSet(t))
 
-			cfg := configuration.DefaultConfiguration()
-			handler := NewPolicyChangeHandler(log, agentInfo, nil, cfg, &storage.NullStore{}, failStore, ch, defaultLogLevelSet(t))
+	err := handler.Handle(context.Background(), action, tacker)
 
-			err := handler.Handle(context.Background(), action, tacker)
-
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "failed to persist policy action to state store")
-			assert.Empty(t, ch, "policyChange must not be queued when state store write fails")
-			assert.Empty(t, tacker.Items(), "Fleet must not be ACKed when state store write fails")
-			failStore.AssertExpectations(t)
-		})
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to persist policy action to state store")
+	assert.Empty(t, ch, "policyChange must not be queued when state store write fails")
+	assert.Empty(t, tacker.Items(), "Fleet must not be ACKed when state store write fails")
+	failStore.AssertExpectations(t)
 }
 
 func TestPolicyChangeSaveConfigFail(t *testing.T) {

--- a/internal/pkg/agent/application/actions/handlers/handler_action_unenroll.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_unenroll.go
@@ -26,6 +26,7 @@ type stateStore interface {
 	SetAckToken(ackToken string)
 	Save() error
 	Action() fleetapi.Action
+	SaveAction(fleetapi.Action) error
 }
 
 // Unenroll results in  running agent entering idle state, non managed non standalone.

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -1733,8 +1733,6 @@ func (c *Coordinator) processConfigChange(ctx context.Context, change ConfigChan
 	}
 
 	if err := change.Ack(); err != nil {
-		// This currently only happens if we fail to save the action to the state store.
-		// Not a transient failure, so return error instead of just logging.
 		return fmt.Errorf("failed to ack new policy change: %w", err)
 	}
 

--- a/internal/pkg/agent/storage/store/state_store.go
+++ b/internal/pkg/agent/storage/store/state_store.go
@@ -265,9 +265,9 @@ func (s *StateStore) Queue() []fleetapi.ScheduledAction {
 }
 
 // SaveAction atomically persists the action to disk and, on success, updates
-// the in-memory state. The write lock is held for the entire operation so
-// concurrent Action() calls always observe either the old or the new action —
-// never a state that has been set in memory but not yet written to disk.
+// the in-memory state. Concurrent reads always observe either the old or the
+// new action — never a partially committed state.
+// If the action is already current (same ID), the call is a no-op and returns nil.
 func (s *StateStore) SaveAction(a fleetapi.Action) error {
 	if isNilAction(a) {
 		return fmt.Errorf("cannot save nil action")
@@ -287,8 +287,7 @@ func (s *StateStore) SaveAction(a fleetapi.Action) error {
 		return nil
 	}
 
-	// Serialize state with the new action without mutating s.state yet.
-	// tmp is a shallow copy; safe because mx.Lock() is held for the entire operation.
+	// tmp is a shallow copy; safe because the write lock is held throughout.
 	tmp := s.state
 	tmp.ActionSerializer.Action = a
 	reader, err := jsonToReader(&tmp)
@@ -299,9 +298,6 @@ func (s *StateStore) SaveAction(a fleetapi.Action) error {
 		return err
 	}
 
-	// Disk write succeeded — commit to memory.
-	// s.dirty tracks whether in-memory state is synced with on-disk state;
-	// clear it since both are now consistent.
 	s.state.ActionSerializer.Action = a
 	s.dirty = false
 	return nil

--- a/internal/pkg/agent/storage/store/state_store.go
+++ b/internal/pkg/agent/storage/store/state_store.go
@@ -158,20 +158,22 @@ func readState(reader io.ReadCloser) (state, error) {
 	return st, nil
 }
 
+// isNilAction reports whether a is nil, including the typed-nil case where a
+// non-nil interface holds a nil pointer. A plain `a == nil` check is not
+// sufficient because a typed nil (e.g. (*ActionPolicyChange)(nil)) stored in
+// a fleetapi.Action interface is never equal to untyped nil. See
+// https://go.dev/ref/spec#Type_switches for details.
+func isNilAction(a fleetapi.Action) bool {
+	return a == nil || reflect.ValueOf(a).IsNil()
+}
+
 // SetAction sets the current action. It accepts ActionPolicyChange or
 // ActionUnenroll. Any other type will be silently discarded.
 func (s *StateStore) SetAction(a fleetapi.Action) {
 	s.mx.Lock()
 	defer s.mx.Unlock()
 
-	// the reflect.ValueOf(v).IsNil() is required as the type of 'v' on switch
-	// clause with multiple types will, in this case, preserve the original type.
-	// See details on https://go.dev/ref/spec#Type_switches
-	// Without using reflect accessing the concrete type stored in the interface
-	// isn't possible and as a is of type fleetapi.Action and has a concrete
-	// value, a is never nil, neither v is nil as it has the same type of a
-	// on both clauses.
-	if a == nil || reflect.ValueOf(a).IsNil() {
+	if isNilAction(a) {
 		s.log.Debugf("trying to set an nil '%T' action, ignoring the action", a)
 		return
 	}
@@ -260,6 +262,49 @@ func (s *StateStore) Queue() []fleetapi.ScheduledAction {
 	q := make([]fleetapi.ScheduledAction, len(s.state.Queue))
 	copy(q, s.state.Queue)
 	return q
+}
+
+// SaveAction atomically persists the action to disk and, on success, updates
+// the in-memory state. The write lock is held for the entire operation so
+// concurrent Action() calls always observe either the old or the new action —
+// never a state that has been set in memory but not yet written to disk.
+func (s *StateStore) SaveAction(a fleetapi.Action) error {
+	if isNilAction(a) {
+		return fmt.Errorf("cannot save nil action")
+	}
+	switch a.(type) {
+	case *fleetapi.ActionPolicyChange, *fleetapi.ActionUnenroll:
+		// ok
+	default:
+		return fmt.Errorf("incompatible action type %T, expected ActionPolicyChange or ActionUnenroll", a)
+	}
+
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	// Skip if the action is already current.
+	if current := s.state.ActionSerializer.Action; current != nil && current.ID() == a.ID() {
+		return nil
+	}
+
+	// Serialize state with the new action without mutating s.state yet.
+	// tmp is a shallow copy; safe because mx.Lock() is held for the entire operation.
+	tmp := s.state
+	tmp.ActionSerializer.Action = a
+	reader, err := jsonToReader(&tmp)
+	if err != nil {
+		return fmt.Errorf("could not marshal state: %w", err)
+	}
+	if err := s.store.Save(reader); err != nil {
+		return err
+	}
+
+	// Disk write succeeded — commit to memory.
+	// s.dirty tracks whether in-memory state is synced with on-disk state;
+	// clear it since both are now consistent.
+	s.state.ActionSerializer.Action = a
+	s.dirty = false
+	return nil
 }
 
 // Action the action to execute. See SetAction for the possible action types.

--- a/testing/integration/ess/policy_change_persistence_test.go
+++ b/testing/integration/ess/policy_change_persistence_test.go
@@ -95,7 +95,7 @@ func TestPolicyChangeNotAcknowledgedOnStateStoreFail(t *testing.T) {
 	require.NoError(t, err, "failed to set immutable flag on state dir: %s", out)
 	t.Cleanup(func() {
 		if out, err := exec.CommandContext(context.TODO(), "chattr", "-i", stateDir).CombinedOutput(); err != nil {
-			t.Logf("warning: failed to clear immutable flag on state dir: %v: %s", err, out)
+			t.Errorf("failed to clear immutable flag on state dir: %v: %s", err, out)
 		}
 	})
 

--- a/testing/integration/ess/policy_change_persistence_test.go
+++ b/testing/integration/ess/policy_change_persistence_test.go
@@ -1,0 +1,147 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build integration
+
+package ess
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/kibana"
+	atesting "github.com/elastic/elastic-agent/pkg/testing"
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+	"github.com/elastic/elastic-agent/pkg/testing/tools"
+	"github.com/elastic/elastic-agent/testing/integration"
+)
+
+// TestPolicyChangeNotAcknowledgedOnStateStoreFail verifies the fix for
+// https://github.com/elastic/elastic-agent/issues/15126.
+//
+// When the state store write fails during policy processing the agent must not
+// ACK the action. Fleet will then re-deliver the action after the agent
+// restarts, allowing recovery once the underlying problem (e.g. a full or
+// read-only disk) is resolved.
+func TestPolicyChangeNotAcknowledgedOnStateStoreFail(t *testing.T) {
+	info := define.Require(t, define.Requirements{
+		Group: integration.Fleet,
+		Stack: &define.Stack{},
+		Local: false,
+		Sudo:  true,
+		OS: []define.OS{
+			{Type: define.Linux},
+		},
+	})
+
+	ctx := t.Context()
+
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
+	require.NoError(t, err)
+
+	createPolicyReq := kibana.AgentPolicy{
+		Name:        fmt.Sprintf("test-policy-state-store-fail-%d", time.Now().UnixNano()),
+		Namespace:   info.Namespace,
+		Description: "test policy for state store failure no-ack",
+		MonitoringEnabled: []kibana.MonitoringEnabledOption{
+			kibana.MonitoringEnabledLogs,
+			kibana.MonitoringEnabledMetrics,
+		},
+	}
+
+	installOpts := atesting.InstallOpts{
+		NonInteractive: true,
+		Force:          true,
+		Insecure:       true,
+	}
+
+	policy, agentID, err := tools.InstallAgentWithPolicy(ctx, t, installOpts, fixture, info.KibanaClient, createPolicyReq)
+	require.NoError(t, err)
+	t.Logf("enrolled agent %s with policy %s", agentID, policy.ID)
+
+	t.Cleanup(func() {
+		// context.TODO: cleanup runs after the test context is cancelled, so we
+		// need an independent context here.
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.TODO(), time.Minute)
+		defer cleanupCancel()
+		_, err := info.KibanaClient.UnEnrollAgent(cleanupCtx, kibana.UnEnrollAgentRequest{ID: agentID, Revoke: true})
+		assert.NoError(t, err, "failed to unenroll agent %s", agentID)
+	})
+
+	// Find the versioned data directory that contains state.enc.
+	stateDirs, err := filepath.Glob(filepath.Join(fixture.AgentDataDir(), "data", "elastic-agent-*"))
+	require.NoError(t, err)
+	require.NotEmpty(t, stateDirs, "versioned agent data directory not found under %s", fixture.AgentDataDir())
+	stateDir := stateDirs[len(stateDirs)-1]
+	t.Logf("versioned state directory: %s", stateDir)
+
+	initialAgent, err := info.KibanaClient.GetAgent(ctx, kibana.GetAgentRequest{ID: agentID})
+	require.NoError(t, err)
+	initialRevision := initialAgent.PolicyRevision
+	t.Logf("initial policy revision: %d", initialRevision)
+
+	// Block state store writes before triggering the policy change.
+	// chattr +i makes the directory immutable so no new files can be created
+	// in it even by root.
+	out, err := exec.CommandContext(ctx, "chattr", "+i", stateDir).CombinedOutput()
+	require.NoError(t, err, "failed to set immutable flag on state dir: %s", out)
+	t.Cleanup(func() {
+		if out, err := exec.CommandContext(context.TODO(), "chattr", "-i", stateDir).CombinedOutput(); err != nil {
+			t.Logf("warning: failed to clear immutable flag on state dir: %v: %s", err, out)
+		}
+	})
+
+	// Trigger a policy change from Fleet.
+	updatePolicyReq := kibana.AgentPolicyUpdateRequest{
+		Name:              policy.Name,
+		Namespace:         info.Namespace,
+		Description:       "test policy for state store failure no-ack - revision bump",
+		MonitoringEnabled: createPolicyReq.MonitoringEnabled,
+	}
+	updatedPolicy, err := info.KibanaClient.UpdatePolicy(ctx, policy.ID, updatePolicyReq)
+	require.NoError(t, err)
+	targetRevision := updatedPolicy.Revision
+	t.Logf("triggered policy update to revision %d", targetRevision)
+
+	// The agent must not advance the policy revision while the state store is unwritable.
+	require.Never(t,
+		tools.IsMinPolicyRevision(ctx, t, info.KibanaClient, agentID, targetRevision),
+		90*time.Second,
+		10*time.Second,
+		"policy was acknowledged despite state store write failure (expected revision to stay at %d)", initialRevision,
+	)
+
+	// Stop the agent while the state store is still read-only, mirroring the
+	// real-world scenario where a disk problem causes the agent to shut down.
+	out, err = exec.CommandContext(ctx, "sudo", "systemctl", "stop", "elastic-agent").CombinedOutput()
+	require.NoError(t, err, "failed to stop elastic-agent: %s", out)
+
+	// Confirm the revision is still at the initial value after the agent stops.
+	stoppedAgent, err := info.KibanaClient.GetAgent(ctx, kibana.GetAgentRequest{ID: agentID})
+	require.NoError(t, err)
+	require.Equal(t, initialRevision, stoppedAgent.PolicyRevision,
+		"policy revision advanced while state store was read-only")
+
+	// Restore write access, then start the agent.
+	out, err = exec.CommandContext(ctx, "chattr", "-i", stateDir).CombinedOutput()
+	require.NoError(t, err, "failed to clear immutable flag on state dir: %s", out)
+
+	out, err = exec.CommandContext(ctx, "sudo", "systemctl", "start", "elastic-agent").CombinedOutput()
+	require.NoError(t, err, "failed to start elastic-agent: %s", out)
+
+	// Fleet re-delivers; the agent must apply and acknowledge the policy.
+	require.Eventually(t,
+		tools.IsMinPolicyRevision(ctx, t, info.KibanaClient, agentID, targetRevision),
+		8*time.Minute,
+		10*time.Second,
+		"agent did not reach policy revision %d after restart with write access restored", targetRevision,
+	)
+}


### PR DESCRIPTION
## What does this PR do?

- Changes `stateStore.Save()` failure from a warning to an error, so the handler returns an error and no ACK is sent to Fleet. Fleet re-delivers the policy automatically once the agent recovers.
- Restores the in-memory stateStore action on save failure, so the checkin heartbeat does not accidentally report the new policy revision to Fleet Server before it is committed to disk.
- Rolls back in-memory config mutations (logging, fleet client, monitoring) if `saveConfig` fails, keeping the in-memory state consistent with what is on disk.

## Why is it important?

A transient disk problem (full disk, read-only mount) would permanently lose a policy change — Fleet marked it delivered, never re-sent it, and the agent stayed on the old config after restart with no recovery path.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## Known limitations / follow-up

When a policy changes the Fleet Server host or proxy and `saveConfig` fails, the registered fleet client objects are left pointing at the new host for the rest of the session. The agent reconnects to the old host on restart and Fleet re-delivers — transient, self-correcting. Tracked separately.

## Disruptive User Impact

None.

## How to test this PR locally

Run the ESS integration test (requires a Linux host with `e2e-testing` environment):

```
SNAPSHOT=true TEST_PLATFORMS="linux/amd64" AGENT_KEEP_INSTALLED="false" TEST_INTEG_CLEAN_ON_EXIT="false" GOTEST_FLAGS="-test.count=1" mage -v integration:single TestPolicyChangeNotAcknowledgedOnStateStoreFail
```

The test:
1. Enrolls an agent and records the initial policy revision.
2. Sets `chattr +i` on the versioned state directory to block all writes.
3. Triggers a policy update from Fleet.
4. Asserts the agent's revision does **not** advance for 90 seconds (`require.Never`).
5. Stops the agent, restores write access, restarts.
6. Asserts the agent reaches the target revision within 8 minutes (`require.Eventually`).

## Related issues

- Closes #15126
- Relates #13677