### PR TITLE
Add local stack provisioner

### DIFF
--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -229,8 +229,7 @@ share similar leavers as the packaging process.
    containers being attachable to the elastic-package compose network and
    reachable over that network — a model that assumes Docker is running on the
    host itself, not inside a VM. Use the cloud (`stateful` / `serverless`)
-   provisioners on macOS instead, or use a Linux machine where Docker runs
-   natively.
+   provisioners on macOS instead.
 
    Example (no cloud account required):
    ```

--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -176,6 +176,59 @@ share similar leavers as the packaging process.
        container (with sshd) instead of a VM. It builds an Ubuntu image on first use and the
        runner drives the container over SSH exactly like a VM. Requires Docker.
 
+ - `STACK_PROVISIONER`: Sets the provisioner used to create the Elastic Stack
+   (Elasticsearch, Kibana, Fleet Server) the tests talk to. Possible values are:
+     - `stateful`: Provisions a cloud ESS deployment (the default). Requires an
+       ESS API key (`mage integration:auth`).
+     - `serverless`: Provisions a cloud serverless project. Also requires an ESS
+       API key.
+     - `local`: Brings up a fully local stack with
+       [`elastic-package stack up`](https://github.com/elastic/elastic-package) —
+       no cloud account needed. Requires the `elastic-package` binary on `PATH`
+       (`go install github.com/elastic/elastic-package@latest`, or point
+       `ELASTIC_PACKAGE_BIN` at it). It uses a dedicated elastic-package profile
+       (`elastic-agent-integration`, override with `ELASTIC_PACKAGE_PROFILE`) so it
+       does not disturb a stack you may run yourself in the `default` profile.
+
+       The stack pulls Elastic images from `docker.elastic.co`, including the
+       package-registry image, which requires authentication. Run a one-time
+       `docker login docker.elastic.co` before first use. (elastic-package has no
+       supported way to skip the package-registry — Kibana depends on it — and its
+       image has no override, so authenticating is currently the simplest path.)
+
+   The `local` stack is designed to pair with the `docker` instance provisioner.
+   The local stack serves Elasticsearch/Kibana/Fleet over HTTPS with a self-signed
+   CA, so the runner:
+     - installs that CA into the test container's system trust store, so both the
+       test clients and the agent under test trust the stack with no `--insecure`
+       or per-test certificate configuration (both fall back to the system trust
+       store when no CA is configured); and
+     - attaches the test container to elastic-package's compose network, so the
+       container reaches the stack by service name (`https://elasticsearch:9200`,
+       `https://kibana:5601`, `https://fleet-server:8220`) — the names covered by
+       each service certificate's SANs, so TLS hostname verification passes; and
+     - relaxes a couple of Elasticsearch cluster settings on the single-node local
+       stack (disables disk-watermark-based allocation and raises the per-node shard
+       cap), since the suites create many data streams and would otherwise hit
+     `503 no_shard_available_action_exception`.
+
+   It also works with `mage integration:local`: host-mode tests use the stack's
+   published loopback endpoints and trust its CA via `SSL_CERT_FILE`, without
+   modifying the host's system trust store.
+
+   Remote stack provisioners work with both local and remote instance
+   provisioners. The local stack provisioner requires a local instance
+   provisioner with an implemented connectivity bridge; currently `docker` and
+   the host-local runner are supported. Multipass and Kind are rejected before
+   provisioning until their local-stack networking support is implemented.
+
+   Example (no cloud account required):
+   ```
+   STACK_PROVISIONER=local INSTANCE_PROVISIONER=docker \
+     TEST_PLATFORMS="linux/amd64/ubuntu/24.04" AGENT_VERSION="9.5.0-SNAPSHOT" \
+     TEST_PACKAGES=tar.gz mage integration:single TestSystemMetricsWithLogstashOutput
+   ```
+
 When running local mode integration tests, `BUILD_AGENT=true` will build the agent for the current platform before running.
 
 An example for running a single test, including packaging the artifacts for it is:

--- a/docs/test-framework-dev-guide.md
+++ b/docs/test-framework-dev-guide.md
@@ -222,6 +222,16 @@ share similar leavers as the packaging process.
    the host-local runner are supported. Multipass and Kind are rejected before
    provisioning until their local-stack networking support is implemented.
 
