### PR TITLE
Revert Win 2016 images to 1785546083

### DIFF
--- a/.buildkite/bk.integration.pipeline.yml
+++ b/.buildkite/bk.integration.pipeline.yml
@@ -16,7 +16,7 @@ env:
   IMAGE_DEBIAN_13: "platform-ingest-elastic-agent-debian-13-1786755708"
   IMAGE_WIN_2022: "platform-ingest-elastic-agent-windows-2022-1786755708"
   IMAGE_WIN_2025: "platform-ingest-elastic-agent-windows-2025-1786755708"
-  IMAGE_WIN_2016: "platform-ingest-elastic-agent-windows-2016-1786755708"
+  IMAGE_WIN_2016: "platform-ingest-elastic-agent-windows-2016-1785546083"
   IMAGE_WIN_10: "platform-ingest-elastic-agent-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-elastic-agent-windows-11-pro"
   IMAGE_WIN_11_ARM64: "platform-ingest-elastic-agent-windows-11-pro-arm64"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,7 +23,7 @@ env:
   # Please do not change them manually.
   IMAGE_UBUNTU_2204_X86_64: "platform-ingest-elastic-agent-ubuntu-2204-1786755708"
   IMAGE_UBUNTU_2204_ARM_64: "platform-ingest-elastic-agent-ubuntu-2204-aarch64-1786755708"
-  IMAGE_WIN_2016: "platform-ingest-elastic-agent-windows-2016-1786755708"
+  IMAGE_WIN_2016: "platform-ingest-elastic-agent-windows-2016-1785546083"
   IMAGE_WIN_2022: "platform-ingest-elastic-agent-windows-2022-1786755708"
   IMAGE_WIN_10: "platform-ingest-elastic-agent-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-elastic-agent-windows-11-pro"


### PR DESCRIPTION
Investigating issues with the Win 2016 amd64 CI runner after the latest update https://github.com/elastic/elastic-agent/pull/16210.

Seeing CI behavior when reverting to previous known good image version.