### PR TITLE
validate component working directory path to prevent path traversal

### DIFF
--- a/changelog/fragments/1788440317-validate-component-working-directory-path-to-prevent-path-traversal.yaml
+++ b/changelog/fragments/1788440317-validate-component-working-directory-path-to-prevent-path-traversal.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: security
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: validate component working directory path to prevent path traversal
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/16226

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -631,26 +631,30 @@ func (c *Component) WorkDirPath(parentDirPath string) string {
 	return filepath.Join(parentDirPath, c.WorkDirName())
 }
 
-// validateWorkDir verifies that the component's working directory ($parentDirPath/$ID)
-// resolves strictly inside parentDirPath. Both paths are resolved to absolute form
-// so that ".", "..", and multi-segment traversal are normalised by the path library
-// before comparison.
-func (c *Component) validateWorkDir(parentDirPath string) error {
-	if c.ID == "" {
+// validateComponentID verifies that joining parentDirPath with id stays strictly inside
+// parentDirPath. Both paths are resolved to absolute form before comparison so that
+// ".", "..", and multi-segment traversal are all normalised by the path library.
+func validateComponentID(parentDirPath, id string) error {
+	if id == "" {
 		return errors.New("component ID must not be empty")
 	}
 	absParent, err := filepath.Abs(parentDirPath)
 	if err != nil {
 		return fmt.Errorf("failed to resolve runtime directory %q: %w", parentDirPath, err)
 	}
-	absCandidate, err := filepath.Abs(filepath.Join(absParent, c.ID))
+	absCandidate, err := filepath.Abs(filepath.Join(absParent, id))
 	if err != nil {
-		return fmt.Errorf("failed to resolve component working directory for ID %q: %w", c.ID, err)
+		return fmt.Errorf("failed to resolve component working directory for ID %q: %w", id, err)
 	}
-	if !strings.HasPrefix(absCandidate, absParent+string(filepath.Separator)) {
-		return fmt.Errorf("component ID %q resolves outside the runtime directory", c.ID)
+	rel, err := filepath.Rel(absParent, absCandidate)
+	if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+		return fmt.Errorf("component ID %q must resolve strictly inside the runtime directory", id)
 	}
 	return nil
+}
+
+func (c *Component) validateWorkDir(parentDirPath string) error {
+	return validateComponentID(parentDirPath, c.ID)
 }
 
 // PrepareWorkDir prepares the component working directory under the provided parent path. This involves creating
@@ -840,6 +844,9 @@ func (r *RuntimeSpecs) componentsForInputType(
 			componentID = inputType
 		}
 
+		if componentErr == nil {
+			componentErr = validateComponentID(paths.Run(), componentID)
+		}
 		if componentErr == nil && !containsStr(inputSpec.Spec.Outputs, output.OutputType) {
 			// This output is unsupported.
 			componentErr = ErrOutputNotSupported
@@ -900,6 +907,10 @@ func (r *RuntimeSpecs) componentsForInputType(
 				componentID = fmt.Sprintf("%s-%s", inputType, input.id)
 			}
 
+			var componentErr error
+			if err := validateComponentID(paths.Run(), componentID); err != nil {
+				componentErr = err
+			}
 			if componentErr == nil && !containsStr(inputSpec.Spec.Outputs, output.OutputType) {
 				// This output is unsupported.
 				componentErr = ErrOutputNotSupported

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -643,9 +643,6 @@ func validateComponentID(parentDirPath, id string) error {
 		return fmt.Errorf("failed to resolve runtime directory %q: %w", parentDirPath, err)
 	}
 	absCandidate := filepath.Clean(filepath.Join(absParent, id))
-	if err != nil {
-		return fmt.Errorf("failed to resolve component working directory for ID %q: %w", id, err)
-	}
 	rel, err := filepath.Rel(absParent, absCandidate)
 	if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
 		return fmt.Errorf("component ID %q must resolve strictly inside the runtime directory", id)

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -631,9 +631,34 @@ func (c *Component) WorkDirPath(parentDirPath string) string {
 	return filepath.Join(parentDirPath, c.WorkDirName())
 }
 
+// validateWorkDir verifies that the component's working directory ($parentDirPath/$ID)
+// resolves strictly inside parentDirPath. Both paths are resolved to absolute form
+// so that ".", "..", and multi-segment traversal are normalised by the path library
+// before comparison.
+func (c *Component) validateWorkDir(parentDirPath string) error {
+	if c.ID == "" {
+		return errors.New("component ID must not be empty")
+	}
+	absParent, err := filepath.Abs(parentDirPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve runtime directory %q: %w", parentDirPath, err)
+	}
+	absCandidate, err := filepath.Abs(filepath.Join(absParent, c.ID))
+	if err != nil {
+		return fmt.Errorf("failed to resolve component working directory for ID %q: %w", c.ID, err)
+	}
+	if !strings.HasPrefix(absCandidate, absParent+string(filepath.Separator)) {
+		return fmt.Errorf("component ID %q resolves outside the runtime directory", c.ID)
+	}
+	return nil
+}
+
 // PrepareWorkDir prepares the component working directory under the provided parent path. This involves creating
 // it under the right ownership and ACLs. This method is idempotent.
 func (c *Component) PrepareWorkDir(parentDirPath string) error {
+	if err := c.validateWorkDir(parentDirPath); err != nil {
+		return err
+	}
 	uid, gid := os.Geteuid(), os.Getegid()
 	path := c.WorkDirPath(parentDirPath)
 	err := os.MkdirAll(path, workDirPathMod)
@@ -656,6 +681,9 @@ func (c *Component) PrepareWorkDir(parentDirPath string) error {
 
 // RemoveWorkDir removes the component working directory under the provided parent path. This method is idempotent.
 func (c *Component) RemoveWorkDir(parentDirPath string) error {
+	if err := c.validateWorkDir(parentDirPath); err != nil {
+		return err
+	}
 	return os.RemoveAll(c.WorkDirPath(parentDirPath))
 }
 

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -642,7 +642,7 @@ func validateComponentID(parentDirPath, id string) error {
 	if err != nil {
 		return fmt.Errorf("failed to resolve runtime directory %q: %w", parentDirPath, err)
 	}
-	absCandidate, err := filepath.Abs(filepath.Join(absParent, id))
+	absCandidate := filepath.Clean(filepath.Join(absParent, id))
 	if err != nil {
 		return fmt.Errorf("failed to resolve component working directory for ID %q: %w", id, err)
 	}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -650,14 +650,10 @@ func validateComponentID(parentDirPath, id string) error {
 	return nil
 }
 
-func (c *Component) validateWorkDir(parentDirPath string) error {
-	return validateComponentID(parentDirPath, c.ID)
-}
-
 // PrepareWorkDir prepares the component working directory under the provided parent path. This involves creating
 // it under the right ownership and ACLs. This method is idempotent.
 func (c *Component) PrepareWorkDir(parentDirPath string) error {
-	if err := c.validateWorkDir(parentDirPath); err != nil {
+	if err := validateComponentID(parentDirPath, c.ID); err != nil {
 		return err
 	}
 	uid, gid := os.Geteuid(), os.Getegid()
@@ -682,7 +678,7 @@ func (c *Component) PrepareWorkDir(parentDirPath string) error {
 
 // RemoveWorkDir removes the component working directory under the provided parent path. This method is idempotent.
 func (c *Component) RemoveWorkDir(parentDirPath string) error {
-	if err := c.validateWorkDir(parentDirPath); err != nil {
+	if err := validateComponentID(parentDirPath, c.ID); err != nil {
 		return err
 	}
 	return os.RemoveAll(c.WorkDirPath(parentDirPath))

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -3666,6 +3666,19 @@ func TestComponent_WorkDir_PathTraversal(t *testing.T) {
 		require.Error(t, err, "PrepareWorkDir must reject '.' component ID")
 	})
 
+	t.Run("PrepareWorkDir allows absolute path ID safely contained inside runtimeDir", func(t *testing.T) {
+		// In Go, filepath.Join(absParent, "/abs/path") embeds the absolute path
+		// under absParent rather than replacing it, so "/etc/passwd" resolves to
+		// runtimeDir+"/etc/passwd" — still inside runtimeDir.
+		c := &Component{ID: "/etc/passwd"}
+
+		err := c.PrepareWorkDir(runtimeDir)
+		require.NoError(t, err, "absolute path ID is safe in Go — resolves inside runtimeDir")
+		assert.DirExists(t, filepath.Join(runtimeDir, "etc", "passwd"),
+			"absolute path ID must create a directory inside runtimeDir, not at the root")
+		_ = c.RemoveWorkDir(runtimeDir)
+	})
+
 	t.Run("WorkDirPath stays within runtimeDir for benign ID", func(t *testing.T) {
 		c := &Component{ID: "filebeat-default"}
 		resolved := c.WorkDirPath(runtimeDir)

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -3607,6 +3607,85 @@ func TestComponent_WorkDir(t *testing.T) {
 	})
 }
 
+// TestComponent_WorkDir_PathTraversal asserts the fix for
+// https://github.com/elastic/elastic-agent/issues/16226: component IDs derived
+// from externally supplied input IDs must be validated before any filesystem
+// operation so that a crafted ID cannot escape the Agent runtime directory.
+//
+// All sub-tests except the last currently FAIL — no validation exists yet.
+func TestComponent_WorkDir_PathTraversal(t *testing.T) {
+	runtimeDir := t.TempDir()
+	sentinelDir := t.TempDir()
+	sentinelBase := filepath.Base(sentinelDir)
+
+	require.Equal(t, filepath.Dir(runtimeDir), filepath.Dir(sentinelDir),
+		"test setup: runtimeDir and sentinelDir must share the same parent")
+
+	t.Run("PrepareWorkDir rejects dotdot traversal", func(t *testing.T) {
+		c := &Component{ID: filepath.Join("..", sentinelBase, "escaped")}
+
+		err := c.PrepareWorkDir(runtimeDir)
+		require.Error(t, err, "PrepareWorkDir must reject a '..' component ID")
+		assert.NoDirExists(t, filepath.Join(sentinelDir, "escaped"),
+			"no directory must be created outside runtimeDir")
+	})
+
+	t.Run("PrepareWorkDir rejects multi-level dotdot traversal", func(t *testing.T) {
+		nestedRuntime := filepath.Join(runtimeDir, "sub", "nested")
+		require.NoError(t, os.MkdirAll(nestedRuntime, 0o755))
+
+		c := &Component{ID: filepath.Join("..", "..", sentinelBase, "escaped-deep")}
+
+		err := c.PrepareWorkDir(nestedRuntime)
+		require.Error(t, err, "PrepareWorkDir must reject multi-level '..' component IDs")
+		assert.NoDirExists(t, filepath.Join(sentinelDir, "escaped-deep"),
+			"no directory must be created outside runtimeDir")
+	})
+
+	t.Run("RemoveWorkDir rejects dotdot traversal", func(t *testing.T) {
+		victim := filepath.Join(sentinelDir, "victim-dir")
+		require.NoError(t, os.MkdirAll(victim, 0o755))
+
+		c := &Component{ID: filepath.Join("..", sentinelBase, "victim-dir")}
+
+		err := c.RemoveWorkDir(runtimeDir)
+		require.Error(t, err, "RemoveWorkDir must reject a '..' component ID")
+		assert.DirExists(t, victim, "RemoveWorkDir must not delete directories outside runtimeDir")
+	})
+
+	t.Run("PrepareWorkDir rejects empty ID", func(t *testing.T) {
+		c := &Component{ID: ""}
+
+		err := c.PrepareWorkDir(runtimeDir)
+		require.Error(t, err, "PrepareWorkDir must reject an empty component ID")
+	})
+
+	t.Run("PrepareWorkDir rejects single dot ID", func(t *testing.T) {
+		// "." resolves to runtimeDir itself, not strictly beneath it.
+		c := &Component{ID: "."}
+
+		err := c.PrepareWorkDir(runtimeDir)
+		require.Error(t, err, "PrepareWorkDir must reject '.' component ID")
+	})
+
+
+	t.Run("WorkDirPath stays within runtimeDir for benign ID", func(t *testing.T) {
+		c := &Component{ID: "filebeat-default"}
+		resolved := c.WorkDirPath(runtimeDir)
+
+		assert.True(t,
+			strings.HasPrefix(resolved, runtimeDir+string(filepath.Separator)),
+			"WorkDirPath for a normal ID must be strictly inside runtimeDir, got %q", resolved)
+	})
+
+	t.Run("PrepareWorkDir allows cloudbeat-style nested ID", func(t *testing.T) {
+		c := &Component{ID: "cloudbeat/cis_aws-default-my-input"}
+		err := c.PrepareWorkDir(runtimeDir)
+		require.NoError(t, err, "PrepareWorkDir must allow legitimate nested IDs like cloudbeat/cis_aws-default-*")
+		_ = c.RemoveWorkDir(runtimeDir)
+	})
+}
+
 func TestRuntimeConfigValidate(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -3611,8 +3611,6 @@ func TestComponent_WorkDir(t *testing.T) {
 // https://github.com/elastic/elastic-agent/issues/16226: component IDs derived
 // from externally supplied input IDs must be validated before any filesystem
 // operation so that a crafted ID cannot escape the Agent runtime directory.
-//
-// All sub-tests except the last currently FAIL — no validation exists yet.
 func TestComponent_WorkDir_PathTraversal(t *testing.T) {
 	runtimeDir := t.TempDir()
 	sentinelDir := t.TempDir()
@@ -3667,7 +3665,6 @@ func TestComponent_WorkDir_PathTraversal(t *testing.T) {
 		err := c.PrepareWorkDir(runtimeDir)
 		require.Error(t, err, "PrepareWorkDir must reject '.' component ID")
 	})
-
 
 	t.Run("WorkDirPath stays within runtimeDir for benign ID", func(t *testing.T) {
 		c := &Component{ID: "filebeat-default"}


### PR DESCRIPTION
## What does this PR do?

Adds `validateComponentID` — a path-containment check that verifies a component's working directory resolves strictly inside the runtime directory before any filesystem operation is performed

The validation is applied at two layers:

- **Build time** (`componentsForInputType`): called as soon as the component ID is assembled from the policy. A traversal ID causes the component to be created with `Err` set, surfacing as degraded immediately without touching the filesystem.
- **Runtime** (`PrepareWorkDir`, `RemoveWorkDir`): defense-in-depth; the check runs again immediately before any directory is created or removed.

## Why is it important?

Component IDs for inputs with `isolate_units: true` (currently only cloudbeat specs) embed the user-supplied `input.id` field verbatim. Because those IDs were used as path segments without validation, a crafted value such as `../../../etc` could cause `PrepareWorkDir` to create directories — and `chmod` them — outside the Agent runtime directory, or cause `RemoveWorkDir` to delete arbitrary directories on the host. Running as root amplifies the impact.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

A cloudbeat `input.id` containing `..` or path separators that resolves outside the runtime directory will now cause the component to be rejected at policy-apply time with an error status, instead of proceeding to create or delete directories. Legitimate IDs (alphanumeric slugs, forward-slash-separated namespaces like `cloudbeat/cis_aws-default-input-0`) are unaffected.

## How to test this PR locally

Run the unit tests:

```
go test ./pkg/component/... -run TestComponent_WorkDir_PathTraversal -v
```

To reproduce the vulnerability before the fix: configure a standalone Agent with a cloudbeat input whose `id` contains `../../<target>`, start the Agent, and observe that `PrepareWorkDir` creates a directory outside the `run/` tree. With the fix, the component is immediately degraded and no directory is created.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/16226
