### PR TITLE
Use json as the wire format for otel collector configuration

### DIFF
--- a/internal/pkg/otel/manager/execution_subprocess.go
+++ b/internal/pkg/otel/manager/execution_subprocess.go
@@ -7,6 +7,7 @@ package manager
 import (
 	"context"
 	"encoding/gob"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -21,7 +22,6 @@ import (
 	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/confmap"
 	"go.uber.org/zap/zapcore"
-	"gopkg.in/yaml.v3"
 
 	runtimeLogger "github.com/elastic/elastic-agent/pkg/component/runtime"
 
@@ -122,7 +122,7 @@ func (r *subprocessExecution) startCollector(
 	}
 
 	// prepare and serialize config first so we can exit early if there's a problem
-	cfgYamlBytes, err := prepareAndSerializeConfig(cfg)
+	cfgBytes, err := prepareAndSerializeConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func (r *subprocessExecution) startCollector(
 		stdOutLast, stdErrLast,
 	)
 	ctl.startBackgroundWorkers()
-	ctl.updateConfigYamlBytes(cfgYamlBytes)
+	ctl.updateConfigBytes(cfgBytes)
 	return ctl, nil
 }
 
@@ -546,24 +546,24 @@ func (s *procHandle) Stopped() bool {
 
 // UpdateConfig submits a new configuration to the collector process.
 func (s *procHandle) UpdateConfig(cfg *confmap.Conf) error {
-	yamlBytes, err := prepareAndSerializeConfig(cfg)
+	cfgBytes, err := prepareAndSerializeConfig(cfg)
 	if err != nil {
 		return err
 	}
 
-	s.updateConfigYamlBytes(yamlBytes)
+	s.updateConfigBytes(cfgBytes)
 
 	return nil
 }
 
-// updateConfigYamlBytes submits a new serialized configuration to the collector process.
-func (s *procHandle) updateConfigYamlBytes(cfgYamlBytes []byte) {
+// updateConfigBytes submits a new serialized configuration to the collector process.
+func (s *procHandle) updateConfigBytes(cfgBytes []byte) {
 	// Drain any pending config (latest-wins semantics).
 	select {
 	case <-s.configCh:
 	default:
 	}
-	s.configCh <- cfgYamlBytes
+	s.configCh <- cfgBytes
 }
 
 // LogLevel return the otel collector's log level.
@@ -571,19 +571,25 @@ func (s *procHandle) LogLevel() logp.Level {
 	return s.collectorLogLevel
 }
 
-// prepareAndSerializeConfig serializes the configuration to yaml.
+// prepareAndSerializeConfig serializes the configuration to JSON.
+// JSON is used rather than YAML because yaml.Marshal can corrupt or fail to
+// round-trip multi-line strings whose content lines have inconsistent leading
+// whitespace (e.g. audit_rules block scalars). JSON strings always use explicit
+// \n escaping, which avoids the YAML block-scalar indentation ambiguity.
+// confmap.NewRetrievedFromYAML on the receiver side accepts JSON because JSON
+// is a strict subset of YAML.
 func prepareAndSerializeConfig(cfg *confmap.Conf) ([]byte, error) {
 	if cfg == nil {
 		return nil, errors.New("no configuration provided")
 	}
 
 	confMap := cfg.ToStringMap()
-	yamlBytes, err := yaml.Marshal(confMap)
+	jsonBytes, err := json.Marshal(confMap)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal config to yaml: %w", err)
+		return nil, fmt.Errorf("failed to marshal config to json: %w", err)
 	}
 
-	return yamlBytes, nil
+	return jsonBytes, nil
 }
 
 type zapWriter interface {

--- a/internal/pkg/otel/manager/execution_subprocess_test.go
+++ b/internal/pkg/otel/manager/execution_subprocess_test.go
@@ -7,6 +7,7 @@ package manager
 import (
 	"context"
 	"encoding/gob"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -158,8 +159,8 @@ func TestProcHandle_UpdateConfigYamlBytes_LatestWins(t *testing.T) {
 	h := newTestProcHandle(t, doneCh, func(context.Context, error) {})
 
 	// Send two configs rapidly; only the latest should remain.
-	h.updateConfigYamlBytes([]byte("first"))
-	h.updateConfigYamlBytes([]byte("second"))
+	h.updateConfigBytes([]byte("first"))
+	h.updateConfigBytes([]byte("second"))
 
 	got := <-h.configCh
 	assert.Equal(t, "second", string(got))
@@ -187,7 +188,7 @@ func TestProcHandle_WriteToPipe(t *testing.T) {
 
 	// Send a config and read it from the pipe.
 	expected := []byte("receivers:\n  nop:\n")
-	h.updateConfigYamlBytes(expected)
+	h.updateConfigBytes(expected)
 
 	decoder := gob.NewDecoder(pipeReader)
 	var got []byte
@@ -217,7 +218,7 @@ func TestProcHandle_WriteToPipe_SuppressesClosedPipeError(t *testing.T) {
 		h.writeToPipe(t.Context(), pipeWriter)
 	}()
 
-	h.updateConfigYamlBytes([]byte("test"))
+	h.updateConfigBytes([]byte("test"))
 
 	// Give the goroutine time to process, then verify no error was reported.
 	select {
@@ -264,11 +265,23 @@ func TestPrepareAndSerializeConfig(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("serializes to yaml", func(t *testing.T) {
+	t.Run("serializes to json", func(t *testing.T) {
 		cfg := confmap.NewFromStringMap(map[string]any{"key": "value"})
-		yamlBytes, err := prepareAndSerializeConfig(cfg)
+		cfgBytes, err := prepareAndSerializeConfig(cfg)
 		require.NoError(t, err)
-		assert.Contains(t, string(yamlBytes), "key: value")
+		assert.Contains(t, string(cfgBytes), `"key":"value"`)
+	})
+
+	t.Run("round-trips multiline strings with inconsistent indentation", func(t *testing.T) {
+		// regression test for https://github.com/elastic/elastic-agent/issues/16174
+		auditRules := "      ## comment\n-a never,exit -S all -F exe=/usr/bin/example\n  -a always,exit -F arch=b64\n"
+		cfg := confmap.NewFromStringMap(map[string]any{"audit_rules": auditRules})
+		cfgBytes, err := prepareAndSerializeConfig(cfg)
+		require.NoError(t, err)
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(cfgBytes, &decoded))
+		assert.Equal(t, auditRules, decoded["audit_rules"])
 	})
 }
 


### PR DESCRIPTION
## What does this PR do?

Changes the wire format used to pass otel configuration from Elastic Agent to the supervised otel collector. This used to be yaml, now it's json.

## Why is it important?

https://github.com/elastic/elastic-agent/issues/16174 ran into an upstream bug with yaml marshalling. In general, there's no reason to use yaml here. JSON is faster to serialize/deserialize and simpler, so less chance of weird formatting bugs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/16174

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
