### PR TITLE
internal/pkg/agent/application/upgrade: suppress spurious warn on fresh volume

### DIFF
--- a/changelog/fragments/1788737506-suppress-spurious-warn-absent-symlink-fresh-volume.yaml
+++ b/changelog/fragments/1788737506-suppress-spurious-warn-absent-symlink-fresh-volume.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Suppress spurious warn log when live-install symlink is absent on a fresh volume
+component: elastic-agent

--- a/internal/pkg/agent/application/upgrade/cleanup_agent_directories.go
+++ b/internal/pkg/agent/application/upgrade/cleanup_agent_directories.go
@@ -182,10 +182,19 @@ func cleanupAgentDirectories(
 
 	symlinkTarget, symlinkErr := liveVersionedHome(topDir)
 	if symlinkErr != nil {
-		log.Warnw("could not resolve live versioned home symlink during cleanup; orphan directories will be kept conservatively",
-			"error.message", symlinkErr.Error())
+		if errors.Is(symlinkErr, errSymlinkAbsent) && marker == nil && markerErr == nil {
+			// Fresh volume: symlink absent and no upgrade marker present. The
+			// agent creates the symlink on first start, after this cleanup pass
+			// runs. Log at debug — this is the expected state, not a degraded
+			// one.
+			log.Debugw("live versioned home symlink is absent; orphan directories will be kept conservatively",
+				"error.message", symlinkErr.Error())
+		} else {
+			log.Warnw("could not resolve live versioned home symlink during cleanup; orphan directories will be kept conservatively",
+				"error.message", symlinkErr.Error())
+			degraded = true
+		}
 		symlinkTarget = ""
-		degraded = true
 	}
 
 	dc := &dirClassifier{

--- a/internal/pkg/agent/application/upgrade/cleanup_agent_directories_test.go
+++ b/internal/pkg/agent/application/upgrade/cleanup_agent_directories_test.go
@@ -15,7 +15,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/upgrade/ttl"
 	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
 	"github.com/elastic/elastic-agent/pkg/upgrade/details"
@@ -194,14 +196,111 @@ func TestCleanupAgentDirectories_Orphan_TerminalMarker_AllowsRemoval(t *testing.
 	assert.True(t, dc.shouldRemove(filepath.Join("data", "elastic-agent-orphan")))
 }
 
-func TestCleanupAgentDirectories_ReturnsDegradedSentinel_OnSymlinkErr(t *testing.T) {
+func TestCleanupAgentDirectories_AbsentSymlink_NotDegraded(t *testing.T) {
+	log, obs := loggertest.New(t.Name())
+	topDir := t.TempDir()
+
+	// One install, no symlink — models a fresh or freshly-cleaned EFS volume.
+	relHome := createFakeAgentInstall(t, topDir, "1.0.0", "aaaaaa", true)
+
+	// Unexpired TTL on the install — must be preserved.
+	validUntil := time.Now().Add(24 * time.Hour)
+	wantMarker := ttl.TTLMarker{Version: "1.0.0", Hash: "aaaaaa", ValidUntil: validUntil}
+	source := ttl.NewTTLMarkerRegistry(log, topDir)
+	require.NoError(t,
+		source.Set(map[string]ttl.TTLMarker{relHome: wantMarker}),
+		"writing unexpired TTL marker for fixture")
+
+	leftover, err := cleanupAgentDirectories(log, topDir, time.Now(), source, CleanupExpiredRollbacks, nil, cleanupOpts{requireMarkerDetails: true})
+	// An absent symlink is not a degraded state — the agent creates it on first
+	// start, after this cleanup pass runs.
+	require.NoError(t, err)
+
+	// Unexpired rollback must be preserved even without the symlink — the caller
+	// uses leftoverRollbacks to schedule the next cleanup.
+	require.NotNil(t, leftover)
+	got, ok := leftover[relHome]
+	require.True(t, ok, "unexpired TTL entry must be in leftoverRollbacks")
+	assert.Equal(t, wantMarker.Version, got.Version)
+	assert.Equal(t, wantMarker.Hash, got.Hash)
+	// YAML round-trip strips monotonic clock; tolerate sub-second drift.
+	assert.WithinDuration(t, wantMarker.ValidUntil, got.ValidUntil, time.Second)
+
+	// The absence must be logged at debug, not warn — a missing symlink on a
+	// fresh volume is expected and must not produce a spurious warning.
+	warnLogs := obs.FilterLevelExact(zapcore.WarnLevel).All()
+	for _, entry := range warnLogs {
+		assert.NotContains(t, entry.Message, "symlink",
+			"absent symlink must not be logged at warn level; got: %q", entry.Message)
+	}
+	debugEntries := obs.FilterLevelExact(zapcore.DebugLevel).FilterMessageSnippet("symlink is absent").All()
+	assert.NotEmpty(t, debugEntries, "absent symlink must produce a debug log entry")
+}
+
+func TestCleanupAgentDirectories_AbsentSymlink_WithMarker_IsDegraded(t *testing.T) {
 	log, _ := loggertest.New(t.Name())
 	topDir := t.TempDir()
 
-	// One install, no symlink.
 	relHome := createFakeAgentInstall(t, topDir, "1.0.0", "aaaaaa", true)
+	source := ttl.NewTTLMarkerRegistry(log, topDir)
 
-	// Unexpired TTL on the install — must be returned in leftoverRollbacks even when cleanup is degraded.
+	// Write an upgrade marker — this means an upgrade was in progress.
+	require.NoError(t, os.MkdirAll(filepath.Join(topDir, "data"), 0o750))
+	require.NoError(t,
+		SaveMarker(paths.DataFrom(topDir), &UpdateMarker{Version: "1.0.0", Hash: "aaaaaa"}, true),
+		"writing upgrade marker fixture")
+
+	// No symlink. The marker's presence means this is not a fresh-volume start,
+	// so cleanup must still treat it as degraded.
+	leftover, err := cleanupAgentDirectories(log, topDir, time.Now(), source, CleanupExpiredRollbacks, nil, cleanupOpts{requireMarkerDetails: true})
+	require.Error(t, err)
+	require.ErrorIs(t, err, errCleanupDegraded,
+		"absent symlink with an upgrade marker must still return errCleanupDegraded")
+
+	// The install must be kept conservatively.
+	require.NotNil(t, leftover)
+	assert.DirExists(t, filepath.Join(topDir, relHome))
+}
+
+func TestCleanupAgentDirectories_DanglingSymlink_IsDegraded(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires elevated privileges on Windows")
+	}
+	log, _ := loggertest.New(t.Name())
+	topDir := t.TempDir()
+
+	// Create a symlink pointing to a directory that does not exist. This is path
+	// 2 in liveVersionedHome: os.Readlink succeeds, os.Stat on the target fails
+	// with ErrNotExist. This represents a broken installation, not a fresh volume,
+	// and must be treated as degraded.
+	absentTarget := filepath.Join(topDir, "data", "elastic-agent-gone", AgentName)
+	require.NoError(t, os.Symlink(absentTarget, filepath.Join(topDir, AgentName)))
+
+	relHome := createFakeAgentInstall(t, topDir, "1.0.0", "aaaaaa", true)
+	source := ttl.NewTTLMarkerRegistry(log, topDir)
+
+	leftover, err := cleanupAgentDirectories(log, topDir, time.Now(), source, CleanupExpiredRollbacks, nil, cleanupOpts{requireMarkerDetails: true})
+	require.Error(t, err)
+	require.ErrorIs(t, err, errCleanupDegraded,
+		"a dangling symlink (present but target absent) must return errCleanupDegraded")
+
+	// Install must be kept conservatively.
+	require.NotNil(t, leftover)
+	assert.DirExists(t, filepath.Join(topDir, relHome))
+}
+
+func TestCleanupAgentDirectories_ReturnsDegradedSentinel_OnSymlinkNotReadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("placing a directory at the symlink path to cause EINVAL is not portable on Windows")
+	}
+	log, _ := loggertest.New(t.Name())
+	topDir := t.TempDir()
+
+	// Place a directory where the symlink should be — os.Readlink returns EINVAL
+	// (not ErrNotExist), which must still be treated as a degraded state.
+	require.NoError(t, os.MkdirAll(filepath.Join(topDir, AgentName), 0o750))
+
+	relHome := createFakeAgentInstall(t, topDir, "1.0.0", "aaaaaa", true)
 	validUntil := time.Now().Add(24 * time.Hour)
 	wantMarker := ttl.TTLMarker{Version: "1.0.0", Hash: "aaaaaa", ValidUntil: validUntil}
 	source := ttl.NewTTLMarkerRegistry(log, topDir)

--- a/internal/pkg/agent/application/upgrade/manual_rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/manual_rollback_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -1047,12 +1048,38 @@ func TestPerformScheduledCleanup(t *testing.T) {
 			},
 		},
 		{
-			name: "Degraded cleanup (no symlink): retry at minInterval regardless of unexpired TTL",
+			name: "No symlink, no marker: schedule at TTL expiry (fresh volume, not degraded)",
 			setup: func(t *testing.T, log *logger.Logger, topDir string, source *ttl.MockSource) {
-				// Create a fake install without a symlink so liveVersionedHome() fails,
-				// causing cleanupAgentDirectories to return errCleanupDegraded.
-				// A degraded run retries at minInterval so the broken symlink is
-				// rechecked promptly rather than waiting until TTL expiry.
+				// No symlink, no upgrade marker — models a fresh volume. The absent
+				// symlink is not a degraded state when there is no marker, so the
+				// next run is scheduled at the TTL expiry time rather than minInterval.
+				createFakeAgentInstall(t, topDir, v456Valid.version, v456Valid.hash, true)
+				source.EXPECT().GetAll().Return(
+					map[string]ttl.TTLMarker{
+						filepath.Join("data", "elastic-agent-4.5.6-valid1"): {
+							Version:    "4.5.6",
+							Hash:       "valid1",
+							ValidUntil: now.Add(1 * time.Hour),
+						},
+					},
+					nil, nil)
+			},
+			args: args{
+				currentVersionedHome: filepath.Join("data", "elastic-agent-4.5.6-valid1"),
+				minInterval:          cleanupInterval,
+			},
+			want: now.Add(1 * time.Hour),
+		},
+		{
+			name: "Degraded cleanup (symlink path occupied by dir): retry at minInterval",
+			setup: func(t *testing.T, log *logger.Logger, topDir string, source *ttl.MockSource) {
+				if runtime.GOOS == "windows" {
+					t.Skip("directory-at-symlink-path to force EINVAL is not portable on Windows")
+				}
+				// Place a directory where the symlink should be — os.Readlink returns
+				// EINVAL (not ErrNotExist). This is a genuine degraded state and must
+				// cause a minInterval retry so the broken state is rechecked promptly.
+				require.NoError(t, os.MkdirAll(filepath.Join(topDir, AgentName), 0o750))
 				createFakeAgentInstall(t, topDir, v456Valid.version, v456Valid.hash, true)
 				source.EXPECT().GetAll().Return(
 					map[string]ttl.TTLMarker{

--- a/internal/pkg/agent/application/upgrade/rollback.go
+++ b/internal/pkg/agent/application/upgrade/rollback.go
@@ -303,13 +303,21 @@ func restartAgent(ctx context.Context, log *logger.Logger, c client.Client) erro
 	return nil
 }
 
+// errSymlinkAbsent is returned by liveVersionedHome when the agent symlink
+// file itself does not exist. It wraps os.ErrNotExist so callers can
+// distinguish this expected-on-fresh-volume case from a dangling symlink
+// (symlink present, target directory absent), which wraps os.ErrNotExist too
+// but is a different condition.
+var errSymlinkAbsent = fmt.Errorf("live symlink absent: %w", os.ErrNotExist)
+
 // liveVersionedHome resolves the versioned home that the top-level agent
 // symlink points at, returned as a path relative to topDirPath. Used by
 // cleanup as a defense against stale keep lists deleting the live install
 // (https://github.com/elastic/elastic-agent/issues/13505).
 //
 // Returns the empty string and a non-nil error if the symlink can't be read
-// or doesn't resolve to a path under topDirPath.
+// or doesn't resolve to a path under topDirPath. Returns errSymlinkAbsent
+// specifically when the symlink file itself does not exist.
 func liveVersionedHome(topDirPath string) (string, error) {
 	symlinkPath := filepath.Join(topDirPath, AgentName)
 	if runtime.GOOS == windowsOSName {
@@ -317,6 +325,9 @@ func liveVersionedHome(topDirPath string) (string, error) {
 	}
 	target, err := os.Readlink(symlinkPath)
 	if err != nil {
+		if goerrors.Is(err, os.ErrNotExist) {
+			return "", errSymlinkAbsent
+		}
 		return "", fmt.Errorf("reading symlink %q: %w", symlinkPath, err)
 	}
 	// Resolve a relative symlink target against the symlink's directory.

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -1110,19 +1110,23 @@ func TestLiveVersionedHome(t *testing.T) {
 }
 
 // TestCleanup_DegradesGracefullyWhenLiveHomeUnresolvable encodes the
-// graceful-degradation contract: when the symlink cannot be resolved, cleanup
-// must still proceed (sweeping directories that the parsed TTL marks as
-// removable) but flag the run as degraded via errCleanupDegraded. The upgrade
-// marker is preserved so that the next run can revisit cleanup with full
-// verification.
+// graceful-degradation contract: when the symlink cannot be resolved but an
+// upgrade marker is present, cleanup must still proceed (sweeping directories
+// that the parsed TTL marks as removable) but flag the run as degraded via
+// errCleanupDegraded. The upgrade marker is preserved so that the next run can
+// revisit cleanup with full verification.
+//
+// When the symlink is absent AND there is no upgrade marker (a fresh volume),
+// no degraded error is returned — that is the expected state at first start.
 func TestCleanup_DegradesGracefullyWhenLiveHomeUnresolvable(t *testing.T) {
-	t.Run("removeMarker=false: degraded error returned, expired TTL swept, orphan kept", func(t *testing.T) {
+	t.Run("no marker: not degraded, expired TTL swept, orphan kept", func(t *testing.T) {
 		testLogger, _ := loggertest.New(t.Name())
 		topDir := t.TempDir()
 
-		// Two installs:
-		// - expired: has an expired TTL, no symlink target -> should be swept
-		// - orphan : has no TTL, no symlink target          -> must be kept
+		// Two installs, no symlink, no upgrade marker — models a fresh EFS volume
+		// that has prior versioned directories but the symlink was cleaned:
+		// - expired: has an expired TTL -> should be swept
+		// - orphan : has no TTL         -> must be kept (cannot verify it isn't live)
 		expiredHome := createFakeAgentInstall(t, topDir, "1.2.3", "expire", true)
 		orphanHome := createFakeAgentInstall(t, topDir, "4.5.6", "orphan", true)
 		now := time.Now()
@@ -1132,18 +1136,18 @@ func TestCleanup_DegradesGracefullyWhenLiveHomeUnresolvable(t *testing.T) {
 			}),
 			"writing TTL registry with expired entry")
 
-		// No symlink.
+		// No symlink, no upgrade marker.
 
 		err := cleanup(testLogger, topDir, false, false, 0)
-		require.Error(t, err)
-		require.ErrorIs(t, err, errCleanupDegraded)
+		// No marker means this is a fresh-volume start, not a degraded state.
+		require.NoError(t, err)
 
-		// Expired TTL is swept even when the symlink is unresolvable.
+		// Expired TTL is swept even without a symlink.
 		assert.NoDirExists(t, filepath.Join(topDir, expiredHome),
-			"expired TTL entry should be swept even when symlink is unresolvable")
+			"expired TTL entry should be swept even without a symlink")
 		// Orphan is preserved because we cannot verify it isn't the live install.
 		assert.DirExists(t, filepath.Join(topDir, orphanHome),
-			"orphan must be preserved when symlink is unresolvable")
+			"orphan must be preserved when symlink is absent")
 	})
 
 	t.Run("removeMarker=true: marker survives because verification was degraded", func(t *testing.T) {
@@ -1165,12 +1169,12 @@ func TestCleanup_DegradesGracefullyWhenLiveHomeUnresolvable(t *testing.T) {
 	})
 }
 
-// TestCleanAvailableRollbacks_DegradesGracefullyWhenSymlinkUnresolvable
-// verifies that CleanAvailableRollbacks proceeds with degraded verification
-// when the agent symlink cannot be resolved: expired TTL entries are swept,
-// orphans are kept conservatively, unexpired TTL entries are returned, and
-// the error wraps errCleanupDegraded.
-func TestCleanAvailableRollbacks_DegradesGracefullyWhenSymlinkUnresolvable(t *testing.T) {
+// TestCleanAvailableRollbacks_AbsentSymlink_NoMarker verifies that
+// CleanAvailableRollbacks succeeds (not degraded) when the agent symlink is
+// absent and no upgrade marker is present — the expected state on a fresh
+// volume. Expired TTL entries are swept, orphans are kept conservatively, and
+// unexpired TTL entries are returned.
+func TestCleanAvailableRollbacks_AbsentSymlink_NoMarker(t *testing.T) {
 	testLogger, _ := loggertest.New(t.Name())
 	topDir := t.TempDir()
 
@@ -1184,7 +1188,7 @@ func TestCleanAvailableRollbacks_DegradesGracefullyWhenSymlinkUnresolvable(t *te
 	relC := createFakeAgentInstall(t, topDir, versionC.version, versionC.hash, true)
 	relD := createFakeAgentInstall(t, topDir, versionD.version, versionD.hash, true)
 
-	// No symlink.
+	// No symlink, no upgrade marker.
 
 	now := time.Now()
 	validUntil := now.Add(24 * time.Hour)
@@ -1197,9 +1201,8 @@ func TestCleanAvailableRollbacks_DegradesGracefullyWhenSymlinkUnresolvable(t *te
 
 	leftover, err := CleanAvailableRollbacks(testLogger, registry, topDir, relB, now, CleanupExpiredRollbacks)
 
-	require.Error(t, err)
-	require.ErrorIs(t, err, errCleanupDegraded,
-		"symlink-unresolvable cleanup must return errCleanupDegraded")
+	// No marker means this is a fresh-volume start, not a degraded state.
+	require.NoError(t, err)
 	if assert.Len(t, leftover, 1, "unexpired rollback must be returned for future cleanup") {
 		m := leftover[relA]
 		assert.Equal(t, versionA.version, m.Version)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

```
internal/pkg/agent/application/upgrade: suppress spurious warn on fresh volume

When cleanup runs on a fresh or freshly-cleaned volume the live-install
symlink does not yet exist — the agent creates it on first start, after
the cleanup pass runs. Previously this fired a warn-level log and
returned errCleanupDegraded unconditionally, producing noise on every
fresh pod start.

The fix checks whether an upgrade marker is also absent. An absent
symlink with no marker means the volume is fresh: log at debug and do
not return errCleanupDegraded. When a marker is present (an upgrade was
in progress), the absent symlink remains a degraded state and all
existing conservative behaviour is preserved. Any other symlink error
(e.g. EINVAL from a directory at the symlink path) is always degraded
regardless of marker state.

liveVersionedHome now returns a sentinel errSymlinkAbsent (wrapping
os.ErrNotExist) when the symlink file itself is absent, so the
freshness check in cleanupAgentDirectories can distinguish path 1
(symlink file absent) from path 2 (symlink present but target directory
absent). Previously errors.Is(symlinkErr, os.ErrNotExist) was true for
both; path 2 represents a broken installation and should remain
degraded.
```

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

See above.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Elastic Agent.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Questions to ask yourself

- How are we going to support this in production?
- How are we going to measure its adoption?
- How are we going to debug this?
- What are the metrics I should take care of?
- ...

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
