### PR TITLE
docs: improve container restart loop known issue workaround

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -86,18 +86,49 @@ On 9.5.0, browser monitors on {{fleet}}-managed private locations fail for two i
 Both issues are addressed in 9.5.1. There is no supported workaround on 9.5.0 that restores browser monitors without changing the agent version.
 ::::
 
-::::{dropdown} {{agent}} restarts repeatedly in containers after a {{fleet}} policy update
+:::{dropdown} {{agent}} restarts repeatedly in containers after a {{fleet}} policy update
 
 **Applies to: {{agent}} 9.3.7, 9.3.8, 9.4.3, 9.4.4**
 
 On July 9, 2026, a known issue was discovered where {{agent}} can restart repeatedly when it is deployed in a {{fleet}}-managed container. When it processes a policy update, the agent uses the default logging values instead of the configuration already active in the container. It incorrectly detects a logging change, restarts and repeats this process indefinitely.
 
+This restart does not increment the container restart count. On Linux, the agent replaces its own process image in place (`execve`), so the PID and container stay alive while the agent loops. Confirm the issue by counting the initialisation banner in the agent logs — a healthy agent prints it once, a looping agent prints it tens or hundreds of times within minutes:
+
+```bash
+grep -c 'agent container initialisation - chown paths' <agent-container-logs>
+```
+
 **Workaround**
 
-Make the policy's logging outputs match the container configuration. In the agent policy's **Advanced settings**, set `agent_logging_to_stderr` to `true` and `agent_logging_to_files` to `false`.
+Update the agent policy to set `agent.logging.to_stderr` to `true` and `agent.logging.to_files` to `false`, so the policy matches the container's logging configuration. Use the {{fleet}} API to apply these settings:
+
+```bash
+curl -k -u <user>:<password> \
+  -X PUT https://<kibana-host>/api/fleet/agent_policies/<policy-id> \
+  -H 'Content-Type: application/json' \
+  -H 'kbn-xsrf: true' \
+  -d '{
+    "name": "<policy-name>",
+    "namespace": "<policy-namespace>",
+    "overrides": {
+      "agent": {
+        "logging": {
+          "to_stderr": true,
+          "to_files": false
+        }
+      }
+    }
+  }'
+```
+
+The `name` and `namespace` values are required by the API and must match the existing policy. Retrieve them first with a GET request to `/api/fleet/agent_policies/<policy-id>`.
+
+After updating the policy, clear the agent state to break the loop. An agent already looping replays the cached policy action faster than a {{fleet}} check-in interval, so the corrected policy never reaches it. Clear the state by removing `/usr/share/elastic-agent/state/fleet.yml` — either from inside the running container, from the mounted volume on the host, or by recreating the container. Alternatively, set the `FLEET_FORCE=1` environment variable and restart to force re-enrollment regardless of existing state.
+
+To prevent the loop from occurring, set the `LOGS_PATH` environment variable on the container. This prevents the entrypoint from injecting the forced logging configuration that causes the mismatch. Agent logs will be written to files instead of stderr when this variable is set.
 
 For more information, check [Issue #15432](https://github.com/elastic/elastic-agent/issues/15432).
-::::
+:::
 
 :::{dropdown} {{agent}} logs a "failed to unmarshal checkin actions" error on almost every {{fleet}} check-in
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -92,7 +92,7 @@ Both issues are addressed in 9.5.1. There is no supported workaround on 9.5.0 th
 
 On July 9, 2026, a known issue was discovered where {{agent}} can restart repeatedly when it is deployed in a {{fleet}}-managed container. When it processes a policy update, the agent uses the default logging values instead of the configuration already active in the container. It incorrectly detects a logging change, restarts and repeats this process indefinitely.
 
-This restart does not increment the container restart count. On Linux, the agent replaces its own process image in place (`execve`), so the PID and container stay alive while the agent loops. Confirm the issue by counting the initialisation banner in the agent logs — a healthy agent prints it once, a looping agent prints it tens or hundreds of times within minutes:
+This restart does not increment the container restart count. On Linux, the agent replaces its own process image in place (`execve`), so the PID and container stay alive while the agent loops. Confirm the issue by counting the initialization banner in the agent logs — a healthy agent prints it once, a looping agent prints it tens or hundreds of times within minutes:
 
 ```bash
 grep -c 'agent container initialisation - chown paths' <agent-container-logs>

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -103,7 +103,7 @@ grep -c 'agent container initialisation - chown paths' <agent-container-logs>
 Update the agent policy to set `agent.logging.to_stderr` to `true` and `agent.logging.to_files` to `false`, so the policy matches the container's logging configuration. Use the {{fleet}} API to apply these settings:
 
 ```bash
-curl -k -u <user>:<password> \
+curl -u <user>:<password> \
   -X PUT https://<kibana-host>/api/fleet/agent_policies/<policy-id> \
   -H 'Content-Type: application/json' \
   -H 'kbn-xsrf: true' \
@@ -123,9 +123,11 @@ curl -k -u <user>:<password> \
 
 The `name` and `namespace` values are required by the API and must match the existing policy. Retrieve them first with a GET request to `/api/fleet/agent_policies/<policy-id>`.
 
-After updating the policy, clear the agent state to break the loop. An agent already looping replays the cached policy action faster than a {{fleet}} check-in interval, so the corrected policy never reaches it. Clear the state by removing `/usr/share/elastic-agent/state/fleet.yml` — either from inside the running container, from the mounted volume on the host, or by recreating the container. Alternatively, set the `FLEET_FORCE=1` environment variable and restart to force re-enrollment regardless of existing state.
+After updating the policy, clear the agent state to break the loop. An agent already looping replays the cached policy action faster than a {{fleet}} check-in interval, so the corrected policy never reaches it. Clear the state by removing `/usr/share/elastic-agent/state/fleet.yml` — from inside the running container, from the mounted volume on the host, or by recreating the container. Alternatively, set the `FLEET_FORCE=1` environment variable and restart to force re-enrollment regardless of existing state.
 
-To prevent the loop from occurring, set the `LOGS_PATH` environment variable on the container. This prevents the entrypoint from injecting the forced logging configuration that causes the mismatch. Agent logs will be written to files instead of stderr when this variable is set.
+**Alternative workaround**
+
+Instead of updating the agent policy with the API call, you can prevent the loop from occurring by setting the `LOGS_PATH` environment variable on the container before it starts. This stops the container entrypoint from injecting a logging configuration, so no mismatch between the container and the policy can occur. Note that when `LOGS_PATH` is set, agent logs are written to files rather than stderr.
 
 For more information, check [Issue #15432](https://github.com/elastic/elastic-agent/issues/15432).
 :::


### PR DESCRIPTION
## Summary

- Adds confirmation steps to identify the restart loop (grep command against agent logs)
- Corrects the workaround: replaces the incorrect Advanced internal YAML settings guidance with the Fleet API call including the required `name` and `namespace` fields
- Explains why a plain restart is insufficient and how to clear `fleet.yml` to break an already-looping agent
- Adds `LOGS_PATH` as a preventive measure

## Related

Closes #15432

🤖 Generated with [Claude Code](https://claude.com/claude-code)