### PR TITLE
[mage] Load .package-version by default only for select targets

### DIFF
--- a/.buildkite/scripts/steps/build-agent-core.sh
+++ b/.buildkite/scripts/steps/build-agent-core.sh
@@ -18,8 +18,7 @@ if [[ "$DRA_WORKFLOW" == "staging" ]] && [[ -n "$VERSION_QUALIFIER" ]]; then
     BEAT_VERSION_FULL="${BEAT_VERSION_FULL}-${VERSION_QUALIFIER}"
 fi
 
-# USE_PACKAGE_VERSION=false: binary-DRA stamps version.go's version, not .package-version's.
-SNAPSHOT=$SNAPSHOT WINDOWS_NPCAP="true" USE_PACKAGE_VERSION=false mage packageAgentCore
+SNAPSHOT=$SNAPSHOT WINDOWS_NPCAP="true" mage packageAgentCore
 chmod -R 777 build/distributions
 
 echo "+++ Generate dependencies report"

--- a/.buildkite/scripts/steps/helm-charts.sh
+++ b/.buildkite/scripts/steps/helm-charts.sh
@@ -18,10 +18,6 @@ if [[ "${SNAPSHOT}" == "true" && "${HELM_REPO_ENV}" == "prod" ]]; then
   exit 1
 fi
 
-# The Helm Chart package doesn't care about what's in the manifest for a prod build
-# Workaround for https://github.com/elastic/elastic-agent/issues/16026
-export USE_PACKAGE_VERSION=${SNAPSHOT}
-
 echo "--- mage helm:package"
 mage helm:package
 

--- a/.buildkite/scripts/steps/package.sh
+++ b/.buildkite/scripts/steps/package.sh
@@ -6,12 +6,11 @@ _SELF=$(dirname $0)
 source "${_SELF}/../common.sh"
 
 # Default behavior (no MANIFEST_URL): compile core from this checkout and read
-# version/snapshot from .package-version (AGENT_CORE_SOURCE=local and
-# USE_PACKAGE_VERSION=true are both defaults). When MANIFEST_URL is provided
-# (DRA full-package run), download core from the manifest instead.
+# version/snapshot from .package-version (the `package` target reads it by
+# default). When MANIFEST_URL is provided (DRA full-package run), the manifest
+# is authoritative instead: download core from it and skip .package-version.
 if [ -n "${MANIFEST_URL:-}" ]; then
   export AGENT_CORE_SOURCE=manifest
-  export USE_PACKAGE_VERSION=false
 fi
 
 mage clean
@@ -30,7 +29,7 @@ mage "${MAGE_TARGETS[@]}"
 
 echo "+++ Generate dependencies report"
 # When the pipeline set MANIFEST_URL we already have it; otherwise read it from
-# .package-version (mage did the same internally via USE_PACKAGE_VERSION).
+# .package-version (the package target read the same file internally).
 REPORT_MANIFEST_URL="${MANIFEST_URL:-$(jq -r .manifest_url .package-version)}"
 BEAT_VERSION_FULL=$(curl -sf --retry 5 --retry-delay 5 --retry-all-errors -XGET "${REPORT_MANIFEST_URL}" |jq '.version' -r )
 bash "${_SELF}/../../../dev-tools/dependencies-report"

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -323,7 +323,12 @@ func (b GolangCrossBuilder) Build() error {
 		"--env", fmt.Sprintf("SNAPSHOT=%v", cfg.Build.Snapshot),
 		"--env", fmt.Sprintf("DEV=%v", cfg.Build.DevBuild),
 		"--env", fmt.Sprintf("FIPS=%v", cfg.Build.FIPSBuild),
-		"--env", fmt.Sprintf("USE_PACKAGE_VERSION=%v", cfg.Packaging.UsePackageVersion),
+		// The container re-runs LoadSettings for the inner mage target, so
+		// forward the resolved core version instead of USE_PACKAGE_VERSION:
+		// the inner build must not re-derive values from .package-version,
+		// which would bypass the opt-in decision the host target already made
+		// (see Settings.WithPackageVersionOverrides).
+		"--env", fmt.Sprintf("BEAT_VERSION=%s", cfg.AgentCoreVersion()),
 		"-v", repoInfo.RootDir+":"+mountPoint,
 	)
 

--- a/dev-tools/mage/packageversion.go
+++ b/dev-tools/mage/packageversion.go
@@ -25,9 +25,11 @@ type packageVersion struct {
 	StackBuildID string `json:"stack_build_id"`
 }
 
