### PR TITLE
[9.5] Update versions to 9.5.2

### DIFF
--- a/.package-version
+++ b/.package-version
@@ -1,9 +1,9 @@
 {
-  "version": "9.5.1-SNAPSHOT",
-  "build_id": "9.5.1-33282ac6",
-  "manifest_url": "https://snapshots.elastic.co/9.5.1-33282ac6/manifest-9.5.1-SNAPSHOT.json",
-  "summary_url": "https://snapshots.elastic.co/9.5.1-33282ac6/summary-9.5.1-SNAPSHOT.html",
-  "core_version": "9.5.1",
-  "stack_version": "9.5.1-SNAPSHOT",
-  "stack_build_id": "9.5.1-33282ac6-SNAPSHOT"
+  "version": "9.5.2",
+  "build_id": "9.5.2-6859b2a4",
+  "manifest_url": "https://artifacts.elastic.co/downloads/9.5.2.json",
+  "summary_url": "",
+  "core_version": "9.5.2",
+  "stack_version": "9.5.2",
+  "stack_build_id": "9.5.2-6859b2a4"
 }


### PR DESCRIPTION
There's a problem with 9.5 snapshots, so I'm manually making this branch use the 9.5.2 release instead.