### PR TITLE
Add support for Fleet UNINSTALL action

### DIFF
--- a/changelog/fragments/1789200000-add-uninstall-action.yaml
+++ b/changelog/fragments/1789200000-add-uninstall-action.yaml
@@ -1,0 +1,52 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Add support for the Fleet UNINSTALL action.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: >
+  Managed Elastic Agents now handle a dedicated UNINSTALL action from Fleet. The
+  agent spawns a detached process that uninstalls it (the uninstall cannot run
+  in-process because it stops the agent service). Because the uninstall is
+  terminal, the action is acknowledged to Fleet by the detached uninstaller at
+  the point of no return, before the agent's credentials are removed. If the
+  uninstall fails before that point the action is acknowledged with the error so
+  Fleet learns it did not complete and the agent remains installed.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/3367

--- a/internal/pkg/agent/application/actions/handlers/handler_action_uninstall.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_uninstall.go
@@ -1,0 +1,121 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/elastic/elastic-agent/internal/pkg/fleetapi/acker"
+	"github.com/elastic/elastic-agent/pkg/core/logger"
+	"github.com/elastic/elastic-agent/pkg/features"
+	"github.com/elastic/elastic-agent/pkg/fleetapi"
+)
+
+// uninstallCoordinator is the subset of the coordinator used by the Uninstall handler.
+type uninstallCoordinator interface {
+	actionCoordinator
+	// Uninstall spawns a detached process that uninstalls the agent. The action
+	// is acknowledged by that process, not here.
+	Uninstall(ctx context.Context, action *fleetapi.ActionUninstall) error
+}
+
+// Uninstall is a handler for the UNINSTALL action. It performs the checks that
+// can still be recovered from (expiry, capability, tamper protection) and, when
+// they pass, hands off to the coordinator which spawns a detached uninstaller.
+//
+// The success path is NOT acknowledged here: the uninstall is terminal, so the
+// detached uninstaller acknowledges the action to Fleet at the point of no
+// return. Only failures that happen before the agent is handed off (invalid
+// action, or the coordinator refusing/failing to spawn the uninstaller) are
+// acknowledged here, so Fleet learns the uninstall did not start.
+type Uninstall struct {
+	log   *logger.Logger
+	coord uninstallCoordinator
+
+	tamperProtectionFn func() bool // allows to inject the flag for tests, defaults to features.TamperProtection
+	nowFn              func() time.Time
+}
+
+// NewUninstall creates a new Uninstall handler.
+func NewUninstall(log *logger.Logger, coord uninstallCoordinator) *Uninstall {
+	return &Uninstall{
+		log:                log,
+		coord:              coord,
+		tamperProtectionFn: features.TamperProtection,
+		nowFn:              time.Now,
+	}
+}
+
+// Handle handles the UNINSTALL action.
+func (h *Uninstall) Handle(ctx context.Context, a fleetapi.Action, ack acker.Acker) error {
+	h.log.Debugf("handlerUninstall: action '%+v' received", a)
+	action, ok := a.(*fleetapi.ActionUninstall)
+	if !ok {
+		return fmt.Errorf("invalid type, expected ActionUninstall and received %T", a)
+	}
+
+	// Do not uninstall if the action is expired or carries an invalid
+	// expiration. In both cases we ack the error so Fleet learns about the
+	// failure instead of silently uninstalling.
+	exp, err := action.Expiration()
+	switch {
+	case err == nil:
+		if h.nowFn().After(exp) {
+			h.log.Warnf("handlerUninstall: action '%s' expired at %s, skipping uninstall", action.ActionID, exp)
+			action.Err = fmt.Errorf("uninstall action expired at %s", exp)
+			return h.ackNow(ctx, ack, action)
+		}
+	case errors.Is(err, fleetapi.ErrNoExpiration):
+		// No expiration set; the action never expires, proceed with the uninstall.
+	default:
+		// Malformed expiration timestamp; treat the action as invalid.
+		h.log.Warnf("handlerUninstall: action '%s' has an invalid expiration, skipping uninstall: %v", action.ActionID, err)
+		action.Err = fmt.Errorf("uninstall action has an invalid expiration: %w", err)
+		return h.ackNow(ctx, ack, action)
+	}
+
+	// Under tamper protection, Endpoint needs to receive the signed UNINSTALL
+	// action so it can uncontain itself before the agent is removed. Mirrors the
+	// UNENROLL flow.
+	if h.tamperProtectionFn() {
+		state := h.coord.State()
+		ucs := findMatchingUnitsByActionType(state, a.Type())
+		if len(ucs) > 0 {
+			if err := notifyUnitsOfProxiedAction(ctx, h.log, action, ucs, h.coord.PerformAction); err != nil {
+				return err
+			}
+		} else {
+			h.log.Debugf("No components running for %v action type", a.Type())
+		}
+	}
+
+	if err := h.coord.Uninstall(ctx, action); err != nil {
+		// The uninstaller never started, so it will not acknowledge the action.
+		// Ack the failure now so Fleet learns the uninstall did not happen; the
+		// agent remains installed and functional.
+		action.Err = err
+		if aerr := h.ackNow(ctx, ack, action); aerr != nil {
+			return errors.Join(err, aerr)
+		}
+		return err
+	}
+
+	// Success: the detached uninstaller owns the acknowledgement. Do not ack here.
+	return nil
+}
+
+// ackNow acknowledges the action and commits immediately.
+func (h *Uninstall) ackNow(ctx context.Context, ack acker.Acker, action *fleetapi.ActionUninstall) error {
+	if err := ack.Ack(ctx, action); err != nil {
+		return fmt.Errorf("failed to ack uninstall action: %w", err)
+	}
+	if err := ack.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit uninstall action ack: %w", err)
+	}
+	return nil
+}

