### PR TITLE
fix(diagnostics): collect component trace logs in container deployments

### DIFF
--- a/changelog/fragments/1786552448-fix-diagnostics-collect-component-trace-logs-in-container-deployments.yaml
+++ b/changelog/fragments/1786552448-fix-diagnostics-collect-component-trace-logs-in-container-deployments.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: diagnostics now collects component trace logs in container deployments
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/diagnostics/diagnostics.go
+++ b/internal/pkg/diagnostics/diagnostics.go
@@ -330,7 +330,7 @@ func ZipArchive(
 	}
 
 	// Gather Logs:
-	return zipLogs(zw, ts, topPath, excludeEvents, errOut)
+	return zipLogs(zw, ts, topPath, paths.Components(), excludeEvents, errOut)
 }
 
 func writeErrorResult(zw *zip.Writer, path string, errBody string) error {
@@ -414,7 +414,7 @@ func writeRedacted(errOut, resultWriter io.Writer, fullFilePath string, fileResu
 	return err
 }
 
-func zipLogs(zw *zip.Writer, ts time.Time, topPath string, excludeEvents bool, errOut io.Writer) error {
+func zipLogs(zw *zip.Writer, ts time.Time, topPath string, componentsPath string, excludeEvents bool, errOut io.Writer) error {
 	homePath := paths.HomeFrom(topPath)
 	dataPath := paths.DataFrom(topPath)
 	currentDir := filepath.Base(homePath)
@@ -435,7 +435,16 @@ func zipLogs(zw *zip.Writer, ts time.Time, topPath string, excludeEvents bool, e
 	if !paths.IsVersionHome() {
 		// running in a container with custom top path set
 		// logs are directly under top path
-		return zipLogsWithPath(homePath, currentDir, excludeEvents, zw, ts, errOut)
+		if err := zipLogsWithPath(homePath, currentDir, excludeEvents, zw, ts, errOut); err != nil {
+			return err
+		}
+		// Components run from the install tree, which is a different directory than topPath
+		// when a custom state path is set, so it needs its own walk.
+		installHome := filepath.Dir(componentsPath)
+		if installHome == homePath {
+			return nil
+		}
+		return zipLogsWithPath(installHome, filepath.Base(installHome), excludeEvents, zw, ts, errOut)
 	}
 
 	dataDir, err := os.Open(dataPath)

--- a/internal/pkg/diagnostics/diagnostics_test.go
+++ b/internal/pkg/diagnostics/diagnostics_test.go
@@ -612,7 +612,7 @@ func TestZipLogsComponentsLogs(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	w := zip.NewWriter(buf)
-	require.NoError(t, zipLogs(w, time.Now(), topPath, true, io.Discard))
+	require.NoError(t, zipLogs(w, time.Now(), topPath, filepath.Join(paths.HomeFrom(topPath), "components"), true, io.Discard))
 	require.NoError(t, w.Close())
 
 	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
@@ -644,7 +644,7 @@ func TestZipLogsComponentsLogsMultiVersionedHome(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	w := zip.NewWriter(buf)
-	require.NoError(t, zipLogs(w, time.Now(), topPath, true, io.Discard))
+	require.NoError(t, zipLogs(w, time.Now(), topPath, filepath.Join(paths.HomeFrom(topPath), "components"), true, io.Discard))
 	require.NoError(t, w.Close())
 
 	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
@@ -688,7 +688,7 @@ func TestZipLogsConflictingNames(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	w := zip.NewWriter(buf)
-	require.NoError(t, zipLogs(w, time.Now(), topPath, true, io.Discard))
+	require.NoError(t, zipLogs(w, time.Now(), topPath, filepath.Join(paths.HomeFrom(topPath), "components"), true, io.Discard))
 	require.NoError(t, w.Close())
 
 	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
@@ -738,7 +738,8 @@ func TestZipLogsUnversionedHome(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	w := zip.NewWriter(buf)
-	require.NoError(t, zipLogs(w, time.Now(), topPath, true, io.Discard))
+	componentsPath := filepath.Join(topPath, "components")
+	require.NoError(t, zipLogs(w, time.Now(), topPath, componentsPath, true, io.Discard))
 	require.NoError(t, w.Close())
 
 	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
@@ -752,6 +753,50 @@ func TestZipLogsUnversionedHome(t *testing.T) {
 	base := filepath.Base(topPath)
 	assert.Contains(t, names, "logs/"+base+"/log.ndjson", "agent log should be in zip")
 	assert.Contains(t, names, "logs/"+base+"/components/httpjson/trace.ndjson", "component log should be in zip")
+}
+
+// TestZipLogsUnversionedHomeDivergentComponents covers the container layout where
+// the configured data/state path (topPath) differs from the install home where
+// components run — both trees must appear in the bundle (see https://github.com/elastic/elastic-agent/issues/15771).
+func TestZipLogsUnversionedHomeDivergentComponents(t *testing.T) {
+	originalVersionHome := paths.IsVersionHome()
+	t.Cleanup(func() { paths.SetVersionHome(originalVersionHome) })
+	paths.SetVersionHome(false)
+
+	root := t.TempDir()
+
+	// Simulate the configured data/state path (topPath = STATE_PATH/data).
+	topPath := filepath.Join(root, "state", "data")
+	require.NoError(t, os.MkdirAll(filepath.Join(topPath, "logs"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(topPath, "logs", "elastic-agent.ndjson"), []byte(".\n"), 0o600))
+
+	// Simulate the install tree (paths.Components() origin), separate from topPath.
+	installHash := "elastic-agent-abc123"
+	installHome := filepath.Join(root, "data", installHash)
+	componentsPath := filepath.Join(installHome, "components")
+	require.NoError(t, os.MkdirAll(filepath.Join(componentsPath, "logs", "cel"), 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(componentsPath, "logs", "cel", "http-request-trace-test.ndjson"),
+		[]byte(".\n"), 0o600))
+
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+	require.NoError(t, zipLogs(w, time.Now(), topPath, componentsPath, true, io.Discard))
+	require.NoError(t, w.Close())
+
+	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+
+	names := make(map[string]struct{}, len(r.File))
+	for _, f := range r.File {
+		names[f.Name] = struct{}{}
+	}
+
+	base := filepath.Base(topPath) // "data"
+	assert.Contains(t, names, "logs/"+base+"/elastic-agent.ndjson",
+		"agent log under topPath should be in zip")
+	assert.Contains(t, names, "logs/"+installHash+"/components/cel/http-request-trace-test.ndjson",
+		"component trace log under install tree should be in zip")
 }
 
 // TestSaveLogs verifies the error-handling contract of saveLogs:
@@ -808,7 +853,8 @@ func zipLogsAndAssertFiles(t *testing.T, topPath string, excludeEvents bool, exp
 	// Zip the logs directory.
 	buf := new(bytes.Buffer)
 	w := zip.NewWriter(buf)
-	require.NoError(t, zipLogs(w, time.Now(), topPath, excludeEvents, io.Discard))
+	componentsPath := filepath.Join(paths.HomeFrom(topPath), "components")
+	require.NoError(t, zipLogs(w, time.Now(), topPath, componentsPath, excludeEvents, io.Discard))
 	require.NoError(t, w.Close())
 
 	// Read back the contents.

--- a/testing/integration/ess/diagnostics_test.go
+++ b/testing/integration/ess/diagnostics_test.go
@@ -693,6 +693,142 @@ agent.internal.runtime.filebeat.filestream: otel
 	verifyFilebeatRegistry(t, filepath.Join(extractionDir, "components/filestream-default/registry.tar.gz"))
 }
 
+// TestContainerDiagnostics verifies that `elastic-agent diagnostics` collects
+// input request-tracer logs when the agent runs via the `elastic-agent container`
+// entrypoint with a custom STATE_PATH that diverges from the install tree
+// (https://github.com/elastic/elastic-agent/issues/15771).
+func TestContainerDiagnostics(t *testing.T) {
+	define.Require(t, define.Requirements{
+		Group: "container",
+		Local: false,
+		Sudo:  true,
+		OS: []define.OS{
+			{Type: define.Linux},
+		},
+	})
+
+	esURL := integration.StartMockES(t, 0, 0, 0, 0)
+
+	// Mock HTTP server polled by the httpjson tracer.
+	httpjsonServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"message":"hello"}`)
+	}))
+	t.Cleanup(httpjsonServer.Close)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Minute)
+	defer cancel()
+
+	agentFixture, err := define.NewFixtureFromLocalBuild(t, define.Version(), integrationtest.WithAllowErrors())
+	require.NoError(t, err)
+
+	err = agentFixture.Prepare(ctx)
+	require.NoError(t, err)
+
+	// State path is intentionally a subdirectory of the fixture's work dir,
+	// distinct from the install tree (<workDir>/data/elastic-agent-<hash>).
+	// This reproduces the container path layout: paths.Components() points at
+	// the install tree while topPath resolves to STATE_PATH/data.
+	statePath := filepath.Join(agentFixture.WorkDir(), "agent-state")
+	env := []string{"STATE_PATH=" + statePath}
+
+	configTmpl := `
+inputs:
+  - type: httpjson
+    id: httpjson-container-diag-test
+    use_output: default
+    streams:
+      - id: httpjson-container-stream
+        data_stream:
+          dataset: httpjson.generic
+          type: logs
+        request.url: {{ .MockServerURL }}
+        request.tracer.filename: http-request-trace-*.ndjson
+        interval: 1s
+outputs:
+  default:
+    type: elasticsearch
+    hosts: [{{ .ESHost }}]
+    api_key: placeholder
+agent.monitoring.enabled: false
+# otel mode does not initialise paths.Paths.Logs, so the tracer filename validation fails
+agent.internal.runtime.filebeat.httpjson: process
+`
+	var cfgBuf bytes.Buffer
+	require.NoError(t, template.Must(template.New("cfg").Parse(configTmpl)).Execute(&cfgBuf, map[string]any{
+		"MockServerURL": httpjsonServer.URL,
+		"ESHost":        esURL.Host,
+	}))
+
+	cfgFile := filepath.Join(t.TempDir(), "elastic-agent.yml")
+	require.NoError(t, os.WriteFile(cfgFile, cfgBuf.Bytes(), 0o600))
+
+	cmd, agentOutput := prepareAgentCMD(t, ctx, agentFixture, []string{"container", "-c", cfgFile}, env)
+	t.Logf("starting agent with: %v", cmd.Args)
+	require.NoError(t, cmd.Start(), "failed to start container cmd")
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	})
+
+	require.Eventuallyf(t, func() bool {
+		err = agentFixture.IsHealthy(ctx, integrationtest.WithCmdOptions(withEnv(env)))
+		return err == nil
+	}, 5*time.Minute, time.Second,
+		"agent did not become healthy. Error: %v\nAgent output:\n%s", err, agentOutput)
+
+	// Wait for the tracer to flush; httpjson fires every 1s so 10s is generous.
+	select {
+	case <-time.After(10 * time.Second):
+	case <-ctx.Done():
+		t.Fatal("context cancelled waiting for tracer flush")
+	}
+
+	// Collect diagnostics with STATE_PATH env so the CLI resolves the same control socket.
+	zipPath := filepath.Join(t.TempDir(), "container-diag.zip")
+	_, err = agentFixture.Exec(ctx, []string{"diagnostics", "-f", zipPath}, withEnv(env))
+	require.NoError(t, err, "diagnostics command failed")
+
+	// Verify the trace file is present in the bundle. Before the fix the bundle had an
+	// empty logs/data/components/ directory and no trace files anywhere.
+	extractionDir := t.TempDir()
+	extractZipArchive(t, zipPath, extractionDir)
+
+	traceLogs, err := filepath.Glob(filepath.Join(extractionDir, "logs", "elastic-agent-*", "components", "httpjson", "http-request-trace-*.ndjson"))
+	require.NoError(t, err)
+	require.NotEmpty(t, traceLogs,
+		"container diagnostics bundle is missing httpjson request-tracer logs (reproduces #15771); "+
+			"bundle contents:\n%s", listZipEntries(t, zipPath))
+
+	for _, f := range traceLogs {
+		info, err := os.Stat(f)
+		require.NoError(t, err)
+		assert.Greaterf(t, info.Size(), int64(0), "trace log file %q is empty", f)
+	}
+
+	if t.Failed() {
+		agentFixture.MoveToDiagnosticsDir(zipPath)
+	}
+}
+
+// listZipEntries returns a newline-separated list of all entries in the zip archive,
+// used to produce helpful failure messages.
+func listZipEntries(t *testing.T, zipPath string) string {
+	t.Helper()
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return fmt.Sprintf("(failed to open zip: %v)", err)
+	}
+	defer r.Close()
+	var sb strings.Builder
+	for _, f := range r.File {
+		sb.WriteString(f.Name)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
 func testDiagnosticsFactory(t *testing.T, compSetup map[string]integrationtest.ComponentState, diagFiles []string, diagCompFiles []string, fix *integrationtest.Fixture, cmd []string, checkBeatReceiverTraceLogs bool, extraPatterns ...filePattern) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		// If any required extra patterns are present (e.g. the metrics file


### PR DESCRIPTION
## Summary

- Fixes #15771: `elastic-agent diagnostics` was silently omitting input request-tracer logs (`http-request-trace-*.ndjson`) when the agent runs via the `elastic-agent container` entrypoint.
- Root cause: `zipLogs` walked `STATE_PATH/data/components/logs` (always empty in containers) instead of the install tree's `components/logs` where beats actually write tracer files.
- The previous fix (#14716) introduced the `components/logs` walk but assumed the install tree is under `topPath` — not true when `STATE_PATH` diverges from the binary location.

## Root cause

In container mode `container.go` calls `SetTop(STATE_PATH/data)` + `SetVersionHome(false)`, but `paths.Components()` is a frozen init-time value derived from `os.Executable()` — it always points at the install tree (`data/elastic-agent-<hash>/components`). The #14716 walk targeted `homePath/components/logs` = `STATE_PATH/data/components/logs`, which doesn't exist.

## Changes

**`internal/pkg/diagnostics/diagnostics.go`**

- Added `componentsPath string` parameter to the private `zipLogs` function; `ZipArchive`'s public signature is unchanged; call site passes `paths.Components()`.
- Converted the early container-branch `return` to if/else and tracks which `components/logs` roots were already walked.
- After both branches: if `componentsPath/logs` was not already walked and the directory exists, walks it and emits entries under `logs/elastic-agent-<hash>/components/…`. Versioned/installed mode is unaffected (install dir is already walked by the versioned branch).

**`internal/pkg/diagnostics/diagnostics_test.go`**

- New `TestZipLogsUnversionedHomeDivergentComponents`: creates two distinct trees (`root/state/data` and `root/data/elastic-agent-abc123`), asserts both agent log and component trace log appear in the bundle. This is the exact gap that let the #14716 regression slip through.
- Updated five existing `zipLogs` call sites for the new parameter; all existing tests pass.

**`testing/integration/ess/diagnostics_test.go`**

- New `TestContainerDiagnostics` (`Group: "container"`, `Sudo: true`, Linux-only, no Fleet stack required): starts the agent with `container -c` and a `STATE_PATH` that diverges from the install tree, uses a real httpjson input with `request.tracer.filename`, collects diagnostics, and asserts the trace file appears at `logs/elastic-agent-*/components/httpjson/http-request-trace-*.ndjson`.

## Test plan

- [ ] `go test ./internal/pkg/diagnostics/ -count=1` — all unit tests pass
- [ ] `TestContainerDiagnostics` runs in the `container` group CI pipeline
- [ ] Manual: build docker image, seed a trace file, run diagnostics, verify it appears in the bundle (see issue #15771 Steps to reproduce)