### PR TITLE
Add integration test review agent skill

### DIFF
--- a/.agents/skills/integration-test-review/SKILL.md
+++ b/.agents/skills/integration-test-review/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: integration-test-review
+description: Review elastic-agent integration test changes (testing/integration/**) for flakiness risks before merge. Use when reviewing a PR, diff, or commit that adds or modifies integration tests, or when asked whether an integration test will be stable in CI.
+---
+
+# Integration test flakiness review
+
+Integration tests in this repo run on real VMs against live ESS stacks, on hosts that
+vary in speed, distro, kernel, and concurrent load. The dominant failure mode is a test
+that passes locally and in the PR run, then flakes weeks later on a slower host, a
+different distro, or after an unrelated product change. This skill encodes the failure
+modes actually observed in a year of flake fixes (see
+[references/flake-taxonomy.md](references/flake-taxonomy.md) for the evidence: every
+rule below cites real incidents).
+
+## Method
+
+1. Read the diff. For each **added or modified test function**, also read enough
+   surrounding file context to understand the test's setup, assertions, and cleanup —
+   flakes usually live in the interaction, not the changed lines alone.
+2. Run the Tier 1 mechanical scan over the changed files.
+3. For each test, walk the Tier 2 semantic questions that match what the test does.
+4. Check Tier 3 idioms: is the test hand-rolling something a shared helper does safely?
+5. Report findings: `file:line`, category, why it will flake (concrete scenario on a
+   slow/parallel/different-OS host), and the fix. Rank by likelihood × blast radius.
+   A test that can leave an installed agent, a root-owned dir, or a mutated shared
+   Fleet object behind poisons *other* tests — rank that above a self-contained flake.
+
+Judge only realistic nondeterminism. Do not flag a wait as "racy" if the condition is
+polled with a generous budget; do flag budgets with no headroom over known product
+intervals (see Tier 2 §Timeouts).
+
+## Tier 1 — mechanical red flags (grep the diff first)
+
+Each of these has caused real CI failures; they are close to always-wrong.
+
+| Pattern | Why it breaks | Fix |
+|---|---|---|
+| `require.*(t, ...)` or `assert.*(t, ...)` inside an `Eventually`/`EventuallyWithT` closure (outer `t`, not the `*assert.CollectT` param) | First transient error fails the test instead of retrying; `FailNow` off the test goroutine can panic | Assert on the `CollectT` parameter; use `EventuallyWithT` |
+| `require`/`assert` on `t` inside any `go func` | On failure after the test ends: `panic: Fail in goroutine after test has completed` — kills the whole binary | Join via `t.Cleanup(wg.Wait)` registered right after `wg.Add`; never inline `wg.Wait()` on the happy path only |
+| `context.Background()` for waits/queries in a test | Ignores the test deadline; hangs mask the real failure | `t.Context()`; for cleanups `context.WithoutCancel(t.Context())` |
+| `os.CreateTemp` when only file *content* is needed | Held handle (no FILE_SHARE_DELETE) makes `t.TempDir()` cleanup fail on Windows → passing test marked failed | `os.WriteFile(filepath.Join(t.TempDir(), ...), data, 0o600)` |
+| Hardcoded `localhost:9200` / `127.0.0.1:9200` as a placeholder output | Output health reporting makes the agent DEGRADED at a nondeterministic moment; health asserts become a race | Per-test mock ES (`integration.StartMockES`) or `IsHealthyOrDegradedFromOutput` |
+| Hardcoded `"namespace": "default"` in Fleet request bodies | Runner assigns a per-test namespace; writes hit the wrong data stream or get rejected | Interpolate `info.Namespace` |
+| Test-spawned OTel collector config without `service.telemetry.metrics.level: none` | Every collector binds `:8888` by default → port collision between parallel tests | Disable internal telemetry metrics |
+| Fixed listening ports of any kind | Parallel tests on one host collide | `:0`, or disable the listener if unasserted |
+| Exact-count asserts on live-pipeline data: `Equal(0, len(...))`, exact doc counts, exact component counts from one status snapshot | Retries, restarts, and re-ingestion legitimately vary counts | Threshold (`LessOrEqual`/`GreaterOrEqual`) or poll until stable |
+| `==` on a monotonic counter computed as `snapshot + 1` (e.g. policy revision) | Any concurrent bump skips past the expected value forever | Use the value returned by the mutating API call, compare with `>=` (`IsMinPolicyRevision`) |
+| Duplicate keys in inline YAML configs | Parser silently keeps the last; the test believes it configured something it didn't | Deduplicate; read the final merged config critically |
+| `filelog`/`filestream` receiver reading a file the test pre-populates, without `start_at: beginning` | Defaults to `end`; if the collector starts after the write, content is silently skipped forever | `start_at: beginning` |
+| Non-fatal `assert.Eventually*` followed by unguarded indexing (`Hits.Hits[0]`) | On timeout, execution continues into an index-out-of-range panic | `require.Eventually*`, or guard the access |
+| `t.Skip` without an issue link, before `define.Require`, or unconditional for a platform-specific problem | Untracked coverage loss; skips must stay discoverable and self-expiring | `t.Skip("... issues/NNN")` placed after `define.Require`, scoped to the affected platform/version |
+| Zero-valued fields in Kibana/Fleet API request structs — check **every** `Create*`/`Update*` call (`CreateFleetProxy`, `CreateDownloadSource`, …); a missing `ID` marshals as `"id": ""` when the struct lacks `omitempty` | Server-side validation tightening turns tolerated `""` into a hard 400 | Set explicit unique values (`name + uuid`) on every such call, not just the ones near assertions |
+
+## Tier 2 — semantic questions
+
+### Every Elasticsearch query the test asserts on
+- **Who generates the matching data, and is production guaranteed?** A test that waits
+  for ambient events (auditd, network traffic, host logs) it never causes will pass or
+  fail with host activity. The test must trigger its own events — ideally *inside* the
+  poll loop, so each retry tick regenerates the signal (rule activation, restarts, and
+  slow pipelines are then covered automatically).
+- **Is the filter tight enough to match only that data?** Broad `exists:` queries plus
+  `Hits[0]` select an arbitrary ambient document. Filter on values the test controls:
+  its own tag, namespace, `process.name`, generated message. If two documents are
+  *compared* (e.g. process-runtime vs otel-runtime), both sides must provably be the
+  same underlying event, and build-metadata / event-type-specific fields
+  (`agent.version`, `auditd.data.*`) belong in the ignore list.
+- **Is a `@timestamp >= watermark` bound captured *before* the action that produces the
+  document?** Capturing `time.Now()` after `Install`/`Enroll` returns excludes events
+  emitted during the call — the query can then never match. (This exact bug shipped twice.)
+
+### Every wait / Eventually
+- **Poll the value you assert, not a weaker proxy.** File existence ≠ file has content;
+  process exists ≠ upgrade progressing; Kibana 200 on a policy PUT ≠ agent applied it
+  (gate on the applied policy revision instead).
+- **Read agent-local state locally.** Fleet's agent document only advances on checkin,
+  which the test cannot force. If the value exists in `elastic-agent status` /
+  `fixture.ExecStatus`, poll that, never Kibana. This explicitly includes upgrade state:
+  `UpgradeDetails` in Kibana's agent doc is a checkin-lagged *mirror* of agent-local
+  state, not "Fleet-side state" — raising the timeout on the Kibana copy is the wrong
+  fix when the local status has the value immediately.
+- **"Reset then assert absence" on async streams is a race.** Draining a log buffer and
+  requiring zero later occurrences fails when late writes land after the drain. Assert
+  monotonic cumulative counts or post-marker occurrences instead.
+- **Drive state machines by observed condition, not magic counts.** "Restart 3 times,
+  sleep 10s" encodes internal timing; loop while the observable condition (reported
+  version, state) still holds, under a bounded context.
+
+### Timeouts
+- **Compare every budget against the product interval that bounds it.** Fleet checkin
+  long-poll is **5 minutes**: any wait for a Fleet-reported status transition must
+  strictly exceed it (6m+). A budget equal to the interval has zero headroom and *will*
+  flake on slow hosts.
+- **Nested budgets:** an outer context must exceed the sum of the serial inner
+  `Eventually` budgets it wraps.
+- **Big blind timeouts are a smell in both directions.** For long operations (artifact
+  downloads are ~450MB), don't just raise the number — poll the reported state
+  (`UpgradeDetails.State`, `DownloadPercent`), fail fast on FAILED/ROLLBACK, detect
+  stalls; then a generous ceiling is safe.
+
+### Health assertions
+- **Does the config intentionally break something?** Unreachable output, invalid input,
+  missing credentials — then global-HEALTHY is wrong by construction. Assert only the
+  units the test controls (`IsHealthyOrDegradedFromOutput`, or per-unit checks), or give
+  the test a real mock ES.
+- **Is the asserted field guaranteed populated?** e.g. `VersionInfo.Name` is
+  intermittently empty for some monitoring components; empty vs wrong must be
+  distinguishable.
+
+### Environment & versions
+- **OS/distro/arch:** kernel-coupled behavior (auditd, systemd, package managers) must
+  pin the distros it was validated on in `define.Requirements`. Windows: file handles
+  block deletion; slower hosts widen race windows.
+- **Runtime topology:** don't assume beats run as separate processes (PID scraping,
+  process-name regexes, process-only metric fields, one shared build hash). Pin
+  `_runtime_experimental` explicitly when behavior depends on it; switch on
+  `VersionInfo.Name` (`beat-v2-client` vs `beats-receiver`).
+- **Dynamically resolved versions:** "latest snapshot" can equal the local build
+  (`rpm -U` refuses; migration assertions become invalid) and "previous minor" may not
+  exist for the platform (windows/arm64 < 9.3.0). Handle the equal-version case; gate on
+  capability, not availability.
+- **Third-party fixtures:** leave nothing security/protocol-relevant implicit
+  (`ssl_enabled => false` if the client speaks plain TCP) — vendor defaults are computed
+  from the host and change across versions.
+- **Exact product log strings** in allow-lists/assertions silently break when the
+  product rewords errors; prefer stable substrings or structured fields.
+
+### Shared state & cleanup (blast radius: other tests)
+- **Cluster-global ES objects** (index templates, pipelines, policies) must be named
+  per-test/namespace — a hardcoded shared name means the second test silently overwrites
+  the first.
+- **Never mutate well-known shared Fleet objects** (`fleet-default-output`) mid-suite on
+  a shared stack; it bumps policy revisions for every enrolled agent. If unavoidable, do
+  it before enrollment.
+- **Cleanup must survive the failure path**: registered via `t.Cleanup` (LIFO), with
+  credentials (uninstall tokens) re-fetched *after* the state changes they must survive.
+  A failed cleanup that leaves an installed/tamper-protected agent or root-owned
+  `/tmp` dir breaks unrelated later tests.
+- **Anything writing to stdout** (progress bars, spinners) must be terminated — `go test`
+  output is machine-parsed and pollution fails *other* tests.
+
+## Tier 3 — use the shared tooling
+
+Hand-rolled equivalents of these have all caused flakes:
+
+- **Agent lifecycle**: `define.NewFixtureFromLocalBuild` → `Prepare`/`Configure` →
+  `fixture.Install(...)`. Never `PrepareAgentCommand` + `cmd.Start()` + stdout scraping —
+  it yields no diagnostics on failure and leaks agent processes.
+- **Config switching**: `fixture.Configure` (reload) instead of teardown/restart.
+- **Logs**: `fixture.Exec(ctx, []string{"logs", ...})` instead of scraping process output.
+- **Health**: `fixture.IsHealthy` only when everything is genuinely expected healthy;
+  `IsHealthyOrDegradedFromOutput` when the output is intentionally absent.
+- **Policy propagation barrier**: `tools.IsMinPolicyRevision` with the revision returned
+  by `UpdatePolicy`.
+- **Placeholder ES**: `integration.StartMockES`, not a dead `localhost:9200`
+  (and never `status_reporting.enabled: false` — it masks real product bugs).
+- **Doc comparisons across runtimes**: reuse the established ignore-list machinery
+  (`assert_tools.go`) rather than fresh map-diff code.
+
+When in doubt about whether a pattern has bitten before, check
+[references/flake-taxonomy.md](references/flake-taxonomy.md) — it maps every category to
+the commits/PRs that fixed real instances, useful for citing precedent in review
+comments.

--- a/.agents/skills/integration-test-review/references/flake-taxonomy.md
+++ b/.agents/skills/integration-test-review/references/flake-taxonomy.md
@@ -1,0 +1,130 @@
+# Precedent index: integration test flakes (Aug 2025 – Aug 2026)
+
+Companion to [SKILL.md](../SKILL.md). Every rule in the skill was derived from real CI
+incidents; this file is the evidence, organized by the same category vocabulary the
+skill uses for findings. Use it to:
+
+- **cite precedent in review comments** — "this exact pattern caused #15149" carries
+  more weight than an unsourced rule;
+- **decide edge cases** the checklist doesn't cleanly match — check whether something
+  similar has bitten before;
+- **audit a rule** that looks wrong or stale — trace it back to the incidents it came
+  from before changing it.
+
+Sourced from all 60 test-only commits in the window (50 touching only
+`testing/integration/ess/`, 10 also touching shared test helpers), each reviewed with
+full diff, PR body, and linked flaky-test issues.
+
+## Observed frequency
+
+How often each failure mode was the primary cause of a flake fix or skip in the window.
+Use this to calibrate severity: the top two categories account for over half of all
+incidents and deserve the closest reading.
+
+| Category | Count | One-line description |
+|---|---|---|
+| assert-before-settled | ~12 | Asserting on state an async pipeline hasn't reached; watermark/barrier missing or on the wrong side of the producer |
+| overly-strict-assertion | ~11 | Exact match / exact count / global-HEALTHY on legitimately varying data |
+| environment-assumption | ~8 | OS/distro/arch/kernel/JVM/CI-image specifics; implicit runtime topology |
+| test-harness-misuse | ~6 | testify misuse, goroutines outliving tests, stdout pollution, unguarded indexing |
+| cross-test-interference | ~6 | Shared cluster/host state: template names, fixed ports, root-owned dirs, leftover installs |
+| timeout-too-short | ~4 | Especially budgets equal to a known product interval (Fleet 5m checkin long-poll) |
+| version-drift | ~3 | Same-version snapshot upgrades, beats vs agent version skew, previous-minor gaps |
+| external-dependency | ~3 | Kibana API changes, DRA artifact availability, real large downloads |
+| test-config-bug | ~2 | Test's own YAML silently wrong: duplicate keys, missing `start_at` |
+
+A further ~4 incidents in the window were **not** test bugs at all: the test correctly
+caught a real product defect. Those are covered under
+[Patterns across incidents](#patterns-across-incidents) — the reviewer-relevant lesson
+there is about how such failures were handled, not about the tests being wrong.
+
+## assert-before-settled
+
+- **#11038 (3e7d103977)** TestClassicAndReceiverAgentMonitoring: `time.Now()` watermark for the ES `@timestamp >= X` filter captured AFTER `InstallWithoutEnroll` — the log line it queries for is emitted *during* install, so the query could never match. Fixed by capturing the timestamp before install. **The same bug shipped again in #15172 (0d91cf0e7c)** in the OTel phase of the same test — cite both when a watermark sits after its producing action.
+- **#16328 (c69e464065)** TestSystemMetricsWithLogstashOutput: polled for output *file existence* but read/parsed contents *outside* the retry loop; Logstash creates the file before writing the first record. Fixed by parsing inside `EventuallyWithT` and requiring non-nil data — poll the value you assert, not a weaker proxy.
+- **#15201 (4aa75de209)** TestOtelAPMIngestion: filelog receiver without `start_at: beginning` defaults to `end`; the test wrote the file before the collector finished starting, so content was silently skipped forever. Also had `context.Background()` in wait loops, ignoring the test deadline.
+- **#10004 (5372f245a0)** monitoring-probe tests: treated Kibana 200 on a policy PUT as "agent applied the policy", then immediately dialed the agent's monitoring port. Fixed by gating on `IsPolicyRevision(agentID, resp.Revision)`. Cautionary detail: the retry added alongside wrapped only `http.NewRequest` (which never fails), not `client.Do` — a retry must wrap the fallible call.
+- **#11911 (b14334e263)**, after stop-gap skip **#11910**, TestFleetDownloadProxyURL: polled Fleet/Kibana's agent document for upgrade state, which only advances on an uncontrollable agent checkin, while local `elastic-agent status` had the value immediately. Fixed by switching to `fixture.ExecStatus`. Cite when a test reads agent-local state through Kibana.
+- **#16329 (91498ad393)** TestPolicyReassignWithTamperProtectedEndpoint: uninstall token fetched *before* the policy reassignment it must survive; readiness keyed on `policy.id`, which flips before the tamper-protection material is durably applied — stale token on slow hosts left a tamper-protected endpoint installed on the CI host.
+- **#11324 (2f2631b1e9)** TestStandaloneUpgradeRollbackOnRestarts: hardcoded "restart 3 times, sleep 10s" to drive the watcher's rollback state machine; the correct count silently encoded watcher-internal PID accounting. Fixed by looping on an observable condition (agent still reports the upgraded version).
+- **#12159 (023091862c)** TestLogReloading: `zapLogs.TakeAll()` to "reset" an async log-capture buffer, then `require.Zero` on a message the earlier phase legitimately produced — the drain races the producer. Fixed with cumulative monotonic counts.
+- **#14048 (f396421abb)** (skip) TestOtelElasticsearchStateStore_Agentless: one-shot assertion on the *first* `since` value after restart, gated on ES near-real-time visibility of the persisted cursor. First-sample-after-restart is unrepeatable.
+- **#16052 (52aa8844f0)** auditd: the event-generating action ran once, *before* the poll loop that waits for the events, racing audit-rule activation. Fixed by generating a fresh event on every retry tick inside `EventuallyWithT`.
+- **#15206 (99dc67ee2b)** TestEventLogFile (secondary cause): expected-file list built from a directory scan taken before the action under test — a snapshot-then-collect window that turned a config bug into a Windows-only flake.
+- **#14121 (e3c1ffc27b)** (skip) TestSwitchToUnprivilegedDeduplication: fired five concurrent Fleet privilege-switch actions to exercise action deduplication, so the tested precondition (duplicates landing in one checkin batch) existed only when the race happened to land right — most runs never exercised the condition the test claimed to check, and when dedup genuinely failed, a duplicate action executed after the privilege drop and wedged the agent. Create preconditions deterministically (e.g. inject duplicate actions directly), never via a race. (The failures also exposed a real dedup gap, tracked in #14079.)
+
+## overly-strict-assertion
+
+- **#15514 (3dfe762f37)** TestMonitoringNoDuplicates: `require.Equal(0, len(buckets))` directly contradicting its own adjacent comment ("possible to have a small number") — runtime transitions legitimately re-ingest a few documents. Fixed with `LessOrEqual` against a budget. Bonus: `%d` applied to a float64 garbled the failure diagnostic.
+- **#15199 (15b6967d62)** TestNetworkTraffic compare: compared `Hits[0]` of a broad `exists:` query over *ambient* TLS traffic between two phases — different destinations, legitimately different geo/TLS fields. Fixed by generating controlled traffic (dial ES on every poll tick) and filtering on it; also replaced a silent `t.Skip` on missing upstream data with `require.NotNil`.
+- **The auditd sequence #15867 → #15914 → #16052 (2b6f73e61e, ec1d03a308, 52aa8844f0)**: (a) no audit rules configured, so the test asserted on data it never caused to be produced — it passed only via install-time noise; (b) selection by broad exists-filter picked heterogeneous ambient events whose field sets vary by kernel/PAM config; (c) even scoped by tag, the two runtime modes picked execve events from different processes. Stable end state: the test generates its own events, filters on its own rule tag + `process.name`, ignores event-type-specific `auditd.data.*`. Cite the whole sequence when a comparison selects "the first matching ambient document".
+- **#15153 (1f4f63561c)** auditd monitoring: same lesson — pin both compared documents to the same `event.action`; ignore `auditd.data`.
+- **#11257 (1fa09721ca) + #11539 (b8a142f544)** (7 tests): asserted HEALTHY while the config intentionally pointed the ES output at a dead `localhost:9200` — output health reporting works, so DEGRADED arrives at a nondeterministic moment. The interim fix (`status_reporting.enabled: false`) was later *reverted* by **#12710 (203484cde9)** because it masked real product bugs (#12586); the durable fixes are a per-test mock ES (`integration.StartMockES`) or **#11997 (ec86428439)**'s `IsHealthyOrDegradedFromOutput`, which tolerates DEGRADED only when every degraded unit is an OUTPUT unit. Cite this chain when a test suppresses status reporting instead of scoping its assertion.
+- **#10153 (71ece0de92)**, after skip **#9891 (ba9c156513)**, TestBeatsReceiverLogs: asserted agent + all units HEALTHY and an exact component count while deliberately configuring an unreachable output; also managed the agent process by hand and scraped stdout, leaking an agent on failure. Fixed by asserting only what the test controls (component count, `VersionInfo.Name`, INPUT units) and using the fixture lifecycle.
+- **#14911 (7047441f0a)** TestFQDN: expected policy revision computed as `snapshot + 1` with exact `==` on a monotonic counter; any concurrent bump skips past it forever. Fixed by using the revision returned by the mutating call plus `>=` (`IsMinPolicyRevision`).
+- **#10851 (89c9b279d7)**: doc comparisons asserted `agent.version` equality between the beats process (beats repo version) and the beats receiver (vendored dependency version) — build-metadata drift, not behavior. Fixed via the ignore-list.
+- **#11231 (259dd3e966)** (assertion skip): runtime name derived from `comp.VersionInfo.Name`, which is intermittently empty for `http/metrics-monitoring` (product bug #11162) — an empty value was indistinguishable from a wrong one.
+
+## environment-assumption
+
+- **#14685 (d1e89db2e8)**, and again in **#14956 (294efa35ab)**: `os.CreateTemp` keeps a handle without FILE_SHARE_DELETE; Go 1.25's `os.RemoveAll` in `t.TempDir()` cleanup then fails on Windows, marking a passing test failed. Fixed with `os.WriteFile` where only content is needed. Recurred across two PRs — cite when reviewing any test temp-file handling.
+- **#14363 (86babefe16)**: Logstash pipeline fixture left SSL implicit; Logstash 9.2.2 validates host-JVM-derived `ssl_supported_protocols` (containing nil on some CI hosts) even when SSL is unused. Fixed with explicit `ssl_enabled => false`, matching the client's plain-TCP behavior.
+- **#15867 (2b6f73e61e)**: auditd in passive multicast mode observes only ambient kernel activity; a quiescent host produced zero events for the full 10-minute window.
+- **#10873 (05c9876946)** (skip): auditd broke on a new Debian CI image; `OS: {Type: Linux}` was narrowed to the validated distros (ubuntu, rhel). Kernel-coupled tests should pin distros.
+- **#15377 (a5ae22e11e)** (skip): a previous-minor agent used as upgrade *source* can't resolve windows/arm64 packages before 9.3.0. Fixed with a self-expiring capability gate, `SupportsUpgradeSourceOnPlatform`.
+- **#10537 (3ccf28da2e)**: five latent "beats are separate OS processes" assumptions (PID scraping from status messages, a process-name regex over-matching the otel collector, process-only metric fields, one shared build hash for all components) — all broke when monitoring moved in-process. Pin `_runtime_experimental` explicitly; switch on `VersionInfo.Name`.
+- **#13496 (8a4ace66ce)** (also version-drift): rpm `--prefix` installs — scriptlets don't restart the service; `rpm -U` refuses same-version upgrades; data-dir migration assertions are invalid when versions are equal.
+- **#10735 (d3306c51d2)** TestAgentMetricsInput: set the experimental runtime on only the *input* and left agent self-monitoring at its implicit default, so the `otel` case silently ran an untested mixed-runtime configuration (which happened to be genuinely broken — ingest-dev#6295). Pin the runtime explicitly on every subsystem the test spins up; an implicit default is an untested combination waiting to change under you.
+
+## test-harness-misuse
+
+- **#11499 (f32807c8af)**: `require.NoErrorf(t, ...)` inside `EventuallyWithT(func(ct *assert.CollectT))` — the first transient error fails the test instead of retrying, and `FailNow` fires off the test goroutine. The same bug was fixed at 9 more sites in **#14956 (294efa35ab)** and 2 in **#11971 (577400b0ca)** — three PRs for one grep-able pattern.
+- **#13893 (0df409cba9)**: a goroutine calling `require.NoError(t, ...)` was joined by an inline `wg.Wait()` placed after fatal-capable assertions; on the failure path the goroutine outlived the test → `panic: Fail in goroutine after test completed`, killing the whole binary. Fixed with `t.Cleanup(wg.Wait)` registered immediately after `wg.Add`.
+- **#15695 (c71db977a7)**: an indeterminate progress bar handed to `EnsureUserAndGroup` was never finalized and kept writing to stdout, corrupting `go test` output — *unrelated passing tests* were parsed as failed.
+- **#11229 (4f8fbe9759)**: non-fatal `assert.EventuallyWithT` followed by unguarded `Hits.Hits[0]` — an index-out-of-range panic on timeout instead of a clean failure.
+- **#11507 (cfa14fac0c)** (secondary): error path `fmt.Errorf("incorrect response code: %v", err)` with a nil `err` discarded the actual status code and body; the response body was never closed.
+- **#10717 (020adf82d6)**: launching the agent via `PrepareAgentCommand` + `cmd.Start()` instead of `fixture.Install` — no diagnostics on failure, and a stray agent process survived the test.
+
+## cross-test-interference
+
+- **#11507 (cfa14fac0c)**: two tests PUT an index template under the same hardcoded name (`no-dynamic-template`) on the shared ES cluster; whichever ran second overwrote the first, silently removing its strict mapping. Name cluster-global resources after the test/namespace.
+- **#12804 (7a83205bdc)**: every plain-mode otel collector binds `:8888` for internal telemetry by default — collisions between parallel tests. Fixed with `service.telemetry.metrics.level: none` in every test collector config.
+- **#11971 (577400b0ca)**: a sudo test created a root-owned `/tmp/elastic-agent` fallback dir; later unprivileged tests got permission denied. Fixed with `t.Cleanup(os.RemoveAll)` in the shared `runOrSkip`.
+- **#14705 (48b56d8e08)**: suite setup mutated the shared `fleet-default-output` (latency preset), bumping policy revisions for every enrolled agent — which broke TestFQDN's revision math (**#14911**). Cite this pair when a PR mutates well-known shared Fleet objects mid-run.
+- **#14956 (294efa35ab)**: Fleet request bodies hardcoding `"namespace": "default"` instead of `info.Namespace` — writes landed in the wrong data stream under the runner's assigned namespace.
+- **#16329 (91498ad393)**: a failed cleanup (stale uninstall token) left a tamper-protected endpoint installed on the shared CI host, poisoning subsequent tests.
+
+## timeout-too-short
+
+- **#15747 (fbff8ad801)** and **#14119 (b552fdf549)**: wait budgets of exactly 5 minutes against Fleet Server's 5-minute checkin long-poll — zero headroom, flaked on any added latency. Cite both when a Fleet-status wait is ≤ 5m.
+- **#15135 (124e3d413a)**: a blind 5-minute process-existence wait (`WaitForWatcher`) guarded a ~450MB artifact download through a proxy chain; raising the timeout alone would make genuine failures burn the whole budget. Fixed with a state-aware wait — poll `UpgradeDetails.State`, fail fast on FAILED/ROLLBACK, detect stalls via `DownloadPercent` — after which a 15m ceiling is safe. The flake was seeded when the test was added in **#11577 (8c0f918ffb)**.
+- **#11229 (4f8fbe9759)**: 2 minutes for an end-to-end install → emit → ship → searchable-in-ES path.
+- **#15977 (e70a74ed43)** (caught in review, pre-merge): an outer 10m context wrapping four serial 5m `Eventually` blocks — the outer deadline must exceed the sum of the serial inner budgets.
+
+## version-drift
+
+- **#13496 (8a4ace66ce)**: "latest snapshot on this branch" can equal the locally built version — `rpm -U` refuses, and migration assertions become structurally invalid. Handle the equal-version case in any dynamically resolved upgrade pair.
+- **#10851 (89c9b279d7)**: beats-process vs beats-receiver `agent.version` skew during dependency-bump windows.
+- **#13275 (8d1bcc62b2)**: a log allow-list keyed on an exact product error string silently stopped matching when the product reworded its error wrapping.
+
+## external-dependency
+
+- **#14505 (e5b6a39af4)**: `ProxiesRequest.ID` without `omitempty` marshaled `"id": ""`; a Kibana-side validation tightening turned tolerated-empty into a hard 400. Don't rely on the server tolerating zero values in any `Create*`/`Update*` call.
+- **#11577 (8c0f918ffb)**: a new test pulled a real ~450MB artifact from snapshots.elastic.co through two proxies, with `t.Cleanup(proxy.Close)` able to fire mid-download — seeded the #15135 timeout flake.
+- **#10200 (cfd9085c1a)**: an unconditional `t.Skip` for a windows/arm64-only DRA gap disabled upgrade coverage on *all* platforms. Scope skips to the affected platform so they self-expire.
+
+## test-config-bug
+
+- **#15206 (99dc67ee2b)**: two `agent.monitoring:` keys in one inline YAML document — the parser keeps the last, silently discarding `metrics: false`; surfaced as a Windows-only timing flake.
+- **#14705 (48b56d8e08)**: left `preset: latency` immediately followed by `preset: balanced` in the same output block, silently defeating the change.
+- **#15201 (4aa75de209)**: missing `start_at: beginning` on a filelog receiver reading a pre-populated file (defaults to `end`).
+
+## Patterns across incidents
+
+Worth knowing when judging a borderline finding or reviewing a proposed flake fix:
+
+- **First fixes routinely treat the symptom, not the nondeterminism.** auditd took four commits to converge; the placeholder-output problem took three approaches; TestFleetDownloadProxyURL went seed (#11577) → skip (#11910) → fix (#11911) → timeout rework (#15135); the watermark bug shipped twice in the same test. When reviewing a flake fix, ask whether the underlying nondeterminism is gone or merely made less likely — cite these chains if it isn't.
+- **Not every CI failure is a test bug — and loosening a correct test is the worst outcome.** In ~4 incidents the test rightly caught a real product defect: #15107 re-enabled an assertion that had been correct all along once the receiver-naming bug was fixed; #14048 and #14121 were suspected product bugs handled with tracked skips; and the `status_reporting.enabled: false` escape hatch had to be reverted (#12710) precisely because it hid real status regressions (#12586). When a "flaky" test tracks to product misbehavior, the right response is a product fix or an issue-linked skip — never weakening the assertion until it can no longer catch the bug.
+- **Skips have a convention**: `t.Skip("… link to issue …")` placed *after* `define.Require` (explicit review feedback on #14048), scoped to the affected platform/version where possible so coverage elsewhere survives and the skip self-expires.
+- **Refactors of shared test infrastructure can introduce flakes elsewhere**: #14705's mutation of `fleet-default-output` broke an unrelated test's revision math (#14911). A change that touches shared stack state or suite-level setup needs an interference review even if no test logic changed.
+- **The process-vs-otel document comparison idiom** (same data collected under both runtimes, compared via `AssertMapsEqual` + ignore-lists in `assert_tools.go`) is the single flakiest pattern in the suite. Its stable form, converged on across #15199/#15153/#16052/#10851: the test generates the events itself, both sides are filtered to provably the same underlying event, and build-metadata plus event-type-specific fields are ignored. Hold any new comparison of this shape to that standard.

--- a/.claude/skills/integration-test-review
+++ b/.claude/skills/integration-test-review
@@ -1,0 +1,1 @@
+../../.agents/skills/integration-test-review


### PR DESCRIPTION
## What does this PR do

Adds an `integration-test-review` agent skill that encodes a year's worth of observed flake patterns from real CI incidents. The skill provides a structured review methodology (three tiers: mechanical red flags, semantic questions, shared tooling checks) backed by a precedent index (`flake-taxonomy.md`) that maps every rule to the actual commits and PRs that fixed real instances.

The skill is placed in `.agents/skills/integration-test-review/` (usable by any agent in the repo) and symlinked into `.claude/skills/` for local Claude Code sessions.

The intent is to eventually run this as a reviewer on each PR that modifies an integration test. Eventually, we can also have it check for typical sources of slow execution.

## Why is it important

Integration tests in this repo frequently flake in CI weeks after merging - they pass locally and in the initial PR run, then fail on slower hosts, different distros, or after unrelated product changes. There was no systematic way for reviewers or AI agents to catch these problems before merge.

## How to test this PR locally

Invoke the skill on a PR or branch that modifies `testing/integration/**`:
```
/integration-test-review
```
Verify that the skill loads and produces structured findings against the diff.