+   **macOS limitation:** the `local` stack provisioner does not currently work
+   on macOS. On macOS, Docker runs inside the Docker Desktop VM, so containers
+   (including the test instances spun up by the `docker` provisioner) are not
+   reachable from the host by their container IP. The provisioner relies on
+   containers being attachable to the elastic-package compose network and
+   reachable over that network — a model that assumes Docker is running on the
+   host itself, not inside a VM. Use the cloud (`stateful` / `serverless`)
+   provisioners on macOS instead, or use a Linux machine where Docker runs
+   natively.
+
    Example (no cloud account required):
    ```
    STACK_PROVISIONER=local INSTANCE_PROVISIONER=docker \

--- a/magefile.go
+++ b/magefile.go
@@ -2146,8 +2146,11 @@ func (Integration) Clean(ctx context.Context) error {
 
 	_, err := os.Stat(".integration-cache")
 	if err != nil {
-		fmt.Println(">>> No .integration-cache found; nothing to clean via the runner (orphaned VMs or stacks will not be touched)")
-		return nil
+		if errors.Is(err, os.ErrNotExist) {
+			fmt.Println(">>> No .integration-cache found; nothing to clean via the runner (orphaned VMs or stacks will not be touched)")
+			return nil
+		}
+		return err
 	}
 	fmt.Println(">>> Found .integration-cache; running runner.Clean")
 

--- a/magefile.go
+++ b/magefile.go
@@ -2144,9 +2144,6 @@ func (Integration) Clean(ctx context.Context) error {
 	fmt.Println("--- Clean mage artifacts")
 	_ = os.RemoveAll(".agent-testing")
 
-	// Clean out .integration-cache always
-	defer os.RemoveAll(".integration-cache")
-
 	_, err := os.Stat(".integration-cache")
 	if err != nil {
 		fmt.Println(">>> No .integration-cache found; nothing to clean via the runner (orphaned VMs or stacks will not be touched)")
@@ -2156,13 +2153,18 @@ func (Integration) Clean(ctx context.Context) error {
 
 	cfg := devtools.SettingsFromContext(ctx)
 
-	// If INSTANCE_PROVISIONER is not explicitly set, detect it from the saved state
-	// so that the right provisioner's Clean method is called instead of defaulting to gcloud.
-	if cfg.IntegrationTest.InstanceProvisioner == "" {
-		if state, stateErr := readFrameworkState(); stateErr == nil && len(state.Instances) > 0 {
+	// Detect provisioners from saved state when they are not explicitly selected,
+	// so cleanup reconstructs the same provisioners that created the resources.
+	if state, stateErr := readFrameworkState(); stateErr == nil {
+		if cfg.IntegrationTest.InstanceProvisioner == "" && len(state.Instances) > 0 {
 			detected := state.Instances[0].Provisioner
 			fmt.Printf(">>> Detected instance provisioner from state: %s\n", detected)
 			cfg = cfg.WithInstanceProvisioner(detected)
+		}
+		if cfg.IntegrationTest.StackProvisioner == "" && len(state.Stacks) > 0 {
+			detected := state.Stacks[0].Provisioner
+			fmt.Printf(">>> Detected stack provisioner from state: %s\n", detected)
+			cfg = cfg.WithStackProvisioner(detected)
 		}
 	}
 
@@ -2173,6 +2175,9 @@ func (Integration) Clean(ctx context.Context) error {
 	err = r.Clean()
 	if err != nil {
 		return fmt.Errorf("error running clean: %w", err)
+	}
+	if err := os.RemoveAll(".integration-cache"); err != nil {
+		return fmt.Errorf("error removing integration cache: %w", err)
 	}
 	fmt.Println(">>> runner.Clean completed")
 	return nil
@@ -3159,21 +3164,6 @@ func createTestRunner(cfg *devtools.Settings, matrix bool, singleTest string, go
 	if agentBuildDir == "" {
 		agentBuildDir = filepath.Join("build", "distributions")
 	}
-	essToken, ok, err := ess.GetESSAPIKey()
-	if err != nil {
-		return nil, err
-	}
-	if !ok {
-		return nil, fmt.Errorf("ESS api key missing; run 'mage integration:auth'")
-	}
-
-	// Possible to change the region for deployment, default is gcp-us-west2 which is
-	// the CFT region.
-	essRegion := cfg.IntegrationTest.ESSRegion
-	if essRegion == "" {
-		essRegion = "gcp-us-west2"
-	}
-
 	var instanceProvisioner tcommon.InstanceProvisioner
 	instanceProvisionerMode := cfg.IntegrationTest.InstanceProvisioner
 	var identifier string
@@ -3221,32 +3211,18 @@ func createTestRunner(cfg *devtools.Settings, matrix bool, singleTest string, go
 		return nil, fmt.Errorf("INSTANCE_PROVISIONER environment variable must be one of 'gcloud', 'multipass', 'kind', or 'docker', not %s", instanceProvisionerMode)
 	}
 
-	provisionCfg := ess.ProvisionerConfig{
-		Identifier: identifier,
-		APIKey:     essToken,
-		Region:     essRegion,
+	// The local stack provisioner runs elastic-package locally and needs no ESS
+	// credentials; only the cloud (stateful/serverless) provisioners require an API key.
+	var provisionCfg ess.ProvisionerConfig
+	if cfg.IntegrationTest.StackProvisioner != ess.ProvisionerLocal {
+		provisionCfg, err = essProvisionerConfig(cfg, identifier)
+		if err != nil {
+			return nil, err
+		}
 	}
-
-	var stackProvisioner tcommon.StackProvisioner
-	stackProvisionerMode := cfg.IntegrationTest.StackProvisioner
-	switch stackProvisionerMode {
-	case "", ess.ProvisionerStateful:
-		stackProvisioner, err = ess.NewProvisioner(provisionCfg)
-		if err != nil {
-			return nil, err
-		}
-	case ess.ProvisionerServerless:
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
-		stackProvisioner, err = ess.NewServerlessProvisioner(ctx, provisionCfg)
-		if err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("STACK_PROVISIONER environment variable must be one of %q or %q, not %s",
-			ess.ProvisionerStateful,
-			ess.ProvisionerServerless,
-			stackProvisionerMode)
+	stackProvisioner, _, err := newStackProvisioner(cfg, provisionCfg)
+	if err != nil {
+		return nil, err
 	}
 
 	timestamp := cfg.IntegrationTest.TimestampEnabled
@@ -3317,6 +3293,57 @@ func createTestRunner(cfg *devtools.Settings, matrix bool, singleTest string, go
 		return nil, fmt.Errorf("failed to create runner: %w", err)
 	}
 	return r, nil
+}
+
+// essProvisionerConfig builds the ESS provisioner configuration (API key + region)
+// used by both the stateful and serverless stack provisioners.
+func essProvisionerConfig(cfg *devtools.Settings, identifier string) (ess.ProvisionerConfig, error) {
+	essToken, ok, err := ess.GetESSAPIKey()
+	if err != nil {
+		return ess.ProvisionerConfig{}, err
+	}
+	if !ok {
+		return ess.ProvisionerConfig{}, fmt.Errorf("ESS api key missing; run 'mage integration:auth'")
+	}
+
+	// Possible to change the region for deployment, default is gcp-us-west2 which is
+	// the CFT region.
+	essRegion := cfg.IntegrationTest.ESSRegion
+	if essRegion == "" {
+		essRegion = "gcp-us-west2"
+	}
+
+	return ess.ProvisionerConfig{
+		Identifier: identifier,
+		APIKey:     essToken,
+		Region:     essRegion,
+	}, nil
+}
+
+// newStackProvisioner creates the stack provisioner selected by STACK_PROVISIONER
+// (defaulting to stateful), returning the provisioner and its resolved mode.
+func newStackProvisioner(cfg *devtools.Settings, provisionCfg ess.ProvisionerConfig) (tcommon.StackProvisioner, string, error) {
+	mode := cfg.IntegrationTest.StackProvisioner
+	switch mode {
+	case "", ess.ProvisionerStateful:
+		mode = ess.ProvisionerStateful
+		sp, err := ess.NewProvisioner(provisionCfg)
+		return sp, mode, err
+	case ess.ProvisionerServerless:
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		sp, err := ess.NewServerlessProvisioner(ctx, provisionCfg)
+		return sp, mode, err
+	case ess.ProvisionerLocal:
+		sp, err := ess.NewLocalProvisioner()
+		return sp, mode, err
+	default:
+		return nil, "", fmt.Errorf("STACK_PROVISIONER environment variable must be one of %q, %q or %q, not %s",
+			ess.ProvisionerStateful,
+			ess.ProvisionerServerless,
+			ess.ProvisionerLocal,
+			mode)
+	}
 }
 
 func shouldBuildAgent(cfg *devtools.Settings) bool {

--- a/pkg/testing/common/instance.go
+++ b/pkg/testing/common/instance.go
@@ -18,6 +18,15 @@ const (
 	ProvisionerTypeLocal
 )
 
+// ProvisionerLocation describes whether a provisioner's resources run in the
+// local development environment or in remote infrastructure.
+type ProvisionerLocation uint32
+
+const (
+	ProvisionerLocationRemote ProvisionerLocation = iota
+	ProvisionerLocationLocal
+)
+
 // Instance represents a provisioned instance.
 type Instance struct {
 	// Provider is the instance provider for the instance.
@@ -57,6 +66,9 @@ type InstanceProvisioner interface {
 	// Type returns the type of the provisioner.
 	Type() ProvisionerType
 
+	// Location returns whether the provisioned instances run locally or remotely.
+	Location() ProvisionerLocation
+
 	// SetLogger sets the logger for it to use.
 	SetLogger(l Logger)
 
@@ -70,4 +82,27 @@ type InstanceProvisioner interface {
 
 	// Clean cleans up all provisioned resources.
 	Clean(ctx context.Context, cfg Config, instances []Instance) error
+}
+
+// InstanceNetworkAttacher is an optional interface an InstanceProvisioner may
+// implement to attach a provisioned instance to an additional, externally-managed
+// network so it can reach a stack that lives on that network.
+//
+// It is used by the local stack provisioner together with the docker instance
+// provisioner: the local stack runs as a set of containers on its own compose
+// network, and the test container must join that network to resolve the stack's
+// services by name (so TLS hostnames match). The runner calls this when the stack
+// advertises a network and the instance provisioner implements this interface;
+// otherwise it is a no-op.
+type InstanceNetworkAttacher interface {
+	// AttachInstanceToNetwork attaches the given instance to the named network.
+	// It must be idempotent (attaching an already-attached instance is not an error).
+	AttachInstanceToNetwork(ctx context.Context, instance Instance, network string) error
+}
+
+// LocalStackCompatible is implemented by local instance provisioners that can
+// reach a local stack. Locality alone is not sufficient: for example, a VM or a
+// Kubernetes cluster running locally still needs an explicit networking bridge.
+type LocalStackCompatible interface {
+	SupportsLocalStack() bool
 }

--- a/pkg/testing/common/stack.go
+++ b/pkg/testing/common/stack.go
@@ -41,6 +41,13 @@ type Stack struct {
 	// Password is the password.
 	Password string `yaml:"password"`
 
+	// CACert is the PEM-encoded CA certificate that signed the stack's
+	// Elasticsearch/Kibana/Fleet Server certificates. It is empty when the stack
+	// uses publicly-trusted certificates (e.g. cloud ESS); local stacks that serve
+	// TLS with a self-signed CA set it so the runner can install it into the test
+	// instance's trust store.
+	CACert string `yaml:"ca_cert"`
+
 	// Internal holds internal information used by the provisioner.
 	// Best to not touch the contents of this, and leave it be for
 	// the provisioner.
@@ -71,6 +78,9 @@ type StackRequest struct {
 type StackProvisioner interface {
 	// Name returns the name of the stack provisioner.
 	Name() string
+
+	// Location returns whether the provisioned stack runs locally or remotely.
+	Location() ProvisionerLocation
 
 	// SetLogger sets the logger for it to use.
 	SetLogger(l Logger)

--- a/pkg/testing/docker/provisioner.go
+++ b/pkg/testing/docker/provisioner.go
@@ -85,6 +85,12 @@ func (p *provisioner) Type() common.ProvisionerType {
 	return common.ProvisionerTypeVM
 }
 
+func (p *provisioner) Location() common.ProvisionerLocation {
+	return common.ProvisionerLocationLocal
+}
+
+func (p *provisioner) SupportsLocalStack() bool { return true }
+
 // Supported returns true if the docker provisioner supports this OS.
 //
 // Only Ubuntu on the same architecture as the host is supported: the container
@@ -249,6 +255,21 @@ func (p *provisioner) Clean(ctx context.Context, _ common.Config, instances []co
 		if _, err := p.docker(ctx, nil, "rm", "-fv", id); err != nil {
 			p.logger.Logf("Delete leftover container %s failed: %s", id, err)
 		}
+	}
+	return nil
+}
+
+// AttachInstanceToNetwork connects the instance's container to an additional docker
+// network so it can reach a stack running on that network (see
+// common.InstanceNetworkAttacher). It is idempotent: re-attaching an
+// already-connected container is treated as success.
+func (p *provisioner) AttachInstanceToNetwork(ctx context.Context, instance common.Instance, network string) error {
+	out, err := p.docker(ctx, nil, "network", "connect", network, instance.Name)
+	if err != nil {
+		if strings.Contains(out, "already exists in network") || strings.Contains(out, "already connected") {
+			return nil
+		}
+		return fmt.Errorf("failed to connect container %s to network %s: %w", instance.Name, network, err)
 	}
 	return nil
 }

--- a/pkg/testing/ess/local_provisioner.go
+++ b/pkg/testing/ess/local_provisioner.go
@@ -1,0 +1,401 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package ess
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/elastic/elastic-agent/pkg/testing/common"
+)
+
+// ProvisionerLocal is the name of the local stack provisioner. It brings up a
+// fully local Elastic Stack with the `elastic-package stack up` command instead of
+// a cloud ESS deployment, so integration tests can run without cloud credentials.
+const ProvisionerLocal = "local"
+
+const (
+	// localDefaultProfile is the dedicated elastic-package profile used for the
+	// local integration-test stack, kept separate from the user's "default"
+	// profile so this does not clobber a stack they may be running themselves.
+	localDefaultProfile = "elastic-agent-integration"
+
+	// localComposeProjectBase is the base docker compose project name
+	// elastic-package uses for the stack (see internal/stack/boot.go in
+	// elastic/elastic-package). The compose network is "<project>_default".
+	localComposeProjectBase = "elastic-package-stack"
+)
+
+// The stack is reached from a test instance that has joined the stack's compose
+// network, so it addresses the services by their compose service names. Those names
+// are present in each service certificate's SANs (alongside localhost/127.0.0.1),
+// so TLS hostname verification succeeds once the CA is trusted.
+const (
+	localElasticsearchURL = "https://elasticsearch:9200"
+	localKibanaURL        = "https://kibana:5601"
+	localFleetServerURL   = "https://fleet-server:8220"
+	localHostFleetURL     = "https://127.0.0.1:8220"
+)
+
+// elastic-package shellinit environment variable names (see internal/stack/shellinit.go).
+const (
+	// epElasticsearchHostEnv is the host-published Elasticsearch URL (e.g.
+	// https://127.0.0.1:9200). The Stack's Elasticsearch field uses the in-network
+	// service name instead, so this is kept separately for host-side admin calls
+	// the provisioner makes (e.g. relaxing cluster settings).
+	epElasticsearchHostEnv     = "ELASTIC_PACKAGE_ELASTICSEARCH_HOST"
+	epElasticsearchUsernameEnv = "ELASTIC_PACKAGE_ELASTICSEARCH_USERNAME"
+	epElasticsearchPasswordEnv = "ELASTIC_PACKAGE_ELASTICSEARCH_PASSWORD"
+	epKibanaHostEnv            = "ELASTIC_PACKAGE_KIBANA_HOST"
+	epFleetServerHostEnv       = "ELASTIC_PACKAGE_FLEET_SERVER_HOST"
+	epCACertEnv                = "ELASTIC_PACKAGE_CA_CERT"
+
+	// epProfileEnv selects the elastic-package profile for every subcommand. It is
+	// used instead of the --profile/-p flag because that flag is registered only on
+	// some subcommands (e.g. it is absent on `profiles create`), and there is no
+	// global -p flag.
+	epProfileEnv = "ELASTIC_PACKAGE_PROFILE"
+)
+
+// LocalProvisioner provisions a local Elastic Stack using the elastic-package CLI.
+type LocalProvisioner struct {
+	logger  common.Logger
+	bin     string
+	profile string
+}
+
+// NewLocalProvisioner creates the local stack provisioner. It requires the
+// elastic-package binary to be available (on PATH or via the ELASTIC_PACKAGE_BIN
+// environment variable); the profile can be overridden with ELASTIC_PACKAGE_PROFILE.
+func NewLocalProvisioner() (common.StackProvisioner, error) {
+	bin := os.Getenv("ELASTIC_PACKAGE_BIN")
+	if bin == "" {
+		found, err := exec.LookPath("elastic-package")
+		if err != nil {
+			return nil, fmt.Errorf("the %q stack provisioner requires the elastic-package binary "+
+				"(install it with `go install github.com/elastic/elastic-package@latest` or set ELASTIC_PACKAGE_BIN): %w",
+				ProvisionerLocal, err)
+		}
+		bin = found
+	}
+	profile := os.Getenv("ELASTIC_PACKAGE_PROFILE")
+	if profile == "" {
+		profile = localDefaultProfile
+	}
+	return &LocalProvisioner{
+		bin:     bin,
+		profile: profile,
+	}, nil
+}
+
+func (p *LocalProvisioner) Name() string {
+	return ProvisionerLocal
+}
+
+func (p *LocalProvisioner) Location() common.ProvisionerLocation {
+	return common.ProvisionerLocationLocal
+}
+
+func (p *LocalProvisioner) SetLogger(l common.Logger) {
+	p.logger = l
+}
+
+// Create brings up the local stack and returns its connection details.
+func (p *LocalProvisioner) Create(ctx context.Context, request common.StackRequest) (common.Stack, error) {
+	if err := p.ensureProfile(ctx); err != nil {
+		return common.Stack{}, err
+	}
+
+	p.logger.Logf("Bringing up local elastic-package stack %s (profile %q); this can take several minutes...",
+		request.Version, p.profile)
+	// `stack up` waits for all services to be healthy before returning, so a
+	// generous timeout covers the initial image pulls on a cold machine.
+	upCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+	if _, err := p.run(upCtx, "stack", "up", "-d", "--version", request.Version); err != nil {
+		return common.Stack{}, fmt.Errorf("failed to bring up local stack: %w", err)
+	}
+
+	env, err := p.shellinit(ctx)
+	if err != nil {
+		return common.Stack{}, err
+	}
+
+	caCert, err := readCACert(env[epCACertEnv])
+	if err != nil {
+		return common.Stack{}, err
+	}
+
+	// The integration suites create a large number of data streams/indices, which
+	// quickly trips a single-node cluster's defaults (disk watermarks leaving shards
+	// unassigned, and the per-node shard cap), surfacing as 503
+	// no_shard_available_action_exception during searches. Relax those for this
+	// throwaway local stack. Best-effort: a failure here doesn't block the stack.
+	if esHost := env[epElasticsearchHostEnv]; esHost != "" {
+		p.logger.Logf("Relaxing local stack cluster settings (disk watermarks, max shards per node)")
+		if err := applyLocalClusterSettings(ctx, esHost, env[epElasticsearchUsernameEnv], env[epElasticsearchPasswordEnv], caCert); err != nil {
+			p.logger.Logf("WARNING: failed to relax local stack cluster settings; shard-heavy tests may fail: %s", err)
+		}
+	}
+
+	return common.Stack{
+		ID:                 request.ID,
+		Provisioner:        p.Name(),
+		Version:            request.Version,
+		Elasticsearch:      localElasticsearchURL,
+		Kibana:             localKibanaURL,
+		IntegrationsServer: localFleetServerURL,
+		Username:           env[epElasticsearchUsernameEnv],
+		Password:           env[epElasticsearchPasswordEnv],
+		CACert:             caCert,
+		Internal: map[string]interface{}{
+			// Consumed by the runner to join the test instance to the stack's
+			// network (see common.InstanceNetworkAttacher).
+			"network": p.networkName(),
+			"profile": p.profile,
+			// The in-process local runner executes on the host rather than in the
+			// compose network, so it uses elastic-package's published endpoints
+			// and CA file instead of the service-name endpoints above.
+			"host_elasticsearch":       env[epElasticsearchHostEnv],
+			"host_kibana":              env[epKibanaHostEnv],
+			"host_integrations_server": valueOrDefault(env[epFleetServerHostEnv], localHostFleetURL),
+			"ca_cert_path":             env[epCACertEnv],
+		},
+		Ready: true,
+	}, nil
+}
+
+func valueOrDefault(value, fallback string) string {
+	if value != "" {
+		return value
+	}
+	return fallback
+}
+
+// WaitForReady verifies the stack is healthy. `stack up` already blocks until the
+// services are ready, so this is a lightweight confirmation via `stack status`.
+func (p *LocalProvisioner) WaitForReady(ctx context.Context, stack common.Stack) (common.Stack, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+	if _, err := p.run(ctx, "stack", "status"); err != nil {
+		return stack, fmt.Errorf("local stack is not healthy: %w", err)
+	}
+	stack.Ready = true
+	return stack, nil
+}
+
+// Delete tears the local stack down.
+func (p *LocalProvisioner) Delete(ctx context.Context, stack common.Stack) error {
+	profile := p.profile
+	if savedProfile, ok := stack.Internal["profile"].(string); ok && savedProfile != "" {
+		profile = savedProfile
+	}
+	p.logger.Logf("Destroying local elastic-package stack (profile %q)", profile)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	if _, err := p.runWithProfile(ctx, profile, "stack", "down"); err != nil {
+		return fmt.Errorf("failed to destroy local stack: %w", err)
+	}
+	return nil
+}
+
+// Upgrade re-runs `stack up` at the new version.
+func (p *LocalProvisioner) Upgrade(ctx context.Context, stack common.Stack, newVersion string) error {
+	p.logger.Logf("Upgrading local elastic-package stack (profile %q) to %s", p.profile, newVersion)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+	if _, err := p.run(ctx, "stack", "up", "-d", "--version", newVersion); err != nil {
+		return fmt.Errorf("failed to upgrade local stack: %w", err)
+	}
+	return nil
+}
+
+// networkName returns the docker compose network name backing the stack. The
+// project name is "elastic-package-stack" for the default profile, or
+// "elastic-package-stack-<profile>" otherwise; the network is "<project>_default".
+func (p *LocalProvisioner) networkName() string {
+	project := localComposeProjectBase
+	if p.profile != "" && p.profile != "default" {
+		project = localComposeProjectBase + "-" + p.profile
+	}
+	return project + "_default"
+}
+
+// ensureProfile creates the dedicated elastic-package profile if it does not
+// already exist. Creating an existing profile is treated as success.
+func (p *LocalProvisioner) ensureProfile(ctx context.Context) error {
+	if p.profile == "default" {
+		return nil // always exists
+	}
+	out, err := p.run(ctx, "profiles", "create", p.profile)
+	if err != nil {
+		if strings.Contains(out, "already exists") {
+			return nil
+		}
+		return fmt.Errorf("failed to create elastic-package profile %q: %w", p.profile, err)
+	}
+	return nil
+}
+
+// shellinit runs `elastic-package stack shellinit` and parses the exported
+// environment variables (lines of the form `export NAME=value`).
+func (p *LocalProvisioner) shellinit(ctx context.Context) (map[string]string, error) {
+	out, err := p.run(ctx, "stack", "shellinit", "--shell", "bash")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read stack shellinit: %w", err)
+	}
+	return parseShellinit(out), nil
+}
+
+// parseShellinit parses `elastic-package stack shellinit` output, which is a list of
+// `export NAME=value` lines (POSIX shell format), into a name→value map.
+func parseShellinit(out string) map[string]string {
+	env := map[string]string{}
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		line = strings.TrimPrefix(line, "export ")
+		name, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		env[strings.TrimSpace(name)] = strings.Trim(value, `"'`)
+	}
+	return env
+}
+
+// command builds the elastic-package command for the given arguments, selecting the
+// configured profile via the ELASTIC_PACKAGE_PROFILE environment variable.
+func (p *LocalProvisioner) command(ctx context.Context, args ...string) *exec.Cmd {
+	return p.commandWithProfile(ctx, p.profile, args...)
+}
+
+func (p *LocalProvisioner) commandWithProfile(ctx context.Context, profile string, args ...string) *exec.Cmd {
+	//nolint:gosec // G204: p.bin is the elastic-package binary resolved by the test framework and args are framework-controlled, not external input.
+	cmd := exec.CommandContext(ctx, p.bin, args...)
+	cmd.Env = append(os.Environ(), epProfileEnv+"="+profile)
+	return cmd
+}
+
+// run executes the elastic-package binary with the configured profile, streaming
+// its output to the logger and also returning it (for parsing/error inspection).
+func (p *LocalProvisioner) run(ctx context.Context, args ...string) (string, error) {
+	return p.runWithProfile(ctx, p.profile, args...)
+}
+
+func (p *LocalProvisioner) runWithProfile(ctx context.Context, profile string, args ...string) (string, error) {
+	cmd := p.commandWithProfile(ctx, profile, args...)
+
+	var buf bytes.Buffer
+	ll := &lineLogger{logger: p.logger}
+	w := io.MultiWriter(&buf, ll)
+	cmd.Stdout = w
+	cmd.Stderr = w
+
+	err := cmd.Run()
+	ll.flush()
+	if err != nil {
+		return buf.String(), fmt.Errorf("elastic-package %s failed: %w (output: %s)",
+			strings.Join(args, " "), err, strings.TrimSpace(buf.String()))
+	}
+	return buf.String(), nil
+}
+
+// localClusterSettings is the persistent cluster settings body applied to the
+// local stack. It disables disk-based shard allocation thresholds (a single-node
+// dev cluster easily crosses the watermarks, leaving shards unassigned) and raises
+// the per-node shard cap (the suites create many data streams).
+const localClusterSettings = `{"persistent":{` +
+	`"cluster.routing.allocation.disk.threshold_enabled":false,` +
+	`"cluster.max_shards_per_node":3000}}`
+
+// applyLocalClusterSettings PUTs localClusterSettings to the stack's Elasticsearch.
+// The CA (PEM) is trusted for the request; if it cannot be parsed the request falls
+// back to skipping verification, which is acceptable for a local stack on loopback.
+func applyLocalClusterSettings(ctx context.Context, esURL, username, password, caPEM string) error {
+	pool := x509.NewCertPool()
+	insecure := !pool.AppendCertsFromPEM([]byte(caPEM))
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:            pool,
+				InsecureSkipVerify: insecure, //nolint:gosec // local self-signed stack reached over loopback
+			},
+		},
+	}
+
+	url := strings.TrimRight(esURL, "/") + "/_cluster/settings"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, strings.NewReader(localClusterSettings))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(username, password)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return nil
+}
+
+// readCACert reads the PEM contents of the CA certificate at the given path.
+func readCACert(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("elastic-package shellinit did not report a CA certificate path (%s)", epCACertEnv)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read elastic-package CA certificate %q: %w", path, err)
+	}
+	return string(b), nil
+}
+
+// lineLogger buffers bytes written to it and emits whole lines to the logger, so
+// the streamed elastic-package output appears as tidy per-line log entries.
+type lineLogger struct {
+	logger common.Logger
+	buf    bytes.Buffer
+}
+
+func (l *lineLogger) Write(p []byte) (int, error) {
+	l.buf.Write(p)
+	for {
+		line, err := l.buf.ReadString('\n')
+		if err != nil {
+			// no full line yet; put the partial back for the next write
+			l.buf.WriteString(line)
+			break
+		}
+		if s := strings.TrimRight(line, "\r\n"); s != "" && l.logger != nil {
+			l.logger.Logf("%s", s)
+		}
+	}
+	//nolint:nilerr // a non-nil ReadString error just means no complete line yet; all bytes were buffered, so the write succeeded.
+	return len(p), nil
+}
+
+func (l *lineLogger) flush() {
+	if s := strings.TrimSpace(l.buf.String()); s != "" && l.logger != nil {
+		l.logger.Logf("%s", s)
+	}
+	l.buf.Reset()
+}

