### PR TITLE
[docs] Add known issue for elastic/fleet-server#7739

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -23,11 +23,11 @@ Known issues are significant defects or limitations that may impact your impleme
 % Workaround description.
 % :::
 
-::::{dropdown} Elastic Agent crash-loop when a remote Elasticsearch monitoring output is configured.
+:::{dropdown} Elastic Agent crash-loop when a remote Elasticsearch monitoring output is configured.
 
 **Applies to: {{agent}} 9.4.6, 9.5.3**
 
-On August 28, 2026, a known issue was discoverd where {{agent}} can enter a crash-restart loop immediately after startup
+On August 28, 2026, a known issue was discovered where {{agent}} can enter a crash-restart loop immediately after startup
 or after a policy update when the agent policy is configured to use a remote {{es}} output for agent monitoring.
 The {{agent}} crashes with
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -23,6 +23,30 @@ Known issues are significant defects or limitations that may impact your impleme
 % Workaround description.
 % :::
 
+::::{dropdown} Elastic Agent crash-loop when a remote Elasticsearch monitoring output is configured.
+
+**Applies to: {{agent}} 9.4.6, 9.5.3**
+
+On August 28, 2026, a known issue was discoverd where {{agent}} can enter a crash-restart loop immediately after startup
+or after a policy update when the agent policy is configured to use a remote {{es}} output for agent monitoring.
+The {{agent}} crashes with
+
+```shell
+panic: runtime error: index out of range [-1] in diagnostics.addSecretMarkers and exits with status INVALIDARGUMENT
+```
+making {{agent}} unreachable. A fix will be included in {{agent}} 9.4.7 and 9.5.4.
+
+**Workaround**
+
+In {{fleet}}, navigate to the affected agent policy and change the Output for agent monitoring from the remote {{es}}
+output to the local (default) {{es}} output. This prevents the corrupted policy from being generated.
+
+For agents already stuck in a crash loop, stop the agent service and delete `state.enc` from the {{agent}} `data` directory,
+then restart. Restarting clears the corrupted state without requiring re-enrollment.
+
+For more information, check [Issue #7739](https://github.com/elastic/fleet-server/issues/7739).
+::::
+
 ::::{dropdown} Kafka Kerberos authentication is dropped when using the OTel runtime
 
 **Applies to: {{agent}} 9.4.0 to 9.4.5, 9.5.0 to 9.5.1**

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -29,7 +29,7 @@ Known issues are significant defects or limitations that may impact your impleme
 
 On August 28, 2026, a known issue was discovered where {{agent}} can enter a crash-restart loop immediately after startup
 or after a policy update when the agent policy is configured to use a remote {{es}} output .
-The {{agent}} crashes with
+The {{agent}} crashes with:
 
 ```shell
 panic: runtime error: index out of range [-1] in diagnostics.addSecretMarkers and exits with status INVALIDARGUMENT

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -28,7 +28,7 @@ Known issues are significant defects or limitations that may impact your impleme
 **Applies to: {{agent}} 9.4.6, 9.5.3**
 
 On August 28, 2026, a known issue was discovered where {{agent}} can enter a crash-restart loop immediately after startup
-or after a policy update when the agent policy is configured to use a remote {{es}} output for agent monitoring.
+or after a policy update when the agent policy is configured to use a remote {{es}} output .
 The {{agent}} crashes with
 
 ```shell

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -45,7 +45,7 @@ For agents already stuck in a crash loop, stop the agent service and delete `sta
 then restart. Restarting clears the corrupted state without requiring re-enrollment.
 
 For more information, check [Issue #7739](https://github.com/elastic/fleet-server/issues/7739).
-::::
+:::
 
 ::::{dropdown} Kafka Kerberos authentication is dropped when using the OTel runtime
 


### PR DESCRIPTION
Add a known issue entry for elastic/fleet-server#7739 which causes agent to enter a crash-loop when a remote Elasticsearch monitoring output is configured.