### PR TITLE
Verify provisioning ESS variables to buildkite agents

### DIFF
--- a/.buildkite/scripts/steps/ess_start.sh
+++ b/.buildkite/scripts/steps/ess_start.sh
@@ -53,6 +53,11 @@ function set_buildkite_metadata() {
   local max_attempts=3
   local delay=5
 
+  if [[ -z "$value" ]]; then
+    echo "ERROR: value for '$key' is empty — ESS provisioning may have failed" >&2
+    return 1
+  fi
+
   local attempt
   for attempt in $(seq 1 "$max_attempts"); do
     if buildkite-agent meta-data set --redacted-vars='' "$key" "$value"; then

--- a/.buildkite/scripts/steps/ess_start.sh
+++ b/.buildkite/scripts/steps/ess_start.sh
@@ -28,10 +28,37 @@ if [[ "${FIPS:-false}" == "true" ]]; then
   echo "Using FIPS metadata prefix: ${METADATA_PREFIX}"
 fi
 
-buildkite-agent meta-data set --redacted-vars='' "${METADATA_PREFIX}es.host" $ELASTICSEARCH_HOST
-buildkite-agent meta-data set --redacted-vars='' "${METADATA_PREFIX}es.username" $ELASTICSEARCH_USERNAME
-buildkite-agent meta-data set --redacted-vars='' "${METADATA_PREFIX}es.pwd" $ELASTICSEARCH_PASSWORD
-buildkite-agent meta-data set --redacted-vars='' "${METADATA_PREFIX}kibana.host" $KIBANA_HOST
-buildkite-agent meta-data set --redacted-vars='' "${METADATA_PREFIX}kibana.username" $KIBANA_USERNAME
-buildkite-agent meta-data set --redacted-vars='' "${METADATA_PREFIX}kibana.pwd" $KIBANA_PASSWORD
-buildkite-agent meta-data set --redacted-vars='' "${METADATA_PREFIX}integrations_server.host" $ELASTIC_APM_SERVER_URL
+metadata_keys=(
+  "${METADATA_PREFIX}es.host"
+  "${METADATA_PREFIX}es.username"
+  "${METADATA_PREFIX}es.pwd"
+  "${METADATA_PREFIX}kibana.host"
+  "${METADATA_PREFIX}kibana.username"
+  "${METADATA_PREFIX}kibana.pwd"
+  "${METADATA_PREFIX}integrations_server.host"
+)
+metadata_values=(
+  "$ELASTICSEARCH_HOST"
+  "$ELASTICSEARCH_USERNAME"
+  "$ELASTICSEARCH_PASSWORD"
+  "$KIBANA_HOST"
+  "$KIBANA_USERNAME"
+  "$KIBANA_PASSWORD"
+  "$ELASTIC_APM_SERVER_URL"
+)
+
+echo "~~~ Publishing and verifying ESS stack metadata"
+for i in "${!metadata_keys[@]}"; do
+  key="${metadata_keys[$i]}"
+  value="${metadata_values[$i]}"
+  buildkite-agent meta-data set --redacted-vars='' "$key" "$value"
+  stored=$(buildkite-agent meta-data get "$key") || {
+    echo "ERROR: failed to read back metadata key '$key' after setting it" >&2
+    exit 1
+  }
+  if [[ -z "$stored" ]]; then
+    echo "ERROR: metadata key '$key' was set but reads back as empty" >&2
+    exit 1
+  fi
+  echo "✓ $key"
+done

--- a/.buildkite/scripts/steps/ess_start.sh
+++ b/.buildkite/scripts/steps/ess_start.sh
@@ -47,18 +47,30 @@ metadata_values=(
   "$ELASTIC_APM_SERVER_URL"
 )
 
+function set_buildkite_metadata() {
+  local key="$1"
+  local value="$2"
+  local max_attempts=3
+  local delay=5
+
+  local attempt
+  for attempt in $(seq 1 "$max_attempts"); do
+    if buildkite-agent meta-data set --redacted-vars='' "$key" "$value"; then
+      local stored
+      stored=$(buildkite-agent meta-data get "$key" 2>/dev/null) && [[ -n "$stored" ]] && return 0
+    fi
+    if [[ $attempt -lt $max_attempts ]]; then
+      echo "Attempt $attempt/$max_attempts failed for '$key', retrying in ${delay}s..." >&2
+      sleep "$delay"
+    fi
+  done
+
+  echo "ERROR: failed to set/verify metadata key '$key' after $max_attempts attempts" >&2
+  return 1
+}
+
 echo "~~~ Publishing and verifying ESS stack metadata"
 for i in "${!metadata_keys[@]}"; do
-  key="${metadata_keys[$i]}"
-  value="${metadata_values[$i]}"
-  buildkite-agent meta-data set --redacted-vars='' "$key" "$value"
-  stored=$(buildkite-agent meta-data get "$key") || {
-    echo "ERROR: failed to read back metadata key '$key' after setting it" >&2
-    exit 1
-  }
-  if [[ -z "$stored" ]]; then
-    echo "ERROR: metadata key '$key' was set but reads back as empty" >&2
-    exit 1
-  fi
-  echo "✓ $key"
+  set_buildkite_metadata "${metadata_keys[$i]}" "${metadata_values[$i]}"
+  echo "✓ ${metadata_keys[$i]}"
 done

--- a/.buildkite/scripts/steps/integration_tests_tf_fips.ps1
+++ b/.buildkite/scripts/steps/integration_tests_tf_fips.ps1
@@ -50,7 +50,7 @@ $envMap = @{
 foreach ($name in $envMap.Keys) {
     $value = & buildkite-agent meta-data get $envMap[$name]
     if ($LASTEXITCODE -ne 0 -or -not $value) {
-        Write-Error "Failed to read meta-data key $($envMap[$name])"
+        Write-Error "ESS provisioning incomplete: metadata key '$($envMap[$name])' not found. Check the 'Start ESS stack for FIPS integration tests' step."
         exit 1
     }
     [System.Environment]::SetEnvironmentVariable($name, $value)

--- a/.buildkite/scripts/steps/integration_tests_tf_fips.ps1
+++ b/.buildkite/scripts/steps/integration_tests_tf_fips.ps1
@@ -50,7 +50,7 @@ $envMap = @{
 foreach ($name in $envMap.Keys) {
     $value = & buildkite-agent meta-data get $envMap[$name]
     if ($LASTEXITCODE -ne 0 -or -not $value) {
-        Write-Error "ESS provisioning incomplete: metadata key '$($envMap[$name])' not found. Check the 'Start ESS stack for FIPS integration tests' step."
+        Write-Error "Failed to read meta-data key $($envMap[$name])"
         exit 1
     }
     [System.Environment]::SetEnvironmentVariable($name, $value)


### PR DESCRIPTION
https://buildkite.com/elastic/elastic-agent/builds/44769/list?jid=019ff4bd-671a-4412-a59e-154eb87d6a26&tab=output failed due to lack of `fips.es.host` variable. It is hard to confirm what is the exact reason for that, but seems like the variable is not set. Hardening `ess_start.sh` to ensure the variable is set correctly

example run: https://buildkite.com/elastic/elastic-agent/builds/44785/list?sid=019ff511-8698-4794-a4d3-960d0045ddae&tab=output

```
Publishing and verifying ESS stack metadata
✓ fips.es.host
✓ fips.es.username
✓ fips.es.pwd
✓ fips.kibana.host
✓ fips.kibana.username
✓ fips.kibana.pwd
✓ fips.integrations_server.host
```