### PR TITLE
Fix regex in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -136,12 +136,12 @@
         "gomod"
       ],
       "matchPackageNames": [
-        "/^github\\.com/elastic/beats//",
+        "/^github\\.com/elastic/beats/",
         "/^github\\.com/elastic/sarama$/",
         "/^go\\.opentelemetry\\.io//",
         "/^github\\.com/open-telemetry//",
         "/^github\\.com/elastic/opentelemetry-collector-components//",
-        "/^github\\.com/elastic/elastic-agent//"
+        "/^github\\.com/elastic/elastic-agent/"
       ],
       "enabled": false
     },


### PR DESCRIPTION
The two beats and elastic-agent exclusions are intended for all modules from those repositories.

Gets rid of the spurious elastic-agent bump in https://github.com/elastic/elastic-agent/pull/16325.