### PR TITLE
fix: don't degrade rollback cleaner when live-install symlink is absent

### DIFF
--- a/changelog/fragments/1788737507-fix-cleanup-degrade-absent-symlink-rpm.yaml
+++ b/changelog/fragments/1788737507-fix-cleanup-degrade-absent-symlink-rpm.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix rollback cleaner permanently skipping cleanup on RPM/DEB installs due to absent live-install symlink
+component: elastic-agent

--- a/internal/pkg/agent/application/upgrade/cleanup_agent_directories.go
+++ b/internal/pkg/agent/application/upgrade/cleanup_agent_directories.go
@@ -182,13 +182,14 @@ func cleanupAgentDirectories(
 
 	symlinkTarget, symlinkErr := liveVersionedHome(topDir)
 	if symlinkErr != nil {
-		if errors.Is(symlinkErr, errSymlinkAbsent) && marker == nil && markerErr == nil {
-			// Fresh volume: symlink absent and no upgrade marker present. The
-			// agent creates the symlink on first start, after this cleanup pass
-			// runs. Log at debug — this is the expected state, not a degraded
-			// one.
-			log.Debugw("live versioned home symlink is absent; orphan directories will be kept conservatively",
+		if errors.Is(symlinkErr, errSymlinkAbsent) {
+			// Symlink absent — callerProtected already covers the live versioned home,
+			// so cleanup can proceed safely without it. This is the expected state on
+			// package-managed installs (RPM/DEB), which never create this symlink.
+			// Clear symlinkErr so shouldRemove does not conservatively preserve everything.
+			log.Debugw("live versioned home symlink is absent; cleanup will rely on caller-protected list",
 				"error.message", symlinkErr.Error())
+			symlinkErr = nil
 		} else {
 			log.Warnw("could not resolve live versioned home symlink during cleanup; orphan directories will be kept conservatively",
 				"error.message", symlinkErr.Error())

--- a/internal/pkg/agent/application/upgrade/cleanup_agent_directories.go
+++ b/internal/pkg/agent/application/upgrade/cleanup_agent_directories.go
@@ -187,7 +187,7 @@ func cleanupAgentDirectories(
 			// so cleanup can proceed safely without it. This is the expected state on
 			// package-managed installs (RPM/DEB), which never create this symlink.
 			// Clear symlinkErr so shouldRemove does not conservatively preserve everything.
-			log.Debugw("live versioned home symlink is absent; cleanup will rely on caller-protected list",
+			log.Debugw("live versioned home symlink is absent; live install identified via running process executable",
 				"error.message", symlinkErr.Error())
 			symlinkErr = nil
 		} else {

--- a/internal/pkg/agent/application/upgrade/cleanup_agent_directories_test.go
+++ b/internal/pkg/agent/application/upgrade/cleanup_agent_directories_test.go
@@ -237,29 +237,49 @@ func TestCleanupAgentDirectories_AbsentSymlink_NotDegraded(t *testing.T) {
 	assert.NotEmpty(t, debugEntries, "absent symlink must produce a debug log entry")
 }
 
-func TestCleanupAgentDirectories_AbsentSymlink_WithMarker_IsDegraded(t *testing.T) {
+func TestCleanupAgentDirectories_AbsentSymlink_WithMarker_NotDegraded(t *testing.T) {
 	log, _ := loggertest.New(t.Name())
 	topDir := t.TempDir()
 
 	relHome := createFakeAgentInstall(t, topDir, "1.0.0", "aaaaaa", true)
 	source := ttl.NewTTLMarkerRegistry(log, topDir)
 
-	// Write an upgrade marker — this means an upgrade was in progress.
+	// Write an upgrade marker — models an RPM/DEB install that has been upgraded
+	// at least once and therefore has a marker, but no live symlink.
 	require.NoError(t, os.MkdirAll(filepath.Join(topDir, "data"), 0o750))
 	require.NoError(t,
 		SaveMarker(paths.DataFrom(topDir), &UpdateMarker{Version: "1.0.0", Hash: "aaaaaa"}, true),
 		"writing upgrade marker fixture")
 
-	// No symlink. The marker's presence means this is not a fresh-volume start,
-	// so cleanup must still treat it as degraded.
-	leftover, err := cleanupAgentDirectories(log, topDir, time.Now(), source, CleanupExpiredRollbacks, nil, cleanupOpts{requireMarkerDetails: true})
-	require.Error(t, err)
-	require.ErrorIs(t, err, errCleanupDegraded,
-		"absent symlink with an upgrade marker must still return errCleanupDegraded")
+	// No symlink. callerProtected covers the live versioned home, so cleanup must
+	// proceed without degrading — this is the normal state on RPM/DEB installs.
+	callerProtected := map[string]bool{filepath.Clean(relHome): true}
+	leftover, err := cleanupAgentDirectories(log, topDir, time.Now(), source, CleanupExpiredRollbacks, callerProtected, cleanupOpts{requireMarkerDetails: true})
+	require.NoError(t, err, "absent symlink with callerProtected must not be treated as degraded")
 
-	// The install must be kept conservatively.
+	// The live versioned home is protected via callerProtected and must be kept.
 	require.NotNil(t, leftover)
 	assert.DirExists(t, filepath.Join(topDir, relHome))
+}
+
+func TestCleanupAgentDirectories_AbsentSymlink_OrphansRemoved(t *testing.T) {
+	log, _ := loggertest.New(t.Name())
+	topDir := t.TempDir()
+
+	// Models an RPM/DEB host after several upgrades: one live install and two orphans.
+	liveHome := createFakeAgentInstall(t, topDir, "9.5.2", "92fc15", true)
+	orphan1 := createFakeAgentInstall(t, topDir, "8.18.2", "52ce20", true)
+	orphan2 := createFakeAgentInstall(t, topDir, "9.3.1", "2ec825", true)
+	source := ttl.NewTTLMarkerRegistry(log, topDir)
+
+	// No symlink, no upgrade marker (upgrade completed and marker was cleaned up).
+	callerProtected := map[string]bool{filepath.Clean(liveHome): true}
+	_, err := cleanupAgentDirectories(log, topDir, time.Now(), source, CleanupExpiredRollbacks, callerProtected, cleanupOpts{requireMarkerDetails: false})
+	require.NoError(t, err, "absent symlink with callerProtected must not be treated as degraded")
+
+	assert.DirExists(t, filepath.Join(topDir, liveHome), "live versioned home must be preserved")
+	assert.NoDirExists(t, filepath.Join(topDir, orphan1), "orphan must be removed")
+	assert.NoDirExists(t, filepath.Join(topDir, orphan2), "orphan must be removed")
 }
 
 func TestCleanupAgentDirectories_DanglingSymlink_IsDegraded(t *testing.T) {

--- a/internal/pkg/agent/application/upgrade/cleanup_agent_directories_test.go
+++ b/internal/pkg/agent/application/upgrade/cleanup_agent_directories_test.go
@@ -244,15 +244,15 @@ func TestCleanupAgentDirectories_AbsentSymlink_WithMarker_NotDegraded(t *testing
 	relHome := createFakeAgentInstall(t, topDir, "1.0.0", "aaaaaa", true)
 	source := ttl.NewTTLMarkerRegistry(log, topDir)
 
-	// Write an upgrade marker — models an RPM/DEB install that has been upgraded
-	// at least once and therefore has a marker, but no live symlink.
+	// Write an upgrade marker — exercises the code path where the symlink is
+	// absent but a marker is present (e.g. the symlink was deleted externally).
 	require.NoError(t, os.MkdirAll(filepath.Join(topDir, "data"), 0o750))
 	require.NoError(t,
 		SaveMarker(paths.DataFrom(topDir), &UpdateMarker{Version: "1.0.0", Hash: "aaaaaa"}, true),
 		"writing upgrade marker fixture")
 
 	// No symlink. callerProtected covers the live versioned home, so cleanup must
-	// proceed without degrading — this is the normal state on RPM/DEB installs.
+	// proceed without degrading even when a marker is present.
 	callerProtected := map[string]bool{filepath.Clean(relHome): true}
 	leftover, err := cleanupAgentDirectories(log, topDir, time.Now(), source, CleanupExpiredRollbacks, callerProtected, cleanupOpts{requireMarkerDetails: true})
 	require.NoError(t, err, "absent symlink with callerProtected must not be treated as degraded")

--- a/internal/pkg/agent/application/upgrade/rollback_test.go
+++ b/internal/pkg/agent/application/upgrade/rollback_test.go
@@ -1119,14 +1119,14 @@ func TestLiveVersionedHome(t *testing.T) {
 // When the symlink is absent AND there is no upgrade marker (a fresh volume),
 // no degraded error is returned — that is the expected state at first start.
 func TestCleanup_DegradesGracefullyWhenLiveHomeUnresolvable(t *testing.T) {
-	t.Run("no marker: not degraded, expired TTL swept, orphan kept", func(t *testing.T) {
+	t.Run("no marker: not degraded, expired TTL swept, orphan swept", func(t *testing.T) {
 		testLogger, _ := loggertest.New(t.Name())
 		topDir := t.TempDir()
 
 		// Two installs, no symlink, no upgrade marker — models a fresh EFS volume
 		// that has prior versioned directories but the symlink was cleaned:
 		// - expired: has an expired TTL -> should be swept
-		// - orphan : has no TTL         -> must be kept (cannot verify it isn't live)
+		// - orphan : has no TTL and is not caller-protected -> also swept
 		expiredHome := createFakeAgentInstall(t, topDir, "1.2.3", "expire", true)
 		orphanHome := createFakeAgentInstall(t, topDir, "4.5.6", "orphan", true)
 		now := time.Now()
@@ -1145,12 +1145,14 @@ func TestCleanup_DegradesGracefullyWhenLiveHomeUnresolvable(t *testing.T) {
 		// Expired TTL is swept even without a symlink.
 		assert.NoDirExists(t, filepath.Join(topDir, expiredHome),
 			"expired TTL entry should be swept even without a symlink")
-		// Orphan is preserved because we cannot verify it isn't the live install.
-		assert.DirExists(t, filepath.Join(topDir, orphanHome),
-			"orphan must be preserved when symlink is absent")
+		// Orphan is swept: absent symlink is no longer a guard; callerProtected
+		// (derived from paths.Home() in real usage) is the safety net, and no
+		// homes were passed to this cleanup call.
+		assert.NoDirExists(t, filepath.Join(topDir, orphanHome),
+			"orphan must be swept when symlink is absent and no caller-protected homes are set")
 	})
 
-	t.Run("removeMarker=true: marker survives because verification was degraded", func(t *testing.T) {
+	t.Run("removeMarker=true: absent symlink is not degraded; marker is removed", func(t *testing.T) {
 		testLogger, _ := loggertest.New(t.Name())
 		topDir := t.TempDir()
 
@@ -1160,12 +1162,13 @@ func TestCleanup_DegradesGracefullyWhenLiveHomeUnresolvable(t *testing.T) {
 			SaveMarker(paths.DataFrom(topDir), &UpdateMarker{Version: "1.2.3", Hash: "deadbeef"}, true),
 			"writing valid upgrade marker fixture")
 
+		// No symlink. Absent symlink is no longer treated as degraded, so
+		// removeMarker=true must proceed and remove the marker.
 		err := cleanup(testLogger, topDir, true, false, 0)
-		require.Error(t, err)
-		require.ErrorIs(t, err, errCleanupDegraded)
+		require.NoError(t, err)
 
-		assert.FileExists(t, markerPath,
-			"upgrade marker must survive a degraded cleanup so the next run can verify with full info")
+		assert.NoFileExists(t, markerPath,
+			"upgrade marker must be removed when cleanup is not degraded and removeMarker=true")
 	})
 }
 
@@ -1222,8 +1225,10 @@ func TestCleanAvailableRollbacks_AbsentSymlink_NoMarker(t *testing.T) {
 	// Expired TTL — swept even though symlink is unresolvable.
 	assert.NoDirExists(t, filepath.Join(topDir, relC),
 		"expired TTL entry should be swept even when symlink is unresolvable")
-	// Orphan — kept because we cannot prove it is not the live install.
-	assertAgentInstallExists(t, filepath.Join(topDir, relD), agentExecutableName)
+	// Orphan — swept because callerProtected (relB) already identifies the live
+	// install; absent symlink no longer conservatively blocks cleanup.
+	assert.NoDirExists(t, filepath.Join(topDir, relD),
+		"orphan must be swept when symlink is absent and callerProtected identifies the live install")
 }
 
 // TestCleanAvailableRollbacks_NilDetailsMarker_LenientMode verifies that


### PR DESCRIPTION
## Summary

- On RPM/DEB installs the symlink at `<top>/elastic-agent` is never created — only Fleet-managed self-upgrades create it, and RPM installs are not Fleet-upgradable. The rollback cleaner was treating any absent-symlink case where an upgrade marker exists as "degraded", permanently blocking cleanup and allowing old versioned homes to accumulate indefinitely (observed in practice: 11 directories totalling several GB after 8.18.2→9.5.2).
- The symlink guard was redundant: `callerProtected`, always populated from `os.Executable()` via `paths.Home()`, already ensures the live install is never deleted. This PR changes the absent-symlink branch to clear `symlinkErr` and proceed normally; a truly unreadable or dangling symlink (non-`ErrNotExist` error) still triggers the degraded path.
- Tests updated to reflect the new behaviour: orphans are swept when `callerProtected` identifies the live install, and `removeMarker=true` on a non-degraded run correctly removes the upgrade marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)