-// GetPackageVersionInfo reads the package version file if USE_PACKAGE_VERSION is set.
-// The file is looked up in cfg.RepoInfo.RootDir.
-// Returns nil if USE_PACKAGE_VERSION is not set or the file doesn't exist.
+// GetPackageVersionInfo reads the package version file if
+// cfg.Packaging.UsePackageVersion is true. The file is looked up in
+// cfg.RepoInfo.RootDir.
+// Returns nil if cfg.Packaging.UsePackageVersion is false or the file
+// doesn't exist.
 func GetPackageVersionInfo(cfg *Settings) (*packageVersion, error) {
 	if !cfg.Packaging.UsePackageVersion {
 		return nil, nil
@@ -38,7 +40,7 @@ func GetPackageVersionInfo(cfg *Settings) (*packageVersion, error) {
 	_, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("USE_PACKAGE_VERSION is set, but %q does not exist, not overriding\n", path)
+			log.Printf("%q does not exist, not applying package version overrides\n", path)
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to stat %q: %w", path, err)

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -735,12 +735,13 @@ func (s *Settings) setCrossBuildDefaults() {
 
 // setPackagingDefaults sets default values for PackagingSettings.
 func (s *Settings) setPackagingDefaults() {
-	// Default to reading .package-version so `mage package` works from a
-	// fresh checkout without ceremony: the loader below will pull in the
-	// manifest URL, version and snapshot flag for the branch. Flows that
-	// need version.go's version instead (notably the binary-DRA builder
-	// in .buildkite/scripts/steps/build-agent-core.sh) set
-	// USE_PACKAGE_VERSION=false explicitly.
+	// Reading .package-version is opt-in per mage target: only targets that
+	// call WithPackageVersionOverrides consume it. Default it to on so that
+	// `mage package` works from a fresh checkout without ceremony (the
+	// override pulls in the manifest URL, version and snapshot flag for the
+	// branch), while targets that never call WithPackageVersionOverrides
+	// ignore .package-version entirely. USE_PACKAGE_VERSION=false disables
+	// the overrides for the opt-in targets too.
 	s.Packaging.UsePackageVersion = true
 }
 
@@ -914,6 +915,82 @@ func (s *Settings) WithManifestInfo(ctx context.Context) (*Settings, error) {
 	return clone, nil
 }
 
+// WithPackageVersionOverrides returns a copy of the settings with the
+// .package-version file's contents applied: the manifest URL, the package and
+// core versions, the snapshot flag, the integration-test agent/stack versions,
+// and a default agent drop path. Values provided explicitly via the
+// environment (AGENT_PACKAGE_VERSION, BEAT_VERSION, AGENT_VERSION,
+// AGENT_STACK_VERSION, AGENT_DROP_PATH) win over the file's.
+//
+// Reading .package-version is opt-in per mage target: only targets whose
+// output must stay consistent with the published snapshot build call this
+// (package and the targets built on it, downloadManifest, ironbank, the cloud
+// image targets, and the integration-test runners). All other targets never
+// read the file, so for example `SNAPSHOT=false mage helm:package` behaves as
+// written.
+//
+// USE_PACKAGE_VERSION=false disables the overrides for opt-in targets too. An
+// explicit MANIFEST_URL also disables them, since the manifest is then
+// authoritative for versions (combining MANIFEST_URL with an explicit
+// USE_PACKAGE_VERSION=true is rejected during settings loading).
+//
+// An explicit SNAPSHOT value that contradicts .package-version is an error
+// rather than silently overridden: packaging snapshot dependencies into an
+// artifact labeled as a release build (or vice versa) produces a broken
+// package.
+func (s *Settings) WithPackageVersionOverrides() (*Settings, error) {
+	if !s.Packaging.UsePackageVersion || s.Packaging.ManifestURL != "" {
+		return s, nil
+	}
+
+	pv, err := GetPackageVersionInfo(s)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", PackageVersionFilename, err)
+	}
+	if pv == nil {
+		return s, nil
+	}
+
+	parsedVersion, err := version.ParseVersion(pv.Version)
+	if err != nil {
+		return nil, fmt.Errorf("parsing version %q from %s: %w", pv.Version, PackageVersionFilename, err)
+	}
+	snapshot := parsedVersion.IsSnapshot()
+	if s.Build.SnapshotSet && s.Build.Snapshot != snapshot {
+		return nil, fmt.Errorf(
+			"SNAPSHOT=%v conflicts with %s (version %s): the package's snapshot flag must match its dependencies; "+
+				"set USE_PACKAGE_VERSION=false or provide MANIFEST_URL instead",
+			s.Build.Snapshot, PackageVersionFilename, pv.Version)
+	}
+
+	clone := s.Clone()
+	clone.Packaging.ManifestURL = pv.ManifestURL
+	clone.Build.Snapshot = snapshot
+	// AgentPackageVersion and AgentCoreVersion are both set from pv.CoreVersion
+	// because the full package's agent_package_version must match the core
+	// archive's agent_core_version (extractAgentCoreForPackage looks up the
+	// core archive by the same version). For packageAgentCore running as a
+	// dependency of package, this means the core archive is named with
+	// .package-version's version rather than version/version.go's; that is
+	// intentional.
+	if os.Getenv("AGENT_PACKAGE_VERSION") == "" {
+		clone.Packaging.AgentPackageVersion = pv.CoreVersion
+	}
+	if os.Getenv("BEAT_VERSION") == "" {
+		clone.Build.AgentCoreVersion = pv.CoreVersion
+	}
+	if os.Getenv("AGENT_VERSION") == "" {
+		clone.IntegrationTest.AgentVersion = pv.Version
+	}
+	if os.Getenv("AGENT_STACK_VERSION") == "" {
+		clone.IntegrationTest.AgentStackVersion = pv.StackVersion
+	}
+	if clone.Packaging.AgentDropPath == "" {
+		clone.Packaging.AgentDropPath = filepath.Join(clone.RepoInfo.RootDir, "build", "distributions", "elastic-agent-drop")
+	}
+	return clone, nil
+}
+
 // WithAgentDropPath returns a copy of the settings with the specified agent drop path.
 func (s *Settings) WithAgentDropPath(path string) *Settings {
 	clone := s.Clone()
@@ -969,6 +1046,12 @@ type BuildSettings struct {
 
 	// Snapshot indicates whether this is a snapshot build (from SNAPSHOT env var, default true)
 	Snapshot bool
+
+	// SnapshotSet indicates whether the SNAPSHOT env var was explicitly set.
+	// This is needed to distinguish "not set" from "explicitly set to the
+	// default" so that WithPackageVersionOverrides can error on an explicit
+	// value that contradicts .package-version instead of silently ignoring it.
+	SnapshotSet bool
 
 	// DevBuild indicates whether this is a development build (from DEV env var)
 	DevBuild bool
@@ -1162,8 +1245,15 @@ type PackagingSettings struct {
 	// Manifest is the downloaded manifest response. Populated by WithManifestInfo when ManifestURL is set.
 	Manifest *manifest.Build
 
-	// UsePackageVersion enables reading version from .package-version file (from USE_PACKAGE_VERSION env var)
+	// UsePackageVersion enables reading version from .package-version file (from USE_PACKAGE_VERSION env var).
+	// Only consulted by targets that call WithPackageVersionOverrides; it has no
+	// effect on any other target.
 	UsePackageVersion bool
+
+	// UsePackageVersionSet indicates whether the USE_PACKAGE_VERSION env var was
+	// explicitly set, distinguishing an explicit opt-in from the default when
+	// combined with MANIFEST_URL (explicit true + MANIFEST_URL is an error).
+	UsePackageVersionSet bool
 
 	// AgentDropPath is the path for dropping agent artifacts (from AGENT_DROP_PATH env var)
 	AgentDropPath string
@@ -1421,6 +1511,7 @@ func (s *Settings) loadBuildSettingsFromEnv() error {
 
 	var err error
 
+	_, s.Build.SnapshotSet = os.LookupEnv("SNAPSHOT")
 	s.Build.Snapshot, err = parseBoolEnv("SNAPSHOT", s.Build.Snapshot)
 	if err != nil {
 		return fmt.Errorf("failed to parse SNAPSHOT: %w", err)
@@ -1561,14 +1652,18 @@ func (s *Settings) loadPackagingSettingsFromEnv() error {
 		manifestURLSet = true
 	}
 	var err error
+	_, s.Packaging.UsePackageVersionSet = os.LookupEnv("USE_PACKAGE_VERSION")
 	s.Packaging.UsePackageVersion, err = parseBoolEnv("USE_PACKAGE_VERSION", s.Packaging.UsePackageVersion)
 	if err != nil {
 		return fmt.Errorf("failed to parse USE_PACKAGE_VERSION: %w", err)
 	}
-	if manifestURLSet && s.Packaging.UsePackageVersion {
+	// An explicit MANIFEST_URL is authoritative and makes
+	// WithPackageVersionOverrides a no-op, so only reject the combination when
+	// USE_PACKAGE_VERSION=true was explicitly requested alongside it.
+	if manifestURLSet && s.Packaging.UsePackageVersionSet && s.Packaging.UsePackageVersion {
 		return errors.New("MANIFEST_URL and USE_PACKAGE_VERSION=true are mutually exclusive: " +
 			"USE_PACKAGE_VERSION reads .package-version to set the manifest URL; " +
-			"set USE_PACKAGE_VERSION=false when providing MANIFEST_URL explicitly")
+			"unset USE_PACKAGE_VERSION when providing MANIFEST_URL explicitly")
 	}
 	if v := os.Getenv("AGENT_DROP_PATH"); v != "" {
 		s.Packaging.AgentDropPath = v
@@ -1585,31 +1680,6 @@ func (s *Settings) loadPackagingSettingsFromEnv() error {
 		return fmt.Errorf("unknown AGENT_CORE_SOURCE=%s", v)
 	}
 
-	// Apply .package-version overrides when USE_PACKAGE_VERSION is set.
-	// AgentPackageVersion and AgentCoreVersion are both set from pv.CoreVersion
-	// because the full package's agent_package_version must match the core
-	// archive's agent_core_version (extractAgentCoreForPackage looks up the
-	// core archive by the same version). For standalone packageAgentCore, this
-	// means the core archive is named with .package-version's version rather
-	// than version/version.go's; that is intentional.
-	if s.Packaging.UsePackageVersion {
-		pv, err := GetPackageVersionInfo(s)
-		if err != nil {
-			log.Printf("Warning: failed to get package version info: %v", err)
-		}
-		if pv != nil {
-			s.Packaging.ManifestURL = pv.ManifestURL
-			s.Packaging.AgentPackageVersion = pv.CoreVersion
-			s.Build.AgentCoreVersion = pv.CoreVersion
-			s.Build.Snapshot = true
-			s.IntegrationTest.AgentVersion = pv.Version
-			s.IntegrationTest.AgentStackVersion = pv.StackVersion
-
-			if s.Packaging.AgentDropPath == "" {
-				s.Packaging.AgentDropPath = filepath.Join(s.RepoInfo.RootDir, "build", "distributions", "elastic-agent-drop")
-			}
-		}
-	}
 	return nil
 }
 

--- a/dev-tools/mage/settings_test.go
+++ b/dev-tools/mage/settings_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -746,9 +747,6 @@ func TestLoadSettings(t *testing.T) {
 	})
 
 	t.Run("loads build settings from env vars", func(t *testing.T) {
-		// Disable the USE_PACKAGE_VERSION default so .package-version does
-		// not override BEAT_VERSION etc. during this test.
-		t.Setenv("USE_PACKAGE_VERSION", "false")
 		t.Setenv("SNAPSHOT", "true")
 		t.Setenv("DEV", "true")
 		t.Setenv("EXTERNAL", "true")
@@ -833,9 +831,6 @@ func TestLoadSettings(t *testing.T) {
 	})
 
 	t.Run("loads packaging settings from env vars", func(t *testing.T) {
-		// Disable the USE_PACKAGE_VERSION default so .package-version does
-		// not override AGENT_PACKAGE_VERSION / MANIFEST_URL during this test.
-		t.Setenv("USE_PACKAGE_VERSION", "false")
 		t.Setenv("AGENT_PACKAGE_VERSION", "2.0.0")
 		t.Setenv("MANIFEST_URL", "https://manifest.url")
 		t.Setenv("AGENT_DROP_PATH", "/drop/path")
@@ -850,23 +845,33 @@ func TestLoadSettings(t *testing.T) {
 		assert.True(t, settings.Packaging.KeepArchive)
 	})
 
-	t.Run("applies .package-version overrides when USE_PACKAGE_VERSION is set", func(t *testing.T) {
-		t.Setenv("USE_PACKAGE_VERSION", "true")
-
+	t.Run("does not apply .package-version overrides by default", func(t *testing.T) {
 		settings, err := LoadSettings()
 		require.NoError(t, err)
 
-		// Read the real .package-version file from the repo root.
-		pv, err := readPackageVersion(settings.RepoInfo.RootDir)
-		require.NoError(t, err)
+		// The overrides are opt-in per target via WithPackageVersionOverrides;
+		// plain settings loading must leave these untouched.
+		assert.Empty(t, settings.Packaging.ManifestURL)
+		assert.Empty(t, settings.Packaging.AgentPackageVersion)
+		assert.Empty(t, settings.IntegrationTest.AgentVersion)
+		assert.Empty(t, settings.IntegrationTest.AgentStackVersion)
+		assert.Empty(t, settings.Packaging.AgentDropPath)
+	})
 
-		isSnapshot := strings.HasSuffix(pv.Version, SnapshotSuffix)
-		assert.Equal(t, pv.ManifestURL, settings.Packaging.ManifestURL)
-		assert.Equal(t, pv.CoreVersion, settings.Packaging.AgentPackageVersion)
-		assert.Equal(t, isSnapshot, settings.Build.Snapshot)
-		assert.Equal(t, pv.Version, settings.IntegrationTest.AgentVersion)
-		assert.Equal(t, pv.StackVersion, settings.IntegrationTest.AgentStackVersion)
-		assert.NotEmpty(t, settings.Packaging.AgentDropPath)
+	t.Run("allows MANIFEST_URL without disabling USE_PACKAGE_VERSION", func(t *testing.T) {
+		t.Setenv("MANIFEST_URL", "https://manifest.url")
+
+		settings, err := LoadSettings()
+		require.NoError(t, err)
+		assert.Equal(t, "https://manifest.url", settings.Packaging.ManifestURL)
+	})
+
+	t.Run("rejects MANIFEST_URL combined with explicit USE_PACKAGE_VERSION=true", func(t *testing.T) {
+		t.Setenv("MANIFEST_URL", "https://manifest.url")
+		t.Setenv("USE_PACKAGE_VERSION", "true")
+
+		_, err := LoadSettings()
+		assert.ErrorContains(t, err, "mutually exclusive")
 	})
 
 	t.Run("loads integration test settings from env vars", func(t *testing.T) {
@@ -970,6 +975,103 @@ func TestLoadSettings(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "SNAPSHOT")
+	})
+}
+
+func TestWithPackageVersionOverrides(t *testing.T) {
+	t.Run("applies .package-version overrides", func(t *testing.T) {
+		settings, err := LoadSettings()
+		require.NoError(t, err)
+
+		// Read the real .package-version file from the repo root.
+		pv, err := readPackageVersion(settings.RepoInfo.RootDir)
+		require.NoError(t, err)
+
+		overridden, err := settings.WithPackageVersionOverrides()
+		require.NoError(t, err)
+
+		isSnapshot := strings.HasSuffix(pv.Version, SnapshotSuffix)
+		assert.Equal(t, pv.ManifestURL, overridden.Packaging.ManifestURL)
+		assert.Equal(t, pv.CoreVersion, overridden.Packaging.AgentPackageVersion)
+		assert.Equal(t, isSnapshot, overridden.Build.Snapshot)
+		assert.Equal(t, pv.Version, overridden.IntegrationTest.AgentVersion)
+		assert.Equal(t, pv.StackVersion, overridden.IntegrationTest.AgentStackVersion)
+		assert.NotEmpty(t, overridden.Packaging.AgentDropPath)
+
+		// The receiver must not be mutated.
+		assert.Empty(t, settings.Packaging.ManifestURL)
+	})
+
+	t.Run("explicit env values win over .package-version", func(t *testing.T) {
+		t.Setenv("AGENT_PACKAGE_VERSION", "1.2.3")
+		t.Setenv("BEAT_VERSION", "1.2.3")
+		t.Setenv("AGENT_VERSION", "1.2.3-SNAPSHOT")
+		t.Setenv("AGENT_STACK_VERSION", "1.2.4-SNAPSHOT")
+		t.Setenv("AGENT_DROP_PATH", "/drop/path")
+
+		settings, err := LoadSettings()
+		require.NoError(t, err)
+
+		overridden, err := settings.WithPackageVersionOverrides()
+		require.NoError(t, err)
+
+		pv, err := readPackageVersion(settings.RepoInfo.RootDir)
+		require.NoError(t, err)
+
+		assert.Equal(t, pv.ManifestURL, overridden.Packaging.ManifestURL)
+		assert.Equal(t, "1.2.3", overridden.Packaging.AgentPackageVersion)
+		assert.Equal(t, "1.2.3", overridden.Build.AgentCoreVersion)
+		assert.Equal(t, "1.2.3-SNAPSHOT", overridden.IntegrationTest.AgentVersion)
+		assert.Equal(t, "1.2.4-SNAPSHOT", overridden.IntegrationTest.AgentStackVersion)
+		assert.Equal(t, "/drop/path", overridden.Packaging.AgentDropPath)
+	})
+
+	t.Run("no-op when USE_PACKAGE_VERSION=false", func(t *testing.T) {
+		t.Setenv("USE_PACKAGE_VERSION", "false")
+
+		settings, err := LoadSettings()
+		require.NoError(t, err)
+
+		overridden, err := settings.WithPackageVersionOverrides()
+		require.NoError(t, err)
+		assert.Same(t, settings, overridden)
+	})
+
+	t.Run("no-op when MANIFEST_URL is set", func(t *testing.T) {
+		t.Setenv("MANIFEST_URL", "https://manifest.url")
+
+		settings, err := LoadSettings()
+		require.NoError(t, err)
+
+		overridden, err := settings.WithPackageVersionOverrides()
+		require.NoError(t, err)
+		assert.Same(t, settings, overridden)
+		assert.Equal(t, "https://manifest.url", overridden.Packaging.ManifestURL)
+	})
+
+	t.Run("errors when explicit SNAPSHOT conflicts with .package-version", func(t *testing.T) {
+		settings, err := LoadSettings()
+		require.NoError(t, err)
+
+		pv, err := readPackageVersion(settings.RepoInfo.RootDir)
+		require.NoError(t, err)
+		isSnapshot := strings.HasSuffix(pv.Version, SnapshotSuffix)
+
+		// Request the opposite of what .package-version contains.
+		t.Setenv("SNAPSHOT", strconv.FormatBool(!isSnapshot))
+		settings, err = LoadSettings()
+		require.NoError(t, err)
+
+		_, err = settings.WithPackageVersionOverrides()
+		assert.ErrorContains(t, err, "SNAPSHOT")
+
+		// A matching explicit value is fine.
+		t.Setenv("SNAPSHOT", strconv.FormatBool(isSnapshot))
+		settings, err = LoadSettings()
+		require.NoError(t, err)
+
+		_, err = settings.WithPackageVersionOverrides()
+		assert.NoError(t, err)
 	})
 }
 

--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -132,16 +132,22 @@ It will pull the remaining dependencies from a manifest specified in [.package-v
 This process can be controlled through the following environment variables:
 
 - `AGENT_CORE_SOURCE=local|manifest`: Build the aforementioned binaries locally or pull from the manifest. Default is `local`. Manifest is defined either by [.package-version](/.package-version) or the `MANIFEST_URL` environment variable.
-- `USE_PACKAGE_VERSION=true|false`: Use the content of [.package-version](/.package-version) for configuring the package, most importantly the manifest url, but the version is effective as well. Mutually exclusive with `MANIFEST_URL`. Default is `true`.
-- `MANIFEST_URL`: The manifest url from which to pull the dependencies. Mutually exclusive with `USE_PACKAGE_VERSION=true`. Default is empty.
+- `USE_PACKAGE_VERSION=true|false`: Use the content of [.package-version](/.package-version) for configuring the package, most importantly the manifest url, but the version is effective as well. Default is `true`.
+  Only targets that need consistency with the published snapshot build read this file (`package` and the targets built on it,
+  `downloadManifest`, `ironbank`, the `cloud:*` image targets, and the `integration:*` test runners); it has no effect on any
+  other target (for example `helm:package` or plain builds). Providing `MANIFEST_URL` also disables it, since the manifest is
+  then authoritative; explicitly setting both `MANIFEST_URL` and `USE_PACKAGE_VERSION=true` is an error.
+- `MANIFEST_URL`: The manifest url from which to pull the dependencies. Takes precedence over [.package-version](/.package-version). Default is empty.
 - `SNAPSHOT=true|false`: Create a snapshot build. This is just versioning metadata indicating that the
   package doesn't contain a release build. Read from the manifest if present, otherwise defaults to `true`.
+  For targets that read [.package-version](/.package-version), an explicit value that contradicts the file is an error,
+  because mixing snapshot dependencies with a release package (or vice versa) produces a broken artifact.
 - `EXTERNAL=true|false`: If you want to build with dependencies you've provided locally (you have a custom build of endpoint, for example), then set this to `false` and `USE_PACKAGE_VERSION=false`. Default is `true`.
 
 For example, if you want to create a package the same way as the unified release job, you'd run:
 
 ```bash
-USE_PACKAGE_VERSION=false MANIFEST_URL=... AGENT_CORE_SOURCE=manifest mage package
+MANIFEST_URL=... AGENT_CORE_SOURCE=manifest mage package
 ```
 
 ### Running the tests

--- a/magefile.go
+++ b/magefile.go
@@ -653,7 +653,12 @@ func Package(ctx context.Context) error {
 		return errors.New("elastic-agent package is expected to build at least one platform package")
 	}
 
-	cfg, err := cfg.WithManifestInfo(ctx)
+	cfg, err := cfg.WithPackageVersionOverrides()
+	if err != nil {
+		return fmt.Errorf("failed applying %s overrides: %w", devtools.PackageVersionFilename, err)
+	}
+
+	cfg, err = cfg.WithManifestInfo(ctx)
 	if err != nil {
 		return fmt.Errorf("failed downloading manifest: %w", err)
 	}
@@ -666,6 +671,13 @@ func Package(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error loading agent package spec: %w", err)
 	}
+
+	// Pass the resolved settings to dependency targets. Without this,
+	// PackageAgentCore would re-load settings from the environment and — not
+	// being a .package-version opt-in target — name the core archive with
+	// version/version.go's version instead of the one used for the package,
+	// breaking the lookup in extractAgentCoreForPackage.
+	ctx = devtools.ContextWithSettings(ctx, cfg)
 
 	if cfg.Packaging.CoreSource == devtools.CoreSourceLocal {
 		mg.CtxDeps(ctx, PackageAgentCore)
@@ -690,6 +702,10 @@ func Package(ctx context.Context) error {
 func DownloadManifest(ctx context.Context) error {
 	// Load elastic-agent packaging specs to correctly load component dependencies
 	cfg := devtools.SettingsFromContext(ctx)
+	cfg, err := cfg.WithPackageVersionOverrides()
+	if err != nil {
+		return fmt.Errorf("failed applying %s overrides: %w", devtools.PackageVersionFilename, err)
+	}
 	pkgSpec, err := devtools.LoadElasticAgentPackageSpec(cfg.ElasticBeatsDir)
 	if err != nil {
 		return err
@@ -1049,6 +1065,11 @@ func (Cloud) Image(ctx context.Context) error {
 // DOCKER_IMPORT_SOURCE - override source for import
 func (Cloud) Load(ctx context.Context) error {
 	cfg := devtools.SettingsFromContext(ctx)
+	// Resolve the version the same way Package does so the artifact filename matches.
+	cfg, err := cfg.WithPackageVersionOverrides()
+	if err != nil {
+		return fmt.Errorf("failed applying %s overrides: %w", devtools.PackageVersionFilename, err)
+	}
 	agentVersion := cfg.AgentPackageVersion()
 
 	source := devtools.DistributionsDir + "/elastic-agent-cloud-" + agentVersion + "-SNAPSHOT-linux-" + runtime.GOARCH + ".docker.tar.gz"
@@ -1066,6 +1087,11 @@ func (Cloud) Load(ctx context.Context) error {
 // Previous login to elastic registry is required!
 func (Cloud) Push(ctx context.Context) error {
 	cfg := devtools.SettingsFromContext(ctx)
+	// Resolve the version the same way Package does so the source image tag matches.
+	cfg, err := cfg.WithPackageVersionOverrides()
+	if err != nil {
+		return fmt.Errorf("failed applying %s overrides: %w", devtools.PackageVersionFilename, err)
+	}
 	agentVersion := cfg.AgentPackageVersion()
 
 	sourceCloudImageName := fmt.Sprintf("docker.elastic.co/beats-ci/elastic-agent-cloud:%s-SNAPSHOT", agentVersion)
@@ -1086,7 +1112,7 @@ func (Cloud) Push(ctx context.Context) error {
 	}
 
 	fmt.Printf(">> Setting a docker image tag to %s\n", targetCloudImageName)
-	err := sh.RunV("docker", "tag", sourceCloudImageName, targetCloudImageName)
+	err = sh.RunV("docker", "tag", sourceCloudImageName, targetCloudImageName)
 	if err != nil {
 		return fmt.Errorf("failed setting a docker image tag: %w", err)
 	}
@@ -1996,7 +2022,11 @@ func Ironbank(ctx context.Context) error {
 		return nil
 	}
 	cfg := devtools.SettingsFromContext(ctx)
-	cfg, err := cfg.WithManifestInfo(ctx)
+	cfg, err := cfg.WithPackageVersionOverrides()
+	if err != nil {
+		return fmt.Errorf("failed applying %s overrides: %w", devtools.PackageVersionFilename, err)
+	}
+	cfg, err = cfg.WithManifestInfo(ctx)
 	if err != nil {
 		return fmt.Errorf("failed downloading manifest: %w", err)
 	}
@@ -2884,6 +2914,12 @@ func (i Integration) testForResourceLeaks(ctx context.Context, matrix bool, test
 // TestOnRemote shouldn't be called locally (called on remote host to perform testing)
 func (Integration) TestOnRemote(ctx context.Context) error {
 	cfg := devtools.SettingsFromContextWithOptions(ctx, devtools.LoadOptions{SkipVCS: true})
+	// Default the agent version from .package-version (the repo copy is
+	// present on the remote host); an explicit AGENT_VERSION env var wins.
+	cfg, err := cfg.WithPackageVersionOverrides()
+	if err != nil {
+		return fmt.Errorf("failed applying %s overrides: %w", devtools.PackageVersionFilename, err)
+	}
 	mg.Deps(Build.TestFakeComponent)
 	version := cfg.IntegrationTest.AgentVersion
 	if version == "" {
@@ -2956,6 +2992,12 @@ func (Integration) TestOnRemote(ctx context.Context) error {
 
 func (Integration) Buildkite(ctx context.Context) error {
 	envCfg := devtools.SettingsFromContext(ctx)
+	// Default the agent and stack versions from .package-version; explicit
+	// AGENT_VERSION / AGENT_STACK_VERSION env vars win.
+	envCfg, err := envCfg.WithPackageVersionOverrides()
+	if err != nil {
+		return fmt.Errorf("failed applying %s overrides: %w", devtools.PackageVersionFilename, err)
+	}
 	goTestFlags := envCfg.IntegrationTest.GoTestFlags
 	batches, err := define.DetermineBatches("testing/integration/ess", goTestFlags, "integration")
 	if err != nil {
@@ -3034,6 +3076,13 @@ func integRunner(ctx context.Context, testDir string, matrix bool, singleTest st
 
 func integRunnerOnce(ctx context.Context, matrix bool, testDir string, singleTest string) (int, error) {
 	cfg := devtools.SettingsFromContext(ctx)
+	// Default the agent and stack versions from .package-version so tests run
+	// against the published snapshot build; explicit AGENT_VERSION /
+	// AGENT_STACK_VERSION env vars win.
+	cfg, err := cfg.WithPackageVersionOverrides()
+	if err != nil {
+		return 0, fmt.Errorf("failed applying %s overrides: %w", devtools.PackageVersionFilename, err)
+	}
 	goTestFlags := cfg.IntegrationTest.GoTestFlags
 
 	batches, err := define.DetermineBatches(testDir, goTestFlags, "integration")


### PR DESCRIPTION
## What does this PR do?

Makes reading `.package-version` opt-in per mage target instead of applying it on every settings load.

Previously, `LoadSettings()` unconditionally applied `.package-version` overrides (manifest URL, versions, `Snapshot=true`) unless `USE_PACKAGE_VERSION=false` was set. Every target saw these values, including ones with no component dependencies, which silently clobbered explicit `SNAPSHOT=false` and `BEAT_VERSION` settings (#16026, #15972, #15924).

Now the overrides live in `Settings.WithPackageVersionOverrides()`, called only by targets that need consistency with the published snapshot build: `package` (and `cloud:image`), `downloadManifest`, `ironbank`, `cloud:load`/`cloud:push`, and the integration test runners. All other targets (`helm:package`, `packageAgentCore`, plain builds) never read the file, and `USE_PACKAGE_VERSION` has no effect on them.

Behavior changes:

- Explicit env vars (`AGENT_PACKAGE_VERSION`, `BEAT_VERSION`, `AGENT_VERSION`, `AGENT_STACK_VERSION`) win over `.package-version` instead of being overwritten.
- An explicit `SNAPSHOT` value that contradicts `.package-version` is an error on opt-in targets instead of being silently ignored.
- `MANIFEST_URL` alone disables the overrides; combining it with an explicit `USE_PACKAGE_VERSION=true` is an error. `MANIFEST_URL=... mage package` no longer requires `USE_PACKAGE_VERSION=false`.
- `package` passes its resolved settings to dependency targets via context so `packageAgentCore` names the core archive with the same version.
- Crossbuild containers receive the resolved `BEAT_VERSION` instead of `USE_PACKAGE_VERSION`, so the inner mage invocation doesn't re-derive values from `.package-version`.

CI cleanup: removed the `helm-charts.sh` workaround for #16026 and the now-redundant `USE_PACKAGE_VERSION=false` opt-outs in `build-agent-core.sh` and `package.sh`. `beats_tests.sh` keeps its opt-out, which still applies to the integration runner.

## Why is it important?

`SNAPSHOT=false` was silently ignored by the Helm chart pipeline, producing snapshot-named artifacts from release tags. The root cause - global overrides that most targets never needed - also produced the `BEAT_VERSION` leak in the serverless Beats tests and required scattered opt-outs in CI scripts.

## Related issues

- Closes #16026