### PR TITLE
Add support for Fleet RESTART action

### DIFF
--- a/changelog/fragments/1787200000-add-restart-action.yaml
+++ b/changelog/fragments/1787200000-add-restart-action.yaml
@@ -1,0 +1,50 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Add support for the Fleet RESTART action.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: >
+  Managed Elastic Agents now handle a dedicated RESTART action from Fleet. The
+  action is persisted, the agent re-executes reusing the upgrade restart
+  machinery, and the action is acknowledged on the next startup once the restart
+  has completed. The acknowledgement is retried until Fleet confirms receipt or
+  the action expires.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/3367

--- a/internal/pkg/agent/application/actions/handlers/handler_action_restart.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_restart.go
@@ -1,0 +1,133 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/acker"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+	"github.com/elastic/elastic-agent/pkg/features"
+	"github.com/elastic/elastic-agent/pkg/fleetapi"
+)
+
+// restartCoordinator is the subset of the coordinator used by the Restart handler.
+type restartCoordinator interface {
+	actionCoordinator
+	// Restart re-executes the agent. The action is acknowledged on the next
+	// startup, not here.
+	Restart(ctx context.Context, action *fleetapi.ActionRestart) error
+}
+
+// restartStateStore is the subset of the state store used by the Restart handler.
+type restartStateStore interface {
+	SetPendingAckAction(fleetapi.Action)
+	ClearPendingAckAction()
+	Save() error
+}
+
+// Restart is a handler for the RESTART action. It persists the action, re-execs
+// the agent (reusing the upgrade restart machinery) and does NOT acknowledge the
+// action here. The acknowledgement happens on the next startup, once the restart
+// has actually completed.
+type Restart struct {
+	log        *logger.Logger
+	coord      restartCoordinator
+	stateStore restartStateStore
+
+	tamperProtectionFn func() bool // allows to inject the flag for tests, defaults to features.TamperProtection
+	nowFn              func() time.Time
+}
+
+// NewRestart creates a new Restart handler.
+func NewRestart(log *logger.Logger, coord restartCoordinator, stateStore restartStateStore) *Restart {
+	return &Restart{
+		log:                log,
+		coord:              coord,
+		stateStore:         stateStore,
+		tamperProtectionFn: features.TamperProtection,
+		nowFn:              time.Now,
+	}
+}
+
+// Handle handles the RESTART action.
+func (h *Restart) Handle(ctx context.Context, a fleetapi.Action, ack acker.Acker) error {
+	h.log.Debugf("handlerRestart: action '%+v' received", a)
+	action, ok := a.(*fleetapi.ActionRestart)
+	if !ok {
+		return fmt.Errorf("invalid type, expected ActionRestart and received %T", a)
+	}
+
+	// Do not restart if the action is expired or carries an invalid expiration.
+	// In both cases we ack the error so Fleet learns about the failure instead
+	// of silently restarting.
+	exp, err := action.Expiration()
+	switch {
+	case err == nil:
+		if h.nowFn().After(exp) {
+			h.log.Warnf("handlerRestart: action '%s' expired at %s, skipping restart", action.ActionID, exp)
+			action.Err = fmt.Errorf("restart action expired at %s", exp)
+			return h.ackNow(ctx, ack, action)
+		}
+	case errors.Is(err, fleetapi.ErrNoExpiration):
+		// No expiration set; the action never expires, proceed with the restart.
+	default:
+		// Malformed expiration timestamp; treat the action as invalid.
+		h.log.Warnf("handlerRestart: action '%s' has an invalid expiration, skipping restart: %v", action.ActionID, err)
+		action.Err = fmt.Errorf("restart action has an invalid expiration: %w", err)
+		return h.ackNow(ctx, ack, action)
+	}
+
+	// Under tamper protection, Endpoint needs to receive the signed RESTART
+	// action so it can react to the imminent restart. Mirrors the UPGRADE flow.
+	if h.tamperProtectionFn() {
+		state := h.coord.State()
+		ucs := findMatchingUnitsByActionType(state, a.Type())
+		if len(ucs) > 0 {
+			if err := notifyUnitsOfProxiedAction(ctx, h.log, action, ucs, h.coord.PerformAction); err != nil {
+				return err
+			}
+		} else {
+			h.log.Debugf("No components running for %v action type", a.Type())
+		}
+	}
+
+	// Persist the action before restarting so it can be acknowledged on the
+	// next startup.
+	h.stateStore.SetPendingAckAction(action)
+	if err := h.stateStore.Save(); err != nil {
+		return fmt.Errorf("failed to persist restart action to state store: %w", err)
+	}
+
+	if err := h.coord.Restart(ctx, action); err != nil {
+		// The restart did not happen, so there will be no startup ack. Clear the
+		// persisted action and ack the failure now so Fleet learns about it.
+		h.stateStore.ClearPendingAckAction()
+		if serr := h.stateStore.Save(); serr != nil {
+			h.log.Warnf("failed to clear restart action from state store: %v", serr)
+		}
+		action.Err = err
+		if aerr := h.ackNow(ctx, ack, action); aerr != nil {
+			return errors.Join(err, aerr)
+		}
+		return err
+	}
+
+	return nil
+}
+
+// ackNow acknowledges the action and commits immediately.
+func (h *Restart) ackNow(ctx context.Context, ack acker.Acker, action *fleetapi.ActionRestart) error {
+	if err := ack.Ack(ctx, action); err != nil {
+		return fmt.Errorf("failed to ack restart action: %w", err)
+	}
+	if err := ack.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit restart action ack: %w", err)
+	}
+	return nil
+}