--- a/internal/pkg/agent/application/actions/handlers/handler_action_uninstall_test.go
+++ b/internal/pkg/agent/application/actions/handlers/handler_action_uninstall_test.go
@@ -1,0 +1,152 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
+	"github.com/elastic/elastic-agent/pkg/component"
+	"github.com/elastic/elastic-agent/pkg/core/logger/loggertest"
+	"github.com/elastic/elastic-agent/pkg/fleetapi"
+)
+
+func TestActionUninstallHandler(t *testing.T) {
+	log, _ := loggertest.New("uninstall")
+
+	t.Run("wrong action type", func(t *testing.T) {
+		coord := &fakeUninstallCoordinator{}
+		h := NewUninstall(log, coord)
+		h.tamperProtectionFn = func() bool { return false }
+
+		err := h.Handle(t.Context(), &fleetapi.ActionSettings{}, &fakeAcker{})
+		require.Error(t, err)
+		coord.AssertNotCalled(t, "Uninstall", mock.Anything, mock.Anything)
+	})
+
+	t.Run("happy path spawns uninstaller without acking", func(t *testing.T) {
+		action := &fleetapi.ActionUninstall{ActionID: "u1", ActionType: fleetapi.ActionTypeUninstall}
+
+		coord := &fakeUninstallCoordinator{}
+		coord.On("Uninstall", mock.Anything, action).Return(nil)
+
+		ack := &fakeAcker{}
+
+		h := NewUninstall(log, coord)
+		h.tamperProtectionFn = func() bool { return false }
+
+		require.NoError(t, h.Handle(t.Context(), action, ack))
+		coord.AssertCalled(t, "Uninstall", mock.Anything, action)
+		// Must NOT ack in the handler; the detached uninstaller acks after the
+		// point of no return.
+		ack.AssertNotCalled(t, "Ack", mock.Anything, mock.Anything)
+	})
+
+	t.Run("expired action acks error and does not uninstall", func(t *testing.T) {
+		exp := time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+		action := &fleetapi.ActionUninstall{
+			ActionID:         "u-expired",
+			ActionType:       fleetapi.ActionTypeUninstall,
+			ActionExpiration: exp,
+		}
+
+		coord := &fakeUninstallCoordinator{}
+
+		ack := &fakeAcker{}
+		ack.On("Ack", mock.Anything, action).Return(nil)
+		ack.On("Commit", mock.Anything).Return(nil)
+
+		h := NewUninstall(log, coord)
+		h.tamperProtectionFn = func() bool { return false }
+
+		require.NoError(t, h.Handle(t.Context(), action, ack))
+		require.Error(t, action.Err, "expired action should carry an error for the ack")
+		coord.AssertNotCalled(t, "Uninstall", mock.Anything, mock.Anything)
+		ack.AssertCalled(t, "Ack", mock.Anything, action)
+	})
+
+	t.Run("invalid expiration acks error and does not uninstall", func(t *testing.T) {
+		action := &fleetapi.ActionUninstall{
+			ActionID:         "u-bad-exp",
+			ActionType:       fleetapi.ActionTypeUninstall,
+			ActionExpiration: "not-a-timestamp",
+		}
+
+		coord := &fakeUninstallCoordinator{}
+
+		ack := &fakeAcker{}
+		ack.On("Ack", mock.Anything, action).Return(nil)
+		ack.On("Commit", mock.Anything).Return(nil)
+
+		h := NewUninstall(log, coord)
+		h.tamperProtectionFn = func() bool { return false }
+
+		require.NoError(t, h.Handle(t.Context(), action, ack))
+		require.Error(t, action.Err, "malformed expiration should carry an error for the ack")
+		coord.AssertNotCalled(t, "Uninstall", mock.Anything, mock.Anything)
+		ack.AssertCalled(t, "Ack", mock.Anything, action)
+	})
+
+	t.Run("uninstall error acks failure", func(t *testing.T) {
+		action := &fleetapi.ActionUninstall{ActionID: "u-fail", ActionType: fleetapi.ActionTypeUninstall}
+		uninstallErr := errors.New("not uninstallable")
+
+		coord := &fakeUninstallCoordinator{}
+		coord.On("Uninstall", mock.Anything, action).Return(uninstallErr)
+
+		ack := &fakeAcker{}
+		ack.On("Ack", mock.Anything, action).Return(nil)
+		ack.On("Commit", mock.Anything).Return(nil)
+
+		h := NewUninstall(log, coord)
+		h.tamperProtectionFn = func() bool { return false }
+
+		err := h.Handle(t.Context(), action, ack)
+		require.ErrorIs(t, err, uninstallErr)
+		ack.AssertCalled(t, "Ack", mock.Anything, action)
+		require.ErrorIs(t, action.Err, uninstallErr)
+	})
+
+	t.Run("tamper protection proxies action to endpoint", func(t *testing.T) {
+		action := &fleetapi.ActionUninstall{ActionID: "u-tp", ActionType: fleetapi.ActionTypeUninstall}
+
+		coord := &fakeUninstallCoordinator{}
+		// No proxied units configured, so State() is enough and no PerformAction happens.
+		coord.On("State").Return(coordinator.State{})
+		coord.On("Uninstall", mock.Anything, action).Return(nil)
+
+		h := NewUninstall(log, coord)
+		h.tamperProtectionFn = func() bool { return true }
+
+		require.NoError(t, h.Handle(t.Context(), action, &fakeAcker{}))
+		coord.AssertCalled(t, "State")
+		coord.AssertCalled(t, "Uninstall", mock.Anything, action)
+	})
+}
+
+type fakeUninstallCoordinator struct {
+	mock.Mock
+}
+
+func (f *fakeUninstallCoordinator) State() coordinator.State {
+	args := f.Called()
+	return args.Get(0).(coordinator.State)
+}
+
+func (f *fakeUninstallCoordinator) PerformAction(ctx context.Context, comp component.Component, unit component.Unit, name string, params map[string]interface{}) (map[string]interface{}, error) {
+	args := f.Called(ctx, comp, unit, name, params)
+	return args.Get(0).(map[string]interface{}), args.Error(1)
+}
+
+func (f *fakeUninstallCoordinator) Uninstall(ctx context.Context, action *fleetapi.ActionUninstall) error {
+	args := f.Called(ctx, action)
+	return args.Error(0)
+}

--- a/internal/pkg/agent/application/coordinator/coordinator.go
+++ b/internal/pkg/agent/application/coordinator/coordinator.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"os/exec"
 	"reflect"
 	"strings"
 	"sync"
@@ -60,6 +61,7 @@ import (
 	"github.com/elastic/elastic-agent/pkg/fleetapi"
 	"github.com/elastic/elastic-agent/pkg/limits"
 	"github.com/elastic/elastic-agent/pkg/upgrade/details"
+	"github.com/elastic/elastic-agent/pkg/utils"
 	"github.com/elastic/elastic-agent/pkg/utils/broadcaster"
 )
 