--- a/pkg/testing/ess/local_provisioner.go
+++ b/pkg/testing/ess/local_provisioner.go
@@ -46,7 +46,6 @@ const (
 	localElasticsearchURL = "https://elasticsearch:9200"
 	localKibanaURL        = "https://kibana:5601"
 	localFleetServerURL   = "https://fleet-server:8220"
-	localHostFleetURL     = "https://127.0.0.1:8220"
 )
 
 // elastic-package shellinit environment variable names (see internal/stack/shellinit.go).
@@ -170,18 +169,11 @@ func (p *LocalProvisioner) Create(ctx context.Context, request common.StackReque
 			// and CA file instead of the service-name endpoints above.
 			"host_elasticsearch":       env[epElasticsearchHostEnv],
 			"host_kibana":              env[epKibanaHostEnv],
-			"host_integrations_server": valueOrDefault(env[epFleetServerHostEnv], localHostFleetURL),
+			"host_integrations_server": env[epFleetServerHostEnv],
 			"ca_cert_path":             env[epCACertEnv],
 		},
 		Ready: true,
 	}, nil
-}
-
-func valueOrDefault(value, fallback string) string {
-	if value != "" {
-		return value
-	}
-	return fallback
 }
 
 // WaitForReady verifies the stack is healthy. `stack up` already blocks until the

