### PR TITLE
test(otel/manager): verify findRandomTCPPorts avoids wildcard-bound ports

### DIFF
--- a/internal/pkg/otel/manager/common_test.go
+++ b/internal/pkg/otel/manager/common_test.go
@@ -6,6 +6,7 @@ package manager
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"path/filepath"
 	"runtime"
@@ -93,6 +94,79 @@ func TestFindRandomTCPPorts_PortsVary(t *testing.T) {
 	}
 	assert.Greater(t, len(seen), 1,
 		"findRandomTCPPorts returned the same port on all %d sequential calls; "+
+			"the OS ephemeral-port allocator appears deterministic rather than random",
+		iterations)
+}
+
+// findRandomTCPPortsOnAllInterfaces is a variant of findRandomTCPPorts that probes port
+// availability by binding on 0.0.0.0 instead of localhost. Binding on the wildcard address causes
+// the OS to exclude ports already occupied on 0.0.0.0, avoiding the loopback-vs-wildcard
+// allocation divergence that can cause findRandomTCPPorts to return a port already in use.
+func findRandomTCPPortsOnAllInterfaces(count int) (ports []int, err error) {
+	ports = make([]int, 0, count)
+	listeners := make([]net.Listener, 0, count)
+	defer func() {
+		for _, listener := range listeners {
+			if closeErr := listener.Close(); closeErr != nil {
+				err = errors.Join(err, fmt.Errorf("error closing listener: %w", closeErr))
+			}
+		}
+	}()
+	for range count {
+		l, err := netListen("tcp", "0.0.0.0:0")
+		if err != nil {
+			return nil, err
+		}
+		listeners = append(listeners, l)
+
+		port := l.Addr().(*net.TCPAddr).Port
+		if port == 0 {
+			return nil, fmt.Errorf("failed to find random port")
+		}
+		ports = append(ports, port)
+	}
+
+	return ports, err
+}
+
+// TestFindRandomTCPPortsOnAllInterfaces_AvoidsWildcardBoundPorts is the analogue of
+// TestFindRandomTCPPorts_AvoidsWildcardBoundPorts for the 0.0.0.0 probe variant.
+// It should pass where the localhost variant fails: the wildcard probe causes the OS to exclude
+// ports already bound on 0.0.0.0.
+func TestFindRandomTCPPortsOnAllInterfaces_AvoidsWildcardBoundPorts(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wildcard vs loopback port-allocation behaviour is Linux-specific")
+	}
+
+	l, err := netListen("tcp", "0.0.0.0:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+	boundPort := l.Addr().(*net.TCPAddr).Port
+
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		ports, err := findRandomTCPPortsOnAllInterfaces(1)
+		require.NoError(t, err)
+		require.Len(t, ports, 1)
+		assert.NotEqualf(t, boundPort, ports[0],
+			"findRandomTCPPortsOnAllInterfaces returned port %d which is already bound on 0.0.0.0",
+			boundPort)
+	}
+}
+
+// TestFindRandomTCPPortsOnAllInterfaces_PortsVary is the analogue of
+// TestFindRandomTCPPorts_PortsVary for the 0.0.0.0 probe variant.
+func TestFindRandomTCPPortsOnAllInterfaces_PortsVary(t *testing.T) {
+	const iterations = 50
+	seen := make(map[int]struct{}, iterations)
+	for i := 0; i < iterations; i++ {
+		ports, err := findRandomTCPPortsOnAllInterfaces(1)
+		require.NoError(t, err)
+		require.Len(t, ports, 1)
+		seen[ports[0]] = struct{}{}
+	}
+	assert.Greater(t, len(seen), 1,
+		"findRandomTCPPortsOnAllInterfaces returned the same port on all %d sequential calls; "+
 			"the OS ephemeral-port allocator appears deterministic rather than random",
 		iterations)
 }

--- a/internal/pkg/otel/manager/common_test.go
+++ b/internal/pkg/otel/manager/common_test.go
@@ -77,6 +77,26 @@ func TestFindRandomTCPPorts_AvoidsWildcardBoundPorts(t *testing.T) {
 	}
 }
 