@@ -85,6 +87,29 @@ var ErrNotUpgradable = errors.New(
 var ErrNotRestartable = errors.New(
 	"cannot be restarted; must be installed with install sub-command and " +
 		"running under control of the systems supervisor")
+
+// ErrNotUninstallable error is returned when an uninstall cannot be performed
+// because the agent is not an installed, self-managed agent (for example when
+// running from a non-installed binary). Uninstall in a container is reported
+// separately with ErrContainerNotSupported.
+var ErrNotUninstallable = errors.New(
+	"cannot be uninstalled; must be installed with the install sub-command")
+
+// ErrUninstallRequiresRoot error is returned when an uninstall cannot be
+// performed because the agent process lacks the administrator/root privileges
+// required to remove the service. This is the case for unprivileged
+// installations whose service runs as a non-root user; such an agent cannot
+// uninstall itself and the action is acknowledged as failed instead of failing
+// silently.
+var ErrUninstallRequiresRoot = errors.New(
+	"cannot be uninstalled; requires administrator (root) privileges")
+
+// UninstallFleetAckActionIDFlag is the name of the hidden uninstall sub-command
+// flag that carries the Fleet UNINSTALL action ID. The detached uninstaller uses
+// it to acknowledge the action to Fleet. It is defined here because the
+// coordinator builds the uninstall invocation; the uninstall command registers
+// the flag under the same name.
+const UninstallFleetAckActionIDFlag = "fleet-ack-action-id"
 
 // ErrUpgradeInProgress error is returned if two or more upgrades are
 // attempted at the same time.
@@ -727,6 +752,99 @@ func (c *Coordinator) Restart(_ context.Context, _ *fleetapi.ActionRestart) erro
 
 	// ReExec sets the override state to Stopping and performs the re-execution.
 	c.ReExec(nil)
+	return nil
+}
+
+// uninstallCmd is overridable in tests so Uninstall can be exercised without
+// actually spawning a process. It builds a detached command that runs the
+// uninstall sub-command from the given executable.
+var uninstallCmd = func(executable string, args ...string) *exec.Cmd {
+	return upgrade.InvokeCmdWithArgs(executable, args...)
+}
+
+// uninstallHasRoot reports whether the current process has the
+// administrator/root privileges required to uninstall. It is a var so tests can
+// override it; it defaults to utils.HasRoot.
+var uninstallHasRoot = utils.HasRoot
+
+// Uninstall fulfils an UNINSTALL action by spawning a detached process that runs
+// the uninstall sub-command. The uninstall cannot run in-process: it stops (and
+// removes) the agent service, which would kill this process mid-operation, so
+// the detached process is created in its own session/process group to outlive
+// the agent.
+//
+// The action is NOT acknowledged here. The detached uninstaller acknowledges it
+// to Fleet at the point of no return, and acknowledges a failure if the
+// uninstall fails before that point (see install.Uninstall). Uninstalling is
+// only possible for an installed agent, running with root/administrator
+// privileges, and is unsupported in containers. When those preconditions are
+// not met an error is returned so the handler can acknowledge the failure to
+// Fleet rather than spawning an uninstaller that would fail silently.
+// Called from external goroutines.
+func (c *Coordinator) Uninstall(_ context.Context, action *fleetapi.ActionUninstall) error {
+	if c.isContainerizedEnvironment() {
+		return ErrContainerNotSupported
+	}
+	if !paths.RunningInstalled() {
+		return ErrNotUninstallable
+	}
+	// An unprivileged agent's service runs as a non-root user and cannot remove
+	// its own service, so it cannot uninstall itself. Fail explicitly instead of
+	// spawning an uninstaller that would exit before it could ack.
+	hasRoot, err := uninstallHasRoot()
+	if err != nil {
+		return fmt.Errorf("failed to determine privileges for uninstall: %w", err)
+	}
+	if !hasRoot {
+		return ErrUninstallRequiresRoot
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to resolve agent executable for uninstall: %w", err)
+	}
+
+	args := []string{
+		"uninstall",
+		"--force",
+		"--path.home", paths.Top(),
+		"--path.config", paths.Config(),
+	}
+	if action != nil && action.ActionID != "" {
+		args = append(args, "--"+UninstallFleetAckActionIDFlag, action.ActionID)
+	}
+
+	cmd := uninstallCmd(executable, args...)
+	// The uninstall sub-command refuses to run from within the install
+	// directory on Windows, so run the detached process from elsewhere.
+	cmd.Dir = os.TempDir()
+
+	// Reflect the imminent shutdown in the reported state.
+	c.SetOverrideState(agentclient.Stopping, "Uninstalling")
+
+	if err := cmd.Start(); err != nil {
+		c.ClearOverrideState()
+		return fmt.Errorf("failed to start uninstall process: %w", err)
+	}
+
+	c.logger.Infow("Uninstall process started",
+		"uninstall.process.pid", cmd.Process.Pid,
+		"agent.process.pid", os.Getpid())
+
+	// A successful uninstall stops the agent's service, which terminates this
+	// process; this goroutine then dies with it. If the uninstaller instead exits
+	// while the agent is still installed (an uninstall failure before the service
+	// is stopped), reap it to avoid a zombie and clear the Stopping override so
+	// the agent does not report Stopping indefinitely after it recovers.
+	go func() {
+		_ = cmd.Wait()
+		if paths.RunningInstalled() {
+			c.logger.Warnw("Uninstall process exited but the agent is still installed; clearing Stopping state",
+				"uninstall.process.pid", cmd.Process.Pid)
+			c.ClearOverrideState()
+		}
+	}()
+
 	return nil
 }
 

--- a/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
+++ b/internal/pkg/agent/application/coordinator/coordinator_unit_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -2976,4 +2977,154 @@ func TestCoordinator_Restart(t *testing.T) {
 			t.Fatal("expected an override state to be set")
 		}
 	})
