### PR TITLE
docs: add GCP OTel runtime known issue

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -42,6 +42,35 @@ Alternatively, set `_runtime_experimental: process` on the affected inputs.
 
 For more information, check [Issue #16118](https://github.com/elastic/elastic-agent/issues/16118).
 ::::
+
+:::{dropdown} GCP integration data collected through Pub/Sub is silently dropped on the OTel runtime
+
+**Applies to: {{agent}} 9.5.0 to 9.5.1**
+
+On August 5, 2026, a known issue was discovered where the Filebeat OTel runtime converts values with the Go type `map[string]string` to the string `unknown type: map[string]string` instead of an object. When the destination data stream maps the field as an object, {{es}} rejects the document with a `document_parsing_exception`.
+
+The GCP Pub/Sub input uses a `map[string]string` value for the top-level `labels` field. As a result, this issue affects all GCP integration data streams collected through Pub/Sub, including `gcp.audit`, `gcp.vpcflow`, and `gcp.firewall`.
+
+**Symptoms**
+
+{{fleet}} reports the {{agent}} status as **Healthy**, and agent logs do not contain related errors. The Pub/Sub subscription consumes and acknowledges messages, so no backlog appears. If the destination data stream has the Failure Store enabled, the rejected documents are redirected there and the bulk response reports success. The only visible symptom is that no new documents are searchable.
+
+**Workaround**
+
+Force Filebeat to use the process runtime instead of the OTel runtime:
+
+```yaml
+agent:
+  internal.runtime.filebeat.default: process
+```
+
+**Resolution**
+
+Upgrade to {{agent}} 9.5.2 or later.
+
+For more information, check [Issue #52460](https://github.com/elastic/beats/issues/52460).
+:::
+
 :::{dropdown} Osquery live and scheduled query results are missing in Kibana on {{agent}} 9.5.0
 
 **Applies to: {{agent}} 9.5.0**


### PR DESCRIPTION
## What does this PR do?

Adds an Elastic Agent known-issue entry for GCP integration documents that are rejected when Filebeat 9.5.0 or 9.5.1 uses the default OTel runtime. The entry documents the affected data streams, the otherwise-silent symptoms, the process-runtime workaround, and the resolution in Elastic Agent 9.5.2.

## Why is it important?

Affected agents remain Healthy, Pub/Sub messages are acknowledged, and related errors do not appear in agent logs. Users need this entry to identify why new GCP documents are not searchable and either apply the workaround or upgrade.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)~~
- ~~[ ] I have added an integration test or an E2E test~~

## Disruptive User Impact

None. This PR changes documentation only.

## How to test this PR locally

- Run `git diff --check origin/main...HEAD`.
- Run `vale --output=line docs/release-notes/known-issues.md`. The file has existing findings, but the new entry adds none.
- Run `mage check:docsFiles`.

## Related issues

- Closes elastic/docs-content#8042
- Relates elastic/beats#52460

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
