### PR TITLE
Re-enable TestAuditdCorrectBinaries on Debian

### DIFF
--- a/testing/integration/ess/auditd_monitoring_test.go
+++ b/testing/integration/ess/auditd_monitoring_test.go
@@ -49,9 +49,7 @@ func TestAuditdCorrectBinaries(t *testing.T) {
 		Local: false, // requires Agent installation
 		Sudo:  true,  // requires Agent installation
 		OS: []define.OS{
-			// Skipped on Debian, see https://github.com/elastic/elastic-agent/issues/7813
-			{Type: define.Linux, Distro: "ubuntu"},
-			{Type: define.Linux, Distro: "rhel"},
+			{Type: define.Linux},
 		},
 	})
 


### PR DESCRIPTION
## Proposed commit message

(covers "What does this PR do?" and "Why is it important?")

```
Re-enable TestAuditdCorrectBinaries on Debian (#)

The test was restricted to Ubuntu and RHEL in #10873 because it failed
consistently on Debian 12 after a CI VM image bump. The root cause was
in the test itself, not the platform: with no audit_rules configured,
auditbeat ran in passive multicast mode and could only ship audit events
that the system happened to generate, and a quiet Debian VM generated
none within the 10-minute window.

#15867 made the test deterministic by installing explicit execve rules,
so auditbeat now generates its own events regardless of ambient system
activity. That fix was never exercised on Debian because of the distro
allowlist. Remove the allowlist so the test runs on every Linux image
in the matrix again.

Closes #7813
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## Disruptive User Impact

None.

## CI note
Tier 2 (Debian 13, RHEL 10) only runs on PRs when `.buildkite/**`, `magefile.go`, `dev-tools/**`, `go.mod` or `go.sum` change, so this PR will only run tier 1 (Ubuntu 24.04). The first Debian run will be on the `main` branch build after merge. If it fails there, re-add the skip via `SkipOS` and investigate with the diagnostics from that job (look for auditbeat's `"audit status from kernel at start"` and `"Successfully added N of M audit rules."` log lines).

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/7813
  (flaky-test issue that motivated the Debian skip; the test is now deterministic and this re-enables the last skipped platform)
- Closes https://github.com/elastic/beats/issues/47382
  (beats-side issue tracking the Debian failure; should be closed, assuming the Debian tier 2 job passes on `main`)
- Relates https://github.com/elastic/elastic-agent/pull/10873
  (added the Debian skip)
- Relates https://github.com/elastic/elastic-agent/pull/10806
  (VM image bump that made the flaky test fail consistently on Debian 12)
- Relates https://github.com/elastic/elastic-agent/pull/15867
  (the actual fix: explicit audit rules)
- Relates https://github.com/elastic/elastic-agent/pull/15914, https://github.com/elastic/elastic-agent/pull/16052
  (follow-ups scoping the ES query to the test's own execve events)

<!-- CI Cheatsheet
Trigger comments:
/test             (Or `buildkite test this|it`) Triggers unit test pipeline
/test extended    (Or `buildkite test extended`) Triggers integration test pipeline

PR labels:
skip-ci           Skips unit and integration tests
skip-it           Skips integration tests
-->