### PR TITLE
Ironbank: fix yml file permissions in Dockerfile

### DIFF
--- a/changelog/fragments/1789073037-ironbank-fix-yml-permissions.yaml
+++ b/changelog/fragments/1789073037-ironbank-fix-yml-permissions.yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+
+summary: Fix Ironbank Dockerfile to restore module yml file permissions to 0644 after broad 0666 chmod.
+
+component: elastic-agent

--- a/dev-tools/packaging/templates/ironbank/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/ironbank/Dockerfile.tmpl
@@ -90,6 +90,7 @@ RUN find /usr/share//elastic-agent/data -type d -exec chmod 0777 {} \; && \
     (chmod 0755 /usr/share/elastic-agent/data/elastic-agent-*/components/pf-host-agent || true) && \
     (chmod 0755 /usr/share/elastic-agent/data/elastic-agent-*/otelcol || true) && \
     (chmod 0755 /usr/share/elastic-agent/otelcol || true) && \
+    find /usr/share/elastic-agent/data/elastic-agent-*/components -name "*.yml" -type f -exec chmod 0644 {} \; && \
     chmod +x /usr/share/elastic-agent/data/elastic-agent-*/elastic-agent
 
 COPY jq /usr/local/bin


### PR DESCRIPTION
## What does this PR do?

Adds a missing `chmod 0644` step for `*.yml` files in the Ironbank Dockerfile, aligning it with the standard `Dockerfile.elastic-agent.tmpl`.

## Why is it important?

The Ironbank Dockerfile sets all files under `/data` to `0666` for OpenShift/arbitrary-user-id support, then restores specific executables to `0755`. However, it never restores module `.yml` config files to `0644`. This leaves them world-writable, causing elastic-agent to refuse to load them:

```
Failed to load module config for module 'kafka': loading module configuration from
'.../components/module/kafka/module.yml': config file (...) can only be writable by
the owner but the permissions are "-rw-rw-rw-"
```

The standard Dockerfile already has this step:
```dockerfile
find .../components -name "*.yml*" -type f -exec chmod 0644 {} \;
```

This PR adds the equivalent to the Ironbank Dockerfile.

Verified against `v8.19.20` tag — the gap exists there and on `main`.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)

## Related issues

- Related: https://github.com/elastic/elastic-agent/issues/4539
- Related: https://github.com/elastic/elastic-agent/pull/10228

🤖 Generated with [Claude Code](https://claude.com/claude-code)