--- a/internal/pkg/agent/application/actions/handlers/handler_action_restart_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_restart_test.go
@@ -1,0 +1,189 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
+	"github.com/elastic/elastic-agent/pkg/component"
+	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
+	"github.com/elastic/elastic-agent/pkg/fleetapi"
+)
+
+func TestActionRestartHandler(t *testing.T) {
+	log, _ := loggertest.New("restart")
+
+	t.Run("wrong action type", func(t *testing.T) {
+		coord := &fakeRestartCoordinator{}
+		ss := &fakeRestartStateStore{}
+		h := NewRestart(log, coord, ss)
+		h.tamperProtectionFn = func() bool { return false }
+
+		err := h.Handle(t.Context(), &fleetapi.ActionSettings{}, &fakeAcker{})
+		require.Error(t, err)
+		coord.AssertNotCalled(t, "Restart", mock.Anything, mock.Anything)
+		ss.AssertNotCalled(t, "SetPendingAckAction", mock.Anything)
+	})
+
+	t.Run("happy path persists and restarts without acking", func(t *testing.T) {
+		action := &fleetapi.ActionRestart{ActionID: "r1", ActionType: fleetapi.ActionTypeRestart}
+
+		coord := &fakeRestartCoordinator{}
+		coord.On("Restart", mock.Anything, action).Return(nil)
+
+		ss := &fakeRestartStateStore{}
+		ss.On("SetPendingAckAction", action).Return()
+		ss.On("Save").Return(nil)
+
+		ack := &fakeAcker{}
+
+		h := NewRestart(log, coord, ss)
+		h.tamperProtectionFn = func() bool { return false }
+
+		require.NoError(t, h.Handle(t.Context(), action, ack))
+		ss.AssertCalled(t, "SetPendingAckAction", action)
+		coord.AssertCalled(t, "Restart", mock.Anything, action)
+		// Must NOT ack in the handler; the ack happens after restart on startup.
+		ack.AssertNotCalled(t, "Ack", mock.Anything, mock.Anything)
+	})
+
+	t.Run("expired action acks error and does not restart", func(t *testing.T) {
+		exp := time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+		action := &fleetapi.ActionRestart{
+			ActionID:         "r-expired",
+			ActionType:       fleetapi.ActionTypeRestart,
+			ActionExpiration: exp,
+		}
+
+		coord := &fakeRestartCoordinator{}
+		ss := &fakeRestartStateStore{}
+
+		ack := &fakeAcker{}
+		ack.On("Ack", mock.Anything, action).Return(nil)
+		ack.On("Commit", mock.Anything).Return(nil)
+
+		h := NewRestart(log, coord, ss)
+		h.tamperProtectionFn = func() bool { return false }
+
+		require.NoError(t, h.Handle(t.Context(), action, ack))
+		require.Error(t, action.Err, "expired action should carry an error for the ack")
+		coord.AssertNotCalled(t, "Restart", mock.Anything, mock.Anything)
+		ss.AssertNotCalled(t, "SetPendingAckAction", mock.Anything)
+		ack.AssertCalled(t, "Ack", mock.Anything, action)
+	})
+
+	t.Run("invalid expiration acks error and does not restart", func(t *testing.T) {
+		action := &fleetapi.ActionRestart{
+			ActionID:         "r-bad-exp",
+			ActionType:       fleetapi.ActionTypeRestart,
+			ActionExpiration: "not-a-timestamp",
+		}
+
+		coord := &fakeRestartCoordinator{}
+		ss := &fakeRestartStateStore{}
+
+		ack := &fakeAcker{}
+		ack.On("Ack", mock.Anything, action).Return(nil)
+		ack.On("Commit", mock.Anything).Return(nil)
+
+		h := NewRestart(log, coord, ss)
+		h.tamperProtectionFn = func() bool { return false }
+
+		require.NoError(t, h.Handle(t.Context(), action, ack))
+		require.Error(t, action.Err, "malformed expiration should carry an error for the ack")
+		coord.AssertNotCalled(t, "Restart", mock.Anything, mock.Anything)
+		ss.AssertNotCalled(t, "SetPendingAckAction", mock.Anything)
+		ack.AssertCalled(t, "Ack", mock.Anything, action)
+	})
+
+	t.Run("restart error clears persisted action and acks failure", func(t *testing.T) {
+		action := &fleetapi.ActionRestart{ActionID: "r-fail", ActionType: fleetapi.ActionTypeRestart}
+		restartErr := errors.New("not upgradeable")
+
+		coord := &fakeRestartCoordinator{}
+		coord.On("Restart", mock.Anything, action).Return(restartErr)
+
+		ss := &fakeRestartStateStore{}
+		ss.On("SetPendingAckAction", action).Return()
+		ss.On("ClearPendingAckAction").Return()
+		ss.On("Save").Return(nil)
+
+		ack := &fakeAcker{}
+		ack.On("Ack", mock.Anything, action).Return(nil)
+		ack.On("Commit", mock.Anything).Return(nil)
+
+		h := NewRestart(log, coord, ss)
+		h.tamperProtectionFn = func() bool { return false }
+
+		err := h.Handle(t.Context(), action, ack)
+		require.ErrorIs(t, err, restartErr)
+		ss.AssertCalled(t, "ClearPendingAckAction")
+		ack.AssertCalled(t, "Ack", mock.Anything, action)
+		require.ErrorIs(t, action.Err, restartErr)
+	})
+
+	t.Run("tamper protection proxies action to endpoint", func(t *testing.T) {
+		action := &fleetapi.ActionRestart{ActionID: "r-tp", ActionType: fleetapi.ActionTypeRestart}
+
+		coord := &fakeRestartCoordinator{}
+		// No proxied units configured, so State() is enough and no PerformAction happens.
+		coord.On("State").Return(coordinator.State{})
+		coord.On("Restart", mock.Anything, action).Return(nil)
+
+		ss := &fakeRestartStateStore{}
+		ss.On("SetPendingAckAction", action).Return()
+		ss.On("Save").Return(nil)
+
+		h := NewRestart(log, coord, ss)
+		h.tamperProtectionFn = func() bool { return true }
+
+		require.NoError(t, h.Handle(t.Context(), action, &fakeAcker{}))
+		coord.AssertCalled(t, "State")
+		coord.AssertCalled(t, "Restart", mock.Anything, action)
+	})
+}
+
+type fakeRestartCoordinator struct {
+	mock.Mock
+}
+
+func (f *fakeRestartCoordinator) State() coordinator.State {
+	args := f.Called()
+	return args.Get(0).(coordinator.State)
+}
+
+func (f *fakeRestartCoordinator) PerformAction(ctx context.Context, comp component.Component, unit component.Unit, name string, params map[string]interface{}) (map[string]interface{}, error) {
+	args := f.Called(ctx, comp, unit, name, params)
+	return args.Get(0).(map[string]interface{}), args.Error(1)
+}
+
+func (f *fakeRestartCoordinator) Restart(ctx context.Context, action *fleetapi.ActionRestart) error {
+	args := f.Called(ctx, action)
+	return args.Error(0)
+}
+
+type fakeRestartStateStore struct {
+	mock.Mock
+}
+
+func (f *fakeRestartStateStore) SetPendingAckAction(a fleetapi.Action) {
+	f.Called(a)
+}
+
+func (f *fakeRestartStateStore) ClearPendingAckAction() {
+	f.Called()
+}
+
+func (f *fakeRestartStateStore) Save() error {
+	args := f.Called()
+	return args.Error(0)
+}

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -79,6 +79,13 @@ var ErrNotUpgradable = errors.New(
 	"cannot be upgraded; must be installed with install sub-command and " +
 		"running under control of the systems supervisor")
 
+// ErrNotRestartable error is returned when a restart cannot be performed
+// because the agent is not running in an environment where a re-execution
+// would be recovered.
+var ErrNotRestartable = errors.New(
+	"cannot be restarted; must be installed with install sub-command and " +
+		"running under control of the systems supervisor")
+
 // ErrUpgradeInProgress error is returned if two or more upgrades are
 // attempted at the same time.
 var ErrUpgradeInProgress = errors.New("upgrade already in progress")
