### PR TITLE
fix: fix diagnostics for otel components containing `/`

### DIFF
--- a/changelog/fragments/1788339094-fix-diagnostics-for-otel-components.yaml
+++ b/changelog/fragments/1788339094-fix-diagnostics-for-otel-components.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: fix diagnostics for otel components containing `/`
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: Components containing `/` in id or stream-id has been skipped from diagnostics
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/otel/manager/diagnostics.go
+++ b/internal/pkg/otel/manager/diagnostics.go
@@ -130,7 +130,7 @@ func (m *OTelManager) PerformComponentDiagnostics(
 	for _, extDiag := range extDiagnostics.ComponentDiagnostics {
 		componentIDs := diagnosticComponentIDsFromName(extDiag.Name, currentComponents)
 		if len(componentIDs) == 0 {
-			m.managerLogger.Debugf("skipping EDOT diagnostic %q: it cannot be associated with an active component", extDiag.Name)
+			m.managerLogger.Debugf("skipping EDOT diagnostic for %q: it cannot be associated with an active component", extDiag.Name)
 			continue
 		}
 		if len(componentIDs) > 1 {

--- a/internal/pkg/otel/manager/diagnostics.go
+++ b/internal/pkg/otel/manager/diagnostics.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/elastic/elastic-agent/internal/pkg/otel"
@@ -122,26 +123,49 @@ func (m *OTelManager) PerformComponentDiagnostics(
 		return diagnostics, nil
 	}
 
-	// See translate.ComponentIDFromReceiverName for the receiver-name format and
-	// the "/"-in-ID ambiguity this warning flags. A proper fix requires escaping
-	// "/" in IDs at the source in the beat receiver.
 	diagIdxByCompID := make(map[string]int)
 	for idx, diag := range diagnostics {
-		if strings.Contains(diag.Component.ID, "/") {
-			m.managerLogger.Warnf("component ID %q contains '/', its EDOT diagnostics will be missing from the archive", diag.Component.ID)
-		}
 		diagIdxByCompID[diag.Component.ID] = idx
 	}
 	for _, extDiag := range extDiagnostics.ComponentDiagnostics {
-		compID, ok := translate.ComponentIDFromReceiverName(extDiag.Name)
-		if !ok {
-			m.managerLogger.Debugf("skipping EDOT diagnostic %q: diagnostic name does not contain expected prefix %q", extDiag.Name, translate.OtelNamePrefix)
+		componentIDs := diagnosticComponentIDsFromName(extDiag.Name, currentComponents)
+		if len(componentIDs) == 0 {
+			m.managerLogger.Debugf("skipping EDOT diagnostic %q: it cannot be associated with an active component", extDiag.Name)
 			continue
 		}
-		if idx, ok := diagIdxByCompID[compID]; ok {
-			diagnostics[idx].Results = append(diagnostics[idx].Results, extDiag)
+		if len(componentIDs) > 1 {
+			m.managerLogger.Warnf("EDOT diagnostic %q is associated with multiple components %q; preserving it for each component", extDiag.Name, componentIDs)
+		}
+		for _, compID := range componentIDs {
+			if idx, ok := diagIdxByCompID[compID]; ok {
+				diagnostics[idx].Results = append(diagnostics[idx].Results, extDiag)
+			}
 		}
 	}
 
 	return diagnostics, nil
+}
+
+// diagnosticComponentIDsFromName matches the receiver type and treats component
+// IDs as opaque candidates, without attempting to split out a stream ID. More
+// than one same-type match is retained so diagnostics remain lossless when
+// component and stream IDs make the flattened receiver name ambiguous.
+func diagnosticComponentIDsFromName(name string, components []component.Component) []string {
+	receiverType, suffix, found := strings.Cut(name, "/"+translate.OtelNamePrefix)
+	if !found {
+		return nil
+	}
+
+	componentIDs := make([]string, 0, 1)
+	for _, comp := range components {
+		beatName := comp.BeatName()
+		if beatName == "" || receiverType != beatName+"receiver" {
+			continue
+		}
+		if suffix == comp.ID || strings.HasPrefix(suffix, comp.ID+"/") {
+			componentIDs = append(componentIDs, comp.ID)
+		}
+	}
+	slices.Sort(componentIDs)
+	return componentIDs
 }

--- a/internal/pkg/otel/manager/diagnostics_test.go
+++ b/internal/pkg/otel/manager/diagnostics_test.go
@@ -195,6 +195,114 @@ func TestBeatMetrics(t *testing.T) {
 	})
 }
 
+func TestBeatMetricsComponentIDContainingSlash(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skip test on Windows.",
+			"It's technically cumbersome to set up an npipe http server.",
+			"And it doesn't have anything to do with the code paths being tested.",
+		)
+	}
+	setTemporaryAgentPath(t)
+	logger, _ := loggertest.New("test")
+
+	systemComp := testComponent("system/metrics-default")
+	systemComp.InputSpec.Spec.Command.Args = []string{"metricbeat"}
+	httpComp := testComponent("http/metrics-monitoring")
+	httpComp.InputSpec.Spec.Command.Args = []string{"metricbeat"}
+
+	receiverType := otelcomponent.MustNewType("metricbeatreceiver")
+	systemReceiver := translate.GetReceiverID(receiverType, systemComp.ID+"/system/metrics-system.cpu-policy-id").String()
+	httpReceiver := translate.GetReceiverID(receiverType, httpComp.ID+"/metrics-monitoring-agent").String()
+	metricData := []byte(`{"test":"test"}`)
+
+	expectedResponse := elasticdiagnostics.Response{
+		ComponentDiagnostics: []*proto.ActionDiagnosticUnitResult{
+			{Name: systemReceiver, Filename: "beat_metrics.json", ContentType: "application/json", Content: metricData},
+			{Name: httpReceiver, Filename: "beat_metrics.json", ContentType: "application/json", Content: metricData},
+		},
+	}
+
+	m := &OTelManager{
+		managerLogger: logger,
+		components:    []component.Component{systemComp, httpComp},
+	}
+
+	called := false
+	server := handlers.NewMockServer(t, paths.DiagnosticsExtensionSocket(), &called, &expectedResponse)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close())
+	})
+
+	diags, err := m.PerformComponentDiagnostics(t.Context(), nil)
+	require.NoError(t, err)
+	require.True(t, called)
+	require.Len(t, diags, 2)
+
+	resultsByComp := make(map[string][]string)
+	for _, d := range diags {
+		for _, result := range d.Results {
+			resultsByComp[d.Component.ID] = append(resultsByComp[d.Component.ID], result.Name)
+		}
+	}
+
+	assert.Equal(t, []string{systemReceiver}, resultsByComp[systemComp.ID])
+	assert.Equal(t, []string{httpReceiver}, resultsByComp[httpComp.ID])
+}
+
+func TestBeatMetricsAmbiguousComponentIDsPreserveResults(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skip test on Windows.",
+			"It's technically cumbersome to set up an npipe http server.",
+			"And it doesn't have anything to do with the code paths being tested.",
+		)
+	}
+	setTemporaryAgentPath(t)
+	logger, obs := loggertest.New("test")
+
+	parentComp := testComponent("foo")
+	parentComp.InputSpec.Spec.Command.Args = []string{"metricbeat"}
+	nestedComp := testComponent("foo/bar")
+	nestedComp.InputSpec.Spec.Command.Args = []string{"metricbeat"}
+
+	receiverName := translate.GetReceiverID(otelcomponent.MustNewType("metricbeatreceiver"), "foo/bar/baz").String()
+	expectedResponse := elasticdiagnostics.Response{
+		ComponentDiagnostics: []*proto.ActionDiagnosticUnitResult{
+			{Name: receiverName, Filename: "beat_metrics.json", ContentType: "application/json", Content: []byte(`{}`)},
+		},
+	}
+	m := &OTelManager{
+		managerLogger: logger,
+		components:    []component.Component{parentComp, nestedComp},
+	}
+
+	called := false
+	server := handlers.NewMockServer(t, paths.DiagnosticsExtensionSocket(), &called, &expectedResponse)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close())
+	})
+
+	diags, err := m.PerformComponentDiagnostics(t.Context(), nil)
+	require.NoError(t, err)
+	require.True(t, called)
+	require.Len(t, diags, 2)
+	for _, diag := range diags {
+		require.Len(t, diag.Results, 1)
+		assert.Equal(t, receiverName, diag.Results[0].Name)
+	}
+	assert.NotEmpty(t, obs.FilterLevelExact(zapcore.WarnLevel).FilterMessageSnippet("associated with multiple components").All())
+}
+
+func TestDiagnosticComponentIDsFromNameMatchesReceiverType(t *testing.T) {
+	shortFilebeatComp := testComponent("foo")
+	nestedMetricbeatComp := testComponent("foo/bar")
+	nestedMetricbeatComp.InputSpec.Spec.Command.Args = []string{"metricbeat"}
+
+	receiverName := translate.GetReceiverID(otelcomponent.MustNewType("metricbeatreceiver"), "foo/bar/baz").String()
+	componentIDs := diagnosticComponentIDsFromName(receiverName, []component.Component{shortFilebeatComp, nestedMetricbeatComp})
+
+	assert.Equal(t, []string{nestedMetricbeatComp.ID}, componentIDs)
+}
+
 // TestBeatMetricsPrefixOverlap guards that each EDOT result is assigned to exactly one component.
 // When one component ID is a prefix of another (e.g. "filebeat" and "filebeat-2"), the prefix
 // component must not receive the result of the longer one.