+}
+
+func TestCoordinator_Uninstall(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	action := &fleetapi.ActionUninstall{ActionID: "u1", ActionType: fleetapi.ActionTypeUninstall}
+
+	// linuxSpecs is a non-container platform so isContainerizedEnvironment is false.
+	linuxSpecs, err := pkgcomponent.NewRuntimeSpecs(
+		pkgcomponent.PlatformDetail{Platform: pkgcomponent.Platform{OS: "linux"}}, nil)
+	require.NoError(t, err)
+
+	t.Run("containerized returns ErrContainerNotSupported and does not spawn", func(t *testing.T) {
+		containerSpecs, err := pkgcomponent.NewRuntimeSpecs(
+			pkgcomponent.PlatformDetail{Platform: pkgcomponent.Platform{OS: pkgcomponent.Container}}, nil)
+		require.NoError(t, err)
+
+		spawned := false
+		restore := overrideUninstallCmd(func(string, ...string) *exec.Cmd {
+			spawned = true
+			return noopUninstallCmd()
+		})
+		defer restore()
+
+		coord := &Coordinator{
+			overrideStateChan: make(chan *coordinatorOverrideState, 2),
+			specs:             containerSpecs,
+			logger:            logp.NewLogger("testing"),
+		}
+		err = coord.Uninstall(ctx, action)
+		require.ErrorIs(t, err, ErrContainerNotSupported)
+		assert.False(t, spawned, "should not spawn uninstaller in a container")
+	})
+
+	t.Run("not installed returns ErrNotUninstallable and does not spawn", func(t *testing.T) {
+		top := paths.Top()
+		paths.SetTop(t.TempDir()) // empty dir, no install marker
+		t.Cleanup(func() { paths.SetTop(top) })
+
+		spawned := false
+		restore := overrideUninstallCmd(func(string, ...string) *exec.Cmd {
+			spawned = true
+			return noopUninstallCmd()
+		})
+		defer restore()
+
+		coord := &Coordinator{
+			overrideStateChan: make(chan *coordinatorOverrideState, 2),
+			specs:             linuxSpecs,
+			logger:            logp.NewLogger("testing"),
+		}
+		err := coord.Uninstall(ctx, action)
+		require.ErrorIs(t, err, ErrNotUninstallable)
+		assert.False(t, spawned, "should not spawn uninstaller when not installed")
+	})
+
+	t.Run("installed but not root returns ErrUninstallRequiresRoot and does not spawn", func(t *testing.T) {
+		top := paths.Top()
+		tmpTop := t.TempDir()
+		paths.SetTop(tmpTop)
+		t.Cleanup(func() { paths.SetTop(top) })
+		require.NoError(t, os.WriteFile(
+			filepath.Join(tmpTop, paths.MarkerFileName), []byte("{}"), 0o600))
+
+		defer overrideUninstallHasRoot(func() (bool, error) { return false, nil })()
+
+		spawned := false
+		restore := overrideUninstallCmd(func(string, ...string) *exec.Cmd {
+			spawned = true
+			return noopUninstallCmd()
+		})
+		defer restore()
+
+		coord := &Coordinator{
+			overrideStateChan: make(chan *coordinatorOverrideState, 2),
+			specs:             linuxSpecs,
+			logger:            logp.NewLogger("testing"),
+		}
+		err := coord.Uninstall(ctx, action)
+		require.ErrorIs(t, err, ErrUninstallRequiresRoot)
+		assert.False(t, spawned, "should not spawn uninstaller without root")
+	})
+
+	t.Run("installed spawns uninstaller and sets stopping override state", func(t *testing.T) {
+		top := paths.Top()
+		tmpTop := t.TempDir()
+		paths.SetTop(tmpTop)
+		t.Cleanup(func() { paths.SetTop(top) })
+		// Create the install marker so RunningInstalled() reports installed.
+		require.NoError(t, os.WriteFile(
+			filepath.Join(tmpTop, paths.MarkerFileName), []byte("{}"), 0o600))
+
+		// Unit tests may run as a non-root user; force the root check to pass so
+		// the spawn path is exercised deterministically.
+		defer overrideUninstallHasRoot(func() (bool, error) { return true, nil })()
+
+		var gotArgs []string
+		restore := overrideUninstallCmd(func(_ string, args ...string) *exec.Cmd {
+			gotArgs = args
+			return noopUninstallCmd()
+		})
+		defer restore()
+
+		coord := &Coordinator{
+			overrideStateChan: make(chan *coordinatorOverrideState, 2),
+			specs:             linuxSpecs,
+			logger:            logp.NewLogger("testing"),
+		}
+		err := coord.Uninstall(ctx, action)
+		require.NoError(t, err)
+
+		assert.Contains(t, gotArgs, "uninstall")
+		assert.Contains(t, gotArgs, "--force")
+		assert.Contains(t, gotArgs, "--"+UninstallFleetAckActionIDFlag)
+		assert.Contains(t, gotArgs, action.ActionID)
+
+		select {
+		case os := <-coord.overrideStateChan:
+			require.NotNil(t, os, "uninstall should set an override state")
+			assert.Equal(t, agentclient.Stopping, os.state)
+		default:
+			t.Fatal("expected an override state to be set")
+		}
+	})
+}
+
+// overrideUninstallCmd swaps the package-level uninstallCmd for tests and returns
+// a function that restores the original.
+func overrideUninstallCmd(fn func(string, ...string) *exec.Cmd) func() {
+	orig := uninstallCmd
+	uninstallCmd = fn
+	return func() { uninstallCmd = orig }
+}
+
+// overrideUninstallHasRoot swaps the package-level uninstallHasRoot for tests and
+// returns a function that restores the original.
+func overrideUninstallHasRoot(fn func() (bool, error)) func() {
+	orig := uninstallHasRoot
+	uninstallHasRoot = fn
+	return func() { uninstallHasRoot = orig }
+}
+
+// noopUninstallCmd returns a harmless, fast-exiting command used in tests to
+// stand in for the real detached uninstaller: it re-invokes the test binary with
+// a run filter that matches no tests, so Start() succeeds on any OS without side
+// effects.
+func noopUninstallCmd() *exec.Cmd {
+	// #nosec G204 G702 -- test-only; arguments are constant and reference the test binary.
+	return exec.CommandContext(context.Background(), os.Args[0], "-test.run", "^$")
 }

--- a/internal/pkg/agent/application/managed_mode.go
+++ b/internal/pkg/agent/application/managed_mode.go
@@ -508,6 +508,11 @@ func (m *managedConfigManager) initDispatcher(canceller context.CancelFunc) *han
 	)
 
 	m.dispatcher.MustRegister(
+		&fleetapi.ActionUninstall{},
+		handlers.NewUninstall(m.log, m.coord),
+	)
+
+	m.dispatcher.MustRegister(
 		&fleetapi.ActionUnknown{},
 		handlers.NewUnknown(m.log),
 	)