@@ -337,6 +344,12 @@ type Coordinator struct {
 	upgradeMgr UpgradeManager
 	monitorMgr MonitorManager
 
+	// canReExec reports whether a re-execution of the process will be recovered
+	// (installed and running under a system supervisor). It is a field so tests
+	// can override it; it defaults to reexec.CanReExec. Both the upgrade path
+	// (via UpgradeManager.Upgradeable) and the restart path rely on this check.
+	canReExec func() bool
+
 	monitoringServerReloader configReloader
 
 	runtimeMgr RuntimeManager
@@ -589,6 +602,7 @@ func New(
 
 		fleetAcker:       fleetAcker,
 		secretMarkerFunc: diagnostics.AddSecretMarkers,
+		canReExec:        reexec.CanReExec,
 	}
 	// Setup communication channels for any non-nil components. This pattern
 	// lets us transparently accept nil managers / simulated events during
@@ -697,6 +711,23 @@ func (c *Coordinator) ReExec(callback reexec.ShutdownCallbackFn, argOverrides ..
 	// override the overall state to stopping until the re-execution is complete
 	c.SetOverrideState(agentclient.Stopping, "Re-executing")
 	c.reexecMgr.ReExec(callback, argOverrides...)
+}
+
+// Restart re-executes the agent to fulfil a RESTART action. It reuses the same
+// re-exec machinery as an upgrade, but performs no upgrade steps (no download,
+// marker, or version change). Unlike an upgrade it does not consider the
+// release-level upgrade flag; it only requires that a re-execution will be
+// recovered (canReExec). The action is not acknowledged here; it is
+// acknowledged on the next startup by the managed config manager.
+// Called from external goroutines.
+func (c *Coordinator) Restart(_ context.Context, _ *fleetapi.ActionRestart) error {
+	if !c.canReExec() {
+		return ErrNotRestartable
+	}
+
+	// ReExec sets the override state to Stopping and performs the re-execution.
+	c.ReExec(nil)
+	return nil
 }
 
 // Migrate migrates agent to a new cluster and ACKs success to the old one.

--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -2779,3 +2779,55 @@ func TestGetDynamicInputs(t *testing.T) {
 		assert.False(t, result["env-input"], "env-input should not be marked as dynamic")
 	})
 }
+
+type recordingReExecManager struct {
+	called bool
+}
+
+func (r *recordingReExecManager) ReExec(_ reexec.ShutdownCallbackFn, _ ...string) {
+	r.called = true
+}
+
+func TestCoordinator_Restart(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	action := &fleetapi.ActionRestart{ActionID: "r1", ActionType: fleetapi.ActionTypeRestart}
+
+	t.Run("not restartable returns ErrNotRestartable and does not re-exec", func(t *testing.T) {
+		reexecMgr := &recordingReExecManager{}
+		coord := &Coordinator{
+			// buffered so SetOverrideState (via ReExec) never blocks without a run loop
+			overrideStateChan: make(chan *coordinatorOverrideState, 2),
+			canReExec:         func() bool { return false },
+			reexecMgr:         reexecMgr,
+			logger:            logp.NewLogger("testing"),
+		}
+
+		err := coord.Restart(ctx, action)
+		require.ErrorIs(t, err, ErrNotRestartable)
+		assert.False(t, reexecMgr.called, "should not re-exec when not restartable")
+	})
+
+	t.Run("restartable triggers re-exec and override state", func(t *testing.T) {
+		reexecMgr := &recordingReExecManager{}
+		coord := &Coordinator{
+			overrideStateChan: make(chan *coordinatorOverrideState, 2),
+			canReExec:         func() bool { return true },
+			reexecMgr:         reexecMgr,
+			logger:            logp.NewLogger("testing"),
+		}
+
+		err := coord.Restart(ctx, action)
+		require.NoError(t, err)
+		assert.True(t, reexecMgr.called, "should re-exec when restartable")
+
+		select {
+		case os := <-coord.overrideStateChan:
+			require.NotNil(t, os, "restart should set an override state")
+			assert.Equal(t, agentclient.Stopping, os.state)
+		default:
+			t.Fatal("expected an override state to be set")
+		}
+	})
+}

--- a/internal/pkg/agent/application/managed_mode.go
+++ b/internal/pkg/agent/application/managed_mode.go
@@ -29,6 +29,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/queue"
 	"github.com/elastic/elastic-agent/internal/pkg/remote"
 	"github.com/elastic/elastic-agent/internal/pkg/runner"
+	"github.com/elastic/elastic-agent/pkg/backoff"
 	"github.com/elastic/elastic-agent/pkg/component/runtime"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 	"github.com/elastic/elastic-agent/pkg/fleetapi"