--- a/testing/integration/ess/diagnostics_test.go
+++ b/testing/integration/ess/diagnostics_test.go
@@ -605,6 +605,15 @@ inputs:
     prospector.scanner.fingerprint.enabled: false
     file_identity.native: ~
     use_output: default
+  - id: system-metrics
+    type: system/metrics
+    use_output: default
+    streams:
+      - id: system/metrics-system.cpu
+        metricsets:
+          - cpu
+        period: 1s
+        data_stream.dataset: system.cpu
 agent.grpc:
     port: 6790
 outputs:
@@ -614,6 +623,7 @@ outputs:
     api_key: placeholder
 agent.monitoring.enabled: false
 agent.internal.runtime.filebeat.filestream: otel
+agent.internal.runtime.metricbeat.system/metrics: otel
 `
 
 	ctx, cancel := testcontext.WithDeadline(t, t.Context(), time.Now().Add(10*time.Minute))
@@ -666,6 +676,8 @@ agent.internal.runtime.filebeat.filestream: otel
 	// Beat receivers register diagnostic hooks per input stream via the OTel receiver
 	// instance ID ("<receiverType>/_agent-component/<comp.ID>/<streamID>"). Results are grouped
 	// at the component level and land under the component directory, same as for process-runtime beats.
+	// The system/metrics component and stream IDs contain "/", exercising association using the
+	// complete component ID before the archive path is normalized to "system-metrics-default".
 	expectedFiles := []string{
 		"edot/otel-merged-actual.yaml",
 		"edot/environment.yaml",
@@ -678,6 +690,8 @@ agent.internal.runtime.filebeat.filestream: otel
 		"components/filestream-default/registry.tar.gz",
 		"components/filestream-default/beat_metrics.json",
 		"components/filestream-default/input_metrics.json",
+		"components/system-metrics-default/beat_metrics.json",
+		"components/system-metrics-default/input_metrics.json",
 		"logs/elastic-agent-*/elastic-agent-*.ndjson",
 		"logs/elastic-agent-*/elastic-otel-collector-*.ndjson",
 	}


### PR DESCRIPTION
## What does this PR do?

Fixes the association of EDOT diagnostic results with Elastic Agent components whose IDs contain `/`, such as `system/metrics-default` and `http/metrics-monitoring`.

Instead of splitting the OTel receiver name at the first `/`, the diagnostics manager now:

- Matches the receiver type, such as `metricbeatreceiver` or `filebeatreceiver`.
- Compares the remaining receiver name against the complete IDs of active Agent components.
- Requires an exact match or a `/` boundary after the component ID.
- Preserves a diagnostic for every matching component when the flattened component and stream IDs are genuinely ambiguous.
- Logs a warning when more than one component matches.

For example, the receiver suffix `foo/bar/baz` is ambiguous when both of these combinations exist:

```text
component=foo      stream=bar/baz
component=foo/bar  stream=baz
```

In this case, the diagnostic is included for both components rather than dropped or assigned based on an unreliable guess.

### Trade-off: possible duplicate diagnostics

When a flattened receiver name genuinely matches multiple components, the same diagnostic result is deliberately associated with every matching component. Consequently, the same diagnostic file may appear under two or more component directories in the archive and increase the archive size.

This favors preserving all diagnostic data over either dropping the result or guessing a single owner. A warning containing the receiver name and matching component IDs is logged whenever this happens. Receiver-type matching limits duplication to genuinely ambiguous components using the same Beat receiver type.

The archive layout is unchanged.

The PR adds:

- Unit coverage for `system/metrics-default` and `http/metrics-monitoring`.
- Unit coverage for genuinely ambiguous component IDs.
- Coverage ensuring receiver type disambiguates otherwise matching component IDs.
- An integration-test case using a real `system/metrics` Beat receiver in OTel mode.

## Why is it important?

Component IDs containing `/` are used by standard integrations such as `system/metrics` and `http/metrics`.

Previously, the component ID was extracted by taking only the text before the first `/`. For example:

```text
metricbeatreceiver/_agent-component/system/metrics-default/system/metrics-system.cpu
```

was interpreted as belonging to component `system`, rather than `system/metrics-default`. Because no matching `system` component existed, its EDOT diagnostics were omitted from the archive.

This change allows files such as `beat_metrics.json` and `input_metrics.json` to be included under the correct component directory.

## Checklist

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~ — Not applicable
- [x] ~~I have made corresponding change to the default configuration files~~ — Not applicable
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## Disruptive User Impact

No disruptive impact is expected.

This only affects diagnostic collection. Existing component execution, OTel configuration, and archive directory naming remain unchanged.

In the rare case where a flattened OTel receiver name is genuinely ambiguous, the same diagnostic may appear under more than one component directory and increase the archive size. This is an intentional tradeoff to prevent diagnostic data loss. A warning is logged when it happens.

## How to test this PR locally

Run the focused unit tests:

```shell
go test ./internal/pkg/otel/manager \
  -run '^(TestBeatMetrics|TestBeatMetricsComponentIDContainingSlash|TestBeatMetricsAmbiguousComponentIDsPreserveResults|TestDiagnosticComponentIDsFromNameMatchesReceiverType|TestBeatMetricsPrefixOverlap)$' \
  -count=1
```

Integration test:

- `TestEDOTDiagnostics`

## Related issues

- Fixes regression introduced in https://github.com/elastic/elastic-agent/pull/15108

## Questions to ask yourself

- Production debugging: ambiguous associations produce a warning containing the receiver name and all matching component IDs.
- Adoption: this is an automatic bug fix and does not introduce a user-facing option.
- Metrics: no new runtime metrics are required because this only affects on-demand diagnostic collection.
