### PR TITLE
[mage] Use package-version overrides in helm:package for DRA consistency

### DIFF
--- a/.github/workflows/release-helm-charts-manual.yml
+++ b/.github/workflows/release-helm-charts-manual.yml
@@ -38,6 +38,7 @@ jobs:
           env-vars: |
             SNAPSHOT=${{ inputs.repo-env == 'dev' }}
             HELM_REPO_ENV=${{ inputs.repo-env }}
+            USE_PACKAGE_VERSION=false
 
       - uses: elastic/oblt-actions/slack/send@v1
         if: ${{ failure()  }}

--- a/.github/workflows/release-helm-charts.yml
+++ b/.github/workflows/release-helm-charts.yml
@@ -23,6 +23,7 @@ jobs:
           env-vars: |
             SNAPSHOT=false
             HELM_REPO_ENV=prod
+            USE_PACKAGE_VERSION=false
 
       - uses: elastic/oblt-actions/slack/send@v1
         if: ${{ failure()  }}

--- a/magefile.go
+++ b/magefile.go
@@ -4388,7 +4388,16 @@ func (h Helm) Package(ctx context.Context) error {
 
 	cfg := devtools.SettingsFromContext(ctx)
 
-	cfg, err := cfg.WithManifestInfo(ctx)
+	// Use package-version overrides so the Helm chart version matches the
+	// other snapshot artifacts built in the same DRA run. Use
+	// USE_PACKAGE_VERSION=false to disable this (e.g. during a GHA-triggered
+	// Helm chart release, where the chart version comes from the release tag).
+	cfg, err := cfg.WithPackageVersionOverrides()
+	if err != nil {
+		return fmt.Errorf("failed applying %s overrides: %w", devtools.PackageVersionFilename, err)
+	}
+
+	cfg, err = cfg.WithManifestInfo(ctx)
 	if err != nil {
 		return fmt.Errorf("failed downloading manifest: %w", err)
 	}


### PR DESCRIPTION
## What does this PR do?

Add WithPackageVersionOverrides() to Helm.Package so the chart version matches the other snapshot artifacts in the same DRA run. The GHA-triggered Helm chart release workflows disable this via USE_PACKAGE_VERSION=false, since those builds derive the version from the release tag rather than .package-version.

This fixes a problem introduced in https://github.com/elastic/elastic-agent/pull/16169. For the backports of that PR, it's fixed in the branches directly.

## Why is it important?

The Helm Chart archive version needs to be the same as all the other artifacts uploaded to the DRA.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/16026

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
