### PR TITLE
prevent panic when translating otel config and unit has nil configuration

### DIFF
--- a/changelog/fragments/1788375679-handle-units-with-nil-config.yaml
+++ b/changelog/fragments/1788375679-handle-units-with-nil-config.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: prevent panic when translating otel config and unit has nil configuration
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/16470

--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -404,7 +404,7 @@ func getReceiversConfigForComponent(
 	// get inputs for all the units
 	var inputs []receiverInput
 	for _, unit := range comp.Units {
-		if unit.Type == client.UnitTypeInput {
+		if unit.Type == client.UnitTypeInput && unit.Config != nil {
 			unitInputs, err := getInputsForUnit(unit, info, defaultDataStreamType, comp)
 			if err != nil {
 				return nil, err

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -2801,6 +2801,38 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 			// No expectedReceiverID - no inputs means no receivers
 		},
 		{
+			name: "input unit with nil config is skipped without panic",
+			component: &component.Component{
+				ID:        "nil-config-test-id",
+				InputType: "filestream",
+				InputSpec: &component.InputRuntimeSpec{
+					BinaryName: "elastic-otel-collector",
+					Spec: component.InputSpec{
+						Name: "filestream",
+						Command: &component.CommandSpec{
+							Args: []string{"filebeat"},
+						},
+					},
+				},
+				Units: []component.Unit{
+					{
+						ID:     "input-unit",
+						Type:   client.UnitTypeInput,
+						Config: nil,
+					},
+					{
+						ID:   "output-unit",
+						Type: client.UnitTypeOutput,
+						Config: component.MustExpectedConfig(map[string]any{
+							"type": "elasticsearch",
+						}),
+					},
+				},
+			},
+			outputQueueConfig: nil,
+			// No expectedReceiverID - nil config input is skipped
+		},
+		{
 			name: "unsupported component type",
 			component: &component.Component{
 				ID:        "unsupported-test-id",
@@ -3182,6 +3214,38 @@ func TestVerifyComponentIsOtelSupported(t *testing.T) {
 				},
 			},
 			expectedError: "unsupported configuration for unsupported-config: error translating config for output: default, unit: filestream-default, error: indices is currently not supported: unsupported operation",
+		},
+		{
+			name: "input unit with nil config does not panic",
+			component: &component.Component{
+				ID:         "nil-config-comp",
+				InputType:  "filestream",
+				OutputType: "elasticsearch",
+				OutputName: "default",
+				InputSpec: &component.InputRuntimeSpec{
+					BinaryName: "elastic-otel-collector",
+					Spec: component.InputSpec{
+						Command: &component.CommandSpec{
+							Args: []string{"filebeat"},
+						},
+					},
+				},
+				Units: []component.Unit{
+					{
+						ID:     "filestream-unit",
+						Type:   client.UnitTypeInput,
+						Config: nil,
+					},
+					{
+						ID:   "filestream-default",
+						Type: client.UnitTypeOutput,
+						Config: component.MustExpectedConfig(map[string]any{
+							"type":  "elasticsearch",
+							"hosts": []any{"localhost:9200"},
+						}),
+					},
+				},
+			},
 		},
 	}
 

--- a/internal/pkg/otel/translate/status_test.go
+++ b/internal/pkg/otel/translate/status_test.go
@@ -911,6 +911,17 @@ func TestGetComponentUnitState(t *testing.T) {
 			assert.Equal(t, tt.expected.Payload, result.Payload)
 		})
 	}
+
+	t.Run("nil config is degraded", func(t *testing.T) {
+		nilConfigUnit := component.Unit{
+			ID:     "nil-config-unit",
+			Type:   client.UnitTypeInput,
+			Config: nil,
+		}
+		result := getComponentUnitState(nil, nil, nilConfigUnit, comp)
+		assert.Equal(t, client.UnitStateDegraded, result.State)
+		assert.Equal(t, "unit configuration is nil", result.Message)
+	})
 }
 
 func TestParseEntityStatusId(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Adds a nil guard in getReceiversConfigForComponent (internal/pkg/otel/translate/otelconfig.go) to skip input units whose Config field is nil, and adds regression tests covering both the no-panic and the degraded-status behaviour.

## Why is it important?

The agent was crashing with a nil-pointer dereference whenever the OTel translation path encountered an input unit without a config. The stack trace points to:

```
management.handleSimpleConfig → CreateInputsFromStreamsForReceiver(0x0, ...) → raw.Source.AsMap()
```

## Checklist

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

None.

## How to test this PR locally

```
go test -run "TestGetReceiversConfigForComponent/input_unit_with_nil_config|TestVerifyComponentIsOtelSupported/input_unit_with_nil_config|TestGetComponentUnitState/nil_config_is_degraded" ./internal/pkg/otel/translate/...
```

## Related issues

- Closes #16470 

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
