### PR TITLE
Renovate: disable updates for go.mod replace directives

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -120,6 +120,16 @@
       "groupName": "k8s-ecosystem"
     },
     {
+      "description": "Disabled: replace directives are manually managed Elastic forks; Renovate must not touch them",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepTypes": [
+        "replace"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Disabled: beats (git submodule), sarama (manual path handling), OTel packages (own release cycle)",
       "matchManagers": [
         "gomod"


### PR DESCRIPTION
replace directives in this repo point to manually maintained Elastic forks (e.g. elastic/goja, elastic/fsnotify, elastic/gopacket). Renovate was downgrading or corrupting these entries (see #16217). Disabling the "replace" depType for the gomod manager prevents Renovate from touching them at all.