--- a/pkg/testing/ess/local_provisioner_test.go
+++ b/pkg/testing/ess/local_provisioner_test.go
@@ -73,15 +73,6 @@ func TestNetworkName(t *testing.T) {
 	}
 }
 
-func TestValueOrDefault(t *testing.T) {
-	if got := valueOrDefault("configured", "fallback"); got != "configured" {
-		t.Errorf("valueOrDefault() = %q, want configured", got)
-	}
-	if got := valueOrDefault("", "fallback"); got != "fallback" {
-		t.Errorf("valueOrDefault() = %q, want fallback", got)
-	}
-}
-
 func TestNewLocalProvisioner(t *testing.T) {
 	t.Run("bin and profile from env", func(t *testing.T) {
 		t.Setenv("ELASTIC_PACKAGE_BIN", "/usr/bin/true")

--- a/pkg/testing/ess/local_provisioner_test.go
+++ b/pkg/testing/ess/local_provisioner_test.go
@@ -1,0 +1,258 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package ess
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+)
+
+// testLogger adapts *testing.T to common.Logger.
+type testLogger struct{ t *testing.T }
+
+func (l testLogger) Logf(format string, args ...any) { l.t.Logf(format, args...) }
+
+func TestParseShellinit(t *testing.T) {
+	// Mirrors `elastic-package stack shellinit --shell bash` output (POSIX `export`
+	// lines), with some noise that must be ignored and a quoted value.
+	out := `2026/05/29 18:00:00  WARN CommitHash is undefined
+export ELASTIC_PACKAGE_ELASTICSEARCH_API_KEY=abc123
+export ELASTIC_PACKAGE_ELASTICSEARCH_HOST=https://127.0.0.1:9200
+export ELASTIC_PACKAGE_ELASTICSEARCH_USERNAME=elastic
+export ELASTIC_PACKAGE_ELASTICSEARCH_PASSWORD="changeme"
+export ELASTIC_PACKAGE_KIBANA_HOST=https://127.0.0.1:5601
+export ELASTIC_PACKAGE_CA_CERT=/home/u/.elastic-package/profiles/p/certs/ca-cert.pem
+
+garbage line without equals
+`
+	got := parseShellinit(out)
+
+	want := map[string]string{
+		epElasticsearchUsernameEnv: "elastic",
+		epElasticsearchPasswordEnv: "changeme",
+		epCACertEnv:                "/home/u/.elastic-package/profiles/p/certs/ca-cert.pem",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("parseShellinit()[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+	// The WARN line and the no-equals line must not produce entries.
+	if _, ok := got["garbage line without equals"]; ok {
+		t.Errorf("parseShellinit kept a line without an equals sign")
+	}
+	if v := got["ELASTIC_PACKAGE_KIBANA_HOST"]; v != "https://127.0.0.1:5601" {
+		t.Errorf("kibana host = %q, want https://127.0.0.1:5601", v)
+	}
+}
+
+func TestNetworkName(t *testing.T) {
+	cases := []struct {
+		profile string
+		want    string
+	}{
+		{"default", "elastic-package-stack_default"},
+		{"", "elastic-package-stack_default"},
+		{"elastic-agent-integration", "elastic-package-stack-elastic-agent-integration_default"},
+	}
+	for _, c := range cases {
+		p := &LocalProvisioner{profile: c.profile}
+		if got := p.networkName(); got != c.want {
+			t.Errorf("networkName(profile=%q) = %q, want %q", c.profile, got, c.want)
+		}
+	}
+}
+
+func TestValueOrDefault(t *testing.T) {
+	if got := valueOrDefault("configured", "fallback"); got != "configured" {
+		t.Errorf("valueOrDefault() = %q, want configured", got)
+	}
+	if got := valueOrDefault("", "fallback"); got != "fallback" {
+		t.Errorf("valueOrDefault() = %q, want fallback", got)
+	}
+}
+
+func TestNewLocalProvisioner(t *testing.T) {
+	t.Run("bin and profile from env", func(t *testing.T) {
+		t.Setenv("ELASTIC_PACKAGE_BIN", "/usr/bin/true")
+		t.Setenv("ELASTIC_PACKAGE_PROFILE", "custom-profile")
+		sp, err := NewLocalProvisioner()
+		if err != nil {
+			t.Fatalf("NewLocalProvisioner() error = %v", err)
+		}
+		p := sp.(*LocalProvisioner)
+		if p.bin != "/usr/bin/true" {
+			t.Errorf("bin = %q, want /usr/bin/true", p.bin)
+		}
+		if p.profile != "custom-profile" {
+			t.Errorf("profile = %q, want custom-profile", p.profile)
+		}
+		if sp.Name() != ProvisionerLocal {
+			t.Errorf("Name() = %q, want %q", sp.Name(), ProvisionerLocal)
+		}
+	})
+
+	t.Run("default profile", func(t *testing.T) {
+		t.Setenv("ELASTIC_PACKAGE_BIN", "/usr/bin/true")
+		t.Setenv("ELASTIC_PACKAGE_PROFILE", "")
+		sp, err := NewLocalProvisioner()
+		if err != nil {
+			t.Fatalf("NewLocalProvisioner() error = %v", err)
+		}
+		if sp.(*LocalProvisioner).profile != localDefaultProfile {
+			t.Errorf("profile = %q, want %q", sp.(*LocalProvisioner).profile, localDefaultProfile)
+		}
+	})
+
+	t.Run("missing binary errors", func(t *testing.T) {
+		t.Setenv("ELASTIC_PACKAGE_BIN", "")
+		t.Setenv("PATH", t.TempDir()) // empty dir: elastic-package not findable
+		if _, err := NewLocalProvisioner(); err == nil {
+			t.Error("NewLocalProvisioner() expected an error when the binary is missing")
+		}
+	})
+}
+
+func TestCommandUsesProfileEnvNotFlag(t *testing.T) {
+	p := &LocalProvisioner{bin: "/usr/bin/true", profile: "myprofile"}
+	cmd := p.command(context.Background(), "stack", "status")
+
+	// The profile must be passed via the environment, never as a -p/--profile flag
+	// (which is not accepted by every subcommand, e.g. `profiles create`).
+	wantArgs := []string{"/usr/bin/true", "stack", "status"}
+	if !slices.Equal(cmd.Args, wantArgs) {
+		t.Errorf("cmd.Args = %v, want %v", cmd.Args, wantArgs)
+	}
+	if slices.Contains(cmd.Args, "-p") || slices.Contains(cmd.Args, "--profile") {
+		t.Errorf("cmd.Args unexpectedly contains a profile flag: %v", cmd.Args)
+	}
+	if !slices.Contains(cmd.Env, epProfileEnv+"=myprofile") {
+		t.Errorf("cmd.Env missing %s=myprofile; got %v", epProfileEnv, cmd.Env)
+	}
+}
+
+func TestCommandWithProfileUsesSavedProfile(t *testing.T) {
+	p := &LocalProvisioner{bin: "/usr/bin/true", profile: "current-profile"}
+	cmd := p.commandWithProfile(context.Background(), "saved-profile", "stack", "down")
+	if !slices.Contains(cmd.Env, epProfileEnv+"=saved-profile") {
+		t.Errorf("cmd.Env missing %s=saved-profile; got %v", epProfileEnv, cmd.Env)
+	}
+}
+
+func TestReadCACert(t *testing.T) {
+	t.Run("reads contents", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "ca-cert.pem")
+		content := "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := readCACert(path)
+		if err != nil {
+			t.Fatalf("readCACert() error = %v", err)
+		}
+		if got != content {
+			t.Errorf("readCACert() = %q, want %q", got, content)
+		}
+	})
+
+	t.Run("empty path errors", func(t *testing.T) {
+		if _, err := readCACert(""); err == nil {
+			t.Error("readCACert(\"\") expected an error")
+		}
+	})
+
+	t.Run("missing file errors", func(t *testing.T) {
+		if _, err := readCACert(filepath.Join(t.TempDir(), "nope.pem")); err == nil {
+			t.Error("readCACert(missing) expected an error")
+		}
+	})
+}
+
+func TestApplyLocalClusterSettings(t *testing.T) {
+	t.Run("sends PUT with auth and body", func(t *testing.T) {
+		var gotMethod, gotPath, gotBody, gotUser, gotPass string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			b, _ := io.ReadAll(r.Body)
+			gotBody = string(b)
+			gotUser, gotPass, _ = r.BasicAuth()
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		// Trailing slash on the URL must not produce a double slash in the path.
+		if err := applyLocalClusterSettings(context.Background(), srv.URL+"/", "elastic", "secret", ""); err != nil {
+			t.Fatalf("applyLocalClusterSettings() error = %v", err)
+		}
+		if gotMethod != http.MethodPut {
+			t.Errorf("method = %q, want PUT", gotMethod)
+		}
+		if gotPath != "/_cluster/settings" {
+			t.Errorf("path = %q, want /_cluster/settings", gotPath)
+		}
+		if gotBody != localClusterSettings {
+			t.Errorf("body = %q, want %q", gotBody, localClusterSettings)
+		}
+		if gotUser != "elastic" || gotPass != "secret" {
+			t.Errorf("basic auth = %q:%q, want elastic:secret", gotUser, gotPass)
+		}
+	})
+
+	t.Run("non-2xx is an error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "boom", http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+		if err := applyLocalClusterSettings(context.Background(), srv.URL, "u", "p", ""); err == nil {
+			t.Error("applyLocalClusterSettings() expected an error on 500")
+		}
+	})
+}
+
+// TestEnsureProfileWithBinary exercises ensureProfile against the real
+// elastic-package binary when it is available, in an isolated data directory so it
+// does not touch the developer's real ~/.elastic-package. It is skipped when the
+// binary is not installed.
+func TestEnsureProfileWithBinary(t *testing.T) {
+	bin := os.Getenv("ELASTIC_PACKAGE_BIN")
+	if bin == "" {
+		found, err := exec.LookPath("elastic-package")
+		if err != nil {
+			t.Skip("elastic-package binary not available; skipping binary-backed test")
+		}
+		bin = found
+	}
+
+	// Isolate elastic-package's data directory for this test so it does not touch
+	// the developer's real ~/.elastic-package. The path is used as-is as the root
+	// dir, and elastic-package treats an existing dir as "already installed" and
+	// skips bootstrapping it; so point at a not-yet-created subdir and let
+	// elastic-package's own EnsureInstalled (run on every invocation) create it.
+	t.Setenv("ELASTIC_PACKAGE_DATA_HOME", filepath.Join(t.TempDir(), "ep-home"))
+
+	p := &LocalProvisioner{bin: bin, profile: "eat-local-provisioner-test"}
+	p.SetLogger(testLogger{t})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	if err := p.ensureProfile(ctx); err != nil {
+		t.Fatalf("ensureProfile() first call error = %v", err)
+	}
+	// Second call must be a no-op (profile already exists), not an error.
+	if err := p.ensureProfile(ctx); err != nil {
+		t.Fatalf("ensureProfile() second call (idempotency) error = %v", err)
+	}
+}