@@ -37,6 +38,13 @@ import (
 
 // dispatchFlushInterval is the max time between calls to dispatcher.Dispatch
 const dispatchFlushInterval = time.Minute * 5
+
+// restartAcker is the subset of the fleet acker used to synchronously
+// acknowledge a completed restart. It is kept separate from the lazy/buffered
+// acker so a nil error is a genuine confirmation that Fleet received the ack.
+type restartAcker interface {
+	Ack(ctx context.Context, action fleetapi.Action) error
+}
 
 type managedConfigManager struct {
 	log                      *logger.Logger
@@ -53,6 +61,7 @@ type managedConfigManager struct {
 	fleetInitTimeout         time.Duration
 	initialClientSetters     []actions.ClientSetter
 	fleetAcker               *fleet.Acker
+	restartAcker             restartAcker
 	actionAcker              acker.Acker
 	retrier                  *retrier.Retrier
 	availableRollbacksSource ttl.ReadOnlySource
@@ -83,6 +92,7 @@ func newManagedConfigManager(log *logger.Logger, agentInfo info.Agent, startupCf
 		errCh:                    make(chan error),
 		initialClientSetters:     clientSetters,
 		fleetAcker:               fleetAcker,
+		restartAcker:             fleetAcker,
 		actionAcker:              actionAcker,
 		retrier:                  retrier,
 		availableRollbacksSource: source,
@@ -117,6 +127,12 @@ func (m *managedConfigManager) Run(ctx context.Context) error {
 	if err := m.coord.AckUpgrade(ctx, m.actionAcker); err != nil {
 		m.log.Warnf("Failed to ack upgrade: %v", err)
 	}
+
+	// Acknowledge a completed restart, if one was pending. This runs in the
+	// background and retries until Fleet confirms receipt or the action
+	// expires; the action stays persisted until then so it survives further
+	// restarts.
+	m.ackPendingRestart(ctx)
 
 	// Run the retrier.
 	retrierRun := make(chan bool)
@@ -222,6 +238,94 @@ func (m *managedConfigManager) Run(ctx context.Context) error {
 
 	<-ctx.Done()
 	return gatewayRunner.Err()
+}
+
+const (
+	restartAckBackoffInit = 1 * time.Second
+	restartAckBackoffMax  = 1 * time.Minute
+)
+
+// ackPendingRestart acknowledges a restart action that was persisted before the
+// agent re-executed. Unlike the upgrade ack, we cannot rely on a single
+// (possibly buffered) ack being delivered: the action remains persisted until
+// Fleet actually confirms receipt, so it is retried on every startup as well as
+// in-session via the background loop started here. If the action has expired,
+// Fleet has already inferred the failure, so we simply discard it.
+func (m *managedConfigManager) ackPendingRestart(ctx context.Context) {
+	action := m.stateStore.PendingAckAction()
+	if action == nil {
+		return
+	}
+
+	if m.restartActionExpired(action, time.Now()) {
+		m.log.Warnf("restart action %q expired or has an invalid expiration before it could be acknowledged; discarding", action.ID())
+		m.clearPendingRestart()
+		return
+	}
+
+	m.log.Infof("acknowledging completed restart action %q", action.ID())
+	go m.retryAckPendingRestart(ctx, action)
+}
+
+// retryAckPendingRestart synchronously acks the action against Fleet, retrying
+// with exponential backoff until it succeeds, the action expires, or the
+// context is cancelled. On success or expiration the persisted action is
+// cleared; on cancellation it is left in place to be retried on the next
+// startup.
+func (m *managedConfigManager) retryAckPendingRestart(ctx context.Context, action fleetapi.Action) {
+	bo := backoff.NewExpBackoff(ctx.Done(), restartAckBackoffInit, restartAckBackoffMax)
+	for {
+		// Use the fleet acker directly (not the lazy/buffered acker) so a nil
+		// error is a genuine confirmation that Fleet received the ack.
+		err := m.restartAcker.Ack(ctx, action)
+		if err == nil {
+			m.log.Infof("restart action %q acknowledged", action.ID())
+			m.clearPendingRestart()
+			return
+		}
+
+		if m.restartActionExpired(action, time.Now()) {
+			m.log.Warnf("restart action %q expired or has an invalid expiration before its ack could be delivered; discarding", action.ID())
+			m.clearPendingRestart()
+			return
+		}
+
+		m.log.Warnf("failed to ack restart action %q, will retry: %v", action.ID(), err)
+		if !bo.Wait() {
+			// Context cancelled; leave the action persisted for the next startup.
+			return
+		}
+	}
+}
+
+// restartActionExpired reports whether a persisted restart action should be
+// discarded instead of acknowledged: either its expiration is in the past, or
+// it carries a malformed expiration. A malformed expiration is treated as
+// expired so an invalid action is discarded rather than retried indefinitely.
+func (m *managedConfigManager) restartActionExpired(action fleetapi.Action, now time.Time) bool {
+	sa, ok := action.(fleetapi.ScheduledAction)
+	if !ok {
+		return false
+	}
+	exp, err := sa.Expiration()
+	if errors.Is(err, fleetapi.ErrNoExpiration) {
+		// No expiration set; the action never expires.
+		return false
+	}
+	if err != nil {
+		// Malformed expiration; treat as expired so the invalid action is
+		// discarded rather than persisted and retried forever.
+		return true
+	}
+	return now.After(exp)
+}
+
+// clearPendingRestart removes the persisted pending-ack restart action.
+func (m *managedConfigManager) clearPendingRestart() {
+	m.stateStore.ClearPendingAckAction()
+	if err := m.stateStore.Save(); err != nil {
+		m.log.Warnf("failed to clear pending restart action from state store: %v", err)
+	}
 }
 
 // runDispatcher passes actions collected from gateway to dispatcher or calls Dispatch with no actions every flushInterval.
@@ -396,6 +500,11 @@ func (m *managedConfigManager) initDispatcher(canceller context.CancelFunc) *han
 	m.dispatcher.MustRegister(
 		&fleetapi.ActionPrivilegeLevelChange{},
 		handlers.NewPrivilegeLevelChange(m.log, m.coord, m.ch),
+	)
+
+	m.dispatcher.MustRegister(
+		&fleetapi.ActionRestart{},
+		handlers.NewRestart(m.log, m.coord, m.stateStore),
 	)
 
 	m.dispatcher.MustRegister(

--- a/internal/pkg/agent/application/managed_mode_test.go
+++ b/internal/pkg/agent/application/managed_mode_test.go
@@ -6,17 +6,23 @@ package application
 
 import (
 	"context"
+	"errors"
+	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
 
+	"github.com/elastic/elastic-agent/internal/pkg/agent/storage"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/storage/store"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/acker"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
+	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
 	"github.com/elastic/elastic-agent/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/pkg/upgrade/details"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type mockDispatcher struct {
@@ -144,4 +150,130 @@ func Test_runDispatcher(t *testing.T) {
 			acker.AssertExpectations(t)
 		})
 	}
+}
+
+type fakeRestartAcker struct {
+	errs  []error
+	calls int
+}
+
+func (f *fakeRestartAcker) Ack(_ context.Context, _ fleetapi.Action) error {
+	var err error
+	if f.calls < len(f.errs) {
+		err = f.errs[f.calls]
+	}
+	f.calls++
+	return err
+}
+
+func newTestStateStore(t *testing.T) *store.StateStore {
+	t.Helper()
+	log, _ := loggertest.New("state_store")
+	s, err := storage.NewDiskStore(filepath.Join(t.TempDir(), "state.json"))
+	require.NoError(t, err)
+	ss, err := store.NewStateStore(log, s)
+	require.NoError(t, err)
+	return ss
+}
+
+func restartAction(id string, expiration time.Time) *fleetapi.ActionRestart {
+	a := &fleetapi.ActionRestart{ActionID: id, ActionType: fleetapi.ActionTypeRestart}
+	if !expiration.IsZero() {
+		a.ActionExpiration = expiration.UTC().Format(time.RFC3339)
+	}
+	return a
+}
+
+func TestManagedConfigManager_restartActionExpired(t *testing.T) {
+	m := &managedConfigManager{}
+	now := time.Now()
+
+	assert.True(t, m.restartActionExpired(restartAction("a", now.Add(-time.Minute)), now),
+		"past expiration should be expired")
+	assert.False(t, m.restartActionExpired(restartAction("a", now.Add(time.Minute)), now),
+		"future expiration should not be expired")
+	assert.False(t, m.restartActionExpired(restartAction("a", time.Time{}), now),
+		"missing expiration should never expire")
+	assert.False(t, m.restartActionExpired(&fleetapi.ActionPolicyChange{}, now),
+		"non-scheduled action should never be reported expired")
+	assert.True(t, m.restartActionExpired(
+		&fleetapi.ActionRestart{ActionID: "a", ActionType: fleetapi.ActionTypeRestart, ActionExpiration: "not-a-timestamp"}, now),
+		"malformed expiration should be treated as expired so it is discarded")
+}
+
+func TestManagedConfigManager_ackPendingRestart(t *testing.T) {
+	log, _ := loggertest.New("managed")
+
+	t.Run("no pending action is a no-op", func(t *testing.T) {
+		ss := newTestStateStore(t)
+		ack := &fakeRestartAcker{}
+		m := &managedConfigManager{log: log, stateStore: ss, restartAcker: ack}
+
+		m.ackPendingRestart(t.Context())
+		assert.Equal(t, 0, ack.calls, "should not ack when there is nothing pending")
+	})
+
+	t.Run("expired pending action is discarded without acking", func(t *testing.T) {
+		ss := newTestStateStore(t)
+		ss.SetPendingAckAction(restartAction("expired", time.Now().Add(-time.Hour)))
+		require.NoError(t, ss.Save())
+
+		ack := &fakeRestartAcker{}
+		m := &managedConfigManager{log: log, stateStore: ss, restartAcker: ack}
+
+		m.ackPendingRestart(t.Context())
+		assert.Equal(t, 0, ack.calls, "expired action must not be acked")
+		assert.Nil(t, ss.PendingAckAction(), "expired action must be cleared")
+	})
+}
+
+func TestManagedConfigManager_retryAckPendingRestart(t *testing.T) {
+	log, _ := loggertest.New("managed")
+
+	t.Run("successful ack clears the persisted action", func(t *testing.T) {
+		ss := newTestStateStore(t)
+		action := restartAction("ok", time.Time{})
+		ss.SetPendingAckAction(action)
+		require.NoError(t, ss.Save())
+
+		ack := &fakeRestartAcker{errs: []error{nil}}
+		m := &managedConfigManager{log: log, stateStore: ss, restartAcker: ack}
+
+		m.retryAckPendingRestart(t.Context(), action)
+		assert.Equal(t, 1, ack.calls)
+		assert.Nil(t, ss.PendingAckAction(), "acked action must be cleared")
+	})
+
+	t.Run("failed ack retains the persisted action when context is cancelled", func(t *testing.T) {
+		ss := newTestStateStore(t)
+		action := restartAction("retry", time.Time{})
+		ss.SetPendingAckAction(action)
+		require.NoError(t, ss.Save())
+
+		ack := &fakeRestartAcker{errs: []error{errors.New("fleet unreachable")}}
+		m := &managedConfigManager{log: log, stateStore: ss, restartAcker: ack}
+
+		// Cancelled context makes the backoff return immediately after the first failure.
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		m.retryAckPendingRestart(ctx, action)
+		assert.Equal(t, 1, ack.calls)
+		require.NotNil(t, ss.PendingAckAction(), "unacked action must be retained for the next startup")
+		assert.Equal(t, action, ss.PendingAckAction())
+	})
+
+	t.Run("action that expires mid-retry is discarded", func(t *testing.T) {
+		ss := newTestStateStore(t)
+		action := restartAction("expiring", time.Now().Add(-time.Second))
+		ss.SetPendingAckAction(action)
+		require.NoError(t, ss.Save())
+
+		ack := &fakeRestartAcker{errs: []error{errors.New("fleet unreachable")}}
+		m := &managedConfigManager{log: log, stateStore: ss, restartAcker: ack}
+
+		m.retryAckPendingRestart(t.Context(), action)
+		assert.Equal(t, 1, ack.calls)
+		assert.Nil(t, ss.PendingAckAction(), "expired action must be cleared")
+	})
 }

--- a/internal/pkg/agent/application/reexec/manager.go
+++ b/internal/pkg/agent/application/reexec/manager.go
@@ -5,9 +5,21 @@
 package reexec
 
 import (
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/info"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/errors"
 	"github.com/elastic/elastic-agent/pkg/core/logger"
 )
+
+// CanReExec reports whether the agent is running in an environment where a
+// re-execution of the process will be recovered: installed via the install
+// sub-command and running under the control of the system supervisor
+// (systemd/launchd/Windows service). Actions that re-exec the process (UPGRADE,
+// RESTART) require this to hold. It lives here, rather than in the upgrade
+// manager, so it can be shared by both the upgrade and restart paths.
+func CanReExec() bool {
+	return paths.RunningInstalled() && info.RunningUnderSupervisor()
+}
 
 // ExecManager is the interface that the global reexec manager implements.
 type ExecManager interface {

--- a/internal/pkg/agent/application/upgrade/upgrade.go
+++ b/internal/pkg/agent/application/upgrade/upgrade.go
@@ -137,7 +137,7 @@ type Upgrader struct {
 func IsUpgradeable() bool {
 	// only upgradeable if running from Agent installer and running under the
 	// control of the system supervisor (or built specifically with upgrading enabled)
-	return release.Upgradeable() || (paths.RunningInstalled() && info.RunningUnderSupervisor())
+	return release.Upgradeable() || reexec.CanReExec()
 }
 
 // NewUpgrader creates an upgrader which is capable of performing upgrade operation

--- a/internal/pkg/agent/storage/store/state_store.go
+++ b/internal/pkg/agent/storage/store/state_store.go
@@ -49,8 +49,12 @@ type StateStore struct {
 type state struct {
 	Version          string           `json:"version"`
 	ActionSerializer actionSerializer `json:"action,omitempty"`
-	AckToken         string           `json:"ack_token,omitempty"`
-	Queue            actionQueue      `json:"action_queue,omitempty"`
+	// PendingAck holds an action that must be acknowledged after a restart.
+	// It is stored separately from ActionSerializer so it does not clobber the
+	// persisted policy-change action used to restore policy on startup.
+	PendingAck actionSerializer `json:"pending_ack,omitempty"`
+	AckToken   string           `json:"ack_token,omitempty"`
+	Queue      actionQueue      `json:"action_queue,omitempty"`
 }
 
 // actionSerializer is JSON Marshaler/Unmarshaler for fleetapi.Action.
@@ -194,6 +198,60 @@ func (s *StateStore) SetAction(a fleetapi.Action) {
 	}
 }
 
+// SetPendingAckAction stores an action that must be acknowledged after a
+// restart. It accepts ActionRestart. Any other type is silently discarded.
+func (s *StateStore) SetPendingAckAction(a fleetapi.Action) {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	if a == nil || reflect.ValueOf(a).IsNil() {
+		s.log.Debugf("trying to set a nil '%T' pending-ack action, ignoring the action", a)
+		return
+	}
+
+	switch v := a.(type) {
+	// If any new action type is added, don't forget to update the method's
+	// description and Save.
+	case *fleetapi.ActionRestart:
+		if s.state.PendingAck.Action != nil &&
+			s.state.PendingAck.Action.ID() == v.ID() {
+			return
+		}
+		s.dirty = true
+		s.state.PendingAck.Action = a
+	default:
+		s.log.Debugw("trying to set invalid pending-ack action type on the state store, ignoring the action",
+			"action.type", a.Type(),
+			"action.id", a.ID())
+	}
+}
+
+// PendingAckAction returns the action that must be acknowledged after a
+// restart, or nil if there is none. See SetPendingAckAction for the
+// possible action types.
+func (s *StateStore) PendingAckAction() fleetapi.Action {
+	s.mx.RLock()
+	defer s.mx.RUnlock()
+
+	if s.state.PendingAck.Action == nil {
+		return nil
+	}
+
+	return s.state.PendingAck.Action
+}
+
+// ClearPendingAckAction removes any stored pending-ack action.
+func (s *StateStore) ClearPendingAckAction() {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	if s.state.PendingAck.Action == nil {
+		return
+	}
+	s.dirty = true
+	s.state.PendingAck.Action = nil
+}
+
 // SetAckToken set ack token to the agent state
 func (s *StateStore) SetAckToken(ackToken string) {
 	s.mx.Lock()
@@ -239,6 +297,15 @@ func (s *StateStore) Save() (err error) {
 	default:
 		return fmt.Errorf("incompatible type, expected ActionPolicyChange, "+
 			"ActionUnenroll or nil, but received %T", a)
+	}
+
+	switch a := s.state.PendingAck.Action.(type) {
+	case *fleetapi.ActionRestart,
+		nil:
+		// ok
+	default:
+		return fmt.Errorf("incompatible pending-ack type, expected "+
+			"ActionRestart or nil, but received %T", a)
 	}
 
 	reader, err = jsonToReader(&s.state)

--- a/internal/pkg/agent/storage/store/state_store_test.go
+++ b/internal/pkg/agent/storage/store/state_store_test.go
@@ -677,6 +677,67 @@ func runTestStateStore(t *testing.T, ackToken string) {
 	})
 }
 
+func TestStateStorePendingAckAction(t *testing.T) {
+	log, _ := loggertest.New("state_store_pending_ack")
+
+	newStore := func(t *testing.T, path string) *StateStore {
+		s, err := storage.NewDiskStore(path)
+		require.NoError(t, err, "failed creating DiskStore")
+		store, err := NewStateStore(log, s)
+		require.NoError(t, err)
+		return store
+	}
+
+	t.Run("round-trips a restart action separately from the main action", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.json")
+		store := newStore(t, path)
+
+		policyChange := &fleetapi.ActionPolicyChange{ActionID: "policy-1", ActionType: fleetapi.ActionTypePolicyChange}
+		restart := &fleetapi.ActionRestart{ActionID: "restart-1", ActionType: fleetapi.ActionTypeRestart}
+
+		store.SetAction(policyChange)
+		store.SetPendingAckAction(restart)
+		require.NoError(t, store.Save())
+
+		reloaded := newStore(t, path)
+		assert.Equal(t, policyChange, reloaded.Action(), "main action should be preserved")
+		assert.Equal(t, restart, reloaded.PendingAckAction(), "pending-ack action should be preserved")
+	})
+
+	t.Run("ignores unsupported pending-ack action types", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.json")
+		store := newStore(t, path)
+
+		store.SetPendingAckAction(&fleetapi.ActionUnenroll{ActionID: "u1", ActionType: fleetapi.ActionTypeUnenroll})
+		assert.Nil(t, store.PendingAckAction(), "unsupported pending-ack types must be discarded")
+	})
+
+	t.Run("clears the pending-ack action", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.json")
+		store := newStore(t, path)
+
+		store.SetPendingAckAction(&fleetapi.ActionRestart{ActionID: "restart-2", ActionType: fleetapi.ActionTypeRestart})
+		require.NoError(t, store.Save())
+		require.NotNil(t, store.PendingAckAction())
+
+		store.ClearPendingAckAction()
+		require.NoError(t, store.Save())
+
+		reloaded := newStore(t, path)
+		assert.Nil(t, reloaded.PendingAckAction(), "cleared pending-ack action must not be reloaded")
+	})
+
+	t.Run("loads a store written without the pending-ack field", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.json")
+		// A version "1" store without the pending_ack field must remain loadable.
+		require.NoError(t, os.WriteFile(path, []byte(`{"version":"1","ack_token":"tok"}`), 0o600))
+
+		store := newStore(t, path)
+		assert.Nil(t, store.PendingAckAction())
+		assert.Equal(t, "tok", store.AckToken())
+	})
+}
+
 // hasEmptyFields will check if action has any empty fields. It returns a string
 // slice with any empty field, the field value is the zero value for its type.
 // If the json tag of the field is "-", the field is ignored.

--- a/pkg/fleetapi/action.go
+++ b/pkg/fleetapi/action.go
@@ -29,6 +29,11 @@ const (
 	ActionTypeDiagnostics          = string(api.REQUESTDIAGNOSTICS)
 	ActionTypeMigrate              = string(api.MIGRATE)
 	ActionTypePrivilegeLevelChange = string(api.PRIVILEGELEVELCHANGE)
+	// ActionTypeRestart is defined locally because the Fleet Server API spec
+	// does not yet expose a RESTART action type. Switch to string(api.RESTART)
+	// once it is added upstream.
+	// TODO: Replace with the real reference once Fleet supports the action.
+	ActionTypeRestart = "RESTART"
 )
 
 // Error values that the Action interface can return
@@ -117,6 +122,8 @@ func NewAction(actionType string) Action {
 		action = &ActionMigrate{}
 	case ActionTypePrivilegeLevelChange:
 		action = &ActionPrivilegeLevelChange{}
+	case ActionTypeRestart:
+		action = &ActionRestart{}
 	default:
 		action = &ActionUnknown{OriginalType: actionType}
 	}
@@ -403,6 +410,78 @@ func (a *ActionUpgrade) SetStartTime(t time.Time) {
 
 // MarshalMap marshals ActionUpgrade into a corresponding map
 func (a *ActionUpgrade) MarshalMap() (map[string]interface{}, error) {
+	var res map[string]interface{}
+	err := mapstructure.Decode(a, &res)
+	return res, err
+}
+
+// ActionRestart is a request for the agent to restart itself.
+// It reuses the upgrade restart machinery: the agent persists the action,
+// re-execs, and acknowledges the action on the next startup.
+type ActionRestart struct {
+	ActionID         string  `json:"id" yaml:"id" mapstructure:"id"`
+	ActionType       string  `json:"type" yaml:"type" mapstructure:"type"`
+	ActionStartTime  string  `json:"start_time,omitempty" yaml:"start_time,omitempty" mapstructure:"-"`
+	ActionExpiration string  `json:"expiration,omitempty" yaml:"expiration,omitempty" mapstructure:"-"`
+	Signed           *Signed `json:"signed,omitempty" yaml:"signed,omitempty" mapstructure:"signed,omitempty"`
+
+	Err error `json:"-" yaml:"-" mapstructure:"-"`
+}
+
+func (a *ActionRestart) String() string {
+	var s strings.Builder
+	s.WriteString("id: ")
+	s.WriteString(a.ActionID)
+	s.WriteString(", type: ")
+	s.WriteString(a.ActionType)
+	return s.String()
+}
+
+// Type returns the type of the Action.
+func (a *ActionRestart) Type() string {
+	return a.ActionType
+}
+
+// ID returns the ID of the Action.
+func (a *ActionRestart) ID() string {
+	return a.ActionID
+}
+
+// StartTime returns the start_time as a UTC time.Time or ErrNoStartTime if there is no start time.
+func (a *ActionRestart) StartTime() (time.Time, error) {
+	if a.ActionStartTime == "" {
+		return time.Time{}, ErrNoStartTime
+	}
+	ts, err := time.Parse(time.RFC3339, a.ActionStartTime)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return ts.UTC(), nil
+}
+
+// Expiration returns the expiration as a UTC time.Time or ErrNoExpiration if there is no expiration.
+func (a *ActionRestart) Expiration() (time.Time, error) {
+	if a.ActionExpiration == "" {
+		return time.Time{}, ErrNoExpiration
+	}
+	ts, err := time.Parse(time.RFC3339, a.ActionExpiration)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return ts.UTC(), nil
+}
+
+func (a *ActionRestart) AckEvent(agentID string, ts time.Time) api.AckRequest_Events_Item {
+	event := newGenericEvent(a.ActionID, a.ActionType, agentID, ts)
+	if a.Err != nil {
+		errStr := a.Err.Error()
+		event.Error = &errStr
+	}
+	return toGenericAckEvent(event)
+}
+
+// MarshalMap marshals ActionRestart into a corresponding map.
+func (a *ActionRestart) MarshalMap() (map[string]interface{}, error) {
 	var res map[string]interface{}
 	err := mapstructure.Decode(a, &res)
 	return res, err

--- a/pkg/fleetapi/action_test.go
+++ b/pkg/fleetapi/action_test.go
@@ -7,6 +7,7 @@ package fleetapi
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -174,6 +175,75 @@ func TestActionsUnmarshalJSON(t *testing.T) {
 		require.Len(t, action.Data.AdditionalMetrics, 1)
 		assert.Equal(t, "CPU", action.Data.AdditionalMetrics[0])
 	})
+}
+
+func TestActionRestartUnmarshalJSON(t *testing.T) {
+	t.Run("RESTART maps to ActionRestart", func(t *testing.T) {
+		p := []byte(`[{"id":"testid","type":"RESTART","start_time":"2022-01-02T12:00:00Z","expiration":"2022-01-02T13:00:00Z"}]`)
+		a := &Actions{}
+		require.NoError(t, a.UnmarshalJSON(p))
+
+		action, ok := (*a)[0].(*ActionRestart)
+		require.True(t, ok, "unable to cast action to ActionRestart")
+		assert.Equal(t, "testid", action.ActionID)
+		assert.Equal(t, ActionTypeRestart, action.ActionType)
+		assert.Equal(t, "2022-01-02T12:00:00Z", action.ActionStartTime)
+		assert.Equal(t, "2022-01-02T13:00:00Z", action.ActionExpiration)
+
+		st, err := action.StartTime()
+		require.NoError(t, err)
+		assert.Equal(t, "2022-01-02T12:00:00Z", st.Format(time.RFC3339))
+
+		exp, err := action.Expiration()
+		require.NoError(t, err)
+		assert.Equal(t, "2022-01-02T13:00:00Z", exp.Format(time.RFC3339))
+	})
+
+	t.Run("RESTART without start time or expiration", func(t *testing.T) {
+		p := []byte(`[{"id":"testid","type":"RESTART"}]`)
+		a := &Actions{}
+		require.NoError(t, a.UnmarshalJSON(p))
+
+		action, ok := (*a)[0].(*ActionRestart)
+		require.True(t, ok, "unable to cast action to ActionRestart")
+
+		_, err := action.StartTime()
+		assert.ErrorIs(t, err, ErrNoStartTime)
+		_, err = action.Expiration()
+		assert.ErrorIs(t, err, ErrNoExpiration)
+	})
+}
+
+func TestNewActionRestart(t *testing.T) {
+	a := NewAction(ActionTypeRestart)
+	_, ok := a.(*ActionRestart)
+	assert.True(t, ok, "NewAction(RESTART) should return *ActionRestart")
+}
+
+func TestActionRestartMarshalMap(t *testing.T) {
+	action := ActionRestart{
+		ActionID:   "164a6819-5c58-40f7-a33c-821c98ab0a8c",
+		ActionType: "RESTART",
+		Signed: &Signed{
+			Data:      "eyJAdGltZXN0YW1wIjoiMjAy",
+			Signature: "MEQCIGxsrI742xKL6OSI",
+		},
+	}
+
+	m, err := action.MarshalMap()
+	require.NoError(t, err)
+
+	diff := cmp.Diff(map[string]interface{}{
+		"id":   "164a6819-5c58-40f7-a33c-821c98ab0a8c",
+		"type": "RESTART",
+		"signed": map[string]interface{}{
+			"data":      "eyJAdGltZXN0YW1wIjoiMjAy",
+			"signature": "MEQCIGxsrI742xKL6OSI",
+		},
+	}, m)
+	if diff != "" {
+		t.Fatal(diff)
+	}
 }
 
 func TestActionUnenrollMarshalMap(t *testing.T) {

--- a/testing/integration/ess/restart_action_test.go
+++ b/testing/integration/ess/restart_action_test.go
@@ -1,0 +1,140 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build integration
+
+package ess
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/pkg/fleetapi"
+	integrationtest "github.com/elastic/elastic-agent/pkg/testing"
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/check"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/testcontext"
+	"github.com/elastic/elastic-agent/testing/fleetservertest"
+	"github.com/elastic/elastic-agent/testing/integration"
+)
+
+// TestFleetRestartAction validates the end-to-end RESTART action flow against a
+// Fleet Server: the agent receives a RESTART action on checkin, re-execs itself,
+// and only acknowledges the action to Fleet after it has restarted.
+func TestFleetRestartAction(t *testing.T) {
+	_ = define.Require(t, define.Requirements{
+		Group: integration.Fleet,
+		Stack: &define.Stack{},
+		Local: false, // requires Agent installation
+		Sudo:  true,  // requires Agent installation
+	})
+
+	ctx, cancel := testcontext.WithTimeout(t, t.Context(), time.Minute*10)
+	defer cancel()
+
+	apiKey, policy := createBasicFleetPolicyData(t, "http://fleet-server:8221")
+	checkinWithAcker := fleetservertest.NewCheckinActionsWithAcker()
+	nextActionGenerator := checkinWithAcker.ActionsGenerator()
+
+	handlers := &fleetservertest.Handlers{
+		APIKey:          apiKey.Key,
+		EnrollmentToken: "enrollmentToken",
+		AgentID:         policy.AgentID, // as there is no enroll, the agentID needs to be manually set
+		CheckinFn: func(ctx context.Context, h *fleetservertest.Handlers, id string, userAgent string,
+			acceptEncoding string, checkinRequest fleetservertest.CheckinRequest,
+		) (*fleetservertest.CheckinResponse, *fleetservertest.HTTPError) {
+			if id != policy.AgentID {
+				return nil, &fleetservertest.HTTPError{
+					StatusCode: http.StatusNotFound,
+					Message:    fmt.Sprintf("agent %q not found", id),
+				}
+			}
+
+			data, hErr := nextActionGenerator()
+			if hErr != nil {
+				return nil, hErr
+			}
+
+			respStr := fleetservertest.NewCheckinResponse(data.AckToken, data.Actions...)
+			resp := fleetservertest.CheckinResponse{}
+			if err := json.Unmarshal([]byte(respStr), &resp); err != nil {
+				return nil, &fleetservertest.HTTPError{
+					StatusCode: http.StatusInternalServerError,
+					Message:    fmt.Sprintf("failed to CheckinResponse: %v", err),
+				}
+			}
+
+			// simulate long poll
+			time.Sleep(data.Delay)
+
+			return &resp, nil
+		},
+		EnrollFn: fleetservertest.NewHandlerEnroll(policy.AgentID, policy.PolicyID, apiKey),
+		AckFn:    fleetservertest.NewHandlerAckWithAcker(checkinWithAcker.Acker()),
+		StatusFn: fleetservertest.NewHandlerStatusHealthy(),
+	}
+
+	fleetServer := fleetservertest.NewServer(handlers, fleetservertest.WithRequestLog(t.Logf))
+	defer fleetServer.Close()
+
+	fixture, err := define.NewFixtureFromLocalBuild(t,
+		define.Version(),
+		integrationtest.WithAllowErrors(),
+		integrationtest.WithLogOutput())
+	require.NoError(t, err, "SetupTest: NewFixtureFromLocalBuild failed")
+	err = fixture.EnsurePrepared(ctx)
+	require.NoError(t, err, "SetupTest: fixture.Prepare failed")
+
+	out, err := fixture.Install(
+		ctx,
+		&integrationtest.InstallOpts{
+			Force:          true,
+			NonInteractive: true,
+			Insecure:       true,
+			Privileged:     false,
+			EnrollOpts: integrationtest.EnrollOpts{
+				URL:             fleetServer.LocalhostURL,
+				EnrollmentToken: "anythingWillDO",
+			}})
+	require.NoErrorf(t, err, "Error when installing agent, output: %s", out)
+
+	// Wait for the agent to connect to Fleet and report HEALTHY.
+	check.ConnectedToFleet(ctx, t, fixture, 5*time.Minute)
+
+	// Deliver a RESTART action on the next checkin.
+	restartActionID := "restart-action-id"
+	restartAction, err := fleetservertest.NewAction(fleetservertest.ActionTmpl{
+		AgentID:  policy.AgentID,
+		ActionID: restartActionID,
+		Type:     fleetapi.ActionTypeRestart,
+		Data:     "{}",
+	})
+	require.NoError(t, err, "failed to create restart action")
+	checkinWithAcker.AddCheckin("token", 1*time.Second, restartAction)
+
+	// The RESTART action is acknowledged only after the agent has restarted:
+	// the handler persists the action and re-execs, and the ack is sent on the
+	// next startup via the pending-ack path. A successful ack therefore proves
+	// the full persist -> re-exec -> startup-ack flow worked end-to-end with
+	// Fleet Server. (The agent re-execs in-place, so its PID is unchanged.)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.True(collect, checkinWithAcker.Acked(restartActionID),
+			"restart action has not been acknowledged to Fleet")
+	}, 5*time.Minute, 500*time.Millisecond, "agent did not acknowledge the restart action after restarting")
+
+	// After re-exec the agent must reconnect to Fleet. We assert on the Fleet
+	// connection state (as the initial ConnectedToFleet check did) rather than
+	// the overall agent state: with this minimal mock Fleet policy the agent
+	// does not necessarily reach a fully-HEALTHY overall state, but it must
+	// re-establish its Fleet connection after restarting.
+	require.True(t, check.ConnectedToFleet(ctx, t, fixture, 5*time.Minute),
+		"agent did not reconnect to Fleet after restart")
+}


