### PR TITLE
fix(windows): trust current Agent process user SID in HasStrictExecPerms

### DIFF
--- a/changelog/fragments/1786546956-allow-current-windows-agent-user-to-write-components.yaml
+++ b/changelog/fragments/1786546956-allow-current-windows-agent-user-to-write-components.yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+
+summary: Allow the current Windows Agent user to write component executables
+
+component: elastic-agent

--- a/pkg/utils/perm_windows.go
+++ b/pkg/utils/perm_windows.go
@@ -76,10 +76,23 @@ const writeMask = windows.ACCESS_MASK(
 		windows.DELETE | windows.WRITE_DAC | windows.WRITE_OWNER,
 )
 
-// HasStrictExecPerms ensures that no non-privileged SID has write access to
-// the file at path. Privileged SIDs (SYSTEM, Administrators, and the file
-// owner) may have any access; all other SIDs must not hold write-capable bits.
+// HasStrictExecPerms ensures that no untrusted SID has write access to the file
+// at path. SYSTEM, Administrators, the file owner, and the user running Elastic
+// Agent may have any access; all other SIDs must not hold write-capable bits.
 func HasStrictExecPerms(path string) error {
+	currentOwner, err := CurrentFileOwner()
+	if err != nil {
+		return fmt.Errorf("failed to get current process owner: %w", err)
+	}
+	currentUserSID, err := windows.StringToSid(currentOwner.UID)
+	if err != nil {
+		return fmt.Errorf("failed to parse current process user SID: %w", err)
+	}
+
+	return hasStrictExecPerms(path, currentUserSID)
+}
+
+func hasStrictExecPerms(path string, currentUserSID *windows.SID) error {
 	sd, err := windows.GetNamedSecurityInfo(
 		path,
 		windows.SE_FILE_OBJECT,
@@ -123,8 +136,11 @@ func HasStrictExecPerms(path string) error {
 
 		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
 
-		// SYSTEM, Administrators, and the file owner may hold any access.
-		if sid.Equals(systemSID) || sid.Equals(adminsSID) || (ownerSID != nil && sid.Equals(ownerSID)) {
+		// The current process user already controls this Agent process, so
+		// trusting it does not permit binary tampering by another account. This
+		// also supports Windows tokens whose default file owner differs from the
+		// token user, such as a non-elevated member of Administrators.
+		if isTrustedExecWriter(sid, systemSID, adminsSID, ownerSID, currentUserSID) {
 			continue
 		}
 
@@ -138,6 +154,13 @@ func HasStrictExecPerms(path string) error {
 	// memory subject to a GC finalizer.
 	runtime.KeepAlive(sd)
 	return nil
+}
+
+func isTrustedExecWriter(sid, systemSID, adminsSID, ownerSID, currentUserSID *windows.SID) bool {
+	return sid.Equals(systemSID) ||
+		sid.Equals(adminsSID) ||
+		(ownerSID != nil && sid.Equals(ownerSID)) ||
+		sid.Equals(currentUserSID)
 }
 
 // HasStrictExecPermsAndOwnership ensures that the path is executable by the

--- a/pkg/utils/perm_windows_test.go
+++ b/pkg/utils/perm_windows_test.go
@@ -52,6 +52,23 @@ func TestHasStrictExecPerms_GroupWriteRejected(t *testing.T) {
 	assert.Error(t, err, "expected error: Everyone has write access")
 }
 
+func TestHasStrictExecPerms_CurrentProcessWriteAllowed(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "exec.exe")
+	require.NoError(t, os.WriteFile(path, []byte("dummy"), 0600))
+
+	// Use Everyone as the injected current process user so the test exercises
+	// the distinction between a trusted writer and the file owner.
+	currentUserSID, err := windows.StringToSid(EveryoneSID)
+	require.NoError(t, err)
+	err = acl.Apply(path, false, false,
+		acl.GrantSid(windows.FILE_WRITE_DATA, currentUserSID),
+	)
+	require.NoError(t, err)
+
+	assert.NoError(t, hasStrictExecPerms(path, currentUserSID))
+}
+
 func TestHasStrictExecPermsAndOwnership_DelegatesToHasStrictExecPerms(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "exec.exe")


### PR DESCRIPTION
## What does this PR do?

Adds the current Agent process's token-user SID to the trusted-writer set in `HasStrictExecPerms`. Previously only SYSTEM, Administrators, and the file owner were trusted.

The internal `hasStrictExecPerms(path, currentUserSID)` is split out to keep the function testable without touching the real process token. A new `isTrustedExecWriter` helper encapsulates the full trusted-set check.

## Why is it important?

The 8.19 backport of #16058 exposed a CI failure on Windows integration tests. The failure mode is: when a Windows token's default file owner is the Administrators group SID rather than the token-user's personal SID (which happens for non-elevated members of the local Administrators group), component binaries can have an inherited write ACE for the token-user SID that doesn't match `adminsSID`, `systemSID`, or `ownerSID` — so `HasStrictExecPerms` rejects them. The same scenario applies in production when `elastic-agent-user` holds write ACEs on the binaries it manages.

The failure was only observed in the 8.19 backport (#16155) and not in the original PR to main (#16058), the 9.4 backport (#16154), or the 9.5 backport (#16153) because of differences in the Windows CI VM images used by each branch at the time:

| Branch | Windows image build | Result |
|--------|---------------------|--------|
| main | `1785546083` | Passed |
| 9.5 | `1785286913`* | Passed |
| 9.4 | `1785546083` | Passed |
| 8.19 | `1782867684`* | Failed |

*_These were the image versions in use when the respective PRs ran. Both branches have since been bumped to `1785546083`. Rebasing the 8.19 PR on the updated branch may resolve the CI failure, but the fix is still warranted — the older image exposed a real production scenario that should be handled correctly regardless of CI image configuration._

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None. This strictly expands the set of trusted writers to include the Agent process itself, which already has full control over the process.

## How to test this PR locally

Requires a Windows (amd64) machine running Elastic Agent as an unprivileged service account.

1. Build and install with `--unprivileged`.
2. Confirm agent starts cleanly and does not log `non-privileged SID … has write access` errors for its own component binaries.
3. Unit tests (Windows only): `go test ./pkg/utils/... -run TestHasStrictExecPerms`

## Related issues

- Relates #16058 (original security fix)
- Relates #16155 (8.19 backport where the CI failure was observed)