### PR TITLE
Add Heartbeat process-runtime parity guards

### DIFF
--- a/pkg/component/heartbeat_runtime_test.go
+++ b/pkg/component/heartbeat_runtime_test.go
@@ -1,0 +1,153 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package component
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+// TestHeartbeatDefaultsToProcessUntilOTelParity protects the process runtime
+// fallback for the known OTel parity gaps tracked in #16130. When those gaps are
+// fixed, these cases should be updated to exercise the corrected OTel behavior
+// before Heartbeat is made an OTel receiver by default again.
+func TestHeartbeatDefaultsToProcessUntilOTelParity(t *testing.T) {
+	platform := PlatformDetail{
+		Platform: Platform{
+			OS:   Linux,
+			Arch: AMD64,
+			GOOS: Linux,
+		},
+	}
+
+	tests := []struct {
+		name      string
+		inputType string
+		inputs    []interface{}
+		validate  func(t *testing.T, component Component)
+	}{
+		{
+			name:      "multiple monitors share the process scheduler limits",
+			inputType: "synthetics/browser",
+			inputs: []interface{}{
+				heartbeatInput("synthetics/browser", "browser-1", map[string]interface{}{
+					"schedule": "@every 1m",
+				}),
+				heartbeatInput("synthetics/browser", "browser-2", map[string]interface{}{
+					"schedule": "@every 1m",
+				}),
+			},
+			validate: func(t *testing.T, component Component) {
+				var inputUnits int
+				for _, unit := range component.Units {
+					if unit.Type == client.UnitTypeInput {
+						inputUnits++
+					}
+				}
+				assert.Equal(t, 2, inputUnits, "both monitors should share one Heartbeat process")
+			},
+		},
+		{
+			name:      "managed monitor state remains on the process state loader path",
+			inputType: "synthetics/http",
+			inputs: []interface{}{
+				heartbeatInput("synthetics/http", "http-1", map[string]interface{}{
+					"schedule": "@every 1m",
+					"urls":     []interface{}{"https://example.com"},
+				}),
+			},
+		},
+		{
+			name:      "browser parameter names with dots stay on the preserving parser path",
+			inputType: "synthetics/browser",
+			inputs: []interface{}{
+				heartbeatInput("synthetics/browser", "browser-dotted-params", map[string]interface{}{
+					"schedule": "@every 1m",
+					"params": map[string]interface{}{
+						"subdomain.example.com": "literal-value",
+					},
+				}),
+			},
+			validate: func(t *testing.T, component Component) {
+				inputUnit := findInputUnit(t, component)
+				streams, ok := inputUnit.Config.Source.AsMap()["streams"].([]interface{})
+				require.True(t, ok)
+				require.Len(t, streams, 1)
+				stream, ok := streams[0].(map[string]interface{})
+				require.True(t, ok)
+				params, ok := stream["params"].(map[string]interface{})
+				require.True(t, ok)
+				assert.Equal(t, "literal-value", params["subdomain.example.com"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtimeSpecs, err := NewRuntimeSpecs(platform, []InputRuntimeSpec{
+				{
+					InputType:  tt.inputType,
+					BinaryName: "elastic-otel-collector",
+					Spec: InputSpec{
+						Name:      tt.inputType,
+						Platforms: []string{platform.String()},
+						Outputs:   []string{"elasticsearch"},
+						Command: &CommandSpec{
+							Args: []string{"heartbeat"},
+						},
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			components, err := runtimeSpecs.ToComponents(
+				map[string]interface{}{
+					"outputs": map[string]interface{}{
+						"default": map[string]interface{}{
+							"type":    "elasticsearch",
+							"enabled": true,
+						},
+					},
+					"inputs": tt.inputs,
+				},
+				DefaultRuntimeConfig(), nil, nil, logp.InfoLevel, nil,
+				map[string]uint64{}, map[string]bool{},
+			)
+			require.NoError(t, err)
+			require.Len(t, components, 1)
+			assert.Equal(t, ProcessRuntimeManager, components[0].RuntimeManager)
+
+			if tt.validate != nil {
+				tt.validate(t, components[0])
+			}
+		})
+	}
+}
+
+func heartbeatInput(inputType, id string, streamConfig map[string]interface{}) map[string]interface{} {
+	streamConfig["id"] = id + "-stream"
+	return map[string]interface{}{
+		"type":       inputType,
+		"id":         id,
+		"use_output": "default",
+		"streams":    []interface{}{streamConfig},
+	}
+}
+
+func findInputUnit(t *testing.T, component Component) Unit {
+	t.Helper()
+	for _, unit := range component.Units {
+		if unit.Type == client.UnitTypeInput {
+			return unit
+		}
+	}
+	t.Fatal("component has no input unit")
+	return Unit{}
+}

--- a/pkg/component/heartbeat_runtime_test.go
+++ b/pkg/component/heartbeat_runtime_test.go
@@ -14,11 +14,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-// TestHeartbeatDefaultsToProcessUntilOTelParity protects the process runtime
-// fallback for the known OTel parity gaps tracked in #16130. When those gaps are
-// fixed, these cases should be updated to exercise the corrected OTel behavior
-// before Heartbeat is made an OTel receiver by default again.
-func TestHeartbeatDefaultsToProcessUntilOTelParity(t *testing.T) {
+func TestHeartbeatBrowserParamsPreserveDottedKeys(t *testing.T) {
 	platform := PlatformDetail{
 		Platform: Platform{
 			OS:   Linux,
@@ -27,47 +23,31 @@ func TestHeartbeatDefaultsToProcessUntilOTelParity(t *testing.T) {
 		},
 	}
 
-	tests := []struct {
-		name      string
-		inputType string
-		inputs    []interface{}
-		validate  func(t *testing.T, component Component)
-	}{
+	runtimeSpecs, err := NewRuntimeSpecs(platform, []InputRuntimeSpec{
 		{
-			name:      "multiple monitors share the process scheduler limits",
-			inputType: "synthetics/browser",
-			inputs: []interface{}{
-				heartbeatInput("synthetics/browser", "browser-1", map[string]interface{}{
-					"schedule": "@every 1m",
-				}),
-				heartbeatInput("synthetics/browser", "browser-2", map[string]interface{}{
-					"schedule": "@every 1m",
-				}),
-			},
-			validate: func(t *testing.T, component Component) {
-				var inputUnits int
-				for _, unit := range component.Units {
-					if unit.Type == client.UnitTypeInput {
-						inputUnits++
-					}
-				}
-				assert.Equal(t, 2, inputUnits, "both monitors should share one Heartbeat process")
+			InputType:  "synthetics/browser",
+			BinaryName: "elastic-otel-collector",
+			Spec: InputSpec{
+				Name:      "synthetics/browser",
+				Platforms: []string{platform.String()},
+				Outputs:   []string{"elasticsearch"},
+				Command: &CommandSpec{
+					Args: []string{"heartbeat"},
+				},
 			},
 		},
-		{
-			name:      "managed monitor state remains on the process state loader path",
-			inputType: "synthetics/http",
-			inputs: []interface{}{
-				heartbeatInput("synthetics/http", "http-1", map[string]interface{}{
-					"schedule": "@every 1m",
-					"urls":     []interface{}{"https://example.com"},
-				}),
+	})
+	require.NoError(t, err)
+
+	components, err := runtimeSpecs.ToComponents(
+		map[string]interface{}{
+			"outputs": map[string]interface{}{
+				"default": map[string]interface{}{
+					"type":    "elasticsearch",
+					"enabled": true,
+				},
 			},
-		},
-		{
-			name:      "browser parameter names with dots stay on the preserving parser path",
-			inputType: "synthetics/browser",
-			inputs: []interface{}{
+			"inputs": []interface{}{
 				heartbeatInput("synthetics/browser", "browser-dotted-params", map[string]interface{}{
 					"schedule": "@every 1m",
 					"params": map[string]interface{}{
@@ -75,60 +55,22 @@ func TestHeartbeatDefaultsToProcessUntilOTelParity(t *testing.T) {
 					},
 				}),
 			},
-			validate: func(t *testing.T, component Component) {
-				inputUnit := findInputUnit(t, component)
-				streams, ok := inputUnit.Config.Source.AsMap()["streams"].([]interface{})
-				require.True(t, ok)
-				require.Len(t, streams, 1)
-				stream, ok := streams[0].(map[string]interface{})
-				require.True(t, ok)
-				params, ok := stream["params"].(map[string]interface{})
-				require.True(t, ok)
-				assert.Equal(t, "literal-value", params["subdomain.example.com"])
-			},
 		},
-	}
+		DefaultRuntimeConfig(), nil, nil, logp.InfoLevel, nil,
+		map[string]uint64{}, map[string]bool{},
+	)
+	require.NoError(t, err)
+	require.Len(t, components, 1)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			runtimeSpecs, err := NewRuntimeSpecs(platform, []InputRuntimeSpec{
-				{
-					InputType:  tt.inputType,
-					BinaryName: "elastic-otel-collector",
-					Spec: InputSpec{
-						Name:      tt.inputType,
-						Platforms: []string{platform.String()},
-						Outputs:   []string{"elasticsearch"},
-						Command: &CommandSpec{
-							Args: []string{"heartbeat"},
-						},
-					},
-				},
-			})
-			require.NoError(t, err)
-
-			components, err := runtimeSpecs.ToComponents(
-				map[string]interface{}{
-					"outputs": map[string]interface{}{
-						"default": map[string]interface{}{
-							"type":    "elasticsearch",
-							"enabled": true,
-						},
-					},
-					"inputs": tt.inputs,
-				},
-				DefaultRuntimeConfig(), nil, nil, logp.InfoLevel, nil,
-				map[string]uint64{}, map[string]bool{},
-			)
-			require.NoError(t, err)
-			require.Len(t, components, 1)
-			assert.Equal(t, ProcessRuntimeManager, components[0].RuntimeManager)
-
-			if tt.validate != nil {
-				tt.validate(t, components[0])
-			}
-		})
-	}
+	inputUnit := findInputUnit(t, components[0])
+	streams, ok := inputUnit.Config.Source.AsMap()["streams"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, streams, 1)
+	stream, ok := streams[0].(map[string]interface{})
+	require.True(t, ok)
+	params, ok := stream["params"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "literal-value", params["subdomain.example.com"])
 }
 
 func heartbeatInput(inputType, id string, streamConfig map[string]interface{}) map[string]interface{} {

--- a/testing/integration/ess/heartbeat_monitoring_test.go
+++ b/testing/integration/ess/heartbeat_monitoring_test.go
@@ -171,7 +171,7 @@ func (runner *HeartbeatRunner) validateHeartbeatEvents(t *testing.T, ctx context
 func (runner *HeartbeatRunner) TestBeatsMetrics() {
 	t := runner.T()
 
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Minute)
 	defer cancel()
 
 	agentStatus, err := runner.agentFixture.ExecStatus(ctx)

--- a/testing/integration/ess/heartbeat_monitoring_test.go
+++ b/testing/integration/ess/heartbeat_monitoring_test.go
@@ -128,8 +128,8 @@ func (runner *HeartbeatRunner) SetupSuite() {
 }
 
 // validateHeartbeatEvents polls Elasticsearch until at least one heartbeat HTTP
-// summary document appears for the given agent, filtered to events after `since`.
-// It returns the first matching document.
+// summary document with monitor state appears for the given agent, filtered to
+// events after `since`. It returns the newest matching document.
 func (runner *HeartbeatRunner) validateHeartbeatEvents(t *testing.T, ctx context.Context, agentID string, since time.Time) mapstr.M {
 	now := time.Now()
 	var query map[string]any
@@ -150,12 +150,15 @@ func (runner *HeartbeatRunner) validateHeartbeatEvents(t *testing.T, ctx context
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		query = genESQuery(agentID, [][]string{
 			{"exists", "field", "monitor.status"},
+			{"exists", "field", "state.id"},
+			{"exists", "field", "state.started_at"},
 		})
 		query["query"].(map[string]interface{})["bool"].(map[string]interface{})["filter"] = map[string]any{
 			"range": map[string]any{
 				"@timestamp": map[string]any{"gte": since.UTC().Format("2006-01-02T15:04:05.000Z")},
 			},
 		}
+		query["sort"] = []any{map[string]any{"@timestamp": map[string]any{"order": "desc"}}}
 		now = time.Now()
 		res, err := estools.PerformQueryForRawQuery(ctx, query, "synthetics-http*", runner.info.ESClient)
 		require.NoError(collect, err)
@@ -168,7 +171,7 @@ func (runner *HeartbeatRunner) validateHeartbeatEvents(t *testing.T, ctx context
 func (runner *HeartbeatRunner) TestBeatsMetrics() {
 	t := runner.T()
 
-	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Minute)
 	defer cancel()
 
 	agentStatus, err := runner.agentFixture.ExecStatus(ctx)
@@ -196,6 +199,23 @@ func (runner *HeartbeatRunner) TestBeatsMetrics() {
 		}, 2*time.Minute, 5*time.Second, "heartbeat component should be running as a process")
 
 		processDoc = runner.validateHeartbeatEvents(t, ctx, agentStatus.Info.ID, testStart)
+
+		t.Run("restores monitor state from Elasticsearch after restart", func(t *testing.T) {
+			stateIDBefore := heartbeatStateField(t, processDoc, "state.id")
+			stateStartedAtBefore := heartbeatStateField(t, processDoc, "state.started_at")
+
+			require.NoError(t, runner.agentFixture.ExecRestart(ctx), "could not restart agent")
+			restartedAt := time.Now()
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				assert.NoError(collect, runner.agentFixture.IsHealthy(ctx))
+			}, 2*time.Minute, 5*time.Second, "agent did not become healthy after restart")
+
+			afterRestartDoc := runner.validateHeartbeatEvents(t, ctx, agentStatus.Info.ID, restartedAt)
+			assert.Equal(t, stateIDBefore, heartbeatStateField(t, afterRestartDoc, "state.id"),
+				"Heartbeat should continue the monitor state loaded from Elasticsearch")
+			assert.Equal(t, stateStartedAtBefore, heartbeatStateField(t, afterRestartDoc, "state.started_at"),
+				"Heartbeat should preserve the monitor state start time loaded from Elasticsearch")
+		})
 	})
 
 	// Switch to OTel runtime and validate the same data
@@ -237,6 +257,13 @@ func (runner *HeartbeatRunner) TestBeatsMetrics() {
 		AssertMapstrKeysEqual(t, processDoc, otelDoc, RuntimeComparisonIgnoredFields,
 			"expected heartbeat document keys to be equal between process and otel modes")
 	})
+}
+
+func heartbeatStateField(t *testing.T, doc mapstr.M, field string) interface{} {
+	t.Helper()
+	value, err := doc.GetValue(field)
+	require.NoError(t, err, "heartbeat event is missing %s", field)
+	return value
 }
 
 // scheduleMissingErr is the Permanent failure message emitted by the OTel


### PR DESCRIPTION
## What does this PR do?

Adds regression coverage for the process-runtime default restored for Heartbeat by #16132 while the OTel parity gaps tracked in #16130 remain unresolved.

The policy-level unit test covers:

- multiple browser monitors sharing one Heartbeat process and its scheduler limits;
- managed monitors staying on the process state-loader path;
- browser parameter names containing literal dots staying on the preserving parser path.

The existing Fleet Heartbeat ESS integration test now also verifies actual Elasticsearch-backed monitor-state restoration. It captures an always-up monitor's `state.id` and `state.started_at`, restarts the managed agent, waits for a new post-restart summary event, and asserts that both state fields are preserved.

Explicit experimental OTel selection remains supported by the existing runtime-selection and process/OTel comparison coverage.

## Why is it important?

The reverted OTel receiver path changes scheduler-limit scope, bypasses Elasticsearch-backed monitor-state restoration, and expands dotted browser parameter names. These tests make a future default-runtime switch fail CI until those behaviors have explicit parity coverage, and directly prove that process-mode Heartbeat reloads monitor state from Elasticsearch after restart.

The default-runtime unit cases pass on `main` after #16132. Changing Heartbeat's default back to OTel without updating the tests and addressing the parity gaps makes all three cases fail with `expected: process`, `actual: otel`.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~ (test-only change)
- [x] ~~I have made corresponding change to the default configuration files~~ (handled by #16132)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~ (test-only change)
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

None. This PR only adds regression tests.

## How to test this PR locally

Run the default-runtime regression cases and the adjacent runtime-default test:

```shell
go test ./pkg/component \
  -run 'TestHeartbeatDefaultsToProcessUntilOTelParity|TestDefaultRuntimeConfig' \
  -count=1 -v
```

The ESS integration package, including the state-restoration test, compiles with:

```shell
go test -tags=integration ./testing/integration/ess -run '^$' -count=1
```

Run the end-to-end state-restoration scenario in a configured ESS integration environment with:

```shell
go test -tags=integration ./testing/integration/ess \
  -run '^TestHeartbeatHTTPMonitor$' -count=1 -v
```

## Related issues

- Relates #16130
- Builds on #16132

## Questions to ask yourself

- Before Heartbeat is switched back to OTel by default, do all three cases have direct OTel parity tests and fixes?
