### PR TITLE
Skip renovate updates for internal cross-module imports

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -131,7 +131,7 @@
       "enabled": false
     },
     {
-      "description": "Disabled: beats (git submodule), sarama (manual path handling), OTel packages (own release cycle)",
+      "description": "Disabled: beats (git submodule), sarama (manual path handling), OTel packages (own release cycle), internal imports.",
       "matchManagers": [
         "gomod"
       ],
@@ -140,7 +140,8 @@
         "/^github\\.com/elastic/sarama$/",
         "/^go\\.opentelemetry\\.io//",
         "/^github\\.com/open-telemetry//",
-        "/^github\\.com/elastic/opentelemetry-collector-components//"
+        "/^github\\.com/elastic/opentelemetry-collector-components//",
+        "/^github\\.com/elastic/elastic-agent//"
       ],
       "enabled": false
     },


### PR DESCRIPTION
Prevent renovate from updating internal cross-module imports of the root elastic-agent module. See https://github.com/elastic/elastic-agent/pull/16325 for example.


