### PR TITLE
Fix drop path artifacts being overwritten during upgrade

### DIFF
--- a/changelog/fragments/1787021059-fix-upgrade-drop-path-artifact.yaml
+++ b/changelog/fragments/1787021059-fix-upgrade-drop-path-artifact.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix drop path artifacts being overwritten during upgrade.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/agent/application/upgrade/artifact/download/fetch.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/fetch.go
@@ -180,6 +180,20 @@ func copyFile(log *logger.Logger, sourcePath string, targetPath string, ops file
 	}()
 
 	sourcePath = strings.TrimPrefix(sourcePath, "file://")
+
+	sourceInfo, err := os.Stat(sourcePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("no file found at %s: %w", sourcePath, err)
+		}
+		return fmt.Errorf("could not stat %s: %w", sourcePath, err)
+	}
+
+	if targetInfo, err := os.Stat(targetPath); err == nil && os.SameFile(sourceInfo, targetInfo) {
+		// no copy needed
+		return nil
+	}
+
 	sourceFile, err := ops.openFile(sourcePath, os.O_RDONLY, 0)
 	if err != nil {
 		return errors.New(err, fmt.Sprintf("opening %s file failed", sourcePath), errors.TypeFilesystem, errors.M(errors.MetaKeyPath, sourcePath))

--- a/internal/pkg/agent/application/upgrade/artifact/download/fetch.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/fetch.go
@@ -184,9 +184,9 @@ func copyFile(log *logger.Logger, sourcePath string, targetPath string, ops file
 	sourceInfo, err := os.Stat(sourcePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("no file found at %s: %w", sourcePath, err)
+			return errors.New(err, fmt.Sprintf("no file found at %s", sourcePath), errors.TypeFilesystem, errors.M(errors.MetaKeyPath, sourcePath))
 		}
-		return fmt.Errorf("could not stat %s: %w", sourcePath, err)
+		return errors.New(err, fmt.Sprintf("could not stat %s", sourcePath), errors.TypeFilesystem, errors.M(errors.MetaKeyPath, sourcePath))
 	}
 
 	if targetInfo, err := os.Stat(targetPath); err == nil && os.SameFile(sourceInfo, targetInfo) {

--- a/internal/pkg/agent/application/upgrade/artifact/download/fetch_test.go
+++ b/internal/pkg/agent/application/upgrade/artifact/download/fetch_test.go
@@ -81,6 +81,29 @@ func TestCopy(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("source missing", func(t *testing.T) {
+		baseDir := t.TempDir()
+		src := filepath.Join(baseDir, "source")
+		dst := filepath.Join(baseDir, "artifact")
+
+		log, _ := loggertest.New(t.Name())
+		require.ErrorIs(t, copyFile(log, src, dst, defaultFileOps()), os.ErrNotExist)
+		require.NoFileExists(t, dst)
+	})
+
+	t.Run("source and target are the same file", func(t *testing.T) {
+		baseDir := t.TempDir()
+		path := filepath.Join(baseDir, "artifact")
+		content := []byte("fake archive")
+		require.NoError(t, os.WriteFile(path, content, 0o666))
+
+		log, _ := loggertest.New(t.Name())
+		require.NoError(t, copyFile(log, path, path, defaultFileOps()))
+		read, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Equal(t, content, read)
+	})
 }
 
 func TestDownload(t *testing.T) {

--- a/internal/pkg/agent/application/upgrade/step_download_test.go
+++ b/internal/pkg/agent/application/upgrade/step_download_test.go
@@ -262,6 +262,27 @@ func TestDownloadArtifact(t *testing.T) {
 			},
 		},
 		{
+			name: "remote sourceURI checks drop path without copying if drop path and target directory are equal",
+			run: func(t *testing.T, fx *fixture) {
+				require.NoError(t, os.MkdirAll(fx.settings.TargetDirectory, 0o755))
+				dropPath := fx.settings.TargetDirectory
+				require.NoError(t, os.WriteFile(filepath.Join(dropPath, fx.target.FileName()), archiveContent, 0o644))
+				require.NoError(t, os.WriteFile(filepath.Join(dropPath, fx.target.FileName()+".sha512"), hashFile, 0o644))
+				require.NoError(t, os.WriteFile(filepath.Join(dropPath, fx.target.FileName()+".asc"), signature, 0o644))
+
+				serverURL, requestCounts := newFileServer(t, nil)
+
+				artifactPath, err := fx.downloader.downloadArtifact(t.Context(), fx.target, serverURL,
+					fx.upgradeDetails, false, true, pgpSource)
+				require.NoError(t, err)
+				require.Empty(t, requestCounts)
+				got, err := os.ReadFile(artifactPath)
+				require.NoError(t, err)
+				require.Equal(t, archiveContent, got)
+				require.FileExists(t, download.AddHashExtension(artifactPath))
+			},
+		},
+		{
 			name: "remote sourceURI uses remote source when drop path is set but artifact is missing",
 			run: func(t *testing.T, fx *fixture) {
 				fx.settings.DropPath = t.TempDir()


### PR DESCRIPTION
## What does this PR do?

Add a check to return early when the source and target are equal when copying files in the upgrader's download step.

## Why is it important?

Drop path artifacts were zeroed out when using the default configuration which had the target directory and the drop path both resolving to paths.Downloads().

## Checklist

- [X] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

N/A

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/16191.