### PR DESCRIPTION
## What does this PR do?

Add a new `RESTART` Fleet action that re-execs the agent in place and acknowledges the action to Fleet only after it has restarted.

- Define `ActionRestart` (`fleetapi`) with the same signing/tamper protection as `UPGRADE`.
- Persist the action in a separate pending-ack slot in the state store so it survives re-exec without clobbering the policy-change action.
- Add a restart handler that checks expiry, proxies to Endpoint under tamper protection, persists the action, and calls `Coordinator.Restart`.
- Gate `Coordinator.Restart` on `Upgradeable()` and reuse the `ReExec` machinery.
- Ack the pending restart on startup with exponential-backoff retry, clearing it only once Fleet confirms receipt.
- Add unit tests, an integration test against a mock Fleet Server, and a changelog fragment.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

<details>
<summary>Click for more details regarding the implementation</summary>

## Details

### Flow

```mermaid
sequenceDiagram
    participant Fleet
    participant Gateway as FleetGateway
    participant Disp as Dispatcher
    participant H as RestartHandler
    participant SS as StateStore
    participant Coord as Coordinator
    Fleet->>Gateway: RESTART action (checkin)
    Gateway->>Disp: Actions()
    Disp->>H: Handle(action)
    H->>H: expired? -> ack error, stop
    H->>SS: SetPendingAckAction(RESTART) + Save()
    H->>Coord: Restart() (gates on Upgradeable, ReExec)
    Note over Coord: process re-execs (no ack yet)
    Coord-->>Fleet: (agent restarts)
    Note over SS,Fleet: on startup
    SS->>H: pending RESTART action read in Run()
    H->>H: expired? -> delete, skip
    H->>Fleet: Ack + Commit
    H->>SS: delete pending action on confirmed commit
```