--- a/pkg/testing/ess/serverless_provisioner.go
+++ b/pkg/testing/ess/serverless_provisioner.go
@@ -64,6 +64,10 @@ func (prov *ServerlessProvisioner) Name() string {
 	return ProvisionerServerless
 }
 
+func (prov *ServerlessProvisioner) Location() common.ProvisionerLocation {
+	return common.ProvisionerLocationRemote
+}
+
 // SetLogger sets the logger for the
 func (prov *ServerlessProvisioner) SetLogger(l common.Logger) {
 	prov.log = l

--- a/pkg/testing/ess/statful_provisioner.go
+++ b/pkg/testing/ess/statful_provisioner.go
@@ -66,6 +66,10 @@ func (p *StatefulProvisioner) Name() string {
 	return ProvisionerStateful
 }
 
+func (p *StatefulProvisioner) Location() common.ProvisionerLocation {
+	return common.ProvisionerLocationRemote
+}
+
 func (p *StatefulProvisioner) SetLogger(l common.Logger) {
 	p.logger = l
 	p.client.SetLogger(l)

--- a/pkg/testing/gcloud/provisioner.go
+++ b/pkg/testing/gcloud/provisioner.go
@@ -66,6 +66,10 @@ func (p *provisioner) Type() common.ProvisionerType {
 	return common.ProvisionerTypeVM
 }
 
+func (p *provisioner) Location() common.ProvisionerLocation {
+	return common.ProvisionerLocationRemote
+}
+
 // Supported returns true when the provisioner supports the given OS.
 func (p *provisioner) Supported(os define.OS) bool {
 	_, ok := findOSLayout(os)

--- a/pkg/testing/kubernetes/kind/provisioner.go
+++ b/pkg/testing/kubernetes/kind/provisioner.go
@@ -65,6 +65,10 @@ func (p *provisioner) Type() common.ProvisionerType {
 	return common.ProvisionerTypeK8SCluster
 }
 
+func (p *provisioner) Location() common.ProvisionerLocation {
+	return common.ProvisionerLocationLocal
+}
+
 func (p *provisioner) SetLogger(l common.Logger) {
 	p.logger = l
 }

--- a/pkg/testing/kubernetes/kind/provisioner.go
+++ b/pkg/testing/kubernetes/kind/provisioner.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -280,7 +281,9 @@ type cmdResult struct {
 func (p *provisioner) kindCmd(stdIn io.Reader, args ...string) (cmdResult, error) {
 
 	var stdout, stderr bytes.Buffer
-	cmd := exec.Command("kind", args...)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "kind", args...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if stdIn != nil {

--- a/pkg/testing/local/local.go
+++ b/pkg/testing/local/local.go
@@ -35,6 +35,12 @@ func (p *provisioner) Type() common.ProvisionerType {
 	return common.ProvisionerTypeLocal
 }
 
+func (p *provisioner) Location() common.ProvisionerLocation {
+	return common.ProvisionerLocationLocal
+}
+
+func (p *provisioner) SupportsLocalStack() bool { return true }
+
 func (p *provisioner) SetLogger(l common.Logger) {
 	p.logger = l
 }

--- a/pkg/testing/multipass/provisioner.go
+++ b/pkg/testing/multipass/provisioner.go
@@ -50,6 +50,10 @@ func (p *provisioner) Type() common.ProvisionerType {
 	return common.ProvisionerTypeVM
 }
 
+func (p *provisioner) Location() common.ProvisionerLocation {
+	return common.ProvisionerLocationLocal
+}
+
 // Supported returns true if multipass supports this OS.
 //
 // multipass only supports Ubuntu on the same architecture as the running host.

--- a/pkg/testing/runner/runner.go
+++ b/pkg/testing/runner/runner.go
@@ -79,6 +79,9 @@ type Runner struct {
 
 // NewRunner creates a new runner based on the provided batches.
 func NewRunner(cfg common.Config, ip common.InstanceProvisioner, sp common.StackProvisioner, batches ...define.Batch) (*Runner, error) {
+	if err := validateProvisionerCompatibility(ip, sp); err != nil {
+		return nil, err
+	}
 	err := cfg.Validate()
 	if err != nil {
 		return nil, err
@@ -128,6 +131,20 @@ func NewRunner(cfg common.Config, ip common.InstanceProvisioner, sp common.Stack
 		return nil, err
 	}
 	return r, nil
+}
+
+func validateProvisionerCompatibility(ip common.InstanceProvisioner, sp common.StackProvisioner) error {
+	if sp.Location() == common.ProvisionerLocationRemote {
+		return nil
+	}
+	if ip.Location() == common.ProvisionerLocationRemote {
+		return fmt.Errorf("instance provisioner %q is remote and cannot reach local stack provisioner %q", ip.Name(), sp.Name())
+	}
+	compatible, ok := ip.(common.LocalStackCompatible)
+	if !ok || !compatible.SupportsLocalStack() {
+		return fmt.Errorf("local instance provisioner %q does not yet support local stack provisioner %q", ip.Name(), sp.Name())
+	}
+	return nil
 }
 
 // Logger returns the logger used by the runner.
@@ -240,10 +257,8 @@ func (r *Runner) Clean() error {
 	for _, i := range r.state.Instances {
 		instances = append(instances, i.Instance)
 	}
-	r.state.Instances = nil
 	stacks := make([]common.Stack, len(r.state.Stacks))
 	copy(stacks, r.state.Stacks)
-	r.state.Stacks = nil
 	r.logger.Logf("Cleaning up %d instance(s) and %d stack(s) from state", len(instances), len(stacks))
 	for _, inst := range instances {
 		r.logger.Logf("  - instance: name=%s provisioner=%s ip=%s", inst.Name, inst.Provisioner, inst.IP)
@@ -251,11 +266,6 @@ func (r *Runner) Clean() error {
 	for _, st := range stacks {
 		r.logger.Logf("  - stack: id=%s provisioner=%s", st.ID, st.Provisioner)
 	}
-	err := r.writeState()
-	if err != nil {
-		return err
-	}
-
 	var g errgroup.Group
 	g.Go(func() error {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
@@ -271,7 +281,14 @@ func (r *Runner) Clean() error {
 			}
 		}(stack))
 	}
-	return g.Wait()
+	if err := g.Wait(); err != nil {
+		// Preserve the state so cleanup can be retried. Provisioner cleanup
+		// operations are expected to tolerate resources that are already gone.
+		return err
+	}
+	r.state.Instances = nil
+	r.state.Stacks = nil
+	return r.writeState()
 }
 
 func (r *Runner) stackEnv(batch common.OSBatch, logger common.Logger) (map[string]string, error) {
@@ -285,16 +302,34 @@ func (r *Runner) stackEnv(batch common.OSBatch, logger common.Logger) (map[strin
 		if err != nil {
 			return nil, err
 		}
-		env["ELASTICSEARCH_HOST"] = stack.Elasticsearch
+		elasticsearchHost := stack.Elasticsearch
+		kibanaHost := stack.Kibana
+		integrationsServer := stack.IntegrationsServer
+		if r.ip.Type() == common.ProvisionerTypeLocal {
+			elasticsearchHost = internalString(stack.Internal, "host_elasticsearch", elasticsearchHost)
+			kibanaHost = internalString(stack.Internal, "host_kibana", kibanaHost)
+			integrationsServer = internalString(stack.Internal, "host_integrations_server", integrationsServer)
+			if caCertPath := internalString(stack.Internal, "ca_cert_path", ""); caCertPath != "" {
+				env["SSL_CERT_FILE"] = caCertPath
+			}
+		}
+		env["ELASTICSEARCH_HOST"] = elasticsearchHost
 		env["ELASTICSEARCH_USERNAME"] = stack.Username
 		env["ELASTICSEARCH_PASSWORD"] = stack.Password
-		env["KIBANA_HOST"] = stack.Kibana
+		env["KIBANA_HOST"] = kibanaHost
 		env["KIBANA_USERNAME"] = stack.Username
 		env["KIBANA_PASSWORD"] = stack.Password
-		env["ELASTIC_APM_SERVER_URL"] = stack.IntegrationsServer
-		logger.Logf("Using Stack with Kibana host %s, credentials available under .integration-cache", stack.Kibana)
+		env["ELASTIC_APM_SERVER_URL"] = integrationsServer
+		logger.Logf("Using Stack with Kibana host %s, credentials available under .integration-cache", kibanaHost)
 	}
 	return env, nil
+}
+
+func internalString(internal map[string]interface{}, key, fallback string) string {
+	if value, ok := internal[key].(string); ok && value != "" {
+		return value
+	}
+	return fallback
 }
 
 func (r *Runner) runK8sInstances(ctx context.Context, instances []StateInstance) (map[string]common.OSRunnerResult, error) {
@@ -447,6 +482,38 @@ func (r *Runner) runInstance(ctx context.Context, sshAuth ssh.AuthMethod, logger
 		return common.OSRunnerResult{}, err
 	}
 
+	if batch.Batch.Stack != nil {
+		stack, err := r.getStackForBatchID(batch.ID)
+		if err != nil {
+			return common.OSRunnerResult{}, err
+		}
+
+		// If the stack serves TLS with a private CA (local stacks do; cloud stacks
+		// use publicly-trusted certs and leave this empty), install it into the
+		// instance's system trust store. Both the test clients and the agent under
+		// test fall back to the system trust store when no CA is configured, so this
+		// makes them trust the stack with no per-test configuration.
+		if stack.CACert != "" {
+			if err := installStackCA(ctx, client, logger, stack.CACert); err != nil {
+				return common.OSRunnerResult{}, fmt.Errorf("failed to install stack CA on instance %s: %w", instance.Name, err)
+			}
+		}
+
+		// If the stack lives on its own network (local stacks) and the instance
+		// provisioner can attach to it, join the instance so it resolves the stack's
+		// services by name — which is what their TLS certificate SANs cover.
+		if network, ok := stack.Internal["network"].(string); ok && network != "" {
+			if na, ok := r.ip.(common.InstanceNetworkAttacher); ok {
+				logger.Logf("Attaching instance to stack network %s", network)
+				if err := na.AttachInstanceToNetwork(ctx, instance.Instance, network); err != nil {
+					return common.OSRunnerResult{}, fmt.Errorf("failed to attach instance %s to stack network %s: %w", instance.Name, network, err)
+				}
+			} else {
+				logger.Logf("Stack advertises network %s but instance provisioner %q cannot attach to it; tests may not reach the stack", network, r.ip.Name())
+			}
+		}
+	}
+
 	// set the go test flags
 	env["GOTEST_FLAGS"] = r.cfg.TestFlags
 	env["TEST_BINARY_NAME"] = r.cfg.BinaryName
@@ -469,6 +536,23 @@ func (r *Runner) runInstance(ctx context.Context, sshAuth ssh.AuthMethod, logger
 	}
 
 	return result, nil
+}
+
+// installStackCA installs the PEM-encoded CA certificate into the instance's system
+// trust store over SSH and refreshes the trust store. Used for local stacks that
+// serve TLS with a self-signed CA.
+func installStackCA(ctx context.Context, client tssh.SSHClient, logger common.Logger, caPEM string) error {
+	logger.Logf("Installing stack CA certificate into instance trust store")
+	const dest = "/usr/local/share/ca-certificates/elastic-package-stack-ca.crt"
+	// `tee` (as root) writes the CA piped over stdin; the .crt extension under
+	// /usr/local/share/ca-certificates is what update-ca-certificates picks up.
+	if _, _, err := client.Exec(ctx, "sudo", []string{"tee", dest}, strings.NewReader(caPEM)); err != nil {
+		return fmt.Errorf("failed to write CA certificate to %s: %w", dest, err)
+	}
+	if _, _, err := client.Exec(ctx, "sudo", []string{"update-ca-certificates"}, nil); err != nil {
+		return fmt.Errorf("failed to refresh CA trust store: %w", err)
+	}
+	return nil
 }
 
 // validate ensures that required builds of Elastic Agent exist

--- a/pkg/testing/runner/runner_test.go
+++ b/pkg/testing/runner/runner_test.go
@@ -6,6 +6,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sync"
@@ -100,9 +101,104 @@ func TestNewRunner_Clean(t *testing.T) {
 	assert.ElementsMatch(t, sp.deletedStacks, []common.Stack{s1, s2})
 }
 
+func TestRunnerCleanPreservesStateOnFailure(t *testing.T) {
+	tmpdir := t.TempDir()
+	stateDir := filepath.Join(tmpdir, "state")
+	require.NoError(t, os.MkdirAll(stateDir, 0o755))
+	settings, err := mage.LoadSettings()
+	require.NoError(t, err)
+
+	cfg := common.Config{
+		AgentVersion: "9.6.0-SNAPSHOT",
+		StackVersion: "9.6.0-SNAPSHOT",
+		BuildDir:     filepath.Join(tmpdir, "build"),
+		RepoDir:      filepath.Join(tmpdir, "repo"),
+		StateDir:     stateDir,
+		GOVersion:    settings.GoVersion(),
+	}
+	ip := &fakeInstanceProvisioner{cleanErr: errors.New("instance cleanup failed")}
+	sp := &fakeStackProvisioner{}
+	r, err := NewRunner(cfg, ip, sp)
+	require.NoError(t, err)
+	require.NoError(t, r.addOrUpdateInstance(StateInstance{Instance: common.Instance{Name: "instance", Provisioner: ip.Name()}}))
+	require.NoError(t, r.addOrUpdateStack(common.Stack{ID: "stack", Provisioner: sp.Name()}))
+
+	require.Error(t, r.Clean())
+
+	reloaded, err := NewRunner(cfg, &fakeInstanceProvisioner{}, &fakeStackProvisioner{})
+	require.NoError(t, err)
+	require.Len(t, reloaded.state.Instances, 1)
+	require.Len(t, reloaded.state.Stacks, 1)
+}
+
+func TestInternalString(t *testing.T) {
+	internal := map[string]interface{}{
+		"present": "https://127.0.0.1:9200",
+		"empty":   "",
+		"wrong":   9200,
+	}
+	assert.Equal(t, "https://127.0.0.1:9200", internalString(internal, "present", "fallback"))
+	assert.Equal(t, "fallback", internalString(internal, "empty", "fallback"))
+	assert.Equal(t, "fallback", internalString(internal, "wrong", "fallback"))
+	assert.Equal(t, "fallback", internalString(nil, "missing", "fallback"))
+}
+
+func TestValidateProvisionerCompatibility(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance *fakeInstanceProvisioner
+		stack    *fakeStackProvisioner
+		wantErr  bool
+	}{
+		{
+			name:     "remote stack accepts remote instance",
+			instance: &fakeInstanceProvisioner{location: common.ProvisionerLocationRemote},
+			stack:    &fakeStackProvisioner{location: common.ProvisionerLocationRemote},
+		},
+		{
+			name:     "remote stack accepts local instance",
+			instance: &fakeInstanceProvisioner{location: common.ProvisionerLocationLocal},
+			stack:    &fakeStackProvisioner{location: common.ProvisionerLocationRemote},
+		},
+		{
+			name:     "local stack rejects remote instance",
+			instance: &fakeInstanceProvisioner{location: common.ProvisionerLocationRemote},
+			stack:    &fakeStackProvisioner{location: common.ProvisionerLocationLocal},
+			wantErr:  true,
+		},
+		{
+			name:     "local stack rejects unsupported local instance",
+			instance: &fakeInstanceProvisioner{location: common.ProvisionerLocationLocal},
+			stack:    &fakeStackProvisioner{location: common.ProvisionerLocationLocal},
+			wantErr:  true,
+		},
+		{
+			name: "local stack accepts compatible local instance",
+			instance: &fakeInstanceProvisioner{
+				location:             common.ProvisionerLocationLocal,
+				localStackCompatible: true,
+			},
+			stack: &fakeStackProvisioner{location: common.ProvisionerLocationLocal},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateProvisionerCompatibility(tt.instance, tt.stack)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 type fakeInstanceProvisioner struct {
-	batches   []common.OSBatch
-	instances []common.Instance
+	batches              []common.OSBatch
+	instances            []common.Instance
+	cleanErr             error
+	location             common.ProvisionerLocation
+	localStackCompatible bool
 }
 
 func (p *fakeInstanceProvisioner) Name() string {
@@ -112,6 +208,10 @@ func (p *fakeInstanceProvisioner) Name() string {
 func (p *fakeInstanceProvisioner) Type() common.ProvisionerType {
 	return common.ProvisionerTypeVM
 }
+
+func (p *fakeInstanceProvisioner) Location() common.ProvisionerLocation { return p.location }
+
+func (p *fakeInstanceProvisioner) SupportsLocalStack() bool { return p.localStackCompatible }
 
 func (p *fakeInstanceProvisioner) SetLogger(_ common.Logger) {
 }
@@ -138,18 +238,21 @@ func (p *fakeInstanceProvisioner) Provision(_ context.Context, _ common.Config, 
 
 func (p *fakeInstanceProvisioner) Clean(_ context.Context, _ common.Config, instances []common.Instance) error {
 	p.instances = instances
-	return nil
+	return p.cleanErr
 }
 
 type fakeStackProvisioner struct {
 	mx            sync.Mutex
 	requests      []common.StackRequest
 	deletedStacks []common.Stack
+	location      common.ProvisionerLocation
 }
 
 func (p *fakeStackProvisioner) Name() string {
 	return "fake"
 }
+
+func (p *fakeStackProvisioner) Location() common.ProvisionerLocation { return p.location }
 
 func (p *fakeStackProvisioner) SetLogger(_ common.Logger) {
 }


### PR DESCRIPTION
## What does this PR do?

Adds a local stack provisioner for integration tests. The provisioner uses elastic-package under the hood, which in turn uses docker-compose. Tests run using the provisioner stack's TLS certs.

I've also fixed an issue where if the test run was cancelled, the runner wouldn't save provisioner information about the stack, making it impossible to clean up via `mage integration:clean`.

This currently works with `integration:local` on both Linux and MacOS, and with the docker instance provisioner only on Linux - MacOS support will come in a follow up.

## Why is it important?

Running tests without a remote stack is faster and more accessible. Coding agents can do it without needing to have Elastic Cloud API keys. It's also easier to observe the local stack and reproduce issues which span both agent and the stack.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## How to test this PR locally

```bash
mage package
INSTANCE_PROVISIONER=docker STACK_PROVISIONER=local TEST_PLATFORMS="linux/amd64/ubuntu" AGENT_VERSION="9.6.0-SNAPSHOT" TEST_PACKAGES="tar.gz" TEST_GROUPS="fqdn" mage integration 
```

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
