### PR TITLE
fix: remove data race in TestNotifyFleetAuditUnenroll

### DIFF
--- a/internal/pkg/agent/install/uninstall_test.go
+++ b/internal/pkg/agent/install/uninstall_test.go
@@ -7,7 +7,6 @@ package install
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/schollz/progressbar/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -29,6 +27,11 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/remote"
 	pkgfleetapi "github.com/elastic/elastic-agent/pkg/fleetapi"
 )
+
+// noopProgressDescriber is a no-op ProgressDescriber for use in tests.
+type noopProgressDescriber struct{}
+
+func (n *noopProgressDescriber) Describe(string) {}
 
 func Test_checkForUnprivilegedVault(t *testing.T) {
 	type postVaultInit func(t *testing.T, vaultPath string)
@@ -176,7 +179,7 @@ func TestNotifyFleetAuditUnenroll(t *testing.T) {
 	}}
 
 	log, _ := logp.NewInMemoryLocal("test", zap.NewDevelopmentEncoderConfig())
-	pt := progressbar.NewOptions(-1, progressbar.OptionSetWriter(io.Discard))
+	pt := &noopProgressDescriber{}
 	var agentID agentInfo = "testID"
 
 	for _, tc := range tests {
@@ -231,13 +234,13 @@ type MockNotifyFleetAuditUninstall struct {
 	Called bool
 }
 
-func (m *MockNotifyFleetAuditUninstall) Call(ctx context.Context, log *logp.Logger, pt *progressbar.ProgressBar, cfg *configuration.Configuration, ai pkgfleetapi.AgentInfo) {
+func (m *MockNotifyFleetAuditUninstall) Call(ctx context.Context, log *logp.Logger, pt ProgressDescriber, cfg *configuration.Configuration, ai pkgfleetapi.AgentInfo) {
 	m.Called = true
 }
 
 func TestSkipFleetAuditUnenroll(t *testing.T) {
 	log := &logp.Logger{}
-	pt := &progressbar.ProgressBar{}
+	pt := &noopProgressDescriber{}
 	cfg := &configuration.Configuration{}
 	var agentID agentInfo = "testID"
 


### PR DESCRIPTION
## What does this PR do?

Fixes a data race detected by the Go race detector in `TestNotifyFleetAuditUnenroll` (`internal/pkg/agent/install/uninstall_test.go`), which caused sporadic failures in the `Unit tests - fips140=only Windows 2022` CI job.

## Root cause

The test created a single `*progressbar.ProgressBar` and shared it across all subtests:

```go
pt := progressbar.NewOptions(-1, progressbar.OptionSetWriter(io.Discard))
// ...reused across t.Run subtests
```

The `schollz/progressbar` library uses internal goroutines for rendering. Concurrent calls to `Describe()` (which calls `render()`, writing internal state at `progressbar.go:940`) raced with `IsStarted()` (reading the same state at `progressbar.go:930`):

```
WARNING: DATA RACE
Write at 0x00c0000dc2c8 by goroutine 104:
  github.com/schollz/progressbar/v3.(*ProgressBar).render()
    progressbar.go:940
  ...notifyFleetAuditUninstall() -- uninstall.go:200

Previous read at 0x00c0000dc2c8 by goroutine 103:
  github.com/schollz/progressbar/v3.(*ProgressBar).IsStarted()
    progressbar.go:930
```

## Fix

Replace the real `*progressbar.ProgressBar` with a simple no-op `ProgressDescriber` in the test. The tests exercise retry logic and Fleet notification behaviour — not progress rendering — so there's no value in using the real progressbar implementation.

Also corrects `MockNotifyFleetAuditUninstall.Call` to accept `ProgressDescriber` (the interface) instead of the concrete `*progressbar.ProgressBar` type, and removes the now-unused `progressbar` and `io` imports.

## How to test it

```
go test -race -run "TestNotifyFleetAuditUnenroll|TestSkipFleetAuditUnenroll" ./internal/pkg/agent/install/...
```