### PR TITLE
Register synthetics/api input for the beat-receiver (Heartbeat) component

### DIFF
--- a/changelog/fragments/1789031742-register-synthetics-api-input.yaml
+++ b/changelog/fragments/1789031742-register-synthetics-api-input.yaml
@@ -9,7 +9,7 @@
 # - security: impacts on the security of a product or a user’s deployment.
 # - upgrade: important information for someone upgrading from a prior version
 # - other: does not fit into any of the other categories
-kind: bug-fix
+kind: feature
 
 # REQUIRED for all kinds
 # Change summary; a 80ish characters long description of the change.

--- a/changelog/fragments/1789031742-register-synthetics-api-input.yaml
+++ b/changelog/fragments/1789031742-register-synthetics-api-input.yaml
@@ -1,0 +1,53 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Register the `synthetics/api` input so API Journey monitors can run
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: >
+  Heartbeat gained an `api` monitor type (elastic/beats#50802) for Synthetics
+  API Journeys, exposed to Fleet policies as the `synthetics/api` input. The
+  Elastic Distribution for OpenTelemetry Collector's component spec only
+  listed `synthetics/browser`, `synthetics/http`, `synthetics/icmp`, and
+  `synthetics/tcp`, so agents rejected `synthetics/api` with "input not
+  supported - ensure you have installed the correct flavor" and API Journey
+  monitors on private locations never ran. This adds `synthetics/api` to the
+  spec alongside the other Heartbeat-backed inputs.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/edot/spec.yml
+++ b/internal/edot/spec.yml
@@ -315,6 +315,11 @@ inputs:
     platforms: *platforms
     outputs: *outputs
     command: *heartbeat_command
+  - name: synthetics/api
+    description: "Synthetics API Monitor"
+    platforms: *platforms
+    outputs: *outputs
+    command: *heartbeat_command
   - name: beat/metrics
     description: "Beat metrics"
     platforms: *platforms

--- a/internal/edot/spec_test.go
+++ b/internal/edot/spec_test.go
@@ -1,0 +1,33 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSpecIncludesSyntheticsAPIInput(t *testing.T) {
+	specData, err := os.ReadFile("spec.yml")
+	require.NoError(t, err)
+
+	var spec struct {
+		Inputs []struct {
+			Name string `yaml:"name"`
+		} `yaml:"inputs"`
+	}
+	require.NoError(t, yaml.Unmarshal(specData, &spec))
+
+	for _, input := range spec.Inputs {
+		if input.Name == "synthetics/api" {
+			return
+		}
+	}
+
+	t.Fatal("spec.yml must register the synthetics/api input")
+}

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -2984,6 +2984,33 @@ func TestGetReceiversConfigForComponentBrowserMonitor(t *testing.T) {
 	assert.Equal(t, "browser", monitors[0]["type"], "the emitted monitor must be the browser stream")
 }
 
+func TestGetInputsForUnitSyntheticsAPI(t *testing.T) {
+	unit := component.Unit{
+		ID:   "heartbeat-api-test-unit",
+		Type: client.UnitTypeInput,
+		Config: component.MustExpectedConfig(map[string]any{
+			"id":         "test",
+			"use_output": "default",
+			"type":       "synthetics/api",
+			"streams": []any{
+				map[string]any{
+					"id": "test-1",
+					"data_stream": map[string]any{
+						"dataset": "generic-1",
+					},
+					"schedule": "@every 5s",
+				},
+			},
+		}),
+	}
+	comp := &component.Component{InputType: "synthetics/api"}
+
+	inputs, err := getInputsForUnit(unit, &info.AgentInfo{}, "logs", comp)
+	require.NoError(t, err)
+	require.Len(t, inputs, 1)
+	assert.Equal(t, "api", inputs[0].config["type"])
+}
+
 // TestKeepScheduledMonitors verifies the schedule-based filtering used to drop
 // auxiliary Synthetics browser sub-streams, including the malformed-config fallback.
 func TestKeepScheduledMonitors(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Adds a `synthetics/api` entry to the Elastic Distribution for OpenTelemetry Collector's component spec (`internal/edot/spec.yml`), alongside the existing `synthetics/browser`, `synthetics/http`, `synthetics/icmp`, and `synthetics/tcp` entries, so it routes to the same Heartbeat `beat-receiver` command.

## Why is it important?

Heartbeat added an `api` monitor type for Synthetics API Journeys in elastic/beats#50802 (merged), exposed to Fleet policies as the `synthetics/api` input. Elastic Agent's input router only recognizes input types that are registered in this spec file, so it rejected `synthetics/api` with:

```
input not supported - ensure you have installed the correct flavor: https://www.elastic.co/docs/reference/fleet/install-elastic-agents#elastic-agent-installation-flavors
```

This left API Journey monitors on private locations unable to run at all (confirmed while testing elastic/kibana#270874, which adds API Journey monitor support in Kibana/Fleet).

The generic `synthetics/<type>` → Heartbeat `type: <type>` translation in `internal/pkg/otel/translate/otelconfig.go` already handles any suffix generically, so registering the input type here is the only change needed to unblock it.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~ (single declarative spec entry, no logic)
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~ (no existing test loads `internal/edot/spec.yml`'s real content against real names; the generic prefix-based translation is already covered by existing `synthetics/http` / `synthetics/browser` test cases)
- [x] I have added an entry in `./changelog/fragments` using the changelog tool
- ~~I have added an integration test or an E2E test~~

## Disruptive User Impact

None. Purely additive: registers a new input type that previously had no matching component and therefore could never run.

## How to test this PR locally

1. Build/package an `elastic-agent-complete` image (or extract a package) with this change.
2. Enroll it into a Fleet policy with a private location, then create a Synthetics **API Journey** monitor targeting that location (via elastic/kibana#270874).
3. Before this change: the `synthetics/api-default` component fails immediately with `input not supported - ensure you have installed the correct flavor`.
4. After this change: the component is recognized and routes to the Heartbeat beat-receiver like the other `synthetics/*` inputs.

I verified locally that:
- `internal/edot/spec.yml` is copied verbatim to `components/elastic-otel-collector.spec.yml` at package time (`dev-tools/packaging/packages.yml`), and the freshly-pulled `elastic-agent-complete:9.6.0-SNAPSHOT` image was missing this entry, reproducing the exact "input not supported" error from a real Fleet-managed agent.
- `go build ./...` in both the main module (`./pkg/component/...`, `./internal/pkg/otel/...`) and the `internal/edot` module succeed with this change.
- `go test ./pkg/component/...` and `go test ./internal/pkg/otel/translate/...` pass.

## Related issues

- Relates elastic/kibana#270874 (adds Synthetics API Journey monitor type)
- Relates elastic/beats#50802 (adds Heartbeat `api` monitor type)