### Design decisions

- **Action string**: the action type is the literal `"RESTART"`.
- **Local definition**: `ActionRestart` is defined locally in `pkg/fleetapi`
  because the Fleet Server API spec does not yet include it. Keeping Fleet
  Server / Kibana in sync is a follow-up, cross-repo task.
- **Signing / tamper protection**: `ActionRestart` carries a `Signed` field
  and, under tamper protection, is proxied to Endpoint units — mirroring the
  `UPGRADE` handler.
- **Separate pending-ack slot**: the action is persisted in a dedicated
  `PendingAck` field of the state store rather than the main action slot, so a
  restart does not clobber the persisted policy-change action used to restore
  policy on startup.
- **Ack survives restart**: the default lazy acker only enqueues acks in
  memory, which would not survive a re-exec. Instead the action is kept
  persisted and re-acked on every startup (with exponential backoff) until
  Fleet confirms receipt, then deleted.
- **Expiry**: if the action is expired when received, the agent acks an error
  and does not restart. If it expires while pending ack, it is deleted and
  skipped on startup.
- **Containerized / non-upgradeable environments**: `Coordinator.Restart` is
  gated on `upgradeMgr.Upgradeable()`, so it behaves the same as `UPGRADE` and
  returns `ErrNotUpgradable` where re-exec is not supported.