--- a/internal/pkg/agent/cmd/install.go
+++ b/internal/pkg/agent/cmd/install.go
@@ -263,7 +263,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 				return err
 			}
 		} else {
-			err := install.Uninstall(cmd.Context(), cfgFile, topPath, "", log, progBar, false)
+			err := install.Uninstall(cmd.Context(), cfgFile, topPath, "", log, progBar, false, "")
 			if err != nil {
 				progBar.Describe("Uninstall from binary failed")
 				return err
@@ -289,7 +289,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		defer func() {
 			if err != nil {
 				progBar.Describe("Uninstalling")
-				innerErr := install.Uninstall(cmd.Context(), cfgFile, topPath, "", log, progBar, false)
+				innerErr := install.Uninstall(cmd.Context(), cfgFile, topPath, "", log, progBar, false, "")
 				if innerErr != nil {
 					progBar.Describe("Failed to Uninstall")
 				} else {

--- a/internal/pkg/agent/cmd/uninstall.go
+++ b/internal/pkg/agent/cmd/uninstall.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent/internal/pkg/agent/application/coordinator"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/application/paths"
 	"github.com/elastic/elastic-agent/internal/pkg/agent/install"
 	"github.com/elastic/elastic-agent/internal/pkg/cli"
@@ -39,6 +40,12 @@ Unless -f is used this command will ask confirmation before performing removal.
 	cmd.Flags().String("uninstall-token", "", "Uninstall token required for protected agent uninstall")
 	cmd.Flags().Bool("skip-fleet-audit", false, "Skip fleet audit/unenroll")
 
+	// Hidden: set by the agent when an uninstall is triggered by a Fleet
+	// UNINSTALL action. The action is acknowledged to Fleet at the point of no
+	// return by this (detached) uninstall process.
+	cmd.Flags().String(coordinator.UninstallFleetAckActionIDFlag, "", "Fleet UNINSTALL action ID to acknowledge after uninstalling")
+	_ = cmd.Flags().MarkHidden(coordinator.UninstallFleetAckActionIDFlag)
+
 	return cmd
 }
 
@@ -63,6 +70,7 @@ func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 	force, _ := cmd.Flags().GetBool("force")
 	uninstallToken, _ := cmd.Flags().GetString("uninstall-token")
 	skipFleetAudit, _ := cmd.Flags().GetBool("skip-fleet-audit")
+	fleetAckActionID, _ := cmd.Flags().GetString(coordinator.UninstallFleetAckActionIDFlag)
 	if status == install.Broken {
 		if !force {
 			fmt.Fprintf(streams.Out, "%s is installed but currently broken: %s\n", paths.ServiceDisplayName(), reason)
@@ -97,7 +105,7 @@ func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		fmt.Fprint(os.Stderr, logBuff.String())
 	}()
 
-	err = install.Uninstall(cmd.Context(), paths.ConfigFile(), paths.Top(), uninstallToken, log, progBar, skipFleetAudit)
+	err = install.Uninstall(cmd.Context(), paths.ConfigFile(), paths.Top(), uninstallToken, log, progBar, skipFleetAudit, fleetAckActionID)
 	if err != nil {
 		progBar.Describe("Failed to uninstall agent")
 		return fmt.Errorf("error uninstalling agent: %w", err)

--- a/internal/pkg/agent/install/uninstall.go
+++ b/internal/pkg/agent/install/uninstall.go
@@ -30,6 +30,7 @@ import (
 	"github.com/elastic/elastic-agent/internal/pkg/config"
 	"github.com/elastic/elastic-agent/internal/pkg/config/operations"
 	"github.com/elastic/elastic-agent/internal/pkg/fleetapi"
+	fleetacker "github.com/elastic/elastic-agent/internal/pkg/fleetapi/acker/fleet"
 	fleetclient "github.com/elastic/elastic-agent/internal/pkg/fleetapi/client"
 	"github.com/elastic/elastic-agent/pkg/backoff"
 	"github.com/elastic/elastic-agent/pkg/component"
@@ -55,7 +56,15 @@ func (a *agentInfo) AgentID() string {
 }
 
 // Uninstall uninstalls persistently Elastic Agent on the system.
-func Uninstall(ctx context.Context, cfgFile, topPath, uninstallToken string, log *logp.Logger, pt ProgressDescriber, skipFleetAudit bool) error {
+//
+// fleetAckActionID, when non-empty, is the ID of a Fleet UNINSTALL action that
+// triggered this uninstall. It is acknowledged to Fleet at the point of no
+// return (after the agent is effectively uninstalled but before its credentials
+// are removed, and before the audit/unenroll notification which can invalidate
+// the API key). If the uninstall fails before that point the action is
+// acknowledged with the error set, so Fleet learns the uninstall did not
+// complete and the agent remains installed.
+func Uninstall(ctx context.Context, cfgFile, topPath, uninstallToken string, log *logp.Logger, pt ProgressDescriber, skipFleetAudit bool, fleetAckActionID string) (err error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("unable to get current working directory")
@@ -97,6 +106,23 @@ func Uninstall(ctx context.Context, cfgFile, topPath, uninstallToken string, log
 			}
 		}
 	}()
+
+	// ackSuccessSent guards against the deferred failure-ack double-acking after
+	// the success ack sent at the point of no return.
+	ackSuccessSent := false
+	if fleetAckActionID != "" {
+		defer func() {
+			if err == nil || ackSuccessSent || !notifyFleet || cfg == nil {
+				return
+			}
+			// The uninstall failed before the point of no return; the agent is
+			// still installed and enrolled. Acknowledge the failure so Fleet does
+			// not consider the action completed.
+			if ackErr := ackFleetUninstallAction(ctx, log, pt, cfg, &agentID, fleetAckActionID, err); ackErr != nil {
+				pt.Describe(fmt.Sprintf("failed to ack uninstall action failure to Fleet: %v", ackErr))
+			}
+		}()
+	}
 
 	// Notify fleet-server while it is still running if it's running locally
 	if notifyFleet && localFleet {
@@ -162,6 +188,20 @@ func Uninstall(ctx context.Context, cfgFile, topPath, uninstallToken string, log
 		}
 	}
 
+	// Point of no return: the service and components have been removed, so the
+	// agent is effectively uninstalled. Acknowledge the Fleet UNINSTALL action
+	// (if any) now, before the audit/unenroll notification below (which can
+	// invalidate the API key) and before the install directory (holding the
+	// credentials) is removed. The uninstall proceeds regardless of the ack
+	// outcome; a failed ack here is best-effort and complemented by the
+	// audit/unenroll notification.
+	if fleetAckActionID != "" && notifyFleet && cfg != nil {
+		if ackErr := ackFleetUninstallAction(ctx, log, pt, cfg, &agentID, fleetAckActionID, nil); ackErr != nil {
+			pt.Describe(fmt.Sprintf("failed to ack uninstall action to Fleet: %v", ackErr))
+		}
+		ackSuccessSent = true
+	}
+
 	// Notify Fleet of the uninstall before removing the top path, at this point the service is stopped and won't run anymore.
 	// Doing this after RemovePath has been linked to some difficult to diagnose runtime panics on Windows, where the implementation
 	// of RemovePath is more complex. See https://github.com/elastic/elastic-agent/issues/14142 and https://github.com/elastic/elastic-agent/issues/8428.
@@ -187,6 +227,48 @@ func notifyFleetIfNeeded(ctx context.Context, log *logp.Logger, pt ProgressDescr
 	if notifyFleet && !localFleet && !skipFleetAudit {
 		notifyFleetAuditUninstall(ctx, log, pt, cfg, &agentID) //nolint:errcheck // ignore the error as we can't act on it)
 	}
+}
+
+// ackFleetUninstallAction acknowledges a Fleet UNINSTALL action to Fleet Server.
+// When ackErr is non-nil the action is acknowledged as failed. It is
+// best-effort with a few retries; callers proceed regardless of the outcome.
+func ackFleetUninstallAction(ctx context.Context, log *logp.Logger, pt ProgressDescriber, cfg *configuration.Configuration, ai pkgfleetapi.AgentInfo, actionID string, ackErr error) error {
+	if cfg == nil || cfg.Fleet == nil {
+		return fmt.Errorf("no fleet configuration available to ack uninstall action")
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	pt.Describe("Acknowledging uninstall action to Fleet")
+
+	client, err := fleetclient.NewAuthWithConfig(log, cfg.Fleet.AccessAPIKey, cfg.Fleet.Client)
+	if err != nil {
+		return fmt.Errorf("unable to create fleetapi client: %w", err)
+	}
+	fleetAcker, err := fleetacker.NewAcker(log, ai, client)
+	if err != nil {
+		return fmt.Errorf("unable to create fleet acker: %w", err)
+	}
+
+	action := &pkgfleetapi.ActionUninstall{
+		ActionID:   actionID,
+		ActionType: pkgfleetapi.ActionTypeUninstall,
+		Err:        ackErr,
+	}
+
+	jitterBackoff := backoffWithContext(ctx)
+	var lastErr error
+	for i := 0; i < fleetAuditAttempts; i++ {
+		lastErr = fleetAcker.Ack(ctx, action)
+		if lastErr == nil {
+			pt.Describe("Acknowledged uninstall action to Fleet")
+			return nil
+		}
+		pt.Describe(fmt.Sprintf("ack uninstall action: %v (retry in %v)", lastErr, jitterBackoff.NextWait()))
+		if !jitterBackoff.Wait() {
+			break
+		}
+	}
+	return lastErr
 }
 
 type NotifyFleetAuditUninstall func(ctx context.Context, log *logp.Logger, pt ProgressDescriber, cfg *configuration.Configuration, ai pkgfleetapi.AgentInfo) error

--- a/pkg/fleetapi/action.go
+++ b/pkg/fleetapi/action.go
@@ -34,6 +34,11 @@ const (
 	// once it is added upstream.
 	// TODO: Replace with the real reference once Fleet supports the action.
 	ActionTypeRestart = "RESTART"
+	// ActionTypeUninstall is defined locally because the Fleet Server API spec
+	// does not yet expose an UNINSTALL action type. Switch to
+	// string(api.UNINSTALL) once it is added upstream.
+	// TODO: Replace with the real reference once Fleet supports the action.
+	ActionTypeUninstall = "UNINSTALL"
 )
 
 // Error values that the Action interface can return
@@ -124,6 +129,8 @@ func NewAction(actionType string) Action {
 		action = &ActionPrivilegeLevelChange{}
 	case ActionTypeRestart:
 		action = &ActionRestart{}
+	case ActionTypeUninstall:
+		action = &ActionUninstall{}
 	default:
 		action = &ActionUnknown{OriginalType: actionType}
 	}
@@ -482,6 +489,82 @@ func (a *ActionRestart) AckEvent(agentID string, ts time.Time) api.AckRequest_Ev
 
 // MarshalMap marshals ActionRestart into a corresponding map.
 func (a *ActionRestart) MarshalMap() (map[string]interface{}, error) {
+	var res map[string]interface{}
+	err := mapstructure.Decode(a, &res)
+	return res, err
+}
+
+// ActionUninstall is a request for the agent to uninstall itself.
+// Unlike an upgrade or restart, the agent cannot acknowledge the action on the
+// next startup because there is none: the uninstall is terminal. Instead the
+// action is acknowledged by the detached uninstaller process at the point of no
+// return (after the agent is effectively uninstalled but before its credentials
+// are removed), and failures before that point are acknowledged with the error
+// set so Fleet learns the uninstall did not complete.
+type ActionUninstall struct {
+	ActionID         string  `json:"id" yaml:"id" mapstructure:"id"`
+	ActionType       string  `json:"type" yaml:"type" mapstructure:"type"`
+	ActionStartTime  string  `json:"start_time,omitempty" yaml:"start_time,omitempty" mapstructure:"-"`
+	ActionExpiration string  `json:"expiration,omitempty" yaml:"expiration,omitempty" mapstructure:"-"`
+	Signed           *Signed `json:"signed,omitempty" yaml:"signed,omitempty" mapstructure:"signed,omitempty"`
+
+	Err error `json:"-" yaml:"-" mapstructure:"-"`
+}
+
+func (a *ActionUninstall) String() string {
+	var s strings.Builder
+	s.WriteString("id: ")
+	s.WriteString(a.ActionID)
+	s.WriteString(", type: ")
+	s.WriteString(a.ActionType)
+	return s.String()
+}
+
+// Type returns the type of the Action.
+func (a *ActionUninstall) Type() string {
+	return a.ActionType
+}
+
+// ID returns the ID of the Action.
+func (a *ActionUninstall) ID() string {
+	return a.ActionID
+}
+
+// StartTime returns the start_time as a UTC time.Time or ErrNoStartTime if there is no start time.
+func (a *ActionUninstall) StartTime() (time.Time, error) {
+	if a.ActionStartTime == "" {
+		return time.Time{}, ErrNoStartTime
+	}
+	ts, err := time.Parse(time.RFC3339, a.ActionStartTime)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return ts.UTC(), nil
+}
+
+// Expiration returns the expiration as a UTC time.Time or ErrNoExpiration if there is no expiration.
+func (a *ActionUninstall) Expiration() (time.Time, error) {
+	if a.ActionExpiration == "" {
+		return time.Time{}, ErrNoExpiration
+	}
+	ts, err := time.Parse(time.RFC3339, a.ActionExpiration)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return ts.UTC(), nil
+}
+
+func (a *ActionUninstall) AckEvent(agentID string, ts time.Time) api.AckRequest_Events_Item {
+	event := newGenericEvent(a.ActionID, a.ActionType, agentID, ts)
+	if a.Err != nil {
+		errStr := a.Err.Error()
+		event.Error = &errStr
+	}
+	return toGenericAckEvent(event)
+}
+
+// MarshalMap marshals ActionUninstall into a corresponding map.
+func (a *ActionUninstall) MarshalMap() (map[string]interface{}, error) {
 	var res map[string]interface{}
 	err := mapstructure.Decode(a, &res)
 	return res, err

--- a/pkg/fleetapi/action_test.go
+++ b/pkg/fleetapi/action_test.go
@@ -246,6 +246,75 @@ func TestActionRestartMarshalMap(t *testing.T) {
 	}
 }
 
+func TestActionUninstallUnmarshalJSON(t *testing.T) {
+	t.Run("UNINSTALL maps to ActionUninstall", func(t *testing.T) {
+		p := []byte(`[{"id":"testid","type":"UNINSTALL","start_time":"2022-01-02T12:00:00Z","expiration":"2022-01-02T13:00:00Z"}]`)
+		a := &Actions{}
+		require.NoError(t, a.UnmarshalJSON(p))
+
+		action, ok := (*a)[0].(*ActionUninstall)
+		require.True(t, ok, "unable to cast action to ActionUninstall")
+		assert.Equal(t, "testid", action.ActionID)
+		assert.Equal(t, ActionTypeUninstall, action.ActionType)
+		assert.Equal(t, "2022-01-02T12:00:00Z", action.ActionStartTime)
+		assert.Equal(t, "2022-01-02T13:00:00Z", action.ActionExpiration)
+
+		st, err := action.StartTime()
+		require.NoError(t, err)
+		assert.Equal(t, "2022-01-02T12:00:00Z", st.Format(time.RFC3339))
+
+		exp, err := action.Expiration()
+		require.NoError(t, err)
+		assert.Equal(t, "2022-01-02T13:00:00Z", exp.Format(time.RFC3339))
+	})
+
+	t.Run("UNINSTALL without start time or expiration", func(t *testing.T) {
+		p := []byte(`[{"id":"testid","type":"UNINSTALL"}]`)
+		a := &Actions{}
+		require.NoError(t, a.UnmarshalJSON(p))
+
+		action, ok := (*a)[0].(*ActionUninstall)
+		require.True(t, ok, "unable to cast action to ActionUninstall")
+
+		_, err := action.StartTime()
+		assert.ErrorIs(t, err, ErrNoStartTime)
+		_, err = action.Expiration()
+		assert.ErrorIs(t, err, ErrNoExpiration)
+	})
+}
+
+func TestNewActionUninstall(t *testing.T) {
+	a := NewAction(ActionTypeUninstall)
+	_, ok := a.(*ActionUninstall)
+	assert.True(t, ok, "NewAction(UNINSTALL) should return *ActionUninstall")
+}
+
+func TestActionUninstallMarshalMap(t *testing.T) {
+	action := ActionUninstall{
+		ActionID:   "164a6819-5c58-40f7-a33c-821c98ab0a8c",
+		ActionType: "UNINSTALL",
+		Signed: &Signed{
+			Data:      "eyJAdGltZXN0YW1wIjoiMjAy",
+			Signature: "MEQCIGxsrI742xKL6OSI",
+		},
+	}
+
+	m, err := action.MarshalMap()
+	require.NoError(t, err)
+
+	diff := cmp.Diff(map[string]interface{}{
+		"id":   "164a6819-5c58-40f7-a33c-821c98ab0a8c",
+		"type": "UNINSTALL",
+		"signed": map[string]interface{}{
+			"data":      "eyJAdGltZXN0YW1wIjoiMjAy",
+			"signature": "MEQCIGxsrI742xKL6OSI",
+		},
+	}, m)
+	if diff != "" {
+		t.Fatal(diff)
+	}
+}
+
 func TestActionUnenrollMarshalMap(t *testing.T) {
 	action := ActionUnenroll{
 		ActionID:   "164a6819-5c58-40f7-a33c-821c98ab0a8c",

--- a/testing/integration/ess/uninstall_action_test.go
+++ b/testing/integration/ess/uninstall_action_test.go
@@ -1,0 +1,146 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build integration
+
+package ess
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent/pkg/fleetapi"
+	integrationtest "github.com/elastic/elastic-agent/pkg/testing"
+	"github.com/elastic/elastic-agent/pkg/testing/define"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/check"
+	"github.com/elastic/elastic-agent/pkg/testing/tools/testcontext"
+	"github.com/elastic/elastic-agent/testing/fleetservertest"
+	"github.com/elastic/elastic-agent/testing/integration"
+)
+
+// TestFleetUninstallAction validates the end-to-end UNINSTALL action flow against
+// a Fleet Server: the agent receives an UNINSTALL action on checkin, spawns a
+// detached uninstaller, and the action is acknowledged to Fleet by that
+// uninstaller at the point of no return (after the agent is effectively
+// uninstalled but before its credentials are removed).
+func TestFleetUninstallAction(t *testing.T) {
+	_ = define.Require(t, define.Requirements{
+		Group: integration.Fleet,
+		Stack: &define.Stack{},
+		Local: false, // requires Agent installation
+		Sudo:  true,  // requires Agent installation
+	})
+
+	ctx, cancel := testcontext.WithTimeout(t, t.Context(), time.Minute*10)
+	defer cancel()
+
+	apiKey, policy := createBasicFleetPolicyData(t, "http://fleet-server:8221")
+	checkinWithAcker := fleetservertest.NewCheckinActionsWithAcker()
+	nextActionGenerator := checkinWithAcker.ActionsGenerator()
+
+	handlers := &fleetservertest.Handlers{
+		APIKey:          apiKey.Key,
+		EnrollmentToken: "enrollmentToken",
+		AgentID:         policy.AgentID, // as there is no enroll, the agentID needs to be manually set
+		CheckinFn: func(ctx context.Context, h *fleetservertest.Handlers, id string, userAgent string,
+			acceptEncoding string, checkinRequest fleetservertest.CheckinRequest,
+		) (*fleetservertest.CheckinResponse, *fleetservertest.HTTPError) {
+			if id != policy.AgentID {
+				return nil, &fleetservertest.HTTPError{
+					StatusCode: http.StatusNotFound,
+					Message:    fmt.Sprintf("agent %q not found", id),
+				}
+			}
+
+			data, hErr := nextActionGenerator()
+			if hErr != nil {
+				return nil, hErr
+			}
+
+			respStr := fleetservertest.NewCheckinResponse(data.AckToken, data.Actions...)
+			resp := fleetservertest.CheckinResponse{}
+			if err := json.Unmarshal([]byte(respStr), &resp); err != nil {
+				return nil, &fleetservertest.HTTPError{
+					StatusCode: http.StatusInternalServerError,
+					Message:    fmt.Sprintf("failed to CheckinResponse: %v", err),
+				}
+			}
+
+			// simulate long poll
+			time.Sleep(data.Delay)
+
+			return &resp, nil
+		},
+		EnrollFn: fleetservertest.NewHandlerEnroll(policy.AgentID, policy.PolicyID, apiKey),
+		AckFn:    fleetservertest.NewHandlerAckWithAcker(checkinWithAcker.Acker()),
+		StatusFn: fleetservertest.NewHandlerStatusHealthy(),
+	}
+
+	fleetServer := fleetservertest.NewServer(handlers, fleetservertest.WithRequestLog(t.Logf))
+	defer fleetServer.Close()
+
+	fixture, err := define.NewFixtureFromLocalBuild(t,
+		define.Version(),
+		integrationtest.WithAllowErrors(),
+		integrationtest.WithLogOutput())
+	require.NoError(t, err, "SetupTest: NewFixtureFromLocalBuild failed")
+	err = fixture.EnsurePrepared(ctx)
+	require.NoError(t, err, "SetupTest: fixture.Prepare failed")
+
+	out, err := fixture.Install(
+		ctx,
+		&integrationtest.InstallOpts{
+			Force:          true,
+			NonInteractive: true,
+			Insecure:       true,
+			// The UNINSTALL action requires root/administrator privileges (an
+			// unprivileged agent's service runs as a non-root user and cannot
+			// remove its own service), so install privileged here.
+			Privileged: true,
+			EnrollOpts: integrationtest.EnrollOpts{
+				URL:             fleetServer.LocalhostURL,
+				EnrollmentToken: "anythingWillDO",
+			}})
+	require.NoErrorf(t, err, "Error when installing agent, output: %s", out)
+
+	// Wait for the agent to connect to Fleet and report HEALTHY.
+	check.ConnectedToFleet(ctx, t, fixture, 5*time.Minute)
+
+	// Deliver an UNINSTALL action on the next checkin.
+	uninstallActionID := "uninstall-action-id"
+	uninstallAction, err := fleetservertest.NewAction(fleetservertest.ActionTmpl{
+		AgentID:  policy.AgentID,
+		ActionID: uninstallActionID,
+		Type:     fleetapi.ActionTypeUninstall,
+		Data:     "{}",
+	})
+	require.NoError(t, err, "failed to create uninstall action")
+	checkinWithAcker.AddCheckin("token", 1*time.Second, uninstallAction)
+
+	// The UNINSTALL action is acknowledged by the detached uninstaller at the
+	// point of no return: after the agent's service and components have been
+	// removed, but before its credentials are removed. Because the uninstall is
+	// terminal, a received ack proves the full spawn -> uninstall -> point-of-
+	// no-return-ack flow worked end-to-end with Fleet Server.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.True(collect, checkinWithAcker.Acked(uninstallActionID),
+			"uninstall action has not been acknowledged to Fleet")
+	}, 5*time.Minute, 500*time.Millisecond, "agent did not acknowledge the uninstall action")
+
+	// After acking, the uninstall completes and removes the install directory.
+	// The agent must no longer be installed; a status check should fail once the
+	// control socket is gone. This confirms the agent actually uninstalled itself
+	// rather than merely acking.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		_, statusErr := fixture.ExecStatus(ctx)
+		assert.Error(collect, statusErr, "agent still responds to status; expected it to be uninstalled")
+	}, 5*time.Minute, 1*time.Second, "agent was not uninstalled after acknowledging the action")
+}


### PR DESCRIPTION
## What does this PR do?

Add a new `UNINSTALL` Fleet action that uninstalls the agent and acknowledges the action to Fleet at the point of no return.

- Define `ActionUninstall` (`fleetapi`) with the same signing/tamper protection as `UNENROLL`.
- Add an uninstall handler that checks expiry, proxies to Endpoint under tamper protection, and calls `Coordinator.Uninstall`; it acks a failure (leaving the agent installed) only when the uninstaller cannot start.
- Gate `Coordinator.Uninstall` on being installed and not containerized (`ErrNotUninstallable` / `ErrContainerNotSupported`) and spawn a detached out-of-tree uninstaller that outlives the agent.
- In `install.Uninstall`, ack the action at the point of no return (after the service/components are removed, before the audit/unenroll notification and credential removal) and ack a failure for errors before that point.
- Add unit tests, an integration test against a mock Fleet Server, and a changelog fragment.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

<details>
<summary>Click for more details</summary>

## UNINSTALL action — implementation details

### Flow

```mermaid                                                                                                                             
sequenceDiagram                                                    
    participant Fleet                                              
    participant Gateway as FleetGateway
    participant Disp as Dispatcher                                                                                                     
    participant H as UninstallHandler                                                                                                  
    participant Coord as Coordinator                                                                                                   
    participant U as DetachedUninstaller       
    Fleet->>Gateway: UNINSTALL action (checkin)                                                                                        
    Gateway->>Disp: Actions()                                                                                                          
    Disp->>H: Handle(action)                                                                                                           
    H->>H: expired or invalid expiration? ack error and stop                                                                           
    H->>H: tamper protection? proxy signed action to Endpoint 
    H->>Coord: Uninstall(action)                                                                                                       
    Coord->>Coord: gate installed and not container, else ack failure          
    Coord->>U: spawn detached uninstall process with action id
    Note over H,Coord: handler returns, success path not acked here
    U->>U: stop service, uninstall components and service          
    Note over U: point of no return reached
    U->>Fleet: Ack action, before audit/unenroll                                                                                       
    U->>Fleet: audit/unenroll with reason uninstall                                                                                    
    U->>U: remove install directory holding credentials                                                                                
    Note over U,Fleet: on early failure, agent still alive     
    U->>Fleet: Ack action with error, agent stays installed                                                                            
```

### Design decisions

- **Action string**: the action type is the literal `"UNINSTALL"`.
- **Local definition**: `ActionUninstall` is defined locally in `pkg/fleetapi`
  because the Fleet Server API spec does not yet include it. Keeping Fleet
  Server / Kibana in sync is a follow-up, cross-repo task.
- **Signing / tamper protection**: `ActionUninstall` carries a `Signed` field
  and, under tamper protection, is proxied to Endpoint units so Endpoint can
  uncontain itself before removal — mirroring the `UNENROLL` handler.
- **Terminal action, no startup ack**: unlike `RESTART`, the agent does not
  come back, so the persist-then-ack-on-startup pattern does not apply. The ack
  is instead sent by the detached uninstaller.
- **Detached uninstaller**: the uninstall stops (and removes) the agent service,
  which would kill an in-process attempt mid-operation. `Coordinator.Uninstall`
  therefore spawns a detached process in its own session/process group (reusing
  the same primitive as the upgrade watcher) that outlives the agent. It runs
  from outside the install directory (required on Windows).
- **Ack at the point of no return**: `install.Uninstall` acks the action only
  after the service and components are removed — the uninstall is effectively
  committed — but before the install directory (holding the credentials) is
  removed. The ack is sent **before** the audit/unenroll notification, which can
  invalidate the API key the ack also needs.
- **Failure handling**: pre-flight/spawn failures in the handler ack a failure
  (`action.Err` set) and leave the agent installed. Failures inside the
  uninstaller before the point of no return are acked as failures via a deferred
  best-effort ack, so Fleet does not consider the action completed.
- **Expiry**: if the action is expired or carries a malformed expiration when
  received, the handler acks an error and does not uninstall.
- **Containerized / non-installed environments**: `Coordinator.Uninstall`
  returns `ErrContainerNotSupported` in containers and `ErrNotUninstallable`
  when the agent is not installed via the `install` sub-command.

### Testing

- **Unit**: action (un)marshalling and `NewAction` wiring, handler behavior
  (wrong type, happy path with no ack, expiry, invalid expiration, spawn-failure
  ack, tamper proxy), and coordinator gating (container, not-installed,
  installed spawn + `Stopping` override state).
- **Integration**: `testing/integration/ess/uninstall_action_test.go` enrolls a
  real agent against the mock Fleet Server (`fleetservertest`), delivers an
  `UNINSTALL` action, asserts the action is acknowledged (proving the
  spawn → uninstall → point-of-no-return-ack flow), and that the agent is
  actually uninstalled afterwards (status no longer responds).
- The mock Fleet Server is used because Kibana / Fleet Server do not yet
  recognize the `UNINSTALL` action type, so a real-Fleet test would be rejected
  at the Kibana layer rather than exercising the agent.

### Open considerations

- **Tamper protection / uninstall-token**: the detached uninstaller runs without
  `--uninstall-token`; it relies on the signed action proxied to Endpoint (as
  `UNENROLL` does). Whether Endpoint permits uninstall of a protected agent from
  the signed action alone is Endpoint-side behavior to confirm.
- **Local fleet-server agents**: `install.Uninstall` sends its audit/unenroll
  early when the agent runs fleet-server locally, so the "ack before
  audit/unenroll" ordering does not hold for that (unusual) case.

</details>

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This feature was requested by our users on multiple occasions.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [x] I have added an integration test or an E2E test

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

There is an integration test. Since Fleet UI does not implement the new action yet, it's not possible to test manually end to end.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates to https://github.com/elastic/elastic-agent/issues/3367

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->
