### PR TITLE
Add regression tests for Kafka lz4 compression startup failure

### DIFF
--- a/internal/edot/go.mod
+++ b/internal/edot/go.mod
@@ -589,7 +589,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.157.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils v0.157.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.157.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka v0.157.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka v0.157.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic v0.157.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.157.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.157.0 // indirect

--- a/internal/edot/otelcol/kafka_output_test.go
+++ b/internal/edot/otelcol/kafka_output_test.go
@@ -1,0 +1,76 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build !requirefips
+
+package otelcol
+
+import (
+	"testing"
+
+	configkafka "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+
+	"github.com/elastic/elastic-agent/internal/pkg/otel/translate"
+)
+
+// Regression test for https://github.com/elastic/sdh-beats/issues/7489:
+// lz4 (and other codecs that don't support compression levels) must produce
+// a ProducerConfig that passes OTel kafkaexporter validation after translation.
+func TestKafkaOutputTranslationValidatesAgainstOTelExporter(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "lz4 without explicit compression_level",
+			input: `
+hosts: ["kafka1:9092"]
+topic: test-topic
+compression: lz4
+`,
+		},
+		{
+			name: "snappy without explicit compression_level",
+			input: `
+hosts: ["kafka1:9092"]
+topic: test-topic
+compression: snappy
+`,
+		},
+		{
+			name: "gzip without explicit compression_level",
+			input: `
+hosts: ["kafka1:9092"]
+topic: test-topic
+compression: gzip
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := config.NewConfigFrom(tc.input)
+			require.NoError(t, err)
+
+			translatedMap, _, err := translate.KafkaToOTelConfig(cfg, "", logp.NewNopLogger())
+			require.NoError(t, err)
+
+			producerMap, ok := translatedMap["producer"].(map[string]any)
+			require.True(t, ok, "translated config must contain a producer key")
+
+			// Decode via confmap — the same path the OTel collector uses at startup.
+			producerConf := confmap.NewFromStringMap(producerMap)
+			producerCfg := configkafka.NewDefaultProducerConfig()
+			require.NoError(t, producerConf.Unmarshal(&producerCfg))
+
+			require.NoError(t, producerCfg.Validate(),
+				"translated kafka producer config must be accepted by the OTel kafkaexporter")
+		})
+	}
+}

--- a/testing/integration/ess/otel_test.go
+++ b/testing/integration/ess/otel_test.go
@@ -3487,3 +3487,123 @@ func downloadData(t *testing.T, file string) mapstr.M {
 	}
 	return nil
 }
+
+// Regression test for https://github.com/elastic/sdh-beats/issues/7489:
+// Elastic Agent must reach healthy state when the Kafka output uses lz4 compression.
+// Before the fix, the OTel translation layer unconditionally passed compression_params.level=4
+// which the OTel kafkaexporter rejects for codecs that don't support levels.
+func TestKafkaOutputLz4CompressionStartsHealthy(t *testing.T) {
+	define.Require(t, define.Requirements{
+		Group: integration.Default,
+		Local: true,
+		OS: []define.OS{
+			{Type: define.Linux},
+			{Type: define.Darwin},
+		},
+		Stack: &define.Stack{},
+	})
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "failed to get current file path")
+	kafkaPath := filepath.Join(filepath.Dir(currentFile), "..", "..", "..", "beats", "testing", "environments", "docker", "kafka")
+
+	composeContent := fmt.Sprintf(`
+services:
+  kafka:
+    build: %s
+    ports:
+      - 9092:9092
+      - 9093:9093
+      - 9094:9094
+      - 2181:2181
+    environment:
+      - KAFKA_ADVERTISED_HOST=localhost
+`, kafkaPath)
+
+	stack := newDockerCompose(t, composeContent)
+	t.Cleanup(func() { _ = stack.down(context.Background()) }) //nolint:forbidigo // t.Context() is cancelled by cleanup time
+	err := stack.up(t.Context())
+	require.NoError(t, err)
+
+	fixture, err := define.NewFixtureFromLocalBuild(t, define.Version())
+	require.NoError(t, err)
+
+	agentConfig := fmt.Sprintf(`
+agent.internal.runtime.output:
+  kafka: otel
+agent.grpc.port: 6799
+inputs:
+  - type: system/metrics
+    id: system-metrics-lz4-test
+    use_output: default
+    streams:
+    - metricsets:
+       - cpu
+      period: 1s
+      data_stream:
+        dataset: e2e
+        namespace: lz4test
+outputs:
+  default:
+    type: kafka
+    hosts: ["localhost:9093"]
+    topic: metrics-e2e-lz4test
+    compression: lz4
+    max_message_bytes: 1000000
+    required_acks: 1
+    broker_timeout: 30s
+    queue.mem.flush.timeout: 1s
+    ssl:
+      certificate_authorities:
+        - %s
+      supported_protocols:
+       - TLSv1.3
+      verification_mode: full
+    username: beats
+    password: KafkaTest
+    protocol: https
+    sasl.mechanism: SCRAM-SHA-256
+agent.monitoring:
+  metrics: false
+  logs: false
+  http:
+    enabled: true
+    port: 6791
+`, filepath.Join(kafkaPath, "certs", "ca-cert"))
+
+	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(3*time.Minute))
+	defer cancel()
+
+	err = fixture.Prepare(ctx)
+	require.NoError(t, err)
+
+	err = fixture.Configure(ctx, []byte(agentConfig))
+	require.NoError(t, err)
+
+	cmd, err := fixture.PrepareAgentCommand(ctx, nil)
+	require.NoError(t, err)
+
+	output := strings.Builder{}
+	cmd.Stderr = &output
+	cmd.Stdout = &output
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Log("Elastic-Agent output:")
+			t.Log(output.String())
+		}
+	})
+
+	err = cmd.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cmd.Wait() })
+
+	require.Eventually(t, func() bool {
+		err = fixture.IsHealthy(ctx)
+		if err != nil {
+			t.Logf("waiting for agent healthy: %s", err.Error())
+			return false
+		}
+		return true
+	}, 30*time.Second, 1*time.Second, "agent must reach healthy state with lz4 kafka output")
+}


### PR DESCRIPTION
## Summary

- Adds a unit/validation test in `internal/edot/otelcol` that decodes the translated Kafka producer config via confmap and calls `ProducerConfig.Validate()` — the exact OTel validation path that rejects `compression_params.level=4` for lz4 at startup.
- Adds an E2E integration test `TestKafkaOutputLz4CompressionStartsHealthy` that starts a real Docker Kafka with `compression: lz4` and asserts the agent reaches healthy state.

Both tests are currently **red** (the bug is not fixed yet). This PR exists to let CI confirm the tests catch the regression before the fix lands.

## Relates to

- SDH issue: https://github.com/elastic/sdh-beats/issues/7489
- Root cause: `internal/pkg/otel/translate/output_kafka.go` unconditionally passes `compression_params.level=4` (beats default) to the OTel kafkaexporter, which in v0.157.0 (9.5) rejects `level` for lz4. Fix will be in a separate PR.

## Test plan

- [ ] Unit test `TestKafkaOutputTranslationValidatesAgainstOTelExporter` fails red before fix, green after
- [ ] E2E test `TestKafkaOutputLz4CompressionStartsHealthy` fails red before fix, green after

🤖 Generated with [Claude Code](https://claude.com/claude-code)