- **In-place re-exec**: on non-Windows the agent re-execs via `unix.Exec`,
  replacing the process image, so the PID is unchanged after a restart.

### Changes by area

| Area | File | Change |
|------|------|--------|
| Action type | `pkg/fleetapi/action.go` | `ActionTypeRestart` const, `ActionRestart` struct, `NewAction` wiring |
| State store | `internal/pkg/agent/storage/store/state_store.go` | `PendingAck` field + Set/Get/Clear methods, `Save()` type switch |
| Handler | `internal/pkg/agent/application/actions/handlers/handler_action_restart.go` | expiry check, tamper proxy, persist, `coord.Restart` |
| Coordinator | `internal/pkg/agent/application/coordinator/coordinator.go` | `Restart()` gated on `Upgradeable()`, reuses `ReExec` |
| Managed mode | `internal/pkg/agent/application/managed_mode.go` | register handler, startup ack with backoff retry |
| Changelog | `changelog/fragments/1787200000-add-restart-action.yaml` | feature fragment |

### Testing

- **Unit**: action (un)marshalling, state-store round-trip and backward
  compatibility, handler behavior, coordinator gating, and startup-ack logic.
- **Integration**: `testing/integration/ess/restart_action_test.go` enrolls a
  real agent against the mock Fleet Server (`fleetservertest`), delivers a
  `RESTART` action, and asserts the action is acknowledged only after the agent
  restarts (proving the persist → re-exec → startup-ack flow) and that the
  agent reconnects and reports HEALTHY.
- The mock Fleet Server is used because Kibana / Fleet Server do not yet
  recognize the `RESTART` action type, so a real-Fleet test would be rejected
  at the Kibana layer rather than exercising the agent.

</details>

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Our users would like to have a restart action they could trigger from the UI in order to resolve certain issues with the agent.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

The change is covered by an integration test. To test is locally with Fleet we need it to add support for the `RESTART` action first.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/kibana/issues/144585