### PR TITLE
[9.5] [beatreceiver] Fallback to process runtime when kafka + kerberos is enabled

### DIFF
--- a/changelog/fragments/1786460214-fallback-process-runtime-kerberos.yaml
+++ b/changelog/fragments/1786460214-fallback-process-runtime-kerberos.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Inputs running in OTel runtime with kafka output and Kerberos authentication enabled will now fallback to process runtime.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/otel/translate/output_kafka.go
+++ b/internal/pkg/otel/translate/output_kafka.go
@@ -237,6 +237,8 @@ func checkUnsupportedKafkaConfig(cfg *config.C, logger *logp.Logger) error {
 		} else if value.HasField("ca_sha_256") {
 			return fmt.Errorf("ca_sha_256 is currently not supported: %w", errors.ErrUnsupported)
 		}
+	} else if cfg.HasField("kerberos") {
+		return fmt.Errorf("kerberos is currently not supported: %w", errors.ErrUnsupported)
 	}
 
 	if cfg.HasField("bulk_flush_frequency") {


### PR DESCRIPTION
## What does this PR do?

Marks Kafka Kerberos config as unsupported in OTel translation so components fall back to the process runtime instead of silently dropping Kerberos settings.

## Why is it important?

Without this, Kafka + Kerberos on the OTel runtime starts successfully but auth is dropped, so Kafka authentication fails. See #16118.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

Users with Kafka + Kerberos who were incorrectly staying on the OTel runtime (with Kerberos dropped) will now fall back to the process runtime.

## Related issues

- Fixes #16118
- Similar to #16144 (9.4)


Made with [Cursor](https://cursor.com)