+// TestFindRandomTCPPorts_PortsVary verifies that findRandomTCPPorts returns different port numbers
+// across sequential calls. If the OS ephemeral-port allocator deterministically hands back the same
+// "first free" port every time, the function would always return the same port — making it
+// vulnerable to repeatedly colliding with a service that transiently occupies that specific port.
+// See https://github.com/elastic/sdh-beats/issues/7463#issuecomment-5541484862.
+func TestFindRandomTCPPorts_PortsVary(t *testing.T) {
+	const iterations = 50
+	seen := make(map[int]struct{}, iterations)
+	for i := 0; i < iterations; i++ {
+		ports, err := findRandomTCPPorts(1)
+		require.NoError(t, err)
+		require.Len(t, ports, 1)
+		seen[ports[0]] = struct{}{}
+	}
+	assert.Greater(t, len(seen), 1,
+		"findRandomTCPPorts returned the same port on all %d sequential calls; "+
+			"the OS ephemeral-port allocator appears deterministic rather than random",
+		iterations)
+}
+
 func testComponent(componentId string) agentcomponent.Component {
 	fileStreamConfig := map[string]any{
 		"id":         "test",

--- a/internal/pkg/otel/manager/common_test.go
+++ b/internal/pkg/otel/manager/common_test.go
@@ -59,7 +59,8 @@ func TestFindRandomTCPPorts_AvoidsWildcardBoundPorts(t *testing.T) {
 	}
 
 	// Simulate a third-party service holding a port on all interfaces.
-	l, err := net.Listen("tcp", "0.0.0.0:0")
+	// netListen is used (rather than net.Listen directly) to satisfy the noctx linter.
+	l, err := netListen("tcp", "0.0.0.0:0")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = l.Close() })
 	boundPort := l.Addr().(*net.TCPAddr).Port

--- a/internal/pkg/otel/manager/common_test.go
+++ b/internal/pkg/otel/manager/common_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"testing"
 
@@ -44,6 +45,35 @@ func TestFindRandomPort(t *testing.T) {
 	}
 	_, err = findRandomTCPPorts(portCount)
 	assert.Error(t, err, "failed to find random port")
+}
+
+// TestFindRandomTCPPorts_AvoidsWildcardBoundPorts verifies that findRandomTCPPorts never returns
+// a port already bound on 0.0.0.0. Third-party services such as HP OpenView Agent bind on the
+// wildcard address; on some Linux kernels the ephemeral-port allocator can hand back a port number
+// that is already occupied on 0.0.0.0 when the availability probe is made only against 127.0.0.1.
+// If this test fails it means the supervised collector will receive a port that it cannot bind,
+// triggering the restart loop described in https://github.com/elastic/elastic-agent/issues/16142.
+func TestFindRandomTCPPorts_AvoidsWildcardBoundPorts(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wildcard vs loopback port-allocation behaviour is Linux-specific")
+	}
+
+	// Simulate a third-party service holding a port on all interfaces.
+	l, err := net.Listen("tcp", "0.0.0.0:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+	boundPort := l.Addr().(*net.TCPAddr).Port
+
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		ports, err := findRandomTCPPorts(1)
+		require.NoError(t, err)
+		require.Len(t, ports, 1)
+		assert.NotEqualf(t, boundPort, ports[0],
+			"findRandomTCPPorts returned port %d which is already bound on 0.0.0.0; "+
+				"the loopback-only availability check does not exclude wildcard-bound ports",
+			boundPort)
+	}
 }
 
 func testComponent(componentId string) agentcomponent.Component {


### PR DESCRIPTION
## What does this PR do?

Adds a Linux-only unit test `TestFindRandomTCPPorts_AvoidsWildcardBoundPorts` that checks whether `findRandomTCPPorts` can return a port already bound on `0.0.0.0`.

## Why is it needed?

`findRandomTCPPorts` probes port availability by binding `localhost:0` (127.0.0.1). On some Linux kernels the ephemeral-port allocator may hand back a port number that is already occupied on the wildcard address (`0.0.0.0`), because the two socket addresses are treated independently. The supervised EDOT collector then fails to bind the returned port, triggering the restart loop in #16142.

This test reproduces that condition: it holds a port on `0.0.0.0` and asserts that `findRandomTCPPorts` never returns that port number. If the test fails on a given kernel, the root cause is confirmed and the fix should either:

- probe `0.0.0.0:port` explicitly after the loopback check, or
- switch the availability probe to `0.0.0.0:0` so the kernel's own conflict detection covers all interfaces.

The test is skipped on non-Linux platforms because the wildcard vs. loopback port-allocation behaviour is Linux-specific.

## Related issues

- #16142 (TOCTOU race in port availability check)

## How to test

```
go test ./internal/pkg/otel/manager/ -run TestFindRandomTCPPorts_AvoidsWildcardBoundPorts -v
```

On a Linux host where the kernel assigns `127.0.0.1:0` ports independently of `0.0.0.0` bindings, this test will fail — confirming the bug. On a host where the kernel correctly excludes wildcard-bound ports, it will pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.